### PR TITLE
Route53/TrafficPolicyDocument - fixes the JSON output for GeoproximityLocations config block

### DIFF
--- a/.changelog/27473.txt
+++ b/.changelog/27473.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/route53: Fixed incorrect capitalization for GeoproximityLocations
+```

--- a/.changelog/27473.txt
+++ b/.changelog/27473.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/route53: Fixed incorrect capitalization for GeoproximityLocations
+data-source/aws_route53_traffic_policy_document: Fixed incorrect capitalization for `GeoproximityLocations`
 ```

--- a/internal/service/route53/traffic_policy_document_data_source_test.go
+++ b/internal/service/route53/traffic_policy_document_data_source_test.go
@@ -124,6 +124,20 @@ func testAccTrafficPolicyDocumentConfigCompleteExpectedJSON() string {
         {
           "RuleReference":"region_selector",
           "Country":"US"
+        },
+        {
+          "RuleReference":"geoproximity_selector",
+          "Country":"UK"
+        }
+      ]
+    },
+    "geoproximity_selector": {
+      "RuleType": "geoproximity",
+      "GeoproximityLocations": [
+        {
+          "EndpointReference": "denied_message",
+          "Latitude": "51.50",
+          "Longitude": "-0.07"
         }
       ]
     },
@@ -244,6 +258,23 @@ data "aws_route53_traffic_policy_document" "test" {
       rule_reference = "region_selector"
       country        = "US"
     }
+    location {
+      rule_reference = "geoproximity_selector"
+      country        = "UK"
+    }
+  }
+
+  rule {
+    id   = "geoproximity_selector"
+    type = "geoproximity"
+
+    geo_proximity_location {
+      longitude              = "-0.07"
+      latitude               = "51.50"
+      endpoint_reference     = "denied_message"
+
+    }
+
   }
   rule {
     id   = "region_selector"

--- a/internal/service/route53/traffic_policy_document_data_source_test.go
+++ b/internal/service/route53/traffic_policy_document_data_source_test.go
@@ -269,13 +269,12 @@ data "aws_route53_traffic_policy_document" "test" {
     type = "geoproximity"
 
     geo_proximity_location {
-      longitude              = "-0.07"
-      latitude               = "51.50"
-      endpoint_reference     = "denied_message"
-
+      longitude          = "-0.07"
+      latitude           = "51.50"
+      endpoint_reference = "denied_message"
     }
-
   }
+
   rule {
     id   = "region_selector"
     type = "latency"
@@ -289,6 +288,7 @@ data "aws_route53_traffic_policy_document" "test" {
       rule_reference = "west_coast_region"
     }
   }
+
   rule {
     id   = "east_coast_region"
     type = "failover"
@@ -300,6 +300,7 @@ data "aws_route53_traffic_policy_document" "test" {
       endpoint_reference = "east_coast_lb2"
     }
   }
+
   rule {
     id   = "west_coast_region"
     type = "failover"

--- a/internal/service/route53/traffic_policy_document_model.go
+++ b/internal/service/route53/traffic_policy_document_model.go
@@ -37,7 +37,7 @@ type TrafficPolicyRule struct {
 	Primary               *TrafficPolicyFailoverRule           `json:",omitempty"`
 	Secondary             *TrafficPolicyFailoverRule           `json:",omitempty"`
 	Locations             []*TrafficPolicyGeolocationRule      `json:",omitempty"`
-	GeoProximityLocations []*TrafficPolicyGeoproximityRule     `json:",omitempty"`
+	GeoProximityLocations []*TrafficPolicyGeoproximityRule     `json:"GeoproximityLocations,omitempty"`
 	Regions               []*TrafficPolicyLatencyRule          `json:",omitempty"`
 	Items                 []*TrafficPolicyMultiValueAnswerRule `json:",omitempty"`
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Small change that corrects the generated JSON for Route53 Traffic Policy document - Changed the capitalization of the `GeoproximityLocations` stanza to match the documentation and ensures the resource is correctly provisioned. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #26481

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

* [Route53 Traffic Policy document format](https://docs.aws.amazon.com/Route53/latest/APIReference/api-policies-traffic-policy-document-format.html#traffic-policy-document-format-rules-geoproximity)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$  make testacc TESTS=TestAccRoute53TrafficPolicyDocumentDataSource_complete PKG=route53
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53/... -v -count 1 -parallel 20 -run='TestAccRoute53TrafficPolicyDocumentDataSource_complete'  -timeout 180m
=== RUN   TestAccRoute53TrafficPolicyDocumentDataSource_complete
=== PAUSE TestAccRoute53TrafficPolicyDocumentDataSource_complete
=== CONT  TestAccRoute53TrafficPolicyDocumentDataSource_complete
--- PASS: TestAccRoute53TrafficPolicyDocumentDataSource_complete (8.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	11.141s
...
```
