### PR TITLE
aws_dx_connection_confirmation: Modify default timeout to 30min instead of the original 10min

### DIFF
--- a/.changelog/27583.txt
+++ b/.changelog/27583.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dx_connection_confirmation: Increase default timeout to 30min instead of 10min.
+```

--- a/internal/service/directconnect/connection_confirmation.go
+++ b/internal/service/directconnect/connection_confirmation.go
@@ -3,6 +3,7 @@ package directconnect
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/directconnect"
@@ -16,6 +17,10 @@ func ResourceConnectionConfirmation() *schema.Resource {
 		Create: resourceConnectionConfirmationCreate,
 		Read:   resourceConnectionConfirmationRead,
 		Delete: resourceConnectionConfirmationDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			"connection_id": {

--- a/website/docs/r/dx_connection_confirmation.html.markdown
+++ b/website/docs/r/dx_connection_confirmation.html.markdown
@@ -34,3 +34,9 @@ from your statefile and management, **but will not destroy the Hosted Connection
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the connection.
+
+## Timeouts
+
+[Configuration options](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts):
+
+- `read` - (Default `30m`)


### PR DESCRIPTION
### Description
Changed the default timeout from **10min** to **30min** for `aws_dx_connection_confirmation` resource.

### Relations

Closes #26335

### Output from Acceptance Testing

I could not run the acceptance testing because I do not have a valid Direct Connect partner AWS account.

```
e6b57177af4f# make testacc TESTS=TestAccDirectConnectConnectionConfirmation_basic PKG=directconnect
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/directconnect/... -v -count 1 -parallel 20 -run='TestAccDirectConnectConnectionConfirmation_basic'  -timeout 180m
=== RUN   TestAccDirectConnectConnectionConfirmation_basic
=== PAUSE TestAccDirectConnectConnectionConfirmation_basic
=== CONT  TestAccDirectConnectConnectionConfirmation_basic
    connection_confirmation_test.go:32: Step 1/1 error: Error running apply: exit status 1
        
        Error: error creating Direct Connect Hosted Connection (tf-dx-jf31p): DirectConnectClientException: Account 123456789 is not an authorized Direct Connect partner in us-east-2.
        
          with aws_dx_hosted_connection.connection,
          on terraform_plugin_test.tf line 8, in resource "aws_dx_hosted_connection" "connection":
           8: resource "aws_dx_hosted_connection" "connection" {
        
--- FAIL: TestAccDirectConnectConnectionConfirmation_basic (12.77s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/directconnect	12.934s
FAIL
make: *** [GNUmakefile:91: testacc] Error 1
```
