### PR TITLE
New Resources: `aws_lightsail_lb_certificate` and `aws_lightsail_lb_certificate_attachment`

### DIFF
--- a/.changelog/27462.txt
+++ b/.changelog/27462.txt
@@ -1,0 +1,7 @@
+```release-note:new-resource
+aws_lightsail_lb_certificate
+```
+
+```release-note:new-resource
+aws_lightsail_lb_certificate_attachment
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1717,6 +1717,8 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_lightsail_key_pair":                             lightsail.ResourceKeyPair(),
 			"aws_lightsail_lb":                                   lightsail.ResourceLoadBalancer(),
 			"aws_lightsail_lb_attachment":                        lightsail.ResourceLoadBalancerAttachment(),
+			"aws_lightsail_lb_certificate":                       lightsail.ResourceLoadBalancerCertificate(),
+			"aws_lightsail_lb_certificate_attachment":            lightsail.ResourceLoadBalancerCertificateAttachment(),
 			"aws_lightsail_static_ip":                            lightsail.ResourceStaticIP(),
 			"aws_lightsail_static_ip_attachment":                 lightsail.ResourceStaticIPAttachment(),
 

--- a/internal/service/lightsail/consts.go
+++ b/internal/service/lightsail/consts.go
@@ -1,10 +1,12 @@
 package lightsail
 
 const (
-	ResCertificate            = "Certificate"
-	ResDatabase               = "Database"
-	ResTags                   = "Tags"
-	ResDomainEntry            = "Domain Entry"
-	ResLoadBalancer           = "Load Balancer"
-	ResLoadBalancerAttachment = "Load Balancer Attachment"
+	ResCertificate                       = "Certificate"
+	ResDatabase                          = "Database"
+	ResTags                              = "Tags"
+	ResDomainEntry                       = "Domain Entry"
+	ResLoadBalancer                      = "Load Balancer"
+	ResLoadBalancerAttachment            = "Load Balancer Attachment"
+	ResLoadBalancerCertificate           = "Load Balancer Certificate"
+	ResLoadBalancerCertificateAttachment = "Load Balancer Certificate Attachment"
 )

--- a/internal/service/lightsail/find.go
+++ b/internal/service/lightsail/find.go
@@ -290,7 +290,7 @@ func FindLoadBalancerCertificateAttachmentById(ctx context.Context, conn *lights
 	entryExists := false
 
 	for _, n := range out.TlsCertificates {
-		if cName == aws.StringValue(n.Name) && true == aws.BoolValue(n.IsAttached) {
+		if cName == aws.StringValue(n.Name) && aws.BoolValue(n.IsAttached) {
 			entry = n.Name
 			entryExists = true
 			break

--- a/internal/service/lightsail/lb_certificate.go
+++ b/internal/service/lightsail/lb_certificate.go
@@ -1,0 +1,252 @@
+package lightsail
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func ResourceLoadBalancerCertificate() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceLoadBalancerCertificateCreate,
+		ReadWithoutTimeout:   resourceLoadBalancerCertificateRead,
+		DeleteWithoutTimeout: resourceLoadBalancerCertificateDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_name": {
+				// AWS Provider 3.0.0 aws_route53_zone references no longer contain a
+				// trailing period, no longer requiring a custom StateFunc
+				// to prevent ACM API error
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringDoesNotMatch(regexp.MustCompile(`\.$`), "cannot end with a period"),
+			},
+			"domain_validation_records": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"domain_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_record_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_record_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_record_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+				Set: domainValidationOptionsHash,
+			},
+			"lb_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(2, 255),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]`), "must begin with an alphabetic character"),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]+[^._\-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
+				),
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(2, 255),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]`), "must begin with an alphabetic character"),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]+[^._\-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
+				),
+			},
+			"subject_alternative_names": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 253),
+						validation.StringDoesNotMatch(regexp.MustCompile(`\.$`), "cannot end with a period"),
+					),
+				},
+				Set: schema.HashString,
+			},
+			"support_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			// Tags are documented in the API, but not supported. API returns:
+			// An error occurred (InvalidInputException) when calling the TagResource operation: The resource type, LoadBalancerTlsCertificate, is not taggable.
+		},
+
+		CustomizeDiff: customdiff.Sequence(
+			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+				// Lightsail automatically adds the domain_name value to the list of SANs. Mimic Lightsail's behavior
+				// so that the user doesn't need to explicitly set it themselves.
+				if diff.HasChange("domain_name") || diff.HasChange("subject_alternative_names") {
+					domain_name := diff.Get("domain_name").(string)
+
+					if sanSet, ok := diff.Get("subject_alternative_names").(*schema.Set); ok {
+						sanSet.Add(domain_name)
+						if err := diff.SetNew("subject_alternative_names", sanSet); err != nil {
+							return fmt.Errorf("error setting new subject_alternative_names diff: %w", err)
+						}
+					}
+				}
+
+				return nil
+			},
+		),
+	}
+}
+
+func resourceLoadBalancerCertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	in := lightsail.CreateLoadBalancerTlsCertificateInput{
+		CertificateDomainName: aws.String(d.Get("domain_name").(string)),
+		CertificateName:       aws.String(d.Get("name").(string)),
+		LoadBalancerName:      aws.String(d.Get("lb_name").(string)),
+	}
+
+	if v, ok := d.GetOk("subject_alternative_names"); ok {
+		in.CertificateAlternativeNames = aws.StringSlice(expandSubjectAlternativeNames(v))
+	}
+
+	out, err := conn.CreateLoadBalancerTlsCertificateWithContext(ctx, &in)
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeCreateLoadBalancerTlsCertificate, ResLoadBalancerCertificate, d.Get("name").(string), err)
+	}
+
+	if len(out.Operations) == 0 {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeCreateLoadBalancerTlsCertificate, ResLoadBalancerCertificate, d.Get("name").(string), errors.New("No operations found for Create Load Balancer Certificate request"))
+	}
+
+	op := out.Operations[0]
+
+	err = waitOperation(conn, op.Id)
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeCreateLoadBalancerTlsCertificate, ResLoadBalancerCertificate, d.Get("name").(string), errors.New("Error waiting for Create Load Balancer request operation"))
+	}
+
+	// Generate an ID
+	vars := []string{
+		d.Get("lb_name").(string),
+		d.Get("name").(string),
+	}
+
+	d.SetId(strings.Join(vars, ","))
+
+	return resourceLoadBalancerCertificateRead(ctx, d, meta)
+}
+
+func resourceLoadBalancerCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	out, err := FindLoadBalancerCertificateById(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		create.LogNotFoundRemoveState(names.Lightsail, create.ErrActionReading, ResLoadBalancerCertificate, d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, create.ErrActionReading, ResLoadBalancerCertificate, d.Id(), err)
+	}
+
+	d.Set("arn", out.Arn)
+	d.Set("created_at", out.CreatedAt.Format(time.RFC3339))
+	d.Set("domain_name", out.DomainName)
+	d.Set("domain_validation_records", flattenLoadBalancerDomainValidationRecords(out.DomainValidationRecords))
+	d.Set("lb_name", out.LoadBalancerName)
+	d.Set("name", out.Name)
+	d.Set("subject_alternative_names", aws.StringValueSlice(out.SubjectAlternativeNames))
+	d.Set("support_code", out.SupportCode)
+
+	return nil
+}
+
+func resourceLoadBalancerCertificateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	id_parts := strings.SplitN(d.Id(), ",", -1)
+	lbName := id_parts[0]
+	cName := id_parts[1]
+
+	out, err := conn.DeleteLoadBalancerTlsCertificateWithContext(ctx, &lightsail.DeleteLoadBalancerTlsCertificateInput{
+		CertificateName:  aws.String(cName),
+		LoadBalancerName: aws.String(lbName),
+	})
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeDeleteLoadBalancerTlsCertificate, ResLoadBalancerCertificate, d.Get("name").(string), err)
+	}
+
+	if len(out.Operations) == 0 {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeDeleteLoadBalancerTlsCertificate, ResLoadBalancerCertificate, d.Get("name").(string), errors.New("No operations found for Delete Load Balancer Certificate request"))
+	}
+
+	op := out.Operations[0]
+
+	err = waitOperation(conn, op.Id)
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeCreateLoadBalancerTlsCertificate, ResLoadBalancerCertificate, d.Get("name").(string), errors.New("Error waiting for Delete Load Balancer Certificate request operation"))
+	}
+
+	return nil
+}
+
+func flattenLoadBalancerDomainValidationRecords(domainValidationRecords []*lightsail.LoadBalancerTlsCertificateDomainValidationRecord) []map[string]interface{} {
+	var domainValidationResult []map[string]interface{}
+
+	for _, o := range domainValidationRecords {
+		validationOption := map[string]interface{}{
+			"domain_name":           aws.StringValue(o.DomainName),
+			"resource_record_name":  aws.StringValue(o.Name),
+			"resource_record_type":  aws.StringValue(o.Type),
+			"resource_record_value": aws.StringValue(o.Value),
+		}
+		domainValidationResult = append(domainValidationResult, validationOption)
+	}
+
+	return domainValidationResult
+}

--- a/internal/service/lightsail/lb_certificate_attachment.go
+++ b/internal/service/lightsail/lb_certificate_attachment.go
@@ -1,0 +1,112 @@
+package lightsail
+
+import (
+	"context"
+	"errors"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func ResourceLoadBalancerCertificateAttachment() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceLoadBalancerCertificateAttachmentCreate,
+		ReadWithoutTimeout:   resourceLoadBalancerCertificateAttachmentRead,
+		DeleteWithoutTimeout: resourceLoadBalancerCertificateAttachmentDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"lb_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(2, 255),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]`), "must begin with an alphabetic character"),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]+[^._\-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
+				),
+			},
+			"certificate_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceLoadBalancerCertificateAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	req := lightsail.AttachLoadBalancerTlsCertificateInput{
+		LoadBalancerName: aws.String(d.Get("lb_name").(string)),
+		CertificateName:  aws.String(d.Get("certificate_name").(string)),
+	}
+
+	out, err := conn.AttachLoadBalancerTlsCertificateWithContext(ctx, &req)
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeAttachLoadBalancerTlsCertificate, ResLoadBalancerCertificateAttachment, d.Get("certificate_name").(string), err)
+	}
+
+	if len(out.Operations) == 0 {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeAttachLoadBalancerTlsCertificate, ResLoadBalancerCertificateAttachment, d.Get("certificate_name").(string), errors.New("No operations found for Attach Load Balancer Certificate to Load Balancer request"))
+	}
+
+	op := out.Operations[0]
+
+	err = waitOperation(conn, op.Id)
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeAttachLoadBalancerTlsCertificate, ResLoadBalancerCertificateAttachment, d.Get("certificate_name").(string), errors.New("Error waiting for Attach Load Balancer Certificate to Load Balancer request operation"))
+	}
+
+	// Generate an ID
+	vars := []string{
+		d.Get("lb_name").(string),
+		d.Get("certificate_name").(string),
+	}
+
+	d.SetId(strings.Join(vars, ","))
+
+	return resourceLoadBalancerCertificateAttachmentRead(ctx, d, meta)
+}
+
+func resourceLoadBalancerCertificateAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	out, err := FindLoadBalancerCertificateAttachmentById(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		create.LogNotFoundRemoveState(names.Lightsail, create.ErrActionReading, ResLoadBalancerCertificateAttachment, d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, create.ErrActionReading, ResLoadBalancerCertificateAttachment, d.Id(), err)
+	}
+
+	d.Set("certificate_name", out)
+	d.Set("lb_name", expandLoadBalancerNameFromId(d.Id()))
+
+	return nil
+}
+
+func resourceLoadBalancerCertificateAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[WARN] Cannot destroy Lightsail Load Balancer Certificate Attachment. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}

--- a/internal/service/lightsail/lb_certificate_attachment_test.go
+++ b/internal/service/lightsail/lb_certificate_attachment_test.go
@@ -1,0 +1,54 @@
+package lightsail_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccLightsailLoadBalancerCertificateAttachment_basic(t *testing.T) {
+	lbName := sdkacctest.RandomWithPrefix("tf-acc-test")
+	cName := sdkacctest.RandomWithPrefix("tf-acc-test")
+	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(lightsail.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, lightsail.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLoadBalancerCertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccLoadBalancerCertificateAttachmentConfig_basic(lbName, cName, domainName),
+				ExpectError: regexp.MustCompile(`Sorry, you can only attach a validated certificate to a load balancer.`),
+			},
+		},
+	})
+}
+
+func testAccLoadBalancerCertificateAttachmentConfig_basic(lbName string, cName string, domainName string) string {
+	return fmt.Sprintf(`
+resource "aws_lightsail_lb" "test" {
+  name              = %[1]q
+  health_check_path = "/"
+  instance_port     = "80"
+}
+resource "aws_lightsail_lb_certificate" "test" {
+	name        = %[2]q
+	lb_name = aws_lightsail_lb.test.id
+	domain_name = %[3]q
+  }
+resource "aws_lightsail_lb_certificate_attachment" "test" {
+  lb_name       = aws_lightsail_lb.test.name
+  certificate_name = aws_lightsail_lb_certificate.test.name
+}
+`, lbName, cName, domainName)
+}

--- a/internal/service/lightsail/lb_certificate_attachment_test.go
+++ b/internal/service/lightsail/lb_certificate_attachment_test.go
@@ -42,12 +42,12 @@ resource "aws_lightsail_lb" "test" {
   instance_port     = "80"
 }
 resource "aws_lightsail_lb_certificate" "test" {
-	name        = %[2]q
-	lb_name = aws_lightsail_lb.test.id
-	domain_name = %[3]q
-  }
+  name        = %[2]q
+  lb_name     = aws_lightsail_lb.test.id
+  domain_name = %[3]q
+}
 resource "aws_lightsail_lb_certificate_attachment" "test" {
-  lb_name       = aws_lightsail_lb.test.name
+  lb_name          = aws_lightsail_lb.test.name
   certificate_name = aws_lightsail_lb_certificate.test.name
 }
 `, lbName, cName, domainName)

--- a/internal/service/lightsail/lb_certificate_test.go
+++ b/internal/service/lightsail/lb_certificate_test.go
@@ -209,9 +209,9 @@ func testAccCheckLoadBalancerCertificateExists(n string, certificate *lightsail.
 func testAccLoadBalancerCertificateConfigBase(lbName string) string {
 	return fmt.Sprintf(`
 resource "aws_lightsail_lb" "test" {
-	name              = %[1]q
-	health_check_path = "/"
-	instance_port     = "80"
+  name              = %[1]q
+  health_check_path = "/"
+  instance_port     = "80"
 }
 `, lbName)
 }
@@ -222,7 +222,7 @@ func testAccLoadBalancerCertificateConfig_basic(rName string, lbName string, dom
 		fmt.Sprintf(`
 resource "aws_lightsail_lb_certificate" "test" {
   name        = %[1]q
-  lb_name = aws_lightsail_lb.test.id
+  lb_name     = aws_lightsail_lb.test.id
   domain_name = %[2]q
 }
 `, rName, domainName))
@@ -234,7 +234,7 @@ func testAccLoadBalancerCertificateConfig_subjectAlternativeNames(rName string, 
 		fmt.Sprintf(`
 resource "aws_lightsail_lb_certificate" "test" {
   name                      = %[1]q
-  lb_name = aws_lightsail_lb.test.id
+  lb_name                   = aws_lightsail_lb.test.id
   domain_name               = %[2]q
   subject_alternative_names = [%[3]q]
 }

--- a/internal/service/lightsail/lb_certificate_test.go
+++ b/internal/service/lightsail/lb_certificate_test.go
@@ -1,0 +1,242 @@
+package lightsail_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tflightsail "github.com/hashicorp/terraform-provider-aws/internal/service/lightsail"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccLightsailLoadBalancerCertificate_basic(t *testing.T) {
+	var certificate lightsail.LoadBalancerTlsCertificate
+	resourceName := "aws_lightsail_lb_certificate.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	lbName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(lightsail.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, lightsail.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLoadBalancerCertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoadBalancerCertificateConfig_basic(rName, lbName, domainName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLoadBalancerCertificateExists(resourceName, &certificate),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "lightsail", regexp.MustCompile(`LoadBalancerTlsCertificate/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", domainName),
+					resource.TestCheckResourceAttr(resourceName, "subject_alternative_names.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", domainName),
+					// When using a .test domain, Domain Validation Records return a single FAILED entry
+					resource.TestCheckResourceAttr(resourceName, "domain_validation_records.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLightsailLoadBalancerCertificate_subjectAlternativeNames(t *testing.T) {
+	var certificate lightsail.LoadBalancerTlsCertificate
+	resourceName := "aws_lightsail_lb_certificate.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	lbName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName())
+	subjectAlternativeName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(lightsail.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, lightsail.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLoadBalancerCertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoadBalancerCertificateConfig_subjectAlternativeNames(rName, lbName, domainName, subjectAlternativeName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLoadBalancerCertificateExists(resourceName, &certificate),
+					resource.TestCheckResourceAttr(resourceName, "subject_alternative_names.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", subjectAlternativeName),
+					resource.TestCheckTypeSetElemAttr(resourceName, "subject_alternative_names.*", domainName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLightsailLoadBalancerCertificate_domainValidationRecords(t *testing.T) {
+	var certificate lightsail.LoadBalancerTlsCertificate
+	resourceName := "aws_lightsail_lb_certificate.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	lbName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	// Lightsail will only return Domain Validation Options when using a non-test domain.
+	// We need to provide a non-test domain in order to test these values.
+	domainName := fmt.Sprintf("%s.com", acctest.ResourcePrefix)
+	subjectAlternativeName := fmt.Sprintf("%s.com", acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(lightsail.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, lightsail.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLoadBalancerCertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoadBalancerCertificateConfig_subjectAlternativeNames(rName, lbName, domainName, subjectAlternativeName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLoadBalancerCertificateExists(resourceName, &certificate),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_records.*", map[string]string{
+						"domain_name":          domainName,
+						"resource_record_type": "CNAME",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "domain_validation_records.*", map[string]string{
+						"domain_name":          subjectAlternativeName,
+						"resource_record_type": "CNAME",
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLightsailLoadBalancerCertificate_disappears(t *testing.T) {
+	var certificate lightsail.LoadBalancerTlsCertificate
+	resourceName := "aws_lightsail_lb_certificate.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	lbName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	domainName := acctest.ACMCertificateRandomSubDomain(acctest.RandomDomainName())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(lightsail.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, lightsail.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLoadBalancerCertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoadBalancerCertificateConfig_basic(rName, lbName, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoadBalancerCertificateExists(resourceName, &certificate),
+					acctest.CheckResourceDisappears(acctest.Provider, tflightsail.ResourceLoadBalancerCertificate(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckLoadBalancerCertificateDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_lightsail_lb_certificate" {
+			continue
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LightsailConn
+
+		_, err := tflightsail.FindLoadBalancerCertificateById(context.Background(), conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return create.Error(names.Lightsail, create.ErrActionCheckingDestroyed, tflightsail.ResLoadBalancerCertificate, rs.Primary.ID, errors.New("still exists"))
+	}
+
+	return nil
+}
+
+func testAccCheckLoadBalancerCertificateExists(n string, certificate *lightsail.LoadBalancerTlsCertificate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No Certificate ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LightsailConn
+
+		respCertificate, err := tflightsail.FindLoadBalancerCertificateById(context.Background(), conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if respCertificate == nil {
+			return fmt.Errorf("Load Balancer Certificate %q does not exist", rs.Primary.ID)
+		}
+
+		*certificate = *respCertificate
+
+		return nil
+	}
+}
+
+func testAccLoadBalancerCertificateConfigBase(lbName string) string {
+	return fmt.Sprintf(`
+resource "aws_lightsail_lb" "test" {
+	name              = %[1]q
+	health_check_path = "/"
+	instance_port     = "80"
+}
+`, lbName)
+}
+
+func testAccLoadBalancerCertificateConfig_basic(rName string, lbName string, domainName string) string {
+	return acctest.ConfigCompose(
+		testAccLoadBalancerCertificateConfigBase(lbName),
+		fmt.Sprintf(`
+resource "aws_lightsail_lb_certificate" "test" {
+  name        = %[1]q
+  lb_name = aws_lightsail_lb.test.id
+  domain_name = %[2]q
+}
+`, rName, domainName))
+}
+
+func testAccLoadBalancerCertificateConfig_subjectAlternativeNames(rName string, lbName string, domainName string, san string) string {
+	return acctest.ConfigCompose(
+		testAccLoadBalancerCertificateConfigBase(lbName),
+		fmt.Sprintf(`
+resource "aws_lightsail_lb_certificate" "test" {
+  name                      = %[1]q
+  lb_name = aws_lightsail_lb.test.id
+  domain_name               = %[2]q
+  subject_alternative_names = [%[3]q]
+}
+`, rName, domainName, san))
+}

--- a/website/docs/r/lightsail_lb_certificate.html.markdown
+++ b/website/docs/r/lightsail_lb_certificate.html.markdown
@@ -1,0 +1,57 @@
+---
+subcategory: "Lightsail"
+layout: "aws"
+page_title: "AWS: aws_lightsail_lb_certificate"
+description: |-
+  Provides a Lightsail Load Balancer
+---
+
+# Resource: aws_lightsail_lb_certificate
+
+Creates a Lightsail load balancer Certificate resource.
+
+## Example Usage
+
+```terraform
+resource "aws_lightsail_lb" "test" {
+  name              = "test-load-balancer"
+  health_check_path = "/"
+  instance_port     = "80"
+  tags = {
+    foo = "bar"
+  }
+}
+
+resource "aws_lightsail_lb_certificate" "test" {
+  name        = "test-load-balancer-certificate"
+  lb_name     = aws_lightsail_lb.test.id
+  domain_name = "test.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_name` - (Required) The domain name (e.g., example.com) for your SSL/TLS certificate.
+* `lb_name` - (Required) The load balancer name where you want to create the SSL/TLS certificate.
+* `name` - (Required) The SSL/TLS certificate name.
+* `name` - (Required) The SSL/TLS certificate name.
+* `subject_alternative_names` - (Optional) Set of domains that should be SANs in the issued certificate. `domain_name` attribute is automatically added as a Subject Alternative Name.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A combination of attributes to create a unique id: `lb_name`,`name`
+* `arn` - The ARN of the lightsail certificate.
+* `created_at` - The timestamp when the instance was created.
+* `domain_validation_options` - Set of domain validation objects which can be used to complete certificate validation. Can have more than one element, e.g., if SANs are defined.
+
+## Import
+
+`aws_lightsail_lb_certificate` can be imported by using the id attribute, e.g.,
+
+```
+$ terraform import aws_lightsail_lb_certificate.test example-load-balancer,example-load-balancer-certificate
+```

--- a/website/docs/r/lightsail_lb_certificate_attachment.html.markdown
+++ b/website/docs/r/lightsail_lb_certificate_attachment.html.markdown
@@ -1,0 +1,56 @@
+---
+subcategory: "Lightsail"
+layout: "aws"
+page_title: "AWS: aws_lightsail_lb_certificate_attachment"
+description: |-
+  Attaches a Lightsail Load Balancer Certificate to a Lightsail Load Balancer
+---
+
+# Resource: aws_lightsail_lb_certificate_attachment
+
+Attaches a Lightsail Load Balancer Certificate to a Lightsail Load Balancer.
+
+## Example Usage
+
+```terraform
+resource "aws_lightsail_lb" "test" {
+  name              = "test-load-balancer"
+  health_check_path = "/"
+  instance_port     = "80"
+  tags = {
+    foo = "bar"
+  }
+}
+
+resource "aws_lightsail_lb_certificate" "test" {
+  name        = "test-load-balancer-certificate"
+  lb_name     = aws_lightsail_lb.test.id
+  domain_name = "test.com"
+}
+
+resource "aws_lightsail_lb_certificate_attachment" "test" {
+  lb_name          = aws_lightsail_lb.test.name
+  certificate_name = aws_lightsail_lb_certificate.test.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `lb_name` - (Required) The name of the load balancer to which you want to associate the SSL/TLS certificate.
+* `certificate_name` - (Required) The name of your SSL/TLS certificate.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A combination of attributes to create a unique id: `lb_name`,`certificate_name`
+
+## Import
+
+`aws_lightsail_lb_certificate_attachment` can be imported by using the name attribute, e.g.,
+
+```
+$ terraform import aws_lightsail_lb_certificate_attachment.test example-load-balancer,example-certificate
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This Pull request provides the following two resources:
`aws_lightsail_lb_certificate` and `aws_lightsail_lb_certificate_attachment`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

None

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make testacc TESTARGS='-run=TestAccLightsailLoadBalancerCertificate_' PKG=lightsail 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lightsail/... -v -count 1 -parallel 20  -run=TestAccLightsailLoadBalancerCertificate_ -timeout 180m
=== RUN   TestAccLightsailLoadBalancerCertificate_basic
=== PAUSE TestAccLightsailLoadBalancerCertificate_basic
=== RUN   TestAccLightsailLoadBalancerCertificate_subjectAlternativeNames
=== PAUSE TestAccLightsailLoadBalancerCertificate_subjectAlternativeNames
=== RUN   TestAccLightsailLoadBalancerCertificate_domainValidationRecords
=== PAUSE TestAccLightsailLoadBalancerCertificate_domainValidationRecords
=== RUN   TestAccLightsailLoadBalancerCertificate_disappears
=== PAUSE TestAccLightsailLoadBalancerCertificate_disappears
=== CONT  TestAccLightsailLoadBalancerCertificate_basic
=== CONT  TestAccLightsailLoadBalancerCertificate_domainValidationRecords
=== CONT  TestAccLightsailLoadBalancerCertificate_disappears
=== CONT  TestAccLightsailLoadBalancerCertificate_subjectAlternativeNames
--- PASS: TestAccLightsailLoadBalancerCertificate_disappears (148.74s)
--- PASS: TestAccLightsailLoadBalancerCertificate_basic (158.16s)
--- PASS: TestAccLightsailLoadBalancerCertificate_domainValidationRecords (158.31s)
--- PASS: TestAccLightsailLoadBalancerCertificate_subjectAlternativeNames (160.80s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  162.733s

make testacc TESTARGS='-run=TestAccLightsailLoadBalancerCertificateAttachment_' PKG=lightsail
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lightsail/... -v -count 1 -parallel 20  -run=TestAccLightsailLoadBalancerCertificateAttachment_ -timeout 180m
=== RUN   TestAccLightsailLoadBalancerCertificateAttachment_basic
=== PAUSE TestAccLightsailLoadBalancerCertificateAttachment_basic
=== CONT  TestAccLightsailLoadBalancerCertificateAttachment_basic
--- PASS: TestAccLightsailLoadBalancerCertificateAttachment_basic (184.14s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  186.107s

...
```
