### PR TITLE
[Enhancement]: Add Filter to aws_rds_engine_version

### DIFF
--- a/internal/service/rds/engine_version_data_source.go
+++ b/internal/service/rds/engine_version_data_source.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/generate/namevaluesfilters"
 )
 
 func DataSourceEngineVersion() *schema.Resource {
@@ -35,6 +36,8 @@ func DataSourceEngineVersion() *schema.Resource {
 				Computed: true,
 				Set:      schema.HashString,
 			},
+
+			"filter": namevaluesfilters.Schema(),
 
 			"parameter_group_family": {
 				Type:     schema.TypeString,
@@ -148,6 +151,10 @@ func dataSourceEngineVersionRead(d *schema.ResourceData, meta interface{}) error
 		if _, ok := d.GetOk("preferred_versions"); !ok {
 			input.DefaultOnly = aws.Bool(true)
 		}
+	}
+
+	if v, ok := d.GetOk("filter"); ok {
+		input.Filters = namevaluesfilters.New(v.(*schema.Set)).RDSFilters()
 	}
 
 	log.Printf("[DEBUG] Reading RDS engine versions: %v", input)

--- a/internal/service/rds/engine_version_data_source_test.go
+++ b/internal/service/rds/engine_version_data_source_test.go
@@ -107,6 +107,25 @@ func TestAccRDSEngineVersionDataSource_defaultOnly(t *testing.T) {
 	})
 }
 
+func TestAccRDSEngineVersionDataSource_filters(t *testing.T) {
+	dataSourceName := "data.aws_rds_engine_version.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccEngineVersionPreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, rds.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEngineVersionDataSourceConfig_filters(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "version"),
+				),
+			},
+		},
+	})
+}
+
 func testAccEngineVersionPreCheck(t *testing.T) {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn
 
@@ -158,6 +177,18 @@ func testAccEngineVersionDataSourceConfig_defaultOnly() string {
 	return `
 data "aws_rds_engine_version" "test" {
   engine = "mysql"
+}
+`
+}
+
+func testAccEngineVersionDataSourceConfig_filters() string {
+	return `
+data "aws_rds_engine_version" "test" {
+  engine = "aurora"
+  filter {
+    name   = "engine-mode"
+    values = ["serverless"]
+  }
 }
 `
 }

--- a/website/docs/d/rds_engine_version.markdown
+++ b/website/docs/d/rds_engine_version.markdown
@@ -19,6 +19,16 @@ data "aws_rds_engine_version" "test" {
 }
 ```
 
+```terraform
+data "aws_rds_engine_version" "test" {
+  engine             = "aurora"
+  filter {
+    name   = "engine-mode"
+    values = ["serverless"]
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -27,6 +37,7 @@ The following arguments are supported:
 * `parameter_group_family` - (Optional) Name of a specific DB parameter group family. Examples of parameter group families are `mysql8.0`, `mariadb10.4`, and `postgres12`.
 * `preferred_versions` - (Optional) Ordered list of preferred engine versions. The first match in this list will be returned. If no preferred matches are found and the original search returned more than one result, an error is returned. If both the `version` and `preferred_versions` arguments are not configured, the data source will return the default version for the engine.
 * `version` - (Optional) Version of the DB engine. For example, `5.7.22`, `10.1.34`, and `12.3`. If both the `version` and `preferred_versions` arguments are not configured, the data source will return the default version for the engine.
+* `engine-mode` - (Optional) Accepts DB engine modes for Aurora. The results list only includes information about the DB engine versions for these engine modes. Valid DB engine modes are the following: `global`, `multimaster`, `parallelquery`, `provisioned` and `serverless`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Within the Console in AWS, when selecting Aurora, there is a section for filters:

Show versions that support the global database feature
Allows a single Amazon Aurora database to span multiple AWS Regions.

Show versions that support the parallel query feature
Improves the performance of analytic queries by pushing processing down to the Aurora storage layer.

Show versions that support Serverless v2
Offers instance scaling for even the most demanding workloads.

The Data resource aws_rds_engine_version should have these same options to return the default version within the filters defined where version and preferred version are not defined.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #26867

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccRDSEngineVersionDataSource' PKG=rds

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20  -run=TestAccRDSEngineVersionDataSource -timeout 180m
=== RUN   TestAccRDSEngineVersionDataSource_basic
=== PAUSE TestAccRDSEngineVersionDataSource_basic
=== RUN   TestAccRDSEngineVersionDataSource_upgradeTargets
=== PAUSE TestAccRDSEngineVersionDataSource_upgradeTargets
=== RUN   TestAccRDSEngineVersionDataSource_preferred
=== PAUSE TestAccRDSEngineVersionDataSource_preferred
=== RUN   TestAccRDSEngineVersionDataSource_defaultOnly
=== PAUSE TestAccRDSEngineVersionDataSource_defaultOnly
=== RUN   TestAccRDSEngineVersionDataSource_filters
=== PAUSE TestAccRDSEngineVersionDataSource_filters
=== CONT  TestAccRDSEngineVersionDataSource_basic
=== CONT  TestAccRDSEngineVersionDataSource_defaultOnly
=== CONT  TestAccRDSEngineVersionDataSource_preferred
=== CONT  TestAccRDSEngineVersionDataSource_filters
=== CONT  TestAccRDSEngineVersionDataSource_upgradeTargets
--- PASS: TestAccRDSEngineVersionDataSource_defaultOnly (32.29s)
--- PASS: TestAccRDSEngineVersionDataSource_basic (33.76s)
--- PASS: TestAccRDSEngineVersionDataSource_preferred (34.07s)
--- PASS: TestAccRDSEngineVersionDataSource_filters (34.89s)
--- PASS: TestAccRDSEngineVersionDataSource_upgradeTargets (35.13s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        39.248s

...
```
