### PR TITLE
dynamodb/table: Fix stream diff bugs

### DIFF
--- a/.changelog/27566.txt
+++ b/.changelog/27566.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Fix bug causing spurious diffs with and preventing proper updating of `stream_enabled` and `stream_view_type`
+```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -834,7 +834,9 @@ func resourceTableUpdate(d *schema.ResourceData, meta interface{}) error {
 			// in order to change stream view type:
 			//   1) stream have already been enabled, and
 			//   2) it must be disabled and then reenabled (otherwise, ValidationException: Table already has an enabled stream)
-			cycleStreamEnabled(conn, d.Id(), d.Get("stream_view_type").(string), d.Timeout(schema.TimeoutUpdate))
+			if err := cycleStreamEnabled(conn, d.Id(), d.Get("stream_view_type").(string), d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return create.Error(names.DynamoDB, create.ErrActionUpdating, ResNameTable, d.Id(), err)
+			}
 		}
 	}
 

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -843,7 +843,7 @@ func resourceTableUpdate(d *schema.ResourceData, meta interface{}) error {
 	//   stream_enabled has change OR
 	//   stream_view_type has change and stream_enabled is true
 	if !d.HasChange("stream_enabled") && d.HasChange("stream_view_type") {
-		if v, ok := d.GetOk("stream_enabled"); ok && v.(bool) {
+		if v, ok := d.Get("stream_enabled").(bool); ok && v {
 			// in order to change stream view type:
 			//   1) stream have already been enabled, and
 			//   2) it must be disabled and then reenabled (otherwise, ValidationException: Table already has an enabled stream)

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -682,11 +682,9 @@ func resourceTableRead(d *schema.ResourceData, meta interface{}) error {
 
 	if table.StreamSpecification != nil {
 		d.Set("stream_view_type", table.StreamSpecification.StreamViewType)
-		//fmt.Printf("set stream_view_type (from aws): %s\n", aws.StringValue(table.StreamSpecification.StreamViewType))
 		d.Set("stream_enabled", table.StreamSpecification.StreamEnabled)
 	} else {
 		d.Set("stream_enabled", false)
-		//fmt.Printf("set stream_view_type (not from aws): %s\n", d.Get("stream_view_type").(string))
 		d.Set("stream_view_type", d.Get("stream_view_type").(string))
 	}
 
@@ -828,20 +826,9 @@ func resourceTableUpdate(d *schema.ResourceData, meta interface{}) error {
 		input.ProvisionedThroughput = expandProvisionedThroughputUpdate(d.Id(), capacityMap, billingMode, oldBillingMode)
 	}
 
-	if d.HasChanges("stream_enabled", "stream_view_type") {
-		//fmt.Printf("changes one or other:\n")
-		if d.HasChange("stream_enabled") {
-			//fmt.Printf("  hasChanges stream_enabled: %t\n", d.Get("stream_enabled").(bool))
-		}
-
-		if d.HasChange("stream_view_type") {
-			//fmt.Printf("  hasChanges stream_view_type: %s\n", d.Get("stream_view_type").(string))
-		}
-	}
-
 	// make change when
-	//   stream_enabled has change OR
-	//   stream_view_type has change and stream_enabled is true
+	//   stream_enabled has change (below) OR
+	//   stream_view_type has change and stream_enabled is true (special case)
 	if !d.HasChange("stream_enabled") && d.HasChange("stream_view_type") {
 		if v, ok := d.Get("stream_enabled").(bool); ok && v {
 			// in order to change stream view type:

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -797,7 +797,7 @@ func TestAccDynamoDBTable_streamSpecification(t *testing.T) {
 	})
 }
 
-func TestAccDynamoDBTable_streamDiffs(t *testing.T) {
+func TestAccDynamoDBTable_streamSpecificationDiffs(t *testing.T) {
 	var conf dynamodb.DescribeTableOutput
 	resourceName := "aws_dynamodb_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -788,7 +788,92 @@ func TestAccDynamoDBTable_streamSpecification(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "stream_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "stream_view_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "stream_view_type", "KEYS_ONLY"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "stream_arn", "dynamodb", regexp.MustCompile(fmt.Sprintf("table/%s/stream", rName))),
+					resource.TestCheckResourceAttrSet(resourceName, "stream_label"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTable_streamDiffs(t *testing.T) {
+	var conf dynamodb.DescribeTableOutput
+	resourceName := "aws_dynamodb_table.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_streamSpecification(rName, true, "KEYS_ONLY"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "stream_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "stream_view_type", "KEYS_ONLY"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "stream_arn", "dynamodb", regexp.MustCompile(fmt.Sprintf("table/%s/stream", rName))),
+					resource.TestCheckResourceAttrSet(resourceName, "stream_label"),
+				),
+			},
+			{
+				Config: testAccTableConfig_streamSpecification(rName, true, "NEW_IMAGE"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "stream_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "stream_view_type", "NEW_IMAGE"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "stream_arn", "dynamodb", regexp.MustCompile(fmt.Sprintf("table/%s/stream", rName))),
+					resource.TestCheckResourceAttrSet(resourceName, "stream_label"),
+				),
+			},
+			{
+				Config: testAccTableConfig_streamSpecification(rName, false, "NEW_IMAGE"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "stream_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "stream_view_type", "NEW_IMAGE"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "stream_arn", "dynamodb", regexp.MustCompile(fmt.Sprintf("table/%s/stream", rName))),
+					resource.TestCheckResourceAttrSet(resourceName, "stream_label"),
+				),
+			},
+			{
+				Config: testAccTableConfig_streamSpecification(rName, false, "KEYS_ONLY"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "stream_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "stream_view_type", "KEYS_ONLY"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "stream_arn", "dynamodb", regexp.MustCompile(fmt.Sprintf("table/%s/stream", rName))),
+					resource.TestCheckResourceAttrSet(resourceName, "stream_label"),
+				),
+			},
+			{
+				Config: testAccTableConfig_streamSpecification(rName, false, "null"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "stream_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "stream_view_type", "KEYS_ONLY"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "stream_arn", "dynamodb", regexp.MustCompile(fmt.Sprintf("table/%s/stream", rName))),
+					resource.TestCheckResourceAttrSet(resourceName, "stream_label"),
+				),
+			},
+			{
+				Config: testAccTableConfig_streamSpecification(rName, true, "KEYS_ONLY"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "stream_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "stream_view_type", "KEYS_ONLY"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "stream_arn", "dynamodb", regexp.MustCompile(fmt.Sprintf("table/%s/stream", rName))),
+					resource.TestCheckResourceAttrSet(resourceName, "stream_label"),
+				),
+			},
+			{
+				Config: testAccTableConfig_streamSpecification(rName, true, "KEYS_ONLY"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "stream_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "stream_view_type", "KEYS_ONLY"),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "stream_arn", "dynamodb", regexp.MustCompile(fmt.Sprintf("table/%s/stream", rName))),
 					resource.TestCheckResourceAttrSet(resourceName, "stream_label"),
 				),
@@ -2442,6 +2527,9 @@ resource "aws_dynamodb_table" "test" {
 }
 
 func testAccTableConfig_streamSpecification(rName string, enabled bool, viewType string) string {
+	if viewType != "null" {
+		viewType = fmt.Sprintf(`"%s"`, viewType)
+	}
 	return fmt.Sprintf(`
 resource "aws_dynamodb_table" "test" {
   name           = %[1]q
@@ -2455,7 +2543,7 @@ resource "aws_dynamodb_table" "test" {
   }
 
   stream_enabled   = %[2]t
-  stream_view_type = %[3]q
+  stream_view_type = %[3]s
 }
 `, rName, enabled, viewType)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #15189

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccDynamoDBTable_ PKG=dynamodb 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_'  -timeout 180m
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (20.52s)
--- PASS: TestAccDynamoDBTable_basic (53.59s)
--- PASS: TestAccDynamoDBTable_TTL_enabled (54.58s)
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (72.43s)
--- PASS: TestAccDynamoDBTable_TTL_disabled (77.42s)
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (85.43s)
--- PASS: TestAccDynamoDBTable_lsiUpdate (93.09s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (100.83s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (71.73s)
--- PASS: TestAccDynamoDBTable_tags (55.24s)
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (49.65s)
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (4.19s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (78.45s)
--- PASS: TestAccDynamoDBTable_encryption (157.23s)
--- PASS: TestAccDynamoDBTable_gsiUpdateCapacity (76.64s)
--- PASS: TestAccDynamoDBTable_streamSpecification (74.12s)
--- PASS: TestAccDynamoDBTable_enablePITR (79.82s)
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (81.27s)
--- PASS: TestAccDynamoDBTable_disappears (26.12s)
--- PASS: TestAccDynamoDBTable_Replica_singleWithCMK (318.31s)
--- PASS: TestAccDynamoDBTable_streamDiffs (177.98s)
--- PASS: TestAccDynamoDBTable_Replica_pitr (333.19s)
--- PASS: TestAccDynamoDBTable_Replica_tagsOneOfTwo (342.51s)
--- PASS: TestAccDynamoDBTable_Replica_tagsTwoOfTwo (344.82s)
--- PASS: TestAccDynamoDBTable_backupEncryption (355.97s)
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (442.19s)
--- PASS: TestAccDynamoDBTable_extended (288.94s)
--- PASS: TestAccDynamoDBTable_Replica_single (459.19s)
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (556.79s)
--- PASS: TestAccDynamoDBTable_Replica_multiple (573.07s)
--- PASS: TestAccDynamoDBTable_Replica_tagsNext (579.57s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (638.91s)
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (783.98s)
--- PASS: TestAccDynamoDBTable_attributeUpdate (889.98s)
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (879.63s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (853.73s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (883.60s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	939.735s
```
