### PR TITLE
Fix resource/aws_rds_proxy_endpoint: Respect `tags_all` attribute

### DIFF
--- a/.changelog/27367.txt
+++ b/.changelog/27367.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_proxy_endpoint: Respect configured provider `default_tags` value on resource Update
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ ENHANCEMENTS:
 BUG FIXES:
 
 * resource/aws_appstream_stack: Fix panic with `application_settings`. ([#27257](https://github.com/hashicorp/terraform-provider-aws/issues/27257))
+* resource/aws_rds_proxy_endpoint: Respect `tags_all` attribute ([#25477](https://github.com/hashicorp/terraform-provider-aws/issues/25477))
 * resource/aws_sqs_queue: Change `sqs_managed_sse_enabled` to `Computed` as newly created SQS queues use [SSE-SQS encryption by default](https://aws.amazon.com/about-aws/whats-new/2022/10/amazon-sqs-announces-server-side-encryption-ssq-managed-sse-sqs-default/). This means that Terraform will only perform drift detection of the attribute's value when present in a configuration ([#26843](https://github.com/hashicorp/terraform-provider-aws/issues/26843))
 * resource/aws_sqs_queue: Respect configured `sqs_managed_sse_enabled` value on resource Create. In particular a configured `false` value is sent to the AWS API, which overrides the [new service default value of `true`](https://aws.amazon.com/about-aws/whats-new/2022/10/amazon-sqs-announces-server-side-encryption-ssq-managed-sse-sqs-default/) ([#27335](https://github.com/hashicorp/terraform-provider-aws/issues/27335))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ ENHANCEMENTS:
 BUG FIXES:
 
 * resource/aws_appstream_stack: Fix panic with `application_settings`. ([#27257](https://github.com/hashicorp/terraform-provider-aws/issues/27257))
-* resource/aws_rds_proxy_endpoint: Respect `tags_all` attribute ([#25477](https://github.com/hashicorp/terraform-provider-aws/issues/25477))
 * resource/aws_sqs_queue: Change `sqs_managed_sse_enabled` to `Computed` as newly created SQS queues use [SSE-SQS encryption by default](https://aws.amazon.com/about-aws/whats-new/2022/10/amazon-sqs-announces-server-side-encryption-ssq-managed-sse-sqs-default/). This means that Terraform will only perform drift detection of the attribute's value when present in a configuration ([#26843](https://github.com/hashicorp/terraform-provider-aws/issues/26843))
 * resource/aws_sqs_queue: Respect configured `sqs_managed_sse_enabled` value on resource Create. In particular a configured `false` value is sent to the AWS API, which overrides the [new service default value of `true`](https://aws.amazon.com/about-aws/whats-new/2022/10/amazon-sqs-announces-server-side-encryption-ssq-managed-sse-sqs-default/) ([#27335](https://github.com/hashicorp/terraform-provider-aws/issues/27335))
 

--- a/internal/service/rds/proxy_endpoint.go
+++ b/internal/service/rds/proxy_endpoint.go
@@ -206,8 +206,8 @@ func resourceProxyEndpointUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if d.HasChange("tags") {
-		o, n := d.GetChange("tags")
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
 
 		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
 			return fmt.Errorf("Error updating RDS DB Proxy Endpoint (%s) tags: %w", d.Get("arn").(string), err)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Allow provider's default tags to be stored for `aws_rds_proxy_endpoint`, and remove
```
Terraform will perform the following actions:

  # aws_db_proxy_endpoint.rds_proxy_read_only_endpoint will be updated in-place
  ~ resource "aws_db_proxy_endpoint" "rds_proxy_read_only_endpoint" {
        id                     = "production-proxy/production-proxy-read-only"
        tags                   = {
            "Name" = "production-proxy-read-only-endpoint"
        }
      ~ tags_all               = {
          + "environment"     = "production"
          + "service"         = "ticketing"
            # (1 unchanged element hidden)
        }
        # (9 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
from every plan.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #25477
or 
Closes #0000
--->

Relates #25477

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccRDSProxyEndpoint_tags PKG=rds
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSProxyEndpoint_tags'  -timeout 180m
=== RUN   TestAccRDSProxyEndpoint_tags
=== PAUSE TestAccRDSProxyEndpoint_tags
=== CONT  TestAccRDSProxyEndpoint_tags
--- PASS: TestAccRDSProxyEndpoint_tags (1569.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	1569.288s
...
```
