### PR TITLE
aws_connect_routing_profile: increase the hardcoded queue limit to AWS default value of 50

### DIFF
--- a/.changelog/27573.txt
+++ b/.changelog/27573.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/routing_profile: increase the hardcoded queue limit from 10 to 50 to match AWS default quota
+```

--- a/.changelog/27573.txt
+++ b/.changelog/27573.txt
@@ -1,3 +1,3 @@
-```release-note:enhancement
-resource/routing_profile: increase the hardcoded queue limit from 10 to 50 to match AWS default quota
+```release-note:bug
+resource/aws_connect_routing_profile: removed the hardcoded `queue_configs` max limit
 ```

--- a/internal/service/connect/routing_profile.go
+++ b/internal/service/connect/routing_profile.go
@@ -76,7 +76,7 @@ func ResourceRoutingProfile() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				MinItems: 1,
-				MaxItems: 10,
+				MaxItems: 50,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"channel": {

--- a/internal/service/connect/routing_profile.go
+++ b/internal/service/connect/routing_profile.go
@@ -76,7 +76,6 @@ func ResourceRoutingProfile() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				MinItems: 1,
-				MaxItems: 50,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"channel": {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
In the aws_connect_routing_profile,  increase hardcoded limit queues per routing profile from 10 to 50, which is similar to AWS default quota

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27014

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
Could any reviewer help me to run the Acc Test please ? Thank you very much in advance
