### PR TITLE
Add data source for DX Router Configuration

### DIFF
--- a/.changelog/27341.txt
+++ b/.changelog/27341.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_dx_router_configuration
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -521,10 +521,11 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_docdb_engine_version":        docdb.DataSourceEngineVersion(),
 			"aws_docdb_orderable_db_instance": docdb.DataSourceOrderableDBInstance(),
 
-			"aws_dx_connection": directconnect.DataSourceConnection(),
-			"aws_dx_gateway":    directconnect.DataSourceGateway(),
-			"aws_dx_location":   directconnect.DataSourceLocation(),
-			"aws_dx_locations":  directconnect.DataSourceLocations(),
+			"aws_dx_connection":           directconnect.DataSourceConnection(),
+			"aws_dx_gateway":              directconnect.DataSourceGateway(),
+			"aws_dx_location":             directconnect.DataSourceLocation(),
+			"aws_dx_locations":            directconnect.DataSourceLocations(),
+			"aws_dx_router_configuration": directconnect.DataSourceRouterConfiguration(),
 
 			"aws_directory_service_directory": ds.DataSourceDirectory(),
 

--- a/internal/service/directconnect/router_configuration_data_source.go
+++ b/internal/service/directconnect/router_configuration_data_source.go
@@ -3,6 +3,7 @@ package directconnect
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/directconnect"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/internal/service/directconnect/router_configuration_data_source.go
+++ b/internal/service/directconnect/router_configuration_data_source.go
@@ -1,0 +1,152 @@
+package directconnect
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func DataSourceRouterConfiguration() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceRouterConfigurationRead,
+
+		Schema: map[string]*schema.Schema{
+			"customer_router_config": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"router": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"platform": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"router_type_identifier": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"software": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vendor": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"xslt_template_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"xslt_template_name_for_mac_sec": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"router_type_identifier": {
+				Type: schema.TypeString,
+				// even though the API Reference shows this as optional, the API call will fail without this argument
+				Required: true,
+			},
+			"virtual_interface_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"virtual_interface_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+const (
+	DSNameRouterConfiguration = "Router Configuration Data Source"
+)
+
+func dataSourceRouterConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).DirectConnectConn
+
+	routerTypeIdentifier := d.Get("router_type_identifier").(string)
+	virtualInterfaceId := d.Get("virtual_interface_id").(string)
+
+	out, err := findRouterConfigurationByTypeAndVif(conn, routerTypeIdentifier, virtualInterfaceId)
+	if err != nil {
+		return create.DiagError(names.DirectConnect, create.ErrActionReading, DSNameRouterConfiguration, virtualInterfaceId, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", virtualInterfaceId, routerTypeIdentifier))
+
+	d.Set("customer_router_config", out.CustomerRouterConfig)
+	if router_type_out := out.Router.RouterTypeIdentifier; router_type_out != nil {
+		d.Set("router_type_identifier", router_type_out)
+	}
+	d.Set("virtual_interface_id", out.VirtualInterfaceId)
+	d.Set("virtual_interface_name", out.VirtualInterfaceName)
+
+	if err := d.Set("router", flattenRouter(out.Router)); err != nil {
+		return create.DiagError(names.DirectConnect, create.ErrActionSetting, DSNameRouterConfiguration, d.Id(), err)
+	}
+
+	return nil
+}
+
+func findRouterConfigurationByTypeAndVif(conn *directconnect.DirectConnect, routerTypeIdentifier string, virtualInterfaceId string) (*directconnect.DescribeRouterConfigurationOutput, error) {
+	input := &directconnect.DescribeRouterConfigurationInput{
+		RouterTypeIdentifier: aws.String(routerTypeIdentifier),
+		VirtualInterfaceId:   aws.String(virtualInterfaceId),
+	}
+
+	output, err := conn.DescribeRouterConfiguration(input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
+}
+
+func flattenRouter(apiObject *directconnect.RouterType) []interface{} {
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.Platform; v != nil {
+		tfMap["platform"] = v
+	}
+
+	if v := apiObject.RouterTypeIdentifier; v != nil {
+		tfMap["router_type_identifier"] = v
+	}
+
+	if v := apiObject.Software; v != nil {
+		tfMap["software"] = v
+	}
+
+	if v := apiObject.Vendor; v != nil {
+		tfMap["vendor"] = v
+	}
+
+	if v := apiObject.XsltTemplateName; v != nil {
+		tfMap["xslt_template_name"] = v
+	}
+
+	if v := apiObject.XsltTemplateNameForMacSec; v != nil {
+		tfMap["xslt_template_name_for_mac_sec"] = v
+	}
+
+	return []interface{}{tfMap}
+}

--- a/internal/service/directconnect/router_configuration_data_source.go
+++ b/internal/service/directconnect/router_configuration_data_source.go
@@ -125,27 +125,27 @@ func flattenRouter(apiObject *directconnect.RouterType) []interface{} {
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.Platform; v != nil {
-		tfMap["platform"] = v
+		tfMap["platform"] = aws.StringValue(v)
 	}
 
 	if v := apiObject.RouterTypeIdentifier; v != nil {
-		tfMap["router_type_identifier"] = v
+		tfMap["router_type_identifier"] = aws.StringValue(v)
 	}
 
 	if v := apiObject.Software; v != nil {
-		tfMap["software"] = v
+		tfMap["software"] = aws.StringValue(v)
 	}
 
 	if v := apiObject.Vendor; v != nil {
-		tfMap["vendor"] = v
+		tfMap["vendor"] = aws.StringValue(v)
 	}
 
 	if v := apiObject.XsltTemplateName; v != nil {
-		tfMap["xslt_template_name"] = v
+		tfMap["xslt_template_name"] = aws.StringValue(v)
 	}
 
 	if v := apiObject.XsltTemplateNameForMacSec; v != nil {
-		tfMap["xslt_template_name_for_mac_sec"] = v
+		tfMap["xslt_template_name_for_mac_sec"] = aws.StringValue(v)
 	}
 
 	return []interface{}{tfMap}

--- a/internal/service/directconnect/router_configuration_data_source_test.go
+++ b/internal/service/directconnect/router_configuration_data_source_test.go
@@ -49,8 +49,8 @@ func TestAccDirectConnectRouterConfigurationDataSource_basic(t *testing.T) {
 func testAccRouterConfigurationDataSourceConfig_basic(virtualInterfaceId string, routerTypeIdentifier string) string {
 	return fmt.Sprintf(`
 data "aws_dx_router_configuration" "test" {
-  virtual_interface_id    = %[1]q
-  router_type_identifier  = %[2]q
+  virtual_interface_id   = %[1]q
+  router_type_identifier = %[2]q
 }
 `, virtualInterfaceId, routerTypeIdentifier)
 }

--- a/internal/service/directconnect/router_configuration_data_source_test.go
+++ b/internal/service/directconnect/router_configuration_data_source_test.go
@@ -1,0 +1,63 @@
+package directconnect_test
+
+import (
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccDirectConnectRouterConfigurationDataSource_basic(t *testing.T) {
+	key := "VIRTUAL_INTERFACE_ID"
+	virtualInterfaceId := os.Getenv(key)
+	if virtualInterfaceId == "" {
+		t.Skipf("Environment variable %s is not set", key)
+	}
+
+	dataSourceName := "data.aws_dx_router_configuration.test"
+	routerTypeIdentifier := "CiscoSystemsInc-2900SeriesRouters-IOS124"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(directconnect.EndpointsID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, directconnect.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRouterConfigurationDataSourceConfig_basic(virtualInterfaceId, routerTypeIdentifier),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "virtual_interface_id", virtualInterfaceId),
+					resource.TestCheckResourceAttr(dataSourceName, "router_type_identifier", routerTypeIdentifier),
+					resource.TestCheckResourceAttrSet(dataSourceName, "virtual_interface_name"),
+					resource.TestCheckResourceAttr(dataSourceName, "router.0.platform", "2900 Series Routers"),
+					resource.TestCheckResourceAttr(dataSourceName, "router.0.router_type_identifier", routerTypeIdentifier),
+					resource.TestCheckResourceAttr(dataSourceName, "router.0.software", "IOS 12.4+"),
+					resource.TestCheckResourceAttr(dataSourceName, "router.0.vendor", "Cisco Systems, Inc."),
+					resource.TestCheckResourceAttr(dataSourceName, "router.0.xslt_template_name", "customer-router-cisco-generic.xslt"),
+					resource.TestCheckResourceAttr(dataSourceName, "router.0.xslt_template_name_for_mac_sec", ""),
+				),
+			},
+		},
+	})
+}
+
+func testAccRouterConfigurationDataSourceConfig_basic(virtualInterfaceId string, routerTypeIdentifier string) string {
+	return fmt.Sprintf(`
+data "aws_dx_router_configuration" "test" {
+  virtual_interface_id    = %[1]q
+  router_type_identifier  = %[2]q
+}
+`, virtualInterfaceId, routerTypeIdentifier)
+}

--- a/internal/service/directconnect/router_configuration_data_source_test.go
+++ b/internal/service/directconnect/router_configuration_data_source_test.go
@@ -1,13 +1,6 @@
 package directconnect_test
 
 import (
-	// TIP: ==== IMPORTS ====
-	// This is a common set of imports but not customized to your code since
-	// your code hasn't been written yet. Make sure you, your IDE, or
-	// goimports -w <file> fixes these imports.
-	//
-	// The provider linter wants your imports to be in two groups: first,
-	// standard library (i.e., "fmt" or "strings"), second, everything else.
 	"fmt"
 	"os"
 	"testing"

--- a/internal/service/directconnect/router_configuration_data_source_test.go
+++ b/internal/service/directconnect/router_configuration_data_source_test.go
@@ -46,7 +46,7 @@ func TestAccDirectConnectRouterConfigurationDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccRouterConfigurationDataSourceConfig_basic(virtualInterfaceId string, routerTypeIdentifier string) string {
+func testAccRouterConfigurationDataSourceConfig_basic(virtualInterfaceId, routerTypeIdentifier string) string {
 	return fmt.Sprintf(`
 data "aws_dx_router_configuration" "test" {
   virtual_interface_id   = %[1]q

--- a/website/docs/d/dx_router_configuration.html.markdown
+++ b/website/docs/d/dx_router_configuration.html.markdown
@@ -57,6 +57,3 @@ In addition to all arguments above, the following attributes are exported:
   * `vendor` - Router vendor
   * `xslt_template_name` - Router XSLT Template Name
   * `xslt_template_name_for_mac` - Router XSLT Template Name for MacSec
-
-* `arn` - ARN of the Router Configuration. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
-* `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.

--- a/website/docs/d/dx_router_configuration.html.markdown
+++ b/website/docs/d/dx_router_configuration.html.markdown
@@ -1,0 +1,62 @@
+---
+subcategory: "Direct Connect"
+layout: "aws"
+page_title: "AWS: aws_dx_router_configuration"
+description: |-
+  Terraform data source for managing an AWS Direct Connect Router Configuration.
+---
+
+# Data Source: aws_dx_router_configuration
+
+Terraform data source for retrieving Router Configuration instructions for a given AWS Direct Connect Virtual Interface and Router Type.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_dx_router_configuration" "example" {
+  virtual_interface_id = "dxvif-abcde123"
+  router_type_identifier = "CiscoSystemsInc-2900SeriesRouters-IOS124"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `virtual_interface_id` - (Required) ID of the Direct Connect Virtual Interface
+* `router_type_identifier` - (Required) ID of the Router Type. For example: `CiscoSystemsInc-2900SeriesRouters-IOS124`
+
+There is currently no AWS API to retrieve the full list of `router_type_identifier` values. Here is a list of known `RouterType` objects that can be used:
+
+```json
+{
+  "routerTypes": [
+    {"platform":"2900 Series Routers","routerTypeIdentifier":"CiscoSystemsInc-2900SeriesRouters-IOS124","software":"IOS 12.4+","vendor":"Cisco Systems, Inc.","xsltTemplateName":"customer-router-cisco-generic.xslt","xsltTemplateNameForMacSec":""},
+    {"platform":"3700 Series Routers","routerTypeIdentifier":"CiscoSystemsInc-3700SeriesRouters-IOS124","software":"IOS 12.4+","vendor":"Cisco Systems, Inc.","xsltTemplateName":"customer-router-cisco-generic.xslt","xsltTemplateNameForMacSec":""},
+    {"platform":"7200 Series Routers","routerTypeIdentifier":"CiscoSystemsInc-7200SeriesRouters-IOS124","software":"IOS 12.4+","vendor":"Cisco Systems, Inc.","xsltTemplateName":"customer-router-cisco-generic.xslt","xsltTemplateNameForMacSec":""},
+    {"platform":"Nexus 7000 Series Switches","routerTypeIdentifier":"CiscoSystemsInc-Nexus7000SeriesSwitches-NXOS51","software":"NX-OS 5.1+","vendor":"Cisco Systems, Inc.","xsltTemplateName":"customer-switch-cisco-nexus-generic.xslt","xsltTemplateNameForMacSec":""},
+    {"platform":"Nexus 9K+ Series Switches","routerTypeIdentifier":"CiscoSystemsInc-Nexus9KSeriesSwitches-NXOS93","software":"NX-OS 9.3+","vendor":"Cisco Systems, Inc.","xsltTemplateName":"customer-switch-cisco-nexus-generic.xslt","xsltTemplateNameForMacSec":"customer-switch-cisco-nexus-generic-macsec.xslt"},
+    {"platform":"M/MX Series Routers","routerTypeIdentifier":"JuniperNetworksInc-MMXSeriesRouters-JunOS95","software":"JunOS 9.5+","vendor":"Juniper Networks, Inc.","xsltTemplateName":"customer-router-juniper-generic.xslt","xsltTemplateNameForMacSec":"customer-router-juniper-generic-macsec.xslt"},
+    {"platform":"SRX Series Routers","routerTypeIdentifier":"JuniperNetworksInc-SRXSeriesRouters-JunOS95","software":"JunOS 9.5+","vendor":"Juniper Networks, Inc.","xsltTemplateName":"customer-router-juniper-generic.xslt","xsltTemplateNameForMacSec":""},
+    {"platform":"T Series Routers","routerTypeIdentifier":"JuniperNetworksInc-TSeriesRouters-JunOS95","software":"JunOS 9.5+","vendor":"Juniper Networks, Inc.","xsltTemplateName":"customer-router-juniper-generic.xslt","xsltTemplateNameForMacSec":""},
+    {"platform":"PA-3000+ and 5000+ series","routerTypeIdentifier":"PaloAltoNetworks-PA3000and5000series-PANOS803","software":"PAN-OS 8.0.3+","vendor":"Palo Alto Networks","xsltTemplateName":"customer-router-palo-alto-generic.xslt","xsltTemplateNameForMacSec":""}]
+}
+```
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `customer_router_config` - Instructions for configuring your router
+* `router` - Single-item list of the router type details:
+  * `platform` - Router platform
+  * `router_type_identifier` - Router type identifier
+  * `software` - Router operating system
+  * `vendor` - Router vendor
+  * `xslt_template_name` - Router XSLT Template Name
+  * `xslt_template_name_for_mac` - Router XSLT Template Name for MacSec
+
+* `arn` - ARN of the Router Configuration. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.

--- a/website/docs/d/dx_router_configuration.html.markdown
+++ b/website/docs/d/dx_router_configuration.html.markdown
@@ -16,7 +16,7 @@ Terraform data source for retrieving Router Configuration instructions for a giv
 
 ```terraform
 data "aws_dx_router_configuration" "example" {
-  virtual_interface_id = "dxvif-abcde123"
+  virtual_interface_id   = "dxvif-abcde123"
   router_type_identifier = "CiscoSystemsInc-2900SeriesRouters-IOS124"
 }
 ```

--- a/website/docs/d/dx_router_configuration.html.markdown
+++ b/website/docs/d/dx_router_configuration.html.markdown
@@ -54,9 +54,9 @@ In addition to all arguments above, the following attributes are exported:
 
 A `router` block supports the following attributes:
 
-  * `platform` - Router platform
-  * `router_type_identifier` - Router type identifier
-  * `software` - Router operating system
-  * `vendor` - Router vendor
-  * `xslt_template_name` - Router XSLT Template Name
-  * `xslt_template_name_for_mac` - Router XSLT Template Name for MacSec
+* `platform` - Router platform
+* `router_type_identifier` - Router type identifier
+* `software` - Router operating system
+* `vendor` - Router vendor
+* `xslt_template_name` - Router XSLT Template Name
+* `xslt_template_name_for_mac` - Router XSLT Template Name for MacSec

--- a/website/docs/d/dx_router_configuration.html.markdown
+++ b/website/docs/d/dx_router_configuration.html.markdown
@@ -50,7 +50,10 @@ There is currently no AWS API to retrieve the full list of `router_type_identifi
 In addition to all arguments above, the following attributes are exported:
 
 * `customer_router_config` - Instructions for configuring your router
-* `router` - Single-item list of the router type details:
+* `router` - Block of the router type details
+
+A `router` block supports the following attributes:
+
   * `platform` - Router platform
   * `router_type_identifier` - Router type identifier
   * `software` - Router operating system


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds the `aws_dx_router_configuration` data source to allow users to download sample router configurations for their Direct Connect VIF.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #26432

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/directconnect/latest/UserGuide/create-vif.html#vif-router-config 
https://docs.aws.amazon.com/sdk-for-go/api/service/directconnect/#DirectConnect.DescribeRouterConfiguration
https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/directconnect#Client.DescribeRouterConfiguration 
https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeRouterConfiguration.html 
https://docs.aws.amazon.com/directconnect/latest/APIReference/API_RouterType.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Note that a DX VIF must be provided via the `VIRTUAL_INTERFACE_ID` env variable.

```
terraform-provider-aws % AWS_DEFAULT_REGION=eu-west-1 VIRTUAL_INTERFACE_ID=dxvif-xxxxxxxx make testacc TESTS=TestAccDirectConnectRouterConfigurationDataSource_basic PKG=directconnect
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/directconnect/... -v -count 1 -parallel 20 -run='TestAccDirectConnectRouterConfigurationDataSource_basic'  -timeout 180m
=== RUN   TestAccDirectConnectRouterConfigurationDataSource_basic
=== PAUSE TestAccDirectConnectRouterConfigurationDataSource_basic
=== CONT  TestAccDirectConnectRouterConfigurationDataSource_basic
--- PASS: TestAccDirectConnectRouterConfigurationDataSource_basic (19.31s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/directconnect	23.515s
```
