### PR TITLE
aws_s3_bucket: Remove optional from arn and hosted_zone_id

### DIFF
--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -84,7 +84,6 @@ func ResourceBucket() *schema.Resource {
 
 			"arn": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
@@ -230,7 +229,6 @@ func ResourceBucket() *schema.Resource {
 
 			"hosted_zone_id": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Currently, the `arn` and `hosted_zone_id` attributes are marked as optional, hinting that they can be set within a resource block (as opposed to being solely `computed` attributes).

However, `arn` and `hosted_zone_id` should never be set with user-generated values. `arn` is derived from other attributes, and `hosted_zone_id` is looked up [here](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/s3/hosted_zones.go#L10).

### Relations
n/a

### References
https://discuss.hashicorp.com/t/providers-schema-how-to-distinguish-attributes-from-arguments/5029/3

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
