### PR TITLE
fix resource/aws_ecs_service: make task_definition truly optional

### DIFF
--- a/.changelog/27390.txt
+++ b/.changelog/27390.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_service: Make `task_definition` optional. Make EXTERNAL deployments possible
+```

--- a/.changelog/27390.txt
+++ b/.changelog/27390.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_ecs_service: Make `task_definition` optional. Make EXTERNAL deployments possible
+resource/aws_ecs_service: Correctly handle unconfigured `task_definition`, making `EXTERNAL` deployments possible
 ```

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -419,9 +419,12 @@ func resourceServiceCreate(d *schema.ResourceData, meta interface{}) error {
 		DeploymentController: deploymentController,
 		SchedulingStrategy:   aws.String(schedulingStrategy),
 		ServiceName:          aws.String(d.Get("name").(string)),
-		TaskDefinition:       aws.String(d.Get("task_definition").(string)),
 		EnableECSManagedTags: aws.Bool(d.Get("enable_ecs_managed_tags").(bool)),
 		EnableExecuteCommand: aws.Bool(d.Get("enable_execute_command").(bool)),
+	}
+
+	if v, ok := d.GetOk("task_definition"); ok {
+		input.TaskDefinition = aws.String(v.(string))
 	}
 
 	if schedulingStrategy == ecs.SchedulingStrategyDaemon && deploymentMinimumHealthyPercent != 100 {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Make the `task_definition` for `aws_ecs_service` truly optional.

It is defined as so in the schema, but when preparing the request body to be sent to the AWS API, it was adding the taskDefinition parameter with an empty string.

AWS doesn't accept it when defining a Service with `Deployment=EXTERNAL`:
```
An error occurred (InvalidParameterException) when calling the CreateService operation: Family should not be null or empty.
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27362

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Not sure what's the best way to test this. The result of applying the ECS service doesn't change, only what is sent to the AWS API
```
```
