### PR TITLE
`dynamodb_table_item` `create`: use `ConditionExpression`

### DIFF
--- a/.changelog/27517.txt
+++ b/.changelog/27517.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dynamodb_table_item: Allow the creation of items with the same hash key but different rage keys
+```

--- a/.changelog/27517.txt
+++ b/.changelog/27517.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_dynamodb_table_item: Allow the creation of items with the same hash key but different rage keys
+resource/aws_dynamodb_table_item: Allow the creation of items with the same hash key but different range keys
 ```

--- a/internal/service/dynamodb/table_item.go
+++ b/internal/service/dynamodb/table_item.go
@@ -74,7 +74,7 @@ func resourceTableItemCreate(d *schema.ResourceData, meta interface{}) error {
 		Item: attributes,
 		// Explode if item exists. We didn't create it.
 		ConditionExpression: aws.String(fmt.Sprintf("attribute_not_exists(%s)", hashKey)),
-		TableName: aws.String(tableName),
+		TableName:           aws.String(tableName),
 	})
 	if err != nil {
 		return err

--- a/internal/service/dynamodb/table_item.go
+++ b/internal/service/dynamodb/table_item.go
@@ -73,8 +73,9 @@ func resourceTableItemCreate(d *schema.ResourceData, meta interface{}) error {
 	_, err = conn.PutItem(&dynamodb.PutItemInput{
 		Item: attributes,
 		// Explode if item exists. We didn't create it.
-		ConditionExpression: aws.String(fmt.Sprintf("attribute_not_exists(%s)", hashKey)),
-		TableName:           aws.String(tableName),
+		ConditionExpression:      aws.String("attribute_not_exists(#hk)"),
+		ExpressionAttributeNames: aws.StringMap(map[string]string{"#hk": hashKey}),
+		TableName:                aws.String(tableName),
 	})
 	if err != nil {
 		return err

--- a/internal/service/dynamodb/table_item.go
+++ b/internal/service/dynamodb/table_item.go
@@ -73,11 +73,7 @@ func resourceTableItemCreate(d *schema.ResourceData, meta interface{}) error {
 	_, err = conn.PutItem(&dynamodb.PutItemInput{
 		Item: attributes,
 		// Explode if item exists. We didn't create it.
-		Expected: map[string]*dynamodb.ExpectedAttributeValue{
-			hashKey: {
-				Exists: aws.Bool(false),
-			},
-		},
+		ConditionExpression: aws.String(fmt.Sprintf("attribute_not_exists(%s)", hashKey)),
 		TableName: aws.String(tableName),
 	})
 	if err != nil {

--- a/internal/service/dynamodb/table_item_test.go
+++ b/internal/service/dynamodb/table_item_test.go
@@ -2,6 +2,7 @@ package dynamodb_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -105,6 +106,82 @@ func TestAccDynamoDBTableItem_withMultipleItems(t *testing.T) {
 	"two": {"S": "two"},
 	"three": {"S": "three"},
 	"four": {"S": "four"}
+}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableItemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableItemConfig_multiple(tableName, hashKey, rangeKey, firstItem, secondItem),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTableItemExists("aws_dynamodb_table_item.test1", &conf1),
+					testAccCheckTableItemExists("aws_dynamodb_table_item.test2", &conf2),
+					testAccCheckTableItemCount(tableName, 2),
+
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test1", "hash_key", hashKey),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test1", "range_key", rangeKey),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test1", "table_name", tableName),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test1", "item", firstItem+"\n"),
+
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test2", "hash_key", hashKey),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test2", "range_key", rangeKey),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test2", "table_name", tableName),
+					resource.TestCheckResourceAttr("aws_dynamodb_table_item.test2", "item", secondItem+"\n"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTableItem_withDuplicateItemsSameRangeKey(t *testing.T) {
+	tableName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	hashKey := "hashKey"
+	rangeKey := "rangeKey"
+	firstItem := `{
+	"hashKey": {"S": "something"},
+	"rangeKey": {"S": "first"},
+	"one": {"N": "11111"},
+	"two": {"N": "22222"},
+	"three": {"N": "33333"}
+}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableItemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTableItemConfig_multiple(tableName, hashKey, rangeKey, firstItem, firstItem),
+				ExpectError: regexp.MustCompile(`ConditionalCheckFailedException: The conditional request failed`),
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTableItem_withDuplicateItemsDifferentRangeKey(t *testing.T) {
+	var conf1 dynamodb.GetItemOutput
+	var conf2 dynamodb.GetItemOutput
+
+	tableName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	hashKey := "hashKey"
+	rangeKey := "rangeKey"
+	firstItem := `{
+	"hashKey": {"S": "something"},
+	"rangeKey": {"S": "first"},
+	"one": {"N": "11111"},
+	"two": {"N": "22222"},
+	"three": {"N": "33333"}
+}`
+	secondItem := `{
+	"hashKey": {"S": "something"},
+	"rangeKey": {"S": "second"},
+	"one": {"N": "11111"},
+	"two": {"N": "22222"},
+	"three": {"N": "33333"}
 }`
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
### Description

- per [AWS' documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.Expected.html) `Expected` is a legacy parameter and should no longer be used
- should fix https://github.com/hashicorp/terraform-provider-aws/issues/26080, or at least be more predictable, while maintaining the same behavior for tables without composite keys. It seems like `Expected` is only checking that the hash key does not exist whereas this `ConditionExpression` will check whether an item with the same hash key _and_ range key does not exist
- [this blog post](https://www.alexdebrie.com/posts/dynamodb-condition-expressions/) explains how this `ConditionExpression` works, essentially the condition will always be compared against a single item and so it is sufficient to just check for the existence of the hash key

### Relations

Relates #27503
Closes #26080

### References

- https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.Expected.html
- https://www.alexdebrie.com/posts/dynamodb-condition-expressions/