### PR TITLE
d/aws_ip_ranges: Case insensitive comparison for `regions` and `services`

### DIFF
--- a/.changelog/27558.txt
+++ b/.changelog/27558.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_ip_ranges: Fix regression causing filtering on `regions` and `services` to become case-sensitive
+```

--- a/internal/service/meta/ip_ranges_data_source.go
+++ b/internal/service/meta/ip_ranges_data_source.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"golang.org/x/exp/slices"
 )
 
@@ -135,8 +136,8 @@ func (d *dataSourceIPRanges) Read(ctx context.Context, request datasource.ReadRe
 		return
 	}
 
-	regions := flex.ExpandFrameworkStringValueSet(ctx, data.Regions)
-	services := flex.ExpandFrameworkStringValueSet(ctx, data.Services)
+	regions := tfslices.ApplyToAll(flex.ExpandFrameworkStringValueSet(ctx, data.Regions), strings.ToLower)
+	services := tfslices.ApplyToAll(flex.ExpandFrameworkStringValueSet(ctx, data.Services), strings.ToLower)
 	matchFilter := func(region, service string) bool {
 		matchRegion := len(regions) == 0 || slices.Contains(regions, strings.ToLower(region))
 		matchService := slices.Contains(services, strings.ToLower(service))

--- a/internal/service/meta/ip_ranges_data_source_test.go
+++ b/internal/service/meta/ip_ranges_data_source_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestAccMetaIPRangesDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_ip_ranges.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
@@ -24,11 +26,28 @@ func TestAccMetaIPRangesDataSource_basic(t *testing.T) {
 			{
 				Config: testAccIPRangesDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccIPRangesCheckAttributes("data.aws_ip_ranges.some"),
-					testAccIPRangesCheckCIDRBlocksAttribute("data.aws_ip_ranges.some", "cidr_blocks"),
-					testAccIPRangesCheckCIDRBlocksAttribute("data.aws_ip_ranges.some", "ipv6_cidr_blocks"),
-					resource.TestCheckResourceAttr("data.aws_ip_ranges.none", "cidr_blocks.#", "0"),
-					resource.TestCheckResourceAttr("data.aws_ip_ranges.none", "ipv6_cidr_blocks.#", "0"),
+					testAccIPRangesCheckAttributes(dataSourceName),
+					testAccIPRangesCheckCIDRBlocksAttribute(dataSourceName, "cidr_blocks"),
+					testAccIPRangesCheckCIDRBlocksAttribute(dataSourceName, "ipv6_cidr_blocks"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMetaIPRangesDataSource_none(t *testing.T) {
+	dataSourceName := "data.aws_ip_ranges.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIPRangesDataSourceConfig_none,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "cidr_blocks.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "ipv6_cidr_blocks.#", "0"),
 				),
 			},
 		},
@@ -36,6 +55,8 @@ func TestAccMetaIPRangesDataSource_basic(t *testing.T) {
 }
 
 func TestAccMetaIPRangesDataSource_url(t *testing.T) {
+	dataSourceName := "data.aws_ip_ranges.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, tfmeta.PseudoServiceID),
@@ -44,9 +65,9 @@ func TestAccMetaIPRangesDataSource_url(t *testing.T) {
 			{
 				Config: testAccIPRangesDataSourceConfig_url,
 				Check: resource.ComposeTestCheckFunc(
-					testAccIPRangesCheckAttributes("data.aws_ip_ranges.some"),
-					testAccIPRangesCheckCIDRBlocksAttribute("data.aws_ip_ranges.some", "cidr_blocks"),
-					testAccIPRangesCheckCIDRBlocksAttribute("data.aws_ip_ranges.some", "ipv6_cidr_blocks"),
+					testAccIPRangesCheckAttributes(dataSourceName),
+					testAccIPRangesCheckCIDRBlocksAttribute(dataSourceName, "cidr_blocks"),
+					testAccIPRangesCheckCIDRBlocksAttribute(dataSourceName, "ipv6_cidr_blocks"),
 				),
 			},
 		},
@@ -155,12 +176,14 @@ func testAccIPRangesCheckCIDRBlocksAttribute(name, attribute string) resource.Te
 
 // lintignore:AWSAT003
 const testAccIPRangesDataSourceConfig_basic = `
-data "aws_ip_ranges" "some" {
+data "aws_ip_ranges" "test" {
   regions  = ["eu-west-1", "eu-central-1"]
   services = ["ec2"]
 }
+`
 
-data "aws_ip_ranges" "none" {
+const testAccIPRangesDataSourceConfig_none = `
+data "aws_ip_ranges" "test" {
   regions  = ["mars-1"]
   services = ["blueorigin"]
 }
@@ -168,7 +191,7 @@ data "aws_ip_ranges" "none" {
 
 // lintignore:AWSAT003
 const testAccIPRangesDataSourceConfig_url = `
-data "aws_ip_ranges" "some" {
+data "aws_ip_ranges" "test" {
   regions  = ["eu-west-1", "eu-central-1"]
   services = ["ec2"]
   url      = "https://ip-ranges.amazonaws.com/ip-ranges.json"

--- a/internal/service/meta/ip_ranges_data_source_test.go
+++ b/internal/service/meta/ip_ranges_data_source_test.go
@@ -127,7 +127,7 @@ func testAccIPRangesCheckAttributes(n string) resource.TestCheckFunc {
 		for k, v := range a {
 			if regionMember.MatchString(k) {
 				// lintignore:AWSAT003
-				if !(v == "eu-west-1" || v == "eu-central-1") {
+				if v := strings.ToLower(v); !(v == "eu-west-1" || v == "eu-central-1") {
 					return fmt.Errorf("unexpected region %s", v)
 				}
 
@@ -135,7 +135,7 @@ func testAccIPRangesCheckAttributes(n string) resource.TestCheckFunc {
 			}
 
 			if serviceMember.MatchString(k) {
-				if v := strings.ToLower(v); v != "ec2" && v != "amazon" {
+				if v := strings.ToLower(v); !(v == "ec2" || v == "amazon") {
 					return fmt.Errorf("unexpected service %s", v)
 				}
 
@@ -222,7 +222,7 @@ data "aws_ip_ranges" "test" {
 // lintignore:AWSAT003
 const testAccIPRangesDataSourceConfig_uppercase = `
 data "aws_ip_ranges" "test" {
-  regions  = ["eu-west-1", "eu-central-1"]
+  regions  = ["EU-WEST-1", "EU-CENTRAL-1"]
   services = ["AMAZON"]
 }
 `

--- a/internal/service/meta/service_data_source.go
+++ b/internal/service/meta/service_data_source.go
@@ -119,7 +119,7 @@ func (d *dataSourceService) Read(ctx context.Context, request datasource.ReadReq
 
 	if !data.DNSName.IsNull() {
 		v := data.DNSName.Value
-		serviceParts := slices.Reversed(strings.Split(v, "."))
+		serviceParts := slices.Reverse(strings.Split(v, "."))
 		n := len(serviceParts)
 
 		if n < 4 {
@@ -145,12 +145,12 @@ func (d *dataSourceService) Read(ctx context.Context, request datasource.ReadReq
 
 	if data.ReverseDNSPrefix.IsNull() {
 		dnsParts := strings.Split(d.meta.DNSSuffix, ".")
-		data.ReverseDNSPrefix = types.String{Value: strings.Join(slices.Reversed(dnsParts), ".")}
+		data.ReverseDNSPrefix = types.String{Value: strings.Join(slices.Reverse(dnsParts), ".")}
 	}
 
 	reverseDNSName := fmt.Sprintf("%s.%s.%s", data.ReverseDNSPrefix.Value, data.Region.Value, data.ServiceID.Value)
 	data.ReverseDNSName = types.String{Value: reverseDNSName}
-	data.DNSName = types.String{Value: strings.ToLower(strings.Join(slices.Reversed(strings.Split(reverseDNSName, ".")), "."))}
+	data.DNSName = types.String{Value: strings.ToLower(strings.Join(slices.Reverse(strings.Split(reverseDNSName, ".")), "."))}
 
 	data.Supported = types.Bool{Value: true}
 	if partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), data.Region.Value); ok {

--- a/internal/slices/slices.go
+++ b/internal/slices/slices.go
@@ -1,16 +1,7 @@
 package slices
 
-// Reverse reverses a slice in place.
+// Reverse returns a reversed copy of the slice.
 func Reverse[S ~[]E, E any](s S) S {
-	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
-		s[i], s[j] = s[j], s[i]
-	}
-
-	return s
-}
-
-// Reversed returns a reversed copy of the slice.
-func Reversed[S ~[]E, E any](s S) S {
 	v := S([]E{})
 	n := len(s)
 

--- a/internal/slices/slices.go
+++ b/internal/slices/slices.go
@@ -24,3 +24,14 @@ func RemoveAll[E comparable](s []E, r E) []E {
 
 	return v
 }
+
+// ApplyToAll returns a new slice containing the results of applying the function `f` to each element of the original slice `s`.
+func ApplyToAll[T, U any](s []T, f func(T) U) []U {
+	v := make([]U, len(s))
+
+	for i, e := range s {
+		v[i] = f(e)
+	}
+
+	return v
+}

--- a/internal/slices/slices_test.go
+++ b/internal/slices/slices_test.go
@@ -1,6 +1,7 @@
 package slices
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -78,6 +79,40 @@ func TestRemoveAll(t *testing.T) {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			got := RemoveAll(test.input, "one")
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestApplyToAll(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    []string
+		expected []string
+	}
+	tests := map[string]testCase{
+		"three elements": {
+			input:    []string{"one", "two", "3"},
+			expected: []string{"ONE", "TWO", "3"},
+		},
+		"one element": {
+			input:    []string{"abcdEFGH"},
+			expected: []string{"ABCDEFGH"},
+		},
+		"zero elements": {
+			input:    []string{},
+			expected: []string{},
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			got := ApplyToAll(test.input, strings.ToUpper)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)

--- a/internal/slices/slices_test.go
+++ b/internal/slices/slices_test.go
@@ -44,44 +44,6 @@ func TestReverse(t *testing.T) {
 	}
 }
 
-func TestReversed(t *testing.T) {
-	t.Parallel()
-
-	type testCase struct {
-		input    []string
-		expected []string
-	}
-	tests := map[string]testCase{
-		"three elements": {
-			input:    []string{"one", "two", "3"},
-			expected: []string{"3", "two", "one"},
-		},
-		"two elements": {
-			input:    []string{"aa", "bb"},
-			expected: []string{"bb", "aa"},
-		},
-		"one element": {
-			input:    []string{"1"},
-			expected: []string{"1"},
-		},
-		"zero elements": {
-			input:    []string{},
-			expected: []string{},
-		},
-	}
-
-	for name, test := range tests {
-		name, test := name, test
-		t.Run(name, func(t *testing.T) {
-			got := Reversed(test.input)
-
-			if diff := cmp.Diff(got, test.expected); diff != "" {
-				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
-			}
-		})
-	}
-}
-
 func TestRemoveAll(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes a regression introduced in https://github.com/hashicorp/terraform-provider-aws/pull/27221 whereby comparisons for `regions` and `services` became case-sensitive.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/27554.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccMetaIPRangesDataSource_' PKG=meta ACCTEST_PARALLELISM=3 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/meta/... -v -count 1 -parallel 3  -run=TestAccMetaIPRangesDataSource_ -timeout 180m
=== RUN   TestAccMetaIPRangesDataSource_basic
=== PAUSE TestAccMetaIPRangesDataSource_basic
=== RUN   TestAccMetaIPRangesDataSource_none
=== PAUSE TestAccMetaIPRangesDataSource_none
=== RUN   TestAccMetaIPRangesDataSource_url
=== PAUSE TestAccMetaIPRangesDataSource_url
=== RUN   TestAccMetaIPRangesDataSource_uppercase
=== PAUSE TestAccMetaIPRangesDataSource_uppercase
=== CONT  TestAccMetaIPRangesDataSource_basic
=== CONT  TestAccMetaIPRangesDataSource_url
=== CONT  TestAccMetaIPRangesDataSource_none
--- PASS: TestAccMetaIPRangesDataSource_none (14.52s)
=== CONT  TestAccMetaIPRangesDataSource_uppercase
--- PASS: TestAccMetaIPRangesDataSource_basic (15.23s)
--- PASS: TestAccMetaIPRangesDataSource_url (15.31s)
--- PASS: TestAccMetaIPRangesDataSource_uppercase (11.87s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	30.252s
```
