### PR TITLE
BugFix: Resolve import issues on `aws_lb_target_group` when specifying `ip_address_type` of `ipv4`

### DIFF
--- a/.changelog/27464.txt
+++ b/.changelog/27464.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lb_target_group: Fix import issues on `aws_lb_target_group` when specifying `ip_address_type` of `ipv4`
+```

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -913,6 +913,7 @@ func flattenTargetGroupResource(d *schema.ResourceData, meta interface{}, target
 	d.Set("arn_suffix", TargetGroupSuffixFromARN(targetGroup.TargetGroupArn))
 	d.Set("name", targetGroup.TargetGroupName)
 	d.Set("target_type", targetGroup.TargetType)
+	d.Set("ip_address_type", targetGroup.IpAddressType)
 
 	if err := d.Set("health_check", flattenLbTargetGroupHealthCheck(targetGroup)); err != nil {
 		return fmt.Errorf("setting health_check: %w", err)

--- a/internal/service/elbv2/target_group_test.go
+++ b/internal/service/elbv2/target_group_test.go
@@ -273,6 +273,17 @@ func TestAccELBV2TargetGroup_ipAddressType(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ip_address_type", "ipv6"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"connection_termination",
+					"lambda_multi_value_headers_enabled",
+					"proxy_protocol_v2",
+					"slow_start",
+				},
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds the reading and setting of the `ip_address_type` value during the resource read.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27463

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make testacc TESTARGS='-run=TestAccELBV2TargetGroup_ipAddressType' PKG=elbv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20  -run=TestAccELBV2TargetGroup_ipAddressType -timeout 180m
=== RUN   TestAccELBV2TargetGroup_ipAddressType
=== PAUSE TestAccELBV2TargetGroup_ipAddressType
=== CONT  TestAccELBV2TargetGroup_ipAddressType
--- PASS: TestAccELBV2TargetGroup_ipAddressType (22.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      23.960s

...
```
