### PR TITLE
Add attribute arn_without_revision on aws_ecs_task_definition

### DIFF
--- a/.changelog/27351.txt
+++ b/.changelog/27351.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ecs_task_definition: Add `arn_without_revision` attribute
+```

--- a/internal/service/ecs/task_definition_data_source.go
+++ b/internal/service/ecs/task_definition_data_source.go
@@ -77,7 +77,7 @@ func dataSourceTaskDefinitionRead(ctx context.Context, d *schema.ResourceData, m
 
 	d.SetId(aws.StringValue(taskDefinition.TaskDefinitionArn))
 	d.Set("arn", taskDefinition.TaskDefinitionArn)
-	d.Set("arn_without_revision", computeArnWithoutRevision(*taskDefinition.TaskDefinitionArn))
+	d.Set("arn_without_revision", StripRevision(aws.StringValue(taskDefinition.TaskDefinitionArn)))
 	d.Set("family", taskDefinition.Family)
 	d.Set("network_mode", taskDefinition.NetworkMode)
 	d.Set("revision", taskDefinition.Revision)

--- a/internal/service/ecs/task_definition_data_source.go
+++ b/internal/service/ecs/task_definition_data_source.go
@@ -27,6 +27,10 @@ func DataSourceTaskDefinition() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"arn_without_revision": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"family": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -73,6 +77,7 @@ func dataSourceTaskDefinitionRead(ctx context.Context, d *schema.ResourceData, m
 
 	d.SetId(aws.StringValue(taskDefinition.TaskDefinitionArn))
 	d.Set("arn", taskDefinition.TaskDefinitionArn)
+	d.Set("arn_without_revision", computeArnWithoutRevision(*taskDefinition.TaskDefinitionArn))
 	d.Set("family", taskDefinition.Family)
 	d.Set("network_mode", taskDefinition.NetworkMode)
 	d.Set("revision", taskDefinition.Revision)

--- a/website/docs/d/ecs_task_definition.html.markdown
+++ b/website/docs/d/ecs_task_definition.html.markdown
@@ -64,10 +64,11 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - ARN of the task definition
-* `arn` - ARN of the task definition
-* `family` - Family of this task definition
+* `id` - ARN of the task definition.
+* `arn` - ARN of the task definition.
+* `arn_without_revision` - ARN of the Task Definition with the trailing `revision` removed. This may be useful for situations where the latest task definition is always desired. If a revision isn't specified, the latest ACTIVE revision is used. See the [AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_StartTask.html#ECS-StartTask-request-taskDefinition) for details.
+* `family` - Family of this task definition.
 * `network_mode` - Docker networking mode to use for the containers in this task.
-* `revision` - Revision of this task definition
-* `status` - Status of this task definition
-* `task_role_arn` - ARN of the IAM role that containers in this task can assume
+* `revision` - Revision of this task definition.
+* `status` - Status of this task definition.
+* `task_role_arn` - ARN of the IAM role that containers in this task can assume.

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -330,6 +330,7 @@ For more information, see [Specifying an FSX Windows File Server volume in your 
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - Full ARN of the Task Definition (including both `family` and `revision`).
+* `arn_without_revision` - ARN of the Task Definition with the trailing `revision` removed. This may be useful for situations where the latest task definition is always desired. If a revision isn't specified, the latest ACTIVE revision is used. See the [AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_StartTask.html#ECS-StartTask-request-taskDefinition) for details.
 * `revision` - Revision of the task in a particular family.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 


### PR DESCRIPTION
### Description

This pull requests adds the attribute `arn_without_revision` to the resource `aws_ecs_task_definition` as explained in issue #27119


### Relations

Closes #27119

### Notes

- I do not have an AWS account, so I could not run the tests which require one.
- I'm participating in hacktoberfest 2022. So if you deem this pull request helpful, I'd be glad if you could add the `hacktoberfest-accepted` label to the PR so it helps me reaching the goal :)
