### PR TITLE
Use `SHORT_LIVED_CERTIFICATE` ACMPCA CAs to reduce costs

### DIFF
--- a/internal/service/acmpca/certificate_authority_test.go
+++ b/internal/service/acmpca/certificate_authority_test.go
@@ -52,7 +52,7 @@ func TestAccACMPCACertificateAuthority_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", "PENDING_CERTIFICATE"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "type", "SUBORDINATE"),
-					resource.TestCheckResourceAttr(resourceName, "usage_mode", "GENERAL_PURPOSE"),
+					resource.TestCheckResourceAttr(resourceName, "usage_mode", "SHORT_LIVED_CERTIFICATE"),
 				),
 			},
 			{
@@ -233,7 +233,7 @@ func TestAccACMPCACertificateAuthority_RevocationConfiguration_empty(t *testing.
 					resource.TestCheckResourceAttr(resourceName, "status", "PENDING_CERTIFICATE"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "type", "SUBORDINATE"),
-					resource.TestCheckResourceAttr(resourceName, "usage_mode", "GENERAL_PURPOSE"),
+					resource.TestCheckResourceAttr(resourceName, "usage_mode", "SHORT_LIVED_CERTIFICATE"),
 				),
 			},
 			{
@@ -761,6 +761,7 @@ func testAccCertificateAuthorityConfig_enabled(commonName, certificateAuthorityT
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
   enabled                         = %[1]t
+  usage_mode                      = "SHORT_LIVED_CERTIFICATE"
   permanent_deletion_time_in_days = 7
   type                            = %[2]q
 
@@ -800,6 +801,7 @@ func testAccCertificateAuthorityConfig_root(commonName string) string {
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 7
+  usage_mode                      = "SHORT_LIVED_CERTIFICATE"
   type                            = "ROOT"
 
   certificate_authority_configuration {
@@ -839,6 +841,8 @@ data "aws_partition" "current" {}
 func testAccCertificateAuthorityConfig_required(commonName string) string {
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
+  usage_mode = "SHORT_LIVED_CERTIFICATE"
+
   certificate_authority_configuration {
     key_algorithm     = "RSA_4096"
     signing_algorithm = "SHA512WITHRSA"
@@ -854,6 +858,8 @@ resource "aws_acmpca_certificate_authority" "test" {
 func testAccCertificateAuthorityConfig_revocationConfigurationEmpty(commonName string) string {
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
+  usage_mode = "SHORT_LIVED_CERTIFICATE"
+
   certificate_authority_configuration {
     key_algorithm     = "RSA_4096"
     signing_algorithm = "SHA512WITHRSA"
@@ -875,6 +881,7 @@ func testAccCertificateAuthorityConfig_revocationConfigurationCrlConfigurationCu
 		fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 7
+  usage_mode                      = "SHORT_LIVED_CERTIFICATE"
 
   certificate_authority_configuration {
     key_algorithm     = "RSA_4096"
@@ -905,6 +912,7 @@ func testAccCertificateAuthorityConfig_revocationConfigurationCrlConfigurationEn
 		fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 7
+  usage_mode                      = "SHORT_LIVED_CERTIFICATE"
 
   certificate_authority_configuration {
     key_algorithm     = "RSA_4096"
@@ -932,6 +940,7 @@ func testAccCertificateAuthorityConfig_revocationConfigurationCrlConfigurationEx
 		fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 7
+  usage_mode                      = "SHORT_LIVED_CERTIFICATE"
 
   certificate_authority_configuration {
     key_algorithm     = "RSA_4096"
@@ -959,6 +968,7 @@ func testAccCertificateAuthorityConfig_revocationConfigurationCrlConfigurationS3
 		fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 7
+  usage_mode                      = "SHORT_LIVED_CERTIFICATE"
 
   certificate_authority_configuration {
     key_algorithm     = "RSA_4096"
@@ -987,6 +997,7 @@ func testAccCertificateAuthorityConfig_revocationConfigurationOcspConfigurationC
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 7
+  usage_mode                      = "SHORT_LIVED_CERTIFICATE"
 
   certificate_authority_configuration {
     key_algorithm     = "RSA_4096"
@@ -1011,6 +1022,7 @@ func testAccCertificateAuthorityConfig_revocationConfigurationOcspConfigurationE
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 7
+  usage_mode                      = "SHORT_LIVED_CERTIFICATE"
 
   certificate_authority_configuration {
     key_algorithm     = "RSA_4096"
@@ -1069,6 +1081,7 @@ func testAccCertificateAuthorityConfig_tagsSingle(commonName string) string {
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 7
+  usage_mode                      = "SHORT_LIVED_CERTIFICATE"
 
   certificate_authority_configuration {
     key_algorithm     = "RSA_4096"
@@ -1090,6 +1103,7 @@ func testAccCertificateAuthorityConfig_tagsSingleUpdated(commonName string) stri
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 7
+  usage_mode                      = "SHORT_LIVED_CERTIFICATE"
 
   certificate_authority_configuration {
     key_algorithm     = "RSA_4096"
@@ -1111,6 +1125,7 @@ func testAccCertificateAuthorityConfig_tagsMultiple(commonName string) string {
 	return fmt.Sprintf(`
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 7
+  usage_mode                      = "SHORT_LIVED_CERTIFICATE"
 
   certificate_authority_configuration {
     key_algorithm     = "RSA_4096"


### PR DESCRIPTION
Set `usage_mode` to `SHORT_LIVED_CERTIFICATE` to reduce costs when running ACMPCA CA tests.

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27524

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccACMPCACertificateAuthority_ PKG=acmpca
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/acmpca/... -v -count 1 -parallel 20 -run='TestAccACMPCACertificateAuthority_'  -timeout 180m
=== RUN   TestAccACMPCACertificateAuthority_basic
=== PAUSE TestAccACMPCACertificateAuthority_basic
=== RUN   TestAccACMPCACertificateAuthority_disappears
=== PAUSE TestAccACMPCACertificateAuthority_disappears
=== RUN   TestAccACMPCACertificateAuthority_enabledDeprecated
=== PAUSE TestAccACMPCACertificateAuthority_enabledDeprecated
=== RUN   TestAccACMPCACertificateAuthority_usageMode
=== PAUSE TestAccACMPCACertificateAuthority_usageMode
=== RUN   TestAccACMPCACertificateAuthority_deleteFromActiveState
=== PAUSE TestAccACMPCACertificateAuthority_deleteFromActiveState
=== RUN   TestAccACMPCACertificateAuthority_RevocationConfiguration_empty
=== PAUSE TestAccACMPCACertificateAuthority_RevocationConfiguration_empty
=== RUN   TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME
=== PAUSE TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME
=== RUN   TestAccACMPCACertificateAuthority_RevocationCrl_enabled
=== PAUSE TestAccACMPCACertificateAuthority_RevocationCrl_enabled
=== RUN   TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays
=== PAUSE TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays
=== RUN   TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL
=== PAUSE TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL
=== RUN   TestAccACMPCACertificateAuthority_RevocationOcsp_enabled
=== PAUSE TestAccACMPCACertificateAuthority_RevocationOcsp_enabled
=== RUN   TestAccACMPCACertificateAuthority_RevocationOcsp_customCNAME
=== PAUSE TestAccACMPCACertificateAuthority_RevocationOcsp_customCNAME
=== RUN   TestAccACMPCACertificateAuthority_tags
=== PAUSE TestAccACMPCACertificateAuthority_tags
=== CONT  TestAccACMPCACertificateAuthority_basic
=== CONT  TestAccACMPCACertificateAuthority_RevocationCrl_enabled
=== CONT  TestAccACMPCACertificateAuthority_tags
=== CONT  TestAccACMPCACertificateAuthority_RevocationConfiguration_empty
=== CONT  TestAccACMPCACertificateAuthority_RevocationOcsp_enabled
=== CONT  TestAccACMPCACertificateAuthority_RevocationOcsp_customCNAME
=== CONT  TestAccACMPCACertificateAuthority_deleteFromActiveState
=== CONT  TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME
=== CONT  TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL
=== CONT  TestAccACMPCACertificateAuthority_enabledDeprecated
=== CONT  TestAccACMPCACertificateAuthority_usageMode
=== CONT  TestAccACMPCACertificateAuthority_disappears
=== CONT  TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays
--- PASS: TestAccACMPCACertificateAuthority_disappears (25.10s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationConfiguration_empty (32.61s)
--- PASS: TestAccACMPCACertificateAuthority_usageMode (32.66s)
--- PASS: TestAccACMPCACertificateAuthority_basic (32.82s)
--- PASS: TestAccACMPCACertificateAuthority_deleteFromActiveState (33.10s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL (69.56s)
--- PASS: TestAccACMPCACertificateAuthority_enabledDeprecated (72.08s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays (89.99s)
--- PASS: TestAccACMPCACertificateAuthority_tags (90.59s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationOcsp_enabled (91.39s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationOcsp_customCNAME (110.72s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_enabled (117.20s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME (148.36s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/acmpca     148.431s                   
```
