### PR TITLE
docs: a code block was missing closing backticks

### DIFF
--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -78,6 +78,7 @@ resource "aws_eks_node_group" "example" {
   node_role_arn   = aws_iam_role.example.arn
   subnet_ids      = aws_subnet.example[*].id
 }
+```
 
 ### Example IAM Role for EKS Node Group
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

A code block in [EKS node group docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group) is missing closing backticks and that breaks formatting in the rest of the page.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
N/A

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

[Documentation page that needs reformatting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
N/A
