### PR TITLE
Allow items to be written if they have non-overlapping range keys

### DIFF
--- a/internal/service/dynamodb/table_item.go
+++ b/internal/service/dynamodb/table_item.go
@@ -62,6 +62,7 @@ func resourceTableItemCreate(d *schema.ResourceData, meta interface{}) error {
 
 	tableName := d.Get("table_name").(string)
 	hashKey := d.Get("hash_key").(string)
+	rangeKey := d.Get("range_key").(string)
 	item := d.Get("item").(string)
 	attributes, err := ExpandTableItemAttributes(item)
 	if err != nil {
@@ -75,6 +76,9 @@ func resourceTableItemCreate(d *schema.ResourceData, meta interface{}) error {
 		// Explode if item exists. We didn't create it.
 		Expected: map[string]*dynamodb.ExpectedAttributeValue{
 			hashKey: {
+				Exists: aws.Bool(false),
+			},
+			rangeKey: {
 				Exists: aws.Bool(false),
 			},
 		},

--- a/internal/service/dynamodb/table_item.go
+++ b/internal/service/dynamodb/table_item.go
@@ -88,7 +88,6 @@ func resourceTableItemCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	rangeKey := d.Get("range_key").(string)
 	id := buildTableItemID(tableName, hashKey, rangeKey, attributes)
 
 	d.SetId(id)


### PR DESCRIPTION
Previously this code allowed you to write values into DynamoDB if the table had a composite key. For example if there were 2 rows:

```
{
  "hashKey": "example",
  "rangeKey": "version1",
}
{
  "hashKey": "example",
  "rangeKey": "version2",
}
```

Before this would collide with the error `ConditionalCheckFailedException: The conditional request failed`.

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
