### PR TITLE
Remove `role_arn` argument from `aws_sagemaker_device` documentation

### DIFF
--- a/website/docs/r/sagemaker_device.html.markdown
+++ b/website/docs/r/sagemaker_device.html.markdown
@@ -29,7 +29,6 @@ resource "aws_sagemaker_device" "example" {
 The following arguments are supported:
 
 * `device_fleet_name` - (Required) The name of the Device Fleet.
-* `role_arn` - (Required) The Amazon Resource Name (ARN) that has access to AWS Internet of Things (IoT).
 * `device` - (Required) The device to register with SageMaker Edge Manager. See [Device](#device) details below.
 
 ### Device


### PR DESCRIPTION
### Description

This PR removes the `role_arn` argument from the [`aws_sagemaker_device` documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sagemaker_device), as this is not a valid argument for this resource.

### Relations

Closes #27434

### References

- [Resource Schema](https://github.com/hashicorp/terraform-provider-aws/blob/1cc3df8cb69be164206aef7142c4e1e118b4eafe/internal/service/sagemaker/device.go#L28-L71)
- [`sagemaker.RegisterDevicesInput` type definition](https://docs.aws.amazon.com/sdk-for-go/api/service/sagemaker/#RegisterDevicesInput)


### Output from Acceptance Testing

N/a, docs