### PR TITLE
resource/aws_elasticache_global_replication_group: Update to use `Context` calls

### DIFF
--- a/internal/service/elasticache/find.go
+++ b/internal/service/elasticache/find.go
@@ -1,6 +1,7 @@
 package elasticache
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -127,13 +128,13 @@ func FindCacheClustersByID(conn *elasticache.ElastiCache, idList []string) ([]*e
 	return results, err
 }
 
-// FindGlobalReplicationGroupByID() retrieves an ElastiCache Global Replication Group by id.
-func FindGlobalReplicationGroupByID(conn *elasticache.ElastiCache, id string) (*elasticache.GlobalReplicationGroup, error) {
+// FindGlobalReplicationGroupByID retrieves an ElastiCache Global Replication Group by id.
+func FindGlobalReplicationGroupByID(ctx context.Context, conn *elasticache.ElastiCache, id string) (*elasticache.GlobalReplicationGroup, error) {
 	input := &elasticache.DescribeGlobalReplicationGroupsInput{
 		GlobalReplicationGroupId: aws.String(id),
 		ShowMemberInfo:           aws.Bool(true),
 	}
-	output, err := conn.DescribeGlobalReplicationGroups(input)
+	output, err := conn.DescribeGlobalReplicationGroupsWithContext(ctx, input)
 	if tfawserr.ErrCodeEquals(err, elasticache.ErrCodeGlobalReplicationGroupNotFoundFault) {
 		return nil, &resource.NotFoundError{
 			LastError:   err,
@@ -156,7 +157,7 @@ func FindGlobalReplicationGroupByID(conn *elasticache.ElastiCache, id string) (*
 
 // FindGlobalReplicationGroupMemberByID retrieves a member Replication Group by id from a Global Replication Group.
 func FindGlobalReplicationGroupMemberByID(conn *elasticache.ElastiCache, globalReplicationGroupID string, id string) (*elasticache.GlobalReplicationGroupMember, error) {
-	globalReplicationGroup, err := FindGlobalReplicationGroupByID(conn, globalReplicationGroupID)
+	globalReplicationGroup, err := FindGlobalReplicationGroupByID(context.TODO(), conn, globalReplicationGroupID)
 	if err != nil {
 		return nil, &resource.NotFoundError{
 			Message:   "unable to retrieve enclosing Global Replication Group",

--- a/internal/service/elasticache/global_replication_group.go
+++ b/internal/service/elasticache/global_replication_group.go
@@ -40,7 +40,7 @@ func ResourceGlobalReplicationGroup() *schema.Resource {
 		UpdateWithoutTimeout: resourceGlobalReplicationGroupUpdate,
 		DeleteWithoutTimeout: resourceGlobalReplicationGroupDelete,
 		Importer: &schema.ResourceImporter{
-			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			State: func(d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				re := regexp.MustCompile("^" + GlobalReplicationGroupRegionPrefixFormat)
 				d.Set("global_replication_group_id_suffix", re.ReplaceAllLiteralString(d.Id(), ""))
 
@@ -166,7 +166,7 @@ func descriptionDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 	return false
 }
 
-func descriptionStateFunc(v interface{}) string {
+func descriptionStateFunc(v any) string {
 	s := v.(string)
 	if s == "" {
 		return EmptyDescription
@@ -174,7 +174,7 @@ func descriptionStateFunc(v interface{}) string {
 	return s
 }
 
-func customizeDiffGlobalReplicationGroupEngineVersionErrorOnDowngrade(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+func customizeDiffGlobalReplicationGroupEngineVersionErrorOnDowngrade(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 	if diff.Id() == "" || !diff.HasChange("engine_version") {
 		return nil
 	}
@@ -191,19 +191,19 @@ of the Global Replication Group and all Replication Group members. The AWS provi
 Please use the "-replace" option on the terraform plan and apply commands (see https://www.terraform.io/cli/commands/plan#replace-address).`, diff.Id())
 }
 
-type changesDiffer interface {
+type changeDiffer interface {
 	Id() string
-	GetChange(key string) (interface{}, interface{})
+	GetChange(key string) (any, any)
 	HasChange(key string) bool
 }
 
-func customizeDiffGlobalReplicationGroupParamGroupNameRequiresMajorVersionUpgrade(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+func customizeDiffGlobalReplicationGroupParamGroupNameRequiresMajorVersionUpgrade(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 	return paramGroupNameRequiresMajorVersionUpgrade(diff)
 }
 
 // parameter_group_name can only be set when doing a major update,
 // but we also should allow it to stay set afterwards
-func paramGroupNameRequiresMajorVersionUpgrade(diff changesDiffer) error {
+func paramGroupNameRequiresMajorVersionUpgrade(diff changeDiffer) error {
 	o, n := diff.GetChange("parameter_group_name")
 	if o.(string) == n.(string) {
 		return nil

--- a/internal/service/elasticache/global_replication_group_test.go
+++ b/internal/service/elasticache/global_replication_group_test.go
@@ -1,6 +1,7 @@
 package elasticache_test
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
@@ -1139,6 +1140,8 @@ func TestAccElastiCacheGlobalReplicationGroup_UpdateParameterGroupName(t *testin
 }
 
 func testAccCheckGlobalReplicationGroupExists(resourceName string, v *elasticache.GlobalReplicationGroup) resource.TestCheckFunc {
+	ctx := context.Background()
+
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -1150,7 +1153,7 @@ func testAccCheckGlobalReplicationGroupExists(resourceName string, v *elasticach
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheConn
-		grg, err := tfelasticache.FindGlobalReplicationGroupByID(conn, rs.Primary.ID)
+		grg, err := tfelasticache.FindGlobalReplicationGroupByID(ctx, conn, rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error retrieving ElastiCache Global Replication Group (%s): %w", rs.Primary.ID, err)
 		}
@@ -1167,13 +1170,14 @@ func testAccCheckGlobalReplicationGroupExists(resourceName string, v *elasticach
 
 func testAccCheckGlobalReplicationGroupDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheConn
+	ctx := context.Background()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_elasticache_global_replication_group" {
 			continue
 		}
 
-		_, err := tfelasticache.FindGlobalReplicationGroupByID(conn, rs.Primary.ID)
+		_, err := tfelasticache.FindGlobalReplicationGroupByID(ctx, conn, rs.Primary.ID)
 		if tfresource.NotFound(err) {
 			continue
 		}

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -588,7 +588,7 @@ func resourceReplicationGroupCreate(d *schema.ResourceData, meta interface{}) er
 		// state, but the global replication group can still be in the "modifying" state. Wait for the replication group
 		// to be fully added to the global replication group.
 		// API calls to the global replication group can be made in any region.
-		if _, err := WaitGlobalReplicationGroupAvailable(conn, v.(string), GlobalReplicationGroupDefaultCreatedTimeout); err != nil {
+		if _, err := waitGlobalReplicationGroupAvailable(context.TODO(), conn, v.(string), GlobalReplicationGroupDefaultCreatedTimeout); err != nil {
 			return fmt.Errorf("error waiting for ElastiCache Global Replication Group (%s) to be available: %w", v, err)
 		}
 	}
@@ -1048,7 +1048,7 @@ func DisassociateReplicationGroup(conn *elasticache.ElastiCache, globalReplicati
 		return err
 	}
 
-	_, err = WaitGlobalReplicationGroupMemberDetached(conn, globalReplicationGroupID, id)
+	_, err = waitGlobalReplicationGroupMemberDetached(conn, globalReplicationGroupID, id)
 	if err != nil {
 		return fmt.Errorf("waiting for completion: %w", err)
 	}

--- a/internal/service/elasticache/status.go
+++ b/internal/service/elasticache/status.go
@@ -1,6 +1,8 @@
 package elasticache
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -95,10 +97,10 @@ const (
 	GlobalReplicationGroupStatusDeleted     = "deleted"
 )
 
-// StatusGlobalReplicationGroup fetches the Global Replication Group and its Status
-func StatusGlobalReplicationGroup(conn *elasticache.ElastiCache, globalReplicationGroupID string) resource.StateRefreshFunc {
+// statusGlobalReplicationGroup fetches the Global Replication Group and its Status
+func statusGlobalReplicationGroup(ctx context.Context, conn *elasticache.ElastiCache, globalReplicationGroupID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		grg, err := FindGlobalReplicationGroupByID(conn, globalReplicationGroupID)
+		grg, err := FindGlobalReplicationGroupByID(ctx, conn, globalReplicationGroupID)
 		if tfresource.NotFound(err) {
 			return nil, "", nil
 		}
@@ -114,8 +116,8 @@ const (
 	GlobalReplicationGroupMemberStatusAssociated = "associated"
 )
 
-// StatusGlobalReplicationGroup fetches the Global Replication Group and its Status
-func StatusGlobalReplicationGroupMember(conn *elasticache.ElastiCache, globalReplicationGroupID, id string) resource.StateRefreshFunc {
+// statusGlobalReplicationGroupMember fetches a Global Replication Group Member and its Status
+func statusGlobalReplicationGroupMember(conn *elasticache.ElastiCache, globalReplicationGroupID, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		member, err := FindGlobalReplicationGroupMemberByID(conn, globalReplicationGroupID, id)
 		if tfresource.NotFound(err) {

--- a/internal/service/elasticache/sweep.go
+++ b/internal/service/elasticache/sweep.go
@@ -4,6 +4,7 @@
 package elasticache
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -125,6 +126,7 @@ func sweepGlobalReplicationGroups(region string) error {
 		return fmt.Errorf("error getting client: %w", err)
 	}
 	conn := client.(*conns.AWSClient).ElastiCacheConn
+	ctx := context.Background()
 
 	var grgGroup multierror.Group
 
@@ -150,7 +152,7 @@ func sweepGlobalReplicationGroups(region string) error {
 				}
 
 				log.Printf("[INFO] Deleting ElastiCache Global Replication Group: %s", id)
-				err := DeleteGlobalReplicationGroup(conn, id, sweeperGlobalReplicationGroupDefaultUpdatedTimeout)
+				err := deleteGlobalReplicationGroup(ctx, conn, id, sweeperGlobalReplicationGroupDefaultUpdatedTimeout)
 				if err != nil {
 					sweeperErr := fmt.Errorf("error deleting ElastiCache Global Replication Group (%s): %w", id, err)
 					log.Printf("[ERROR] %s", sweeperErr)


### PR DESCRIPTION
Updates the resource `aws_elasticache_global_replication_group` to use `context.Context` calls

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=elasticache TESTS=TestAccElastiCacheGlobalReplicationGroup_

...
```
