### PR TITLE
docs: add `tags` attribute to RDS Cluster data source

### DIFF
--- a/website/docs/d/rds_cluster.html.markdown
+++ b/website/docs/d/rds_cluster.html.markdown
@@ -27,4 +27,6 @@ The following arguments are supported:
 ## Attributes Reference
 
 See the [RDS Cluster Resource](/docs/providers/aws/r/rds_cluster.html) for details on the
-returned attributes - they are identical.
+returned attributes - they are identical for all attributes, except the `tags_all`. If you need to get the tags for this resource, use the attribute `tags` as described below.
+
+* `tags` - A map of tags assigned to the resource.


### PR DESCRIPTION
### Description

This PR add the `tags` attribute to the RDS Cluster datasource documentation, and fix the error described in #27090. The end user was redirected on the RDS Cluster resource, but the attribute for getting resource tags is different on the datasource than the resource. 

### Relations

Closes #27090 
