### PR TITLE
AWS supports higher throughput ranges for select customers

### DIFF
--- a/.changelog/27598.txt
+++ b/.changelog/27598.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+resource/aws_elasticsearch: Remove validation for EBS storage throughput as AWS has backend limits they can raise for select customers
+```
+

--- a/.changelog/27598.txt
+++ b/.changelog/27598.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_elasticsearch_domain: Remove validation for `ebs_options.throughput` as the 1,000 MB/s limit can be raised
+resource/aws_elasticsearch_domain: Remove upper bound validation for `ebs_options.throughput` as the 1,000 MB/s limit can be raised
 ```

--- a/.changelog/27598.txt
+++ b/.changelog/27598.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_elasticsearch_domain: Remove upper bound validation for `ebs_options.throughput` as the 1,000 MB/s limit can be raised
 ```
+
+```release-note:bug
+resource/aws_opensearch_domain: Remove upper bound validation for `ebs_options.throughput` as the 1,000 MB/s limit can be raised
+```

--- a/.changelog/27598.txt
+++ b/.changelog/27598.txt
@@ -1,4 +1,3 @@
 ```release-note:bug
-resource/aws_elasticsearch: Remove validation for EBS storage throughput as AWS has backend limits they can raise for select customers
+resource/aws_elasticsearch_domain: Remove validation for `ebs_options.throughput` as the 1,000 MB/s limit can be raised
 ```
-

--- a/internal/service/elasticsearch/domain.go
+++ b/internal/service/elasticsearch/domain.go
@@ -386,10 +386,9 @@ func ResourceDomain() *schema.Resource {
 							Optional: true,
 						},
 						"throughput": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validation.IntBetween(125, 1000),
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
 						},
 						"volume_size": {
 							Type:     schema.TypeInt,

--- a/internal/service/elasticsearch/domain.go
+++ b/internal/service/elasticsearch/domain.go
@@ -386,9 +386,10 @@ func ResourceDomain() *schema.Resource {
 							Optional: true,
 						},
 						"throughput": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.IntAtLeast(125),
 						},
 						"volume_size": {
 							Type:     schema.TypeInt,

--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -401,7 +401,7 @@ func ResourceDomain() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							Computed:     true,
-							ValidateFunc: validation.IntBetween(125, 1000),
+							ValidateFunc: validation.IntAtLeast(125),
 						},
 						"volume_size": {
 							Type:     schema.TypeInt,

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -294,7 +294,7 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 
 * `ebs_enabled` - (Required) Whether EBS volumes are attached to data nodes in the domain.
 * `iops` - (Optional) Baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the GP3 and Provisioned IOPS EBS volume types.
-* `throughput` - (Required if `volume_type` is set to `gp3`) Specifies the throughput (in MiB/s) of the EBS volumes attached to data nodes. Applicable only for the gp3 volume type. Valid values are between `125` and `1000`.
+* `throughput` - (Required if `volume_type` is set to `gp3`) Specifies the throughput (in MiB/s) of the EBS volumes attached to data nodes. Applicable only for the gp3 volume type.
 * `volume_size` - (Required if `ebs_enabled` is set to `true`.) Size of EBS volumes attached to data nodes (in GiB).
 * `volume_type` - (Optional) Type of EBS volumes attached to data nodes.
 

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -400,7 +400,7 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 
 * `ebs_enabled` - (Required) Whether EBS volumes are attached to data nodes in the domain.
 * `iops` - (Optional) Baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the GP3 and Provisioned IOPS EBS volume types.
-* `throughput` - (Required if `volume_type` is set to `gp3`) Specifies the throughput (in MiB/s) of the EBS volumes attached to data nodes. Applicable only for the gp3 volume type. Valid values are between `125` and `1000`.
+* `throughput` - (Required if `volume_type` is set to `gp3`) Specifies the throughput (in MiB/s) of the EBS volumes attached to data nodes. Applicable only for the gp3 volume type.
 * `volume_size` - (Required if `ebs_enabled` is set to `true`.) Size of EBS volumes attached to data nodes (in GiB).
 * `volume_type` - (Optional) Type of EBS volumes attached to data nodes.
 


### PR DESCRIPTION
### Description
Removes the validation on the elasticsearch EBS throughput.  The existing values are correct based on limits documentation, however, its not entirely accurate.  AWS can increase these values for select customers (we're one) to be > 1000.

### Relations

### References
Am working with AWS to see if there is any documentation that can be provided here or someone from AWS that can vouch for this.

### Output from Acceptance Testing
All failures appear to have been pre-existing as we see these same issues with current TF code.
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticsearch/... -v -count 1 -parallel 20   -timeout 180m
=== RUN   TestAccElasticsearchDomainDataSource_basic
=== PAUSE TestAccElasticsearchDomainDataSource_basic
=== RUN   TestAccElasticsearchDomainDataSource_advanced
=== PAUSE TestAccElasticsearchDomainDataSource_advanced
=== RUN   TestAccElasticsearchDomainPolicy_basic
=== PAUSE TestAccElasticsearchDomainPolicy_basic
=== RUN   TestAccElasticsearchDomainSAMLOptions_basic
=== PAUSE TestAccElasticsearchDomainSAMLOptions_basic
=== RUN   TestAccElasticsearchDomainSAMLOptions_disappears
=== PAUSE TestAccElasticsearchDomainSAMLOptions_disappears
=== RUN   TestAccElasticsearchDomainSAMLOptions_disappears_Domain
=== PAUSE TestAccElasticsearchDomainSAMLOptions_disappears_Domain
=== RUN   TestAccElasticsearchDomainSAMLOptions_Update
=== PAUSE TestAccElasticsearchDomainSAMLOptions_Update
=== RUN   TestAccElasticsearchDomainSAMLOptions_Disabled
=== PAUSE TestAccElasticsearchDomainSAMLOptions_Disabled
=== RUN   TestAccElasticsearchDomain_basic
=== PAUSE TestAccElasticsearchDomain_basic
=== RUN   TestAccElasticsearchDomain_requireHTTPS
=== PAUSE TestAccElasticsearchDomain_requireHTTPS
=== RUN   TestAccElasticsearchDomain_customEndpoint
=== PAUSE TestAccElasticsearchDomain_customEndpoint
=== RUN   TestAccElasticsearchDomain_Cluster_zoneAwareness
=== PAUSE TestAccElasticsearchDomain_Cluster_zoneAwareness
=== RUN   TestAccElasticsearchDomain_warm
=== PAUSE TestAccElasticsearchDomain_warm
=== RUN   TestAccElasticsearchDomain_withColdStorageOptions
=== PAUSE TestAccElasticsearchDomain_withColdStorageOptions
=== RUN   TestAccElasticsearchDomain_withDedicatedMaster
=== PAUSE TestAccElasticsearchDomain_withDedicatedMaster
=== RUN   TestAccElasticsearchDomain_duplicate
=== PAUSE TestAccElasticsearchDomain_duplicate
=== RUN   TestAccElasticsearchDomain_v23
=== PAUSE TestAccElasticsearchDomain_v23
=== RUN   TestAccElasticsearchDomain_complex
=== PAUSE TestAccElasticsearchDomain_complex
=== RUN   TestAccElasticsearchDomain_vpc
=== PAUSE TestAccElasticsearchDomain_vpc
=== RUN   TestAccElasticsearchDomain_VPC_update
=== PAUSE TestAccElasticsearchDomain_VPC_update
=== RUN   TestAccElasticsearchDomain_internetToVPCEndpoint
=== PAUSE TestAccElasticsearchDomain_internetToVPCEndpoint
=== RUN   TestAccElasticsearchDomain_AutoTuneOptions
=== PAUSE TestAccElasticsearchDomain_AutoTuneOptions
=== RUN   TestAccElasticsearchDomain_AdvancedSecurityOptions_userDB
=== PAUSE TestAccElasticsearchDomain_AdvancedSecurityOptions_userDB
=== RUN   TestAccElasticsearchDomain_AdvancedSecurityOptions_iam
=== PAUSE TestAccElasticsearchDomain_AdvancedSecurityOptions_iam
=== RUN   TestAccElasticsearchDomain_AdvancedSecurityOptions_disabled
=== PAUSE TestAccElasticsearchDomain_AdvancedSecurityOptions_disabled
=== RUN   TestAccElasticsearchDomain_LogPublishingOptions_indexSlowLogs
=== PAUSE TestAccElasticsearchDomain_LogPublishingOptions_indexSlowLogs
=== RUN   TestAccElasticsearchDomain_LogPublishingOptions_searchSlowLogs
=== PAUSE TestAccElasticsearchDomain_LogPublishingOptions_searchSlowLogs
=== RUN   TestAccElasticsearchDomain_LogPublishingOptions_esApplicationLogs
=== PAUSE TestAccElasticsearchDomain_LogPublishingOptions_esApplicationLogs
=== RUN   TestAccElasticsearchDomain_LogPublishingOptions_auditLogs
=== PAUSE TestAccElasticsearchDomain_LogPublishingOptions_auditLogs
=== RUN   TestAccElasticsearchDomain_cognitoOptionsCreateAndRemove
=== PAUSE TestAccElasticsearchDomain_cognitoOptionsCreateAndRemove
=== RUN   TestAccElasticsearchDomain_cognitoOptionsUpdate
=== PAUSE TestAccElasticsearchDomain_cognitoOptionsUpdate
=== RUN   TestAccElasticsearchDomain_policy
=== PAUSE TestAccElasticsearchDomain_policy
=== RUN   TestAccElasticsearchDomain_policyIgnoreEquivalent
=== PAUSE TestAccElasticsearchDomain_policyIgnoreEquivalent
=== RUN   TestAccElasticsearchDomain_Encryption_atRestDefaultKey
=== PAUSE TestAccElasticsearchDomain_Encryption_atRestDefaultKey
=== RUN   TestAccElasticsearchDomain_Encryption_atRestSpecifyKey
=== PAUSE TestAccElasticsearchDomain_Encryption_atRestSpecifyKey
=== RUN   TestAccElasticsearchDomain_Encryption_atRestEnable
=== PAUSE TestAccElasticsearchDomain_Encryption_atRestEnable
=== RUN   TestAccElasticsearchDomain_Encryption_atRestEnableLegacy
=== PAUSE TestAccElasticsearchDomain_Encryption_atRestEnableLegacy
=== RUN   TestAccElasticsearchDomain_Encryption_nodeToNode
=== PAUSE TestAccElasticsearchDomain_Encryption_nodeToNode
=== RUN   TestAccElasticsearchDomain_Encryption_nodeToNodeEnable
=== PAUSE TestAccElasticsearchDomain_Encryption_nodeToNodeEnable
=== RUN   TestAccElasticsearchDomain_Encryption_nodeToNodeEnableLegacy
=== PAUSE TestAccElasticsearchDomain_Encryption_nodeToNodeEnableLegacy
=== RUN   TestAccElasticsearchDomain_tags
=== PAUSE TestAccElasticsearchDomain_tags
=== RUN   TestAccElasticsearchDomain_update
=== PAUSE TestAccElasticsearchDomain_update
=== RUN   TestAccElasticsearchDomain_UpdateVolume_type
=== PAUSE TestAccElasticsearchDomain_UpdateVolume_type
=== RUN   TestAccElasticsearchDomain_WithVolumeType_missing
=== PAUSE TestAccElasticsearchDomain_WithVolumeType_missing
=== RUN   TestAccElasticsearchDomain_Update_version
=== PAUSE TestAccElasticsearchDomain_Update_version
=== RUN   TestAccElasticsearchDomain_disappears
=== PAUSE TestAccElasticsearchDomain_disappears
=== CONT  TestAccElasticsearchDomainDataSource_basic
=== CONT  TestAccElasticsearchDomain_AdvancedSecurityOptions_iam
=== CONT  TestAccElasticsearchDomain_warm
=== CONT  TestAccElasticsearchDomain_vpc
=== CONT  TestAccElasticsearchDomain_AdvancedSecurityOptions_userDB
=== CONT  TestAccElasticsearchDomain_AutoTuneOptions
=== CONT  TestAccElasticsearchDomain_internetToVPCEndpoint
=== CONT  TestAccElasticsearchDomain_VPC_update
=== CONT  TestAccElasticsearchDomain_Encryption_atRestEnable
=== CONT  TestAccElasticsearchDomain_disappears
=== CONT  TestAccElasticsearchDomain_Update_version
=== CONT  TestAccElasticsearchDomain_WithVolumeType_missing
=== CONT  TestAccElasticsearchDomain_UpdateVolume_type
=== CONT  TestAccElasticsearchDomain_update
=== CONT  TestAccElasticsearchDomain_tags
=== CONT  TestAccElasticsearchDomain_Encryption_nodeToNodeEnableLegacy
=== CONT  TestAccElasticsearchDomain_Encryption_nodeToNodeEnable
=== CONT  TestAccElasticsearchDomain_Encryption_nodeToNode
=== CONT  TestAccElasticsearchDomain_Encryption_atRestEnableLegacy
=== CONT  TestAccElasticsearchDomainSAMLOptions_Update
    domain_saml_options_test.go:112: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # aws_elasticsearch_domain.example will be updated in-place
          ~ resource "aws_elasticsearch_domain" "example" {
                id                    = "arn:aws:es:us-east-2:641575277437:domain/acc-test-7718934225753788984"
                # (8 unchanged attributes hidden)






              ~ ebs_options {
                  - iops        = 3000 -> null
                    # (4 unchanged attributes hidden)
                }



                # (8 unchanged blocks hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
=== CONT  TestAccElasticsearchDomain_AdvancedSecurityOptions_userDB
    domain_test.go:612: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # aws_elasticsearch_domain.test will be updated in-place
          ~ resource "aws_elasticsearch_domain" "test" {
                id                    = "arn:aws:es:us-east-2:641575277437:domain/tf-acc-test-36cktywist9ir7ul"
                # (8 unchanged attributes hidden)






              ~ ebs_options {
                  - iops        = 3000 -> null
                    # (4 unchanged attributes hidden)
                }



                # (8 unchanged blocks hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
=== CONT  TestAccElasticsearchDomain_warm
    domain_test.go:211: Step 1/5 error: After applying this test step, the plan was not empty.
        stdout:


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # aws_elasticsearch_domain.test will be updated in-place
          ~ resource "aws_elasticsearch_domain" "test" {
                id                    = "arn:aws:es:us-east-2:641575277437:domain/tf-acc-test-9ymd2s1j8xbflnjc"
                # (8 unchanged attributes hidden)






              ~ ebs_options {
                  - iops        = 3000 -> null
                    # (4 unchanged attributes hidden)
                }



                # (8 unchanged blocks hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
--- PASS: TestAccElasticsearchDomain_AutoTuneOptions (1445.27s)
=== CONT  TestAccElasticsearchDomain_Cluster_zoneAwareness
--- PASS: TestAccElasticsearchDomain_Encryption_nodeToNode (1460.32s)
=== CONT  TestAccElasticsearchDomain_customEndpoint
--- PASS: TestAccElasticsearchDomain_tags (1474.25s)
=== CONT  TestAccElasticsearchDomain_requireHTTPS
--- PASS: TestAccElasticsearchDomainDataSource_basic (1640.18s)
=== CONT  TestAccElasticsearchDomain_basic
--- FAIL: TestAccElasticsearchDomainSAMLOptions_Update (1746.85s)
=== CONT  TestAccElasticsearchDomainSAMLOptions_Disabled
--- FAIL: TestAccElasticsearchDomain_AdvancedSecurityOptions_userDB (1783.25s)
=== CONT  TestAccElasticsearchDomain_cognitoOptionsCreateAndRemove
--- PASS: TestAccElasticsearchDomain_vpc (1839.57s)
=== CONT  TestAccElasticsearchDomain_Encryption_atRestSpecifyKey
=== CONT  TestAccElasticsearchDomain_AdvancedSecurityOptions_iam
    domain_test.go:649: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # aws_elasticsearch_domain.test will be updated in-place
          ~ resource "aws_elasticsearch_domain" "test" {
                id                    = "arn:aws:es:us-east-2:641575277437:domain/tf-acc-test-yperjl8n1vsvatwa"
                # (8 unchanged attributes hidden)






              ~ ebs_options {
                  - iops        = 3000 -> null
                    # (4 unchanged attributes hidden)
                }



                # (8 unchanged blocks hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccElasticsearchDomain_warm (2011.11s)
=== CONT  TestAccElasticsearchDomain_Encryption_atRestDefaultKey
--- PASS: TestAccElasticsearchDomain_WithVolumeType_missing (2459.03s)
=== CONT  TestAccElasticsearchDomain_policyIgnoreEquivalent
--- FAIL: TestAccElasticsearchDomain_AdvancedSecurityOptions_iam (2542.55s)
=== CONT  TestAccElasticsearchDomain_policy
--- PASS: TestAccElasticsearchDomain_disappears (2554.81s)
=== CONT  TestAccElasticsearchDomain_cognitoOptionsUpdate
--- PASS: TestAccElasticsearchDomain_basic (1263.19s)
=== CONT  TestAccElasticsearchDomain_LogPublishingOptions_searchSlowLogs
--- PASS: TestAccElasticsearchDomain_VPC_update (3147.14s)
=== CONT  TestAccElasticsearchDomain_LogPublishingOptions_auditLogs
--- PASS: TestAccElasticsearchDomain_customEndpoint (1979.69s)
=== CONT  TestAccElasticsearchDomain_LogPublishingOptions_esApplicationLogs
=== CONT  TestAccElasticsearchDomainSAMLOptions_Disabled
    domain_saml_options_test.go:146: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # aws_elasticsearch_domain.example will be updated in-place
          ~ resource "aws_elasticsearch_domain" "example" {
                id                    = "arn:aws:es:us-east-2:641575277437:domain/acc-test-8777877970934880381"
                # (8 unchanged attributes hidden)






              ~ ebs_options {
                  - iops        = 3000 -> null
                    # (4 unchanged attributes hidden)
                }



                # (8 unchanged blocks hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
--- PASS: TestAccElasticsearchDomain_internetToVPCEndpoint (3824.99s)
=== CONT  TestAccElasticsearchDomain_LogPublishingOptions_indexSlowLogs
--- PASS: TestAccElasticsearchDomain_policy (1529.30s)
=== CONT  TestAccElasticsearchDomain_AdvancedSecurityOptions_disabled
--- FAIL: TestAccElasticsearchDomainSAMLOptions_Disabled (2444.88s)
=== CONT  TestAccElasticsearchDomainSAMLOptions_basic
--- PASS: TestAccElasticsearchDomain_requireHTTPS (2756.71s)
=== CONT  TestAccElasticsearchDomainSAMLOptions_disappears_Domain
--- PASS: TestAccElasticsearchDomain_Encryption_nodeToNodeEnableLegacy (4284.28s)
=== CONT  TestAccElasticsearchDomainSAMLOptions_disappears
--- PASS: TestAccElasticsearchDomain_Encryption_atRestDefaultKey (2296.52s)
=== CONT  TestAccElasticsearchDomain_duplicate
--- PASS: TestAccElasticsearchDomain_policyIgnoreEquivalent (1853.00s)
=== CONT  TestAccElasticsearchDomain_complex
--- PASS: TestAccElasticsearchDomain_cognitoOptionsCreateAndRemove (2579.51s)
=== CONT  TestAccElasticsearchDomain_v23
--- PASS: TestAccElasticsearchDomain_Encryption_atRestSpecifyKey (2559.72s)
=== CONT  TestAccElasticsearchDomainPolicy_basic
--- PASS: TestAccElasticsearchDomain_UpdateVolume_type (4539.18s)
=== CONT  TestAccElasticsearchDomain_withDedicatedMaster
--- PASS: TestAccElasticsearchDomain_update (4708.12s)
=== CONT  TestAccElasticsearchDomain_withColdStorageOptions
    domain_test.go:268: Step 1/3 error: Error running apply: exit status 1

        Error: error creating Elasticsearch Domain (tf-acc-test-97mxqwccuw8cxk37): InvalidTypeException: Invalid instance type: m3.medium.elasticsearch

          with aws_elasticsearch_domain.test,
          on terraform_plugin_test.tf line 2, in resource "aws_elasticsearch_domain" "test":
           2: resource "aws_elasticsearch_domain" "test" {

--- FAIL: TestAccElasticsearchDomain_withColdStorageOptions (56.34s)
=== CONT  TestAccElasticsearchDomainDataSource_advanced
--- PASS: TestAccElasticsearchDomain_Encryption_atRestEnableLegacy (4813.97s)
--- PASS: TestAccElasticsearchDomain_LogPublishingOptions_auditLogs (1671.97s)
--- PASS: TestAccElasticsearchDomain_Encryption_nodeToNodeEnable (5019.11s)
--- PASS: TestAccElasticsearchDomain_duplicate (772.69s)
=== CONT  TestAccElasticsearchDomainSAMLOptions_basic
    domain_saml_options_test.go:27: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # aws_elasticsearch_domain.example will be updated in-place
          ~ resource "aws_elasticsearch_domain" "example" {
                id                    = "arn:aws:es:us-east-2:641575277437:domain/acc-test-1560630586714378765"
                # (8 unchanged attributes hidden)






              ~ ebs_options {
                  - iops        = 3000 -> null
                    # (4 unchanged attributes hidden)
                }



                # (8 unchanged blocks hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
--- PASS: TestAccElasticsearchDomain_LogPublishingOptions_searchSlowLogs (2315.01s)
=== CONT  TestAccElasticsearchDomain_AdvancedSecurityOptions_disabled
    domain_test.go:686: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # aws_elasticsearch_domain.test will be updated in-place
          ~ resource "aws_elasticsearch_domain" "test" {
                id                    = "arn:aws:es:us-east-2:641575277437:domain/tf-acc-test-k1d2zyahvtpqaezr"
                # (8 unchanged attributes hidden)






              ~ ebs_options {
                  - iops        = 3000 -> null
                    # (4 unchanged attributes hidden)
                }



                # (8 unchanged blocks hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
--- PASS: TestAccElasticsearchDomain_LogPublishingOptions_indexSlowLogs (1558.42s)
--- PASS: TestAccElasticsearchDomain_Encryption_atRestEnable (5497.50s)
=== CONT  TestAccElasticsearchDomainSAMLOptions_disappears
    domain_saml_options_test.go:61: Step 1/1 error: After applying this test step, the plan was not empty.
        stdout:


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # aws_elasticsearch_domain.example will be updated in-place
          ~ resource "aws_elasticsearch_domain" "example" {
                id                    = "arn:aws:es:us-east-2:641575277437:domain/acc-test-7473625484027471502"
                # (8 unchanged attributes hidden)






              ~ ebs_options {
                  - iops        = 3000 -> null
                    # (4 unchanged attributes hidden)
                }



                # (8 unchanged blocks hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccElasticsearchDomainSAMLOptions_basic (1517.27s)
--- PASS: TestAccElasticsearchDomain_complex (1398.04s)
--- PASS: TestAccElasticsearchDomain_Update_version (5712.69s)
--- PASS: TestAccElasticsearchDomainPolicy_basic (1512.66s)
--- FAIL: TestAccElasticsearchDomain_AdvancedSecurityOptions_disabled (1842.45s)
--- PASS: TestAccElasticsearchDomain_cognitoOptionsUpdate (3500.32s)
--- PASS: TestAccElasticsearchDomain_LogPublishingOptions_esApplicationLogs (2763.61s)
--- FAIL: TestAccElasticsearchDomainSAMLOptions_disappears (1981.46s)
--- PASS: TestAccElasticsearchDomainSAMLOptions_disappears_Domain (2124.43s)
--- PASS: TestAccElasticsearchDomain_v23 (2311.18s)
--- PASS: TestAccElasticsearchDomainDataSource_advanced (2057.52s)
--- PASS: TestAccElasticsearchDomain_Cluster_zoneAwareness (6653.53s)
--- PASS: TestAccElasticsearchDomain_withDedicatedMaster (4426.81s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/elasticsearch      8966.268s
FAIL
make: *** [GNUmakefile:91: testacc] Error 1
```