### PR TITLE
Aws acmpca import

### DIFF
--- a/internal/service/acmpca/certificate.go
+++ b/internal/service/acmpca/certificate.go
@@ -28,6 +28,8 @@ func ResourceCertificate() *schema.Resource {
 		Read:   resourceCertificateRead,
 		Delete: resourceCertificateRevoke,
 
+		// Expects ACM PCA ARN format, e.g:
+		// arn:aws:acm-pca:eu-west-1:555885746124:certificate-authority/08322ede-92f9-4200-8f21-c7d12b2b6edb/certificate/a4e9c2aa2ccfab625b1b9136464cd3a6
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				re := regexp.MustCompile(`arn:.+:certificate-authority/[^/]+`)

--- a/website/docs/r/acmpca_certificate.html.markdown
+++ b/website/docs/r/acmpca_certificate.html.markdown
@@ -83,4 +83,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-`aws_acmpca_certificate` can not be imported at this time.
+ACM PCA Certificates can be imported using their ARN, e.g.,
+
+```
+$ terraform import aws_acmpca_certificate.cert arn:aws:acm-pca:eu-west-1:675225743824:certificate-authority/08319ede-83g9-1400-8f21-c7d12b2b6edb/certificate/a4e9c2aa4bcfab625g1b9136464cd3a
+```


### PR DESCRIPTION
### Description
As in #27300, documentation says that ACM PCA certificates cannot be imported, but there is an importer and a test for this functionality. Also, a clarification is requested for the expected format of this custom importer.
 
Here I fix the doc declaring that is possible to import this resources, an example is included.

Also, I add a comment to the resource importer with the exact format expected. Only by the regex, it is now clear if an authority ARN is expected (as in `arn:aws:acm-pca:eu-west-1:665885744424:certificate-authority/01219ede-93f9-4400-8f51-b2d17b2g6edb` or a ACM PCA certificate (as in ` arn:aws:acm-pca:eu-west-1:665885744424:certificate-authority/08319ede-93f9-4422-1a11-c7d17b2b6edb/certificate/a4e9c2aa4ccfab115b1b9136464cd3g2`). 

Not sure if I should add that this import is now added to the changelog, as the functionality is in the code some time ago but only now documented. I can add it if you think it is correct.

### Relations
Closes #27300
