### PR TITLE
Updated CloudFront document example to fix a typo in the example for …

### DIFF
--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -46,7 +46,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
     domain_name              = aws_s3_bucket.b.bucket_regional_domain_name
     origin_access_control_id = aws_cloudfront_origin_access_control.default.id
-    origin_id                = locals.s3_origin_id
+    origin_id                = local.s3_origin_id
   }
 
   enabled             = true


### PR DESCRIPTION
…“aws_cloudfront_distribution”

This pull request fixes a typo in an example in the `aws_cloudfront_distribution` documentation.
This was raised in https://github.com/hashicorp/terraform-provider-aws/issues/27357

Closes #27357