### PR TITLE
r/aws_secretsmanager_(rotation|secret): Correct secrets rotation link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 ## 4.37.0 (Unreleased)
+
+ENHANCEMENTS:
+
+* resource/aws_ec2_transit_gateway: Add support to modify `amazon_side_asn` argument ([#27306](https://github.com/hashicorp/terraform-provider-aws/issues/27306))
+* resource/aws_evidently_project: Support configurable timeouts for create, update, and delete ([#27336](https://github.com/hashicorp/terraform-provider-aws/issues/27336))
+* resource/aws_network_interface_attachment: Added import capabilities for the resource ([#27364](https://github.com/hashicorp/terraform-provider-aws/issues/27364))
+
+BUG FIXES:
+
+* resource/aws_connect_contact_flow: Change `type` to ForceNew ([#27347](https://github.com/hashicorp/terraform-provider-aws/issues/27347))
+
 ## 4.36.1 (October 21, 2022)
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,4 @@
 ## 4.37.0 (Unreleased)
-
-ENHANCEMENTS:
-
-* resource/aws_ec2_transit_gateway: Add support to modify `amazon_side_asn` argument ([#27306](https://github.com/hashicorp/terraform-provider-aws/issues/27306))
-* resource/aws_evidently_project: Support configurable timeouts for create, update, and delete ([#27336](https://github.com/hashicorp/terraform-provider-aws/issues/27336))
-* resource/aws_network_interface_attachment: Added import capabilities for the resource ([#27364](https://github.com/hashicorp/terraform-provider-aws/issues/27364))
-
-BUG FIXES:
-
-* resource/aws_connect_contact_flow: Change `type` to ForceNew ([#27347](https://github.com/hashicorp/terraform-provider-aws/issues/27347))
-
 ## 4.36.1 (October 21, 2022)
 
 BUG FIXES:

--- a/website/docs/r/secretsmanager_secret.html.markdown
+++ b/website/docs/r/secretsmanager_secret.html.markdown
@@ -22,7 +22,7 @@ resource "aws_secretsmanager_secret" "example" {
 
 ### Rotation Configuration
 
-To enable automatic secret rotation, the Secrets Manager service requires usage of a Lambda function. The [Rotate Secrets section in the Secrets Manager User Guide](https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets_strategies.html) provides additional information about deploying a prebuilt Lambda functions for supported credential rotation (e.g., RDS) or deploying a custom Lambda function.
+To enable automatic secret rotation, the Secrets Manager service requires usage of a Lambda function. The [Rotate Secrets section in the Secrets Manager User Guide](https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets.html) provides additional information about deploying a prebuilt Lambda functions for supported credential rotation (e.g., RDS) or deploying a custom Lambda function.
 
 ~> **NOTE:** Configuring rotation causes the secret to rotate once as soon as you store the secret. Before you do this, you must ensure that all of your applications that use the credentials stored in the secret are updated to retrieve the secret from AWS Secrets Manager. The old credentials might no longer be usable after the initial rotation and any applications that you fail to update will break as soon as the old credentials are no longer valid.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes `markdown-link` error:

```
FILE: website/docs/r/secretsmanager_secret.html.markdown
  [✖] https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets_strategies.html → Status: 404

  6 links checked.

  ERROR: 1 dead links found!
  [✖] https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets_strategies.html → Status: 404
```
