### PR TITLE
add support for updating tags in apprunner vpc connection

### DIFF
--- a/.changelog/27345.txt
+++ b/.changelog/27345.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_apprunner_vpc_connector: Add ability to update tags 
+```

--- a/.changelog/27345.txt
+++ b/.changelog/27345.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_apprunner_vpc_connector: Add ability to modify tags 
+resource/aws_apprunner_vpc_connector: Add ability to update `tags` 
 ```

--- a/.changelog/27345.txt
+++ b/.changelog/27345.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_apprunner_vpc_connector: Add ability to update tags 
+resource/aws_apprunner_vpc_connector: Add ability to modify tags 
 ```

--- a/internal/service/apprunner/status.go
+++ b/internal/service/apprunner/status.go
@@ -62,26 +62,6 @@ func StatusObservabilityConfiguration(ctx context.Context, conn *apprunner.AppRu
 	}
 }
 
-func StatusVPCConnector(ctx context.Context, conn *apprunner.AppRunner, arn string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		input := &apprunner.DescribeVpcConnectorInput{
-			VpcConnectorArn: aws.String(arn),
-		}
-
-		output, err := conn.DescribeVpcConnectorWithContext(ctx, input)
-
-		if err != nil {
-			return nil, "", err
-		}
-
-		if output == nil || output.VpcConnector == nil {
-			return nil, "", nil
-		}
-
-		return output.VpcConnector, aws.StringValue(output.VpcConnector.Status), nil
-	}
-}
-
 func StatusConnection(ctx context.Context, conn *apprunner.AppRunner, name string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		c, err := FindConnectionSummaryByName(ctx, conn, name)

--- a/internal/service/apprunner/vpc_connector.go
+++ b/internal/service/apprunner/vpc_connector.go
@@ -171,6 +171,10 @@ func resourceVPCConnectorRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(fmt.Errorf("error setting tags: %w", err))
 	}
 
+	if err := d.Set("tags_all", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return diag.FromErr(fmt.Errorf("error setting tags_all: %w", err))
+	}
+
 	return nil
 }
 

--- a/internal/service/apprunner/vpc_connector.go
+++ b/internal/service/apprunner/vpc_connector.go
@@ -2,18 +2,20 @@ package apprunner
 
 import (
 	"context"
-	"fmt"
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/apprunner"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -29,12 +31,6 @@ func ResourceVPCConnector() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"vpc_connector_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(4, 40),
-			},
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -44,20 +40,24 @@ func ResourceVPCConnector() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"subnets": {
 				Type:     schema.TypeSet,
 				Required: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 			},
 			"tags":     tftags.TagsSchemaComputed(),
 			"tags_all": tftags.TagsSchemaComputed(),
-			"status": {
-				Type:     schema.TypeString,
-				Computed: true,
+			"vpc_connector_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(4, 40),
 			},
 			"vpc_connector_revision": {
 				Type:     schema.TypeInt,
@@ -74,13 +74,10 @@ func resourceVPCConnectorCreate(ctx context.Context, d *schema.ResourceData, met
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
 	vpcConnectorName := d.Get("vpc_connector_name").(string)
-	subnets := flex.ExpandStringSet(d.Get("subnets").(*schema.Set))
-	securityGroups := flex.ExpandStringSet(d.Get("security_groups").(*schema.Set))
-
 	input := &apprunner.CreateVpcConnectorInput{
+		SecurityGroups:   flex.ExpandStringSet(d.Get("security_groups").(*schema.Set)),
+		Subnets:          flex.ExpandStringSet(d.Get("subnets").(*schema.Set)),
 		VpcConnectorName: aws.String(vpcConnectorName),
-		Subnets:          subnets,
-		SecurityGroups:   securityGroups,
 	}
 
 	if len(tags) > 0 {
@@ -90,17 +87,13 @@ func resourceVPCConnectorCreate(ctx context.Context, d *schema.ResourceData, met
 	output, err := conn.CreateVpcConnectorWithContext(ctx, input)
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating App Runner vpc (%s): %w", vpcConnectorName, err))
-	}
-
-	if output == nil {
-		return diag.FromErr(fmt.Errorf("error creating App Runner vpc (%s): empty output", vpcConnectorName))
+		return diag.Errorf("creating App Runner VPC Connector (%s): %s", vpcConnectorName, err)
 	}
 
 	d.SetId(aws.StringValue(output.VpcConnector.VpcConnectorArn))
 
-	if err := waitVPCConnectorActive(ctx, conn, d.Id()); err != nil {
-		return diag.FromErr(fmt.Errorf("error waiting for creating App Runner vpc (%s) creation: %w", d.Id(), err))
+	if err := waitVPCConnectorCreated(ctx, conn, d.Id()); err != nil {
+		return diag.Errorf("waiting for App Runner VPC Connector (%s) create: %s", d.Id(), err)
 	}
 
 	return resourceVPCConnectorRead(ctx, d, meta)
@@ -111,68 +104,41 @@ func resourceVPCConnectorRead(ctx context.Context, d *schema.ResourceData, meta 
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	input := &apprunner.DescribeVpcConnectorInput{
-		VpcConnectorArn: aws.String(d.Id()),
-	}
+	vpcConnector, err := FindVPCConnectorByARN(ctx, conn, d.Id())
 
-	output, err := conn.DescribeVpcConnectorWithContext(ctx, input)
-
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("error reading App Runner vpc connector (%s): %w", d.Id(), err))
-	}
-
-	if output == nil || output.VpcConnector == nil {
-		return diag.FromErr(fmt.Errorf("error reading App Runner vpc connector (%s): empty output", d.Id()))
-	}
-
-	if aws.StringValue(output.VpcConnector.Status) == apprunner.VpcConnectorStatusInactive {
-		if d.IsNewResource() {
-			return diag.FromErr(fmt.Errorf("error reading App Runner vpc connector (%s): %s after creation", d.Id(), aws.StringValue(output.VpcConnector.Status)))
-		}
-		log.Printf("[WARN] App Runner vpc connector (%s) not found, removing from state", d.Id())
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] App Runner VPC Connector (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
-	vpcConnector := output.VpcConnector
-	arn := aws.StringValue(vpcConnector.VpcConnectorArn)
+	if err != nil {
+		return diag.Errorf("reading App Runner VPC Connector (%s): %s", d.Id(), err)
+	}
 
+	arn := aws.StringValue(vpcConnector.VpcConnectorArn)
+	d.Set("arn", vpcConnector.VpcConnectorArn)
+	d.Set("security_groups", aws.StringValueSlice(vpcConnector.SecurityGroups))
+	d.Set("status", vpcConnector.Status)
+	d.Set("subnets", aws.StringValueSlice(vpcConnector.Subnets))
 	d.Set("vpc_connector_name", vpcConnector.VpcConnectorName)
 	d.Set("vpc_connector_revision", vpcConnector.VpcConnectorRevision)
-	d.Set("arn", vpcConnector.VpcConnectorArn)
-	d.Set("status", vpcConnector.Status)
 
-	var subnets []string
-	for _, sn := range vpcConnector.Subnets {
-		subnets = append(subnets, aws.StringValue(sn))
-	}
-	if err := d.Set("subnets", subnets); err != nil {
-		return diag.FromErr(fmt.Errorf("Error saving Subnet IDs to state for App Runner vpc connector (%s): %s", d.Id(), err))
-	}
-
-	var securityGroups []string
-	for _, sn := range vpcConnector.SecurityGroups {
-		securityGroups = append(securityGroups, aws.StringValue(sn))
-	}
-	if err := d.Set("security_groups", securityGroups); err != nil {
-		return diag.FromErr(fmt.Errorf("Error saving securityGroup IDs to state for App Runner vpc connector (%s): %s", d.Id(), err))
-	}
-
-	tags, err := ListTags(conn, arn)
+	tags, err := ListTagsWithContext(ctx, conn, arn)
 
 	if err != nil {
-		return diag.Errorf("error listing tags for App Runner vpc connector (%s): %s", d.Id(), err)
+		return diag.Errorf("listing tags for App Runner VPC Connector (%s): %s", d.Id(), err)
 	}
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting tags: %w", err))
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	if err := d.Set("tags_all", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting tags_all: %w", err))
+		return diag.Errorf("setting tags_all: %s", err)
 	}
 
 	return nil
@@ -184,8 +150,8 @@ func resourceVPCConnectorUpdate(ctx context.Context, d *schema.ResourceData, met
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.Errorf("error updating App Runner vpc Connector (%s) tags: %s", d.Get("arn").(string), err)
+		if err := UpdateTagsWithContext(ctx, conn, d.Get("arn").(string), o, n); err != nil {
+			return diag.Errorf("updating App Runner VPC Connector (%s) tags: %s", d.Id(), err)
 		}
 	}
 
@@ -195,27 +161,110 @@ func resourceVPCConnectorUpdate(ctx context.Context, d *schema.ResourceData, met
 func resourceVPCConnectorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).AppRunnerConn
 
-	input := &apprunner.DeleteVpcConnectorInput{
+	log.Printf("[DEBUG] Deleting App Runner VPC Connector: %s", d.Id())
+	_, err := conn.DeleteVpcConnectorWithContext(ctx, &apprunner.DeleteVpcConnectorInput{
 		VpcConnectorArn: aws.String(d.Id()),
-	}
-
-	_, err := conn.DeleteVpcConnectorWithContext(ctx, input)
+	})
 
 	if tfawserr.ErrCodeEquals(err, apprunner.ErrCodeResourceNotFoundException) {
 		return nil
 	}
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting App Runner vpc connector (%s): %w", d.Id(), err))
+		return diag.Errorf("deleting App Runner VPC Connector (%s): %s", d.Id(), err)
 	}
 
-	if err := waitVPCConnectorInactive(ctx, conn, d.Id()); err != nil {
-		if tfawserr.ErrCodeEquals(err, apprunner.ErrCodeResourceNotFoundException) {
-			return nil
-		}
-
-		return diag.FromErr(fmt.Errorf("error waiting for App Runner vpc connector (%s) deletion: %w", d.Id(), err))
+	if err := waitVPCConnectorDeleted(ctx, conn, d.Id()); err != nil {
+		return diag.Errorf("waiting for App Runner VPC Connector (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil
+}
+
+func FindVPCConnectorByARN(ctx context.Context, conn *apprunner.AppRunner, arn string) (*apprunner.VpcConnector, error) {
+	input := &apprunner.DescribeVpcConnectorInput{
+		VpcConnectorArn: aws.String(arn),
+	}
+
+	output, err := findVPCConnector(ctx, conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if status := aws.StringValue(output.Status); status == apprunner.VpcConnectorStatusInactive {
+		return nil, &resource.NotFoundError{
+			Message:     status,
+			LastRequest: input,
+		}
+	}
+
+	return output, nil
+}
+
+func findVPCConnector(ctx context.Context, conn *apprunner.AppRunner, input *apprunner.DescribeVpcConnectorInput) (*apprunner.VpcConnector, error) {
+	output, err := conn.DescribeVpcConnectorWithContext(ctx, input)
+
+	if tfawserr.ErrCodeEquals(err, apprunner.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.VpcConnector == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.VpcConnector, nil
+}
+
+func statusVPCConnector(ctx context.Context, conn *apprunner.AppRunner, arn string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindVPCConnectorByARN(ctx, conn, arn)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}
+
+const (
+	vpcConnectorCreateTimeout = 2 * time.Minute
+	vpcConnectorDeleteTimeout = 2 * time.Minute
+)
+
+func waitVPCConnectorCreated(ctx context.Context, conn *apprunner.AppRunner, arn string) error {
+	stateConf := &resource.StateChangeConf{
+		Target:  []string{apprunner.VpcConnectorStatusActive},
+		Refresh: statusVPCConnector(ctx, conn, arn),
+		Timeout: vpcConnectorCreateTimeout,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+
+	return err
+}
+
+func waitVPCConnectorDeleted(ctx context.Context, conn *apprunner.AppRunner, arn string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{apprunner.VpcConnectorStatusActive},
+		Target:  []string{},
+		Refresh: statusVPCConnector(ctx, conn, arn),
+		Timeout: vpcConnectorDeleteTimeout,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+
+	return err
 }

--- a/internal/service/apprunner/vpc_connector_test.go
+++ b/internal/service/apprunner/vpc_connector_test.go
@@ -213,7 +213,7 @@ resource "aws_apprunner_vpc_connector" "test" {
 `, rName))
 }
 
-func testAccVPCConnectorConfig_tags1(rName string, tagKey1 string, tagValue1 string) string {
+func testAccVPCConnectorConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccVPCConnectorConfig_base(rName), fmt.Sprintf(`
 resource "aws_apprunner_vpc_connector" "test" {
   vpc_connector_name = %[1]q
@@ -227,7 +227,7 @@ resource "aws_apprunner_vpc_connector" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccVPCConnectorConfig_tags2(rName string, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
+func testAccVPCConnectorConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccVPCConnectorConfig_base(rName), fmt.Sprintf(`
 resource "aws_apprunner_vpc_connector" "test" {
   vpc_connector_name = %[1]q
@@ -235,8 +235,8 @@ resource "aws_apprunner_vpc_connector" "test" {
   security_groups    = [aws_security_group.test.id]
 
   tags = {
-	%[2]q = %[3]q
-	%[4]q = %[5]q
+    %[2]q = %[3]q
+    %[4]q = %[5]q
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))

--- a/internal/service/apprunner/vpc_connector_test.go
+++ b/internal/service/apprunner/vpc_connector_test.go
@@ -204,17 +204,17 @@ resource "aws_security_group" "test" {
 }
 
 func testAccVPCConnectorConfig_basic(rName string) string {
-	return testAccVPCConnectorConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCConnectorConfig_base(rName), fmt.Sprintf(`
 resource "aws_apprunner_vpc_connector" "test" {
   vpc_connector_name = %[1]q
   subnets            = [aws_subnet.test.id]
   security_groups    = [aws_security_group.test.id]
 }
-`, rName)
+`, rName))
 }
 
 func testAccVPCConnectorConfig_tags1(rName string, tagKey1 string, tagValue1 string) string {
-	return testAccVPCConnectorConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCConnectorConfig_base(rName), fmt.Sprintf(`
 resource "aws_apprunner_vpc_connector" "test" {
   vpc_connector_name = %[1]q
   subnets            = [aws_subnet.test.id]
@@ -224,22 +224,22 @@ resource "aws_apprunner_vpc_connector" "test" {
     %[2]q = %[3]q
   }
 }
-`, rName, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
 func testAccVPCConnectorConfig_tags2(rName string, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
-	return testAccVPCConnectorConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCConnectorConfig_base(rName), fmt.Sprintf(`
 resource "aws_apprunner_vpc_connector" "test" {
-	vpc_connector_name = %[1]q
-	subnets            = [aws_subnet.test.id]
-	security_groups    = [aws_security_group.test.id]
+  vpc_connector_name = %[1]q
+  subnets            = [aws_subnet.test.id]
+  security_groups    = [aws_security_group.test.id]
 
-	tags = {
-		%[2]q = %[3]q
-		%[4]q = %[5]q
-	}
+  tags = {
+	%[2]q = %[3]q
+	%[4]q = %[5]q
+  }
 }
-`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
 func testAccPreCheckVPCConnector(t *testing.T) {

--- a/internal/service/apprunner/vpc_connector_test.go
+++ b/internal/service/apprunner/vpc_connector_test.go
@@ -156,39 +156,23 @@ func testAccCheckVPCConnectorExists(n string) resource.TestCheckFunc {
 }
 
 func testAccVPCConnectorConfig_base(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block = "10.1.0.0/16"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_subnet" "test" {
-  cidr_block = "10.1.1.0/24"
-  vpc_id     = aws_vpc.test.id
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
 resource "aws_security_group" "test" {
   vpc_id = aws_vpc.test.id
+  name   = %[1]q
 
   tags = {
     Name = %[1]q
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccVPCConnectorConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccVPCConnectorConfig_base(rName), fmt.Sprintf(`
 resource "aws_apprunner_vpc_connector" "test" {
   vpc_connector_name = %[1]q
-  subnets            = [aws_subnet.test.id]
+  subnets            = aws_subnet.test[*].id
   security_groups    = [aws_security_group.test.id]
 }
 `, rName))
@@ -198,7 +182,7 @@ func testAccVPCConnectorConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccVPCConnectorConfig_base(rName), fmt.Sprintf(`
 resource "aws_apprunner_vpc_connector" "test" {
   vpc_connector_name = %[1]q
-  subnets            = [aws_subnet.test.id]
+  subnets            = aws_subnet.test[*].id
   security_groups    = [aws_security_group.test.id]
 
   tags = {
@@ -212,7 +196,7 @@ func testAccVPCConnectorConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValu
 	return acctest.ConfigCompose(testAccVPCConnectorConfig_base(rName), fmt.Sprintf(`
 resource "aws_apprunner_vpc_connector" "test" {
   vpc_connector_name = %[1]q
-  subnets            = [aws_subnet.test.id]
+  subnets            = aws_subnet.test[*].id
   security_groups    = [aws_security_group.test.id]
 
   tags = {

--- a/internal/service/apprunner/wait.go
+++ b/internal/service/apprunner/wait.go
@@ -17,9 +17,6 @@ const (
 	CustomDomainAssociationCreateTimeout = 5 * time.Minute
 	CustomDomainAssociationDeleteTimeout = 5 * time.Minute
 
-	vpcConnectorCreateTimeout = 2 * time.Minute
-	vpcConnectorDeleteTimeout = 2 * time.Minute
-
 	ServiceCreateTimeout = 20 * time.Minute
 	ServiceDeleteTimeout = 20 * time.Minute
 	ServiceUpdateTimeout = 20 * time.Minute
@@ -151,32 +148,6 @@ func WaitServiceDeleted(ctx context.Context, conn *apprunner.AppRunner, serviceA
 		Target:  []string{apprunner.ServiceStatusDeleted},
 		Refresh: StatusService(ctx, conn, serviceArn),
 		Timeout: ServiceDeleteTimeout,
-	}
-
-	_, err := stateConf.WaitForState()
-
-	return err
-}
-
-func waitVPCConnectorActive(ctx context.Context, conn *apprunner.AppRunner, arn string) error {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{},
-		Target:  []string{apprunner.VpcConnectorStatusActive},
-		Refresh: StatusVPCConnector(ctx, conn, arn),
-		Timeout: vpcConnectorCreateTimeout,
-	}
-
-	_, err := stateConf.WaitForState()
-
-	return err
-}
-
-func waitVPCConnectorInactive(ctx context.Context, conn *apprunner.AppRunner, arn string) error {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{apprunner.VpcConnectorStatusActive},
-		Target:  []string{apprunner.VpcConnectorStatusInactive},
-		Refresh: StatusVPCConnector(ctx, conn, arn),
-		Timeout: vpcConnectorDeleteTimeout,
 	}
 
 	_, err := stateConf.WaitForState()

--- a/website/docs/r/apprunner_vpc_connector.html.markdown
+++ b/website/docs/r/apprunner_vpc_connector.html.markdown
@@ -36,6 +36,7 @@ In addition to all arguments above, the following attributes are exported:
 * `vpc_connector_arn` - ARN of VPC connector.
 * `status` - Current state of the VPC connector. If the status of a connector revision is INACTIVE, it was deleted and can't be used. Inactive connector revisions are permanently removed some time after they are deleted.
 * `vpc_connector_revision` - The revision of VPC connector. It's unique among all the active connectors ("Status": "ACTIVE") that share the same Name.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Import
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Adds the ability to modify tags for `aws_apprunner_vpc_connector `.


### Relations

Closes [#26426](https://github.com/hashicorp/terraform-provider-aws/issues/26426)

### References
https://pkg.go.dev/github.com/aws/aws-sdk-go@v1.44.118/service/apprunner#AppRunner.TagResource
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apprunner_vpc_connector
https://docs.aws.amazon.com/apprunner/latest/api/API_TagResource.html

### Output from Acceptance Testing
```
make testacc PKG=apprunner TESTS=TestAccAppRunnerVPCConnector      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apprunner/... -v -count 1 -parallel 20 -run='TestAccAppRunnerVPCConnector'  -timeout 180m
=== RUN   TestAccAppRunnerVPCConnector_basic
=== PAUSE TestAccAppRunnerVPCConnector_basic
=== RUN   TestAccAppRunnerVPCConnector_disappears
=== PAUSE TestAccAppRunnerVPCConnector_disappears
=== RUN   TestAccAppRunnerVPCConnector_tags
=== PAUSE TestAccAppRunnerVPCConnector_tags
=== CONT  TestAccAppRunnerVPCConnector_basic
=== CONT  TestAccAppRunnerVPCConnector_tags
=== CONT  TestAccAppRunnerVPCConnector_disappears
--- PASS: TestAccAppRunnerVPCConnector_disappears (28.70s)
--- PASS: TestAccAppRunnerVPCConnector_basic (31.70s)
--- PASS: TestAccAppRunnerVPCConnector_tags (60.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apprunner  64.399s

...
```
