### PR TITLE
cognito user pool deletion protection

### DIFF
--- a/.changelog/#27612.txt
+++ b/.changelog/#27612.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cognito_user_pool: add `deletion_protection` argument.
+```

--- a/.changelog/#27612.txt
+++ b/.changelog/#27612.txt
@@ -1,3 +1,3 @@
-```release-note:bug
-resource/aws_cognito_user_pool: add `deletion_protection` argument.
+```release-note:enhancement
+resource/aws_cognito_user_pool: Add `deletion_protection` argument
 ```

--- a/internal/service/cognitoidp/user_pool.go
+++ b/internal/service/cognitoidp/user_pool.go
@@ -116,19 +116,6 @@ func ResourceUserPool() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"custom_domain": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"domain": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"estimated_number_of_users": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-
 			"auto_verified_attributes": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -140,6 +127,16 @@ func ResourceUserPool() *schema.Resource {
 			"creation_date": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"custom_domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"deletion_protection": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      cognitoidentityprovider.DeletionProtectionTypeInactive,
+				ValidateFunc: validation.StringInSlice(cognitoidentityprovider.DeletionProtectionType_Values(), false),
 			},
 			"device_configuration": {
 				Type:     schema.TypeList,
@@ -157,6 +154,10 @@ func ResourceUserPool() *schema.Resource {
 						},
 					},
 				},
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"email_configuration": {
 				Type:             schema.TypeList,
@@ -209,6 +210,10 @@ func ResourceUserPool() *schema.Resource {
 				Computed:      true,
 				ValidateFunc:  validUserPoolEmailVerificationMessage,
 				ConflictsWith: []string{"verification_message_template.0.email_message"},
+			},
+			"estimated_number_of_users": {
+				Type:     schema.TypeInt,
+				Computed: true,
 			},
 			"endpoint": {
 				Type:     schema.TypeString,
@@ -644,6 +649,10 @@ func resourceUserPoolCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	if v, ok := d.GetOk("deletion_protection"); ok {
+		params.DeletionProtection = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("device_configuration"); ok {
 		configs := v.([]interface{})
 		config, ok := configs[0].(map[string]interface{})
@@ -879,6 +888,10 @@ func resourceUserPoolRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("sms_authentication_message", userPool.SmsAuthenticationMessage)
 	}
 
+	if userPool.DeletionProtection != nil {
+		d.Set("deletion_protection", userPool.DeletionProtection)
+	}
+
 	if err := d.Set("device_configuration", flattenUserPoolDeviceConfiguration(userPool.DeviceConfiguration)); err != nil {
 		return fmt.Errorf("failed setting device_configuration: %w", err)
 	}
@@ -1052,6 +1065,7 @@ func resourceUserPoolUpdate(d *schema.ResourceData, meta interface{}) error {
 		"user_pool_add_ons",
 		"verification_message_template",
 		"account_recovery_setting",
+		"deletion_protection",
 	) {
 		params := &cognitoidentityprovider.UpdateUserPoolInput{
 			UserPoolId: aws.String(d.Id()),
@@ -1074,6 +1088,10 @@ func resourceUserPoolUpdate(d *schema.ResourceData, meta interface{}) error {
 			if config, ok := v.([]interface{})[0].(map[string]interface{}); ok {
 				params.AccountRecoverySetting = expandUserPoolAccountRecoverySettingConfig(config)
 			}
+		}
+
+		if v, ok := d.GetOk("deletion_protection"); ok {
+			params.DeletionProtection = aws.String(v.(string))
 		}
 
 		if v, ok := d.GetOk("device_configuration"); ok {

--- a/internal/service/cognitoidp/user_pool_test.go
+++ b/internal/service/cognitoidp/user_pool_test.go
@@ -1557,7 +1557,7 @@ func testAccPreCheckIdentityProvider(t *testing.T) {
 	}
 }
 
-func testAccUserPoolSMSConfigurationBaseConfig(rName string, externalID string) string {
+func testAccUserPoolSMSConfigurationConfig_base(rName string, externalID string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -1762,7 +1762,7 @@ resource "aws_cognito_user_pool" "test" {
 }
 
 func testAccUserPoolConfig_mfaConfigurationSMSConfiguration(rName string) string {
-	return testAccUserPoolSMSConfigurationBaseConfig(rName, "test") + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccUserPoolSMSConfigurationConfig_base(rName, "test"), fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
   mfa_configuration = "ON"
   name              = %[1]q
@@ -1772,11 +1772,11 @@ resource "aws_cognito_user_pool" "test" {
     sns_caller_arn = aws_iam_role.test.arn
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccUserPoolConfig_mfaConfigurationSMSConfigurationAndSoftwareTokenMFAConfigurationEnabled(rName string, enabled bool) string {
-	return testAccUserPoolSMSConfigurationBaseConfig(rName, "test") + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccUserPoolSMSConfigurationConfig_base(rName, "test"), fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
   mfa_configuration = "ON"
   name              = %[1]q
@@ -1790,7 +1790,7 @@ resource "aws_cognito_user_pool" "test" {
     enabled = %[2]t
   }
 }
-`, rName, enabled)
+`, rName, enabled))
 }
 
 func testAccUserPoolConfig_mfaConfigurationSoftwareTokenMFAConfigurationEnabled(rName string, enabled bool) string {
@@ -1816,7 +1816,7 @@ resource "aws_cognito_user_pool" "test" {
 }
 
 func testAccUserPoolConfig_smsConfigurationExternalID(rName string, externalID string) string {
-	return testAccUserPoolSMSConfigurationBaseConfig(rName, externalID) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccUserPoolSMSConfigurationConfig_base(rName, externalID), fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
   name = %[1]q
 
@@ -1825,11 +1825,11 @@ resource "aws_cognito_user_pool" "test" {
     sns_caller_arn = aws_iam_role.test.arn
   }
 }
-`, rName, externalID)
+`, rName, externalID))
 }
 
 func testAccUserPoolConfig_smsConfigurationSNSCallerARN2(rName string) string {
-	return testAccUserPoolSMSConfigurationBaseConfig(rName+"-2", "test") + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccUserPoolSMSConfigurationConfig_base(rName+"-2", "test"), fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
   name = %[1]q
 
@@ -1838,7 +1838,7 @@ resource "aws_cognito_user_pool" "test" {
     sns_caller_arn = aws_iam_role.test.arn
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccUserPoolConfig_smsVerificationMessage(rName, smsVerificationMessage string) string {
@@ -2032,7 +2032,7 @@ resource "aws_cognito_user_pool" "test" {
 `, name)
 }
 
-func testAccUserPoolLambdaBaseConfig(name string) string {
+func testAccUserPoolLambdaConfig_base(name string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -2063,7 +2063,7 @@ resource "aws_lambda_function" "test" {
 }
 
 resource "aws_kms_key" "test" {
-  description             = "Terraform acc test %[1]s"
+  description             = %[1]q
   deletion_window_in_days = 7
 
   policy = <<POLICY
@@ -2088,7 +2088,7 @@ POLICY
 }
 
 func testAccUserPoolConfig_lambda(name string) string {
-	return testAccUserPoolLambdaBaseConfig(name) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccUserPoolLambdaConfig_base(name), fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
   name = %[1]q
 
@@ -2105,11 +2105,11 @@ resource "aws_cognito_user_pool" "test" {
     verify_auth_challenge_response = aws_lambda_function.test.arn
   }
 }
-`, name)
+`, name))
 }
 
 func testAccUserPoolConfig_lambdaUpdated(name string) string {
-	return testAccUserPoolLambdaBaseConfig(name) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccUserPoolLambdaConfig_base(name), fmt.Sprintf(`
 resource "aws_lambda_function" "second" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%[1]s_second"
@@ -2134,11 +2134,11 @@ resource "aws_cognito_user_pool" "test" {
     verify_auth_challenge_response = aws_lambda_function.second.arn
   }
 }
-`, name)
+`, name))
 }
 
 func testAccUserPoolConfig_lambdaEmailSender(name string) string {
-	return testAccUserPoolLambdaBaseConfig(name) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccUserPoolLambdaConfig_base(name), fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
   name = %[1]q
 
@@ -2151,11 +2151,11 @@ resource "aws_cognito_user_pool" "test" {
     }
   }
 }
-`, name)
+`, name))
 }
 
 func testAccUserPoolConfig_lambdaEmailSenderUpdated(name string) string {
-	return testAccUserPoolLambdaBaseConfig(name) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccUserPoolLambdaConfig_base(name), fmt.Sprintf(`
 resource "aws_lambda_function" "second" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%[1]s_second"
@@ -2176,11 +2176,11 @@ resource "aws_cognito_user_pool" "test" {
     }
   }
 }
-`, name)
+`, name))
 }
 
 func testAccUserPoolConfig_lambdaSMSSender(name string) string {
-	return testAccUserPoolLambdaBaseConfig(name) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccUserPoolLambdaConfig_base(name), fmt.Sprintf(`
 resource "aws_cognito_user_pool" "test" {
   name = %[1]q
 
@@ -2193,11 +2193,11 @@ resource "aws_cognito_user_pool" "test" {
     }
   }
 }
-`, name)
+`, name))
 }
 
 func testAccUserPoolConfig_lambdaSMSSenderUpdated(name string) string {
-	return testAccUserPoolLambdaBaseConfig(name) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccUserPoolLambdaConfig_base(name), fmt.Sprintf(`
 resource "aws_lambda_function" "second" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%[1]s_second"
@@ -2218,7 +2218,7 @@ resource "aws_cognito_user_pool" "test" {
     }
   }
 }
-`, name)
+`, name))
 }
 
 func testAccUserPoolConfig_schemaAttributes(name string) string {

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -72,6 +72,7 @@ The following arguments are optional:
 * `admin_create_user_config` - (Optional) Configuration block for creating a new user profile. [Detailed below](#admin_create_user_config).
 * `alias_attributes` - (Optional) Attributes supported as an alias for this user pool. Valid values: `phone_number`, `email`, or `preferred_username`. Conflicts with `username_attributes`.
 * `auto_verified_attributes` - (Optional) Attributes to be auto-verified. Valid values: `email`, `phone_number`.
+* `deletion_protection` - (Optional) When active, DeletionProtection prevents accidental deletion of your user pool. Before you can delete a user pool that you have protected against deletion, you must deactivate this feature. Valid values are `ACTIVE` and `INACTIVE`, Default value is `INACTIVE`.
 * `device_configuration` - (Optional) Configuration block for the user pool's device tracking. [Detailed below](#device_configuration).
 * `email_configuration` - (Optional) Configuration block for configuring email. [Detailed below](#email_configuration).
 * `email_verification_message` - (Optional) String representing the email verification message. Conflicts with `verification_message_template` configuration block `email_message` argument.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27435

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccCognitoIDPUserPool_ PKG=cognitoidp

--- PASS: TestAccCognitoIDPUserPool_disappears (32.93s)
--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy (44.45s)
--- PASS: TestAccCognitoIDPUserPool_basic (47.42s)
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesModified (53.07s)
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesRemoved (53.28s)
--- PASS: TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings (65.88s)
--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUser (73.19s)
--- PASS: TestAccCognitoIDPUserPool_withVerificationMessageTemplate (75.09s)
--- PASS: TestAccCognitoIDPUserPool_withEmailVerificationMessage (75.41s)
--- PASS: TestAccCognitoIDPUserPool_smsAuthenticationMessage (77.99s)
--- PASS: TestAccCognitoIDPUserPool_schemaAttributes (78.32s)
--- PASS: TestAccCognitoIDPUserPool_smsVerificationMessage (81.39s)
--- PASS: TestAccCognitoIDPUserPool_withAdvancedSecurityMode (99.18s)
--- PASS: TestAccCognitoIDPUserPool_SMS_snsCallerARN (112.54s)
--- PASS: TestAccCognitoIDPUserPool_withDevice (68.74s)
--- PASS: TestAccCognitoIDPUserPool_SMS_externalID (116.24s)
--- PASS: TestAccCognitoIDPUserPool_withEmail (38.43s)
--- PASS: TestAccCognitoIDPUserPool_withUsernameAttributes (69.34s)
--- PASS: TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA (123.69s)
--- PASS: TestAccCognitoIDPUserPool_WithLambda_email (126.11s)
--- PASS: TestAccCognitoIDPUserPool_MFA_softwareTokenMFA (96.98s)
--- PASS: TestAccCognitoIDPUserPool_sms (132.44s)
--- PASS: TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS (91.83s)
--- PASS: TestAccCognitoIDPUserPool_withUsername (65.98s)
--- PASS: TestAccCognitoIDPUserPool_withPasswordPolicy (65.09s)
--- PASS: TestAccCognitoIDPUserPool_withAliasAttributes (65.49s)
--- PASS: TestAccCognitoIDPUserPool_MFA_sms (146.22s)
--- PASS: TestAccCognitoIDPUserPool_update (156.27s)
--- PASS: TestAccCognitoIDPUserPool_withTags (85.74s)
--- PASS: TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA (82.75s)
--- PASS: TestAccCognitoIDPUserPool_WithLambda_sms (114.73s)
--- PASS: TestAccCognitoIDPUserPool_deletionProtection (56.88s)
--- PASS: TestAccCognitoIDPUserPool_recovery (86.44s)
--- PASS: TestAccCognitoIDPUserPool_withLambda (140.48s)
```
