### PR TITLE
`/go.mod` dependabot configuration aligns with `terraform-provider-awscc`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,17 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     ignore:
+      # terraform-plugin-go should only be updated via terraform-plugin-framework
+      - dependency-name: "github.com/hashicorp/terraform-plugin-go"
+      # terraform-plugin-log should only be updated via terraform-plugin-framework
+      - dependency-name: "github.com/hashicorp/terraform-plugin-log"
+      # go-hclog should only be updated via terraform-plugin-log
+      - dependency-name: "github.com/hashicorp/go-hclog"
       - dependency-name: "golang.org/x/tools"
       - dependency-name: "google.golang.org/grpc"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 20
+    open-pull-requests-limit: 30
   - package-ecosystem: "gomod"
     directory: "/.ci/providerlint"
     ignore:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Align the `/go.mod` dependabot configuration with [`terraform-provider-awscc`](https://github.com/hashicorp/terraform-provider-awscc).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-awscc/pull/714.
