### PR TITLE
resource/aws_elasticache_global_replication_group: Allow configuring shards

### DIFF
--- a/.changelog/27500.txt
+++ b/.changelog/27500.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_elasticache_global_replication_group: Add `global_node_groups` and `num_node_groups` arguments
+```
+
+```release-note:enhancement
+resource/aws_elasticache_global_replication_group: Add timeouts.
+```

--- a/internal/service/elasticache/global_replication_group_test.go
+++ b/internal/service/elasticache/global_replication_group_test.go
@@ -59,6 +59,8 @@ func TestAccElastiCacheGlobalReplicationGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "global_replication_group_id_suffix", rName),
 					resource.TestMatchResourceAttr(resourceName, "global_replication_group_id", regexp.MustCompile(tfelasticache.GlobalReplicationGroupRegionPrefixFormat+rName)),
 					resource.TestCheckResourceAttr(resourceName, "global_replication_group_description", tfelasticache.EmptyDescription),
+					resource.TestCheckResourceAttr(resourceName, "global_node_groups.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "0"),
 					resource.TestCheckResourceAttr(resourceName, "primary_replication_group_id", primaryReplicationGroupId),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", "false"),
 				),
@@ -501,7 +503,7 @@ func TestAccElastiCacheGlobalReplicationGroup_ReplaceSecondary_differentRegion(t
 	})
 }
 
-func TestAccElastiCacheGlobalReplicationGroup_clusterMode(t *testing.T) {
+func TestAccElastiCacheGlobalReplicationGroup_clusterMode_basic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -527,6 +529,8 @@ func TestAccElastiCacheGlobalReplicationGroup_clusterMode(t *testing.T) {
 					testAccCheckReplicationGroupExists(primaryReplicationGroupResourceName, &primaryReplicationGroup),
 					resource.TestCheckResourceAttrPair(resourceName, "automatic_failover_enabled", primaryReplicationGroupResourceName, "automatic_failover_enabled"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "global_node_groups.#", primaryReplicationGroupResourceName, "num_node_groups"),
+					resource.TestCheckResourceAttrPair(resourceName, "num_node_groups", primaryReplicationGroupResourceName, "num_node_groups"),
 				),
 			},
 			{
@@ -1601,10 +1605,8 @@ resource "aws_elasticache_replication_group" "test" {
 
   parameter_group_name       = "default.redis6.x.cluster.on"
   automatic_failover_enabled = true
-  cluster_mode {
-    num_node_groups         = 2
-    replicas_per_node_group = 1
-  }
+  num_node_groups            = 2
+  replicas_per_node_group    = 1
 }
 `, rName)
 }

--- a/internal/service/elasticache/global_replication_group_test.go
+++ b/internal/service/elasticache/global_replication_group_test.go
@@ -657,7 +657,7 @@ func TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_Decrease(
 					resource.TestCheckResourceAttr(resourceName, "global_node_groups.#", "1"),
 					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "global_node_groups.*", map[string]*regexp.Regexp{
 						"global_node_group_id": regexp.MustCompile(fmt.Sprintf("^[a-z]+-%s-0001$", rName)),
-						"slots":                regexp.MustCompile("^0-16383$"), // all of them
+						"slots":                regexp.MustCompile("^0-16383$"), // all slots
 					}),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "1"),
 					resource.TestCheckResourceAttr(primaryReplicationGroupResourceName, "num_node_groups", "3"),
@@ -781,8 +781,8 @@ func TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Decrease(
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "global_node_groups.#", "1"),
 					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "global_node_groups.*", map[string]*regexp.Regexp{
-						// There is no guarantee which node group will be deleted, so we can't check here
-						"slots": regexp.MustCompile("^0-16383$"), // all slots
+						"global_node_group_id": regexp.MustCompile(fmt.Sprintf("^[a-z]+-%s-0001$", rName)),
+						"slots":                regexp.MustCompile("^0-16383$"), // all slots
 					}),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "1"),
 					resource.TestCheckResourceAttr(primaryReplicationGroupResourceName, "num_node_groups", "2"),

--- a/internal/service/elasticache/global_replication_group_test.go
+++ b/internal/service/elasticache/global_replication_group_test.go
@@ -672,6 +672,131 @@ func TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_Decrease(
 	})
 }
 
+func TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Increase(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var globalReplicationGroup elasticache.GlobalReplicationGroup
+	var primaryReplicationGroup elasticache.ReplicationGroup
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resourceName := "aws_elasticache_global_replication_group.test"
+	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalReplicationGroupConfig_numNodeGroups_inherit(rName, 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(primaryReplicationGroupResourceName, &primaryReplicationGroup),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "global_node_groups.#", "2"),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "global_node_groups.*", map[string]*regexp.Regexp{
+						"global_node_group_id": regexp.MustCompile(fmt.Sprintf("^[a-z]+-%s-0001$", rName)),
+					}),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "global_node_groups.*", map[string]*regexp.Regexp{
+						"global_node_group_id": regexp.MustCompile(fmt.Sprintf("^[a-z]+-%s-0002$", rName)),
+					}),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
+					resource.TestCheckResourceAttr(primaryReplicationGroupResourceName, "num_node_groups", "2"),
+				),
+			},
+			{
+				Config: testAccGlobalReplicationGroupConfig_numNodeGroups(rName, 2, 3),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(primaryReplicationGroupResourceName, &primaryReplicationGroup),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "global_node_groups.#", "3"),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "global_node_groups.*", map[string]*regexp.Regexp{
+						"global_node_group_id": regexp.MustCompile(fmt.Sprintf("^[a-z]+-%s-0001$", rName)),
+					}),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "global_node_groups.*", map[string]*regexp.Regexp{
+						"global_node_group_id": regexp.MustCompile(fmt.Sprintf("^[a-z]+-%s-0002$", rName)),
+					}),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "global_node_groups.*", map[string]*regexp.Regexp{
+						"global_node_group_id": regexp.MustCompile(fmt.Sprintf("^[a-z]+-%s-0003$", rName)),
+					}),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "3"),
+					resource.TestCheckResourceAttr(primaryReplicationGroupResourceName, "num_node_groups", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Decrease(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var globalReplicationGroup elasticache.GlobalReplicationGroup
+	var primaryReplicationGroup elasticache.ReplicationGroup
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resourceName := "aws_elasticache_global_replication_group.test"
+	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckGlobalReplicationGroup(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalReplicationGroupConfig_numNodeGroups_inherit(rName, 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(primaryReplicationGroupResourceName, &primaryReplicationGroup),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "global_node_groups.#", "2"),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "global_node_groups.*", map[string]*regexp.Regexp{
+						"global_node_group_id": regexp.MustCompile(fmt.Sprintf("^[a-z]+-%s-0001$", rName)),
+					}),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "global_node_groups.*", map[string]*regexp.Regexp{
+						"global_node_group_id": regexp.MustCompile(fmt.Sprintf("^[a-z]+-%s-0002$", rName)),
+					}),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
+					resource.TestCheckResourceAttr(primaryReplicationGroupResourceName, "num_node_groups", "2"),
+				),
+			},
+			{
+				Config: testAccGlobalReplicationGroupConfig_numNodeGroups(rName, 2, 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGlobalReplicationGroupExists(resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(primaryReplicationGroupResourceName, &primaryReplicationGroup),
+					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "global_node_groups.#", "1"),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "global_node_groups.*", map[string]*regexp.Regexp{
+						// There is no guarantee which node group will be deleted, so we can't check here
+						"slots": regexp.MustCompile("^0-16383$"), // all slots
+					}),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "1"),
+					resource.TestCheckResourceAttr(primaryReplicationGroupResourceName, "num_node_groups", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_v6(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -1741,6 +1866,33 @@ resource "aws_elasticache_replication_group" "test" {
 `, rName)
 }
 
+func testAccGlobalReplicationGroupConfig_numNodeGroups_inherit(rName string, numNodeGroups int) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_global_replication_group" "test" {
+  global_replication_group_id_suffix = %[1]q
+  primary_replication_group_id       = aws_elasticache_replication_group.test.id
+}
+
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id          = %[1]q
+  replication_group_description = "test"
+
+  engine         = "redis"
+  engine_version = "6.2"
+  node_type      = "cache.m5.large"
+
+  parameter_group_name       = "default.redis6.x.cluster.on"
+  automatic_failover_enabled = true
+  num_node_groups            = %[2]d
+  replicas_per_node_group    = 1
+
+  lifecycle {
+    ignore_changes = [member_clusters, num_node_groups]
+  }
+}
+`, rName, numNodeGroups)
+}
+
 func testAccGlobalReplicationGroupConfig_numNodeGroups(rName string, numNodeGroups, globalNumNodeGroups int) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_global_replication_group" "test" {
@@ -1764,7 +1916,7 @@ resource "aws_elasticache_replication_group" "test" {
   replicas_per_node_group    = 1
 
   lifecycle {
-    ignore_changes = [member_clusters,num_node_groups]
+    ignore_changes = [member_clusters, num_node_groups]
   }
 }
 `, rName, numNodeGroups, globalNumNodeGroups)

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -588,7 +588,7 @@ func resourceReplicationGroupCreate(d *schema.ResourceData, meta interface{}) er
 		// state, but the global replication group can still be in the "modifying" state. Wait for the replication group
 		// to be fully added to the global replication group.
 		// API calls to the global replication group can be made in any region.
-		if _, err := waitGlobalReplicationGroupAvailable(context.TODO(), conn, v.(string), GlobalReplicationGroupDefaultCreatedTimeout); err != nil {
+		if _, err := waitGlobalReplicationGroupAvailable(context.TODO(), conn, v.(string), globalReplicationGroupDefaultCreatedTimeout); err != nil {
 			return fmt.Errorf("error waiting for ElastiCache Global Replication Group (%s) to be available: %w", v, err)
 		}
 	}

--- a/internal/service/elasticache/sweep.go
+++ b/internal/service/elasticache/sweep.go
@@ -152,7 +152,7 @@ func sweepGlobalReplicationGroups(region string) error {
 				}
 
 				log.Printf("[INFO] Deleting ElastiCache Global Replication Group: %s", id)
-				err := deleteGlobalReplicationGroup(ctx, conn, id, sweeperGlobalReplicationGroupDefaultUpdatedTimeout)
+				err := deleteGlobalReplicationGroup(ctx, conn, id, sweeperGlobalReplicationGroupDefaultUpdatedTimeout, globalReplicationGroupDefaultDeletedTimeout)
 				if err != nil {
 					sweeperErr := fmt.Errorf("error deleting ElastiCache Global Replication Group (%s): %w", id, err)
 					log.Printf("[ERROR] %s", sweeperErr)

--- a/internal/service/elasticache/sweep.go
+++ b/internal/service/elasticache/sweep.go
@@ -146,17 +146,13 @@ func sweepGlobalReplicationGroups(region string) error {
 
 				disassociationErrors := DisassociateMembers(conn, globalReplicationGroup)
 				if disassociationErrors != nil {
-					sweeperErr := fmt.Errorf("failed to disassociate ElastiCache Global Replication Group (%s) members: %w", id, disassociationErrors)
-					log.Printf("[ERROR] %s", sweeperErr)
-					return sweeperErr
+					return fmt.Errorf("disassociating ElastiCache Global Replication Group (%s) members: %w", id, disassociationErrors)
 				}
 
 				log.Printf("[INFO] Deleting ElastiCache Global Replication Group: %s", id)
 				err := deleteGlobalReplicationGroup(ctx, conn, id, sweeperGlobalReplicationGroupDefaultUpdatedTimeout, globalReplicationGroupDefaultDeletedTimeout)
 				if err != nil {
-					sweeperErr := fmt.Errorf("error deleting ElastiCache Global Replication Group (%s): %w", id, err)
-					log.Printf("[ERROR] %s", sweeperErr)
-					return sweeperErr
+					return fmt.Errorf("deleting ElastiCache Global Replication Group (%s): %w", id, err)
 				}
 				return nil
 			})
@@ -173,7 +169,7 @@ func sweepGlobalReplicationGroups(region string) error {
 	}
 
 	if err != nil {
-		grgErrs = multierror.Append(grgErrs, fmt.Errorf("error listing ElastiCache Global Replication Groups: %w", err))
+		grgErrs = multierror.Append(grgErrs, fmt.Errorf("listing ElastiCache Global Replication Groups: %w", err))
 	}
 
 	return grgErrs.ErrorOrNil()

--- a/internal/service/elasticache/wait.go
+++ b/internal/service/elasticache/wait.go
@@ -151,9 +151,9 @@ func WaitCacheClusterDeleted(conn *elasticache.ElastiCache, cacheClusterID strin
 }
 
 const (
-	GlobalReplicationGroupDefaultCreatedTimeout = 25 * time.Minute
-	GlobalReplicationGroupDefaultUpdatedTimeout = 40 * time.Minute
-	GlobalReplicationGroupDefaultDeletedTimeout = 20 * time.Minute
+	globalReplicationGroupDefaultCreatedTimeout = 60 * time.Minute
+	globalReplicationGroupDefaultUpdatedTimeout = 60 * time.Minute
+	globalReplicationGroupDefaultDeletedTimeout = 20 * time.Minute
 
 	globalReplicationGroupAvailableMinTimeout = 10 * time.Second
 	globalReplicationGroupAvailableDelay      = 30 * time.Second
@@ -181,8 +181,8 @@ func waitGlobalReplicationGroupAvailable(ctx context.Context, conn *elasticache.
 	return nil, err
 }
 
-// WaitGlobalReplicationGroupDeleted waits for a Global Replication Group to be deleted
-func WaitGlobalReplicationGroupDeleted(ctx context.Context, conn *elasticache.ElastiCache, globalReplicationGroupID string) (*elasticache.GlobalReplicationGroup, error) {
+// waitGlobalReplicationGroupDeleted waits for a Global Replication Group to be deleted
+func waitGlobalReplicationGroupDeleted(ctx context.Context, conn *elasticache.ElastiCache, globalReplicationGroupID string, timeout time.Duration) (*elasticache.GlobalReplicationGroup, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
 			GlobalReplicationGroupStatusAvailable,
@@ -192,7 +192,7 @@ func WaitGlobalReplicationGroupDeleted(ctx context.Context, conn *elasticache.El
 		},
 		Target:     []string{},
 		Refresh:    statusGlobalReplicationGroup(ctx, conn, globalReplicationGroupID),
-		Timeout:    GlobalReplicationGroupDefaultDeletedTimeout,
+		Timeout:    timeout,
 		MinTimeout: globalReplicationGroupDeletedMinTimeout,
 		Delay:      globalReplicationGroupDeletedDelay,
 	}

--- a/website/docs/r/elasticache_global_replication_group.html.markdown
+++ b/website/docs/r/elasticache_global_replication_group.html.markdown
@@ -133,6 +133,11 @@ In addition to all arguments above, the following attributes are exported:
 * `cluster_enabled` - Indicates whether the Global Datastore is cluster enabled.
 * `engine` - The name of the cache engine to be used for the clusters in this global replication group.
 * `global_replication_group_id` - The full ID of the global replication group.
+* `global_node_groups` - Set of node groups (shards) on the global replication group.
+  Has the values:
+    * `global_node_group_id` - The ID of the global node group.
+    * `slots` - The keyspace for this node group.
+* `num_node_groups` - The number of node groups (shards) on the global replication group.
 * `transit_encryption_enabled` - A flag that indicates whether the encryption in transit is enabled.
 
 ## Import

--- a/website/docs/r/elasticache_global_replication_group.html.markdown
+++ b/website/docs/r/elasticache_global_replication_group.html.markdown
@@ -140,6 +140,14 @@ In addition to all arguments above, the following attributes are exported:
     * `slots` - The keyspace for this node group.
 * `transit_encryption_enabled` - A flag that indicates whether the encryption in transit is enabled.
 
+## Timeouts
+
+[Configuration options](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts):
+
+* `create` - (Default `60m`)
+* `update` - (Default `60m`)
+* `delete` - (Default `20m`)
+
 ## Import
 
 ElastiCache Global Replication Groups can be imported using the `global_replication_group_id`, e.g.,

--- a/website/docs/r/elasticache_global_replication_group.html.markdown
+++ b/website/docs/r/elasticache_global_replication_group.html.markdown
@@ -116,6 +116,7 @@ The following arguments are supported:
 * `global_replication_group_id_suffix` – (Required) The suffix name of a Global Datastore. If `global_replication_group_id_suffix` is changed, creates a new resource.
 * `primary_replication_group_id` – (Required) The ID of the primary cluster that accepts writes and will replicate updates to the secondary cluster. If `primary_replication_group_id` is changed, creates a new resource.
 * `global_replication_group_description` – (Optional) A user-created description for the global replication group.
+* `num_node_groups` - (Optional) The number of node groups (shards) on the global replication group.
 * `parameter_group_name` - (Optional) An ElastiCache Parameter Group to use for the Global Replication Group.
   Required when upgrading a major engine version, but will be ignored if left configured after the upgrade is complete.
   Specifying without a major version upgrade will fail.
@@ -137,7 +138,6 @@ In addition to all arguments above, the following attributes are exported:
   Has the values:
     * `global_node_group_id` - The ID of the global node group.
     * `slots` - The keyspace for this node group.
-* `num_node_groups` - The number of node groups (shards) on the global replication group.
 * `transit_encryption_enabled` - A flag that indicates whether the encryption in transit is enabled.
 
 ## Import

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -198,9 +198,14 @@ The following arguments are optional:
 * `notification_topic_arn` – (Optional) ARN of an SNS topic to send ElastiCache notifications to. Example: `arn:aws:sns:us-east-1:012345678999:my_sns_topic`
 * `number_cache_clusters` - (Optional, **Deprecated** use `num_cache_clusters` instead) Number of cache clusters (primary and replicas) this replication group will have. If Multi-AZ is enabled, the value of this parameter must be at least 2. Updates will occur before other modifications. Conflicts with `num_cache_clusters`, `num_node_groups`, or the deprecated `cluster_mode`. Defaults to `1`.
 * `num_cache_clusters` - (Optional) Number of cache clusters (primary and replicas) this replication group will have. If Multi-AZ is enabled, the value of this parameter must be at least 2. Updates will occur before other modifications. Conflicts with `num_node_groups`, the deprecated`number_cache_clusters`, or the deprecated `cluster_mode`. Defaults to `1`.
+* `num_node_groups` - (Optional) Number of node groups (shards) for this Redis replication group.
+  Changing this number will trigger a resizing operation before other settings modifications.
 * `parameter_group_name` - (Optional) Name of the parameter group to associate with this replication group. If this argument is omitted, the default cache parameter group for the specified engine is used. To enable "cluster mode", i.e., data sharding, use a parameter group that has the parameter `cluster-enabled` set to true.
 * `port` – (Optional) Port number on which each of the cache nodes will accept connections. For Memcache the default is 11211, and for Redis the default port is 6379.
 * `preferred_cache_cluster_azs` - (Optional) List of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is considered. The first item in the list will be the primary node. Ignored when updating.
+* `replicas_per_node_group` - (Optional) Number of replica nodes in each node group.
+  Changing this number will trigger a resizing operation before other settings modifications.
+  Valid values are 0 to 5.
 * `security_group_ids` - (Optional) One or more Amazon VPC security groups associated with this replication group. Use this parameter only when you are creating a replication group in an Amazon Virtual Private Cloud
 * `security_group_names` - (Optional) List of cache security group names to associate with this replication group.
 * `snapshot_arns` – (Optional) List of ARNs that identify Redis RDB snapshot files stored in Amazon S3. The names object names cannot contain any commas.


### PR DESCRIPTION
Allow configuring shards (node groups) on ElastiCache Global Replication Groups.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #22752

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=elasticache TESTS=TestAccElastiCacheGlobalReplicationGroup_

--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_NoVersion (8.67s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_MinorUpgrade (863.27s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_v6 (884.56s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgrade_6x (1106.86s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_v6x (1198.54s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_v5 (1199.13s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_NoVersion (1210.21s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgrade_6x (1235.99s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_MinorUpgrade (1292.64s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgrade (1432.50s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgrade_6x (1453.40s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorDowngrade (1658.70s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_basic (1720.67s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgrade (1747.26s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgrade (1760.80s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgrade_6x (1829.60s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgrade (1850.22s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_clusterMode_basic (1179.17s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_NoChange (1446.66s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_automaticFailover_createWithChange (1148.52s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_automaticFailover_update (1350.44s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_automaticFailover_createNoChange (1169.62s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_automaticFailover_setNoChange (1443.53s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_disappears (968.73s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_nodeType_createNoChange (1095.00s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_description (1055.59s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_nodeType_setNoChange (1289.30s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorDowngrade (3106.44s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_UpdateParameterGroupName (1431.39s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_nodeType_update (1959.73s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_Decrease (3441.19s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Increase (3632.16s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_nodeType_createWithChange (2226.46s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_Increase (3092.55s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Decrease (4129.90s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_multipleSecondaries (3447.97s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_ReplaceSecondary_differentRegion (3532.04s)
```
