### PR TITLE
r/aws_evidently_project - waiters

### DIFF
--- a/.changelog/27336.txt
+++ b/.changelog/27336.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_evidently_project: Support configurable timeouts for create, update, and delete
+```

--- a/internal/service/evidently/find.go
+++ b/internal/service/evidently/find.go
@@ -10,9 +10,9 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func FindProjectByName(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, name string) (*cloudwatchevidently.Project, error) {
+func FindProjectByNameOrARN(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string) (*cloudwatchevidently.Project, error) {
 	input := &cloudwatchevidently.GetProjectInput{
-		Project: aws.String(name),
+		Project: aws.String(nameOrARN),
 	}
 
 	output, err := conn.GetProjectWithContext(ctx, input)

--- a/internal/service/evidently/project.go
+++ b/internal/service/evidently/project.go
@@ -184,7 +184,7 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta inter
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	project, err := FindProjectByName(ctx, conn, d.Id())
+	project, err := FindProjectByNameOrARN(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] CloudWatch Evidently Project (%s) not found, removing from state", d.Id())

--- a/internal/service/evidently/project.go
+++ b/internal/service/evidently/project.go
@@ -214,7 +214,6 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	tags := KeyValueTags(project.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
 		return diag.Errorf("setting tags: %s", err)
 	}

--- a/internal/service/evidently/project_test.go
+++ b/internal/service/evidently/project_test.go
@@ -357,7 +357,7 @@ func testAccCheckProjectDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := tfcloudwatchevidently.FindProjectByName(context.Background(), conn, rs.Primary.ID)
+		_, err := tfcloudwatchevidently.FindProjectByNameOrARN(context.Background(), conn, rs.Primary.ID)
 
 		if tfresource.NotFound(err) {
 			continue
@@ -387,7 +387,7 @@ func testAccCheckProjectExists(n string, v *cloudwatchevidently.Project) resourc
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyConn
 
-		output, err := tfcloudwatchevidently.FindProjectByName(context.Background(), conn, rs.Primary.ID)
+		output, err := tfcloudwatchevidently.FindProjectByNameOrARN(context.Background(), conn, rs.Primary.ID)
 
 		if err != nil {
 			return err

--- a/internal/service/evidently/project_test.go
+++ b/internal/service/evidently/project_test.go
@@ -46,7 +46,7 @@ func TestAccEvidentlyProject_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "last_updated_time"),
 					resource.TestCheckResourceAttrSet(resourceName, "launch_count"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttr(resourceName, "status", cloudwatchevidently.ProjectStatusAvailable),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Test Project"),
 				),

--- a/internal/service/evidently/project_test.go
+++ b/internal/service/evidently/project_test.go
@@ -140,8 +140,8 @@ func TestAccEvidentlyProject_updateDataDeliveryCloudWatchLogGroup(t *testing.T) 
 
 	rName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 	rName2 := sdkacctest.RandomWithPrefix("tf-test-bucket")
-	rName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rName4 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName3 := sdkacctest.RandomWithPrefix(fmt.Sprintf("/aws/vendedlogs/%s", acctest.ResourcePrefix))
+	rName4 := sdkacctest.RandomWithPrefix(fmt.Sprintf("/aws/vendedlogs/%s", acctest.ResourcePrefix))
 	rName5 := sdkacctest.RandomWithPrefix("resource-test-terraform")
 	resourceName := "aws_evidently_project.test"
 
@@ -283,8 +283,8 @@ func TestAccEvidentlyProject_updateDataDeliveryCloudWatchToS3(t *testing.T) {
 
 	rName := sdkacctest.RandomWithPrefix("tf-test-bucket")
 	rName2 := sdkacctest.RandomWithPrefix("tf-test-bucket")
-	rName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rName4 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName3 := sdkacctest.RandomWithPrefix(fmt.Sprintf("/aws/vendedlogs/%s", acctest.ResourcePrefix))
+	rName4 := sdkacctest.RandomWithPrefix(fmt.Sprintf("/aws/vendedlogs/%s", acctest.ResourcePrefix))
 	rName5 := sdkacctest.RandomWithPrefix("resource-test-terraform")
 	resourceName := "aws_evidently_project.test"
 	prefix := "tests3prefix"

--- a/internal/service/evidently/status.go
+++ b/internal/service/evidently/status.go
@@ -1,0 +1,26 @@
+package evidently
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func statusProject(conn *cloudwatchevidently.CloudWatchEvidently, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindProjectByNameOrARN(context.Background(), conn, id)
+
+		if tfawserr.ErrCodeEquals(err, cloudwatchevidently.ErrCodeResourceNotFoundException) {
+			return output, cloudwatchevidently.ErrCodeResourceNotFoundException, nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}

--- a/internal/service/evidently/status.go
+++ b/internal/service/evidently/status.go
@@ -5,16 +5,16 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func statusProject(conn *cloudwatchevidently.CloudWatchEvidently, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindProjectByNameOrARN(context.Background(), conn, id)
 
-		if tfawserr.ErrCodeEquals(err, cloudwatchevidently.ErrCodeResourceNotFoundException) {
-			return output, cloudwatchevidently.ErrCodeResourceNotFoundException, nil
+		if tfresource.NotFound(err) {
+			return nil, "", nil
 		}
 
 		if err != nil {

--- a/internal/service/evidently/wait.go
+++ b/internal/service/evidently/wait.go
@@ -17,8 +17,8 @@ func waitProjectCreated(conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if v, ok := outputRaw.(*cloudwatchevidently.GetProjectOutput); ok {
-		return v, err
+	if output, ok := outputRaw.(*cloudwatchevidently.GetProjectOutput); ok {
+		return output, err
 	}
 
 	return nil, err
@@ -34,8 +34,8 @@ func waitProjectUpdated(conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if v, ok := outputRaw.(*cloudwatchevidently.GetProjectOutput); ok {
-		return v, err
+	if output, ok := outputRaw.(*cloudwatchevidently.GetProjectOutput); ok {
+		return output, err
 	}
 
 	return nil, err

--- a/internal/service/evidently/wait.go
+++ b/internal/service/evidently/wait.go
@@ -1,0 +1,59 @@
+package evidently
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func waitProjectCreated(conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string, timeout time.Duration) (*cloudwatchevidently.GetProjectOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{},
+		Target:  []string{cloudwatchevidently.ProjectStatusAvailable},
+		Refresh: statusProject(conn, nameOrARN),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*cloudwatchevidently.GetProjectOutput); ok {
+		return v, err
+	}
+
+	return nil, err
+}
+
+func waitProjectUpdated(conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string, timeout time.Duration) (*cloudwatchevidently.GetProjectOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{cloudwatchevidently.ProjectStatusUpdating},
+		Target:  []string{cloudwatchevidently.ProjectStatusAvailable},
+		Refresh: statusProject(conn, nameOrARN),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if v, ok := outputRaw.(*cloudwatchevidently.GetProjectOutput); ok {
+		return v, err
+	}
+
+	return nil, err
+}
+
+func waitProjectDeleted(conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string, timeout time.Duration) (*cloudwatchevidently.GetProjectOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{cloudwatchevidently.ProjectStatusAvailable},
+		Target:  []string{cloudwatchevidently.ErrCodeResourceNotFoundException},
+		Refresh: statusProject(conn, nameOrARN),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*cloudwatchevidently.GetProjectOutput); ok {
+		return output, err
+	}
+
+	return nil, err
+}

--- a/internal/service/evidently/wait.go
+++ b/internal/service/evidently/wait.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func waitProjectCreated(conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string, timeout time.Duration) (*cloudwatchevidently.GetProjectOutput, error) {
+func waitProjectCreated(conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string, timeout time.Duration) (*cloudwatchevidently.Project, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{},
 		Target:  []string{cloudwatchevidently.ProjectStatusAvailable},
@@ -17,14 +17,14 @@ func waitProjectCreated(conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if output, ok := outputRaw.(*cloudwatchevidently.GetProjectOutput); ok {
+	if output, ok := outputRaw.(*cloudwatchevidently.Project); ok {
 		return output, err
 	}
 
 	return nil, err
 }
 
-func waitProjectUpdated(conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string, timeout time.Duration) (*cloudwatchevidently.GetProjectOutput, error) { //nolint:unparam
+func waitProjectUpdated(conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string, timeout time.Duration) (*cloudwatchevidently.Project, error) { //nolint:unparam
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{cloudwatchevidently.ProjectStatusUpdating},
 		Target:  []string{cloudwatchevidently.ProjectStatusAvailable},
@@ -34,24 +34,24 @@ func waitProjectUpdated(conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if output, ok := outputRaw.(*cloudwatchevidently.GetProjectOutput); ok {
+	if output, ok := outputRaw.(*cloudwatchevidently.Project); ok {
 		return output, err
 	}
 
 	return nil, err
 }
 
-func waitProjectDeleted(conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string, timeout time.Duration) (*cloudwatchevidently.GetProjectOutput, error) {
+func waitProjectDeleted(conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string, timeout time.Duration) (*cloudwatchevidently.Project, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{cloudwatchevidently.ProjectStatusAvailable},
-		Target:  []string{cloudwatchevidently.ErrCodeResourceNotFoundException},
+		Target:  []string{},
 		Refresh: statusProject(conn, nameOrARN),
 		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
 
-	if output, ok := outputRaw.(*cloudwatchevidently.GetProjectOutput); ok {
+	if output, ok := outputRaw.(*cloudwatchevidently.Project); ok {
 		return output, err
 	}
 

--- a/internal/service/evidently/wait.go
+++ b/internal/service/evidently/wait.go
@@ -24,7 +24,7 @@ func waitProjectCreated(conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN
 	return nil, err
 }
 
-func waitProjectUpdated(conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string, timeout time.Duration) (*cloudwatchevidently.GetProjectOutput, error) {
+func waitProjectUpdated(conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string, timeout time.Duration) (*cloudwatchevidently.GetProjectOutput, error) { //nolint:unparam
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{cloudwatchevidently.ProjectStatusUpdating},
 		Target:  []string{cloudwatchevidently.ProjectStatusAvailable},

--- a/website/docs/r/evidently_project.html.markdown
+++ b/website/docs/r/evidently_project.html.markdown
@@ -89,6 +89,14 @@ The `s3_destination` block supports the following arguments:
 * `bucket` - (Optional) The name of the bucket in which Evidently stores evaluation events.
 * `prefix` - (Optional) The bucket prefix in which Evidently stores evaluation events.
 
+## Timeouts
+
+[Configuration options](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts):
+
+* `create` - (Default `2m`)
+* `delete` - (Default `2m`)
+* `update` - (Default `2m`)
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

CloudWatch Evidently Project has a `status` attribute (docs: [API_GetProject](https://docs.aws.amazon.com/cloudwatchevidently/latest/APIReference/API_GetProject.html)). Valid values of `status` are `AVAILABLE` and `UPDATING`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #24263
Relates #22624

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccEvidentlyProject' PKG=evidently
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/evidently/... -v -count 1 -parallel 20  -run=TestAccEvidentlyProject -timeout 180m
=== RUN   TestAccEvidentlyProject_basic
=== PAUSE TestAccEvidentlyProject_basic
=== RUN   TestAccEvidentlyProject_tags
=== PAUSE TestAccEvidentlyProject_tags
=== RUN   TestAccEvidentlyProject_updateDataDeliveryCloudWatchLogGroup
=== PAUSE TestAccEvidentlyProject_updateDataDeliveryCloudWatchLogGroup
=== RUN   TestAccEvidentlyProject_updateDataDeliveryS3Bucket
=== PAUSE TestAccEvidentlyProject_updateDataDeliveryS3Bucket
=== RUN   TestAccEvidentlyProject_updateDataDeliveryS3Prefix
=== PAUSE TestAccEvidentlyProject_updateDataDeliveryS3Prefix
=== RUN   TestAccEvidentlyProject_updateDataDeliveryCloudWatchToS3
=== PAUSE TestAccEvidentlyProject_updateDataDeliveryCloudWatchToS3
=== RUN   TestAccEvidentlyProject_disappears
=== PAUSE TestAccEvidentlyProject_disappears
=== CONT  TestAccEvidentlyProject_basic
=== CONT  TestAccEvidentlyProject_updateDataDeliveryS3Prefix
=== CONT  TestAccEvidentlyProject_updateDataDeliveryCloudWatchLogGroup
=== CONT  TestAccEvidentlyProject_updateDataDeliveryCloudWatchToS3
=== CONT  TestAccEvidentlyProject_updateDataDeliveryS3Bucket
=== CONT  TestAccEvidentlyProject_disappears
=== CONT  TestAccEvidentlyProject_tags
--- PASS: TestAccEvidentlyProject_disappears (22.29s)
--- PASS: TestAccEvidentlyProject_basic (48.00s)
--- PASS: TestAccEvidentlyProject_updateDataDeliveryCloudWatchLogGroup (56.45s)
--- PASS: TestAccEvidentlyProject_updateDataDeliveryCloudWatchToS3 (60.14s)
--- PASS: TestAccEvidentlyProject_updateDataDeliveryS3Bucket (62.86s)
--- PASS: TestAccEvidentlyProject_updateDataDeliveryS3Prefix (63.03s)
--- PASS: TestAccEvidentlyProject_tags (68.95s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/evidently  69.044s

...
```
