### PR TITLE
r/aws_vpc_ipam_pool_cidr: Avoid crash when CIDR not found

### DIFF
--- a/.changelog/27512.txt
+++ b/.changelog/27512.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpc_ipam_pool_cidr: Fix crash when IPAM Pool CIDR not found
+```

--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -42,6 +42,7 @@ const (
 	errCodeInvalidInstanceID                              = "InvalidInstanceID"
 	errCodeInvalidInstanceIDNotFound                      = "InvalidInstanceID.NotFound"
 	errCodeInvalidInternetGatewayIDNotFound               = "InvalidInternetGatewayID.NotFound"
+	ErrCodeInvalidIpamPoolIdNotFound                      = "InvalidIpamPoolId.NotFound"
 	errCodeInvalidKeyPairNotFound                         = "InvalidKeyPair.NotFound"
 	errCodeInvalidLaunchTemplateIdMalformed               = "InvalidLaunchTemplateId.Malformed"
 	errCodeInvalidLaunchTemplateIdNotFound                = "InvalidLaunchTemplateId.NotFound"

--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -42,7 +42,7 @@ const (
 	errCodeInvalidInstanceID                              = "InvalidInstanceID"
 	errCodeInvalidInstanceIDNotFound                      = "InvalidInstanceID.NotFound"
 	errCodeInvalidInternetGatewayIDNotFound               = "InvalidInternetGatewayID.NotFound"
-	ErrCodeInvalidIpamPoolIdNotFound                      = "InvalidIpamPoolId.NotFound"
+	ErrCodeInvalidIPAMPoolIdNotFound                      = "InvalidIpamPoolId.NotFound"
 	errCodeInvalidKeyPairNotFound                         = "InvalidKeyPair.NotFound"
 	errCodeInvalidLaunchTemplateIdMalformed               = "InvalidLaunchTemplateId.Malformed"
 	errCodeInvalidLaunchTemplateIdNotFound                = "InvalidLaunchTemplateId.NotFound"

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -4994,7 +4994,7 @@ func FindIPAMPoolCIDRs(conn *ec2.EC2, input *ec2.GetIpamPoolCidrsInput) ([]*ec2.
 		return !lastPage
 	})
 
-	if tfawserr.ErrCodeEquals(err, ErrCodeInvalidIpamPoolIdNotFound) {
+	if tfawserr.ErrCodeEquals(err, ErrCodeInvalidIPAMPoolIdNotFound) {
 		return nil, &resource.NotFoundError{
 			LastError:   err,
 			LastRequest: input,

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -4959,6 +4959,24 @@ func FindInternetGatewayAttachment(conn *ec2.EC2, internetGatewayID, vpcID strin
 	return attachment, nil
 }
 
+func FindIPAMPoolCIDR(conn *ec2.EC2, input *ec2.GetIpamPoolCidrsInput) (*ec2.IpamPoolCidr, error) {
+	output, err := FindIPAMPoolCIDRs(conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output) == 0 || output[0] == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	if count := len(output); count > 1 {
+		return nil, tfresource.NewTooManyResultsError(count, input)
+	}
+
+	return output[0], nil
+}
+
 func FindIPAMPoolCIDRs(conn *ec2.EC2, input *ec2.GetIpamPoolCidrsInput) ([]*ec2.IpamPoolCidr, error) {
 	var output []*ec2.IpamPoolCidr
 
@@ -4976,7 +4994,7 @@ func FindIPAMPoolCIDRs(conn *ec2.EC2, input *ec2.GetIpamPoolCidrsInput) ([]*ec2.
 		return !lastPage
 	})
 
-	if tfawserr.ErrCodeEquals(err, InvalidIPAMPoolIDNotFound) {
+	if tfawserr.ErrCodeEquals(err, ErrCodeInvalidIpamPoolIdNotFound) {
 		return nil, &resource.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
@@ -4985,6 +5003,37 @@ func FindIPAMPoolCIDRs(conn *ec2.EC2, input *ec2.GetIpamPoolCidrsInput) ([]*ec2.
 
 	if err != nil {
 		return nil, err
+	}
+
+	return output, nil
+}
+
+func FindIPAMPoolCIDRByTwoPartKey(conn *ec2.EC2, cidrBlock, poolID string) (*ec2.IpamPoolCidr, error) {
+	input := &ec2.GetIpamPoolCidrsInput{
+		Filters: BuildAttributeFilterList(map[string]string{
+			"cidr": cidrBlock,
+		}),
+		IpamPoolId: aws.String(poolID),
+	}
+
+	output, err := FindIPAMPoolCIDR(conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if state := aws.StringValue(output.State); state == ec2.IpamPoolCidrStateDeprovisioned {
+		return nil, &resource.NotFoundError{
+			Message:     state,
+			LastRequest: input,
+		}
+	}
+
+	// Eventual consistency check.
+	if aws.StringValue(output.Cidr) != cidrBlock {
+		return nil, &resource.NotFoundError{
+			LastRequest: input,
+		}
 	}
 
 	return output, nil

--- a/internal/service/ec2/ipam_pool.go
+++ b/internal/service/ec2/ipam_pool.go
@@ -195,7 +195,7 @@ func ResourceIPAMPoolRead(d *schema.ResourceData, meta interface{}) error {
 
 	pool, err := FindIPAMPoolById(conn, d.Id())
 
-	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeInvalidIpamPoolIdNotFound) {
+	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeInvalidIPAMPoolIdNotFound) {
 		return err
 	}
 
@@ -376,7 +376,7 @@ func WaitIPAMPoolUpdate(conn *ec2.EC2, ipamPoolId string, timeout time.Duration)
 func WaitIPAMPoolDeleted(conn *ec2.EC2, ipamPoolId string, timeout time.Duration) (*ec2.IpamPool, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{ec2.IpamPoolStateDeleteInProgress},
-		Target:  []string{ErrCodeInvalidIpamPoolIdNotFound},
+		Target:  []string{ErrCodeInvalidIPAMPoolIdNotFound},
 		Refresh: statusIPAMPoolStatus(conn, ipamPoolId),
 		Timeout: timeout,
 		Delay:   ipamPoolDeleteDelay,
@@ -395,8 +395,8 @@ func statusIPAMPoolStatus(conn *ec2.EC2, ipamPoolId string) resource.StateRefres
 	return func() (interface{}, string, error) {
 		output, err := FindIPAMPoolById(conn, ipamPoolId)
 
-		if tfawserr.ErrCodeEquals(err, ErrCodeInvalidIpamPoolIdNotFound) {
-			return output, ErrCodeInvalidIpamPoolIdNotFound, nil
+		if tfawserr.ErrCodeEquals(err, ErrCodeInvalidIPAMPoolIdNotFound) {
+			return output, ErrCodeInvalidIPAMPoolIdNotFound, nil
 		}
 
 		// there was an unhandled error in the Finder

--- a/internal/service/ec2/ipam_pool.go
+++ b/internal/service/ec2/ipam_pool.go
@@ -114,12 +114,11 @@ func ResourceIPAMPool() *schema.Resource {
 }
 
 const (
-	ipamPoolCreateTimeout     = 3 * time.Minute
-	InvalidIPAMPoolIDNotFound = "InvalidIpamPoolId.NotFound"
-	ipamPoolUpdateTimeout     = 3 * time.Minute
-	IPAMPoolDeleteTimeout     = 3 * time.Minute
-	ipamPoolAvailableDelay    = 5 * time.Second
-	ipamPoolDeleteDelay       = 5 * time.Second
+	ipamPoolCreateTimeout  = 3 * time.Minute
+	ipamPoolUpdateTimeout  = 3 * time.Minute
+	IPAMPoolDeleteTimeout  = 3 * time.Minute
+	ipamPoolAvailableDelay = 5 * time.Second
+	ipamPoolDeleteDelay    = 5 * time.Second
 )
 
 func ResourceIPAMPoolCreate(d *schema.ResourceData, meta interface{}) error {
@@ -196,7 +195,7 @@ func ResourceIPAMPoolRead(d *schema.ResourceData, meta interface{}) error {
 
 	pool, err := FindIPAMPoolById(conn, d.Id())
 
-	if err != nil && !tfawserr.ErrCodeEquals(err, InvalidIPAMPoolIDNotFound) {
+	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeInvalidIpamPoolIdNotFound) {
 		return err
 	}
 
@@ -377,7 +376,7 @@ func WaitIPAMPoolUpdate(conn *ec2.EC2, ipamPoolId string, timeout time.Duration)
 func WaitIPAMPoolDeleted(conn *ec2.EC2, ipamPoolId string, timeout time.Duration) (*ec2.IpamPool, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{ec2.IpamPoolStateDeleteInProgress},
-		Target:  []string{InvalidIPAMPoolIDNotFound},
+		Target:  []string{ErrCodeInvalidIpamPoolIdNotFound},
 		Refresh: statusIPAMPoolStatus(conn, ipamPoolId),
 		Timeout: timeout,
 		Delay:   ipamPoolDeleteDelay,
@@ -396,8 +395,8 @@ func statusIPAMPoolStatus(conn *ec2.EC2, ipamPoolId string) resource.StateRefres
 	return func() (interface{}, string, error) {
 		output, err := FindIPAMPoolById(conn, ipamPoolId)
 
-		if tfawserr.ErrCodeEquals(err, InvalidIPAMPoolIDNotFound) {
-			return output, InvalidIPAMPoolIDNotFound, nil
+		if tfawserr.ErrCodeEquals(err, ErrCodeInvalidIpamPoolIdNotFound) {
+			return output, ErrCodeInvalidIpamPoolIdNotFound, nil
 		}
 
 		// there was an unhandled error in the Finder

--- a/internal/service/ec2/ipam_pool_cidr.go
+++ b/internal/service/ec2/ipam_pool_cidr.go
@@ -146,7 +146,7 @@ func resourceIPAMPoolCIDRDelete(d *schema.ResourceData, meta interface{}) error 
 		IpamPoolId: aws.String(poolID),
 	})
 
-	if tfawserr.ErrCodeEquals(err, ErrCodeInvalidIpamPoolIdNotFound) {
+	if tfawserr.ErrCodeEquals(err, ErrCodeInvalidIPAMPoolIdNotFound) {
 		return nil
 	}
 
@@ -181,7 +181,7 @@ func IPAMPoolCIDRParseResourceID(id string) (string, string, error) {
 	return parts[0], parts[1], nil
 }
 
-func expandIpamCidrAuthorizationContext(tfMap map[string]interface{}) *ec2.IpamCidrAuthorizationContext {
+func expandIpamCidrAuthorizationContext(tfMap map[string]interface{}) *ec2.IpamCidrAuthorizationContext { // nosemgrep:ci.caps1-in-func-name,ci.caps2-in-func-name,ci.caps5-in-func-name
 	if tfMap == nil {
 		return nil
 	}

--- a/internal/service/ec2/ipam_pool_cidr.go
+++ b/internal/service/ec2/ipam_pool_cidr.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -22,9 +21,17 @@ func ResourceIPAMPoolCIDR() *schema.Resource {
 		Create: resourceIPAMPoolCIDRCreate,
 		Read:   resourceIPAMPoolCIDRRead,
 		Delete: resourceIPAMPoolCIDRDelete,
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			// Allocations release are eventually consistent with a max time of 20m.
+			Delete: schema.DefaultTimeout(32 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"cidr": {
 				Type:     schema.TypeString,
@@ -65,217 +72,129 @@ func ResourceIPAMPoolCIDR() *schema.Resource {
 	}
 }
 
-const (
-	ipamPoolCIDRCreateTimeout = 10 * time.Minute
-	// allocations releases are eventually consistent with a max time of 20m
-	ipamPoolCIDRDeleteTimeout  = 32 * time.Minute
-	ipamPoolCIDRAvailableDelay = 5 * time.Second
-	ipamPoolCIDRDeleteDelay    = 5 * time.Second
-)
-
 func resourceIPAMPoolCIDRCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
-	pool_id := d.Get("ipam_pool_id").(string)
 
+	poolID := d.Get("ipam_pool_id").(string)
 	input := &ec2.ProvisionIpamPoolCidrInput{
-		IpamPoolId: aws.String(pool_id),
-	}
-
-	if v, ok := d.GetOk("cidr_authorization_context"); ok {
-		input.CidrAuthorizationContext = expandIPAMPoolCIDRCIDRAuthorizationContext(v.([]interface{}))
+		IpamPoolId: aws.String(poolID),
 	}
 
 	if v, ok := d.GetOk("cidr"); ok {
 		input.Cidr = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("cidr_authorization_context"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.CidrAuthorizationContext = expandIpamCidrAuthorizationContext(v.([]interface{})[0].(map[string]interface{}))
+	}
+
 	output, err := conn.ProvisionIpamPoolCidr(input)
+
 	if err != nil {
-		return fmt.Errorf("Error provisioning CIDR in IPAM pool (%s): %w", d.Get("ipam_pool_id").(string), err)
+		return fmt.Errorf("creating IPAM Pool (%s) CIDR: %w", poolID, err)
 	}
 
-	cidr := aws.StringValue(output.IpamPoolCidr.Cidr)
-	id := encodeIPAMPoolCIDRId(cidr, pool_id)
+	cidrBlock := aws.StringValue(output.IpamPoolCidr.Cidr)
+	d.SetId(IPAMPoolCIDRCreateResourceID(cidrBlock, poolID))
 
-	if _, err = WaitIPAMPoolCIDRAvailable(conn, id, ipamPoolCIDRCreateTimeout); err != nil {
-		return fmt.Errorf("error waiting for IPAM Pool CIDR (%s) to be provisioned: %w", id, err)
+	if _, err := WaitIPAMPoolCIDRCreated(conn, cidrBlock, poolID, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return fmt.Errorf("error waiting for IPAM Pool CIDR (%s) create: %w", d.Id(), err)
 	}
 
-	d.SetId(id)
 	return resourceIPAMPoolCIDRRead(d, meta)
 }
 
 func resourceIPAMPoolCIDRRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
-	cidr, pool_id, err := FindIPAMPoolCIDR(conn, d.Id())
+
+	cidrBlock, poolID, err := IPAMPoolCIDRParseResourceID(d.Id())
 
 	if err != nil {
 		return err
 	}
 
-	if !d.IsNewResource() && cidr == nil {
-		log.Printf("[WARN] IPAM Pool CIDR (%s) not found, removing from state", cidr)
+	output, err := FindIPAMPoolCIDRByTwoPartKey(conn, cidrBlock, poolID)
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] IPAM Pool CIDR (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
-	if aws.StringValue(cidr.State) == ec2.IpamPoolCidrStateDeprovisioned {
-		log.Printf("[WARN] IPAM Pool CIDR (%s) was deprovisioned, removing from state", cidr)
-		d.SetId("")
-		return nil
+	if err != nil {
+		return fmt.Errorf("reading IPAM Pool CIDR (%s): %w", d.Id(), err)
 	}
 
-	d.Set("cidr", cidr.Cidr)
-	// pool id is not returned in describe, adding from concatenated id
-	d.Set("ipam_pool_id", pool_id)
+	d.Set("cidr", output.Cidr)
+	d.Set("ipam_pool_id", poolID)
 
 	return nil
 }
 
 func resourceIPAMPoolCIDRDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn
-	cidr, pool_id, err := DecodeIPAMPoolCIDRID(d.Id())
 
-	input := &ec2.DeprovisionIpamPoolCidrInput{
-		Cidr:       aws.String(cidr),
-		IpamPoolId: aws.String(pool_id),
+	cidrBlock, poolID, err := IPAMPoolCIDRParseResourceID(d.Id())
+
+	if err != nil {
+		return err
 	}
-	return resource.Retry(ipamPoolCIDRDeleteTimeout, func() *resource.RetryError {
-		// releasing allocations is eventually consistent and can cause deprovisioning to fail
-		_, err = conn.DeprovisionIpamPoolCidr(input)
 
-		if err != nil {
-			// IncorrectState err can mean: State = "deprovisioned" || State = "pending-deprovision"
-			if tfawserr.ErrCodeEquals(err, "IncorrectState") {
-				output, err := WaitIPAMPoolCIDRDeleted(conn, d.Id(), ipamPoolCIDRDeleteTimeout)
-				if err != nil {
-					// State = failed-deprovision
-					return resource.RetryableError(fmt.Errorf("Expected CIDR to be deprovisioned but was in state %s", aws.StringValue(output.State)))
-				}
-				// State = deprovisioned
-				return nil
-			}
-			return resource.NonRetryableError(fmt.Errorf("error deprovisioning IPAM pool CIDR: (%s): %w", cidr, err))
-		}
-
-		output, err := WaitIPAMPoolCIDRDeleted(conn, d.Id(), ipamPoolCIDRDeleteTimeout)
-		if err != nil {
-			// State = failed-deprovision
-			return resource.RetryableError(fmt.Errorf("Expected CIDR to be deprovisioned but was in state %s", aws.StringValue(output.State)))
-		}
-		// State = deprovisioned
-		return nil
+	log.Printf("[DEBUG] Deleting IPAM Pool CIDR: %s", d.Id())
+	_, err = conn.DeprovisionIpamPoolCidr(&ec2.DeprovisionIpamPoolCidrInput{
+		Cidr:       aws.String(cidrBlock),
+		IpamPoolId: aws.String(poolID),
 	})
-}
 
-func FindIPAMPoolCIDR(conn *ec2.EC2, id string) (*ec2.IpamPoolCidr, string, error) {
-	cidr_block, pool_id, err := DecodeIPAMPoolCIDRID(id)
-	if err != nil {
-		return nil, "", fmt.Errorf("error decoding ID (%s): %w", cidr_block, err)
-	}
-	input := &ec2.GetIpamPoolCidrsInput{
-		IpamPoolId: aws.String(pool_id),
-		Filters: []*ec2.Filter{
-			{
-				Name:   aws.String("cidr"),
-				Values: aws.StringSlice([]string{cidr_block}),
-			},
-		},
-	}
-
-	output, err := conn.GetIpamPoolCidrs(input)
-
-	if err != nil {
-		return nil, "", err
-	}
-
-	if output == nil || len(output.IpamPoolCidrs) == 0 || output.IpamPoolCidrs[0] == nil {
-		return nil, "", nil
-	}
-
-	return output.IpamPoolCidrs[0], pool_id, nil
-}
-
-func WaitIPAMPoolCIDRAvailable(conn *ec2.EC2, id string, timeout time.Duration) (*ec2.IpamPoolCidr, error) {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{ec2.IpamPoolCidrStatePendingProvision},
-		Target:  []string{ec2.IpamPoolCidrStateProvisioned},
-		Refresh: statusIPAMPoolCIDRStatus(conn, id),
-		Timeout: timeout,
-		Delay:   ipamPoolCIDRAvailableDelay,
-	}
-
-	outputRaw, err := stateConf.WaitForState()
-
-	if output, ok := outputRaw.(*ec2.IpamPoolCidr); ok {
-		if failureReason := output.FailureReason; failureReason != nil {
-			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.StringValue(failureReason.Code), aws.StringValue(failureReason.Message)))
-		}
-
-		return output, err
-	}
-
-	return nil, err
-}
-
-func WaitIPAMPoolCIDRDeleted(conn *ec2.EC2, id string, timeout time.Duration) (*ec2.IpamPoolCidr, error) {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{ec2.IpamPoolCidrStatePendingDeprovision, ec2.IpamPoolCidrStateProvisioned},
-		Target:  []string{ec2.IpamPoolCidrStateDeprovisioned},
-		Refresh: statusIPAMPoolCIDRStatus(conn, id),
-		Timeout: timeout,
-		Delay:   ipamPoolCIDRDeleteDelay,
-	}
-
-	outputRaw, err := stateConf.WaitForState()
-
-	if output, ok := outputRaw.(*ec2.IpamPoolCidr); ok {
-		if failureReason := output.FailureReason; failureReason != nil {
-			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.StringValue(failureReason.Code), aws.StringValue(failureReason.Message)))
-		}
-
-		return output, err
-	}
-
-	return nil, err
-}
-
-func statusIPAMPoolCIDRStatus(conn *ec2.EC2, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		output, _, err := FindIPAMPoolCIDR(conn, id)
-
-		// there was an unhandled error in the Finder
-		if err != nil {
-			return nil, "", err
-		}
-
-		return output, aws.StringValue(output.State), nil
-	}
-}
-
-func encodeIPAMPoolCIDRId(cidr, pool_id string) string {
-	return fmt.Sprintf("%s_%s", cidr, pool_id)
-}
-
-func DecodeIPAMPoolCIDRID(id string) (string, string, error) {
-	idParts := strings.Split(id, "_")
-	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
-		return "", "", fmt.Errorf("expected ID in the form of cidr_poolId, given: %q", id)
-	}
-	return idParts[0], idParts[1], nil
-}
-
-func expandIPAMPoolCIDRCIDRAuthorizationContext(l []interface{}) *ec2.IpamCidrAuthorizationContext {
-	if len(l) == 0 || l[0] == nil {
+	if tfawserr.ErrCodeEquals(err, ErrCodeInvalidIpamPoolIdNotFound) {
 		return nil
 	}
 
-	m := l[0].(map[string]interface{})
-
-	cac := &ec2.IpamCidrAuthorizationContext{
-		Message:   aws.String(m["message"].(string)),
-		Signature: aws.String(m["signature"].(string)),
+	// IncorrectState error can mean: State = "deprovisioned" || State = "pending-deprovision".
+	if err != nil && !tfawserr.ErrCodeEquals(err, errCodeIncorrectState) {
+		return fmt.Errorf("deleting IPAM Pool CIDR (%s): %w", d.Id(), err)
 	}
 
-	return cac
+	if _, err := WaitIPAMPoolCIDRDeleted(conn, cidrBlock, poolID, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return fmt.Errorf("error waiting for IPAM Pool CIDR (%s) delete: %w", d.Id(), err)
+	}
+
+	return nil
+}
+
+const ipamPoolCIDRIDSeparator = "_"
+
+func IPAMPoolCIDRCreateResourceID(cidrBlock, poolID string) string {
+	parts := []string{cidrBlock, poolID}
+	id := strings.Join(parts, ipamPoolCIDRIDSeparator)
+
+	return id
+}
+
+func IPAMPoolCIDRParseResourceID(id string) (string, string, error) {
+	parts := strings.Split(id, ipamPoolCIDRIDSeparator)
+
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("unexpected format for ID (%[1]s), expected cidr%[2]spool-id", id, ipamPoolCIDRIDSeparator)
+	}
+
+	return parts[0], parts[1], nil
+}
+
+func expandIpamCidrAuthorizationContext(tfMap map[string]interface{}) *ec2.IpamCidrAuthorizationContext {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &ec2.IpamCidrAuthorizationContext{}
+
+	if v, ok := tfMap["message"].(string); ok && v != "" {
+		apiObject.Message = aws.String(v)
+	}
+
+	if v, ok := tfMap["signature"].(string); ok && v != "" {
+		apiObject.Signature = aws.String(v)
+	}
+
+	return apiObject
 }

--- a/internal/service/ec2/ipam_pool_cidr_allocation.go
+++ b/internal/service/ec2/ipam_pool_cidr_allocation.go
@@ -169,7 +169,7 @@ func resourceIPAMPoolCIDRAllocationDelete(d *schema.ResourceData, meta interface
 
 	output, err := conn.ReleaseIpamPoolAllocation(input)
 	if err != nil || !aws.BoolValue(output.Success) {
-		if tfawserr.ErrCodeEquals(err, InvalidIPAMPoolIDNotFound) {
+		if tfawserr.ErrCodeEquals(err, ErrCodeInvalidIpamPoolIdNotFound) {
 			return nil
 		}
 		return fmt.Errorf("error releasing IPAM Pool Allocation (%s): %w", d.Id(), err)

--- a/internal/service/ec2/ipam_pool_cidr_allocation.go
+++ b/internal/service/ec2/ipam_pool_cidr_allocation.go
@@ -169,7 +169,7 @@ func resourceIPAMPoolCIDRAllocationDelete(d *schema.ResourceData, meta interface
 
 	output, err := conn.ReleaseIpamPoolAllocation(input)
 	if err != nil || !aws.BoolValue(output.Success) {
-		if tfawserr.ErrCodeEquals(err, ErrCodeInvalidIpamPoolIdNotFound) {
+		if tfawserr.ErrCodeEquals(err, ErrCodeInvalidIPAMPoolIdNotFound) {
 			return nil
 		}
 		return fmt.Errorf("error releasing IPAM Pool Allocation (%s): %w", d.Id(), err)

--- a/internal/service/ec2/ipam_pool_cidr_allocation_test.go
+++ b/internal/service/ec2/ipam_pool_cidr_allocation_test.go
@@ -185,7 +185,7 @@ func testAccCheckIPAMPoolAllocationDestroy(s *terraform.State) error {
 		_, _, err := tfec2.FindIPAMPoolCIDRAllocation(conn, id)
 
 		if err != nil {
-			if tfawserr.ErrCodeEquals(err, tfec2.IPAMPoolAllocationNotFound) || tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidIpamPoolIdNotFound) {
+			if tfawserr.ErrCodeEquals(err, tfec2.IPAMPoolAllocationNotFound) || tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidIPAMPoolIdNotFound) {
 				return nil
 			}
 			return err

--- a/internal/service/ec2/ipam_pool_cidr_allocation_test.go
+++ b/internal/service/ec2/ipam_pool_cidr_allocation_test.go
@@ -185,7 +185,7 @@ func testAccCheckIPAMPoolAllocationDestroy(s *terraform.State) error {
 		_, _, err := tfec2.FindIPAMPoolCIDRAllocation(conn, id)
 
 		if err != nil {
-			if tfawserr.ErrCodeEquals(err, tfec2.IPAMPoolAllocationNotFound) || tfawserr.ErrCodeEquals(err, tfec2.InvalidIPAMPoolIDNotFound) {
+			if tfawserr.ErrCodeEquals(err, tfec2.IPAMPoolAllocationNotFound) || tfawserr.ErrCodeEquals(err, tfec2.ErrCodeInvalidIpamPoolIdNotFound) {
 				return nil
 			}
 			return err

--- a/internal/service/ec2/ipam_pool_cidr_test.go
+++ b/internal/service/ec2/ipam_pool_cidr_test.go
@@ -16,19 +16,19 @@ import (
 func TestAccIPAMPoolCIDR_basic(t *testing.T) {
 	var cidr ec2.IpamPoolCidr
 	resourceName := "aws_vpc_ipam_pool_cidr.test"
-	cidr_range := "10.0.0.0/24"
+	cidrBlock := "10.0.0.0/24"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckIPAMProvisionedPoolCIDRDestroy,
+		CheckDestroy:             testAccCheckIPAMPoolCIDRDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIPAMPoolCIDRConfig_provisionedIPv4(cidr_range),
+				Config: testAccIPAMPoolCIDRConfig_provisionedIPv4(cidrBlock),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIPAMCIDRExists(resourceName, &cidr),
-					resource.TestCheckResourceAttr(resourceName, "cidr", cidr_range),
+					testAccCheckIPAMPoolCIDRExists(resourceName, &cidr),
+					resource.TestCheckResourceAttr(resourceName, "cidr", cidrBlock),
 					resource.TestCheckResourceAttrPair(resourceName, "ipam_pool_id", "aws_vpc_ipam_pool.test", "id"),
 				),
 			},
@@ -41,27 +41,38 @@ func TestAccIPAMPoolCIDR_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckIPAMCIDRExists(n string, cidr *ec2.IpamPoolCidr) resource.TestCheckFunc {
+func testAccCheckIPAMPoolCIDRExists(n string, v *ec2.IpamPoolCidr) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		id := rs.Primary.ID
-		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
-		found_cidr, _, err := tfec2.FindIPAMPoolCIDR(conn, id)
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No IPAM Pool CIDR ID is set")
+		}
+
+		cidrBlock, poolID, err := tfec2.IPAMPoolCIDRParseResourceID(rs.Primary.ID)
 
 		if err != nil {
 			return err
 		}
-		*cidr = *found_cidr
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
+
+		output, err := tfec2.FindIPAMPoolCIDRByTwoPartKey(conn, cidrBlock, poolID)
+
+		if err != nil {
+			return err
+		}
+
+		*v = *output
 
 		return nil
 	}
 }
 
-func testAccCheckIPAMProvisionedPoolCIDRDestroy(s *terraform.State) error {
+func testAccCheckIPAMPoolCIDRDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn
 
 	for _, rs := range s.RootModule().Resources {
@@ -69,19 +80,23 @@ func testAccCheckIPAMProvisionedPoolCIDRDestroy(s *terraform.State) error {
 			continue
 		}
 
-		id := rs.Primary.ID
+		cidrBlock, poolID, err := tfec2.IPAMPoolCIDRParseResourceID(rs.Primary.ID)
 
-		_, pool_id, err := tfec2.DecodeIPAMPoolCIDRID(id)
 		if err != nil {
-			return fmt.Errorf("error decoding ID (%s): %w", id, err)
+			return err
 		}
 
-		if _, err = tfec2.WaitIPAMPoolDeleted(conn, pool_id, tfec2.IPAMPoolDeleteTimeout); err != nil {
-			if tfresource.NotFound(err) {
-				return nil
-			}
-			return fmt.Errorf("error waiting for IPAM Pool (%s) to be deleted: %w", id, err)
+		_, err = tfec2.FindIPAMPoolCIDRByTwoPartKey(conn, cidrBlock, poolID)
+
+		if tfresource.NotFound(err) {
+			continue
 		}
+
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("IPAM Pool CIDR still exists: %s", rs.Primary.ID)
 	}
 
 	return nil
@@ -92,6 +107,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   description = "test"
+
   operating_regions {
     region_name = data.aws_region.current.name
   }
@@ -107,10 +123,10 @@ resource "aws_vpc_ipam_pool" "test" {
 `
 
 func testAccIPAMPoolCIDRConfig_provisionedIPv4(cidr string) string {
-	return testAccIPAMPoolCIDRConfig_base + testAccIPAMPoolCIDRConfig_privatePool + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccIPAMPoolCIDRConfig_base, testAccIPAMPoolCIDRConfig_privatePool, fmt.Sprintf(`
 resource "aws_vpc_ipam_pool_cidr" "test" {
   ipam_pool_id = aws_vpc_ipam_pool.test.id
   cidr         = %[1]q
 }
-`, cidr)
+`, cidr))
 }

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -1299,3 +1299,19 @@ func StatusSnapshotStorageTier(conn *ec2.EC2, id string) resource.StateRefreshFu
 		return output, aws.StringValue(output.StorageTier), nil
 	}
 }
+
+func StatusIPAMPoolCIDRState(conn *ec2.EC2, cidrBlock, poolID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindIPAMPoolCIDRByTwoPartKey(conn, cidrBlock, poolID)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.State), nil
+	}
+}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds pagination to pool CIDR lookup, avoiding a crash when the CIDR is not found.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/27424.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccIPAMPoolCIDR_' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccIPAMPoolCIDR_ -timeout 180m
=== RUN   TestAccIPAMPoolCIDR_basic
=== PAUSE TestAccIPAMPoolCIDR_basic
=== RUN   TestAccIPAMPoolCIDR_disappears
=== PAUSE TestAccIPAMPoolCIDR_disappears
=== RUN   TestAccIPAMPoolCIDR_Disappears_ipam
=== PAUSE TestAccIPAMPoolCIDR_Disappears_ipam
=== CONT  TestAccIPAMPoolCIDR_basic
=== CONT  TestAccIPAMPoolCIDR_Disappears_ipam
=== CONT  TestAccIPAMPoolCIDR_disappears
--- PASS: TestAccIPAMPoolCIDR_disappears (74.25s)
--- PASS: TestAccIPAMPoolCIDR_basic (74.51s)
--- PASS: TestAccIPAMPoolCIDR_Disappears_ipam (76.21s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	80.332s
```
