### PR TITLE
Correct supported types for ACM cert data source

### DIFF
--- a/website/docs/d/acm_certificate.html.markdown
+++ b/website/docs/d/acm_certificate.html.markdown
@@ -42,7 +42,7 @@ data "aws_acm_certificate" "rsa_4096" {
 * `statuses` - (Optional) List of statuses on which to filter the returned list. Valid values are `PENDING_VALIDATION`, `ISSUED`,
    `INACTIVE`, `EXPIRED`, `VALIDATION_TIMED_OUT`, `REVOKED` and `FAILED`. If no value is specified, only certificates in the `ISSUED` state
    are returned.
-* `types` - (Optional) List of types on which to filter the returned list. Valid values are `AMAZON_ISSUED` and `IMPORTED`.
+* `types` - (Optional) List of types on which to filter the returned list. Valid values are `AMAZON_ISSUED`, `PRIVATE`, and `IMPORTED`.
 * `most_recent` - (Optional) If set to true, it sorts the certificates matched by previous criteria by the NotBefore field, returning only the most recent one. If set to false, it returns an error if more than one certificate is found. Defaults to false.
 
 ## Attributes Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The `types` property supports `PRIVATE` as a value as well. Current documentation only indicates `AMAZON_ISSUED` and `IMPORTED` only. 


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
None


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
See more on [API documentatio](https://docs.aws.amazon.com/acm/latest/APIReference/API_CertificateDetail.html#ACM-Type-CertificateDetail-Type).

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
None, documentation change only

