### PR TITLE
Fix `acctest` provider acceptance test failures

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -110,7 +110,7 @@ func protoV5ProviderFactoriesInit(providerNames ...string) map[string]func() (tf
 
 	for _, name := range providerNames {
 		factories[name] = func() (tfprotov5.ProviderServer, error) {
-			providerServerFactory, err := provider.ProtoV5ProviderServerFactory(context.Background())
+			providerServerFactory, _, err := provider.ProtoV5ProviderServerFactory(context.Background())
 
 			if err != nil {
 				return nil, err

--- a/internal/acctest/provider_test.go
+++ b/internal/acctest/provider_test.go
@@ -527,17 +527,18 @@ func TestAccProvider_AssumeRole_empty(t *testing.T) {
 }
 
 func testAccProtoV5ProviderFactoriesInternal(t *testing.T, v **schema.Provider) map[string]func() (tfprotov5.ProviderServer, error) {
+	providerServerFactory, p, err := provider.ProtoV5ProviderServerFactory(context.Background())
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	providerServer := providerServerFactory()
+	*v = p
+
 	return map[string]func() (tfprotov5.ProviderServer, error){
 		acctest.ProviderName: func() (tfprotov5.ProviderServer, error) {
-			providerServerFactory, p, err := provider.ProtoV5ProviderServerFactory(context.Background())
-
-			if err != nil {
-				return nil, err
-			}
-
-			*v = p
-
-			return providerServerFactory(), nil
+			return providerServer, nil
 		},
 	}
 }

--- a/internal/acctest/provider_test.go
+++ b/internal/acctest/provider_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -80,10 +79,10 @@ func TestAccProvider_DefaultTags_emptyBlock(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_defaultTagsEmptyConfigurationBlock(),
@@ -99,10 +98,10 @@ func TestAccProvider_DefaultTagsTags_none(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{ // nosemgrep:ci.test-config-funcs-correct-form
 				Config: acctest.ConfigDefaultTags_Tags0(),
@@ -118,10 +117,10 @@ func TestAccProvider_DefaultTagsTags_one(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{ // nosemgrep:ci.test-config-funcs-correct-form
 				Config: acctest.ConfigDefaultTags_Tags1("test", "value"),
@@ -137,10 +136,10 @@ func TestAccProvider_DefaultTagsTags_multiple(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{ // nosemgrep:ci.test-config-funcs-correct-form
 				Config: acctest.ConfigDefaultTags_Tags2("test1", "value1", "test2", "value2"),
@@ -159,10 +158,10 @@ func TestAccProvider_DefaultAndIgnoreTags_emptyBlocks(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_defaultAndIgnoreTagsEmptyConfigurationBlock(),
@@ -186,10 +185,10 @@ func TestAccProvider_endpoints(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_endpoints(endpoints.String()),
@@ -229,10 +228,10 @@ func TestAccProvider_unusualEndpoints(t *testing.T) {
 	unusual3 := []string{"lexmodelbuildingservice", "lexmodels", "http://kingofspain"}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_unusualEndpoints(unusual1, unusual2, unusual3),
@@ -248,10 +247,10 @@ func TestAccProvider_IgnoreTags_emptyBlock(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_ignoreTagsEmptyConfigurationBlock(),
@@ -268,10 +267,10 @@ func TestAccProvider_IgnoreTagsKeyPrefixes_none(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_ignoreTagsKeyPrefixes0(),
@@ -287,10 +286,10 @@ func TestAccProvider_IgnoreTagsKeyPrefixes_one(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_ignoreTagsKeyPrefixes3("test"),
@@ -306,10 +305,10 @@ func TestAccProvider_IgnoreTagsKeyPrefixes_multiple(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_ignoreTagsKeyPrefixes2("test1", "test2"),
@@ -325,10 +324,10 @@ func TestAccProvider_IgnoreTagsKeys_none(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_ignoreTagsKeys0(),
@@ -344,10 +343,10 @@ func TestAccProvider_IgnoreTagsKeys_one(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_ignoreTagsKeys1("test"),
@@ -363,10 +362,10 @@ func TestAccProvider_IgnoreTagsKeys_multiple(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_ignoreTagsKeys2("test1", "test2"),
@@ -382,10 +381,10 @@ func TestAccProvider_Region_c2s(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_region(endpoints.UsIsoEast1RegionID),
@@ -404,10 +403,10 @@ func TestAccProvider_Region_china(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_region(endpoints.CnNorthwest1RegionID),
@@ -426,10 +425,10 @@ func TestAccProvider_Region_commercial(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_region(endpoints.UsWest2RegionID),
@@ -448,10 +447,10 @@ func TestAccProvider_Region_govCloud(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_region(endpoints.UsGovWest1RegionID),
@@ -470,10 +469,10 @@ func TestAccProvider_Region_sc2s(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_region(endpoints.UsIsobEast1RegionID),
@@ -492,10 +491,10 @@ func TestAccProvider_Region_stsRegion(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t),
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
-		CheckDestroy:             nil,
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ErrorCheck:        acctest.ErrorCheck(t),
+		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_stsRegion(endpoints.UsEast1RegionID, endpoints.UsWest2RegionID),
@@ -526,7 +525,8 @@ func TestAccProvider_AssumeRole_empty(t *testing.T) {
 	})
 }
 
-func testAccProtoV5ProviderFactoriesInternal(t *testing.T, v **schema.Provider) map[string]func() (tfprotov5.ProviderServer, error) {
+// Replaces FactoriesInternal.
+func testAccProviderFactoriesInternal(t *testing.T, v **schema.Provider) map[string]func() (*schema.Provider, error) {
 	p, err := provider.New(context.Background())
 
 	if err != nil {
@@ -535,7 +535,9 @@ func testAccProtoV5ProviderFactoriesInternal(t *testing.T, v **schema.Provider) 
 
 	*v = p
 
-	return acctest.ProtoV5ProviderFactories
+	return map[string]func() (*schema.Provider, error){
+		acctest.ProviderName: func() (*schema.Provider, error) { return p, nil }, //nolint:unparam
+	}
 }
 
 func testAccCheckPartition(t *testing.T, p **schema.Provider, expectedPartition string) resource.TestCheckFunc { //nolint:unparam

--- a/internal/acctest/provider_test.go
+++ b/internal/acctest/provider_test.go
@@ -527,15 +527,19 @@ func TestAccProvider_AssumeRole_empty(t *testing.T) {
 }
 
 func testAccProtoV5ProviderFactoriesInternal(t *testing.T, v **schema.Provider) map[string]func() (tfprotov5.ProviderServer, error) {
-	p, err := provider.New(context.Background())
+	return map[string]func() (tfprotov5.ProviderServer, error){
+		acctest.ProviderName: func() (tfprotov5.ProviderServer, error) {
+			providerServerFactory, p, err := provider.ProtoV5ProviderServerFactory(context.Background())
 
-	if err != nil {
-		t.Fatal(err)
+			if err != nil {
+				return nil, err
+			}
+
+			*v = p
+
+			return providerServerFactory(), nil
+		},
 	}
-
-	*v = p
-
-	return acctest.ProtoV5ProviderFactories
 }
 
 func testAccCheckPartition(t *testing.T, p **schema.Provider, expectedPartition string) resource.TestCheckFunc { //nolint:unparam

--- a/internal/acctest/provider_test.go
+++ b/internal/acctest/provider_test.go
@@ -537,7 +537,7 @@ func testAccProtoV5ProviderFactoriesInternal(t *testing.T, v **schema.Provider) 
 	*v = p
 
 	return map[string]func() (tfprotov5.ProviderServer, error){
-		acctest.ProviderName: func() (tfprotov5.ProviderServer, error) {
+		acctest.ProviderName: func() (tfprotov5.ProviderServer, error) { //nolint:unparam
 			return providerServer, nil
 		},
 	}

--- a/internal/acctest/provider_test.go
+++ b/internal/acctest/provider_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -79,10 +80,10 @@ func TestAccProvider_DefaultTags_emptyBlock(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_defaultTagsEmptyConfigurationBlock(),
@@ -98,10 +99,10 @@ func TestAccProvider_DefaultTagsTags_none(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{ // nosemgrep:ci.test-config-funcs-correct-form
 				Config: acctest.ConfigDefaultTags_Tags0(),
@@ -117,10 +118,10 @@ func TestAccProvider_DefaultTagsTags_one(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{ // nosemgrep:ci.test-config-funcs-correct-form
 				Config: acctest.ConfigDefaultTags_Tags1("test", "value"),
@@ -136,10 +137,10 @@ func TestAccProvider_DefaultTagsTags_multiple(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{ // nosemgrep:ci.test-config-funcs-correct-form
 				Config: acctest.ConfigDefaultTags_Tags2("test1", "value1", "test2", "value2"),
@@ -158,10 +159,10 @@ func TestAccProvider_DefaultAndIgnoreTags_emptyBlocks(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_defaultAndIgnoreTagsEmptyConfigurationBlock(),
@@ -185,10 +186,10 @@ func TestAccProvider_endpoints(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_endpoints(endpoints.String()),
@@ -228,10 +229,10 @@ func TestAccProvider_unusualEndpoints(t *testing.T) {
 	unusual3 := []string{"lexmodelbuildingservice", "lexmodels", "http://kingofspain"}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_unusualEndpoints(unusual1, unusual2, unusual3),
@@ -247,10 +248,10 @@ func TestAccProvider_IgnoreTags_emptyBlock(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_ignoreTagsEmptyConfigurationBlock(),
@@ -267,10 +268,10 @@ func TestAccProvider_IgnoreTagsKeyPrefixes_none(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_ignoreTagsKeyPrefixes0(),
@@ -286,10 +287,10 @@ func TestAccProvider_IgnoreTagsKeyPrefixes_one(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_ignoreTagsKeyPrefixes3("test"),
@@ -305,10 +306,10 @@ func TestAccProvider_IgnoreTagsKeyPrefixes_multiple(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_ignoreTagsKeyPrefixes2("test1", "test2"),
@@ -324,10 +325,10 @@ func TestAccProvider_IgnoreTagsKeys_none(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_ignoreTagsKeys0(),
@@ -343,10 +344,10 @@ func TestAccProvider_IgnoreTagsKeys_one(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_ignoreTagsKeys1("test"),
@@ -362,10 +363,10 @@ func TestAccProvider_IgnoreTagsKeys_multiple(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_ignoreTagsKeys2("test1", "test2"),
@@ -381,10 +382,10 @@ func TestAccProvider_Region_c2s(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_region(endpoints.UsIsoEast1RegionID),
@@ -403,10 +404,10 @@ func TestAccProvider_Region_china(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_region(endpoints.CnNorthwest1RegionID),
@@ -425,10 +426,10 @@ func TestAccProvider_Region_commercial(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_region(endpoints.UsWest2RegionID),
@@ -447,10 +448,10 @@ func TestAccProvider_Region_govCloud(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_region(endpoints.UsGovWest1RegionID),
@@ -469,10 +470,10 @@ func TestAccProvider_Region_sc2s(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_region(endpoints.UsIsobEast1RegionID),
@@ -491,10 +492,10 @@ func TestAccProvider_Region_stsRegion(t *testing.T) {
 	var provider *schema.Provider
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ErrorCheck:        acctest.ErrorCheck(t),
-		ProviderFactories: testAccProviderFactoriesInternal(t, &provider),
-		CheckDestroy:      nil,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactoriesInternal(t, &provider),
+		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig_stsRegion(endpoints.UsEast1RegionID, endpoints.UsWest2RegionID),
@@ -525,8 +526,7 @@ func TestAccProvider_AssumeRole_empty(t *testing.T) {
 	})
 }
 
-// Replaces FactoriesInternal.
-func testAccProviderFactoriesInternal(t *testing.T, v **schema.Provider) map[string]func() (*schema.Provider, error) {
+func testAccProtoV5ProviderFactoriesInternal(t *testing.T, v **schema.Provider) map[string]func() (tfprotov5.ProviderServer, error) {
 	p, err := provider.New(context.Background())
 
 	if err != nil {
@@ -535,9 +535,7 @@ func testAccProviderFactoriesInternal(t *testing.T, v **schema.Provider) map[str
 
 	*v = p
 
-	return map[string]func() (*schema.Provider, error){
-		acctest.ProviderName: func() (*schema.Provider, error) { return p, nil }, //nolint:unparam
-	}
+	return acctest.ProtoV5ProviderFactories
 }
 
 func testAccCheckPartition(t *testing.T, p **schema.Provider, expectedPartition string) resource.TestCheckFunc { //nolint:unparam

--- a/internal/acctest/provider_test.go
+++ b/internal/acctest/provider_test.go
@@ -910,7 +910,7 @@ provider "aws" {
 data "aws_caller_identity" "current" {}
 ` //lintignore:AT004
 
-const testAccProviderConfigBase = `
+const testAccProviderConfig_base = `
 data "aws_region" "provider_test" {}
 
 # Required to initialize the provider.
@@ -922,9 +922,7 @@ data "aws_service" "provider_test" {
 
 func testAccProviderConfig_endpoints(endpoints string) string {
 	//lintignore:AT004
-	return acctest.ConfigCompose(
-		testAccProviderConfigBase,
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccProviderConfig_base, fmt.Sprintf(`
 provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
@@ -940,9 +938,7 @@ provider "aws" {
 
 func testAccProviderConfig_fipsEndpoint(endpoint, rName string) string {
 	//lintignore:AT004
-	return acctest.ConfigCompose(
-		testAccProviderConfigBase,
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccProviderConfig_base, fmt.Sprintf(`
 provider "aws" {
   endpoints {
     s3 = %[1]q
@@ -963,9 +959,7 @@ resource "aws_s3_bucket_acl" "test" {
 
 func testAccProviderConfig_unusualEndpoints(unusual1, unusual2, unusual3 []string) string {
 	//lintignore:AT004
-	return acctest.ConfigCompose(
-		testAccProviderConfigBase,
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccProviderConfig_base, fmt.Sprintf(`
 provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
@@ -983,9 +977,7 @@ provider "aws" {
 
 func testAccProviderConfig_ignoreTagsKeys0() string {
 	//lintignore:AT004
-	return acctest.ConfigCompose(
-		testAccProviderConfigBase,
-		`
+	return acctest.ConfigCompose(testAccProviderConfig_base, `
 provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
@@ -997,9 +989,7 @@ provider "aws" {
 
 func testAccProviderConfig_ignoreTagsKeys1(tag1 string) string {
 	//lintignore:AT004
-	return acctest.ConfigCompose(
-		testAccProviderConfigBase,
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccProviderConfig_base, fmt.Sprintf(`
 provider "aws" {
   ignore_tags {
     keys = [%[1]q]
@@ -1015,9 +1005,7 @@ provider "aws" {
 
 func testAccProviderConfig_ignoreTagsKeys2(tag1, tag2 string) string {
 	//lintignore:AT004
-	return acctest.ConfigCompose(
-		testAccProviderConfigBase,
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccProviderConfig_base, fmt.Sprintf(`
 provider "aws" {
   ignore_tags {
     keys = [%[1]q, %[2]q]
@@ -1033,9 +1021,7 @@ provider "aws" {
 
 func testAccProviderConfig_ignoreTagsKeyPrefixes0() string {
 	//lintignore:AT004
-	return acctest.ConfigCompose(
-		testAccProviderConfigBase,
-		`
+	return acctest.ConfigCompose(testAccProviderConfig_base, `
 provider "aws" {
   skip_credentials_validation = true
   skip_get_ec2_platforms      = true
@@ -1047,9 +1033,7 @@ provider "aws" {
 
 func testAccProviderConfig_ignoreTagsKeyPrefixes3(tagPrefix1 string) string {
 	//lintignore:AT004
-	return acctest.ConfigCompose(
-		testAccProviderConfigBase,
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccProviderConfig_base, fmt.Sprintf(`
 provider "aws" {
   ignore_tags {
     key_prefixes = [%[1]q]
@@ -1065,9 +1049,7 @@ provider "aws" {
 
 func testAccProviderConfig_ignoreTagsKeyPrefixes2(tagPrefix1, tagPrefix2 string) string {
 	//lintignore:AT004
-	return acctest.ConfigCompose(
-		testAccProviderConfigBase,
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccProviderConfig_base, fmt.Sprintf(`
 provider "aws" {
   ignore_tags {
     key_prefixes = [%[1]q, %[2]q]
@@ -1083,9 +1065,7 @@ provider "aws" {
 
 func testAccProviderConfig_defaultTagsEmptyConfigurationBlock() string {
 	//lintignore:AT004
-	return acctest.ConfigCompose(
-		testAccProviderConfigBase,
-		`
+	return acctest.ConfigCompose(testAccProviderConfig_base, `
 provider "aws" {
   default_tags {}
 
@@ -1099,9 +1079,7 @@ provider "aws" {
 
 func testAccProviderConfig_defaultAndIgnoreTagsEmptyConfigurationBlock() string {
 	//lintignore:AT004
-	return acctest.ConfigCompose(
-		testAccProviderConfigBase,
-		`
+	return acctest.ConfigCompose(testAccProviderConfig_base, `
 provider "aws" {
   default_tags {}
   ignore_tags {}
@@ -1116,9 +1094,7 @@ provider "aws" {
 
 func testAccProviderConfig_ignoreTagsEmptyConfigurationBlock() string {
 	//lintignore:AT004
-	return acctest.ConfigCompose(
-		testAccProviderConfigBase,
-		`
+	return acctest.ConfigCompose(testAccProviderConfig_base, `
 provider "aws" {
   ignore_tags {}
 
@@ -1132,9 +1108,7 @@ provider "aws" {
 
 func testAccProviderConfig_region(region string) string {
 	//lintignore:AT004
-	return acctest.ConfigCompose(
-		testAccProviderConfigBase,
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccProviderConfig_base, fmt.Sprintf(`
 provider "aws" {
   region                      = %[1]q
   skip_credentials_validation = true
@@ -1147,9 +1121,7 @@ provider "aws" {
 
 func testAccProviderConfig_stsRegion(region, stsRegion string) string {
 	//lintignore:AT004
-	return acctest.ConfigCompose(
-		testAccProviderConfigBase,
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccProviderConfig_base, fmt.Sprintf(`
 provider "aws" {
   region                      = %[1]q
   sts_region                  = %[2]q

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -6,16 +6,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/provider/fwprovider"
 )
 
 // ProtoV5ProviderServerFactory returns a muxed terraform-plugin-go protocol v5 provider factory function.
 // This factory function is suitable for use with the terraform-plugin-go Serve function.
-func ProtoV5ProviderServerFactory(ctx context.Context) (func() tfprotov5.ProviderServer, error) {
+// The primary (Plugin SDK) provider server is also returned (useful for testing).
+func ProtoV5ProviderServerFactory(ctx context.Context) (func() tfprotov5.ProviderServer, *schema.Provider, error) {
 	primary, err := New(ctx)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	servers := []func() tfprotov5.ProviderServer{
@@ -26,8 +28,8 @@ func ProtoV5ProviderServerFactory(ctx context.Context) (func() tfprotov5.Provide
 	muxServer, err := tf5muxserver.NewMuxServer(ctx, servers...)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return muxServer.ProviderServer, nil
+	return muxServer.ProviderServer, primary, nil
 }

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ func main() {
 	debugFlag := flag.Bool("debug", false, "Start provider in debug mode.")
 	flag.Parse()
 
-	serverFactory, err := provider.ProtoV5ProviderServerFactory(context.Background())
+	serverFactory, _, err := provider.ProtoV5ProviderServerFactory(context.Background())
 
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes failing `acctest` provider acceptance tests by using _ProtoV5ProviderFactories_.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/27592.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccProvider_' PKG_NAME=internal/acctest ACCTEST_PARALLELISM=2 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/acctest/... -v -count 1 -parallel 2  -run=TestAccProvider_ -timeout 180m
=== RUN   TestAccProvider_DefaultTags_emptyBlock
=== PAUSE TestAccProvider_DefaultTags_emptyBlock
=== RUN   TestAccProvider_DefaultTagsTags_none
=== PAUSE TestAccProvider_DefaultTagsTags_none
=== RUN   TestAccProvider_DefaultTagsTags_one
=== PAUSE TestAccProvider_DefaultTagsTags_one
=== RUN   TestAccProvider_DefaultTagsTags_multiple
=== PAUSE TestAccProvider_DefaultTagsTags_multiple
=== RUN   TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
=== PAUSE TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
=== RUN   TestAccProvider_endpoints
=== PAUSE TestAccProvider_endpoints
=== RUN   TestAccProvider_fipsEndpoint
=== PAUSE TestAccProvider_fipsEndpoint
=== RUN   TestAccProvider_unusualEndpoints
=== PAUSE TestAccProvider_unusualEndpoints
=== RUN   TestAccProvider_IgnoreTags_emptyBlock
=== PAUSE TestAccProvider_IgnoreTags_emptyBlock
=== RUN   TestAccProvider_IgnoreTagsKeyPrefixes_none
=== PAUSE TestAccProvider_IgnoreTagsKeyPrefixes_none
=== RUN   TestAccProvider_IgnoreTagsKeyPrefixes_one
=== PAUSE TestAccProvider_IgnoreTagsKeyPrefixes_one
=== RUN   TestAccProvider_IgnoreTagsKeyPrefixes_multiple
=== PAUSE TestAccProvider_IgnoreTagsKeyPrefixes_multiple
=== RUN   TestAccProvider_IgnoreTagsKeys_none
=== PAUSE TestAccProvider_IgnoreTagsKeys_none
=== RUN   TestAccProvider_IgnoreTagsKeys_one
=== PAUSE TestAccProvider_IgnoreTagsKeys_one
=== RUN   TestAccProvider_IgnoreTagsKeys_multiple
=== PAUSE TestAccProvider_IgnoreTagsKeys_multiple
=== RUN   TestAccProvider_Region_c2s
=== PAUSE TestAccProvider_Region_c2s
=== RUN   TestAccProvider_Region_china
=== PAUSE TestAccProvider_Region_china
=== RUN   TestAccProvider_Region_commercial
=== PAUSE TestAccProvider_Region_commercial
=== RUN   TestAccProvider_Region_govCloud
=== PAUSE TestAccProvider_Region_govCloud
=== RUN   TestAccProvider_Region_sc2s
=== PAUSE TestAccProvider_Region_sc2s
=== RUN   TestAccProvider_Region_stsRegion
=== PAUSE TestAccProvider_Region_stsRegion
=== RUN   TestAccProvider_AssumeRole_empty
=== PAUSE TestAccProvider_AssumeRole_empty
=== CONT  TestAccProvider_DefaultTags_emptyBlock
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_multiple
--- PASS: TestAccProvider_IgnoreTagsKeyPrefixes_multiple (6.31s)
=== CONT  TestAccProvider_Region_commercial
--- PASS: TestAccProvider_DefaultTags_emptyBlock (6.37s)
=== CONT  TestAccProvider_AssumeRole_empty
--- PASS: TestAccProvider_Region_commercial (3.60s)
=== CONT  TestAccProvider_Region_stsRegion
--- PASS: TestAccProvider_Region_stsRegion (3.73s)
=== CONT  TestAccProvider_Region_sc2s
--- PASS: TestAccProvider_Region_sc2s (4.33s)
=== CONT  TestAccProvider_Region_govCloud
--- PASS: TestAccProvider_AssumeRole_empty (12.74s)
=== CONT  TestAccProvider_IgnoreTagsKeys_multiple
--- PASS: TestAccProvider_Region_govCloud (4.55s)
=== CONT  TestAccProvider_Region_china
--- PASS: TestAccProvider_IgnoreTagsKeys_multiple (5.81s)
=== CONT  TestAccProvider_Region_c2s
--- PASS: TestAccProvider_Region_china (4.30s)
=== CONT  TestAccProvider_IgnoreTagsKeys_one
--- PASS: TestAccProvider_Region_c2s (4.51s)
=== CONT  TestAccProvider_DefaultTagsTags_multiple
--- PASS: TestAccProvider_IgnoreTagsKeys_one (6.49s)
=== CONT  TestAccProvider_fipsEndpoint
--- PASS: TestAccProvider_DefaultTagsTags_multiple (6.31s)
=== CONT  TestAccProvider_endpoints
--- PASS: TestAccProvider_endpoints (19.36s)
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_one
--- PASS: TestAccProvider_IgnoreTagsKeyPrefixes_one (5.17s)
=== CONT  TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
--- PASS: TestAccProvider_DefaultAndIgnoreTags_emptyBlocks (5.20s)
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_none
--- PASS: TestAccProvider_fipsEndpoint (36.60s)
=== CONT  TestAccProvider_DefaultTagsTags_one
--- PASS: TestAccProvider_IgnoreTagsKeyPrefixes_none (5.40s)
=== CONT  TestAccProvider_IgnoreTags_emptyBlock
--- PASS: TestAccProvider_DefaultTagsTags_one (5.74s)
=== CONT  TestAccProvider_unusualEndpoints
--- PASS: TestAccProvider_IgnoreTags_emptyBlock (5.79s)
=== CONT  TestAccProvider_DefaultTagsTags_none
--- PASS: TestAccProvider_DefaultTagsTags_none (5.18s)
=== CONT  TestAccProvider_IgnoreTagsKeys_none
--- PASS: TestAccProvider_IgnoreTagsKeys_none (5.64s)
--- PASS: TestAccProvider_unusualEndpoints (17.32s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/acctest	98.769s
```
