### PR TITLE
remove tags field from aws_secretsmanager_secret_rotation resource

### DIFF
--- a/.changelog/27656.txt
+++ b/.changelog/27656.txt
@@ -1,0 +1,4 @@
+```release-note:breaking-change
+resource/aws_secretsmanager_secret_rotation: Remove unused `tags` attribute
+```
+

--- a/internal/service/secretsmanager/secret_rotation.go
+++ b/internal/service/secretsmanager/secret_rotation.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -52,7 +51,6 @@ func ResourceSecretRotation() *schema.Resource {
 					},
 				},
 			},
-			"tags": tftags.TagsSchema(),
 		},
 	}
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change removes the useless `tags` argument from the `aws_secretsmanager_secret_rotation` resource.

### Relations

Closes #27655


### Output from Acceptance Testing
```
$ make testacc TESTARGS='-run=TestAccSecretsManagerSecretRotation' PKG=secretsmanager
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/secretsmanager/... -v -count 1 -parallel 20  -run=TestAccSecretsManagerSecretRotation -timeout 180m
=== RUN   TestAccSecretsManagerSecretRotationDataSource_basic
=== PAUSE TestAccSecretsManagerSecretRotationDataSource_basic
=== RUN   TestAccSecretsManagerSecretRotation_basic
=== PAUSE TestAccSecretsManagerSecretRotation_basic
=== CONT  TestAccSecretsManagerSecretRotationDataSource_basic
=== CONT  TestAccSecretsManagerSecretRotation_basic
--- PASS: TestAccSecretsManagerSecretRotation_basic (53.01s)
--- PASS: TestAccSecretsManagerSecretRotationDataSource_basic (54.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	57.662s

```
