### PR TITLE
d/aws_default_tags: Fix regression with `null` vs. empty map

### DIFF
--- a/.changelog/27377.txt
+++ b/.changelog/27377.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_default_tags: Fix regression setting `tags` to `null` instead of an empty map (`{}`) when no `default_tags` are defined
+```

--- a/internal/service/meta/default_tags_data_source.go
+++ b/internal/service/meta/default_tags_data_source.go
@@ -74,11 +74,7 @@ func (d *dataSourceDefaultTags) Read(ctx context.Context, request datasource.Rea
 	tags := defaultTagsConfig.GetTags()
 
 	data.ID = types.String{Value: d.meta.Partition}
-	if tags != nil {
-		data.Tags = flex.FlattenFrameworkStringValueMap(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
-	} else {
-		data.Tags = types.Map{ElemType: types.StringType, Null: true}
-	}
+	data.Tags = flex.FlattenFrameworkStringValueMap(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }

--- a/internal/service/meta/default_tags_data_source_test.go
+++ b/internal/service/meta/default_tags_data_source_test.go
@@ -41,10 +41,7 @@ func TestAccMetaDefaultTagsDataSource_empty(t *testing.T) {
 		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.ConfigCompose(
-					acctest.ConfigDefaultTags_Tags0(),
-					testAccDefaultTagsDataSourceConfig_basic(),
-				),
+				Config: testAccDefaultTagsDataSourceConfig_basic(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
 				),
@@ -104,6 +101,35 @@ func TestAccMetaDefaultTagsDataSource_ignore(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccMetaDefaultTagsDataSource_MigrateFromPluginSDK_Empty(t *testing.T) {
+	dataSourceName := "data.aws_default_tags.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "4.35.0",
+					},
+				},
+				Config: testAccDefaultTagsDataSourceConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccDefaultTagsDataSourceConfig_basic(),
+				PlanOnly:                 true,
 			},
 		},
 	})


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes a **v4.36.0** regression where the `aws_default_tags` data source returns `null` vs. an empty map (`{}`) when no `default_tags` are configured.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/27372.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/27221.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

**N.B.** `unset TF_CLI_CONFIG_FILE` before running.

```console
% make testacc TESTARGS='-run=TestAccMetaDefaultTagsDataSource_' PKG=meta 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/meta/... -v -count 1 -parallel 20  -run=TestAccMetaDefaultTagsDataSource_ -timeout 180m
=== RUN   TestAccMetaDefaultTagsDataSource_basic
=== PAUSE TestAccMetaDefaultTagsDataSource_basic
=== RUN   TestAccMetaDefaultTagsDataSource_empty
=== PAUSE TestAccMetaDefaultTagsDataSource_empty
=== RUN   TestAccMetaDefaultTagsDataSource_multiple
=== PAUSE TestAccMetaDefaultTagsDataSource_multiple
=== RUN   TestAccMetaDefaultTagsDataSource_ignore
=== PAUSE TestAccMetaDefaultTagsDataSource_ignore
=== CONT  TestAccMetaDefaultTagsDataSource_basic
=== CONT  TestAccMetaDefaultTagsDataSource_multiple
=== CONT  TestAccMetaDefaultTagsDataSource_ignore
=== CONT  TestAccMetaDefaultTagsDataSource_empty
--- PASS: TestAccMetaDefaultTagsDataSource_basic (9.45s)
--- PASS: TestAccMetaDefaultTagsDataSource_multiple (9.46s)
--- PASS: TestAccMetaDefaultTagsDataSource_empty (9.55s)
--- PASS: TestAccMetaDefaultTagsDataSource_ignore (18.34s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	22.470s
```

After applying this configuration

```hcl
provider "aws" {}

data "aws_default_tags" "test" {}
```

the Terraform state is

```
{
  "version": 4,
  "terraform_version": "1.0.9",
  "serial": 1,
  "lineage": "b136bdbf-dd55-0303-c702-7f5a900401d1",
  "outputs": {},
  "resources": [
    {
      "mode": "data",
      "type": "aws_default_tags",
      "name": "test",
      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "id": "aws",
            "tags": {}
          },
          "sensitive_attributes": []
        }
      ]
    }
  ]
}
```

which matches the **v4.35.0** version.
Unfortunately we can't test state migration as described in [_Migrating from SDK_](https://developer.hashicorp.com/terraform/plugin/framework/migrating/testing#testing-migration) as the provider configuration has to be explictly defined for `default_tags`.