### PR TITLE
Provide multi step example for aws_transfer_workflow resource

### DIFF
--- a/website/docs/r/transfer_workflow.html.markdown
+++ b/website/docs/r/transfer_workflow.html.markdown
@@ -73,8 +73,8 @@ The following arguments are supported:
 
 #### Copy Step Details
 
-* `name` - (Optional) The name of the step, used as an identifier.
 * `destination_file_location` - (Optional) Specifies the location for the file being copied. Use ${Transfer:username} in this field to parametrize the destination prefix by username.
+* `name` - (Optional) The name of the step, used as an identifier.
 * `overwrite_existing` - (Optional) A flag that indicates whether or not to overwrite an existing file of the same name. The default is `FALSE`. Valid values are `TRUE` and `FALSE`.
 * `source_file_location` - (Optional) Specifies which file to use as input to the workflow step: either the output from the previous step, or the originally uploaded file for the workflow. Enter ${previous.file} to use the previous file as the input. In this case, this workflow step uses the output file from the previous workflow step as input. This is the default value. Enter ${original.file} to use the originally-uploaded file location as input for this step.
 

--- a/website/docs/r/transfer_workflow.html.markdown
+++ b/website/docs/r/transfer_workflow.html.markdown
@@ -12,6 +12,8 @@ Provides a AWS Transfer Workflow resource.
 
 ## Example Usage
 
+### Basic single step example
+
 ```terraform
 resource "aws_transfer_workflow" "example" {
   steps {
@@ -20,6 +22,34 @@ resource "aws_transfer_workflow" "example" {
       source_file_location = "$${original.file}"
     }
     type = "DELETE"
+  }
+}
+```
+
+### Multiple steps example
+
+```terraform
+resource "aws_transfer_workflow" "example" {
+  steps {
+    custom_step_details {
+      name                 = "example"
+      source_file_location = "$${original.file}"
+      target               = aws_lambda_function.example.arn
+      timeout_seconds      = 60
+    }
+    type = "CUSTOM"
+  }
+
+  steps {
+    tag_step_details {
+      name                 = "example"
+      source_file_location = "$${original.file}"
+      tags {
+        key   = "Name"
+        value = "Hello World"
+      }
+    }
+    type = "TAG"
   }
 }
 ```

--- a/website/docs/r/transfer_workflow.html.markdown
+++ b/website/docs/r/transfer_workflow.html.markdown
@@ -26,7 +26,7 @@ resource "aws_transfer_workflow" "example" {
 }
 ```
 
-### Multiple steps example
+### Multistep example
 
 ```terraform
 resource "aws_transfer_workflow" "example" {

--- a/website/docs/r/transfer_workflow.html.markdown
+++ b/website/docs/r/transfer_workflow.html.markdown
@@ -73,8 +73,8 @@ The following arguments are supported:
 
 #### Copy Step Details
 
-* `destination_file_location` - (Optional) Specifies the location for the file being copied. Use ${Transfer:username} in this field to parametrize the destination prefix by username.
 * `name` - (Optional) The name of the step, used as an identifier.
+* `destination_file_location` - (Optional) Specifies the location for the file being copied. Use ${Transfer:username} in this field to parametrize the destination prefix by username.
 * `overwrite_existing` - (Optional) A flag that indicates whether or not to overwrite an existing file of the same name. The default is `FALSE`. Valid values are `TRUE` and `FALSE`.
 * `source_file_location` - (Optional) Specifies which file to use as input to the workflow step: either the output from the previous step, or the originally uploaded file for the workflow. Enter ${previous.file} to use the previous file as the input. In this case, this workflow step uses the output file from the previous workflow step as input. This is the default value. Enter ${original.file} to use the originally-uploaded file location as input for this step.
 


### PR DESCRIPTION
### Description
Create an example to demonstrate how multiple steps can be used within the `aws_transfer_workflow` resource.

### Relations

### References
[Example question](https://discuss.hashicorp.com/t/aws-transfer-workflow-resource-syntax-example-for-multiple-steps/44455) on the forums suggesting clarification would be helpful. 
I, personally, worked backwards using `terraform import` to find out the expected syntax for multiple steps. 

### Output from Acceptance Testing

