### PR TITLE
Documentation Improvement: Make examples for S3 bucket references consistent across documentation

### DIFF
--- a/website/docs/d/elb_service_account.html.markdown
+++ b/website/docs/d/elb_service_account.html.markdown
@@ -54,7 +54,7 @@ resource "aws_elb" "bar" {
   availability_zones = ["us-west-2a"]
 
   access_logs {
-    bucket   = aws_s3_bucket.elb_logs.bucket
+    bucket   = aws_s3_bucket.elb_logs.id
     interval = 5
   }
 

--- a/website/docs/d/s3_bucket_object.html.markdown
+++ b/website/docs/d/s3_bucket_object.html.markdown
@@ -46,7 +46,7 @@ data "aws_s3_bucket_object" "lambda" {
 }
 
 resource "aws_lambda_function" "test_lambda" {
-  s3_bucket         = data.aws_s3_bucket_object.lambda.bucket
+  s3_bucket         = data.aws_s3_bucket_object.lambda.id
   s3_key            = data.aws_s3_bucket_object.lambda.key
   s3_object_version = data.aws_s3_bucket_object.lambda.version_id
   function_name     = "lambda_function_name"

--- a/website/docs/d/s3_bucket_objects.html.markdown
+++ b/website/docs/d/s3_bucket_objects.html.markdown
@@ -26,7 +26,7 @@ data "aws_s3_bucket_objects" "my_objects" {
 data "aws_s3_object" "object_info" {
   count  = length(data.aws_s3_bucket_objects.my_objects.keys)
   key    = element(data.aws_s3_bucket_objects.my_objects.keys, count.index)
-  bucket = data.aws_s3_bucket_objects.my_objects.bucket
+  bucket = data.aws_s3_bucket_objects.my_objects.id
 }
 ```
 

--- a/website/docs/d/s3_object.html.markdown
+++ b/website/docs/d/s3_object.html.markdown
@@ -44,7 +44,7 @@ data "aws_s3_object" "lambda" {
 }
 
 resource "aws_lambda_function" "test_lambda" {
-  s3_bucket         = data.aws_s3_object.lambda.bucket
+  s3_bucket         = data.aws_s3_object.lambda.id
   s3_key            = data.aws_s3_object.lambda.key
   s3_object_version = data.aws_s3_object.lambda.version_id
   function_name     = "lambda_function_name"

--- a/website/docs/d/s3_objects.html.markdown
+++ b/website/docs/d/s3_objects.html.markdown
@@ -24,7 +24,7 @@ data "aws_s3_objects" "my_objects" {
 data "aws_s3_object" "object_info" {
   count  = length(data.aws_s3_objects.my_objects.keys)
   key    = element(data.aws_s3_objects.my_objects.keys, count.index)
-  bucket = data.aws_s3_objects.my_objects.bucket
+  bucket = data.aws_s3_objects.my_objects.id
 }
 ```
 

--- a/website/docs/guides/version-4-upgrade.html.md
+++ b/website/docs/guides/version-4-upgrade.html.md
@@ -1201,7 +1201,7 @@ When you create an object whose `version_id` you need and an `aws_s3_bucket_vers
 
 ~> **NOTE:** For critical and/or production S3 objects, do not create a bucket, enable versioning, and create an object in the bucket within the same configuration. Doing so will not allow the AWS-recommended 15 minutes between enabling versioning and writing to the bucket.
 
-This example shows the `aws_s3_object.example` depending implicitly on the versioning resource through the reference to `aws_s3_bucket_versioning.example.bucket` to define `bucket`:
+This example shows the `aws_s3_object.example` depending implicitly on the versioning resource through the reference to `aws_s3_bucket_versioning.example.id` to define `bucket`:
 
 ```terraform
 resource "aws_s3_bucket" "example" {
@@ -1217,7 +1217,7 @@ resource "aws_s3_bucket_versioning" "example" {
 }
 
 resource "aws_s3_object" "example" {
-  bucket = aws_s3_bucket_versioning.example.bucket
+  bucket = aws_s3_bucket_versioning.example.id
   key    = "droeloe"
   source = "example.txt"
 }
@@ -2697,7 +2697,7 @@ resource "aws_s3_bucket_versioning" "example" {
 }
 
 resource "aws_s3_object" "example" {
-  bucket = aws_s3_bucket_versioning.example.bucket
+  bucket = aws_s3_bucket_versioning.example.id
   key    = "droeloe"
   source = "example.txt"
 }

--- a/website/docs/r/athena_database.html.markdown
+++ b/website/docs/r/athena_database.html.markdown
@@ -19,7 +19,7 @@ resource "aws_s3_bucket" "example" {
 
 resource "aws_athena_database" "example" {
   name   = "database_name"
-  bucket = aws_s3_bucket.example.bucket
+  bucket = aws_s3_bucket.example.id
 }
 ```
 
@@ -66,7 +66,7 @@ Certain resource arguments, like `encryption_configuration` and `bucket`, do not
 ```terraform
 resource "aws_athena_database" "example" {
   name   = "database_name"
-  bucket = aws_s3_bucket.example.bucket
+  bucket = aws_s3_bucket.example.id
 
   # There is no API for reading bucket
   lifecycle {

--- a/website/docs/r/elastictranscoder_pipeline.html.markdown
+++ b/website/docs/r/elastictranscoder_pipeline.html.markdown
@@ -14,17 +14,17 @@ Provides an Elastic Transcoder pipeline resource.
 
 ```terraform
 resource "aws_elastictranscoder_pipeline" "bar" {
-  input_bucket = aws_s3_bucket.input_bucket.bucket
+  input_bucket = aws_s3_bucket.input_bucket.id
   name         = "aws_elastictranscoder_pipeline_tf_test_"
   role         = aws_iam_role.test_role.arn
 
   content_config {
-    bucket        = aws_s3_bucket.content_bucket.bucket
+    bucket        = aws_s3_bucket.content_bucket.id
     storage_class = "Standard"
   }
 
   thumbnail_config {
-    bucket        = aws_s3_bucket.thumb_bucket.bucket
+    bucket        = aws_s3_bucket.thumb_bucket.id
     storage_class = "Standard"
   }
 }

--- a/website/docs/r/gamelift_build.html.markdown
+++ b/website/docs/r/gamelift_build.html.markdown
@@ -18,7 +18,7 @@ resource "aws_gamelift_build" "test" {
   operating_system = "WINDOWS_2012"
 
   storage_location {
-    bucket   = aws_s3_bucket.test.bucket
+    bucket   = aws_s3_bucket.test.id
     key      = aws_s3_object.test.key
     role_arn = aws_iam_role.test.arn
   }

--- a/website/docs/r/gamelift_script.html.markdown
+++ b/website/docs/r/gamelift_script.html.markdown
@@ -17,7 +17,7 @@ resource "aws_gamelift_script" "example" {
   name = "example-script"
 
   storage_location {
-    bucket   = aws_s3_bucket.example.bucket
+    bucket   = aws_s3_bucket.example.id
     key      = aws_s3_object.example.key
     role_arn = aws_iam_role.example.arn
   }

--- a/website/docs/r/kinesisanalyticsv2_application.html.markdown
+++ b/website/docs/r/kinesisanalyticsv2_application.html.markdown
@@ -23,7 +23,7 @@ resource "aws_s3_bucket" "example" {
 }
 
 resource "aws_s3_object" "example" {
-  bucket = aws_s3_bucket.example.bucket
+  bucket = aws_s3_bucket.example.id
   key    = "example-flink-application"
   source = "flink-app.jar"
 }
@@ -221,7 +221,7 @@ resource "aws_s3_bucket" "example" {
 }
 
 resource "aws_s3_object" "example" {
-  bucket = aws_s3_bucket.example.bucket
+  bucket = aws_s3_bucket.example.id
   key    = "example-flink-application"
   source = "flink-app.jar"
 }

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -27,7 +27,7 @@ resource "aws_lb" "test" {
   enable_deletion_protection = true
 
   access_logs {
-    bucket  = aws_s3_bucket.lb_logs.bucket
+    bucket  = aws_s3_bucket.lb_logs.id
     prefix  = "test-lb"
     enabled = true
   }

--- a/website/docs/r/s3_bucket_accelerate_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_accelerate_configuration.html.markdown
@@ -18,7 +18,7 @@ resource "aws_s3_bucket" "mybucket" {
 }
 
 resource "aws_s3_bucket_accelerate_configuration" "example" {
-  bucket = aws_s3_bucket.mybucket.bucket
+  bucket = aws_s3_bucket.mybucket.id
   status = "Enabled"
 }
 ```

--- a/website/docs/r/s3_bucket_analytics_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_analytics_configuration.html.markdown
@@ -16,7 +16,7 @@ Provides a S3 bucket [analytics configuration](https://docs.aws.amazon.com/Amazo
 
 ```terraform
 resource "aws_s3_bucket_analytics_configuration" "example-entire-bucket" {
-  bucket = aws_s3_bucket.example.bucket
+  bucket = aws_s3_bucket.example.id
   name   = "EntireBucket"
 
   storage_class_analysis {
@@ -43,7 +43,7 @@ resource "aws_s3_bucket" "analytics" {
 
 ```terraform
 resource "aws_s3_bucket_analytics_configuration" "example-filtered" {
-  bucket = aws_s3_bucket.example.bucket
+  bucket = aws_s3_bucket.example.id
   name   = "ImportantBlueDocuments"
 
   filter {

--- a/website/docs/r/s3_bucket_intelligent_tiering_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_intelligent_tiering_configuration.html.markdown
@@ -16,7 +16,7 @@ Provides an [S3 Intelligent-Tiering](https://docs.aws.amazon.com/AmazonS3/latest
 
 ```terraform
 resource "aws_s3_bucket_intelligent_tiering_configuration" "example-entire-bucket" {
-  bucket = aws_s3_bucket.example.bucket
+  bucket = aws_s3_bucket.example.id
   name   = "EntireBucket"
 
   tiering {
@@ -38,7 +38,7 @@ resource "aws_s3_bucket" "example" {
 
 ```terraform
 resource "aws_s3_bucket_intelligent_tiering_configuration" "example-filtered" {
-  bucket = aws_s3_bucket.example.bucket
+  bucket = aws_s3_bucket.example.id
   name   = "ImportantBlueDocuments"
 
   status = "Disabled"

--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -258,7 +258,7 @@ resource "aws_s3_bucket_acl" "bucket_acl" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "bucket-config" {
-  bucket = aws_s3_bucket.bucket.bucket
+  bucket = aws_s3_bucket.bucket.id
 
   rule {
     id = "log"

--- a/website/docs/r/s3_bucket_metric.html.markdown
+++ b/website/docs/r/s3_bucket_metric.html.markdown
@@ -20,7 +20,7 @@ resource "aws_s3_bucket" "example" {
 }
 
 resource "aws_s3_bucket_metric" "example-entire-bucket" {
-  bucket = aws_s3_bucket.example.bucket
+  bucket = aws_s3_bucket.example.id
   name   = "EntireBucket"
 }
 ```
@@ -33,7 +33,7 @@ resource "aws_s3_bucket" "example" {
 }
 
 resource "aws_s3_bucket_metric" "example-filtered" {
-  bucket = aws_s3_bucket.example.bucket
+  bucket = aws_s3_bucket.example.id
   name   = "ImportantBlueDocuments"
 
   filter {

--- a/website/docs/r/s3_bucket_object_lock_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_object_lock_configuration.html.markdown
@@ -26,7 +26,7 @@ resource "aws_s3_bucket" "example" {
 }
 
 resource "aws_s3_bucket_object_lock_configuration" "example" {
-  bucket = aws_s3_bucket.example.bucket
+  bucket = aws_s3_bucket.example.id
 
   rule {
     default_retention {
@@ -51,7 +51,7 @@ resource "aws_s3_bucket" "example" {
 }
 
 resource "aws_s3_bucket_versioning" "example" {
-  bucket = aws_s3_bucket.example.bucket
+  bucket = aws_s3_bucket.example.id
 
   versioning_configuration {
     status = "Enabled"
@@ -66,7 +66,7 @@ resource "aws_s3_bucket_versioning" "example" {
 <!-- markdownlint-disable MD029 -->
 ```terraform
 resource "aws_s3_bucket_object_lock_configuration" "example" {
-  bucket = aws_s3_bucket.example.bucket
+  bucket = aws_s3_bucket.example.id
 
   rule {
     default_retention {

--- a/website/docs/r/s3_bucket_request_payment_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_request_payment_configuration.html.markdown
@@ -16,7 +16,7 @@ Provides an S3 bucket request payment configuration resource. For more informati
 
 ```terraform
 resource "aws_s3_bucket_request_payment_configuration" "example" {
-  bucket = aws_s3_bucket.example.bucket
+  bucket = aws_s3_bucket.example.id
   payer  = "Requester"
 }
 ```

--- a/website/docs/r/s3_bucket_server_side_encryption_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_server_side_encryption_configuration.html.markdown
@@ -23,7 +23,7 @@ resource "aws_s3_bucket" "mybucket" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "example" {
-  bucket = aws_s3_bucket.mybucket.bucket
+  bucket = aws_s3_bucket.mybucket.id
 
   rule {
     apply_server_side_encryption_by_default {

--- a/website/docs/r/s3_bucket_versioning.html.markdown
+++ b/website/docs/r/s3_bucket_versioning.html.markdown
@@ -80,7 +80,7 @@ resource "aws_s3_bucket_versioning" "example" {
 }
 
 resource "aws_s3_object" "example" {
-  bucket = aws_s3_bucket_versioning.example.bucket
+  bucket = aws_s3_bucket_versioning.example.id
   key    = "droeloe"
   source = "example.txt"
 }

--- a/website/docs/r/s3_bucket_website_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_website_configuration.html.markdown
@@ -16,7 +16,7 @@ Provides an S3 bucket website configuration resource. For more information, see 
 
 ```terraform
 resource "aws_s3_bucket_website_configuration" "example" {
-  bucket = aws_s3_bucket.example.bucket
+  bucket = aws_s3_bucket.example.id
 
   index_document {
     suffix = "index.html"
@@ -41,7 +41,7 @@ resource "aws_s3_bucket_website_configuration" "example" {
 
 ```terraform
 resource "aws_s3_bucket_website_configuration" "example" {
-  bucket = aws_s3_bucket.example.bucket
+  bucket = aws_s3_bucket.example.id
 
   index_document {
     suffix = "index.html"

--- a/website/docs/r/spot_datafeed_subscription.html.markdown
+++ b/website/docs/r/spot_datafeed_subscription.html.markdown
@@ -21,7 +21,7 @@ resource "aws_s3_bucket" "default" {
 }
 
 resource "aws_spot_datafeed_subscription" "default" {
-  bucket = aws_s3_bucket.default.bucket
+  bucket = aws_s3_bucket.default.id
   prefix = "my_subdirectory"
 }
 ```

--- a/website/docs/r/ssm_maintenance_window_task.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_task.html.markdown
@@ -84,7 +84,7 @@ resource "aws_ssm_maintenance_window_task" "example" {
 
   task_invocation_parameters {
     run_command_parameters {
-      output_s3_bucket     = aws_s3_bucket.example.bucket
+      output_s3_bucket     = aws_s3_bucket.example.id
       output_s3_key_prefix = "output"
       service_role_arn     = aws_iam_role.example.arn
       timeout_seconds      = 600

--- a/website/docs/r/ssm_resource_data_sync.html.markdown
+++ b/website/docs/r/ssm_resource_data_sync.html.markdown
@@ -18,7 +18,7 @@ resource "aws_s3_bucket" "hoge" {
 }
 
 resource "aws_s3_bucket_policy" "hoge" {
-  bucket = aws_s3_bucket.hoge.bucket
+  bucket = aws_s3_bucket.hoge.id
 
   policy = <<EOF
 {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
It looks like some of the newer documentation prefers to reference S3 bucket names using the `bucket` attribute instead of the `id` attribute. This works, but the rest of the documentation is overwhelmingly using `id`: there are currently 163 places where `id` is used and 35 where `bucket` is used.

This pull request standardizes references to S3 bucket names so that `id` is always used. That seems consistent with most S3 bucket name references and with how other resources are referenced.

This is the regex I used to find all references, which could be modified to replace all `id` references to `bucket` if that is more desirable:
`(bucket\s{0,}=[\sa-zA-Z0-9_.]{1,}\.)(bucket)$`
