### PR TITLE
EC2: API idempotency

### DIFF
--- a/.changelog/27561.txt
+++ b/.changelog/27561.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/aws_instance: Use EC2 API idempotency to ensure that only a single Instance is created
+```
+
+```release-note:enhancement
+resource/aws_ami_copy: Add `imds_support` attribute
+```
+
+```release-note:enhancement
+resource/aws_ami_from_instance: Add `imds_support` attribute
+```

--- a/internal/service/ec2/ebs_volume.go
+++ b/internal/service/ec2/ebs_volume.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -122,6 +123,7 @@ func resourceEBSVolumeCreate(d *schema.ResourceData, meta interface{}) error {
 
 	input := &ec2.CreateVolumeInput{
 		AvailabilityZone:  aws.String(d.Get("availability_zone").(string)),
+		ClientToken:       aws.String(resource.UniqueId()),
 		TagSpecifications: tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeVolume),
 	}
 
@@ -161,7 +163,6 @@ func resourceEBSVolumeCreate(d *schema.ResourceData, meta interface{}) error {
 		input.VolumeType = aws.String(value.(string))
 	}
 
-	log.Printf("[DEBUG] Creating EBS Volume: %s", input)
 	output, err := conn.CreateVolume(input)
 
 	if err != nil {

--- a/internal/service/ec2/ec2_ami.go
+++ b/internal/service/ec2/ec2_ami.go
@@ -31,9 +31,8 @@ const (
 func ResourceAMI() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAMICreate,
-		// The Read, Update and Delete operations are shared with aws_ami_copy
-		// and aws_ami_from_instance, since they differ only in how the image
-		// is created.
+		// The Read, Update and Delete operations are shared with aws_ami_copy and aws_ami_from_instance,
+		// since they differ only in how the image is created.
 		Read:   resourceAMIRead,
 		Update: resourceAMIUpdate,
 		Delete: resourceAMIDelete,
@@ -48,6 +47,7 @@ func ResourceAMI() *schema.Resource {
 			Delete: schema.DefaultTimeout(amiDeleteTimeout),
 		},
 
+		// Keep in sync with aws_ami_copy's and aws_ami_from_instance's schemas.
 		Schema: map[string]*schema.Schema{
 			"architecture": {
 				Type:         schema.TypeString,

--- a/internal/service/ec2/ec2_ami_copy.go
+++ b/internal/service/ec2/ec2_ami_copy.go
@@ -31,6 +31,7 @@ func ResourceAMICopy() *schema.Resource {
 			Delete: schema.DefaultTimeout(amiDeleteTimeout),
 		},
 
+		// Keep in sync with aws_ami's schema.
 		Schema: map[string]*schema.Schema{
 			"architecture": {
 				Type:     schema.TypeString,
@@ -166,6 +167,10 @@ func ResourceAMICopy() *schema.Resource {
 				Computed: true,
 			},
 			"image_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"imds_support": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/internal/service/ec2/ec2_ami_copy.go
+++ b/internal/service/ec2/ec2_ami_copy.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -262,6 +263,7 @@ func resourceAMICopyCreate(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	sourceImageID := d.Get("source_ami_id").(string)
 	input := &ec2.CopyImageInput{
+		ClientToken:   aws.String(resource.UniqueId()),
 		Description:   aws.String(d.Get("description").(string)),
 		Encrypted:     aws.Bool(d.Get("encrypted").(bool)),
 		Name:          aws.String(name),
@@ -280,7 +282,7 @@ func resourceAMICopyCreate(d *schema.ResourceData, meta interface{}) error {
 	output, err := conn.CopyImage(input)
 
 	if err != nil {
-		return fmt.Errorf("error creating EC2 AMI (%s) from source EC2 AMI (%s): %w", name, sourceImageID, err)
+		return fmt.Errorf("creating EC2 AMI (%s) from source EC2 AMI (%s): %w", name, sourceImageID, err)
 	}
 
 	d.SetId(aws.StringValue(output.ImageId))
@@ -288,12 +290,12 @@ func resourceAMICopyCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if len(tags) > 0 {
 		if err := CreateTags(conn, d.Id(), tags); err != nil {
-			return fmt.Errorf("error adding tags: %s", err)
+			return fmt.Errorf("adding tags: %w", err)
 		}
 	}
 
 	if _, err := WaitImageAvailable(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return fmt.Errorf("error waiting for EC2 AMI (%s) create: %w", d.Id(), err)
+		return fmt.Errorf("waiting for EC2 AMI (%s) create: %w", d.Id(), err)
 	}
 
 	if v, ok := d.GetOk("deprecation_time"); ok {

--- a/internal/service/ec2/ec2_ami_from_instance.go
+++ b/internal/service/ec2/ec2_ami_from_instance.go
@@ -30,6 +30,7 @@ func ResourceAMIFromInstance() *schema.Resource {
 			Delete: schema.DefaultTimeout(amiDeleteTimeout),
 		},
 
+		// Keep in sync with aws_ami's schema.
 		Schema: map[string]*schema.Schema{
 			"architecture": {
 				Type:     schema.TypeString,
@@ -157,6 +158,10 @@ func ResourceAMIFromInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"imds_support": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"kernel_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -254,14 +259,14 @@ func resourceAMIFromInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	output, err := conn.CreateImage(input)
 
 	if err != nil {
-		return fmt.Errorf("error creating EC2 AMI (%s) from EC2 Instance (%s): %w", name, instanceID, err)
+		return fmt.Errorf("creating EC2 AMI (%s) from EC2 Instance (%s): %w", name, instanceID, err)
 	}
 
 	d.SetId(aws.StringValue(output.ImageId))
 	d.Set("manage_ebs_snapshots", true)
 
 	if _, err := WaitImageAvailable(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return fmt.Errorf("error waiting for EC2 AMI (%s) create: %w", d.Id(), err)
+		return fmt.Errorf("waiting for EC2 AMI (%s) create: %w", d.Id(), err)
 	}
 
 	if v, ok := d.GetOk("deprecation_time"); ok {

--- a/internal/service/ec2/ec2_host_test.go
+++ b/internal/service/ec2/ec2_host_test.go
@@ -242,7 +242,7 @@ func testAccCheckHostDestroy(s *terraform.State) error {
 func testAccHostConfig_basic() string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
 resource "aws_ec2_host" "test" {
-  availability_zone = data.aws_availability_zones.available.names[0]
+  availability_zone = data.aws_availability_zones.available.names[1]
   instance_type     = "a1.large"
 }
 `)

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -816,6 +816,7 @@ func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	input := &ec2.RunInstancesInput{
 		BlockDeviceMappings:               instanceOpts.BlockDeviceMappings,
 		CapacityReservationSpecification:  instanceOpts.CapacityReservationSpecification,
+		ClientToken:                       aws.String(resource.UniqueId()),
 		CpuOptions:                        instanceOpts.CpuOptions,
 		CreditSpecification:               instanceOpts.CreditSpecification,
 		DisableApiTermination:             instanceOpts.DisableAPITermination,

--- a/internal/service/ec2/ec2_spot_fleet_request.go
+++ b/internal/service/ec2/ec2_spot_fleet_request.go
@@ -836,14 +836,14 @@ func resourceSpotFleetRequestCreate(d *schema.ResourceData, meta interface{}) er
 
 	// http://docs.aws.amazon.com/sdk-for-go/api/service/ec2.html#type-SpotFleetRequestConfigData
 	spotFleetConfig := &ec2.SpotFleetRequestConfigData{
-		IamFleetRole:                     aws.String(d.Get("iam_fleet_role").(string)),
-		TargetCapacity:                   aws.Int64(int64(d.Get("target_capacity").(int))),
 		ClientToken:                      aws.String(resource.UniqueId()),
-		TerminateInstancesWithExpiration: aws.Bool(d.Get("terminate_instances_with_expiration").(bool)),
-		ReplaceUnhealthyInstances:        aws.Bool(d.Get("replace_unhealthy_instances").(bool)),
+		IamFleetRole:                     aws.String(d.Get("iam_fleet_role").(string)),
 		InstanceInterruptionBehavior:     aws.String(d.Get("instance_interruption_behaviour").(string)),
-		Type:                             aws.String(d.Get("fleet_type").(string)),
+		ReplaceUnhealthyInstances:        aws.Bool(d.Get("replace_unhealthy_instances").(bool)),
 		TagSpecifications:                tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeSpotFleetRequest),
+		TargetCapacity:                   aws.Int64(int64(d.Get("target_capacity").(int))),
+		TerminateInstancesWithExpiration: aws.Bool(d.Get("terminate_instances_with_expiration").(bool)),
+		Type:                             aws.String(d.Get("fleet_type").(string)),
 	}
 
 	if launchSpecificationOk {

--- a/internal/service/ec2/vpc_egress_only_internet_gateway.go
+++ b/internal/service/ec2/vpc_egress_only_internet_gateway.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -45,15 +46,15 @@ func resourceEgressOnlyInternetGatewayCreate(d *schema.ResourceData, meta interf
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
 	input := &ec2.CreateEgressOnlyInternetGatewayInput{
+		ClientToken:       aws.String(resource.UniqueId()),
 		TagSpecifications: tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeEgressOnlyInternetGateway),
 		VpcId:             aws.String(d.Get("vpc_id").(string)),
 	}
 
-	log.Printf("[DEBUG] Creating EC2 Egress-only Internet Gateway: %s", input)
 	output, err := conn.CreateEgressOnlyInternetGateway(input)
 
 	if err != nil {
-		return fmt.Errorf("error creating EC2 Egress-only Internet Gateway: %w", err)
+		return fmt.Errorf("creating EC2 Egress-only Internet Gateway: %w", err)
 	}
 
 	d.SetId(aws.StringValue(output.EgressOnlyInternetGateway.EgressOnlyInternetGatewayId))
@@ -77,7 +78,7 @@ func resourceEgressOnlyInternetGatewayRead(d *schema.ResourceData, meta interfac
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading EC2 Egress-only Internet Gateway (%s): %w", d.Id(), err)
+		return fmt.Errorf("reading EC2 Egress-only Internet Gateway (%s): %w", d.Id(), err)
 	}
 
 	ig := outputRaw.(*ec2.EgressOnlyInternetGateway)
@@ -92,11 +93,11 @@ func resourceEgressOnlyInternetGatewayRead(d *schema.ResourceData, meta interfac
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
+		return fmt.Errorf("setting tags: %w", err)
 	}
 
 	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return fmt.Errorf("error setting tags_all: %w", err)
+		return fmt.Errorf("setting tags_all: %w", err)
 	}
 
 	return nil
@@ -109,7 +110,7 @@ func resourceEgressOnlyInternetGatewayUpdate(d *schema.ResourceData, meta interf
 		o, n := d.GetChange("tags_all")
 
 		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
-			return fmt.Errorf("error updating EC2 Egress-only Internet Gateway (%s) tags: %w", d.Id(), err)
+			return fmt.Errorf("updating EC2 Egress-only Internet Gateway (%s) tags: %w", d.Id(), err)
 		}
 	}
 
@@ -129,7 +130,7 @@ func resourceEgressOnlyInternetGatewayDelete(d *schema.ResourceData, meta interf
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting EC2 Egress-only Internet Gateway (%s): %w", d.Id(), err)
+		return fmt.Errorf("deleting EC2 Egress-only Internet Gateway (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/ec2/vpc_network_interface.go
+++ b/internal/service/ec2/vpc_network_interface.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -28,6 +29,7 @@ func ResourceNetworkInterface() *schema.Resource {
 		Read:   resourceNetworkInterfaceRead,
 		Update: resourceNetworkInterfaceUpdate,
 		Delete: resourceNetworkInterfaceDelete,
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -330,7 +332,8 @@ func resourceNetworkInterfaceCreate(d *schema.ResourceData, meta interface{}) er
 	ipv6PrefixesSpecified := false
 
 	input := &ec2.CreateNetworkInterfaceInput{
-		SubnetId: aws.String(d.Get("subnet_id").(string)),
+		ClientToken: aws.String(resource.UniqueId()),
+		SubnetId:    aws.String(d.Get("subnet_id").(string)),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -409,17 +412,16 @@ func resourceNetworkInterfaceCreate(d *schema.ResourceData, meta interface{}) er
 		input.TagSpecifications = tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeNetworkInterface)
 	}
 
-	log.Printf("[DEBUG] Creating EC2 Network Interface: %s", input)
 	output, err := conn.CreateNetworkInterface(input)
 
 	if err != nil {
-		return fmt.Errorf("error creating EC2 Network Interface: %w", err)
+		return fmt.Errorf("creating EC2 Network Interface: %w", err)
 	}
 
 	d.SetId(aws.StringValue(output.NetworkInterface.NetworkInterfaceId))
 
 	if _, err := WaitNetworkInterfaceCreated(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return fmt.Errorf("error waiting for EC2 Network Interface (%s) create: %w", d.Id(), err)
+		return fmt.Errorf("waiting for EC2 Network Interface (%s) create: %w", d.Id(), err)
 	}
 
 	if !d.Get("private_ip_list_enabled").(bool) {
@@ -432,9 +434,11 @@ func resourceNetworkInterfaceCreate(d *schema.ResourceData, meta interface{}) er
 						NetworkInterfaceId:             aws.String(d.Id()),
 						SecondaryPrivateIpAddressCount: aws.Int64(int64(privateIPsCount.(int) + 1 - totalPrivateIPs)),
 					}
+
 					_, err := conn.AssignPrivateIpAddresses(input)
+
 					if err != nil {
-						return fmt.Errorf("Failure to assign Private IPs: %s", err)
+						return fmt.Errorf("assigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
 					}
 				}
 			}
@@ -443,7 +447,7 @@ func resourceNetworkInterfaceCreate(d *schema.ResourceData, meta interface{}) er
 
 	if len(tags) > 0 && (ipv4PrefixesSpecified || ipv6PrefixesSpecified) {
 		if err := UpdateTags(conn, d.Id(), nil, tags); err != nil {
-			return fmt.Errorf("error updating EC2 Network Interface (%s) tags: %w", d.Id(), err)
+			return fmt.Errorf("updating EC2 Network Interface (%s) tags: %w", d.Id(), err)
 		}
 	}
 
@@ -454,11 +458,10 @@ func resourceNetworkInterfaceCreate(d *schema.ResourceData, meta interface{}) er
 			SourceDestCheck:    &ec2.AttributeBooleanValue{Value: aws.Bool(false)},
 		}
 
-		log.Printf("[INFO] Modifying EC2 Network Interface: %s", input)
 		_, err := conn.ModifyNetworkInterfaceAttribute(input)
 
 		if err != nil {
-			return fmt.Errorf("error modifying EC2 Network Interface (%s) SourceDestCheck: %w", d.Id(), err)
+			return fmt.Errorf("modifying EC2 Network Interface (%s) SourceDestCheck: %w", d.Id(), err)
 		}
 	}
 
@@ -491,7 +494,7 @@ func resourceNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading EC2 Network Interface (%s): %w", d.Id(), err)
+		return fmt.Errorf("reading EC2 Network Interface (%s): %w", d.Id(), err)
 	}
 
 	eni := outputRaw.(*ec2.NetworkInterface)
@@ -505,60 +508,45 @@ func resourceNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) erro
 		Resource:  fmt.Sprintf("network-interface/%s", d.Id()),
 	}.String()
 	d.Set("arn", arn)
-
 	if eni.Attachment != nil {
 		if err := d.Set("attachment", []interface{}{flattenNetworkInterfaceAttachment(eni.Attachment)}); err != nil {
-			return fmt.Errorf("error setting attachment: %w", err)
+			return fmt.Errorf("setting attachment: %w", err)
 		}
 	} else {
 		d.Set("attachment", nil)
 	}
-
 	d.Set("description", eni.Description)
 	d.Set("interface_type", eni.InterfaceType)
-
 	if err := d.Set("ipv4_prefixes", flattenIPv4PrefixSpecifications(eni.Ipv4Prefixes)); err != nil {
-		return fmt.Errorf("error setting ipv4_prefixes: %w", err)
+		return fmt.Errorf("setting ipv4_prefixes: %w", err)
 	}
-
 	d.Set("ipv4_prefix_count", len(eni.Ipv4Prefixes))
-
 	d.Set("ipv6_address_count", len(eni.Ipv6Addresses))
-
 	if err := d.Set("ipv6_address_list", flattenNetworkInterfaceIPv6Addresses(eni.Ipv6Addresses)); err != nil {
-		return fmt.Errorf("error setting ipv6 address list: %s", err)
+		return fmt.Errorf("setting ipv6 address list: %s", err)
 	}
-
 	if err := d.Set("ipv6_addresses", flattenNetworkInterfaceIPv6Addresses(eni.Ipv6Addresses)); err != nil {
-		return fmt.Errorf("error setting ipv6_addresses: %w", err)
+		return fmt.Errorf("setting ipv6_addresses: %w", err)
 	}
-
 	if err := d.Set("ipv6_prefixes", flattenIPv6PrefixSpecifications(eni.Ipv6Prefixes)); err != nil {
-		return fmt.Errorf("error setting ipv6_prefixes: %w", err)
+		return fmt.Errorf("setting ipv6_prefixes: %w", err)
 	}
-
 	d.Set("ipv6_prefix_count", len(eni.Ipv6Prefixes))
-
 	d.Set("mac_address", eni.MacAddress)
 	d.Set("outpost_arn", eni.OutpostArn)
 	d.Set("owner_id", ownerID)
 	d.Set("private_dns_name", eni.PrivateDnsName)
 	d.Set("private_ip", eni.PrivateIpAddress)
-
 	if err := d.Set("private_ips", FlattenNetworkInterfacePrivateIPAddresses(eni.PrivateIpAddresses)); err != nil {
-		return fmt.Errorf("error setting private_ips: %w", err)
+		return fmt.Errorf("setting private_ips: %w", err)
 	}
-
 	d.Set("private_ips_count", len(eni.PrivateIpAddresses)-1)
-
 	if err := d.Set("private_ip_list", FlattenNetworkInterfacePrivateIPAddresses(eni.PrivateIpAddresses)); err != nil {
-		return fmt.Errorf("error setting private_ip_list: %s", err)
+		return fmt.Errorf("setting private_ip_list: %s", err)
 	}
-
 	if err := d.Set("security_groups", FlattenGroupIdentifiers(eni.Groups)); err != nil {
-		return fmt.Errorf("error setting security_groups: %w", err)
+		return fmt.Errorf("setting security_groups: %w", err)
 	}
-
 	d.Set("source_dest_check", eni.SourceDestCheck)
 	d.Set("subnet_id", eni.SubnetId)
 
@@ -566,11 +554,11 @@ func resourceNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) erro
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
+		return fmt.Errorf("setting tags: %w", err)
 	}
 
 	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return fmt.Errorf("error setting tags_all: %w", err)
+		return fmt.Errorf("setting tags_all: %w", err)
 	}
 
 	return nil
@@ -624,11 +612,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 				PrivateIpAddresses: flex.ExpandStringSet(unassignIPs),
 			}
 
-			log.Printf("[INFO] Unassigning private IPv4 addresses: %s", input)
 			_, err := conn.UnassignPrivateIpAddresses(input)
 
 			if err != nil {
-				return fmt.Errorf("error unassigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
+				return fmt.Errorf("unassigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
 			}
 
 			privateIPsNetChange -= unassignIPs.Len()
@@ -642,11 +629,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 				PrivateIpAddresses: flex.ExpandStringSet(assignIPs),
 			}
 
-			log.Printf("[INFO] Assigning private IPv4 addresses: %s", input)
 			_, err := conn.AssignPrivateIpAddresses(input)
 
 			if err != nil {
-				return fmt.Errorf("error assigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
+				return fmt.Errorf("assigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
 			}
 			privateIPsNetChange += assignIPs.Len()
 		}
@@ -669,7 +655,6 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 					continue
 				}
 				privateIPsToUnassign[idx] = ip
-				log.Printf("[INFO] Unassigning private ip %s", ip)
 				idx += 1
 			}
 
@@ -678,9 +663,11 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 				NetworkInterfaceId: aws.String(d.Id()),
 				PrivateIpAddresses: flex.ExpandStringList(privateIPsToUnassign),
 			}
+
 			_, err := conn.UnassignPrivateIpAddresses(input)
+
 			if err != nil {
-				return fmt.Errorf("Failure to unassign Private IPs: %s", err)
+				return fmt.Errorf("unassigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
 			}
 		}
 
@@ -691,15 +678,16 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 				continue
 			}
 			privateIPToAssign := []interface{}{ip}
-			log.Printf("[INFO] Assigning private ip %s", ip)
 
 			input := &ec2.AssignPrivateIpAddressesInput{
 				NetworkInterfaceId: aws.String(d.Id()),
 				PrivateIpAddresses: flex.ExpandStringList(privateIPToAssign),
 			}
+
 			_, err := conn.AssignPrivateIpAddresses(input)
+
 			if err != nil {
-				return fmt.Errorf("Failure to assign Private IPs: %s", err)
+				return fmt.Errorf("assigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
 			}
 		}
 	}
@@ -723,11 +711,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 					SecondaryPrivateIpAddressCount: aws.Int64(int64(diff)),
 				}
 
-				log.Printf("[INFO] Assigning private IPv4 addresses: %s", input)
 				_, err := conn.AssignPrivateIpAddresses(input)
 
 				if err != nil {
-					return fmt.Errorf("error assigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
+					return fmt.Errorf("assigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
 				}
 			} else if diff < 0 {
 				input := &ec2.UnassignPrivateIpAddressesInput{
@@ -735,11 +722,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 					PrivateIpAddresses: flex.ExpandStringList(privateIPsFiltered[0:-diff]),
 				}
 
-				log.Printf("[INFO] Unassigning private IPv4 addresses: %s", input)
 				_, err := conn.UnassignPrivateIpAddresses(input)
 
 				if err != nil {
-					return fmt.Errorf("error unassigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
+					return fmt.Errorf("unassigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
 				}
 			}
 		}
@@ -756,11 +742,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 					Ipv4PrefixCount:    aws.Int64(int64(diff)),
 				}
 
-				log.Printf("[INFO] Assigning private IPv4 addresses: %s", input)
 				_, err := conn.AssignPrivateIpAddresses(input)
 
 				if err != nil {
-					return fmt.Errorf("error assigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
+					return fmt.Errorf("assigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
 				}
 			} else if diff < 0 {
 				input := &ec2.UnassignPrivateIpAddressesInput{
@@ -768,11 +753,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 					Ipv4Prefixes:       flex.ExpandStringList(ipv4Prefixes[0:-diff]),
 				}
 
-				log.Printf("[INFO] Unassigning private IPv4 addresses: %s", input)
 				_, err := conn.UnassignPrivateIpAddresses(input)
 
 				if err != nil {
-					return fmt.Errorf("error unassigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
+					return fmt.Errorf("unassigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
 				}
 			}
 		}
@@ -798,11 +782,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 				Ipv4Prefixes:       flex.ExpandStringSet(unassignPrefixes),
 			}
 
-			log.Printf("[INFO] Unassigning private IPv4 addresses: %s", input)
 			_, err := conn.UnassignPrivateIpAddresses(input)
 
 			if err != nil {
-				return fmt.Errorf("error unassigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
+				return fmt.Errorf("unassigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
 			}
 		}
 
@@ -814,11 +797,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 				Ipv4Prefixes:       flex.ExpandStringSet(assignPrefixes),
 			}
 
-			log.Printf("[INFO] Assigning private IPv4 addresses: %s", input)
 			_, err := conn.AssignPrivateIpAddresses(input)
 
 			if err != nil {
-				return fmt.Errorf("error assigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
+				return fmt.Errorf("assigning EC2 Network Interface (%s) private IPv4 addresses: %w", d.Id(), err)
 			}
 		}
 	}
@@ -843,11 +825,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 				Ipv6Addresses:      flex.ExpandStringSet(unassignIPs),
 			}
 
-			log.Printf("[INFO] Unassigning IPv6 addresses: %s", input)
 			_, err := conn.UnassignIpv6Addresses(input)
 
 			if err != nil {
-				return fmt.Errorf("error unassigning EC2 Network Interface (%s) IPv6 addresses: %w", d.Id(), err)
+				return fmt.Errorf("unassigning EC2 Network Interface (%s) IPv6 addresses: %w", d.Id(), err)
 			}
 		}
 
@@ -859,11 +840,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 				Ipv6Addresses:      flex.ExpandStringSet(assignIPs),
 			}
 
-			log.Printf("[INFO] Assigning IPv6 addresses: %s", input)
 			_, err := conn.AssignIpv6Addresses(input)
 
 			if err != nil {
-				return fmt.Errorf("error assigning EC2 Network Interface (%s) IPv6 addresses: %w", d.Id(), err)
+				return fmt.Errorf("assigning EC2 Network Interface (%s) IPv6 addresses: %w", d.Id(), err)
 			}
 		}
 	}
@@ -879,11 +859,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 					Ipv6AddressCount:   aws.Int64(int64(diff)),
 				}
 
-				log.Printf("[INFO] Assigning IPv6 addresses: %s", input)
 				_, err := conn.AssignIpv6Addresses(input)
 
 				if err != nil {
-					return fmt.Errorf("error assigning EC2 Network Interface (%s) IPv6 addresses: %w", d.Id(), err)
+					return fmt.Errorf("assigning EC2 Network Interface (%s) IPv6 addresses: %w", d.Id(), err)
 				}
 			} else if diff < 0 {
 				input := &ec2.UnassignIpv6AddressesInput{
@@ -891,11 +870,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 					Ipv6Addresses:      flex.ExpandStringList(ipv6Addresses[0:-diff]),
 				}
 
-				log.Printf("[INFO] Unassigning IPv6 addresses: %s", input)
 				_, err := conn.UnassignIpv6Addresses(input)
 
 				if err != nil {
-					return fmt.Errorf("error unassigning EC2 Network Interface (%s) IPv6 addresses: %w", d.Id(), err)
+					return fmt.Errorf("unassigning EC2 Network Interface (%s) IPv6 addresses: %w", d.Id(), err)
 				}
 			}
 		}
@@ -915,32 +893,33 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 			unassignIPs := make([]interface{}, len(o.([]interface{})))
 			for i, ip := range o.([]interface{}) {
 				unassignIPs[i] = ip
-				log.Printf("[INFO] Unassigning ipv6 address %s", ip)
 			}
 
-			log.Printf("[INFO] Unassigning ipv6 addresses")
 			input := &ec2.UnassignIpv6AddressesInput{
 				NetworkInterfaceId: aws.String(d.Id()),
 				Ipv6Addresses:      flex.ExpandStringList(unassignIPs),
 			}
+
 			_, err := conn.UnassignIpv6Addresses(input)
+
 			if err != nil {
-				return fmt.Errorf("failure to unassign IPV6 Addresses: %s", err)
+				return fmt.Errorf("unassigning EC2 Network Interface (%s) private IPv6 addresses: %w", d.Id(), err)
 			}
 		}
 
 		// Assign each ip one-by-one in order to retain order
 		for _, ip := range n.([]interface{}) {
 			privateIPToAssign := []interface{}{ip}
-			log.Printf("[INFO] Assigning ipv6 address %s", ip)
 
 			input := &ec2.AssignIpv6AddressesInput{
 				NetworkInterfaceId: aws.String(d.Id()),
 				Ipv6Addresses:      flex.ExpandStringList(privateIPToAssign),
 			}
+
 			_, err := conn.AssignIpv6Addresses(input)
+
 			if err != nil {
-				return fmt.Errorf("Failure to assign IPV6 Addresses: %s", err)
+				return fmt.Errorf("assigning EC2 Network Interface (%s) private IPv6 addresses: %w", d.Id(), err)
 			}
 		}
 	}
@@ -965,11 +944,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 				Ipv6Prefixes:       flex.ExpandStringSet(unassignPrefixes),
 			}
 
-			log.Printf("[INFO] Unassigning IPv6 addresses: %s", input)
 			_, err := conn.UnassignIpv6Addresses(input)
 
 			if err != nil {
-				return fmt.Errorf("error unassigning EC2 Network Interface (%s) IPv6 addresses: %w", d.Id(), err)
+				return fmt.Errorf("unassigning EC2 Network Interface (%s) IPv6 addresses: %w", d.Id(), err)
 			}
 		}
 
@@ -981,11 +959,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 				Ipv6Prefixes:       flex.ExpandStringSet(assignPrefixes),
 			}
 
-			log.Printf("[INFO] Assigning IPv6 addresses: %s", input)
 			_, err := conn.AssignIpv6Addresses(input)
 
 			if err != nil {
-				return fmt.Errorf("error assigning EC2 Network Interface (%s) IPv6 addresses: %w", d.Id(), err)
+				return fmt.Errorf("assigning EC2 Network Interface (%s) IPv6 addresses: %w", d.Id(), err)
 			}
 		}
 	}
@@ -1001,11 +978,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 					Ipv6PrefixCount:    aws.Int64(int64(diff)),
 				}
 
-				log.Printf("[INFO] Assigning IPv6 addresses: %s", input)
 				_, err := conn.AssignIpv6Addresses(input)
 
 				if err != nil {
-					return fmt.Errorf("error assigning EC2 Network Interface (%s) IPv6 addresses: %w", d.Id(), err)
+					return fmt.Errorf("assigning EC2 Network Interface (%s) IPv6 addresses: %w", d.Id(), err)
 				}
 			} else if diff < 0 {
 				input := &ec2.UnassignIpv6AddressesInput{
@@ -1013,11 +989,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 					Ipv6Prefixes:       flex.ExpandStringList(ipv6Prefixes[0:-diff]),
 				}
 
-				log.Printf("[INFO] Unassigning IPv6 addresses: %s", input)
 				_, err := conn.UnassignIpv6Addresses(input)
 
 				if err != nil {
-					return fmt.Errorf("error unassigning EC2 Network Interface (%s) IPv6 addresses: %w", d.Id(), err)
+					return fmt.Errorf("unassigning EC2 Network Interface (%s) IPv6 addresses: %w", d.Id(), err)
 				}
 			}
 		}
@@ -1029,11 +1004,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 			SourceDestCheck:    &ec2.AttributeBooleanValue{Value: aws.Bool(d.Get("source_dest_check").(bool))},
 		}
 
-		log.Printf("[INFO] Modifying EC2 Network Interface: %s", input)
 		_, err := conn.ModifyNetworkInterfaceAttribute(input)
 
 		if err != nil {
-			return fmt.Errorf("error modifying EC2 Network Interface (%s) SourceDestCheck: %w", d.Id(), err)
+			return fmt.Errorf("modifying EC2 Network Interface (%s) SourceDestCheck: %w", d.Id(), err)
 		}
 	}
 
@@ -1043,11 +1017,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 			Groups:             flex.ExpandStringSet(d.Get("security_groups").(*schema.Set)),
 		}
 
-		log.Printf("[INFO] Modifying EC2 Network Interface: %s", input)
 		_, err := conn.ModifyNetworkInterfaceAttribute(input)
 
 		if err != nil {
-			return fmt.Errorf("error modifying EC2 Network Interface (%s) Groups: %w", d.Id(), err)
+			return fmt.Errorf("modifying EC2 Network Interface (%s) Groups: %w", d.Id(), err)
 		}
 	}
 
@@ -1057,11 +1030,10 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 			Description:        &ec2.AttributeValue{Value: aws.String(d.Get("description").(string))},
 		}
 
-		log.Printf("[INFO] Modifying EC2 Network Interface: %s", input)
 		_, err := conn.ModifyNetworkInterfaceAttribute(input)
 
 		if err != nil {
-			return fmt.Errorf("error modifying EC2 Network Interface (%s) Description: %w", d.Id(), err)
+			return fmt.Errorf("modifying EC2 Network Interface (%s) Description: %w", d.Id(), err)
 		}
 	}
 
@@ -1069,7 +1041,7 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 		o, n := d.GetChange("tags_all")
 
 		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
-			return fmt.Errorf("error updating EC2 Network Interface (%s) tags: %w", d.Id(), err)
+			return fmt.Errorf("updating EC2 Network Interface (%s) tags: %w", d.Id(), err)
 		}
 	}
 
@@ -1099,11 +1071,10 @@ func attachNetworkInterface(conn *ec2.EC2, networkInterfaceID, instanceID string
 		NetworkInterfaceId: aws.String(networkInterfaceID),
 	}
 
-	log.Printf("[INFO] Attaching EC2 Network Interface: %s", input)
 	output, err := conn.AttachNetworkInterface(input)
 
 	if err != nil {
-		return "", fmt.Errorf("error attaching EC2 Network Interface (%s/%s): %w", networkInterfaceID, instanceID, err)
+		return "", fmt.Errorf("attaching EC2 Network Interface (%s/%s): %w", networkInterfaceID, instanceID, err)
 	}
 
 	attachmentID := aws.StringValue(output.AttachmentId)
@@ -1111,7 +1082,7 @@ func attachNetworkInterface(conn *ec2.EC2, networkInterfaceID, instanceID string
 	_, err = WaitNetworkInterfaceAttached(context.TODO(), conn, attachmentID, timeout)
 
 	if err != nil {
-		return attachmentID, fmt.Errorf("error waiting for EC2 Network Interface (%s/%s) attach: %w", networkInterfaceID, attachmentID, err)
+		return attachmentID, fmt.Errorf("waiting for EC2 Network Interface (%s/%s) attach: %w", networkInterfaceID, attachmentID, err)
 	}
 
 	return attachmentID, nil
@@ -1143,13 +1114,11 @@ func DetachNetworkInterface(conn *ec2.EC2, networkInterfaceID, attachmentID stri
 }
 
 func DetachNetworkInterfaceWithContext(ctx context.Context, conn *ec2.EC2, networkInterfaceID, attachmentID string, timeout time.Duration) error {
-	input := &ec2.DetachNetworkInterfaceInput{
+	log.Printf("[INFO] Detaching EC2 Network Interface: %s", networkInterfaceID)
+	_, err := conn.DetachNetworkInterfaceWithContext(ctx, &ec2.DetachNetworkInterfaceInput{
 		AttachmentId: aws.String(attachmentID),
 		Force:        aws.Bool(true),
-	}
-
-	log.Printf("[INFO] Detaching EC2 Network Interface: %s", input)
-	_, err := conn.DetachNetworkInterfaceWithContext(ctx, input)
+	})
 
 	if tfawserr.ErrCodeEquals(err, errCodeInvalidAttachmentIDNotFound) {
 		return nil
@@ -1542,7 +1511,7 @@ func deleteLingeringLambdaENIs(ctx context.Context, g *multierror.Group, conn *e
 	})
 
 	if err != nil {
-		return fmt.Errorf("error listing EC2 Network Interfaces: %w", err)
+		return fmt.Errorf("listing EC2 Network Interfaces: %w", err)
 	}
 
 	for _, v := range networkInterfaces {
@@ -1597,7 +1566,7 @@ func deleteLingeringComprehendENIs(ctx context.Context, g *multierror.Group, con
 		}),
 	})
 	if err != nil {
-		return fmt.Errorf("error listing EC2 Network Interfaces: %w", err)
+		return fmt.Errorf("listing EC2 Network Interfaces: %w", err)
 	}
 
 	networkInterfaces := make([]*ec2.NetworkInterface, 0, len(enis))

--- a/internal/service/ec2/vpc_network_interface.go
+++ b/internal/service/ec2/vpc_network_interface.go
@@ -891,9 +891,7 @@ func resourceNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{}) er
 		// Unassign old IPV6 addresses
 		if len(o.([]interface{})) > 0 {
 			unassignIPs := make([]interface{}, len(o.([]interface{})))
-			for i, ip := range o.([]interface{}) {
-				unassignIPs[i] = ip
-			}
+			copy(unassignIPs, o.([]interface{}))
 
 			input := &ec2.UnassignIpv6AddressesInput{
 				NetworkInterfaceId: aws.String(d.Id()),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Uses the EC2 API `ClientToken` where applicable to ensure API idempotency.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/27543.

AMI changes - Relates https://github.com/hashicorp/terraform-provider-aws/issues/27083.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

EC2 API Reference: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Run_Instance_Idempotency.html.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccEC2Instance_withIAMInstanceProfile' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccEC2Instance_withIAMInstanceProfile -timeout 180m
=== RUN   TestAccEC2Instance_withIAMInstanceProfile
=== PAUSE TestAccEC2Instance_withIAMInstanceProfile
=== RUN   TestAccEC2Instance_withIAMInstanceProfilePath
=== PAUSE TestAccEC2Instance_withIAMInstanceProfilePath
=== CONT  TestAccEC2Instance_withIAMInstanceProfile
=== CONT  TestAccEC2Instance_withIAMInstanceProfilePath
--- PASS: TestAccEC2Instance_withIAMInstanceProfilePath (118.69s)
--- PASS: TestAccEC2Instance_withIAMInstanceProfile (129.70s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	133.578s
% make testacc TESTARGS='-run=TestAccEC2Host_basic' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccEC2Host_basic -timeout 180m
=== RUN   TestAccEC2Host_basic
=== PAUSE TestAccEC2Host_basic
=== CONT  TestAccEC2Host_basic
--- PASS: TestAccEC2Host_basic (19.93s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	24.429s
% make testacc TESTARGS='-run=TestAccEC2AMICopy_basic\|TestAccEC2AMIFromInstance_basic' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccEC2AMICopy_basic\|TestAccEC2AMIFromInstance_basic -timeout 180m
=== RUN   TestAccEC2AMICopy_basic
=== PAUSE TestAccEC2AMICopy_basic
=== RUN   TestAccEC2AMIFromInstance_basic
=== PAUSE TestAccEC2AMIFromInstance_basic
=== CONT  TestAccEC2AMICopy_basic
=== CONT  TestAccEC2AMIFromInstance_basic
--- PASS: TestAccEC2AMIFromInstance_basic (267.72s)
--- PASS: TestAccEC2AMICopy_basic (381.52s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	388.656s
% make testacc TESTARGS='-run=TestAccVPCEgressOnlyInternetGateway_basic' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccVPCEgressOnlyInternetGateway_basic -timeout 180m
=== RUN   TestAccVPCEgressOnlyInternetGateway_basic
=== PAUSE TestAccVPCEgressOnlyInternetGateway_basic
=== CONT  TestAccVPCEgressOnlyInternetGateway_basic
--- PASS: TestAccVPCEgressOnlyInternetGateway_basic (32.06s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	36.357s
% make testacc TESTARGS='-run=TestAccVPCFlowLog_vpcID' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccVPCFlowLog_vpcID -timeout 180m
=== RUN   TestAccVPCFlowLog_vpcID
=== PAUSE TestAccVPCFlowLog_vpcID
=== CONT  TestAccVPCFlowLog_vpcID
--- PASS: TestAccVPCFlowLog_vpcID (37.15s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	41.431s
% make testacc TESTARGS='-run=TestAccVPCNATGateway_basic' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccVPCNATGateway_basic -timeout 180m
=== RUN   TestAccVPCNATGateway_basic
=== PAUSE TestAccVPCNATGateway_basic
=== CONT  TestAccVPCNATGateway_basic
--- PASS: TestAccVPCNATGateway_basic (160.42s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	165.162s
% make testacc TESTARGS='-run=TestAccEC2EBSVolume_basic' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccEC2EBSVolume_basic -timeout 180m
=== RUN   TestAccEC2EBSVolume_basic
=== PAUSE TestAccEC2EBSVolume_basic
=== CONT  TestAccEC2EBSVolume_basic
--- PASS: TestAccEC2EBSVolume_basic (39.30s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	43.688s
% make testacc TESTARGS='-run=TestAccVPCEndpoint_gatewayBasic' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccVPCEndpoint_gatewayBasic -timeout 180m
=== RUN   TestAccVPCEndpoint_gatewayBasic
=== PAUSE TestAccVPCEndpoint_gatewayBasic
=== CONT  TestAccVPCEndpoint_gatewayBasic
--- PASS: TestAccVPCEndpoint_gatewayBasic (34.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	38.569s
% make testacc TESTARGS='-run=TestAccEC2SpotInstanceRequest_basic' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccEC2SpotInstanceRequest_basic -timeout 180m
=== RUN   TestAccEC2SpotInstanceRequest_basic
=== PAUSE TestAccEC2SpotInstanceRequest_basic
=== CONT  TestAccEC2SpotInstanceRequest_basic
--- PASS: TestAccEC2SpotInstanceRequest_basic (75.06s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	79.407s
```
