### PR TITLE
r/aws_sqs_queue: Send any configured value of `sqs_managed_sse_enabled` on Create

### DIFF
--- a/.changelog/27335.txt
+++ b/.changelog/27335.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sqs_queue: Respect configured `sqs_managed_sse_enabled` value on resource Create. In particular a configured `false` value is sent to the AWS API, which overrides the [new service default value of `true`](https://aws.amazon.com/about-aws/whats-new/2022/10/amazon-sqs-announces-server-side-encryption-ssq-managed-sse-sqs-default/) 
+```

--- a/internal/attrmap/attrmap.go
+++ b/internal/attrmap/attrmap.go
@@ -13,13 +13,14 @@ import (
 // AttributeMap represents a map of Terraform resource attribute name to AWS API attribute name.
 // Useful for SQS Queue or SNS Topic attribute handling.
 type attributeInfo struct {
-	apiAttributeName string
-	tfType           schema.ValueType
-	tfComputed       bool
-	tfOptional       bool
-	isIAMPolicy      bool
-	missingSetToNil  bool
-	skipUpdate       bool
+	alwaysSendConfiguredValueOnCreate bool
+	apiAttributeName                  string
+	tfType                            schema.ValueType
+	tfComputed                        bool
+	tfOptional                        bool
+	isIAMPolicy                       bool
+	missingSetToNil                   bool
+	skipUpdate                        bool
 }
 
 type AttributeMap map[string]attributeInfo
@@ -106,11 +107,12 @@ func (m AttributeMap) ResourceDataToAPIAttributesCreate(d *schema.ResourceData) 
 		}
 
 		var apiAttributeValue string
+		configuredValue := d.GetRawConfig().GetAttr(tfAttributeName)
 		tfOptionalComputed := attributeInfo.tfComputed && attributeInfo.tfOptional
 
 		switch v, t := d.Get(tfAttributeName), attributeInfo.tfType; t {
 		case schema.TypeBool:
-			if v := v.(bool); v {
+			if v := v.(bool); v || (attributeInfo.alwaysSendConfiguredValueOnCreate && !configuredValue.IsNull()) {
 				apiAttributeValue = strconv.FormatBool(v)
 			}
 		case schema.TypeInt:
@@ -199,6 +201,18 @@ func (m AttributeMap) APIAttributeNames() []string {
 	}
 
 	return apiAttributeNames
+}
+
+// WithAlwaysSendConfiguredBooleanValueOnCreate marks the specified Terraform Boolean attribute as always having any configured value sent on resource create.
+// By default a Boolean value is only sent to the API on resource create if its configured value is true.
+// This method is intended to be chained with other similar helper methods in a builder pattern.
+func (m AttributeMap) WithAlwaysSendConfiguredBooleanValueOnCreate(tfAttributeName string) AttributeMap {
+	if attributeInfo, ok := m[tfAttributeName]; ok && attributeInfo.tfType == schema.TypeBool {
+		attributeInfo.alwaysSendConfiguredValueOnCreate = true
+		m[tfAttributeName] = attributeInfo
+	}
+
+	return m
 }
 
 // WithIAMPolicyAttribute marks the specified Terraform attribute as holding an AWS IAM policy.

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -167,7 +167,7 @@ var (
 		"redrive_policy":                    sqs.QueueAttributeNameRedrivePolicy,
 		"sqs_managed_sse_enabled":           sqs.QueueAttributeNameSqsManagedSseEnabled,
 		"visibility_timeout_seconds":        sqs.QueueAttributeNameVisibilityTimeout,
-	}, queueSchema).WithIAMPolicyAttribute("policy").WithMissingSetToNil("*")
+	}, queueSchema).WithIAMPolicyAttribute("policy").WithMissingSetToNil("*").WithAlwaysSendConfiguredBooleanValueOnCreate("sqs_managed_sse_enabled")
 )
 
 func ResourceQueue() *schema.Resource {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Always send any configured value of `sqs_managed_sse_enabled` when creating an SQS Queue.
In particular a configured `false` value is sent, which overrides the [new service default value of `true`](https://aws.amazon.com/about-aws/whats-new/2022/10/amazon-sqs-announces-server-side-encryption-ssq-managed-sse-sqs-default/).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/22197.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/26843#issuecomment-1283586205.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccSQSQueue_managedEncryption\|TestAccSQSQueue_basic\|TestAccSQSQueue_encryption' PKG=sqs ==> Checking that code complies with gofmt requirements... TF_ACC=1 go test ./internal/service/sqs/... -v -count 1 -parallel 20  -run=TestAccSQSQueue_managedEncryption\|TestAccSQSQueue_basic\|TestAccSQSQueue_encryption -timeout 180m
=== RUN   TestAccSQSQueue_basic
=== PAUSE TestAccSQSQueue_basic
=== RUN   TestAccSQSQueue_encryption
=== PAUSE TestAccSQSQueue_encryption
=== RUN   TestAccSQSQueue_managedEncryption
=== PAUSE TestAccSQSQueue_managedEncryption
=== CONT  TestAccSQSQueue_basic
=== CONT  TestAccSQSQueue_encryption
=== CONT  TestAccSQSQueue_managedEncryption
--- PASS: TestAccSQSQueue_basic (49.88s)
--- PASS: TestAccSQSQueue_encryption (128.82s)
--- PASS: TestAccSQSQueue_managedEncryption (129.25s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	133.199s
```
