### PR TITLE
r/aws_secretsmanager_rotation: Correct secrets rotation link

### DIFF
--- a/website/docs/r/secretsmanager_secret_rotation.html.markdown
+++ b/website/docs/r/secretsmanager_secret_rotation.html.markdown
@@ -27,7 +27,7 @@ resource "aws_secretsmanager_secret_rotation" "example" {
 
 ### Rotation Configuration
 
-To enable automatic secret rotation, the Secrets Manager service requires usage of a Lambda function. The [Rotate Secrets section in the Secrets Manager User Guide](https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets_strategies.html) provides additional information about deploying a prebuilt Lambda functions for supported credential rotation (e.g., RDS) or deploying a custom Lambda function.
+To enable automatic secret rotation, the Secrets Manager service requires usage of a Lambda function. The [Rotate Secrets section in the Secrets Manager User Guide](https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets.html) provides additional information about deploying a prebuilt Lambda functions for supported credential rotation (e.g., RDS) or deploying a custom Lambda function.
 
 ~> **NOTE:** Configuring rotation causes the secret to rotate once as soon as you enable rotation. Before you do this, you must ensure that all of your applications that use the credentials stored in the secret are updated to retrieve the secret from AWS Secrets Manager. The old credentials might no longer be usable after the initial rotation and any applications that you fail to update will break as soon as the old credentials are no longer valid.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes `markdown-link` error:

```
FILE: website/docs/r/secretsmanager_secret_rotation.html.markdown
  [✖] https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets_strategies.html → Status: 404

  3 links checked.

  ERROR: 1 dead links found!
  [✖] https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets_strategies.html → Status: 404
```
