### PR TITLE
Documentation update for Route53 Traffic Policy data source

### DIFF
--- a/website/docs/d/route53_traffic_policy_document.html.markdown
+++ b/website/docs/d/route53_traffic_policy_document.html.markdown
@@ -53,6 +53,91 @@ resource "aws_route53_traffic_policy" "example" {
 }
 ```
 
+### Complex Example
+
+The following example showcases the use of nested rules within the traffic policy document and introduces the `geoproximity` rule type.
+
+```terraform
+data "aws_route53_traffic_policy_document" "example" {
+  record_type = "A"
+  start_rule  = "geoproximity_rule"
+
+  # NA Region endpoints
+  endpoint {
+    id    = "na_endpoint_a"
+    type  = "elastic-load-balancer"
+    value = "elb-111111.us-west-1.elb.amazonaws.com"
+  }
+
+  endpoint {
+    id    = "na_endpoint_b"
+    type  = "elastic-load-balancer"
+    value = "elb-222222.us-west-1.elb.amazonaws.com"
+  }
+
+  # EU Region endpoint
+  endpoint {
+    id    = "eu_endpoint"
+    type  = "elastic-load-balancer"
+    value = "elb-333333.eu-west-1.elb.amazonaws.com"
+  }
+
+  # AP Region endpoint
+  endpoint {
+    id    = "ap_endpoint"
+    type  = "elastic-load-balancer"
+    value = "elb-444444.ap-northeast-2.elb.amazonaws.com"
+  }
+
+  rule {
+    id   = "na_rule"
+    type = "failover"
+
+    primary {
+      endpoint_reference = "na_endpoint_a"
+    }
+
+    secondary {
+      endpoint_reference = "na_endpoint_b"
+    }
+
+  }
+
+  rule {
+    id   = "geoproximity_rule"
+    type = "geoproximity"
+
+    geo_proximity_location {
+      region                 = "aws:route53:us-west-1"
+      bias                   = 10
+      evaluate_target_health = true
+      rule_reference         = "na_rule"
+    }
+
+    geo_proximity_location {
+      region                 = "aws:route53:eu-west-1"
+      bias                   = 10
+      evaluate_target_health = true
+      endpoint_reference     = "eu_endpoint"
+    }
+
+    geo_proximity_location {
+      region                 = "aws:route53:ap-northeast-2"
+      bias                   = 0
+      evaluate_target_health = true
+      endpoint_reference     = "ap_endpoint"
+    }
+  }
+
+}
+
+resource "aws_route53_traffic_policy" "example" {
+  name     = "example"
+  comment  = "example comment"
+  document = data.aws_route53_traffic_policy_document.example.json
+}
+```
+
 ## Argument Reference
 
 The following arguments are optional:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Added an example of a complex traffic policy with nested rules while showcasing the use of the `geoproximity` rule type. The coded example builds on the details provided in the AWS documentation for [Geoproximity routing policy](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-geoproximity.html)


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

N/A

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

* https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-geoproximity.html
### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

N/A
