### PR TITLE
EMR Clusters: Fix acceptance tests

### DIFF
--- a/internal/service/emrcontainers/virtual_cluster_test.go
+++ b/internal/service/emrcontainers/virtual_cluster_test.go
@@ -202,7 +202,7 @@ func testAccCheckVirtualClusterDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccVirtualClusterBase(rName string) string {
+func testAccVirtualClusterConfig_base(rName string) string {
 	//lintignore:AT004
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 data "aws_partition" "current" {}
@@ -470,7 +470,7 @@ EOF
 }
 
 func testAccVirtualClusterConfig_basic(rName string) string {
-	return acctest.ConfigCompose(testAccVirtualClusterBase(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVirtualClusterConfig_base(rName), fmt.Sprintf(`
 resource "aws_emrcontainers_virtual_cluster" "test" {
   container_provider {
     id   = aws_eks_cluster.test.name
@@ -491,7 +491,7 @@ resource "aws_emrcontainers_virtual_cluster" "test" {
 }
 
 func testAccVirtualClusterConfig_tags1(rName, tagKey1, tagValue1 string) string {
-	return acctest.ConfigCompose(testAccVirtualClusterBase(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVirtualClusterConfig_base(rName), fmt.Sprintf(`
 resource "aws_emrcontainers_virtual_cluster" "test" {
   container_provider {
     id   = aws_eks_cluster.test.name
@@ -516,7 +516,7 @@ resource "aws_emrcontainers_virtual_cluster" "test" {
 }
 
 func testAccVirtualClusterConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccVirtualClusterBase(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVirtualClusterConfig_base(rName), fmt.Sprintf(`
 resource "aws_emrcontainers_virtual_cluster" "test" {
   container_provider {
     id   = aws_eks_cluster.test.name

--- a/internal/service/emrcontainers/virtual_cluster_test.go
+++ b/internal/service/emrcontainers/virtual_cluster_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestAccEMRContainersVirtualCluster_basic(t *testing.T) {
 	var v emrcontainers.VirtualCluster
-	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_emrcontainers_virtual_cluster.test"
 	testExternalProviders := map[string]resource.ExternalProvider{
 		"kubernetes": {
@@ -72,7 +72,7 @@ func TestAccEMRContainersVirtualCluster_basic(t *testing.T) {
 
 func TestAccEMRContainersVirtualCluster_disappears(t *testing.T) {
 	var v emrcontainers.VirtualCluster
-	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_emrcontainers_virtual_cluster.test"
 	testExternalProviders := map[string]resource.ExternalProvider{
 		"kubernetes": {
@@ -105,7 +105,7 @@ func TestAccEMRContainersVirtualCluster_disappears(t *testing.T) {
 
 func TestAccEMRContainersVirtualCluster_tags(t *testing.T) {
 	var v emrcontainers.VirtualCluster
-	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_emrcontainers_virtual_cluster.test"
 	testExternalProviders := map[string]resource.ExternalProvider{
 		"kubernetes": {
@@ -378,9 +378,13 @@ provider "kubernetes" {
   host                   = aws_eks_cluster.test.endpoint
   cluster_ca_certificate = base64decode(aws_eks_cluster.test.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.cluster.token
+
+  alias = "emr"
 }
 
 resource "kubernetes_role" "emrcontainers_role" {
+  provider = kubernetes.emr
+
   metadata {
     name      = "emr-containers"
     namespace = "default"
@@ -430,6 +434,8 @@ resource "kubernetes_role" "emrcontainers_role" {
 }
 
 resource "kubernetes_role_binding" "emrcontainers_rolemapping" {
+  provider = kubernetes.emr
+
   metadata {
     name      = "emr-containers"
     namespace = "default"
@@ -449,6 +455,8 @@ resource "kubernetes_role_binding" "emrcontainers_rolemapping" {
 }
 
 resource "kubernetes_config_map" "aws_auth" {
+  provider = kubernetes.emr
+
   metadata {
     name      = "aws-auth"
     namespace = "kube-system"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Use an alias for the external Kubernetes provider to fix EMR Containers acceptance test failures.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/27603.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccEMRContainersVirtualCluster_basic' PKG=emrcontainers
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/emrcontainers/... -v -count 1 -parallel 20  -run=TestAccEMRContainersVirtualCluster_basic -timeout 180m
=== RUN   TestAccEMRContainersVirtualCluster_basic
=== PAUSE TestAccEMRContainersVirtualCluster_basic
=== CONT  TestAccEMRContainersVirtualCluster_basic
--- PASS: TestAccEMRContainersVirtualCluster_basic (1145.36s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/emrcontainers	1149.676s
```
