### PR TITLE
[WIP] Add additional checksum algorithms in `aws_s3_object` resource and data source 

### DIFF
--- a/.changelog/27370.txt
+++ b/.changelog/27370.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_s3_object: Add `checksum_algorithm` argument and `checksum_crc32`, `checksum_crc32c`, `checksum_sha1` and `checksum_sha256` attributes
+```
+
+```release-note:enhancement
+data-source/aws_s3_object: Add `checksum_crc32`, `checksum_crc32c`, `checksum_sha1` and `checksum_sha256` attributes
+```

--- a/internal/service/s3/object_data_source.go
+++ b/internal/service/s3/object_data_source.go
@@ -37,6 +37,22 @@ func DataSourceObject() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"checksum_crc32": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"checksum_crc32c": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"checksum_sha1": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"checksum_sha256": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"content_disposition": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -133,8 +149,9 @@ func dataSourceObjectRead(d *schema.ResourceData, meta interface{}) error {
 	key := d.Get("key").(string)
 
 	input := s3.HeadObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(key),
+		Bucket:       aws.String(bucket),
+		Key:          aws.String(key),
+		ChecksumMode: aws.String(s3.ChecksumModeEnabled),
 	}
 	if v, ok := d.GetOk("range"); ok {
 		input.Range = aws.String(v.(string))
@@ -165,6 +182,10 @@ func dataSourceObjectRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("bucket_key_enabled", out.BucketKeyEnabled)
 	d.Set("cache_control", out.CacheControl)
+	d.Set("checksum_crc32", out.ChecksumCRC32)
+	d.Set("checksum_crc32c", out.ChecksumCRC32C)
+	d.Set("checksum_sha1", out.ChecksumSHA1)
+	d.Set("checksum_sha256", out.ChecksumSHA256)
 	d.Set("content_disposition", out.ContentDisposition)
 	d.Set("content_encoding", out.ContentEncoding)
 	d.Set("content_language", out.ContentLanguage)

--- a/internal/service/s3/object_data_source_test.go
+++ b/internal/service/s3/object_data_source_test.go
@@ -230,6 +230,11 @@ func TestAccS3ObjectDataSource_allParams(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_legal_hold_status", resourceName, "object_lock_legal_hold_status"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_mode", resourceName, "object_lock_mode"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_retain_until_date", resourceName, "object_lock_retain_until_date"),
+					// Additional checksum algorithm
+					resource.TestCheckResourceAttrPair(dataSourceName, "checksum_crc32", resourceName, "checksum_crc32"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "checksum_crc32c", resourceName, "checksum_crc32c"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "checksum_sha1", resourceName, "checksum_sha1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "checksum_sha256", resourceName, "checksum_sha256"),
 				),
 			},
 		},
@@ -423,6 +428,150 @@ func TestAccS3ObjectDataSource_singleSlashAsKey(t *testing.T) {
 				Config: testAccObjectDataSourceConfig_singleSlashAsKey(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckObjectExistsDataSource(dataSourceName, &dsObj),
+				),
+			},
+		},
+	})
+}
+
+func TestAccS3ObjectDataSource_checksumCRC32(t *testing.T) {
+	rInt := sdkacctest.RandInt()
+
+	var rObj s3.GetObjectOutput
+	var dsObj s3.GetObjectOutput
+
+	resourceName := "aws_s3_object.object"
+	dataSourceName := "data.aws_s3_object.obj"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                  func() { acctest.PreCheck(t) },
+		ErrorCheck:                acctest.ErrorCheck(t, s3.EndpointsID),
+		ProtoV5ProviderFactories:  acctest.ProtoV5ProviderFactories,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObjectDataSourceConfig_checksum(rInt, s3.ChecksumAlgorithmCrc32),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectExists(resourceName, &rObj),
+					testAccCheckObjectExistsDataSource(dataSourceName, &dsObj),
+					resource.TestCheckResourceAttr(dataSourceName, "content_length", "11"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "etag", resourceName, "etag"),
+					resource.TestMatchResourceAttr(dataSourceName, "last_modified", regexp.MustCompile(rfc1123RegexPattern)),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_legal_hold_status", resourceName, "object_lock_legal_hold_status"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_mode", resourceName, "object_lock_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_retain_until_date", resourceName, "object_lock_retain_until_date"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "body"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "checksum_crc32", resourceName, "checksum_crc32"),
+					resource.TestCheckResourceAttr(dataSourceName, "checksum_crc32", "ShexVg=="),
+				),
+			},
+		},
+	})
+}
+
+func TestAccS3ObjectDataSource_checksumCRC32C(t *testing.T) {
+	rInt := sdkacctest.RandInt()
+
+	var rObj s3.GetObjectOutput
+	var dsObj s3.GetObjectOutput
+
+	resourceName := "aws_s3_object.object"
+	dataSourceName := "data.aws_s3_object.obj"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                  func() { acctest.PreCheck(t) },
+		ErrorCheck:                acctest.ErrorCheck(t, s3.EndpointsID),
+		ProtoV5ProviderFactories:  acctest.ProtoV5ProviderFactories,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObjectDataSourceConfig_checksum(rInt, s3.ChecksumAlgorithmCrc32c),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectExists(resourceName, &rObj),
+					testAccCheckObjectExistsDataSource(dataSourceName, &dsObj),
+					resource.TestCheckResourceAttr(dataSourceName, "content_length", "11"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "etag", resourceName, "etag"),
+					resource.TestMatchResourceAttr(dataSourceName, "last_modified", regexp.MustCompile(rfc1123RegexPattern)),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_legal_hold_status", resourceName, "object_lock_legal_hold_status"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_mode", resourceName, "object_lock_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_retain_until_date", resourceName, "object_lock_retain_until_date"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "body"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "checksum_crc32c", resourceName, "checksum_crc32c"),
+					resource.TestCheckResourceAttr(dataSourceName, "checksum_crc32c", "aR2qLw=="),
+				),
+			},
+		},
+	})
+}
+
+func TestAccS3ObjectDataSource_checksumSHA1(t *testing.T) {
+	rInt := sdkacctest.RandInt()
+
+	var rObj s3.GetObjectOutput
+	var dsObj s3.GetObjectOutput
+
+	resourceName := "aws_s3_object.object"
+	dataSourceName := "data.aws_s3_object.obj"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                  func() { acctest.PreCheck(t) },
+		ErrorCheck:                acctest.ErrorCheck(t, s3.EndpointsID),
+		ProtoV5ProviderFactories:  acctest.ProtoV5ProviderFactories,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObjectDataSourceConfig_checksum(rInt, s3.ChecksumAlgorithmSha1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectExists(resourceName, &rObj),
+					testAccCheckObjectExistsDataSource(dataSourceName, &dsObj),
+					resource.TestCheckResourceAttr(dataSourceName, "content_length", "11"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "etag", resourceName, "etag"),
+					resource.TestMatchResourceAttr(dataSourceName, "last_modified", regexp.MustCompile(rfc1123RegexPattern)),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_legal_hold_status", resourceName, "object_lock_legal_hold_status"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_mode", resourceName, "object_lock_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_retain_until_date", resourceName, "object_lock_retain_until_date"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "body"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "checksum_sha1", resourceName, "checksum_sha1"),
+					resource.TestCheckResourceAttr(dataSourceName, "checksum_sha1", "Ck1VqNd45QIvq3AZd8XYQLvEhtA="),
+				),
+			},
+		},
+	})
+}
+
+func TestAccS3ObjectDataSource_checksumSHA256(t *testing.T) {
+	rInt := sdkacctest.RandInt()
+
+	var rObj s3.GetObjectOutput
+	var dsObj s3.GetObjectOutput
+
+	resourceName := "aws_s3_object.object"
+	dataSourceName := "data.aws_s3_object.obj"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                  func() { acctest.PreCheck(t) },
+		ErrorCheck:                acctest.ErrorCheck(t, s3.EndpointsID),
+		ProtoV5ProviderFactories:  acctest.ProtoV5ProviderFactories,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObjectDataSourceConfig_checksum(rInt, s3.ChecksumAlgorithmSha256),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectExists(resourceName, &rObj),
+					testAccCheckObjectExistsDataSource(dataSourceName, &dsObj),
+					resource.TestCheckResourceAttr(dataSourceName, "content_length", "11"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "content_type", resourceName, "content_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "etag", resourceName, "etag"),
+					resource.TestMatchResourceAttr(dataSourceName, "last_modified", regexp.MustCompile(rfc1123RegexPattern)),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_legal_hold_status", resourceName, "object_lock_legal_hold_status"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_mode", resourceName, "object_lock_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "object_lock_retain_until_date", resourceName, "object_lock_retain_until_date"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "body"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "checksum_sha256", resourceName, "checksum_sha256"),
+					resource.TestCheckResourceAttr(dataSourceName, "checksum_sha256", "pZGm1Av0IEBKARczz7exkNYsZb8LzaMrV7J32a2fFG4="),
 				),
 			},
 		},
@@ -770,4 +919,24 @@ data "aws_s3_object" "test" {
   key    = "/"
 }
 `, rName)
+}
+
+func testAccObjectDataSourceConfig_checksum(randInt int, algorithm string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "object_bucket" {
+  bucket = "tf-object-test-bucket-%[1]d"
+}
+
+resource "aws_s3_object" "object" {
+  bucket             = aws_s3_bucket.object_bucket.bucket
+  key                = "tf-testing-obj-%[1]d"
+  content            = "Hello World"
+  checksum_algorithm = %[2]q
+}
+
+data "aws_s3_object" "obj" {
+  bucket = aws_s3_bucket.object_bucket.bucket
+  key    = aws_s3_object.object.key
+}
+`, randInt, algorithm)
 }

--- a/internal/service/s3/object_test.go
+++ b/internal/service/s3/object_test.go
@@ -1306,6 +1306,354 @@ func TestAccS3Object_ignoreTags(t *testing.T) {
 	})
 }
 
+func TestAccS3Object_checksumCRC32(t *testing.T) {
+	var obj, updatedObj s3.GetObjectOutput
+	resourceName := "aws_s3_object.object"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	startingData := "{anything will do }"
+	source := testAccObjectCreateTempFile(t, startingData)
+	defer os.Remove(source)
+
+	updatedData := "{anything will update }"
+	updateSource := func(*terraform.State) error {
+		if err := os.WriteFile(source, []byte(updatedData), 0644); err != nil {
+			os.Remove(source)
+			t.Fatal(err)
+		}
+		return nil
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {},
+				Config:    testAccObjectConfig_checksumSource(rName, source, s3.ChecksumAlgorithmCrc32),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectExists(resourceName, &obj),
+					testAccCheckObjectBody(&obj, startingData),
+					resource.TestCheckResourceAttr(resourceName, "checksum_crc32", "mB9I0g=="),
+					updateSource,
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				PreConfig: func() {},
+				Config:    testAccObjectConfig_checksumSource(rName, source, s3.ChecksumAlgorithmCrc32),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectExists(resourceName, &updatedObj),
+					testAccCheckObjectBody(&updatedObj, updatedData),
+					resource.TestCheckResourceAttr(resourceName, "checksum_crc32", "4TGf1g=="),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"acl", "source", "checksum_algorithm", "force_destroy", "source_hash"},
+				ImportStateId:           fmt.Sprintf("s3://%s/test-key", rName),
+			},
+		},
+	})
+}
+
+func TestAccS3Object_checksumCRC32FromContent(t *testing.T) {
+	var obj s3.GetObjectOutput
+	resourceName := "aws_s3_object.object"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	content := "{anything will do }"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {},
+				Config:    testAccObjectConfig_checksumContent(rName, content, s3.ChecksumAlgorithmCrc32),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectExists(resourceName, &obj),
+					testAccCheckObjectBody(&obj, content),
+					resource.TestCheckResourceAttrSet(resourceName, "checksum_crc32"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"acl", "content", "checksum_algorithm", "force_destroy"},
+				ImportStateId:           fmt.Sprintf("s3://%s/test-key", rName),
+			},
+		},
+	})
+}
+
+func TestAccS3Object_checksumCRC32C(t *testing.T) {
+	var obj, updatedObj s3.GetObjectOutput
+	resourceName := "aws_s3_object.object"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	startingData := "{anything will do }"
+	source := testAccObjectCreateTempFile(t, startingData)
+	defer os.Remove(source)
+
+	updatedData := "{anything will update }"
+	updateSource := func(*terraform.State) error {
+		if err := os.WriteFile(source, []byte(updatedData), 0644); err != nil {
+			os.Remove(source)
+			t.Fatal(err)
+		}
+		return nil
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {},
+				Config:    testAccObjectConfig_checksumSource(rName, source, s3.ChecksumAlgorithmCrc32c),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectExists(resourceName, &obj),
+					testAccCheckObjectBody(&obj, startingData),
+					resource.TestCheckResourceAttr(resourceName, "checksum_crc32c", "dGm6gA=="),
+					updateSource,
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				PreConfig: func() {},
+				Config:    testAccObjectConfig_checksumSource(rName, source, s3.ChecksumAlgorithmCrc32c),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectExists(resourceName, &updatedObj),
+					testAccCheckObjectBody(&updatedObj, updatedData),
+					resource.TestCheckResourceAttr(resourceName, "checksum_crc32c", "mXikYA=="),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"acl", "source", "checksum_algorithm", "force_destroy", "source_hash"},
+				ImportStateId:           fmt.Sprintf("s3://%s/test-key", rName),
+			},
+		},
+	})
+}
+
+func TestAccS3Object_checksumCRC32CFromContent(t *testing.T) {
+	var obj s3.GetObjectOutput
+	resourceName := "aws_s3_object.object"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	content := "{anything will do }"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {},
+				Config:    testAccObjectConfig_checksumContent(rName, content, s3.ChecksumAlgorithmCrc32c),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectExists(resourceName, &obj),
+					testAccCheckObjectBody(&obj, content),
+					resource.TestCheckResourceAttrSet(resourceName, "checksum_crc32c"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"acl", "content", "checksum_algorithm", "force_destroy"},
+				ImportStateId:           fmt.Sprintf("s3://%s/test-key", rName),
+			},
+		},
+	})
+}
+
+func TestAccS3Object_checksumSHA1(t *testing.T) {
+	var obj, updatedObj s3.GetObjectOutput
+	resourceName := "aws_s3_object.object"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	startingData := "{anything will do }"
+	source := testAccObjectCreateTempFile(t, startingData)
+	defer os.Remove(source)
+
+	updatedData := "{anything will update }"
+	updateSource := func(*terraform.State) error {
+		if err := os.WriteFile(source, []byte(updatedData), 0644); err != nil {
+			os.Remove(source)
+			t.Fatal(err)
+		}
+		return nil
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {},
+				Config:    testAccObjectConfig_checksumSource(rName, source, s3.ChecksumAlgorithmSha1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectExists(resourceName, &obj),
+					testAccCheckObjectBody(&obj, startingData),
+					resource.TestCheckResourceAttr(resourceName, "checksum_sha1", "Jfq5VokkqJ4AYDAg1MaVaclbdUM="),
+					updateSource,
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				PreConfig: func() {},
+				Config:    testAccObjectConfig_checksumSource(rName, source, s3.ChecksumAlgorithmSha1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectExists(resourceName, &updatedObj),
+					testAccCheckObjectBody(&updatedObj, updatedData),
+					resource.TestCheckResourceAttr(resourceName, "checksum_sha1", "k+oPZ7IuZQdqRMINlp2DL/aYykA="),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"acl", "source", "checksum_algorithm", "force_destroy", "source_hash"},
+				ImportStateId:           fmt.Sprintf("s3://%s/test-key", rName),
+			},
+		},
+	})
+}
+
+func TestAccS3Object_checksumSHA1FromContent(t *testing.T) {
+	var obj s3.GetObjectOutput
+	resourceName := "aws_s3_object.object"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	content := "{anything will do }"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {},
+				Config:    testAccObjectConfig_checksumContent(rName, content, s3.ChecksumAlgorithmSha1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectExists(resourceName, &obj),
+					testAccCheckObjectBody(&obj, content),
+					resource.TestCheckResourceAttrSet(resourceName, "checksum_sha1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"acl", "content", "checksum_algorithm", "force_destroy"},
+				ImportStateId:           fmt.Sprintf("s3://%s/test-key", rName),
+			},
+		},
+	})
+}
+
+func TestAccS3Object_checksumSHA256(t *testing.T) {
+	var obj, updatedObj s3.GetObjectOutput
+	resourceName := "aws_s3_object.object"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	startingData := "{anything will do }"
+	source := testAccObjectCreateTempFile(t, startingData)
+	defer os.Remove(source)
+
+	updatedData := "{anything will update }"
+	updateSource := func(*terraform.State) error {
+		if err := os.WriteFile(source, []byte(updatedData), 0644); err != nil {
+			os.Remove(source)
+			t.Fatal(err)
+		}
+		return nil
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {},
+				Config:    testAccObjectConfig_checksumSource(rName, source, s3.ChecksumAlgorithmSha256),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectExists(resourceName, &obj),
+					testAccCheckObjectBody(&obj, startingData),
+					resource.TestCheckResourceAttr(resourceName, "checksum_sha256", "E+Q1+EhtC9yu+TpP/VmppQbF8Kogbm/MdvZvBLc/qyk="),
+					updateSource,
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				PreConfig: func() {},
+				Config:    testAccObjectConfig_checksumSource(rName, source, s3.ChecksumAlgorithmSha256),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectExists(resourceName, &updatedObj),
+					testAccCheckObjectBody(&updatedObj, updatedData),
+					resource.TestCheckResourceAttr(resourceName, "checksum_sha256", "6dbPtaVLFtEf5EVs3VlxI2b0+aqKImunUL4uDo0/Hvk="),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"acl", "source", "checksum_algorithm", "force_destroy", "source_hash"},
+				ImportStateId:           fmt.Sprintf("s3://%s/test-key", rName),
+			},
+		},
+	})
+}
+
+func TestAccS3Object_checksumSHA256FromContent(t *testing.T) {
+	var obj s3.GetObjectOutput
+	resourceName := "aws_s3_object.object"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	content := "{anything will do }"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {},
+				Config:    testAccObjectConfig_checksumContent(rName, content, s3.ChecksumAlgorithmSha256),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectExists(resourceName, &obj),
+					testAccCheckObjectBody(&obj, content),
+					resource.TestCheckResourceAttrSet(resourceName, "checksum_sha256"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"acl", "content", "checksum_algorithm", "force_destroy"},
+				ImportStateId:           fmt.Sprintf("s3://%s/test-key", rName),
+			},
+		},
+	})
+}
+
 func testAccCheckObjectVersionIdDiffers(first, second *s3.GetObjectOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if first.VersionId == nil {
@@ -2114,4 +2462,35 @@ resource "aws_s3_object" "object" {
   content = %[2]q
 }
 `, rName, content)
+}
+
+func testAccObjectConfig_checksumSource(rName string, source string, algorithm string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_object" "object" {
+  bucket             = aws_s3_bucket.test.bucket
+  key                = "test-key"
+  source             = %[2]q
+  source_hash        = filemd5(%[2]q)
+  checksum_algorithm = %[3]q
+}
+`, rName, source, algorithm)
+}
+
+func testAccObjectConfig_checksumContent(rName string, content string, algorithm string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_object" "object" {
+  bucket             = aws_s3_bucket.test.bucket
+  key                = "test-key"
+  content            = %[2]q
+  checksum_algorithm = %[3]q
+}
+`, rName, content, algorithm)
 }

--- a/website/docs/d/s3_object.html.markdown
+++ b/website/docs/d/s3_object.html.markdown
@@ -68,6 +68,10 @@ In addition to all arguments above, the following attributes are exported:
 * `body` - Object data (see **limitations above** to understand cases in which this field is actually available)
 * `bucket_key_enabled` - (Optional) Whether or not to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS.
 * `cache_control` - Caching behavior along the request/reply chain.
+* `checksum_crc32` - The checksum value of the object, if object additional checksum algorithm is `CRC32`.
+* `checksum_crc32c` - The checksum value of the object, if object additional checksum algorithm is `CRC32C`.
+* `checksum_sha1` -The checksum value of the object, if object additional checksum algorithm is `SHA1`.
+* `checksum_sha256` - The checksum value of the object, if object additional checksum algorithm is `SHA256`.
 * `content_disposition` - Presentational information for the object.
 * `content_encoding` - What content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.
 * `content_language` - Language the content is in.

--- a/website/docs/r/s3_object.html.markdown
+++ b/website/docs/r/s3_object.html.markdown
@@ -143,6 +143,7 @@ The following arguments are optional:
 * `acl` - (Optional) [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Valid values are `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, `bucket-owner-read`, and `bucket-owner-full-control`. Defaults to `private`.
 * `bucket_key_enabled` - (Optional) Whether or not to use [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) for SSE-KMS.
 * `cache_control` - (Optional) Caching behavior along the request/reply chain Read [w3c cache_control](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9) for further details.
+* `checksum_algorithm` - (Optional) [Additional checksum algorithm](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#using-additional-checksums) of the object in S3. Valid values are `CRC32`, `CRC32C`, `SHA1`, `SHA256`.
 * `content_base64` - (Optional, conflicts with `source` and `content`) Base64-encoded data that will be decoded and uploaded as raw bytes for the object content. This allows safely uploading non-UTF8 binary data, but is recommended only for small content such as the result of the `gzipbase64` function with small text strings. For larger objects, use `source` to stream the content from a disk file.
 * `content_disposition` - (Optional) Presentational information for the object. Read [w3c content_disposition](http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1) for further information.
 * `content_encoding` - (Optional) Content encodings that have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field. Read [w3c content encoding](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11) for further information.
@@ -171,6 +172,10 @@ If no content is provided through `source`, `content` or `content_base64`, then 
 
 In addition to all arguments above, the following attributes are exported:
 
+* `checksum_crc32` - The checksum value of the object, if object additional checksum algorithm is `CRC32`.
+* `checksum_crc32c` - The checksum value of the object, if object additional checksum algorithm is `CRC32C`.
+* `checksum_sha1` -The checksum value of the object, if object additional checksum algorithm is `SHA1`.
+* `checksum_sha256` - The checksum value of the object, if object additional checksum algorithm is `SHA256`.
 * `etag` - ETag generated for the object (an MD5 sum of the object content). For plaintext objects or objects encrypted with an AWS-managed key, the hash is an MD5 digest of the object data. For objects encrypted with a KMS key or objects created by either the Multipart Upload or Part Copy operation, the hash is not an MD5 digest, regardless of the method of encryption. More information on possible values can be found on [Common Response Headers](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html).
 * `id` - `key` of the resource supplied above
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add additional checksum algorithms (`CRC32`, `CRC32C`, `SHA1`, `SHA256`) to S3 object resource and data source.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Related #23901
Related #25647

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- [New – Additional Checksum Algorithms for Amazon S3](https://aws.amazon.com/de/blogs/aws/new-additional-checksum-algorithms-for-amazon-s3/)
- [Using supported checksum algorithms](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#using-additional-checksums)
- [PutObject API Reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html)
- [HeadObject API Reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccS3Object_checksum\|TestAccS3Object_source\|TestAccS3ObjectDataSource_checksum\|TestAccS3ObjectDataSource_allParams PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3Object_checksum|TestAccS3Object_source|TestAccS3ObjectDataSource_checksum|TestAccS3ObjectDataSource_allParams'  -timeout 180m
=== RUN   TestAccS3ObjectDataSource_allParams
=== PAUSE TestAccS3ObjectDataSource_allParams
=== RUN   TestAccS3ObjectDataSource_checksumCRC32
=== PAUSE TestAccS3ObjectDataSource_checksumCRC32
=== RUN   TestAccS3ObjectDataSource_checksumCRC32C
=== PAUSE TestAccS3ObjectDataSource_checksumCRC32C
=== RUN   TestAccS3ObjectDataSource_checksumSHA1
=== PAUSE TestAccS3ObjectDataSource_checksumSHA1
=== RUN   TestAccS3ObjectDataSource_checksumSHA256
=== PAUSE TestAccS3ObjectDataSource_checksumSHA256
=== RUN   TestAccS3Object_source
=== PAUSE TestAccS3Object_source
=== RUN   TestAccS3Object_sourceHashTrigger
=== PAUSE TestAccS3Object_sourceHashTrigger
=== RUN   TestAccS3Object_checksumCRC32
=== PAUSE TestAccS3Object_checksumCRC32
=== RUN   TestAccS3Object_checksumCRC32FromContent
=== PAUSE TestAccS3Object_checksumCRC32FromContent
=== RUN   TestAccS3Object_checksumCRC32C
=== PAUSE TestAccS3Object_checksumCRC32C
=== RUN   TestAccS3Object_checksumCRC32CFromContent
=== PAUSE TestAccS3Object_checksumCRC32CFromContent
=== RUN   TestAccS3Object_checksumSHA1
=== PAUSE TestAccS3Object_checksumSHA1
=== RUN   TestAccS3Object_checksumSHA1FromContent
=== PAUSE TestAccS3Object_checksumSHA1FromContent
=== RUN   TestAccS3Object_checksumSHA256
=== PAUSE TestAccS3Object_checksumSHA256
=== RUN   TestAccS3Object_checksumSHA256FromContent
=== PAUSE TestAccS3Object_checksumSHA256FromContent
=== CONT  TestAccS3ObjectDataSource_allParams
=== CONT  TestAccS3Object_checksumCRC32FromContent
=== CONT  TestAccS3Object_checksumSHA1FromContent
=== CONT  TestAccS3Object_checksumSHA256FromContent
=== CONT  TestAccS3Object_checksumSHA1
=== CONT  TestAccS3Object_checksumSHA256
=== CONT  TestAccS3Object_checksumCRC32C
=== CONT  TestAccS3ObjectDataSource_checksumSHA256
=== CONT  TestAccS3Object_checksumCRC32CFromContent
=== CONT  TestAccS3ObjectDataSource_checksumCRC32C
=== CONT  TestAccS3Object_checksumCRC32
=== CONT  TestAccS3ObjectDataSource_checksumSHA1
=== CONT  TestAccS3Object_sourceHashTrigger
=== CONT  TestAccS3Object_source
=== CONT  TestAccS3ObjectDataSource_checksumCRC32
--- PASS: TestAccS3ObjectDataSource_checksumSHA256 (202.11s)
--- PASS: TestAccS3ObjectDataSource_checksumCRC32C (202.27s)
--- PASS: TestAccS3ObjectDataSource_checksumCRC32 (208.73s)
--- PASS: TestAccS3ObjectDataSource_checksumSHA1 (208.74s)
--- PASS: TestAccS3ObjectDataSource_allParams (213.26s)
--- PASS: TestAccS3Object_checksumSHA256FromContent (224.77s)
--- PASS: TestAccS3Object_checksumSHA1FromContent (234.12s)
--- PASS: TestAccS3Object_checksumCRC32FromContent (234.42s)
--- PASS: TestAccS3Object_checksumCRC32CFromContent (234.71s)
--- PASS: TestAccS3Object_source (235.57s)
--- PASS: TestAccS3Object_sourceHashTrigger (293.14s)
--- PASS: TestAccS3Object_checksumCRC32C (294.43s)
--- PASS: TestAccS3Object_checksumSHA1 (295.33s)
--- PASS: TestAccS3Object_checksumCRC32 (296.25s)
--- PASS: TestAccS3Object_checksumSHA256 (297.32s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 300.476s
```
