### PR TITLE
Add `scaling_mode` attribute for  `aws_sesv2_dedicated_ip_pool`

### DIFF
--- a/.changelog/27388.txt
+++ b/.changelog/27388.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sesv2_dedicated_ip_pool: Add `scaling_mode` attribute
+```

--- a/internal/service/sesv2/dedicated_ip_pool.go
+++ b/internal/service/sesv2/dedicated_ip_pool.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -49,6 +50,13 @@ func ResourceDedicatedIPPool() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"scaling_mode": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: enum.Validate[types.ScalingMode](),
+			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 		},
@@ -66,6 +74,9 @@ func resourceDedicatedIPPoolCreate(ctx context.Context, d *schema.ResourceData, 
 
 	in := &sesv2.CreateDedicatedIpPoolInput{
 		PoolName: aws.String(d.Get("pool_name").(string)),
+	}
+	if v, ok := d.GetOk("scaling_mode"); ok {
+		in.ScalingMode = types.ScalingMode(v.(string))
 	}
 
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
@@ -89,7 +100,7 @@ func resourceDedicatedIPPoolCreate(ctx context.Context, d *schema.ResourceData, 
 func resourceDedicatedIPPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).SESV2Conn
 
-	_, err := FindDedicatedIPPoolByID(ctx, conn, d.Id())
+	out, err := FindDedicatedIPPoolByID(ctx, conn, d.Id())
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SESV2 DedicatedIPPool (%s) not found, removing from state", d.Id())
 		d.SetId("")
@@ -98,16 +109,10 @@ func resourceDedicatedIPPoolRead(ctx context.Context, d *schema.ResourceData, me
 	if err != nil {
 		return create.DiagError(names.SESV2, create.ErrActionReading, ResNameDedicatedIPPool, d.Id(), err)
 	}
-	d.Set("pool_name", d.Id())
-
-	poolNameARN := arn.ARN{
-		Partition: meta.(*conns.AWSClient).Partition,
-		Service:   "ses",
-		Region:    meta.(*conns.AWSClient).Region,
-		AccountID: meta.(*conns.AWSClient).AccountID,
-		Resource:  fmt.Sprintf("dedicated-ip-pool/%s", d.Id()),
-	}.String()
-	d.Set("arn", poolNameARN)
+	poolName := aws.ToString(out.DedicatedIpPool.PoolName)
+	d.Set("pool_name", poolName)
+	d.Set("scaling_mode", string(out.DedicatedIpPool.ScalingMode))
+	d.Set("arn", poolNameToARN(meta, poolName))
 
 	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
 	if err != nil {
@@ -162,11 +167,11 @@ func resourceDedicatedIPPoolDelete(ctx context.Context, d *schema.ResourceData, 
 	return nil
 }
 
-func FindDedicatedIPPoolByID(ctx context.Context, conn *sesv2.Client, id string) (*sesv2.GetDedicatedIpsOutput, error) {
-	in := &sesv2.GetDedicatedIpsInput{
+func FindDedicatedIPPoolByID(ctx context.Context, conn *sesv2.Client, id string) (*sesv2.GetDedicatedIpPoolOutput, error) {
+	in := &sesv2.GetDedicatedIpPoolInput{
 		PoolName: aws.String(id),
 	}
-	out, err := conn.GetDedicatedIps(ctx, in)
+	out, err := conn.GetDedicatedIpPool(ctx, in)
 	if err != nil {
 		var nfe *types.NotFoundException
 		if errors.As(err, &nfe) {
@@ -179,9 +184,19 @@ func FindDedicatedIPPoolByID(ctx context.Context, conn *sesv2.Client, id string)
 		return nil, err
 	}
 
-	if out == nil {
+	if out == nil || out.DedicatedIpPool == nil {
 		return nil, tfresource.NewEmptyResultError(in)
 	}
 
 	return out, nil
+}
+
+func poolNameToARN(meta interface{}, poolName string) string {
+	return arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   "ses",
+		Region:    meta.(*conns.AWSClient).Region,
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Resource:  fmt.Sprintf("dedicated-ip-pool/%s", poolName),
+	}.String()
 }

--- a/internal/service/sesv2/dedicated_ip_pool_data_source.go
+++ b/internal/service/sesv2/dedicated_ip_pool_data_source.go
@@ -2,16 +2,18 @@ package sesv2
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/sesv2"
 	"github.com/aws/aws-sdk-go-v2/service/sesv2/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -47,7 +49,10 @@ func DataSourceDedicatedIPPool() *schema.Resource {
 			"pool_name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
+			},
+			"scaling_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"tags": tftags.TagsSchemaComputed(),
 		},
@@ -60,24 +65,21 @@ const (
 
 func dataSourceDedicatedIPPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).SESV2Conn
-	poolName := d.Get("pool_name").(string)
 
-	out, err := FindDedicatedIPPoolByID(ctx, conn, poolName)
+	out, err := FindDedicatedIPPoolByID(ctx, conn, d.Get("pool_name").(string))
+	if err != nil {
+		return create.DiagError(names.SESV2, create.ErrActionReading, DSNameDedicatedIPPool, d.Get("pool_name").(string), err)
+	}
+	poolName := aws.ToString(out.DedicatedIpPool.PoolName)
+	d.SetId(poolName)
+	d.Set("scaling_mode", string(out.DedicatedIpPool.ScalingMode))
+	d.Set("arn", poolNameToARN(meta, poolName))
+
+	outIP, err := findDedicatedIPPoolIPs(ctx, conn, poolName)
 	if err != nil {
 		return create.DiagError(names.SESV2, create.ErrActionReading, DSNameDedicatedIPPool, poolName, err)
 	}
-	d.SetId(poolName)
-
-	poolNameARN := arn.ARN{
-		Partition: meta.(*conns.AWSClient).Partition,
-		Service:   "ses",
-		Region:    meta.(*conns.AWSClient).Region,
-		AccountID: meta.(*conns.AWSClient).AccountID,
-		Resource:  fmt.Sprintf("dedicated-ip-pool/%s", d.Id()),
-	}.String()
-	d.Set("arn", poolNameARN)
-
-	d.Set("dedicated_ips", flattenDedicatedIPs(out.DedicatedIps))
+	d.Set("dedicated_ips", flattenDedicatedIPs(outIP.DedicatedIps))
 
 	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
 	if err != nil {
@@ -112,4 +114,28 @@ func flattenDedicatedIPs(apiObjects []types.DedicatedIp) []interface{} {
 	}
 
 	return dedicatedIps
+}
+
+func findDedicatedIPPoolIPs(ctx context.Context, conn *sesv2.Client, poolName string) (*sesv2.GetDedicatedIpsOutput, error) {
+	in := &sesv2.GetDedicatedIpsInput{
+		PoolName: aws.String(poolName),
+	}
+	out, err := conn.GetDedicatedIps(ctx, in)
+	if err != nil {
+		var nfe *types.NotFoundException
+		if errors.As(err, &nfe) {
+			return nil, &resource.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
 }

--- a/internal/service/sesv2/dedicated_ip_pool_test.go
+++ b/internal/service/sesv2/dedicated_ip_pool_test.go
@@ -68,6 +68,41 @@ func TestAccSESV2DedicatedIPPool_disappears(t *testing.T) {
 	})
 }
 
+func TestAccSESV2DedicatedIPPool_scalingMode(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sesv2_dedicated_ip_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDedicatedIPPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDedicatedIPPoolConfig_scalingMode(rName, string(types.ScalingModeManaged)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDedicatedIPPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "pool_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "scaling_mode", string(types.ScalingModeManaged)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDedicatedIPPoolConfig_scalingMode(rName, string(types.ScalingModeStandard)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDedicatedIPPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "pool_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "scaling_mode", string(types.ScalingModeStandard)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccSESV2DedicatedIPPool_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
@@ -180,6 +215,15 @@ resource "aws_sesv2_dedicated_ip_pool" "test" {
   pool_name = %[1]q
 }
 `, rName)
+}
+
+func testAccDedicatedIPPoolConfig_scalingMode(rName, scalingMode string) string {
+	return fmt.Sprintf(`
+resource "aws_sesv2_dedicated_ip_pool" "test" {
+  pool_name    = %[1]q
+  scaling_mode = %[2]q
+}
+`, rName, scalingMode)
 }
 
 func testAccDedicatedIPPoolConfig_tags1(rName, tagKey1, tagValue1 string) string {

--- a/website/docs/d/sesv2_dedicated_ip_pool.html.markdown
+++ b/website/docs/d/sesv2_dedicated_ip_pool.html.markdown
@@ -32,6 +32,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - ARN of the Dedicated IP Pool.
 * `dedicated_ips` - A list of objects describing the pool's dedicated IP's. See [`dedicated_ips`](#dedicated_ips).
+* `scaling_mode` - (Optional) IP pool scaling mode. Valid values: `STANDARD`, `MANAGED`.
 * `tags` - A map of tags attached to the pool.
 
 ### dedicated_ips

--- a/website/docs/r/sesv2_dedicated_ip_pool.html.markdown
+++ b/website/docs/r/sesv2_dedicated_ip_pool.html.markdown
@@ -20,6 +20,15 @@ resource "aws_sesv2_dedicated_ip_pool" "example" {
 }
 ```
 
+### Managed Pool
+
+```terraform
+resource "aws_sesv2_dedicated_ip_pool" "example" {
+  pool_name    = "my-managed-pool"
+  scaling_mode = "MANAGED"
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -28,6 +37,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
+* `scaling_mode` - (Optional) IP pool scaling mode. Valid values: `STANDARD`, `MANAGED`. If omitted, the AWS API will default to a standard pool.
 * `tags` - (Optional) A map of tags to assign to the pool. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference


### PR DESCRIPTION
### Description
Adds support for the `scaling_mode` attribute released in [`v1.14.0` of the SES Go SDK](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/sesv2@v1.14.0#CreateDedicatedIpPoolInput).

### Relations
Relates #26796


### Output from Acceptance Testing
```console
$ make testacc PKG=sesv2 TESTS="TestAccSESV2DedicatedIPPool" ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sesv2/... -v -count 1 -parallel 2 -run='TestAccSESV2DedicatedIPPool'  -timeout 180m
=== RUN   TestAccSESV2DedicatedIPPoolDataSource_basic
=== PAUSE TestAccSESV2DedicatedIPPoolDataSource_basic
=== RUN   TestAccSESV2DedicatedIPPool_basic
=== PAUSE TestAccSESV2DedicatedIPPool_basic
=== RUN   TestAccSESV2DedicatedIPPool_disappears
=== PAUSE TestAccSESV2DedicatedIPPool_disappears
=== RUN   TestAccSESV2DedicatedIPPool_scalingMode
=== PAUSE TestAccSESV2DedicatedIPPool_scalingMode
=== RUN   TestAccSESV2DedicatedIPPool_tags
=== PAUSE TestAccSESV2DedicatedIPPool_tags
=== CONT  TestAccSESV2DedicatedIPPoolDataSource_basic
=== CONT  TestAccSESV2DedicatedIPPool_scalingMode
--- PASS: TestAccSESV2DedicatedIPPoolDataSource_basic (16.45s)
=== CONT  TestAccSESV2DedicatedIPPool_tags
--- PASS: TestAccSESV2DedicatedIPPool_scalingMode (26.68s)
=== CONT  TestAccSESV2DedicatedIPPool_disappears
--- PASS: TestAccSESV2DedicatedIPPool_disappears (10.16s)
=== CONT  TestAccSESV2DedicatedIPPool_basic
--- PASS: TestAccSESV2DedicatedIPPool_tags (34.71s)
--- PASS: TestAccSESV2DedicatedIPPool_basic (14.80s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sesv2	54.131s
```