### PR TITLE
d/Add examples for retrieving managed CloudFront policies

### DIFF
--- a/website/docs/d/cloudfront_cache_policy.html.markdown
+++ b/website/docs/d/cloudfront_cache_policy.html.markdown
@@ -13,6 +13,7 @@ Use this data source to retrieve information about a CloudFront cache policy.
 ## Example Usage
 
 This example shows how to retrieve a custom cache policy:
+
 ```terraform
 data "aws_cloudfront_cache_policy" "example" {
   name = "example-policy"
@@ -20,6 +21,7 @@ data "aws_cloudfront_cache_policy" "example" {
 ```
 
 To retrieve an AWS-managed cache policy, use the following syntax:
+
 ```terraform
 data "aws_cloudfront_cache_policy" "example" {
   name = "Managed-CachingOptimized"

--- a/website/docs/d/cloudfront_cache_policy.html.markdown
+++ b/website/docs/d/cloudfront_cache_policy.html.markdown
@@ -12,9 +12,17 @@ Use this data source to retrieve information about a CloudFront cache policy.
 
 ## Example Usage
 
+This example shows how to retrieve a custom cache policy:
 ```terraform
 data "aws_cloudfront_cache_policy" "example" {
   name = "example-policy"
+}
+```
+
+To retrieve an AWS-managed cache policy, use the following syntax:
+```terraform
+data "aws_cloudfront_cache_policy" "example" {
+  name = "Managed-CachingOptimized"
 }
 ```
 

--- a/website/docs/d/cloudfront_cache_policy.html.markdown
+++ b/website/docs/d/cloudfront_cache_policy.html.markdown
@@ -12,7 +12,7 @@ Use this data source to retrieve information about a CloudFront cache policy.
 
 ## Example Usage
 
-This example shows how to retrieve a custom cache policy:
+### Basic Usage
 
 ```terraform
 data "aws_cloudfront_cache_policy" "example" {
@@ -20,7 +20,9 @@ data "aws_cloudfront_cache_policy" "example" {
 }
 ```
 
-To retrieve an AWS-managed cache policy, use the following syntax:
+### AWS-Managed Policies
+
+AWS managed cache policy names are prefixed with `Managed-`:
 
 ```terraform
 data "aws_cloudfront_cache_policy" "example" {

--- a/website/docs/d/cloudfront_origin_request_policy.html.markdown
+++ b/website/docs/d/cloudfront_origin_request_policy.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 ## Example Usage
 
-This example shows how to retrieve a custom origin request policy:
+### Basic Usage
 
 ```terraform
 data "aws_cloudfront_origin_request_policy" "example" {
@@ -18,7 +18,9 @@ data "aws_cloudfront_origin_request_policy" "example" {
 }
 ```
 
-To retrieve an AWS-managed origin request policy, use the following syntax:
+### AWS-Managed Policies
+
+AWS managed origin request policy names are prefixed with `Managed-`:
 
 ```terraform
 data "aws_cloudfront_origin_request_policy" "ua_referer" {

--- a/website/docs/d/cloudfront_origin_request_policy.html.markdown
+++ b/website/docs/d/cloudfront_origin_request_policy.html.markdown
@@ -10,7 +10,6 @@ description: |-
 
 ## Example Usage
 
-
 This example shows how to retrieve a custom origin request policy:
 
 ```terraform

--- a/website/docs/d/cloudfront_origin_request_policy.html.markdown
+++ b/website/docs/d/cloudfront_origin_request_policy.html.markdown
@@ -12,6 +12,7 @@ description: |-
 
 
 This example shows how to retrieve a custom origin request policy:
+
 ```terraform
 data "aws_cloudfront_origin_request_policy" "example" {
   name = "example-policy"
@@ -19,6 +20,7 @@ data "aws_cloudfront_origin_request_policy" "example" {
 ```
 
 To retrieve an AWS-managed origin request policy, use the following syntax:
+
 ```terraform
 data "aws_cloudfront_origin_request_policy" "ua_referer" {
   name = "Managed-UserAgentRefererHeaders"

--- a/website/docs/d/cloudfront_origin_request_policy.html.markdown
+++ b/website/docs/d/cloudfront_origin_request_policy.html.markdown
@@ -10,13 +10,19 @@ description: |-
 
 ## Example Usage
 
-The following example below creates a CloudFront origin request policy.
 
+This example shows how to retrieve a custom origin request policy:
 ```terraform
 data "aws_cloudfront_origin_request_policy" "example" {
   name = "example-policy"
 }
+```
 
+To retrieve an AWS-managed origin request policy, use the following syntax:
+```terraform
+data "aws_cloudfront_origin_request_policy" "ua_referer" {
+  name = "Managed-UserAgentRefererHeaders"
+}
 ```
 
 ## Argument Reference

--- a/website/docs/d/cloudfront_response_headers_policy.html.markdown
+++ b/website/docs/d/cloudfront_response_headers_policy.html.markdown
@@ -12,9 +12,21 @@ Use this data source to retrieve information about a CloudFront cache policy.
 
 ## Example Usage
 
+### Basic Usage
+
 ```terraform
 data "aws_cloudfront_response_headers_policy" "example" {
   name = "example-policy"
+}
+```
+
+### AWS-Managed Policies
+
+AWS managed response header policy names are prefixed with `Managed-`:
+
+```terraform
+data "aws_cloudfront_response_headers_policy" "example" {
+  name = "Managed-SimpleCORS"
 }
 ```
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR adds examples for retrieving managed CloudFront cache and origin request policies.

The syntax is somewhat obscure, and it doesn't look like it's explained anywhere.
I found it buried a Reddit discussion. Not the first place I would look at...

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27492 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://www.reddit.com/r/Terraform/comments/qzqt8a/how_to_get_cache_policy_id_for_cloudfront/

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
N/A