### PR TITLE
[Enhancement] Support Amazon VPC Flow Logs to Kinesis Data Firehose

### DIFF
--- a/.changelog/27340.txt
+++ b/.changelog/27340.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_flow_log: Amazon VPC Flow Logs supports Kinesis Data Firehose as destination
+```

--- a/internal/service/ec2/vpc_flow_log_test.go
+++ b/internal/service/ec2/vpc_flow_log_test.go
@@ -227,6 +227,37 @@ func TestAccVPCFlowLog_LogDestinationType_cloudWatchLogs(t *testing.T) {
 	})
 }
 
+func TestAccVPCFlowLog_LogDestinationType_kinesisFirehose(t *testing.T) {
+	var flowLog ec2.FlowLog
+	kinesisFirehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
+	//s3ResourceName := "aws_s3_bucket.test"
+	resourceName := "aws_flow_log.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFlowLogDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCFlowLogConfig_destinationTypeKinesisFirehose(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFlowLogExists(resourceName, &flowLog),
+					resource.TestCheckResourceAttrPair(resourceName, "log_destination", kinesisFirehoseResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_type", "kinesis-data-firehose"),
+					resource.TestCheckResourceAttr(resourceName, "log_group_name", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccVPCFlowLog_LogDestinationType_s3(t *testing.T) {
 	var flowLog ec2.FlowLog
 	s3ResourceName := "aws_s3_bucket.test"
@@ -1134,5 +1165,85 @@ resource "aws_flow_log" "test" {
   max_aggregation_interval      = 60
   transit_gateway_attachment_id = aws_ec2_transit_gateway_vpc_attachment.test.id
 }
+`, rName))
+}
+
+func testAccVPCFlowLogConfig_destinationTypeKinesisFirehose(rName string) string {
+	return acctest.ConfigCompose(testAccFlowLogConfigBase(rName), fmt.Sprintf(`
+
+resource "aws_flow_log" "test" {
+  log_destination      = aws_kinesis_firehose_delivery_stream.test.arn
+  log_destination_type = "kinesis-data-firehose"
+  traffic_type         = "ALL"
+  vpc_id               = aws_vpc.test.id
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+	name        = "kinesis_firehose_test"
+	destination = "extended_s3"
+  
+	extended_s3_configuration {
+	  role_arn   = aws_iam_role.test.arn
+	  bucket_arn = aws_s3_bucket.bucket.arn
+  
+	}
+
+	tags = {
+		"LogDeliveryEnabled" = "true"
+	}
+  }
+  
+  resource "aws_s3_bucket" "bucket" {
+	bucket = %[1]q
+  }
+  
+  resource "aws_s3_bucket_acl" "bucket_acl" {
+	bucket = aws_s3_bucket.bucket.id
+	acl    = "private"
+  }
+  
+  resource "aws_iam_role" "test" {
+	name = "firehose_test_role"
+  
+	assume_role_policy = <<EOF
+  {
+	"Version": "2012-10-17",
+	"Statement": [
+	  {
+		"Action": "sts:AssumeRole",
+		"Principal": {
+		  "Service": "firehose.amazonaws.com"
+		},
+		"Effect": "Allow",
+		"Sid": ""
+	  }
+	]
+  }
+  EOF
+  }
+
+  resource "aws_iam_role_policy" "test" {
+	name = "test"
+	role = aws_iam_role.test.id
+  
+	policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "logs:CreateLogDelivery",
+                "logs:DeleteLogDelivery",
+                "logs:ListLogDeliveries",
+                "logs:GetLogDelivery",
+                "firehose:TagDeliveryStream"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ]
+}
+  EOF
+  }
 `, rName))
 }

--- a/internal/service/ec2/vpc_flow_log_test.go
+++ b/internal/service/ec2/vpc_flow_log_test.go
@@ -230,7 +230,6 @@ func TestAccVPCFlowLog_LogDestinationType_cloudWatchLogs(t *testing.T) {
 func TestAccVPCFlowLog_LogDestinationType_kinesisFirehose(t *testing.T) {
 	var flowLog ec2.FlowLog
 	kinesisFirehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
-	//s3ResourceName := "aws_s3_bucket.test"
 	resourceName := "aws_flow_log.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -1170,80 +1169,78 @@ resource "aws_flow_log" "test" {
 
 func testAccVPCFlowLogConfig_destinationTypeKinesisFirehose(rName string) string {
 	return acctest.ConfigCompose(testAccFlowLogConfigBase(rName), fmt.Sprintf(`
-
 resource "aws_flow_log" "test" {
-  log_destination      = aws_kinesis_firehose_delivery_stream.test.arn
-  log_destination_type = "kinesis-data-firehose"
-  traffic_type         = "ALL"
-  vpc_id               = aws_vpc.test.id
+	log_destination      = aws_kinesis_firehose_delivery_stream.test.arn
+	log_destination_type = "kinesis-data-firehose"
+	traffic_type         = "ALL"
+	vpc_id               = aws_vpc.test.id
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {
 	name        = "kinesis_firehose_test"
 	destination = "extended_s3"
-  
+
 	extended_s3_configuration {
-	  role_arn   = aws_iam_role.test.arn
-	  bucket_arn = aws_s3_bucket.bucket.arn
-  
+		role_arn   = aws_iam_role.test.arn
+		bucket_arn = aws_s3_bucket.bucket.arn
 	}
 
 	tags = {
 		"LogDeliveryEnabled" = "true"
 	}
-  }
-  
-  resource "aws_s3_bucket" "bucket" {
+}
+
+resource "aws_s3_bucket" "bucket" {
 	bucket = %[1]q
-  }
-  
-  resource "aws_s3_bucket_acl" "bucket_acl" {
+}
+
+resource "aws_s3_bucket_acl" "bucket_acl" {
 	bucket = aws_s3_bucket.bucket.id
 	acl    = "private"
-  }
-  
-  resource "aws_iam_role" "test" {
-	name = "firehose_test_role"
-  
-	assume_role_policy = <<EOF
-  {
-	"Version": "2012-10-17",
-	"Statement": [
-	  {
-		"Action": "sts:AssumeRole",
-		"Principal": {
-		  "Service": "firehose.amazonaws.com"
-		},
-		"Effect": "Allow",
-		"Sid": ""
-	  }
-	]
-  }
-  EOF
-  }
-
-  resource "aws_iam_role_policy" "test" {
-	name = "test"
-	role = aws_iam_role.test.id
-  
-	policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": [
-                "logs:CreateLogDelivery",
-                "logs:DeleteLogDelivery",
-                "logs:ListLogDeliveries",
-                "logs:GetLogDelivery",
-                "firehose:TagDeliveryStream"
-            ],
-            "Effect": "Allow",
-            "Resource": "*"
-        }
-    ]
 }
-  EOF
-  }
+
+resource "aws_iam_role" "test" {
+	name = "firehose_test_role"
+
+	assume_role_policy = <<EOF
+{
+	"Version":"2012-10-17",
+	"Statement":[
+	{
+		"Action":"sts:AssumeRole",
+		"Principal":{
+			"Service":"firehose.amazonaws.com"
+		},
+		"Effect":"Allow",
+		"Sid":""
+	}
+	]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test" {
+name = "test"
+role = aws_iam_role.test.id
+
+policy = <<EOF
+{
+	"Version":"2012-10-17",
+	"Statement":[
+	{
+		"Action":[
+			"logs:CreateLogDelivery",
+			"logs:DeleteLogDelivery",
+			"logs:ListLogDeliveries",
+			"logs:GetLogDelivery",
+			"firehose:TagDeliveryStream"
+		],
+		"Effect":"Allow",
+		"Resource":"*"
+	}
+	]
+}
+EOF
+}
 `, rName))
 }

--- a/internal/service/ec2/vpc_flow_log_test.go
+++ b/internal/service/ec2/vpc_flow_log_test.go
@@ -1170,75 +1170,75 @@ resource "aws_flow_log" "test" {
 func testAccVPCFlowLogConfig_destinationTypeKinesisFirehose(rName string) string {
 	return acctest.ConfigCompose(testAccFlowLogConfigBase(rName), fmt.Sprintf(`
 resource "aws_flow_log" "test" {
-	log_destination      = aws_kinesis_firehose_delivery_stream.test.arn
-	log_destination_type = "kinesis-data-firehose"
-	traffic_type         = "ALL"
-	vpc_id               = aws_vpc.test.id
+  log_destination      = aws_kinesis_firehose_delivery_stream.test.arn
+  log_destination_type = "kinesis-data-firehose"
+  traffic_type         = "ALL"
+  vpc_id               = aws_vpc.test.id
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {
-	name        = "kinesis_firehose_test"
-	destination = "extended_s3"
+  name        = "kinesis_firehose_test"
+  destination = "extended_s3"
 
-	extended_s3_configuration {
-		role_arn   = aws_iam_role.test.arn
-		bucket_arn = aws_s3_bucket.bucket.arn
-	}
+  extended_s3_configuration {
+    role_arn   = aws_iam_role.test.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
+  }
 
-	tags = {
-		"LogDeliveryEnabled" = "true"
-	}
+  tags = {
+    "LogDeliveryEnabled" = "true"
+  }
 }
 
 resource "aws_s3_bucket" "bucket" {
-	bucket = %[1]q
+  bucket = %[1]q
 }
 
 resource "aws_s3_bucket_acl" "bucket_acl" {
-	bucket = aws_s3_bucket.bucket.id
-	acl    = "private"
+  bucket = aws_s3_bucket.bucket.id
+  acl    = "private"
 }
 
 resource "aws_iam_role" "test" {
-	name = "firehose_test_role"
+  name = "firehose_test_role"
 
-	assume_role_policy = <<EOF
+  assume_role_policy = <<EOF
 {
-	"Version":"2012-10-17",
-	"Statement":[
-	{
-		"Action":"sts:AssumeRole",
-		"Principal":{
-			"Service":"firehose.amazonaws.com"
-		},
-		"Effect":"Allow",
-		"Sid":""
-	}
-	]
+  "Version":"2012-10-17",
+  "Statement": [
+    {
+      "Action":"sts:AssumeRole",
+      "Principal":{
+        "Service":"firehose.amazonaws.com"
+      },
+      "Effect":"Allow",
+      "Sid":""
+    }
+  ]
 }
 EOF
 }
 
 resource "aws_iam_role_policy" "test" {
-name = "test"
-role = aws_iam_role.test.id
+  name = "test"
+  role = aws_iam_role.test.id
 
-policy = <<EOF
+  policy = <<EOF
 {
-	"Version":"2012-10-17",
-	"Statement":[
-	{
-		"Action":[
-			"logs:CreateLogDelivery",
-			"logs:DeleteLogDelivery",
-			"logs:ListLogDeliveries",
-			"logs:GetLogDelivery",
-			"firehose:TagDeliveryStream"
-		],
-		"Effect":"Allow",
-		"Resource":"*"
-	}
-	]
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Action": [
+        "logs:CreateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:GetLogDelivery",
+        "firehose:TagDeliveryStream"
+      ],
+      "Effect":"Allow",
+      "Resource":"*"
+    }
+  ]
 }
 EOF
 }

--- a/website/docs/r/flow_log.html.markdown
+++ b/website/docs/r/flow_log.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # Resource: aws_flow_log
 
 Provides a VPC/Subnet/ENI/Transit Gateway/Transit Gateway Attachment Flow Log to capture IP traffic for a specific network
-interface, subnet, or VPC. Logs are sent to a CloudWatch Log Group or a S3 Bucket.
+interface, subnet, or VPC. Logs are sent to a CloudWatch Log Group, a S3 Bucket or Amazon Kinesis Data Firehose
 
 ## Example Usage
 
@@ -72,6 +72,65 @@ EOF
 }
 ```
 
+### Amazon Kinesis Data Firehose logging
+
+```terraform
+resource "aws_flow_log" "example" {
+  iam_role_arn    = aws_iam_role.example.arn
+  log_destination = aws_cloudwatch_log_group.example.arn
+  traffic_type    = "ALL"
+  vpc_id          = aws_vpc.example.id
+}
+
+resource "aws_cloudwatch_log_group" "example" {
+  name = "example"
+}
+
+resource "aws_iam_role" "example" {
+  name = "example"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "delivery.logs.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "example" {
+  name = "example"
+  role = aws_iam_role.example.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "logs:CreateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:GetLogDelivery",
+        "firehose:TagDeliveryStream"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+```
+
 ### S3 Logging
 
 ```terraform
@@ -115,7 +174,7 @@ The following arguments are supported:
 * `traffic_type` - (Required) The type of traffic to capture. Valid values: `ACCEPT`,`REJECT`, `ALL`.
 * `eni_id` - (Optional) Elastic Network Interface ID to attach to
 * `iam_role_arn` - (Optional) The ARN for the IAM role that's used to post flow logs to a CloudWatch Logs log group
-* `log_destination_type` - (Optional) The type of the logging destination. Valid values: `cloud-watch-logs`, `s3`. Default: `cloud-watch-logs`.
+* `log_destination_type` - (Optional) The type of the logging destination. Valid values: `cloud-watch-logs`, `s3`, `kinesis-data-firehose`. Default: `cloud-watch-logs`.
 * `log_destination` - (Optional) The ARN of the logging destination. Either `log_destination` or `log_group_name` must be set.
 * `log_group_name` - (Optional) *Deprecated:* Use `log_destination` instead. The name of the CloudWatch log group. Either `log_group_name` or `log_destination` must be set.
 * `subnet_id` - (Optional) Subnet ID to attach to

--- a/website/docs/r/flow_log.html.markdown
+++ b/website/docs/r/flow_log.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # Resource: aws_flow_log
 
 Provides a VPC/Subnet/ENI/Transit Gateway/Transit Gateway Attachment Flow Log to capture IP traffic for a specific network
-interface, subnet, or VPC. Logs are sent to a CloudWatch Log Group, a S3 Bucket or Amazon Kinesis Data Firehose
+interface, subnet, or VPC. Logs are sent to a CloudWatch Log Group, a S3 Bucket, or Amazon Kinesis Data Firehose
 
 ## Example Usage
 


### PR DESCRIPTION
### Description

Adds validation for VPC Flow logs destination type as Kinesis Data Firehose

### Relations

Closes #26730

### Output from Acceptance Testing

```
$make testacc TESTARGS='-run=TestAccVPCFlowLog' PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 2  -run=TestAccVPCFlowLog -timeout 180m
=== RUN   TestAccVPCFlowLog_vpcID
=== PAUSE TestAccVPCFlowLog_vpcID
=== RUN   TestAccVPCFlowLog_logFormat
=== PAUSE TestAccVPCFlowLog_logFormat
=== RUN   TestAccVPCFlowLog_subnetID
=== PAUSE TestAccVPCFlowLog_subnetID
=== RUN   TestAccVPCFlowLog_transitGatewayID
=== PAUSE TestAccVPCFlowLog_transitGatewayID
=== RUN   TestAccVPCFlowLog_transitGatewayAttachmentID
=== PAUSE TestAccVPCFlowLog_transitGatewayAttachmentID
=== RUN   TestAccVPCFlowLog_LogDestinationType_cloudWatchLogs
=== PAUSE TestAccVPCFlowLog_LogDestinationType_cloudWatchLogs
=== RUN   TestAccVPCFlowLog_LogDestinationType_kinesisFirehose
=== PAUSE TestAccVPCFlowLog_LogDestinationType_kinesisFirehose
=== RUN   TestAccVPCFlowLog_LogDestinationType_s3
=== PAUSE TestAccVPCFlowLog_LogDestinationType_s3
=== RUN   TestAccVPCFlowLog_LogDestinationTypeS3_invalid
=== PAUSE TestAccVPCFlowLog_LogDestinationTypeS3_invalid
=== RUN   TestAccVPCFlowLog_LogDestinationTypeS3DO_plainText
=== PAUSE TestAccVPCFlowLog_LogDestinationTypeS3DO_plainText
=== RUN   TestAccVPCFlowLog_LogDestinationTypeS3DOPlainText_hiveCompatible
=== PAUSE TestAccVPCFlowLog_LogDestinationTypeS3DOPlainText_hiveCompatible
=== RUN   TestAccVPCFlowLog_LogDestinationTypeS3DO_parquet
=== PAUSE TestAccVPCFlowLog_LogDestinationTypeS3DO_parquet
=== RUN   TestAccVPCFlowLog_LogDestinationTypeS3DOParquet_hiveCompatible
=== PAUSE TestAccVPCFlowLog_LogDestinationTypeS3DOParquet_hiveCompatible
=== RUN   TestAccVPCFlowLog_LogDestinationTypeS3DOParquetHiveCompatible_perHour
=== PAUSE TestAccVPCFlowLog_LogDestinationTypeS3DOParquetHiveCompatible_perHour
=== RUN   TestAccVPCFlowLog_LogDestinationType_maxAggregationInterval
=== PAUSE TestAccVPCFlowLog_LogDestinationType_maxAggregationInterval
=== RUN   TestAccVPCFlowLog_tags
=== PAUSE TestAccVPCFlowLog_tags
=== RUN   TestAccVPCFlowLog_disappears
=== PAUSE TestAccVPCFlowLog_disappears
=== CONT  TestAccVPCFlowLog_vpcID
=== CONT  TestAccVPCFlowLog_LogDestinationTypeS3DO_plainText
--- PASS: TestAccVPCFlowLog_LogDestinationTypeS3DO_plainText (21.89s)
=== CONT  TestAccVPCFlowLog_LogDestinationType_cloudWatchLogs
--- PASS: TestAccVPCFlowLog_vpcID (34.36s)
=== CONT  TestAccVPCFlowLog_LogDestinationTypeS3_invalid
--- PASS: TestAccVPCFlowLog_LogDestinationType_cloudWatchLogs (20.21s)
=== CONT  TestAccVPCFlowLog_transitGatewayID
--- PASS: TestAccVPCFlowLog_LogDestinationTypeS3_invalid (11.94s)
=== CONT  TestAccVPCFlowLog_LogDestinationType_s3
--- PASS: TestAccVPCFlowLog_LogDestinationType_s3 (21.65s)
=== CONT  TestAccVPCFlowLog_transitGatewayAttachmentID
--- PASS: TestAccVPCFlowLog_transitGatewayID (175.61s)
=== CONT  TestAccVPCFlowLog_LogDestinationType_kinesisFirehose
--- PASS: TestAccVPCFlowLog_transitGatewayAttachmentID (264.53s)
=== CONT  TestAccVPCFlowLog_subnetID
--- PASS: TestAccVPCFlowLog_subnetID (19.00s)
=== CONT  TestAccVPCFlowLog_LogDestinationTypeS3DOParquetHiveCompatible_perHour
--- PASS: TestAccVPCFlowLog_LogDestinationType_kinesisFirehose (146.47s)
=== CONT  TestAccVPCFlowLog_LogDestinationTypeS3DO_parquet
--- PASS: TestAccVPCFlowLog_LogDestinationTypeS3DOParquetHiveCompatible_perHour (18.98s)
=== CONT  TestAccVPCFlowLog_disappears
--- PASS: TestAccVPCFlowLog_LogDestinationTypeS3DO_parquet (18.68s)
=== CONT  TestAccVPCFlowLog_LogDestinationTypeS3DOParquet_hiveCompatible
--- PASS: TestAccVPCFlowLog_disappears (15.63s)
=== CONT  TestAccVPCFlowLog_tags
--- PASS: TestAccVPCFlowLog_LogDestinationTypeS3DOParquet_hiveCompatible (18.87s)
=== CONT  TestAccVPCFlowLog_LogDestinationTypeS3DOPlainText_hiveCompatible
--- PASS: TestAccVPCFlowLog_LogDestinationTypeS3DOPlainText_hiveCompatible (17.75s)
=== CONT  TestAccVPCFlowLog_LogDestinationType_maxAggregationInterval
--- PASS: TestAccVPCFlowLog_tags (40.92s)
=== CONT  TestAccVPCFlowLog_logFormat
--- PASS: TestAccVPCFlowLog_LogDestinationType_maxAggregationInterval (17.21s)
--- PASS: TestAccVPCFlowLog_logFormat (32.05s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	460.028s

```
