### PR TITLE
Sagemaker workforce - vpc support

### DIFF
--- a/.changelog/27538.txt
+++ b/.changelog/27538.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sagemaker_workforce: Add `workforce_vpc_config` argument
+```

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -314,6 +314,7 @@ func init() {
 		F:    sweepVPCEndpoints,
 		Dependencies: []string{
 			"aws_route_table",
+			"aws_sagemaker_workforce",
 		},
 	})
 

--- a/internal/service/sagemaker/sagemaker_test.go
+++ b/internal/service/sagemaker/sagemaker_test.go
@@ -70,6 +70,7 @@ func TestAccSageMaker_serial(t *testing.T) {
 			"CognitoConfig":  testAccWorkforce_cognitoConfig,
 			"OidcConfig":     testAccWorkforce_oidcConfig,
 			"SourceIpConfig": testAccWorkforce_sourceIPConfig,
+			"VPC":            testAccWorkforce_vpc,
 		},
 		"Workteam": {
 			"disappears":         testAccWorkteam_disappears,

--- a/internal/service/sagemaker/status.go
+++ b/internal/service/sagemaker/status.go
@@ -248,3 +248,19 @@ func StatusProject(conn *sagemaker.SageMaker, name string) resource.StateRefresh
 		return output, aws.StringValue(output.ProjectStatus), nil
 	}
 }
+
+func StatusWorkforce(conn *sagemaker.SageMaker, name string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindWorkforceByName(conn, name)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}

--- a/internal/service/sagemaker/workforce.go
+++ b/internal/service/sagemaker/workforce.go
@@ -146,6 +146,35 @@ func ResourceWorkforce() *schema.Resource {
 					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-])*$`), "Valid characters are a-z, A-Z, 0-9, and - (hyphen)."),
 				),
 			},
+			"workforce_vpc_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"security_group_ids": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							MaxItems: 5,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"subnets": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							MaxItems: 16,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"vpc_endpoint_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -170,6 +199,10 @@ func resourceWorkforceCreate(d *schema.ResourceData, meta interface{}) error {
 		input.SourceIpConfig = expandWorkforceSourceIPConfig(v.([]interface{}))
 	}
 
+	if v, ok := d.GetOk("workforce_vpc_config"); ok {
+		input.WorkforceVpcConfig = expandWorkforceVpcConfig(v.([]interface{}))
+	}
+
 	log.Printf("[DEBUG] Creating SageMaker Workforce: %s", input)
 	_, err := conn.CreateWorkforce(input)
 
@@ -178,6 +211,10 @@ func resourceWorkforceCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(name)
+
+	if _, err := WaitWorkforceActive(conn, name); err != nil {
+		return fmt.Errorf("waiting for SageMaker Workfoce (%s) to be created: %w", d.Id(), err)
+	}
 
 	return resourceWorkforceRead(d, meta)
 }
@@ -215,6 +252,10 @@ func resourceWorkforceRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("setting source_ip_config: %w", err)
 	}
 
+	if err := d.Set("workforce_vpc_config", flattenWorkforceVpcConfig(workforce.WorkforceVpcConfig)); err != nil {
+		return fmt.Errorf("setting workforce_vpc_config: %w", err)
+	}
+
 	return nil
 }
 
@@ -233,11 +274,19 @@ func resourceWorkforceUpdate(d *schema.ResourceData, meta interface{}) error {
 		input.OidcConfig = expandWorkforceOIDCConfig(d.Get("oidc_config").([]interface{}))
 	}
 
+	if d.HasChange("workforce_vpc_config") {
+		input.WorkforceVpcConfig = expandWorkforceVpcConfig(d.Get("workforce_vpc_config").([]interface{}))
+	}
+
 	log.Printf("[DEBUG] Updating SageMaker Workforce: %s", input)
 	_, err := conn.UpdateWorkforce(input)
 
 	if err != nil {
 		return fmt.Errorf("updating SageMaker Workforce (%s): %w", d.Id(), err)
+	}
+
+	if _, err := WaitWorkforceActive(conn, d.Id()); err != nil {
+		return fmt.Errorf("waiting for SageMaker Workfoce (%s) to be updated: %w", d.Id(), err)
 	}
 
 	return resourceWorkforceRead(d, meta)
@@ -257,6 +306,10 @@ func resourceWorkforceDelete(d *schema.ResourceData, meta interface{}) error {
 
 	if err != nil {
 		return fmt.Errorf("deleting SageMaker Workforce (%s): %w", d.Id(), err)
+	}
+
+	if _, err := WaitWorkforceDeleted(conn, d.Id()); err != nil {
+		return fmt.Errorf("waiting for SageMaker Workfoce (%s) to be deleted: %w", d.Id(), err)
 	}
 
 	return nil
@@ -351,6 +404,37 @@ func flattenWorkforceOIDCConfig(config *sagemaker.OidcConfigForResponse, clientS
 		"logout_endpoint":        aws.StringValue(config.LogoutEndpoint),
 		"token_endpoint":         aws.StringValue(config.TokenEndpoint),
 		"user_info_endpoint":     aws.StringValue(config.UserInfoEndpoint),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func expandWorkforceVpcConfig(l []interface{}) *sagemaker.WorkforceVpcConfigRequest {
+	if len(l) == 0 || l[0] == nil {
+		return &sagemaker.WorkforceVpcConfigRequest{}
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.WorkforceVpcConfigRequest{
+		SecurityGroupIds: flex.ExpandStringSet(m["security_group_ids"].(*schema.Set)),
+		Subnets:          flex.ExpandStringSet(m["subnets"].(*schema.Set)),
+		VpcId:            aws.String(m["vpc_id"].(string)),
+	}
+
+	return config
+}
+
+func flattenWorkforceVpcConfig(config *sagemaker.WorkforceVpcConfigResponse) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"security_group_ids": flex.FlattenStringSet(config.SecurityGroupIds),
+		"subnets":            flex.FlattenStringSet(config.Subnets),
+		"vpc_endpoint_id":    aws.StringValue(config.VpcEndpointId),
+		"vpc_id":             aws.StringValue(config.VpcId),
 	}
 
 	return []map[string]interface{}{m}

--- a/internal/service/sagemaker/workforce.go
+++ b/internal/service/sagemaker/workforce.go
@@ -203,7 +203,6 @@ func resourceWorkforceCreate(d *schema.ResourceData, meta interface{}) error {
 		input.WorkforceVpcConfig = expandWorkforceVPCConfig(v.([]interface{}))
 	}
 
-	log.Printf("[DEBUG] Creating SageMaker Workforce: %s", input)
 	_, err := conn.CreateWorkforce(input)
 
 	if err != nil {
@@ -213,7 +212,7 @@ func resourceWorkforceCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(name)
 
 	if _, err := WaitWorkforceActive(conn, name); err != nil {
-		return fmt.Errorf("waiting for SageMaker Workfoce (%s) to be created: %w", d.Id(), err)
+		return fmt.Errorf("waiting for SageMaker Workforce (%s) create: %w", d.Id(), err)
 	}
 
 	return resourceWorkforceRead(d, meta)
@@ -278,7 +277,6 @@ func resourceWorkforceUpdate(d *schema.ResourceData, meta interface{}) error {
 		input.WorkforceVpcConfig = expandWorkforceVPCConfig(d.Get("workforce_vpc_config").([]interface{}))
 	}
 
-	log.Printf("[DEBUG] Updating SageMaker Workforce: %s", input)
 	_, err := conn.UpdateWorkforce(input)
 
 	if err != nil {
@@ -286,7 +284,7 @@ func resourceWorkforceUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if _, err := WaitWorkforceActive(conn, d.Id()); err != nil {
-		return fmt.Errorf("waiting for SageMaker Workfoce (%s) to be updated: %w", d.Id(), err)
+		return fmt.Errorf("waiting for SageMaker Workforce (%s) update: %w", d.Id(), err)
 	}
 
 	return resourceWorkforceRead(d, meta)
@@ -309,7 +307,7 @@ func resourceWorkforceDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if _, err := WaitWorkforceDeleted(conn, d.Id()); err != nil {
-		return fmt.Errorf("waiting for SageMaker Workfoce (%s) to be deleted: %w", d.Id(), err)
+		return fmt.Errorf("waiting for SageMaker Workforce (%s) delete: %w", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/sagemaker/workforce.go
+++ b/internal/service/sagemaker/workforce.go
@@ -200,7 +200,7 @@ func resourceWorkforceCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("workforce_vpc_config"); ok {
-		input.WorkforceVpcConfig = expandWorkforceVpcConfig(v.([]interface{}))
+		input.WorkforceVpcConfig = expandWorkforceVPCConfig(v.([]interface{}))
 	}
 
 	log.Printf("[DEBUG] Creating SageMaker Workforce: %s", input)
@@ -252,7 +252,7 @@ func resourceWorkforceRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("setting source_ip_config: %w", err)
 	}
 
-	if err := d.Set("workforce_vpc_config", flattenWorkforceVpcConfig(workforce.WorkforceVpcConfig)); err != nil {
+	if err := d.Set("workforce_vpc_config", flattenWorkforceVPCConfig(workforce.WorkforceVpcConfig)); err != nil {
 		return fmt.Errorf("setting workforce_vpc_config: %w", err)
 	}
 
@@ -275,7 +275,7 @@ func resourceWorkforceUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("workforce_vpc_config") {
-		input.WorkforceVpcConfig = expandWorkforceVpcConfig(d.Get("workforce_vpc_config").([]interface{}))
+		input.WorkforceVpcConfig = expandWorkforceVPCConfig(d.Get("workforce_vpc_config").([]interface{}))
 	}
 
 	log.Printf("[DEBUG] Updating SageMaker Workforce: %s", input)
@@ -409,7 +409,7 @@ func flattenWorkforceOIDCConfig(config *sagemaker.OidcConfigForResponse, clientS
 	return []map[string]interface{}{m}
 }
 
-func expandWorkforceVpcConfig(l []interface{}) *sagemaker.WorkforceVpcConfigRequest {
+func expandWorkforceVPCConfig(l []interface{}) *sagemaker.WorkforceVpcConfigRequest {
 	if len(l) == 0 || l[0] == nil {
 		return &sagemaker.WorkforceVpcConfigRequest{}
 	}
@@ -425,7 +425,7 @@ func expandWorkforceVpcConfig(l []interface{}) *sagemaker.WorkforceVpcConfigRequ
 	return config
 }
 
-func flattenWorkforceVpcConfig(config *sagemaker.WorkforceVpcConfigResponse) []map[string]interface{} {
+func flattenWorkforceVPCConfig(config *sagemaker.WorkforceVpcConfigResponse) []map[string]interface{} {
 	if config == nil {
 		return []map[string]interface{}{}
 	}

--- a/website/docs/r/sagemaker_workforce.html.markdown
+++ b/website/docs/r/sagemaker_workforce.html.markdown
@@ -64,9 +64,10 @@ resource "aws_sagemaker_workforce" "example" {
 The following arguments are supported:
 
 * `workforce_name` - (Required) The name of the Workforce (must be unique).
-* `cognito_config` - (Required) Use this parameter to configure an Amazon Cognito private workforce. A single Cognito workforce is created using and corresponds to a single Amazon Cognito user pool. Conflicts with `oidc_config`. see [Cognito Config](#cognito-config) details below.
-* `oidc_config` - (Required) Use this parameter to configure a private workforce using your own OIDC Identity Provider. Conflicts with `cognito_config`. see [OIDC Config](#oidc-config) details below.
-* `source_ip_config` - (Required) A list of IP address ranges Used to create an allow list of IP addresses for a private workforce. By default, a workforce isn't restricted to specific IP addresses. see [Source Ip Config](#source-ip-config) details below.
+* `cognito_config` - (Optional) Use this parameter to configure an Amazon Cognito private workforce. A single Cognito workforce is created using and corresponds to a single Amazon Cognito user pool. Conflicts with `oidc_config`. see [Cognito Config](#cognito-config) details below.
+* `oidc_config` - (Optional) Use this parameter to configure a private workforce using your own OIDC Identity Provider. Conflicts with `cognito_config`. see [OIDC Config](#oidc-config) details below.
+* `source_ip_config` - (Optional) A list of IP address ranges Used to create an allow list of IP addresses for a private workforce. By default, a workforce isn't restricted to specific IP addresses. see [Source Ip Config](#source-ip-config) details below.
+* `workforce_vpc_config` - (Optional) configure a workforce using VPC. see [Workforce VPC Config](#workforce-vpc-config) details below.
 
 ### Cognito Config
 
@@ -88,6 +89,12 @@ The following arguments are supported:
 
 * `cidrs` - (Required) A list of up to 10 CIDR values.
 
+### Workforce VPC Config
+
+* `security_group_ids` - (Optional) The VPC security group IDs. The security groups must be for the same VPC as specified in the subnet.
+* `subnets` - (Optional) The ID of the subnets in the VPC that you want to connect.
+* `vpc_id` - (Optional) The ID of the VPC that the workforce uses for communication.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -95,6 +102,7 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The Amazon Resource Name (ARN) assigned by AWS to this Workforce.
 * `id` - The name of the Workforce.
 * `subdomain` - The subdomain for your OIDC Identity Provider.
+* `workforce_vpc_config.0.vpc_endpoint_id` - The IDs for the VPC service endpoints of your VPC workforce.
 
 ## Import
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Add support for VPC config for sagemaker workforce.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccSageMaker_serial/Workforce PKG=sagemaker

--- PASS: TestAccSageMaker_serial (641.34s)
    --- PASS: TestAccSageMaker_serial/Workforce (641.34s)
        --- PASS: TestAccSageMaker_serial/Workforce/OidcConfig (67.75s)
        --- PASS: TestAccSageMaker_serial/Workforce/SourceIpConfig (114.52s)
        --- PASS: TestAccSageMaker_serial/Workforce/VPC (366.91s)
        --- PASS: TestAccSageMaker_serial/Workforce/disappears (43.61s)
        --- PASS: TestAccSageMaker_serial/Workforce/CognitoConfig (48.55s)
```
