### PR TITLE
New Resources: `aws_lightsail_disk` and `aws_lightsail_disk_attachment`

### DIFF
--- a/.changelog/27537.txt
+++ b/.changelog/27537.txt
@@ -1,0 +1,7 @@
+```release-note:new-resource
+aws_lightsail_disk
+```
+
+```release-note:new-resource
+aws_lightsail_disk_attachment
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1712,6 +1712,8 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_lightsail_container_service":                    lightsail.ResourceContainerService(),
 			"aws_lightsail_container_service_deployment_version": lightsail.ResourceContainerServiceDeploymentVersion(),
 			"aws_lightsail_database":                             lightsail.ResourceDatabase(),
+			"aws_lightsail_disk":                                 lightsail.ResourceDisk(),
+			"aws_lightsail_disk_attachment":                      lightsail.ResourceDiskAttachment(),
 			"aws_lightsail_domain":                               lightsail.ResourceDomain(),
 			"aws_lightsail_domain_entry":                         lightsail.ResourceDomainEntry(),
 			"aws_lightsail_instance":                             lightsail.ResourceInstance(),

--- a/internal/service/lightsail/consts.go
+++ b/internal/service/lightsail/consts.go
@@ -3,6 +3,9 @@ package lightsail
 const (
 	ResCertificate                       = "Certificate"
 	ResDatabase                          = "Database"
+	ResDisk                              = "Disk"
+	ResDiskAttachment                    = "Disk Attachment"
+	ResInstance                          = "Instance"
 	ResTags                              = "Tags"
 	ResDomainEntry                       = "Domain Entry"
 	ResLoadBalancer                      = "Load Balancer"

--- a/internal/service/lightsail/disk.go
+++ b/internal/service/lightsail/disk.go
@@ -1,0 +1,192 @@
+package lightsail
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func ResourceDisk() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceDiskCreate,
+		ReadWithoutTimeout:   resourceDiskRead,
+		UpdateWithoutTimeout: resourceDiskUpdate,
+		DeleteWithoutTimeout: resourceDiskDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(2, 255),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]`), "must begin with an alphabetic character"),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]+[^._\-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
+				),
+			},
+			"size_in_gb": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"support_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+func resourceDiskCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	in := lightsail.CreateDiskInput{
+		AvailabilityZone: aws.String(d.Get("availability_zone").(string)),
+		SizeInGb:         aws.Int64(int64(d.Get("size_in_gb").(int))),
+		DiskName:         aws.String(d.Get("name").(string)),
+	}
+
+	if len(tags) > 0 {
+		in.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	out, err := conn.CreateDiskWithContext(ctx, &in)
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeCreateDisk, ResDisk, d.Get("name").(string), err)
+	}
+
+	if len(out.Operations) == 0 {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeCreateDisk, ResDisk, d.Get("name").(string), errors.New("No operations found for Create Disk request"))
+	}
+
+	op := out.Operations[0]
+	d.SetId(d.Get("name").(string))
+
+	err = waitOperation(conn, op.Id)
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeCreateDisk, ResDisk, d.Get("name").(string), errors.New("Error waiting for Create Disk request operation"))
+	}
+
+	return resourceDiskRead(ctx, d, meta)
+}
+
+func resourceDiskRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	out, err := FindDiskById(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		create.LogNotFoundRemoveState(names.Lightsail, create.ErrActionReading, ResDisk, d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, create.ErrActionReading, ResDisk, d.Id(), err)
+	}
+
+	d.Set("arn", out.Arn)
+	d.Set("availability_zone", out.Location.AvailabilityZone)
+	d.Set("created_at", out.CreatedAt.Format(time.RFC3339))
+	d.Set("name", out.Name)
+	d.Set("size_in_gb", out.SizeInGb)
+	d.Set("support_code", out.SupportCode)
+
+	tags := KeyValueTags(out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return create.DiagError(names.Lightsail, create.ErrActionReading, ResDisk, d.Id(), err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return create.DiagError(names.Lightsail, create.ErrActionReading, ResDisk, d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceDiskUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	if d.HasChange("tags") {
+		o, n := d.GetChange("tags")
+
+		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
+			return create.DiagError(names.Lightsail, create.ErrActionUpdating, ResDisk, d.Id(), err)
+		}
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
+			return create.DiagError(names.Lightsail, create.ErrActionUpdating, ResDisk, d.Id(), err)
+		}
+	}
+
+	return resourceDiskRead(ctx, d, meta)
+}
+
+func resourceDiskDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	out, err := conn.DeleteDiskWithContext(ctx, &lightsail.DeleteDiskInput{
+		DiskName: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeDeleteDisk, ResDisk, d.Get("name").(string), err)
+	}
+
+	if len(out.Operations) == 0 {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeDeleteDisk, ResDisk, d.Get("name").(string), errors.New("No operations found for Delete Disk request"))
+	}
+
+	op := out.Operations[0]
+
+	err = waitOperation(conn, op.Id)
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeDeleteDisk, ResDisk, d.Get("name").(string), errors.New("Error waiting for Delete Disk request operation"))
+	}
+
+	return nil
+}

--- a/internal/service/lightsail/disk_attachment.go
+++ b/internal/service/lightsail/disk_attachment.go
@@ -1,0 +1,189 @@
+package lightsail
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func ResourceDiskAttachment() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceDiskAttachmentCreate,
+		ReadWithoutTimeout:   resourceDiskAttachmentRead,
+		DeleteWithoutTimeout: resourceDiskAttachmentDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"disk_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"instance_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"disk_path": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceDiskAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	in := lightsail.AttachDiskInput{
+		DiskName:     aws.String(d.Get("disk_name").(string)),
+		DiskPath:     aws.String(d.Get("disk_path").(string)),
+		InstanceName: aws.String(d.Get("instance_name").(string)),
+	}
+
+	out, err := conn.AttachDiskWithContext(ctx, &in)
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeAttachDisk, ResDiskAttachment, d.Get("name").(string), err)
+	}
+
+	if len(out.Operations) == 0 {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeAttachDisk, ResDiskAttachment, d.Get("name").(string), errors.New("No operations found for Attach Disk request"))
+	}
+
+	op := out.Operations[0]
+
+	err = waitOperation(conn, op.Id)
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeAttachDisk, ResDiskAttachment, d.Get("name").(string), errors.New("Error waiting for Attach Disk request operation"))
+	}
+
+	// Generate an ID
+	vars := []string{
+		d.Get("disk_name").(string),
+		d.Get("instance_name").(string),
+	}
+
+	d.SetId(strings.Join(vars, ","))
+
+	return resourceDiskAttachmentRead(ctx, d, meta)
+}
+
+func resourceDiskAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	out, err := FindDiskAttachmentById(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		create.LogNotFoundRemoveState(names.Lightsail, create.ErrActionReading, ResDiskAttachment, d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, create.ErrActionReading, ResDiskAttachment, d.Id(), err)
+	}
+
+	d.Set("disk_name", out.Name)
+	d.Set("disk_path", out.Path)
+	d.Set("instance_name", out.AttachedTo)
+
+	return nil
+}
+
+func resourceDiskAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn
+
+	id_parts := strings.SplitN(d.Id(), ",", -1)
+	dName := id_parts[0]
+	iName := id_parts[1]
+
+	// A Disk can only be detached from a stopped instance
+	iStateOut, err := waitInstanceStateWithContext(ctx, conn, &iName)
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, create.ErrActionReading, ResInstance, iName, errors.New("Error waiting for Instance to enter running or stopped state"))
+	}
+
+	if aws.StringValue(iStateOut.State.Name) == "running" {
+		stopOut, err := conn.StopInstanceWithContext(ctx, &lightsail.StopInstanceInput{
+			InstanceName: aws.String(iName),
+		})
+
+		if err != nil {
+			return create.DiagError(names.Lightsail, lightsail.OperationTypeStopInstance, ResInstance, iName, err)
+		}
+
+		if len(stopOut.Operations) == 0 {
+			return create.DiagError(names.Lightsail, lightsail.OperationTypeStopInstance, ResInstance, iName, errors.New("No operations found for Stop Instance request"))
+		}
+
+		op := stopOut.Operations[0]
+
+		err = waitOperation(conn, op.Id)
+		if err != nil {
+			return create.DiagError(names.Lightsail, lightsail.OperationTypeStopInstance, ResInstance, iName, errors.New("Error waiting for Stop Instance operation"))
+		}
+	}
+
+	out, err := conn.DetachDiskWithContext(ctx, &lightsail.DetachDiskInput{
+		DiskName: aws.String(dName),
+	})
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeDetachDisk, ResDiskAttachment, d.Get("name").(string), err)
+	}
+
+	if len(out.Operations) == 0 {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeDetachDisk, ResDiskAttachment, d.Get("name").(string), errors.New("No operations found for Detach Disk request"))
+	}
+
+	op := out.Operations[0]
+
+	err = waitOperation(conn, op.Id)
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeDetachDisk, ResDiskAttachment, d.Get("name").(string), errors.New("Error waiting for Detach Disk request operation"))
+	}
+
+	iStateOut, err = waitInstanceStateWithContext(ctx, conn, &iName)
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, create.ErrActionReading, ResInstance, iName, errors.New("Error waiting for Instance to enter running or stopped state"))
+	}
+
+	if aws.StringValue(iStateOut.State.Name) != "running" {
+		stopOut, err := conn.StartInstanceWithContext(ctx, &lightsail.StartInstanceInput{
+			InstanceName: aws.String(iName),
+		})
+
+		if err != nil {
+			return create.DiagError(names.Lightsail, lightsail.OperationTypeStartInstance, ResInstance, iName, err)
+		}
+
+		if len(stopOut.Operations) == 0 {
+			return create.DiagError(names.Lightsail, lightsail.OperationTypeStartInstance, ResInstance, iName, errors.New("No operations found for Start Instance request"))
+		}
+
+		op := stopOut.Operations[0]
+
+		err = waitOperation(conn, op.Id)
+		if err != nil {
+			return create.DiagError(names.Lightsail, lightsail.OperationTypeStartInstance, ResInstance, iName, errors.New("Error waiting for Start Instance operation"))
+		}
+	}
+
+	return nil
+}

--- a/internal/service/lightsail/disk_attachment_test.go
+++ b/internal/service/lightsail/disk_attachment_test.go
@@ -1,0 +1,162 @@
+package lightsail_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tflightsail "github.com/hashicorp/terraform-provider-aws/internal/service/lightsail"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccLightsailDiskAttachment_basic(t *testing.T) {
+	var disk lightsail.Disk
+	resourceName := "aws_lightsail_disk_attachment.test"
+	dName := sdkacctest.RandomWithPrefix("tf-acc-test")
+	liName := sdkacctest.RandomWithPrefix("tf-acc-test")
+	diskPath := "/dev/xvdf"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(lightsail.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, lightsail.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDiskAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDiskAttachmentConfig_basic(dName, liName, diskPath),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDiskAttachmentExists(resourceName, disk),
+					resource.TestCheckResourceAttr(resourceName, "disk_name", dName),
+					resource.TestCheckResourceAttr(resourceName, "disk_path", diskPath),
+					resource.TestCheckResourceAttr(resourceName, "instance_name", liName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLightsailDiskAttachment_disappears(t *testing.T) {
+	var disk lightsail.Disk
+	resourceName := "aws_lightsail_disk_attachment.test"
+	dName := sdkacctest.RandomWithPrefix("tf-acc-test")
+	liName := sdkacctest.RandomWithPrefix("tf-acc-test")
+	diskPath := "/dev/xvdf"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(lightsail.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, lightsail.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDiskAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDiskAttachmentConfig_basic(dName, liName, diskPath),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDiskAttachmentExists(resourceName, disk),
+					acctest.CheckResourceDisappears(acctest.Provider, tflightsail.ResourceDiskAttachment(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDiskAttachmentExists(n string, disk lightsail.Disk) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No LightsailDiskAttachment ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LightsailConn
+
+		out, err := tflightsail.FindDiskAttachmentById(context.Background(), conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if out == nil {
+			return fmt.Errorf("Disk Attachment %q does not exist", rs.Primary.ID)
+		}
+
+		disk = *out
+
+		return nil
+	}
+}
+
+func testAccCheckDiskAttachmentDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_lightsail_disk_attachment" {
+			continue
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LightsailConn
+
+		_, err := tflightsail.FindDiskAttachmentById(context.Background(), conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return create.Error(names.Lightsail, create.ErrActionCheckingDestroyed, tflightsail.ResDiskAttachment, rs.Primary.ID, errors.New("still exists"))
+	}
+
+	return nil
+}
+
+func testAccDiskAttachmentConfig_basic(dName string, liName string, diskPath string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+resource "aws_lightsail_disk" "test" {
+  name              = %[1]q
+  size_in_gb        = 8
+  availability_zone = data.aws_availability_zones.available.names[0]
+}
+
+resource "aws_lightsail_instance" "test" {
+  name              = %[2]q
+  availability_zone = data.aws_availability_zones.available.names[0]
+  blueprint_id      = "amazon_linux"
+  bundle_id         = "nano_1_0"
+}
+
+resource "aws_lightsail_disk_attachment" "test" {
+  disk_name     = aws_lightsail_disk.test.name
+  instance_name = aws_lightsail_instance.test.name
+  disk_path     = %[3]q
+}
+`, dName, liName, diskPath)
+}

--- a/internal/service/lightsail/disk_test.go
+++ b/internal/service/lightsail/disk_test.go
@@ -1,0 +1,241 @@
+package lightsail_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tflightsail "github.com/hashicorp/terraform-provider-aws/internal/service/lightsail"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccLightsailDisk_basic(t *testing.T) {
+	var disk lightsail.Disk
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lightsail_disk.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(lightsail.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, lightsail.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDiskDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDiskConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDiskExists(resourceName, &disk),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "lightsail", regexp.MustCompile(`Disk/.+`)),
+					resource.TestCheckResourceAttrSet(resourceName, "availability_zone"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "size_in_gb", "8"),
+					resource.TestCheckResourceAttrSet(resourceName, "support_code"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLightsailDisk_Tags(t *testing.T) {
+	var disk1, disk2, disk3 lightsail.Disk
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lightsail_disk.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(lightsail.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, lightsail.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDiskDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDiskConfig_tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDiskExists(resourceName, &disk1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDiskConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDiskExists(resourceName, &disk2),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccDiskConfig_tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDiskExists(resourceName, &disk3),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDiskExists(n string, disk *lightsail.Disk) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No LightsailDisk ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LightsailConn
+
+		resp, err := tflightsail.FindDiskById(context.Background(), conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if resp == nil {
+			return fmt.Errorf("Disk %q does not exist", rs.Primary.ID)
+		}
+
+		*disk = *resp
+
+		return nil
+	}
+}
+
+func TestAccLightsailDisk_disappears(t *testing.T) {
+	var disk lightsail.Disk
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lightsail_disk.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(lightsail.EndpointsID, t)
+			testAccPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, lightsail.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDiskDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDiskConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDiskExists(resourceName, &disk),
+					acctest.CheckResourceDisappears(acctest.Provider, tflightsail.ResourceDisk(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDiskDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_lightsail_disk" {
+			continue
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LightsailConn
+
+		_, err := tflightsail.FindDiskById(context.Background(), conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return create.Error(names.Lightsail, create.ErrActionCheckingDestroyed, tflightsail.ResDisk, rs.Primary.ID, errors.New("still exists"))
+	}
+
+	return nil
+}
+
+func testAccDiskConfigBase() string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+`)
+}
+
+func testAccDiskConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccDiskConfigBase(),
+		fmt.Sprintf(`
+resource "aws_lightsail_disk" "test" {
+  name              = %[1]q
+  size_in_gb        = 8
+  availability_zone = data.aws_availability_zones.available.names[0]
+}
+`, rName))
+}
+
+func testAccDiskConfig_tags1(rName string, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(
+		testAccDiskConfigBase(),
+		fmt.Sprintf(`
+resource "aws_lightsail_disk" "test" {
+  name              = %[1]q
+  size_in_gb        = 8
+  availability_zone = data.aws_availability_zones.available.names[0]
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1))
+}
+
+func testAccDiskConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(
+		testAccDiskConfigBase(),
+		fmt.Sprintf(`
+resource "aws_lightsail_disk" "test" {
+  name              = %[1]q
+  size_in_gb        = 8
+  availability_zone = data.aws_availability_zones.available.names[0]
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
+}

--- a/internal/service/lightsail/disk_test.go
+++ b/internal/service/lightsail/disk_test.go
@@ -185,7 +185,7 @@ func testAccCheckDiskDestroy(s *terraform.State) error {
 }
 
 func testAccDiskConfigBase() string {
-	return fmt.Sprintf(`
+	return `
 data "aws_availability_zones" "available" {
   state = "available"
 
@@ -194,7 +194,7 @@ data "aws_availability_zones" "available" {
     values = ["opt-in-not-required"]
   }
 }
-`)
+`
 }
 
 func testAccDiskConfig_basic(rName string) string {

--- a/internal/service/lightsail/status.go
+++ b/internal/service/lightsail/status.go
@@ -118,3 +118,28 @@ func statusDatabaseBackupRetention(conn *lightsail.Lightsail, db *string) resour
 		return output, strconv.FormatBool(*output.RelationalDatabase.BackupRetentionEnabled), nil
 	}
 }
+
+func statusInstance(conn *lightsail.Lightsail, iName *string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		in := &lightsail.GetInstanceStateInput{
+			InstanceName: iName,
+		}
+
+		iNameValue := aws.StringValue(iName)
+
+		log.Printf("[DEBUG] Checking if Lightsail Instance (%s) is in a ready state.", iNameValue)
+
+		out, err := conn.GetInstanceState(in)
+
+		if err != nil {
+			return out, "FAILED", err
+		}
+
+		if out.State == nil {
+			return nil, "Failed", fmt.Errorf("Error retrieving Instance info for (%s)", iNameValue)
+		}
+
+		log.Printf("[DEBUG] Lightsail Instance (%s) State is currently (%s)", iNameValue, *out.State.Name)
+		return out, *out.State.Name, nil
+	}
+}

--- a/internal/service/lightsail/wait.go
+++ b/internal/service/lightsail/wait.go
@@ -209,3 +209,22 @@ func waitContainerServiceDeploymentVersionActive(ctx context.Context, conn *ligh
 
 	return err
 }
+
+func waitInstanceStateWithContext(ctx context.Context, conn *lightsail.Lightsail, id *string) (*lightsail.GetInstanceStateOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"pending", "stopping"},
+		Target:     []string{"stopped", "running"},
+		Refresh:    statusInstance(conn, id),
+		Timeout:    OperationTimeout,
+		Delay:      OperationDelay,
+		MinTimeout: OperationMinTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if out, ok := outputRaw.(*lightsail.GetInstanceStateOutput); ok {
+		return out, err
+	}
+
+	return nil, err
+}

--- a/website/docs/r/lightsail_disk.html.markdown
+++ b/website/docs/r/lightsail_disk.html.markdown
@@ -1,0 +1,57 @@
+---
+subcategory: "Lightsail"
+layout: "aws"
+page_title: "AWS: aws_lightsail_disk"
+description: |-
+  Provides a Lightsail Disk resource
+---
+
+# Resource: aws_lightsail_disk
+
+Provides a Lightsail Disk resource.
+
+## Example Usage
+
+```terraform
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_lightsail_disk" "test" {
+  name              = "test"
+  size_in_gb        = 8
+  availability_zone = data.aws_availability_zones.available.names[0]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Lightsail load balancer.
+* `size_in_gb` - (Required) The instance port the load balancer will connect.
+* `availability_zone` - (Required) The Availability Zone in which to create your disk.
+* `tags` - (Optional) A map of tags to assign to the resource. To create a key-only tag, use an empty string as the value. If configured with a provider `default_tags` configuration block present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The name of the disk  (matches `name`).
+* `arn` - The ARN of the Lightsail load balancer.
+* `created_at` - The timestamp when the load balancer was created.
+* `support_code` - The support code for the disk. Include this code in your email to support when you have questions about a disk in Lightsail. This code enables our support team to look up your Lightsail information more easily.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+
+## Import
+
+`aws_lightsail_disk` can be imported by using the name attribute, e.g.,
+
+```shell
+$ terraform import aws_lightsail_disk.test test
+```

--- a/website/docs/r/lightsail_disk_attachment.html.markdown
+++ b/website/docs/r/lightsail_disk_attachment.html.markdown
@@ -1,0 +1,65 @@
+---
+subcategory: "Lightsail"
+layout: "aws"
+page_title: "AWS: aws_lightsail_disk_attachment"
+description: |-
+  Attaches a Lightsail disk to a Lightsail Instance
+---
+
+# Resource: aws_lightsail_disk_attachment
+
+Attaches a Lightsail disk to a Lightsail Instance
+
+## Example Usage
+
+```terraform
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_lightsail_disk" "test" {
+  name              = "test-disk"
+  size_in_gb        = 8
+  availability_zone = data.aws_availability_zones.available.names[0]
+}
+
+resource "aws_lightsail_instance" "test" {
+  name              = "test-instance"
+  availability_zone = data.aws_availability_zones.available.names[0]
+  blueprint_id      = "amazon_linux"
+  bundle_id         = "nano_1_0"
+}
+
+resource "aws_lightsail_disk_attachment" "test" {
+  disk_name     = aws_lightsail_disk.test.name
+  instance_name = aws_lightsail_instance.test.name
+  disk_path     = "/dev/xvdf"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `disk_name` - (Required) The name of the Lightsail Disk.
+* `instance_name` - (Required) The name of the Lightsail Instance to attach to.
+* `disk_path` - (Required) The disk path to expose to the instance.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A combination of attributes to create a unique id: `disk_name`,`instance_name`
+
+## Import
+
+`aws_lightsail_disk` can be imported by using the id attribute, e.g.,
+
+```shell
+$ terraform import aws_lightsail_disk_attachment.test test-disk,test-instance
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR provides the following two resources: `aws_lightsail_disk` and `aws_lightsail_disk_attachment` 

Users will be able to manage lightsail disks and attaching them to instances with terraform. 

This is a revive of the #9975 pull request. I was unable to pull in commits from that PR as i received an access denied error when attempting. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #9975

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccLightsailDisk' PKG=lightsail
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lightsail/... -v -count 1 -parallel 20  -run=TestAccLightsailDisk -timeout 180m
=== RUN   TestAccLightsailDiskAttachment_basic
=== PAUSE TestAccLightsailDiskAttachment_basic
=== RUN   TestAccLightsailDiskAttachment_disappears
=== PAUSE TestAccLightsailDiskAttachment_disappears
=== RUN   TestAccLightsailDisk_basic
=== PAUSE TestAccLightsailDisk_basic
=== RUN   TestAccLightsailDisk_Tags
=== PAUSE TestAccLightsailDisk_Tags
=== RUN   TestAccLightsailDisk_disappears
=== PAUSE TestAccLightsailDisk_disappears
=== CONT  TestAccLightsailDiskAttachment_basic
=== CONT  TestAccLightsailDisk_disappears
=== CONT  TestAccLightsailDisk_basic
=== CONT  TestAccLightsailDiskAttachment_disappears
=== CONT  TestAccLightsailDisk_Tags
--- PASS: TestAccLightsailDisk_disappears (49.75s)
--- PASS: TestAccLightsailDisk_basic (53.54s)
--- PASS: TestAccLightsailDisk_Tags (80.48s)
--- PASS: TestAccLightsailDiskAttachment_disappears (179.95s)
--- PASS: TestAccLightsailDiskAttachment_basic (180.86s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  182.881s

...
```
