### PR TITLE
New Resource: `aws_lightsail_lb_stickiness_policy` 

### DIFF
--- a/.changelog/27514.txt
+++ b/.changelog/27514.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_lightsail_lb_stickiness_policy
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1720,6 +1720,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_lightsail_lb_attachment":                        lightsail.ResourceLoadBalancerAttachment(),
 			"aws_lightsail_lb_certificate":                       lightsail.ResourceLoadBalancerCertificate(),
 			"aws_lightsail_lb_certificate_attachment":            lightsail.ResourceLoadBalancerCertificateAttachment(),
+			"aws_lightsail_lb_stickiness_policy":                 lightsail.ResourceLoadBalancerStickinessPolicy(),
 			"aws_lightsail_static_ip":                            lightsail.ResourceStaticIP(),
 			"aws_lightsail_static_ip_attachment":                 lightsail.ResourceStaticIPAttachment(),
 

--- a/internal/service/lightsail/consts.go
+++ b/internal/service/lightsail/consts.go
@@ -9,4 +9,5 @@ const (
 	ResLoadBalancerAttachment            = "Load Balancer Attachment"
 	ResLoadBalancerCertificate           = "Load Balancer Certificate"
 	ResLoadBalancerCertificateAttachment = "Load Balancer Certificate Attachment"
+	ResLoadBalancerStickinessPolicy      = "Load Balancer StickinessPolicy"
 )

--- a/internal/service/lightsail/find.go
+++ b/internal/service/lightsail/find.go
@@ -319,10 +319,8 @@ func FindLoadBalancerStickinessPolicyById(ctx context.Context, conn *lightsail.L
 		return nil, err
 	}
 
-	if val, ok := out.LoadBalancer.ConfigurationOptions["SessionStickinessEnabled"]; ok {
-		if aws.StringValue(val) == "false" {
-			return nil, tfresource.NewEmptyResultError(in)
-		}
+	if out == nil || out.LoadBalancer.ConfigurationOptions == nil {
+		return nil, tfresource.NewEmptyResultError(in)
 	}
 
 	return out.LoadBalancer.ConfigurationOptions, nil

--- a/internal/service/lightsail/find.go
+++ b/internal/service/lightsail/find.go
@@ -303,3 +303,27 @@ func FindLoadBalancerCertificateAttachmentById(ctx context.Context, conn *lights
 
 	return entry, nil
 }
+
+func FindLoadBalancerStickinessPolicyById(ctx context.Context, conn *lightsail.Lightsail, id string) (map[string]*string, error) {
+	in := &lightsail.GetLoadBalancerInput{LoadBalancerName: aws.String(id)}
+	out, err := conn.GetLoadBalancerWithContext(ctx, in)
+
+	if tfawserr.ErrCodeEquals(err, lightsail.ErrCodeNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if val, ok := out.LoadBalancer.ConfigurationOptions["SessionStickinessEnabled"]; ok {
+		if aws.StringValue(val) == "false" {
+			return nil, tfresource.NewEmptyResultError(in)
+		}
+	}
+
+	return out.LoadBalancer.ConfigurationOptions, nil
+}

--- a/internal/service/lightsail/lb_stickiness_policy.go
+++ b/internal/service/lightsail/lb_stickiness_policy.go
@@ -1,0 +1,190 @@
+package lightsail
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func ResourceLoadBalancerStickinessPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceLoadBalancerStickinessPolicyCreate,
+		ReadWithoutTimeout:   resourceLoadBalancerStickinessPolicyRead,
+		UpdateWithoutTimeout: resourceLoadBalancerStickinessPolicyUpdate,
+		DeleteWithoutTimeout: resourceLoadBalancerStickinessPolicyDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"cookie_duration": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"lb_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(2, 255),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]`), "must begin with an alphabetic character"),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]+[^._\-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
+				),
+			},
+		},
+	}
+}
+
+func resourceLoadBalancerStickinessPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	for _, v := range []string{"enabled", "cookie_duration"} {
+
+		in := lightsail.UpdateLoadBalancerAttributeInput{
+			LoadBalancerName: aws.String(d.Get("lb_name").(string)),
+		}
+
+		if v == "enabled" {
+			in.AttributeName = aws.String(lightsail.LoadBalancerAttributeNameSessionStickinessEnabled)
+			in.AttributeValue = aws.String("true")
+		}
+		if v == "cookie_duration" {
+			in.AttributeName = aws.String(lightsail.LoadBalancerAttributeNameSessionStickinessLbCookieDurationSeconds)
+			in.AttributeValue = aws.String(fmt.Sprint(d.Get("cookie_duration").(int)))
+		}
+
+		out, err := conn.UpdateLoadBalancerAttributeWithContext(ctx, &in)
+
+		if err != nil {
+			return create.DiagError(names.Lightsail, lightsail.OperationTypeUpdateLoadBalancerAttribute, ResLoadBalancerStickinessPolicy, d.Get("lb_name").(string), err)
+		}
+
+		if len(out.Operations) == 0 {
+			return create.DiagError(names.Lightsail, lightsail.OperationTypeUpdateLoadBalancerAttribute, ResLoadBalancerStickinessPolicy, d.Get("lb_name").(string), errors.New("No operations found for Update Load Balancer Attribute request"))
+		}
+
+		op := out.Operations[0]
+
+		err = waitOperation(conn, op.Id)
+
+		if err != nil {
+			return create.DiagError(names.Lightsail, lightsail.OperationTypeUpdateLoadBalancerAttribute, ResLoadBalancerStickinessPolicy, d.Get("lb_name").(string), errors.New("Error waiting for Update Load Balancer Attribute request operation"))
+		}
+
+	}
+
+	d.SetId(d.Get("lb_name").(string))
+
+	return resourceLoadBalancerStickinessPolicyRead(ctx, d, meta)
+}
+
+func resourceLoadBalancerStickinessPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	out, err := FindLoadBalancerStickinessPolicyById(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		create.LogNotFoundRemoveState(names.Lightsail, create.ErrActionReading, ResLoadBalancerStickinessPolicy, d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, create.ErrActionReading, ResLoadBalancerStickinessPolicy, d.Id(), err)
+	}
+
+	boolValue, err := strconv.ParseBool(*out[lightsail.LoadBalancerAttributeNameSessionStickinessEnabled])
+	if err != nil {
+		return create.DiagError(names.Lightsail, create.ErrActionReading, ResLoadBalancerStickinessPolicy, d.Id(), err)
+	}
+
+	intValue, err := strconv.Atoi(*out[lightsail.LoadBalancerAttributeNameSessionStickinessLbCookieDurationSeconds])
+	if err != nil {
+		return create.DiagError(names.Lightsail, create.ErrActionReading, ResLoadBalancerStickinessPolicy, d.Id(), err)
+	}
+
+	d.Set("cookie_duration", intValue)
+	d.Set("enabled", boolValue)
+	d.Set("lb_name", d.Id())
+
+	return nil
+}
+
+func resourceLoadBalancerStickinessPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	if d.HasChange("cookie_duration") {
+		in := lightsail.UpdateLoadBalancerAttributeInput{
+			LoadBalancerName: aws.String(d.Get("lb_name").(string)),
+			AttributeName:    aws.String(lightsail.LoadBalancerAttributeNameSessionStickinessLbCookieDurationSeconds),
+			AttributeValue:   aws.String(fmt.Sprint(d.Get("cookie_duration").(int))),
+		}
+
+		out, err := conn.UpdateLoadBalancerAttributeWithContext(ctx, &in)
+
+		if err != nil {
+			return create.DiagError(names.Lightsail, lightsail.OperationTypeUpdateLoadBalancerAttribute, ResLoadBalancerStickinessPolicy, d.Get("lb_name").(string), err)
+		}
+
+		if len(out.Operations) == 0 {
+			return create.DiagError(names.Lightsail, lightsail.OperationTypeUpdateLoadBalancerAttribute, ResLoadBalancerStickinessPolicy, d.Get("lb_name").(string), errors.New("No operations found for Update Load Balancer Attribute request"))
+		}
+
+		op := out.Operations[0]
+
+		err = waitOperation(conn, op.Id)
+
+		if err != nil {
+			return create.DiagError(names.Lightsail, lightsail.OperationTypeUpdateLoadBalancerAttribute, ResLoadBalancerStickinessPolicy, d.Get("lb_name").(string), errors.New("Error waiting for Update Load Balancer Attribute request operation"))
+		}
+	}
+
+	return resourceLoadBalancerStickinessPolicyRead(ctx, d, meta)
+}
+
+func resourceLoadBalancerStickinessPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	in := lightsail.UpdateLoadBalancerAttributeInput{
+		LoadBalancerName: aws.String(d.Get("lb_name").(string)),
+		AttributeName:    aws.String(lightsail.LoadBalancerAttributeNameSessionStickinessEnabled),
+		AttributeValue:   aws.String("false"),
+	}
+
+	out, err := conn.UpdateLoadBalancerAttributeWithContext(ctx, &in)
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeUpdateLoadBalancerAttribute, ResLoadBalancerStickinessPolicy, d.Get("lb_name").(string), err)
+	}
+
+	if len(out.Operations) == 0 {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeUpdateLoadBalancerAttribute, ResLoadBalancerStickinessPolicy, d.Get("lb_name").(string), errors.New("No operations found for Update Load Balancer Attribute request"))
+	}
+
+	op := out.Operations[0]
+
+	err = waitOperation(conn, op.Id)
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeUpdateLoadBalancerAttribute, ResLoadBalancerStickinessPolicy, d.Get("lb_name").(string), errors.New("Error waiting for Update Load Balancer Attribute request operation"))
+	}
+
+	return nil
+}

--- a/internal/service/lightsail/lb_stickiness_policy.go
+++ b/internal/service/lightsail/lb_stickiness_policy.go
@@ -56,7 +56,6 @@ func resourceLoadBalancerStickinessPolicyCreate(ctx context.Context, d *schema.R
 	conn := meta.(*conns.AWSClient).LightsailConn
 
 	for _, v := range []string{"enabled", "cookie_duration"} {
-
 		in := lightsail.UpdateLoadBalancerAttributeInput{
 			LoadBalancerName: aws.String(d.Get("lb_name").(string)),
 		}
@@ -65,6 +64,7 @@ func resourceLoadBalancerStickinessPolicyCreate(ctx context.Context, d *schema.R
 			in.AttributeName = aws.String(lightsail.LoadBalancerAttributeNameSessionStickinessEnabled)
 			in.AttributeValue = aws.String("true")
 		}
+
 		if v == "cookie_duration" {
 			in.AttributeName = aws.String(lightsail.LoadBalancerAttributeNameSessionStickinessLbCookieDurationSeconds)
 			in.AttributeValue = aws.String(fmt.Sprint(d.Get("cookie_duration").(int)))
@@ -81,13 +81,11 @@ func resourceLoadBalancerStickinessPolicyCreate(ctx context.Context, d *schema.R
 		}
 
 		op := out.Operations[0]
-
 		err = waitOperation(conn, op.Id)
 
 		if err != nil {
 			return create.DiagError(names.Lightsail, lightsail.OperationTypeUpdateLoadBalancerAttribute, ResLoadBalancerStickinessPolicy, d.Get("lb_name").(string), errors.New("Error waiting for Update Load Balancer Attribute request operation"))
 		}
-
 	}
 
 	d.SetId(d.Get("lb_name").(string))
@@ -148,7 +146,6 @@ func resourceLoadBalancerStickinessPolicyUpdate(ctx context.Context, d *schema.R
 		}
 
 		op := out.Operations[0]
-
 		err = waitOperation(conn, op.Id)
 
 		if err != nil {
@@ -179,7 +176,6 @@ func resourceLoadBalancerStickinessPolicyDelete(ctx context.Context, d *schema.R
 	}
 
 	op := out.Operations[0]
-
 	err = waitOperation(conn, op.Id)
 
 	if err != nil {

--- a/internal/service/lightsail/lb_stickiness_policy_test.go
+++ b/internal/service/lightsail/lb_stickiness_policy_test.go
@@ -155,7 +155,7 @@ resource "aws_lightsail_lb" "test" {
   instance_port     = "80"
 }
 resource "aws_lightsail_lb_stickiness_policy" "test" {
-  lb_name = aws_lightsail_lb.test.name
+  lb_name         = aws_lightsail_lb.test.name
   cookie_duration = %[2]s
 }
 `, rName, cookieDuration)

--- a/internal/service/lightsail/lb_stickiness_policy_test.go
+++ b/internal/service/lightsail/lb_stickiness_policy_test.go
@@ -1,0 +1,162 @@
+package lightsail_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tflightsail "github.com/hashicorp/terraform-provider-aws/internal/service/lightsail"
+)
+
+func TestAccLightsailLoadBalancerStickinessPolicy_basic(t *testing.T) {
+	var enabled bool
+	resourceName := "aws_lightsail_lb_stickiness_policy.test"
+	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
+	cookieDuration := "150"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(lightsail.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, lightsail.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoadBalancerStickinessPolicyConfig_basic(rName, cookieDuration),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoadBalancerStickinessPolicyExists(resourceName, enabled),
+					resource.TestCheckResourceAttr(resourceName, "cookie_duration", cookieDuration),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "lb_name", rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLightsailLoadBalancerStickinessPolicy_CookieDuration(t *testing.T) {
+	var enabled bool
+	resourceName := "aws_lightsail_lb_stickiness_policy.test"
+	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
+	cookieDuration1 := "200"
+	cookieDuration2 := "500"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(lightsail.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, lightsail.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoadBalancerStickinessPolicyConfig_basic(rName, cookieDuration1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoadBalancerStickinessPolicyExists(resourceName, enabled),
+					resource.TestCheckResourceAttr(resourceName, "cookie_duration", cookieDuration1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccLoadBalancerStickinessPolicyConfig_basic(rName, cookieDuration2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoadBalancerStickinessPolicyExists(resourceName, enabled),
+					resource.TestCheckResourceAttr(resourceName, "cookie_duration", cookieDuration2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLightsailLoadBalancerStickinessPolicy_disappears(t *testing.T) {
+	var enabled bool
+	resourceName := "aws_lightsail_lb_stickiness_policy.test"
+	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
+	cookieDuration := "200"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(lightsail.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, lightsail.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoadBalancerStickinessPolicyConfig_basic(rName, cookieDuration),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoadBalancerStickinessPolicyExists(resourceName, enabled),
+					acctest.CheckResourceDisappears(acctest.Provider, tflightsail.ResourceLoadBalancerStickinessPolicy(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckLoadBalancerStickinessPolicyExists(n string, enabled bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No LightsailLoadBalancerStickinessPolicy ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LightsailConn
+
+		out, err := tflightsail.FindLoadBalancerStickinessPolicyById(context.Background(), conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if out == nil {
+			return fmt.Errorf("Load Balancer Stickiness Policy %q does not exist", rs.Primary.ID)
+		}
+
+		boolValue, err := strconv.ParseBool(*out["SessionStickinessEnabled"])
+		if err != nil {
+			return fmt.Errorf("Load Balancer Stickiness Policy %q does not exist. Error parsing enabled bool", rs.Primary.ID)
+		}
+
+		enabled = boolValue
+
+		return nil
+	}
+}
+
+func testAccLoadBalancerStickinessPolicyConfig_basic(rName string, cookieDuration string) string {
+	return fmt.Sprintf(`
+resource "aws_lightsail_lb" "test" {
+  name              = %[1]q
+  health_check_path = "/"
+  instance_port     = "80"
+}
+resource "aws_lightsail_lb_stickiness_policy" "test" {
+  lb_name = aws_lightsail_lb.test.name
+  cookie_duration = %[2]s
+}
+`, rName, cookieDuration)
+}

--- a/internal/service/lightsail/lb_stickiness_policy_test.go
+++ b/internal/service/lightsail/lb_stickiness_policy_test.go
@@ -187,7 +187,7 @@ resource "aws_lightsail_lb" "test" {
   instance_port     = "80"
 }
 resource "aws_lightsail_lb_stickiness_policy" "test" {
-  enabled = %[2]s
+  enabled         = %[2]s
   cookie_duration = %[3]s
   lb_name         = aws_lightsail_lb.test.name
 }

--- a/website/docs/r/lightsail_lb_stickiness_policy.html.markdown
+++ b/website/docs/r/lightsail_lb_stickiness_policy.html.markdown
@@ -23,7 +23,7 @@ resource "aws_lightsail_lb" "test" {
 }
 
 resource "aws_lightsail_lb_stickiness_policy" "test" {
-  lb_name          = aws_lightsail_lb.test.name
+  lb_name         = aws_lightsail_lb.test.name
   cookie_duration = 900
 }
 ```

--- a/website/docs/r/lightsail_lb_stickiness_policy.html.markdown
+++ b/website/docs/r/lightsail_lb_stickiness_policy.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "Lightsail"
+layout: "aws"
+page_title: "AWS: aws_lightsail_lb_stickiness_policy"
+description: |-
+  Enables and configures Session Stickiness for a Lightsail Load Balancer
+---
+
+# Resource: aws_lightsail_lb_stickiness_policy
+
+Enables and configures Session Stickiness for a Lightsail Load Balancer.
+
+## Example Usage
+
+```terraform
+resource "aws_lightsail_lb" "test" {
+  name              = "test-load-balancer"
+  health_check_path = "/"
+  instance_port     = "80"
+  tags = {
+    foo = "bar"
+  }
+}
+
+resource "aws_lightsail_lb_stickiness_policy" "test" {
+  lb_name          = aws_lightsail_lb.test.name
+  cookie_duration = 900
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `lb_name` - (Required) The name of the load balancer to which you want to enable session stickiness.
+* `cookie_duration` - (Required) The cookie duration in seconds. This determines the length of the session stickiness.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The name used for this load balancer (matches `lb_name`).
+
+## Import
+
+`aws_lightsail_lb_stickiness_policy` can be imported by using the `lb_name` attribute, e.g.,
+
+```
+$ terraform import aws_lightsail_lb_stickiness_policy.test example-load-balancer
+```

--- a/website/docs/r/lightsail_lb_stickiness_policy.html.markdown
+++ b/website/docs/r/lightsail_lb_stickiness_policy.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Lightsail"
 layout: "aws"
 page_title: "AWS: aws_lightsail_lb_stickiness_policy"
 description: |-
-  Enables and configures Session Stickiness for a Lightsail Load Balancer
+  Configures Session Stickiness for a Lightsail Load Balancer
 ---
 
 # Resource: aws_lightsail_lb_stickiness_policy
 
-Enables and configures Session Stickiness for a Lightsail Load Balancer.
+Configures Session Stickiness for a Lightsail Load Balancer.
 
 ## Example Usage
 
@@ -25,6 +25,7 @@ resource "aws_lightsail_lb" "test" {
 resource "aws_lightsail_lb_stickiness_policy" "test" {
   lb_name         = aws_lightsail_lb.test.name
   cookie_duration = 900
+  enabled         = true
 }
 ```
 
@@ -34,6 +35,7 @@ The following arguments are supported:
 
 * `lb_name` - (Required) The name of the load balancer to which you want to enable session stickiness.
 * `cookie_duration` - (Required) The cookie duration in seconds. This determines the length of the session stickiness.
+* `enabled` - (Required) - The Session Stickiness state of the load balancer. `true` to activate session stickiness or `false` to deactivate session stickiness.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR adds a new `aws_lightsail_lb_stickiness_policy`  resource. This allows management of Stickiness settings on Lightsail Load balancers. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccLightsailLoadBalancerStickinessPolicy_' PKG=lightsail      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lightsail/... -v -count 1 -parallel 20  -run=TestAccLightsailLoadBalancerStickinessPolicy_ -timeout 180m
=== RUN   TestAccLightsailLoadBalancerStickinessPolicy_basic
=== PAUSE TestAccLightsailLoadBalancerStickinessPolicy_basic
=== RUN   TestAccLightsailLoadBalancerStickinessPolicy_CookieDuration
=== PAUSE TestAccLightsailLoadBalancerStickinessPolicy_CookieDuration
=== RUN   TestAccLightsailLoadBalancerStickinessPolicy_disappears
=== PAUSE TestAccLightsailLoadBalancerStickinessPolicy_disappears
=== CONT  TestAccLightsailLoadBalancerStickinessPolicy_basic
=== CONT  TestAccLightsailLoadBalancerStickinessPolicy_disappears
=== CONT  TestAccLightsailLoadBalancerStickinessPolicy_CookieDuration
--- PASS: TestAccLightsailLoadBalancerStickinessPolicy_disappears (134.99s)
--- PASS: TestAccLightsailLoadBalancerStickinessPolicy_basic (145.16s)
--- PASS: TestAccLightsailLoadBalancerStickinessPolicy_CookieDuration (168.28s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  170.224s

...
```
