### PR TITLE
cognito user pool client - add `auth_session_validity` arg

### DIFF
--- a/.changelog/27620.txt
+++ b/.changelog/27620.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cognito_user_pool_client: Add `auth_session_validity` argument
+```

--- a/internal/service/cognitoidp/user_pool_client.go
+++ b/internal/service/cognitoidp/user_pool_client.go
@@ -101,6 +101,11 @@ func ResourceUserPoolClient() *schema.Resource {
 					},
 				},
 			},
+			"auth_session_validity": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(3, 15),
+			},
 			"callback_urls": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -261,6 +266,10 @@ func resourceUserPoolClientCreate(d *schema.ResourceData, meta interface{}) erro
 		UserPoolId: aws.String(d.Get("user_pool_id").(string)),
 	}
 
+	if v, ok := d.GetOk("auth_session_validity"); ok {
+		params.AuthSessionValidity = aws.Int64(int64(v.(int)))
+	}
+
 	if v, ok := d.GetOk("generate_secret"); ok {
 		params.GenerateSecret = aws.Bool(v.(bool))
 	}
@@ -384,6 +393,7 @@ func resourceUserPoolClientRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("supported_identity_providers", flex.FlattenStringSet(userPoolClient.SupportedIdentityProviders))
 	d.Set("enable_token_revocation", userPoolClient.EnableTokenRevocation)
 	d.Set("enable_propagate_additional_user_context_data", userPoolClient.EnablePropagateAdditionalUserContextData)
+	d.Set("auth_session_validity", userPoolClient.AuthSessionValidity)
 
 	if err := d.Set("analytics_configuration", flattenUserPoolClientAnalyticsConfig(userPoolClient.AnalyticsConfiguration)); err != nil {
 		return fmt.Errorf("error setting analytics_configuration: %w", err)
@@ -475,6 +485,10 @@ func resourceUserPoolClientUpdate(d *schema.ResourceData, meta interface{}) erro
 
 	if v, ok := d.GetOk("enable_propagate_additional_user_context_data"); ok {
 		params.EnablePropagateAdditionalUserContextData = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("auth_session_validity"); ok {
+		params.AuthSessionValidity = aws.Int64(int64(v.(int)))
 	}
 
 	log.Printf("[DEBUG] Updating Cognito User Pool Client: %s", params)

--- a/internal/service/cognitoidp/user_pool_client.go
+++ b/internal/service/cognitoidp/user_pool_client.go
@@ -104,6 +104,7 @@ func ResourceUserPoolClient() *schema.Resource {
 			"auth_session_validity": {
 				Type:         schema.TypeInt,
 				Optional:     true,
+				Default:      3,
 				ValidateFunc: validation.IntBetween(3, 15),
 			},
 			"callback_urls": {

--- a/internal/service/cognitoidp/user_pool_client_test.go
+++ b/internal/service/cognitoidp/user_pool_client_test.go
@@ -549,7 +549,7 @@ func TestAccCognitoIDPUserPoolClient_authSessionValidity(t *testing.T) {
 				Config: testAccUserPoolClientConfig_authSessionValidity(rName, 15),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckUserPoolClientExists(resourceName, &client),
-					resource.TestCheckResourceAttr(resourceName, "auth_session_validity", "3"),
+					resource.TestCheckResourceAttr(resourceName, "auth_session_validity", "15"),
 				),
 			},
 		},

--- a/internal/service/cognitoidp/user_pool_client_test.go
+++ b/internal/service/cognitoidp/user_pool_client_test.go
@@ -901,8 +901,8 @@ func testAccUserPoolClientConfig_authSessionValidity(rName string, validity int)
 resource "aws_cognito_user_pool_client" "test" {
   name                  = %[1]q
   auth_session_validity = %[2]d
-  user_pool_id        = aws_cognito_user_pool.test.id
-  explicit_auth_flows = ["ADMIN_NO_SRP_AUTH"]
+  user_pool_id          = aws_cognito_user_pool.test.id
+  explicit_auth_flows   = ["ADMIN_NO_SRP_AUTH"]
 }
 `, rName, validity)
 }

--- a/internal/service/cognitoidp/user_pool_client_test.go
+++ b/internal/service/cognitoidp/user_pool_client_test.go
@@ -36,6 +36,7 @@ func TestAccCognitoIDPUserPoolClient_basic(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "explicit_auth_flows.*", "ADMIN_NO_SRP_AUTH"),
 					resource.TestCheckResourceAttr(resourceName, "token_validity_units.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "analytics_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "auth_session_validity", "3"),
 				),
 			},
 			{

--- a/internal/service/cognitoidp/user_pool_client_test.go
+++ b/internal/service/cognitoidp/user_pool_client_test.go
@@ -521,6 +521,41 @@ func TestAccCognitoIDPUserPoolClient_analyticsWithARN(t *testing.T) {
 	})
 }
 
+func TestAccCognitoIDPUserPoolClient_authSessionValidity(t *testing.T) {
+	var client cognitoidentityprovider.UserPoolClientType
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool_client.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIdentityProvider(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolClientDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolClientConfig_authSessionValidity(rName, 3),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolClientExists(resourceName, &client),
+					resource.TestCheckResourceAttr(resourceName, "auth_session_validity", "3"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccUserPoolClientImportStateIDFunc(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccUserPoolClientConfig_authSessionValidity(rName, 15),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolClientExists(resourceName, &client),
+					resource.TestCheckResourceAttr(resourceName, "auth_session_validity", "3"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCognitoIDPUserPoolClient_disappears(t *testing.T) {
 	var client cognitoidentityprovider.UserPoolClientType
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -858,6 +893,17 @@ resource "aws_cognito_user_pool_client" "test" {
   }
 }
 `, rName)
+}
+
+func testAccUserPoolClientConfig_authSessionValidity(rName string, validity int) string {
+	return testAccUserPoolClientBaseConfig(rName) + fmt.Sprintf(`
+resource "aws_cognito_user_pool_client" "test" {
+  name                  = %[1]q
+  auth_session_validity = %[2]d
+  user_pool_id        = aws_cognito_user_pool.test.id
+  explicit_auth_flows = ["ADMIN_NO_SRP_AUTH"]
+}
+`, rName, validity)
 }
 
 func testAccPreCheckPinpointApp(t *testing.T) {

--- a/website/docs/r/cognito_user_pool_client.markdown
+++ b/website/docs/r/cognito_user_pool_client.markdown
@@ -142,7 +142,7 @@ The following arguments are optional:
 * `allowed_oauth_flows` - (Optional) List of allowed OAuth flows (code, implicit, client_credentials).
 * `allowed_oauth_scopes` - (Optional) List of allowed OAuth scopes (phone, email, openid, profile, and aws.cognito.signin.user.admin).
 * `analytics_configuration` - (Optional) Configuration block for Amazon Pinpoint analytics for collecting metrics for this user pool. [Detailed below](#analytics_configuration).
-* `auth_session_validity` - (Optional) Amazon Cognito creates a session token for each API request in an authentication flow. AuthSessionValidity is the duration, in minutes, of that session token. Your user pool native user must respond to each authentication challenge before the session expires. Valid values between `3` and `15`.
+* `auth_session_validity` - (Optional) Amazon Cognito creates a session token for each API request in an authentication flow. AuthSessionValidity is the duration, in minutes, of that session token. Your user pool native user must respond to each authentication challenge before the session expires. Valid values between `3` and `15`. Default value is `3`.
 * `callback_urls` - (Optional) List of allowed callback URLs for the identity providers.
 * `default_redirect_uri` - (Optional) Default redirect URI. Must be in the list of callback URLs.
 * `enable_token_revocation` - (Optional) Enables or disables token revocation.

--- a/website/docs/r/cognito_user_pool_client.markdown
+++ b/website/docs/r/cognito_user_pool_client.markdown
@@ -142,6 +142,7 @@ The following arguments are optional:
 * `allowed_oauth_flows` - (Optional) List of allowed OAuth flows (code, implicit, client_credentials).
 * `allowed_oauth_scopes` - (Optional) List of allowed OAuth scopes (phone, email, openid, profile, and aws.cognito.signin.user.admin).
 * `analytics_configuration` - (Optional) Configuration block for Amazon Pinpoint analytics for collecting metrics for this user pool. [Detailed below](#analytics_configuration).
+* `auth_session_validity` - (Optional) Amazon Cognito creates a session token for each API request in an authentication flow. AuthSessionValidity is the duration, in minutes, of that session token. Your user pool native user must respond to each authentication challenge before the session expires. Valid values between `3` and `15`.
 * `callback_urls` - (Optional) List of allowed callback URLs for the identity providers.
 * `default_redirect_uri` - (Optional) Default redirect URI. Must be in the list of callback URLs.
 * `enable_token_revocation` - (Optional) Enables or disables token revocation.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccCognitoIDPUserPoolClient_ PKG=cognitoidp

--- PASS: TestAccCognitoIDPUserPoolClient_Disappears_userPool (37.30s)
--- PASS: TestAccCognitoIDPUserPoolClient_disappears (44.93s)
--- PASS: TestAccCognitoIDPUserPoolClient_basic (48.98s)
--- PASS: TestAccCognitoIDPUserPoolClient_allFields (52.26s)
--- PASS: TestAccCognitoIDPUserPoolClient_idTokenValidity (74.28s)
--- PASS: TestAccCognitoIDPUserPoolClient_accessTokenValidity (75.13s)
--- PASS: TestAccCognitoIDPUserPoolClient_allFieldsUpdatingOneField (75.13s)
--- PASS: TestAccCognitoIDPUserPoolClient_tokenValidityUnits (75.13s)
--- PASS: TestAccCognitoIDPUserPoolClient_authSessionValidity (76.26s)
--- PASS: TestAccCognitoIDPUserPoolClient_analyticsWithARN (76.64s)
--- PASS: TestAccCognitoIDPUserPoolClient_refreshTokenValidity (76.67s)
--- PASS: TestAccCognitoIDPUserPoolClient_name (77.32s)
--- PASS: TestAccCognitoIDPUserPoolClient_tokenValidityUnitsWTokenValidity (78.11s)
--- PASS: TestAccCognitoIDPUserPoolClient_enableRevocation (101.16s)
--- PASS: TestAccCognitoIDPUserPoolClient_analytics (156.73s)
```
