### PR TITLE
aws_ec2_capacity_reservation placement_group_arn attribute support

### DIFF
--- a/.changelog/27458.txt
+++ b/.changelog/27458.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ec2_capacity_reservation: Add `placement_group_arn` argument
+```

--- a/internal/service/ec2/ec2_capacity_reservation.go
+++ b/internal/service/ec2/ec2_capacity_reservation.go
@@ -92,7 +92,7 @@ func ResourceCapacityReservation() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"placement_group_arm": {
+			"placement_group_arn": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: verify.ValidARN,

--- a/internal/service/ec2/ec2_capacity_reservation.go
+++ b/internal/service/ec2/ec2_capacity_reservation.go
@@ -92,6 +92,11 @@ func ResourceCapacityReservation() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"placement_group_arm": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: verify.ValidARN,
+			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 			"tenancy": {
@@ -139,6 +144,10 @@ func resourceCapacityReservationCreate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("outpost_arn"); ok {
 		input.OutpostArn = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("placement_group_arn"); ok {
+		input.PlacementGroupArn = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("tenancy"); ok {
@@ -194,6 +203,7 @@ func resourceCapacityReservationRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("instance_type", reservation.InstanceType)
 	d.Set("outpost_arn", reservation.OutpostArn)
 	d.Set("owner_id", reservation.OwnerId)
+	d.Set("placement_group_arn", reservation.PlacementGroupArn)
 	d.Set("tenancy", reservation.Tenancy)
 
 	tags := KeyValueTags(reservation.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)

--- a/internal/service/ec2/ec2_capacity_reservation_test.go
+++ b/internal/service/ec2/ec2_capacity_reservation_test.go
@@ -44,6 +44,7 @@ func TestAccEC2CapacityReservation_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "instance_type", "t2.micro"),
 					resource.TestCheckResourceAttr(resourceName, "outpost_arn", ""),
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
+					resource.TestCheckResourceAttr(resourceName, "placement_group_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tenancy", "default"),
 				),

--- a/website/docs/r/ec2_capacity_reservation.html.markdown
+++ b/website/docs/r/ec2_capacity_reservation.html.markdown
@@ -35,6 +35,7 @@ The following arguments are supported:
 * `instance_platform` - (Required) The type of operating system for which to reserve capacity. Valid options are `Linux/UNIX`, `Red Hat Enterprise Linux`, `SUSE Linux`, `Windows`, `Windows with SQL Server`, `Windows with SQL Server Enterprise`, `Windows with SQL Server Standard` or `Windows with SQL Server Web`.
 * `instance_type` - (Required) The instance type for which to reserve capacity.
 * `outpost_arn` - (Optional) The Amazon Resource Name (ARN) of the Outpost on which to create the Capacity Reservation.
+* `placement_group_arn` - (Optional) The Amazon Resource Name (ARN) of the cluster placement group in which to create the Capacity Reservation.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `tenancy` - (Optional) Indicates the tenancy of the Capacity Reservation. Specify either `default` or `dedicated`.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Adds support for placement_group_arn attribute
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/27429.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/cli/latest/reference/ec2/create-capacity-reservation.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
❯ make testacc TESTS=TestAccEC2CapacityReservation_basic PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2CapacityReservation_basic'  -timeout 180m
=== RUN   TestAccEC2CapacityReservation_basic
=== PAUSE TestAccEC2CapacityReservation_basic
=== CONT  TestAccEC2CapacityReservation_basic
--- PASS: TestAccEC2CapacityReservation_basic (19.41s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        19.476s

...
```
