### PR TITLE
Ensure Suricata flat file comments are supported for ANFW Rule Group tests

### DIFF
--- a/internal/service/networkfirewall/rule_group_test.go
+++ b/internal/service/networkfirewall/rule_group_test.go
@@ -152,7 +152,8 @@ func TestAccNetworkFirewallRuleGroup_Basic_rules(t *testing.T) {
 	var ruleGroup networkfirewall.DescribeRuleGroupOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_networkfirewall_rule_group.test"
-	rules := `alert http any any -> any any (http_response_line; content:"403 Forbidden"; sid:1;)`
+	rules := `#test comment
+alert http any any -> any any (http_response_line; content:"403 Forbidden"; sid:1;)`
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(t) },


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Small modification to the ANFW Rule Group stateful rules test in Suricata flat file format. This ensures that multi-line and comments are supported by both the Terraform provider and the upstream service. No changelog required per the Changelog policy.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #26517

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/network-firewall/latest/APIReference/API_CreateRuleGroup.html


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
terraform-provider-aws % make testacc TESTARGS='-run=TestAccNetworkFirewallRuleGroup_Basic_rules' PKG=networkfirewall
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkfirewall/... -v -count 1 -parallel 20  -run=TestAccNetworkFirewallRuleGroup_Basic_rules -timeout 180m
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_rulesSourceList
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_rulesSourceList
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_rules
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_rules
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_rulesSourceList
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_rules
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_rules (143.35s)
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_rulesSourceList (143.80s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall	147.834s
```
