### PR TITLE
[Enhancement]: Changed id to use the ServicePermissionID - the ID of the actual resource.

### DIFF
--- a/.changelog/27640.txt
+++ b/.changelog/27640.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_vpc_endpoint_service_allowed_principal: Changed id to use ServicePermissionId
+```

--- a/internal/service/cognitoidp/find.go
+++ b/internal/service/cognitoidp/find.go
@@ -112,11 +112,12 @@ func FindCognitoUserPoolClientByName(ctx context.Context, conn *cognitoidentityp
 		return nil, err
 	}
 
-	if err := tfresource.ExpectSingleResult(clientDescs); err != nil {
+	client, err := tfresource.AssertSingleResult(clientDescs)
+	if err != nil {
 		return nil, err
 	}
 
-	return FindCognitoUserPoolClientByID(ctx, conn, userPoolId, aws.StringValue(clientDescs[0].ClientId))
+	return FindCognitoUserPoolClientByID(ctx, conn, userPoolId, aws.StringValue(client.ClientId))
 }
 
 type cognitoUserPoolClientDescriptionNameFilter func(string) (bool, error)

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -3345,7 +3345,7 @@ func FindVPCEndpointServicePermissions(ctx context.Context, conn *ec2.EC2, input
 	return output, nil
 }
 
-func FindVPCEndpointServicePermissionsByID(ctx context.Context, conn *ec2.EC2, id string) ([]*ec2.AllowedPrincipal, error) {
+func FindVPCEndpointServicePermissionsByServiceID(ctx context.Context, conn *ec2.EC2, id string) ([]*ec2.AllowedPrincipal, error) {
 	input := &ec2.DescribeVpcEndpointServicePermissionsInput{
 		ServiceId: aws.String(id),
 	}
@@ -3353,22 +3353,13 @@ func FindVPCEndpointServicePermissionsByID(ctx context.Context, conn *ec2.EC2, i
 	return FindVPCEndpointServicePermissions(ctx, conn, input)
 }
 
-func FindVPCEndpointServicePermissionExists(ctx context.Context, conn *ec2.EC2, serviceID, principalARN string) error {
-	allowedPrincipals, err := FindVPCEndpointServicePermissionsByID(ctx, conn, serviceID)
-
+func FindVPCEndpointServicePermission(ctx context.Context, conn *ec2.EC2, serviceID, principalARN string) (*ec2.AllowedPrincipal, error) {
+	allowedPrincipals, err := FindVPCEndpointServicePermissionsByServiceID(ctx, conn, serviceID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	for _, v := range allowedPrincipals {
-		if aws.StringValue(v.Principal) == principalARN {
-			return nil
-		}
-	}
-
-	return &retry.NotFoundError{
-		LastError: fmt.Errorf("VPC Endpoint Service (%s) Principal (%s) not found", serviceID, principalARN),
-	}
+	return tfresource.AssertSingleResult(allowedPrincipals)
 }
 
 // FindVPCEndpointRouteTableAssociationExists returns NotFoundError if no association for the specified VPC endpoint and route table IDs is found.

--- a/internal/service/ec2/vpc_endpoint_service.go
+++ b/internal/service/ec2/vpc_endpoint_service.go
@@ -248,7 +248,7 @@ func resourceVPCEndpointServiceRead(ctx context.Context, d *schema.ResourceData,
 
 	SetTagsOut(ctx, svcCfg.Tags)
 
-	allowedPrincipals, err := FindVPCEndpointServicePermissionsByID(ctx, conn, d.Id())
+	allowedPrincipals, err := FindVPCEndpointServicePermissionsByServiceID(ctx, conn, d.Id())
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading EC2 VPC Endpoint Service (%s) permissions: %s", d.Id(), err)

--- a/internal/service/ec2/vpc_endpoint_service_allowed_principal.go
+++ b/internal/service/ec2/vpc_endpoint_service_allowed_principal.go
@@ -2,7 +2,6 @@ package ec2
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -11,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
@@ -45,7 +43,7 @@ func resourceVPCEndpointServiceAllowedPrincipalCreate(ctx context.Context, d *sc
 	serviceID := d.Get("vpc_endpoint_service_id").(string)
 	principalARN := d.Get("principal_arn").(string)
 
-	_, err := conn.ModifyVpcEndpointServicePermissionsWithContext(ctx, &ec2.ModifyVpcEndpointServicePermissionsInput{
+	output, err := conn.ModifyVpcEndpointServicePermissionsWithContext(ctx, &ec2.ModifyVpcEndpointServicePermissionsInput{
 		AddAllowedPrincipals: aws.StringSlice([]string{principalARN}),
 		ServiceId:            aws.String(serviceID),
 	})
@@ -54,7 +52,11 @@ func resourceVPCEndpointServiceAllowedPrincipalCreate(ctx context.Context, d *sc
 		return sdkdiag.AppendErrorf(diags, "modifying EC2 VPC Endpoint Service (%s) permissions: %s", serviceID, err)
 	}
 
-	d.SetId(fmt.Sprintf("a-%s%d", serviceID, create.StringHashcode(principalARN)))
+	for _, v := range output.AddedPrincipals {
+		if aws.StringValue(v.Principal) == principalARN {
+			d.SetId(aws.StringValue(v.ServicePermissionId))
+		}
+	}
 
 	return append(diags, resourceVPCEndpointServiceAllowedPrincipalRead(ctx, d, meta)...)
 }

--- a/internal/service/ec2/vpc_endpoint_service_allowed_principal.go
+++ b/internal/service/ec2/vpc_endpoint_service_allowed_principal.go
@@ -68,7 +68,7 @@ func resourceVPCEndpointServiceAllowedPrincipalRead(ctx context.Context, d *sche
 	serviceID := d.Get("vpc_endpoint_service_id").(string)
 	principalARN := d.Get("principal_arn").(string)
 
-	err := FindVPCEndpointServicePermissionExists(ctx, conn, serviceID, principalARN)
+	output, err := FindVPCEndpointServicePermission(ctx, conn, serviceID, principalARN)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] EC2 VPC Endpoint Service Allowed Principal %s not found, removing from state", d.Id())
@@ -79,6 +79,8 @@ func resourceVPCEndpointServiceAllowedPrincipalRead(ctx context.Context, d *sche
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading EC2 VPC Endpoint Service (%s) Allowed Principal (%s): %s", serviceID, principalARN, err)
 	}
+
+	d.SetId(aws.StringValue(output.ServicePermissionId))
 
 	return diags
 }

--- a/internal/service/ec2/vpc_endpoint_service_allowed_principal_test.go
+++ b/internal/service/ec2/vpc_endpoint_service_allowed_principal_test.go
@@ -40,6 +40,37 @@ func TestAccVPCEndpointServiceAllowedPrincipal_basic(t *testing.T) {
 	})
 }
 
+func TestAccVPCEndpointServiceAllowedPrincipal_migrateID(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_vpc_endpoint_service_allowed_principal.test"
+	rName := sdkacctest.RandomWithPrefix("tfacctest")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ec2.EndpointsID),
+		CheckDestroy: testAccCheckVPCEndpointServiceAllowedPrincipalDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "4.63.0",
+					},
+				},
+				Config: testAccVPCEndpointServiceAllowedPrincipalConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVPCEndpointServiceAllowedPrincipalExists(ctx, resourceName),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccVPCEndpointServiceAllowedPrincipalConfig_basic(rName),
+				PlanOnly:                 true,
+			},
+		},
+	})
+}
+
 func testAccCheckVPCEndpointServiceAllowedPrincipalDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Conn()

--- a/internal/tfresource/not_found_error.go
+++ b/internal/tfresource/not_found_error.go
@@ -92,13 +92,13 @@ func SingularDataSourceFindError(resourceType string, err error) error {
 	return fmt.Errorf("reading %s: %w", resourceType, err)
 }
 
-func ExpectSingleResult[T any](a []*T) error {
+func AssertSingleResult[T any](a []*T) (*T, error) {
 	if l := len(a); l == 0 {
-		return NewEmptyResultError(nil)
+		return nil, NewEmptyResultError(nil)
 	} else if l > 1 {
-		return NewTooManyResultsError(l, nil)
+		return nil, NewTooManyResultsError(l, nil)
 	} else if a[0] == nil {
-		return NewEmptyResultError(nil)
+		return nil, NewEmptyResultError(nil)
 	}
-	return nil
+	return a[0], nil
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27599 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
This change provides a usable ID & supports the ability to apply tags to the service principal using `ec2_tags` resource type. 


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make testacc TESTS=TestAccVPCEndpointServiceAllowedPrincipal_basic PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCEndpointServiceAllowedPrincipal_basic'  -timeout 180m
=== RUN   TestAccVPCEndpointServiceAllowedPrincipal_basic
=== PAUSE TestAccVPCEndpointServiceAllowedPrincipal_basic
=== CONT  TestAccVPCEndpointServiceAllowedPrincipal_basic
--- PASS: TestAccVPCEndpointServiceAllowedPrincipal_basic (325.10s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        329.724s

...
```
