### PR TITLE
fix: Use cluster ID when present, otherwise use cluster name for `id`

### DIFF
--- a/internal/service/eks/cluster_auth_data_source.go
+++ b/internal/service/eks/cluster_auth_data_source.go
@@ -40,7 +40,14 @@ func dataSourceClusterAuthRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error getting token: %w", err)
 	}
 
-	d.SetId(name)
+	var identifier string
+	if v, ok := d.GetOk("id"); ok {
+		identifier = v.(string)
+	} else {
+		identifier = d.Get("name").(string)
+	}
+
+	d.SetId(identifier)
 	d.Set("token", toke.Token)
 
 	return nil

--- a/internal/service/eks/cluster_data_source.go
+++ b/internal/service/eks/cluster_data_source.go
@@ -44,6 +44,10 @@ func DataSourceCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"identity": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -179,7 +183,14 @@ func dataSourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error reading EKS Cluster (%s): %w", name, err)
 	}
 
-	d.SetId(name)
+	var identifier string
+	if v, ok := d.GetOk("id"); ok {
+		identifier = v.(string)
+	} else {
+		identifier = d.Get("name").(string)
+	}
+
+	d.SetId(identifier)
 	d.Set("arn", cluster.Arn)
 
 	if err := d.Set("certificate_authority", flattenCertificate(cluster.CertificateAuthority)); err != nil {

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -21,6 +21,8 @@ import (
 const (
 	clusterVersionUpgradeInitial = "1.21"
 	clusterVersionUpgradeUpdated = "1.22"
+
+	uuidRegex = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 )
 
 func TestAccEKSCluster_basic(t *testing.T) {
@@ -623,6 +625,8 @@ func TestAccEKSCluster_Outpost_create(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "outpost_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "outpost_config.0.control_plane_instance_type", controlPlaneInstanceType),
 					resource.TestCheckResourceAttr(resourceName, "outpost_config.0.outpost_arns.#", "1"),
+					// https://github.com/hashicorp/terraform-provider-aws/issues/27560
+					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(uuidRegex)),
 				),
 			},
 			{

--- a/website/docs/d/eks_cluster.html.markdown
+++ b/website/docs/d/eks_cluster.html.markdown
@@ -37,7 +37,7 @@ output "identity-oidc-issuer" {
 
 ## Attributes Reference
 
-* `id` - Name of the cluster
+* `id` - ID of the cluster
 * `arn` - ARN of the cluster.
 * `certificate_authority` - Nested attribute containing `certificate-authority-data` for your cluster.
     * `data` - The base64 encoded certificate data required to communicate with your cluster. Add this to the `certificate-authority-data` section of the `kubeconfig` file for your cluster.

--- a/website/docs/d/eks_cluster_auth.html.markdown
+++ b/website/docs/d/eks_cluster_auth.html.markdown
@@ -42,5 +42,5 @@ provider "kubernetes" {
 
 ## Attributes Reference
 
-* `id` - Name of the cluster.
+* `id` - ID of the cluster.
 * `token` - Token to use to authenticate with the cluster.

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -255,7 +255,7 @@ In addition to all arguments above, the following attributes are exported:
 * `certificate_authority` - Attribute block containing `certificate-authority-data` for your cluster. Detailed below.
 * `created_at` - Unix epoch timestamp in seconds for when the cluster was created.
 * `endpoint` - Endpoint for your Kubernetes API server.
-* `id` - Name of the cluster.
+* `id` - ID of the cluster.
 * `identity` - Attribute block containing identity provider information for your cluster. Only available on Kubernetes version 1.13 and 1.14 clusters created or upgraded on or after September 3, 2019. Detailed below.
 * `kubernetes_network_config.service_ipv6_cidr` - The CIDR block that Kubernetes pod and service IP addresses are assigned from if you specified `ipv6` for ipFamily when you created the cluster. Kubernetes assigns service addresses from the unique local address range (fc00::/7) because you can't specify a custom IPv6 CIDR block when you create the cluster.
 * `platform_version` - Platform version for the cluster.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations

Closes #27560

### References

The `Cluster` type has an `Id` attribute that is (currently) populated when deploying EKS on Outpost (local cluster), but is `null` for clusters deployed into AWS cloud. Ref https://docs.aws.amazon.com/sdk-for-go/api/service/eks/#Cluster

This poses a challenge when using the cluster ID for authentication to the cluster API server when using the exec method on providers such as the Kubernetes provider due to the fact that the ID passed is actually the name and not the true ID:

```hcl
provider "kubernetes" {
  host                   = aws_eks_cluster.test.endpoint
  cluster_ca_certificate = base64decode(aws_eks_cluster.this[0].certificate_authority[0].data)

  exec {
    api_version = "client.authentication.k8s.io/v1beta1"
    command     = "aws"
    args        = ["eks", "get-token", "--cluster-id", aws_eks_cluster.this.id, "--region", data.aws_region.current.name]
  }
}
```

Or when using the `aws_eks_cluster_auth` data source since the data source is again using the cluster name as the ID internally:

```hcl
provider "kubernetes" {
  host                   = aws_eks_cluster.test.endpoint
  cluster_ca_certificate = base64decode(aws_eks_cluster.this[0].certificate_authority[0].data)
  token                  = data.aws_eks_cluster_auth.this.token
}

data "aws_eks_cluster_auth" "this" {
  name = aws_eks_cluster.test.id
}
```

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
