### PR TITLE
r/aws_sesv2_configuration_set_event_destination: new resource

### DIFF
--- a/.changelog/27565.txt
+++ b/.changelog/27565.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_sesv2_configuration_set_event_destination
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2102,6 +2102,9 @@ func New(ctx context.Context) (*schema.Provider, error) {
 			"aws_sesv2_email_identity_feedback_attributes":  sesv2.ResourceEmailIdentityFeedbackAttributes(),
 			"aws_sesv2_email_identity_mail_from_attributes": sesv2.ResourceEmailIdentityMailFromAttributes(),
 
+			"aws_sfn_activity":      sfn.ResourceActivity(),
+			"aws_sfn_state_machine": sfn.ResourceStateMachine(),
+
 			"aws_shield_protection":                          shield.ResourceProtection(),
 			"aws_shield_protection_group":                    shield.ResourceProtectionGroup(),
 			"aws_shield_protection_health_check_association": shield.ResourceProtectionHealthCheckAssociation(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2095,14 +2095,12 @@ func New(ctx context.Context) (*schema.Provider, error) {
 			"aws_ses_template":                     ses.ResourceTemplate(),
 
 			"aws_sesv2_configuration_set":                   sesv2.ResourceConfigurationSet(),
+			"aws_sesv2_configuration_set_event_destination": sesv2.ResourceConfigurationSetEventDestination(),
 			"aws_sesv2_dedicated_ip_assignment":             sesv2.ResourceDedicatedIPAssignment(),
 			"aws_sesv2_dedicated_ip_pool":                   sesv2.ResourceDedicatedIPPool(),
 			"aws_sesv2_email_identity":                      sesv2.ResourceEmailIdentity(),
 			"aws_sesv2_email_identity_feedback_attributes":  sesv2.ResourceEmailIdentityFeedbackAttributes(),
 			"aws_sesv2_email_identity_mail_from_attributes": sesv2.ResourceEmailIdentityMailFromAttributes(),
-
-			"aws_sfn_activity":      sfn.ResourceActivity(),
-			"aws_sfn_state_machine": sfn.ResourceStateMachine(),
 
 			"aws_shield_protection":                          shield.ResourceProtection(),
 			"aws_shield_protection_group":                    shield.ResourceProtectionGroup(),

--- a/internal/service/sesv2/configuration_set_event_destination.go
+++ b/internal/service/sesv2/configuration_set_event_destination.go
@@ -569,11 +569,6 @@ func expandCloudWatchDimensionConfiguration(tfMap map[string]interface{}) types.
 	return a
 }
 
-type ConfigurationSetEventDestinationID struct {
-	ConfigurationSetName string
-	EventDestinationName string
-}
-
 func FormatConfigurationSetEventDestinationID(configurationSetName, eventDestinationName string) string {
 	return fmt.Sprintf("%s|%s", configurationSetName, eventDestinationName)
 }

--- a/internal/service/sesv2/configuration_set_event_destination.go
+++ b/internal/service/sesv2/configuration_set_event_destination.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
@@ -49,6 +50,12 @@ func ResourceConfigurationSetEventDestination() *schema.Resource {
 							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
+							ExactlyOneOf: []string{
+								"event_destination.0.cloud_watch_destination",
+								"event_destination.0.kinesis_firehose_destination",
+								"event_destination.0.pinpoint_destination",
+								"event_destination.0.sns_destination",
+							},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"dimension_configuration": {
@@ -57,16 +64,19 @@ func ResourceConfigurationSetEventDestination() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"default_dimension_value": {
-													Type:     schema.TypeString,
-													Required: true,
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringLenBetween(1, 256),
 												},
 												"dimension_name": {
-													Type:     schema.TypeString,
-													Required: true,
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringLenBetween(1, 256),
 												},
 												"dimension_value_source": {
-													Type:     schema.TypeString,
-													Required: true,
+													Type:             schema.TypeString,
+													Required:         true,
+													ValidateDiagFunc: enum.Validate[types.DimensionValueSource](),
 												},
 											},
 										},
@@ -82,6 +92,12 @@ func ResourceConfigurationSetEventDestination() *schema.Resource {
 							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
+							ExactlyOneOf: []string{
+								"event_destination.0.cloud_watch_destination",
+								"event_destination.0.kinesis_firehose_destination",
+								"event_destination.0.pinpoint_destination",
+								"event_destination.0.sns_destination",
+							},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"delivery_stream_arn": {
@@ -100,12 +116,21 @@ func ResourceConfigurationSetEventDestination() *schema.Resource {
 						"matching_event_types": {
 							Type:     schema.TypeList,
 							Required: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type:             schema.TypeString,
+								ValidateDiagFunc: enum.Validate[types.EventType](),
+							},
 						},
 						"pinpoint_destination": {
 							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
+							ExactlyOneOf: []string{
+								"event_destination.0.cloud_watch_destination",
+								"event_destination.0.kinesis_firehose_destination",
+								"event_destination.0.pinpoint_destination",
+								"event_destination.0.sns_destination",
+							},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"application_arn": {
@@ -120,6 +145,12 @@ func ResourceConfigurationSetEventDestination() *schema.Resource {
 							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
+							ExactlyOneOf: []string{
+								"event_destination.0.cloud_watch_destination",
+								"event_destination.0.kinesis_firehose_destination",
+								"event_destination.0.pinpoint_destination",
+								"event_destination.0.sns_destination",
+							},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"topic_arn": {

--- a/internal/service/sesv2/configuration_set_event_destination.go
+++ b/internal/service/sesv2/configuration_set_event_destination.go
@@ -1,0 +1,417 @@
+package sesv2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sesv2"
+	"github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func ResourceConfigurationSetEventDestination() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceConfigurationSetEventDestinationCreate,
+		ReadWithoutTimeout:   resourceConfigurationSetEventDestinationRead,
+		UpdateWithoutTimeout: resourceConfigurationSetEventDestinationUpdate,
+		DeleteWithoutTimeout: resourceConfigurationSetEventDestinationDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"configuration_set_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"event_destination": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cloud_watch_destination": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"dimension_configuration": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"default_dimension_value": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"dimension_name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"dimension_value_source": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"matching_event_types": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"event_destination_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+const (
+	ResNameConfigurationSetEventDestination = "Configuration Set Event Destination"
+)
+
+func resourceConfigurationSetEventDestinationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).SESV2Conn
+
+	in := &sesv2.CreateConfigurationSetEventDestinationInput{
+		ConfigurationSetName: aws.String(d.Get("configuration_set_name").(string)),
+		EventDestination:     expandEventDestination(d.Get("event_destination").([]interface{})[0].(map[string]interface{})),
+		EventDestinationName: aws.String(d.Get("event_destination_name").(string)),
+	}
+
+	configurationSetEventDestinationID := FormatConfigurationSetEventDestinationID(d.Get("configuration_set_name").(string), d.Get("event_destination_name").(string))
+
+	out, err := conn.CreateConfigurationSetEventDestination(ctx, in)
+	if err != nil {
+		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameConfigurationSetEventDestination, configurationSetEventDestinationID, err)
+	}
+
+	if out == nil {
+		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameConfigurationSetEventDestination, configurationSetEventDestinationID, errors.New("empty output"))
+	}
+
+	d.SetId(configurationSetEventDestinationID)
+
+	return resourceConfigurationSetEventDestinationRead(ctx, d, meta)
+}
+
+func resourceConfigurationSetEventDestinationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).SESV2Conn
+
+	configurationSetEventDestinationID, err := ParseConfigurationSetEventDestinationID(d.Id())
+	if err != nil {
+		return create.DiagError(names.SESV2, create.ErrActionReading, ResNameConfigurationSetEventDestination, d.Id(), err)
+	}
+
+	out, err := FindConfigurationSetEventDestinationByID(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] SESV2 ConfigurationSetEventDestination (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.SESV2, create.ErrActionReading, ResNameConfigurationSetEventDestination, d.Id(), err)
+	}
+
+	d.Set("configuration_set_name", configurationSetEventDestinationID.ConfigurationSetName)
+	d.Set("event_destination_name", out.Name)
+
+	if err := d.Set("event_destination", []interface{}{flattenEventDestination(out)}); err != nil {
+		return create.DiagError(names.SESV2, create.ErrActionSetting, ResNameConfigurationSetEventDestination, d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceConfigurationSetEventDestinationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// conn := meta.(*conns.AWSClient).SESV2Conn
+
+	// update := false
+
+	// in := &sesv2.UpdateConfigurationSetEventDestinationInput{
+	// 	Id: aws.String(d.Id()),
+	// }
+
+	// if d.HasChanges("an_argument") {
+	// 	in.AnArgument = aws.String(d.Get("an_argument").(string))
+	// 	update = true
+	// }
+
+	// if !update {
+	// 	return nil
+	// }
+
+	// log.Printf("[DEBUG] Updating SESV2 ConfigurationSetEventDestination (%s): %#v", d.Id(), in)
+	// out, err := conn.UpdateConfigurationSetEventDestination(ctx, in)
+	// if err != nil {
+	// 	return create.DiagError(names.SESV2, create.ErrActionUpdating, ResNameConfigurationSetEventDestination, d.Id(), err)
+	// }
+
+	return resourceConfigurationSetEventDestinationRead(ctx, d, meta)
+}
+
+func resourceConfigurationSetEventDestinationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).SESV2Conn
+
+	log.Printf("[INFO] Deleting SESV2 ConfigurationSetEventDestination %s", d.Id())
+
+	configurationSetEventDestinationID, err := ParseConfigurationSetEventDestinationID(d.Id())
+	if err != nil {
+		return create.DiagError(names.SESV2, create.ErrActionReading, ResNameConfigurationSetEventDestination, d.Id(), err)
+	}
+
+	_, err = conn.DeleteConfigurationSetEventDestination(ctx, &sesv2.DeleteConfigurationSetEventDestinationInput{
+		ConfigurationSetName: aws.String(configurationSetEventDestinationID.ConfigurationSetName),
+		EventDestinationName: aws.String(configurationSetEventDestinationID.EventDestinationName),
+	})
+
+	if err != nil {
+		var nfe *types.NotFoundException
+		if errors.As(err, &nfe) {
+			return nil
+		}
+
+		return create.DiagError(names.SESV2, create.ErrActionDeleting, ResNameConfigurationSetEventDestination, d.Id(), err)
+	}
+
+	return nil
+}
+
+func FindConfigurationSetEventDestinationByID(ctx context.Context, conn *sesv2.Client, id string) (types.EventDestination, error) {
+	configurationSetEventDestinationID, err := ParseConfigurationSetEventDestinationID(id)
+	if err != nil {
+		return types.EventDestination{}, err
+	}
+
+	in := &sesv2.GetConfigurationSetEventDestinationsInput{
+		ConfigurationSetName: aws.String(configurationSetEventDestinationID.ConfigurationSetName),
+	}
+	out, err := conn.GetConfigurationSetEventDestinations(ctx, in)
+	if err != nil {
+		var nfe *types.NotFoundException
+		if errors.As(err, &nfe) {
+			return types.EventDestination{}, &resource.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return types.EventDestination{}, err
+	}
+
+	if out == nil {
+		return types.EventDestination{}, tfresource.NewEmptyResultError(in)
+	}
+
+	for _, eventDestination := range out.EventDestinations {
+		if aws.ToString(eventDestination.Name) == configurationSetEventDestinationID.EventDestinationName {
+			return eventDestination, nil
+		}
+	}
+
+	return types.EventDestination{}, &resource.NotFoundError{}
+}
+
+func flattenEventDestination(apiObject types.EventDestination) map[string]interface{} {
+	m := map[string]interface{}{
+		"enabled": apiObject.Enabled,
+	}
+
+	if v := apiObject.CloudWatchDestination; v != nil {
+		m["cloud_watch_destination"] = []interface{}{flattenCloudWatchDestination(v)}
+	}
+
+	if v := apiObject.MatchingEventTypes; v != nil {
+		m["matching_event_types"] = eventTypesToStrings(apiObject.MatchingEventTypes)
+	}
+
+	return m
+}
+
+func flattenCloudWatchDestination(apiObject *types.CloudWatchDestination) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	m := map[string]interface{}{}
+
+	if v := apiObject.DimensionConfigurations; v != nil {
+		m["dimension_configuration"] = flattenCloudWatchDimensionConfigurations(v)
+	}
+
+	return m
+}
+
+func flattenCloudWatchDimensionConfigurations(apiObjects []types.CloudWatchDimensionConfiguration) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var l []interface{}
+
+	for _, apiObject := range apiObjects {
+		l = append(l, flattenCloudWatchDimensionConfiguration(apiObject))
+	}
+
+	return l
+}
+
+func flattenCloudWatchDimensionConfiguration(apiObject types.CloudWatchDimensionConfiguration) map[string]interface{} {
+	m := map[string]interface{}{
+		"dimension_value_source": string(apiObject.DimensionValueSource),
+	}
+
+	if v := apiObject.DefaultDimensionValue; v != nil {
+		m["default_dimension_value"] = aws.ToString(v)
+	}
+
+	if v := apiObject.DimensionName; v != nil {
+		m["dimension_name"] = aws.ToString(v)
+	}
+
+	return m
+}
+
+func expandEventDestination(tfMap map[string]interface{}) *types.EventDestinationDefinition {
+	if tfMap == nil {
+		return nil
+	}
+
+	a := &types.EventDestinationDefinition{}
+
+	if v, ok := tfMap["cloud_watch_destination"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		a.CloudWatchDestination = expandCloudWatchDestination(v[0].(map[string]interface{}))
+	}
+
+	if v, ok := tfMap["enabled"].(bool); ok {
+		a.Enabled = v
+	}
+
+	if v, ok := tfMap["matching_event_types"].([]interface{}); ok && len(v) > 0 {
+		a.MatchingEventTypes = stringsToEventTypes(flex.ExpandStringList(v))
+	}
+
+	return a
+}
+
+func expandCloudWatchDestination(tfMap map[string]interface{}) *types.CloudWatchDestination {
+	if tfMap == nil {
+		return nil
+	}
+
+	a := &types.CloudWatchDestination{}
+
+	if v, ok := tfMap["dimension_configuration"].([]interface{}); ok && len(v) > 0 {
+		a.DimensionConfigurations = expandCloudWatchDimensionConfigurations(v)
+	}
+
+	return a
+}
+
+func expandCloudWatchDimensionConfigurations(tfList []interface{}) []types.CloudWatchDimensionConfiguration {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var s []types.CloudWatchDimensionConfiguration
+
+	for _, r := range tfList {
+		m, ok := r.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		s = append(s, expandCloudWatchDimensionConfiguration(m))
+	}
+
+	return s
+}
+
+func expandCloudWatchDimensionConfiguration(tfMap map[string]interface{}) types.CloudWatchDimensionConfiguration {
+	a := types.CloudWatchDimensionConfiguration{}
+
+	if v, ok := tfMap["default_dimension_value"].(string); ok && v != "" {
+		a.DefaultDimensionValue = aws.String(v)
+	}
+
+	if v, ok := tfMap["dimension_name"].(string); ok && v != "" {
+		a.DimensionName = aws.String(v)
+	}
+
+	if v, ok := tfMap["dimension_value_source"].(string); ok && v != "" {
+		a.DimensionValueSource = types.DimensionValueSource(v)
+	}
+
+	return a
+}
+
+type ConfigurationSetEventDestinationID struct {
+	ConfigurationSetName string
+	EventDestinationName string
+}
+
+func FormatConfigurationSetEventDestinationID(configurationSetName, eventDestinationName string) string {
+	return fmt.Sprintf("%s|%s", configurationSetName, eventDestinationName)
+}
+
+func ParseConfigurationSetEventDestinationID(id string) (ConfigurationSetEventDestinationID, error) {
+	idParts := strings.Split(id, "|")
+	if len(idParts) != 2 {
+		return ConfigurationSetEventDestinationID{}, errors.New("please make sure the ID is in the form CONFIGURATION_SET_NAME|EVENT_DESTINATION_NAME")
+	}
+
+	return ConfigurationSetEventDestinationID{
+		ConfigurationSetName: idParts[0],
+		EventDestinationName: idParts[1],
+	}, nil
+}
+
+func stringsToEventTypes(values []*string) []types.EventType {
+	var eventTypes []types.EventType
+
+	for _, eventType := range values {
+		eventTypes = append(eventTypes, types.EventType(aws.ToString(eventType)))
+	}
+
+	return eventTypes
+}
+
+func eventTypesToStrings(values []types.EventType) []*string {
+	var strings []*string
+
+	for _, eventType := range values {
+		strings = append(strings, aws.String(string(eventType)))
+	}
+
+	return strings
+}

--- a/internal/service/sesv2/configuration_set_event_destination_test.go
+++ b/internal/service/sesv2/configuration_set_event_destination_test.go
@@ -17,64 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestFormatConfigurationSetEventDestinationID(t *testing.T) {
-	expected := "configurationSetName|eventDestinationName"
-	got := tfsesv2.FormatConfigurationSetEventDestinationID("configurationSetName", "eventDestinationName")
-
-	if got != expected {
-		t.Errorf("got %s, expected %s", got, expected)
-	}
-}
-
-func TestParseConfigurationSetEventDestinationID(t *testing.T) {
-	testCases := []struct {
-		TestName string
-		Input    string
-		Expected tfsesv2.ConfigurationSetEventDestinationID
-		Error    bool
-	}{
-		{
-			TestName: "empty",
-			Input:    "",
-			Expected: tfsesv2.ConfigurationSetEventDestinationID{},
-			Error:    true,
-		},
-		{
-			TestName: "no pipe",
-			Input:    "configurationSetNameEventDestinationName",
-			Expected: tfsesv2.ConfigurationSetEventDestinationID{},
-			Error:    true,
-		},
-		{
-			TestName: "valid",
-			Input:    "configurationSetName|eventDestinationName",
-			Expected: tfsesv2.ConfigurationSetEventDestinationID{
-				ConfigurationSetName: "configurationSetName",
-				EventDestinationName: "eventDestinationName",
-			},
-			Error: false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.TestName, func(t *testing.T) {
-			got, err := tfsesv2.ParseConfigurationSetEventDestinationID(testCase.Input)
-
-			if err != nil && !testCase.Error {
-				t.Errorf("got error (%s), expected no error", err)
-			}
-
-			if err == nil && testCase.Error {
-				t.Errorf("got (%s) and no error, expected error", got)
-			}
-
-			if got != testCase.Expected {
-				t.Errorf("got %s, expected %s", got, testCase.Expected)
-			}
-		})
-	}
-}
-
 func TestAccSESV2ConfigurationSetEventDestination_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sesv2_configuration_set_event_destination.test"
@@ -134,7 +76,7 @@ func TestAccSESV2ConfigurationSetEventDestination_disappears(t *testing.T) {
 }
 
 func testAccCheckConfigurationSetEventDestinationDestroy(s *terraform.State) error {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).SESV2Conn
+	conn := acctest.Provider.Meta().(*conns.AWSClient).SESV2Client()
 	ctx := context.Background()
 
 	for _, rs := range s.RootModule().Resources {
@@ -168,7 +110,7 @@ func testAccCheckConfigurationSetEventDestinationExists(name string) resource.Te
 			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameConfigurationSetEventDestination, name, errors.New("not set"))
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).SESV2Conn
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SESV2Client()
 
 		_, err := tfsesv2.FindConfigurationSetEventDestinationByID(context.Background(), conn, rs.Primary.ID)
 

--- a/internal/service/sesv2/configuration_set_event_destination_test.go
+++ b/internal/service/sesv2/configuration_set_event_destination_test.go
@@ -28,7 +28,7 @@ func TestAccSESV2ConfigurationSetEventDestination_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckConfigurationSetEventDestinationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigurationSetEventDestinationConfig_cloudWatchDestination(rName),
+				Config: testAccConfigurationSetEventDestinationConfig_basic(rName, "SEND"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetEventDestinationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "configuration_set_name", rName),
@@ -43,6 +43,18 @@ func TestAccSESV2ConfigurationSetEventDestination_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccConfigurationSetEventDestinationConfig_basic(rName, "REJECT"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationSetEventDestinationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "configuration_set_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.matching_event_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.matching_event_types.0", "REJECT"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination_name", rName),
+				),
 			},
 		},
 	})
@@ -59,14 +71,14 @@ func TestAccSESV2ConfigurationSetEventDestination_cloudWatchDestination(t *testi
 		CheckDestroy:             testAccCheckConfigurationSetEventDestinationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigurationSetEventDestinationConfig_cloudWatchDestination(rName),
+				Config: testAccConfigurationSetEventDestinationConfig_cloudWatchDestination(rName, "test1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetEventDestinationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "event_destination.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_destination.0.cloud_watch_destination.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_destination.0.cloud_watch_destination.0.dimension_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "event_destination.0.cloud_watch_destination.0.dimension_configuration.0.default_dimension_value", rName),
-					resource.TestCheckResourceAttr(resourceName, "event_destination.0.cloud_watch_destination.0.dimension_configuration.0.dimension_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.cloud_watch_destination.0.dimension_configuration.0.default_dimension_value", "test1"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.cloud_watch_destination.0.dimension_configuration.0.dimension_name", "test1"),
 					resource.TestCheckResourceAttr(resourceName, "event_destination.0.cloud_watch_destination.0.dimension_configuration.0.dimension_value_source", "MESSAGE_TAG"),
 				),
 			},
@@ -74,6 +86,18 @@ func TestAccSESV2ConfigurationSetEventDestination_cloudWatchDestination(t *testi
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccConfigurationSetEventDestinationConfig_cloudWatchDestination(rName, "test2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationSetEventDestinationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.cloud_watch_destination.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.cloud_watch_destination.0.dimension_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.cloud_watch_destination.0.dimension_configuration.0.default_dimension_value", "test2"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.cloud_watch_destination.0.dimension_configuration.0.dimension_name", "test2"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.cloud_watch_destination.0.dimension_configuration.0.dimension_value_source", "MESSAGE_TAG"),
+				),
 			},
 		},
 	})
@@ -90,12 +114,12 @@ func TestAccSESV2ConfigurationSetEventDestination_kinesisFirehoseDestination(t *
 		CheckDestroy:             testAccCheckConfigurationSetEventDestinationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigurationSetEventDestinationConfig_kinesisFirehoseDestination(rName),
+				Config: testAccConfigurationSetEventDestinationConfig_kinesisFirehoseDestination1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetEventDestinationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "event_destination.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_destination.0.kinesis_firehose_destination.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "event_destination.0.kinesis_firehose_destination.0.delivery_stream_arn", "aws_kinesis_firehose_delivery_stream.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "event_destination.0.kinesis_firehose_destination.0.delivery_stream_arn", "aws_kinesis_firehose_delivery_stream.test1", "arn"),
 					resource.TestCheckResourceAttrPair(resourceName, "event_destination.0.kinesis_firehose_destination.0.iam_role_arn", "aws_iam_role.delivery_stream", "arn"),
 				),
 			},
@@ -103,6 +127,90 @@ func TestAccSESV2ConfigurationSetEventDestination_kinesisFirehoseDestination(t *
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccConfigurationSetEventDestinationConfig_kinesisFirehoseDestination2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationSetEventDestinationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.kinesis_firehose_destination.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "event_destination.0.kinesis_firehose_destination.0.delivery_stream_arn", "aws_kinesis_firehose_delivery_stream.test2", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "event_destination.0.kinesis_firehose_destination.0.iam_role_arn", "aws_iam_role.delivery_stream", "arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSESV2ConfigurationSetEventDestination_pinpointDestination(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sesv2_configuration_set_event_destination.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfigurationSetEventDestinationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigurationSetEventDestinationConfig_pinpointDestination1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationSetEventDestinationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.pinpoint_destination.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "event_destination.0.pinpoint_destination.0.application_arn", "aws_pinpoint_app.test1", "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccConfigurationSetEventDestinationConfig_pinpointDestination2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationSetEventDestinationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.pinpoint_destination.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "event_destination.0.pinpoint_destination.0.application_arn", "aws_pinpoint_app.test2", "arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSESV2ConfigurationSetEventDestination_snsDestination(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sesv2_configuration_set_event_destination.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfigurationSetEventDestinationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigurationSetEventDestinationConfig_snsDestination1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationSetEventDestinationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.sns_destination.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "event_destination.0.sns_destination.0.topic_arn", "aws_sns_topic.test1", "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccConfigurationSetEventDestinationConfig_snsDestination2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationSetEventDestinationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.sns_destination.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "event_destination.0.sns_destination.0.topic_arn", "aws_sns_topic.test2", "arn"),
+				),
 			},
 		},
 	})
@@ -119,7 +227,7 @@ func TestAccSESV2ConfigurationSetEventDestination_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckConfigurationSetEventDestinationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigurationSetEventDestinationConfig_cloudWatchDestination(rName),
+				Config: testAccConfigurationSetEventDestinationConfig_basic(rName, "SEND"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetEventDestinationExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfsesv2.ResourceConfigurationSetEventDestination(), resourceName),
@@ -177,7 +285,7 @@ func testAccCheckConfigurationSetEventDestinationExists(name string) resource.Te
 	}
 }
 
-func testAccConfigurationSetEventDestinationConfig_cloudWatchDestination(rName string) string {
+func testAccConfigurationSetEventDestinationConfig_basic(rName, matchingEventType string) string {
 	return fmt.Sprintf(`
 resource "aws_sesv2_configuration_set" "test" {
   configuration_set_name = %[1]q
@@ -196,13 +304,38 @@ resource "aws_sesv2_configuration_set_event_destination" "test" {
       }
     }
 
+    matching_event_types = [%[2]q]
+  }
+}
+`, rName, matchingEventType)
+}
+
+func testAccConfigurationSetEventDestinationConfig_cloudWatchDestination(rName, dimension string) string {
+	return fmt.Sprintf(`
+resource "aws_sesv2_configuration_set" "test" {
+  configuration_set_name = %[1]q
+}
+
+resource "aws_sesv2_configuration_set_event_destination" "test" {
+  configuration_set_name = aws_sesv2_configuration_set.test.configuration_set_name
+  event_destination_name = %[1]q
+
+  event_destination {
+    cloud_watch_destination {
+      dimension_configuration {
+        default_dimension_value = %[2]q
+        dimension_name          = %[2]q
+        dimension_value_source  = "MESSAGE_TAG"
+      }
+    }
+
     matching_event_types = ["SEND"]
   }
 }
-`, rName)
+`, rName, dimension)
 }
 
-func testAccConfigurationSetEventDestinationConfig_kinesisFirehoseDestination(rName string) string {
+func testAccConfigurationSetEventDestinationConfig_kinesisFirehoseDestinationBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -231,17 +364,6 @@ resource "aws_iam_role" "bucket" {
   }
   EOF
 }
-
-resource "aws_kinesis_firehose_delivery_stream" "test" {
-  name        = %[1]q
-  destination = "s3"
-
-  s3_configuration {
-    role_arn   = aws_iam_role.bucket.arn
-    bucket_arn = aws_s3_bucket.test.arn
-  }
-}
-
 
 resource "aws_iam_role" "delivery_stream" {
   name = "%[1]s1"
@@ -284,6 +406,22 @@ resource "aws_iam_role_policy" "delivery_stream" {
 }
   EOF
 }
+`, rName)
+}
+
+func testAccConfigurationSetEventDestinationConfig_kinesisFirehoseDestination1(rName string) string {
+	return acctest.ConfigCompose(
+		testAccConfigurationSetEventDestinationConfig_kinesisFirehoseDestinationBase(rName),
+		fmt.Sprintf(`
+resource "aws_kinesis_firehose_delivery_stream" "test1" {
+  name        = "%[1]s-1"
+  destination = "s3"
+
+  s3_configuration {
+    role_arn   = aws_iam_role.bucket.arn
+    bucket_arn = aws_s3_bucket.test.arn
+  }
+}
 
 resource "aws_sesv2_configuration_set" "test" {
   configuration_set_name = %[1]q
@@ -297,9 +435,137 @@ resource "aws_sesv2_configuration_set_event_destination" "test" {
 
   event_destination {
     kinesis_firehose_destination {
-      delivery_stream_arn = aws_kinesis_firehose_delivery_stream.test.arn
+      delivery_stream_arn = aws_kinesis_firehose_delivery_stream.test1.arn
       iam_role_arn        = aws_iam_role.delivery_stream.arn
     }
+
+    matching_event_types = ["SEND"]
+  }
+}
+`, rName))
+}
+
+func testAccConfigurationSetEventDestinationConfig_kinesisFirehoseDestination2(rName string) string {
+	return acctest.ConfigCompose(
+		testAccConfigurationSetEventDestinationConfig_kinesisFirehoseDestinationBase(rName),
+		fmt.Sprintf(`
+resource "aws_kinesis_firehose_delivery_stream" "test2" {
+  name        = "%[1]s-2"
+  destination = "s3"
+
+  s3_configuration {
+    role_arn   = aws_iam_role.bucket.arn
+    bucket_arn = aws_s3_bucket.test.arn
+  }
+}
+
+resource "aws_sesv2_configuration_set" "test" {
+  configuration_set_name = %[1]q
+}
+
+resource "aws_sesv2_configuration_set_event_destination" "test" {
+  depends_on = [aws_iam_role_policy.delivery_stream]
+
+  configuration_set_name = aws_sesv2_configuration_set.test.configuration_set_name
+  event_destination_name = %[1]q
+
+  event_destination {
+    kinesis_firehose_destination {
+      delivery_stream_arn = aws_kinesis_firehose_delivery_stream.test2.arn
+      iam_role_arn        = aws_iam_role.delivery_stream.arn
+    }
+
+    matching_event_types = ["SEND"]
+  }
+}
+`, rName))
+}
+
+func testAccConfigurationSetEventDestinationConfig_pinpointDestination1(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_pinpoint_app" "test1" {}
+
+resource "aws_sesv2_configuration_set" "test" {
+  configuration_set_name = %[1]q
+}
+
+resource "aws_sesv2_configuration_set_event_destination" "test" {
+  configuration_set_name = aws_sesv2_configuration_set.test.configuration_set_name
+  event_destination_name = %[1]q
+
+  event_destination {
+	pinpoint_destination {
+	  application_arn = aws_pinpoint_app.test1.arn
+	}
+
+    matching_event_types = ["SEND"]
+  }
+}
+`, rName)
+}
+
+func testAccConfigurationSetEventDestinationConfig_pinpointDestination2(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_pinpoint_app" "test2" {}
+
+resource "aws_sesv2_configuration_set" "test" {
+  configuration_set_name = %[1]q
+}
+
+resource "aws_sesv2_configuration_set_event_destination" "test" {
+  configuration_set_name = aws_sesv2_configuration_set.test.configuration_set_name
+  event_destination_name = %[1]q
+
+  event_destination {
+	pinpoint_destination {
+	  application_arn = aws_pinpoint_app.test2.arn
+	}
+
+    matching_event_types = ["SEND"]
+  }
+}
+`, rName)
+}
+
+func testAccConfigurationSetEventDestinationConfig_snsDestination1(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sns_topic" "test1" {}
+
+resource "aws_sesv2_configuration_set" "test" {
+  configuration_set_name = %[1]q
+}
+
+resource "aws_sesv2_configuration_set_event_destination" "test" {
+  configuration_set_name = aws_sesv2_configuration_set.test.configuration_set_name
+  event_destination_name = %[1]q
+
+  event_destination {
+	sns_destination {
+	  topic_arn = aws_sns_topic.test1.arn
+	}
+
+    matching_event_types = ["SEND"]
+  }
+}
+`, rName)
+}
+
+func testAccConfigurationSetEventDestinationConfig_snsDestination2(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sns_topic" "test2" {}
+
+resource "aws_sesv2_configuration_set" "test" {
+  configuration_set_name = %[1]q
+}
+
+resource "aws_sesv2_configuration_set_event_destination" "test" {
+  configuration_set_name = aws_sesv2_configuration_set.test.configuration_set_name
+  event_destination_name = %[1]q
+
+  event_destination {
+	sns_destination {
+	  topic_arn = aws_sns_topic.test2.arn
+	}
 
     matching_event_types = ["SEND"]
   }

--- a/internal/service/sesv2/configuration_set_event_destination_test.go
+++ b/internal/service/sesv2/configuration_set_event_destination_test.go
@@ -494,9 +494,9 @@ resource "aws_sesv2_configuration_set_event_destination" "test" {
   event_destination_name = %[1]q
 
   event_destination {
-	pinpoint_destination {
-	  application_arn = aws_pinpoint_app.test1.arn
-	}
+    pinpoint_destination {
+      application_arn = aws_pinpoint_app.test1.arn
+    }
 
     matching_event_types = ["SEND"]
   }
@@ -517,9 +517,9 @@ resource "aws_sesv2_configuration_set_event_destination" "test" {
   event_destination_name = %[1]q
 
   event_destination {
-	pinpoint_destination {
-	  application_arn = aws_pinpoint_app.test2.arn
-	}
+    pinpoint_destination {
+      application_arn = aws_pinpoint_app.test2.arn
+    }
 
     matching_event_types = ["SEND"]
   }
@@ -540,9 +540,9 @@ resource "aws_sesv2_configuration_set_event_destination" "test" {
   event_destination_name = %[1]q
 
   event_destination {
-	sns_destination {
-	  topic_arn = aws_sns_topic.test1.arn
-	}
+    sns_destination {
+      topic_arn = aws_sns_topic.test1.arn
+    }
 
     matching_event_types = ["SEND"]
   }
@@ -563,9 +563,9 @@ resource "aws_sesv2_configuration_set_event_destination" "test" {
   event_destination_name = %[1]q
 
   event_destination {
-	sns_destination {
-	  topic_arn = aws_sns_topic.test2.arn
-	}
+    sns_destination {
+      topic_arn = aws_sns_topic.test2.arn
+    }
 
     matching_event_types = ["SEND"]
   }

--- a/internal/service/sesv2/configuration_set_event_destination_test.go
+++ b/internal/service/sesv2/configuration_set_event_destination_test.go
@@ -1,0 +1,206 @@
+package sesv2_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfsesv2 "github.com/hashicorp/terraform-provider-aws/internal/service/sesv2"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestFormatConfigurationSetEventDestinationID(t *testing.T) {
+	expected := "configurationSetName|eventDestinationName"
+	got := tfsesv2.FormatConfigurationSetEventDestinationID("configurationSetName", "eventDestinationName")
+
+	if got != expected {
+		t.Errorf("got %s, expected %s", got, expected)
+	}
+}
+
+func TestParseConfigurationSetEventDestinationID(t *testing.T) {
+	testCases := []struct {
+		TestName string
+		Input    string
+		Expected tfsesv2.ConfigurationSetEventDestinationID
+		Error    bool
+	}{
+		{
+			TestName: "empty",
+			Input:    "",
+			Expected: tfsesv2.ConfigurationSetEventDestinationID{},
+			Error:    true,
+		},
+		{
+			TestName: "no pipe",
+			Input:    "configurationSetNameEventDestinationName",
+			Expected: tfsesv2.ConfigurationSetEventDestinationID{},
+			Error:    true,
+		},
+		{
+			TestName: "valid",
+			Input:    "configurationSetName|eventDestinationName",
+			Expected: tfsesv2.ConfigurationSetEventDestinationID{
+				ConfigurationSetName: "configurationSetName",
+				EventDestinationName: "eventDestinationName",
+			},
+			Error: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			got, err := tfsesv2.ParseConfigurationSetEventDestinationID(testCase.Input)
+
+			if err != nil && !testCase.Error {
+				t.Errorf("got error (%s), expected no error", err)
+			}
+
+			if err == nil && testCase.Error {
+				t.Errorf("got (%s) and no error, expected error", got)
+			}
+
+			if got != testCase.Expected {
+				t.Errorf("got %s, expected %s", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+func TestAccSESV2ConfigurationSetEventDestination_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sesv2_configuration_set_event_destination.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfigurationSetEventDestinationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigurationSetEventDestinationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationSetEventDestinationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "configuration_set_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.cloud_watch_destination.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.cloud_watch_destination.0.dimension_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.cloud_watch_destination.0.dimension_configuration.0.default_dimension_value", rName),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.cloud_watch_destination.0.dimension_configuration.0.dimension_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.cloud_watch_destination.0.dimension_configuration.0.dimension_value_source", "MESSAGE_TAG"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.matching_event_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination.0.matching_event_types.0", "SEND"),
+					resource.TestCheckResourceAttr(resourceName, "event_destination_name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSESV2ConfigurationSetEventDestination_disappears(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sesv2_configuration_set_event_destination.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfigurationSetEventDestinationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigurationSetEventDestinationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationSetEventDestinationExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfsesv2.ResourceConfigurationSetEventDestination(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckConfigurationSetEventDestinationDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).SESV2Conn
+	ctx := context.Background()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_sesv2_configuration_set_event_destination" {
+			continue
+		}
+
+		_, err := tfsesv2.FindConfigurationSetEventDestinationByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			var nfe *types.NotFoundException
+			if errors.As(err, &nfe) {
+				return nil
+			}
+			return err
+		}
+
+		return create.Error(names.SESV2, create.ErrActionCheckingDestroyed, tfsesv2.ResNameConfigurationSetEventDestination, rs.Primary.ID, errors.New("not destroyed"))
+	}
+
+	return nil
+}
+
+func testAccCheckConfigurationSetEventDestinationExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameConfigurationSetEventDestination, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameConfigurationSetEventDestination, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SESV2Conn
+
+		_, err := tfsesv2.FindConfigurationSetEventDestinationByID(context.Background(), conn, rs.Primary.ID)
+
+		if err != nil {
+			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameConfigurationSetEventDestination, rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccConfigurationSetEventDestinationConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sesv2_configuration_set" "test" {
+  configuration_set_name = %[1]q
+}
+
+resource "aws_sesv2_configuration_set_event_destination" "test" {
+  configuration_set_name = aws_sesv2_configuration_set.test.configuration_set_name
+  event_destination_name = %[1]q
+
+  event_destination {
+	cloud_watch_destination {
+	  dimension_configuration {
+		default_dimension_value = %[1]q
+		dimension_name 			= %[1]q
+		dimension_value_source  = "MESSAGE_TAG"
+	  }
+	}
+
+	matching_event_types = ["SEND"]
+  }
+}
+`, rName)
+}

--- a/website/docs/r/sesv2_configuration_set_event_destination.html.markdown
+++ b/website/docs/r/sesv2_configuration_set_event_destination.html.markdown
@@ -27,12 +27,12 @@ resource "aws_sesv2_configuration_set_event_destination" "example" {
     cloud_watch_destination {
       dimension_configuration {
         default_dimension_value = "example"
-        dimension_name = "example"
-        dimension_value_source = "MESSAGE_TAG"
+        dimension_name          = "example"
+        dimension_value_source  = "MESSAGE_TAG"
       }
     }
 
-    enabled = true
+    enabled              = true
     matching_event_types = ["SEND"]
   }
 }
@@ -54,7 +54,7 @@ resource "aws_sesv2_configuration_set_event_destination" "example" {
       application_arn = aws_pinpoint_app.example.arn
     }
 
-    enabled = true
+    enabled              = true
     matching_event_types = ["SEND"]
   }
 }
@@ -74,10 +74,10 @@ resource "aws_sesv2_configuration_set_event_destination" "example" {
   event_destination {
     kinesis_firehose_destination {
       delivery_stream_arn = aws_kinesis_firehose_delivery_stream.example.arn
-      iam_role_arn = aws_iam_role.example.arn
+      iam_role_arn        = aws_iam_role.example.arn
     }
 
-    enabled = true
+    enabled              = true
     matching_event_types = ["SEND"]
   }
 }
@@ -99,7 +99,7 @@ resource "aws_sesv2_configuration_set_event_destination" "example" {
       topic_arn = aws_sns_topic.example.arn
     }
 
-    enabled = true
+    enabled              = true
     matching_event_types = ["SEND"]
   }
 }
@@ -124,7 +124,7 @@ The following arguments are optional:
 * `cloud_watch_destination` - (Optional) An object that defines an Amazon CloudWatch destination for email events. See [cloud_watch_destination](#cloud_watch_destination) below
 * `enabled` - (Optional) When the event destination is enabled, the specified event types are sent to the destinations. Default: `false`.
 * `kinesis_firehose_destination` - (Optional) An object that defines an Amazon Kinesis Data Firehose destination for email events. See [kinesis_firehose_destination](#kinesis_firehose_destination) below.
-* `pinpoint_destiantion` - (Optional) An object that defines an Amazon Pinpoint project destination for email events. See [pinpoint_destination](#pinpoint_destination) below.
+* `pinpoint_destination` - (Optional) An object that defines an Amazon Pinpoint project destination for email events. See [pinpoint_destination](#pinpoint_destination) below.
 * `sns_destination` - (Optional) An object that defines an Amazon SNS destination for email events. See [sns_destination](#sns_destination) below.
 
 ### cloud_watch_destination

--- a/website/docs/r/sesv2_configuration_set_event_destination.html.markdown
+++ b/website/docs/r/sesv2_configuration_set_event_destination.html.markdown
@@ -1,0 +1,173 @@
+---
+subcategory: "SESv2 (Simple Email V2)"
+layout: "aws"
+page_title: "AWS: aws_sesv2_configuration_set_event_destination"
+description: |-
+  Terraform resource for managing an AWS SESv2 (Simple Email V2) Configuration Set Event Destination.
+---
+
+# Resource: aws_sesv2_configuration_set_event_destination
+
+Terraform resource for managing an AWS SESv2 (Simple Email V2) Configuration Set Event Destination.
+
+## Example Usage
+
+### Cloud Watch Destination
+
+```terraform
+resource "aws_sesv2_configuration_set" "example" {
+  configuration_set_name = "example"
+}
+
+resource "aws_sesv2_configuration_set_event_destination" "example" {
+  configuration_set_name = aws_sesv2_configuration_set.example.configuration_set_name
+  event_destination_name = "example"
+
+  event_destination {
+    cloud_watch_destination {
+      dimension_configuration {
+        default_dimension_value = "example"
+        dimension_name = "example"
+        dimension_value_source = "MESSAGE_TAG"
+      }
+    }
+
+    enabled = true
+    matching_event_types = ["SEND"]
+  }
+}
+```
+
+### Kinesis Firehose Destination
+
+```terraform
+resource "aws_sesv2_configuration_set" "example" {
+  configuration_set_name = "example"
+}
+
+resource "aws_sesv2_configuration_set_event_destination" "example" {
+  configuration_set_name = aws_sesv2_configuration_set.example.configuration_set_name
+  event_destination_name = "example"
+
+  event_destination {
+    pinpoint_destination {
+      application_arn = aws_pinpoint_app.example.arn
+    }
+
+    enabled = true
+    matching_event_types = ["SEND"]
+  }
+}
+```
+
+### Pinpoint Destination
+
+```terraform
+resource "aws_sesv2_configuration_set" "example" {
+  configuration_set_name = "example"
+}
+
+resource "aws_sesv2_configuration_set_event_destination" "example" {
+  configuration_set_name = aws_sesv2_configuration_set.example.configuration_set_name
+  event_destination_name = "example"
+
+  event_destination {
+    kinesis_firehose_destination {
+      delivery_stream_arn = aws_kinesis_firehose_delivery_stream.example.arn
+      iam_role_arn = aws_iam_role.example.arn
+    }
+
+    enabled = true
+    matching_event_types = ["SEND"]
+  }
+}
+```
+
+### SNS Destination
+
+```terraform
+resource "aws_sesv2_configuration_set" "example" {
+  configuration_set_name = "example"
+}
+
+resource "aws_sesv2_configuration_set_event_destination" "example" {
+  configuration_set_name = aws_sesv2_configuration_set.example.configuration_set_name
+  event_destination_name = "example"
+
+  event_destination {
+    sns_destination {
+      topic_arn = aws_sns_topic.example.arn
+    }
+
+    enabled = true
+    matching_event_types = ["SEND"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `configuration_set_name` - (Required) The name of the configuration set.
+* `event_destination` - (Required) A name that identifies the event destination within the configuration set.
+* `event_destination_name` - (Required) An object that defines the event destination. See [event_destination](#event_destination) below.
+
+### event_destination
+
+The following arguments are required:
+
+* `matching_event_types` - (Required) - An array that specifies which events the Amazon SES API v2 should send to the destinations. Valid values: `SEND`, `REJECT`, `BOUNCE`, `COMPLAINT`, `DELIVERY`, `OPEN`, `CLICK`, `RENDERING_FAILURE`, `DELIVERY_DELAY`, `SUBSCRIPTION`.
+
+The following arguments are optional:
+
+* `cloud_watch_destination` - (Optional) An object that defines an Amazon CloudWatch destination for email events. See [cloud_watch_destination](#cloud_watch_destination) below
+* `enabled` - (Optional) When the event destination is enabled, the specified event types are sent to the destinations. Default: `false`.
+* `kinesis_firehose_destination` - (Optional) An object that defines an Amazon Kinesis Data Firehose destination for email events. See [kinesis_firehose_destination](#kinesis_firehose_destination) below.
+* `pinpoint_destiantion` - (Optional) An object that defines an Amazon Pinpoint project destination for email events. See [pinpoint_destination](#pinpoint_destination) below.
+* `sns_destination` - (Optional) An object that defines an Amazon SNS destination for email events. See [sns_destination](#sns_destination) below.
+
+### cloud_watch_destination
+
+The following arguments are required:
+
+* `dimension_configuration` - (Required) An array of objects that define the dimensions to use when you send email events to Amazon CloudWatch. See [dimension_configuration](#dimension_configuration) below.
+
+### dimension_configuration
+
+The following arguments are required:
+
+* `default_dimension_value` - (Required) The default value of the dimension that is published to Amazon CloudWatch if you don't provide the value of the dimension when you send an email.
+( `dimension_name` - (Required) The name of an Amazon CloudWatch dimension associated with an email sending metric.
+* `dimension_value_source` - (Required) The location where the Amazon SES API v2 finds the value of a dimension to publish to Amazon CloudWatch. Valid values: `MESSAGE_TAG`, `EMAIL_HEADER`, `LINK_TAG`.
+
+### kinesis_firehose_destination
+
+The following arguments are required:
+
+* `delivery_stream_arn` - (Required) The Amazon Resource Name (ARN) of the Amazon Kinesis Data Firehose stream that the Amazon SES API v2 sends email events to.
+* `iam_role_arn` - (Required) The Amazon Resource Name (ARN) of the IAM role that the Amazon SES API v2 uses to send email events to the Amazon Kinesis Data Firehose stream.
+
+### pinpoint_destination
+
+The following arguments are required:
+
+* `pinpoint_application_arn` - (Required) The Amazon Resource Name (ARN) of the Amazon Pinpoint project to send email events to.
+
+### sns_destination
+
+The following arguments are required:
+
+* `topic_arn` - (Required) The Amazon Resource Name (ARN) of the Amazon SNS topic to publish email events to.
+
+## Attributes Reference
+
+No additional attributes are exported.
+
+## Import
+
+SESv2 (Simple Email V2) Configuration Set Event Destination can be imported using the `configuration_set_name|event_destination_name`, e.g.,
+
+```
+$ terraform import aws_sesv2_configuration_set_event_destination.example configuration_set_name|event_destination_name
+```

--- a/website/docs/r/sesv2_configuration_set_event_destination.html.markdown
+++ b/website/docs/r/sesv2_configuration_set_event_destination.html.markdown
@@ -162,6 +162,8 @@ The following arguments are required:
 
 ## Attributes Reference
 
+In addition to all arguments above, the following attributes are exported:
+
 * `id` - A pipe-delimited string combining `configuration_set_name` and `event_destination_name`.
 
 ## Import

--- a/website/docs/r/sesv2_configuration_set_event_destination.html.markdown
+++ b/website/docs/r/sesv2_configuration_set_event_destination.html.markdown
@@ -162,12 +162,12 @@ The following arguments are required:
 
 ## Attributes Reference
 
-No additional attributes are exported.
+* `id` - A pipe-delimited string combining `configuration_set_name` and `event_destination_name`.
 
 ## Import
 
-SESv2 (Simple Email V2) Configuration Set Event Destination can be imported using the `configuration_set_name|event_destination_name`, e.g.,
+SESv2 (Simple Email V2) Configuration Set Event Destination can be imported using the `id` (`configuration_set_name|event_destination_name`), e.g.,
 
 ```
-$ terraform import aws_sesv2_configuration_set_event_destination.example configuration_set_name|event_destination_name
+$ terraform import aws_sesv2_configuration_set_event_destination.example example_configuration_set|example_event_destination
 ```

--- a/website/docs/r/sesv2_configuration_set_event_destination.html.markdown
+++ b/website/docs/r/sesv2_configuration_set_event_destination.html.markdown
@@ -50,8 +50,9 @@ resource "aws_sesv2_configuration_set_event_destination" "example" {
   event_destination_name = "example"
 
   event_destination {
-    pinpoint_destination {
-      application_arn = aws_pinpoint_app.example.arn
+    kinesis_firehose_destination {
+      delivery_stream_arn = aws_kinesis_firehose_delivery_stream.example.arn
+      iam_role_arn        = aws_iam_role.example.arn
     }
 
     enabled              = true
@@ -72,9 +73,8 @@ resource "aws_sesv2_configuration_set_event_destination" "example" {
   event_destination_name = "example"
 
   event_destination {
-    kinesis_firehose_destination {
-      delivery_stream_arn = aws_kinesis_firehose_delivery_stream.example.arn
-      iam_role_arn        = aws_iam_role.example.arn
+    pinpoint_destination {
+      application_arn = aws_pinpoint_app.example.arn
     }
 
     enabled              = true


### PR DESCRIPTION
### Description
This PR introduces the `aws_sesv2_configuration_set_event_destination` resource.


### Relations
Relates #26796.
Closes #17570.

### References
https://docs.aws.amazon.com/ses/latest/APIReference-V2/Welcome.html

### Output from Acceptance Testing
```
$ make testacc TESTARGS="-run=TestAccSESV2ConfigurationSetEventDestination_" PKG=sesv2 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sesv2/... -v -count 1 -parallel 2  -run=TestAccSESV2ConfigurationSetEventDestination_ -timeout 180m
=== RUN   TestAccSESV2ConfigurationSetEventDestination_basic
=== PAUSE TestAccSESV2ConfigurationSetEventDestination_basic
=== RUN   TestAccSESV2ConfigurationSetEventDestination_cloudWatchDestination
=== PAUSE TestAccSESV2ConfigurationSetEventDestination_cloudWatchDestination
=== RUN   TestAccSESV2ConfigurationSetEventDestination_kinesisFirehoseDestination
=== PAUSE TestAccSESV2ConfigurationSetEventDestination_kinesisFirehoseDestination
=== RUN   TestAccSESV2ConfigurationSetEventDestination_pinpointDestination
=== PAUSE TestAccSESV2ConfigurationSetEventDestination_pinpointDestination
=== RUN   TestAccSESV2ConfigurationSetEventDestination_snsDestination
=== PAUSE TestAccSESV2ConfigurationSetEventDestination_snsDestination
=== RUN   TestAccSESV2ConfigurationSetEventDestination_disappears
=== PAUSE TestAccSESV2ConfigurationSetEventDestination_disappears
=== CONT  TestAccSESV2ConfigurationSetEventDestination_basic
=== CONT  TestAccSESV2ConfigurationSetEventDestination_pinpointDestination
--- PASS: TestAccSESV2ConfigurationSetEventDestination_basic (33.91s)
=== CONT  TestAccSESV2ConfigurationSetEventDestination_disappears
--- PASS: TestAccSESV2ConfigurationSetEventDestination_pinpointDestination (39.75s)
=== CONT  TestAccSESV2ConfigurationSetEventDestination_snsDestination
--- PASS: TestAccSESV2ConfigurationSetEventDestination_disappears (15.79s)
=== CONT  TestAccSESV2ConfigurationSetEventDestination_kinesisFirehoseDestination
--- PASS: TestAccSESV2ConfigurationSetEventDestination_snsDestination (35.82s)
=== CONT  TestAccSESV2ConfigurationSetEventDestination_cloudWatchDestination
--- PASS: TestAccSESV2ConfigurationSetEventDestination_cloudWatchDestination (31.90s)
--- PASS: TestAccSESV2ConfigurationSetEventDestination_kinesisFirehoseDestination (484.78s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sesv2      536.477s
```
