### PR TITLE
fix: A diff should reflect that the value of the stream arn is computed on change to the stream.

### DIFF
--- a/.changelog/27664.txt
+++ b/.changelog/27664.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Correctly set `stream_arn` as Computed when `stream_enabled` changes
+```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -74,6 +74,14 @@ func ResourceTable() *schema.Resource {
 				}
 				return nil
 			},
+			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+				if diff.Id() != "" && diff.HasChange("stream_enabled") {
+					if err := diff.SetNewComputed("stream_arn"); err != nil {
+						return fmt.Errorf("error setting stream_arn to computed: %s", err)
+					}
+				}
+				return nil
+			},
 			func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
 				if v := diff.Get("restore_source_name"); v != "" {
 					return nil

--- a/internal/service/lambda/event_source_mapping_test.go
+++ b/internal/service/lambda/event_source_mapping_test.go
@@ -213,6 +213,37 @@ func TestAccLambdaEventSourceMapping_DynamoDB_functionResponseTypes(t *testing.T
 	})
 }
 
+func TestAccLambdaEventSourceMapping_DynamoDB_streamAdded(t *testing.T) {
+	var conf lambda.EventSourceMappingConfiguration
+	resourceName := "aws_dynamodb_table.test"
+	mappingResourceName := "aws_lambda_event_source_mapping.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEventSourceMappingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDynamoDBStreamConfig(rName, false),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"last_modified"},
+			},
+			{
+				Config: testAccEventSourceMappingDynamoDBStreamEnabled(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEventSourceMappingExists(mappingResourceName, &conf),
+				),
+			},
+		},
+	})
+}
+
 func TestAccLambdaEventSourceMapping_SQS_batchWindow(t *testing.T) {
 	var conf lambda.EventSourceMappingConfiguration
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1326,6 +1357,78 @@ resource "aws_lambda_function" "test" {
 `, rName)
 }
 
+func testAccDynamoDBStreamConfig(rName string, streamEnabled bool) string {
+	var streamStatus string
+	var streamViewType string
+	if streamEnabled {
+		streamStatus = "stream_enabled   = true"
+		streamViewType = "stream_view_type = \"KEYS_ONLY\""
+	} else {
+		streamStatus = ""
+		streamViewType = ""
+	}
+
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Action": "sts:AssumeRole",
+    "Principal": {
+      "Service": "lambda.amazonaws.com"
+    },
+    "Effect": "Allow"
+  }]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test" {
+  role = aws_iam_role.test.name
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:*"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_dynamodb_table" "test" {
+  name           = %[1]q
+  read_capacity  = 1
+  write_capacity = 2
+  hash_key       = "TestTableHashKey"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+  %[2]s
+  %[3]s
+}
+
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %[1]q
+  handler       = "exports.example"
+  role          = aws_iam_role.test.arn
+  runtime       = "nodejs12.x"
+}
+`, rName, streamStatus, streamViewType)
+}
+
 func testAccEventSourceMappingConfig_kafkaBase(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
 resource "aws_iam_role" "test" {
@@ -1957,6 +2060,18 @@ resource "aws_lambda_event_source_mapping" "test" {
 
 func testAccEventSourceMappingConfig_dynamoDBNoFunctionResponseTypes(rName string) string {
 	return acctest.ConfigCompose(testAccEventSourceMappingConfig_dynamoDBBase(rName), `
+resource "aws_lambda_event_source_mapping" "test" {
+  batch_size        = 150
+  enabled           = true
+  event_source_arn  = aws_dynamodb_table.test.stream_arn
+  function_name     = aws_lambda_function.test.function_name
+  starting_position = "LATEST"
+}
+`)
+}
+
+func testAccEventSourceMappingDynamoDBStreamEnabled(rName string) string {
+	return acctest.ConfigCompose(testAccDynamoDBStreamConfig(rName, true), `
 resource "aws_lambda_event_source_mapping" "test" {
   batch_size        = 150
   enabled           = true


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The stream ARN is set to a default empty string when the stream is not enabled, but when the stream state is updated to enabled the plan doesn't reflect the stream are is computed so fails as the consumer of the stream expects a valid ARN( lambda in my case, hence adding the test to prove the fix in the lambda package). Adding a customdiff that sets the ARN as computed on change ensures the plan does not pass the existing empty string to the consumer.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #20092

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
make testacc TESTS=TestAccLambdaEventSourceMapping_DynamoDB_streamAdded PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaEventSourceMapping_DynamoDB_streamAdded'  -timeout 180m
=== RUN   TestAccLambdaEventSourceMapping_DynamoDB_streamAdded
=== PAUSE TestAccLambdaEventSourceMapping_DynamoDB_streamAdded
=== CONT  TestAccLambdaEventSourceMapping_DynamoDB_streamAdded
--- PASS: TestAccLambdaEventSourceMapping_DynamoDB_streamAdded (114.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     116.859s
```

```
make testacc PKG=dynamodb
================== DynamoDB Tests =================
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 20   -timeout 180m
=== RUN   TestARNForNewRegion
=== RUN   TestARNForNewRegion/basic
=== RUN   TestARNForNewRegion/basic2
--- PASS: TestARNForNewRegion (0.00s)
    --- PASS: TestARNForNewRegion/basic (0.00s)
    --- PASS: TestARNForNewRegion/basic2 (0.00s)
=== RUN   TestAccDynamoDBContributorInsights_basic
=== PAUSE TestAccDynamoDBContributorInsights_basic
=== RUN   TestAccDynamoDBContributorInsights_disappears
=== PAUSE TestAccDynamoDBContributorInsights_disappears
=== RUN   TestAccDynamoDBGlobalTable_basic
=== PAUSE TestAccDynamoDBGlobalTable_basic
=== RUN   TestAccDynamoDBGlobalTable_multipleRegions
=== PAUSE TestAccDynamoDBGlobalTable_multipleRegions
=== RUN   TestAccDynamoDBKinesisStreamingDestination_basic
=== PAUSE TestAccDynamoDBKinesisStreamingDestination_basic
=== RUN   TestAccDynamoDBKinesisStreamingDestination_disappears
=== PAUSE TestAccDynamoDBKinesisStreamingDestination_disappears
=== RUN   TestAccDynamoDBKinesisStreamingDestination_Disappears_dynamoDBTable
=== PAUSE TestAccDynamoDBKinesisStreamingDestination_Disappears_dynamoDBTable
=== RUN   TestAccDynamoDBTableDataSource_basic
=== PAUSE TestAccDynamoDBTableDataSource_basic
=== RUN   TestAccDynamoDBTableItem_basic
=== PAUSE TestAccDynamoDBTableItem_basic
=== RUN   TestAccDynamoDBTableItem_rangeKey
=== PAUSE TestAccDynamoDBTableItem_rangeKey
=== RUN   TestAccDynamoDBTableItem_withMultipleItems
=== PAUSE TestAccDynamoDBTableItem_withMultipleItems
=== RUN   TestAccDynamoDBTableItem_wonkyItems
=== PAUSE TestAccDynamoDBTableItem_wonkyItems
=== RUN   TestAccDynamoDBTableItem_update
=== PAUSE TestAccDynamoDBTableItem_update
=== RUN   TestAccDynamoDBTableItem_updateWithRangeKey
=== PAUSE TestAccDynamoDBTableItem_updateWithRangeKey
=== RUN   TestAccDynamoDBTableItem_disappears
=== PAUSE TestAccDynamoDBTableItem_disappears
=== RUN   TestAccDynamoDBTableReplica_basic
=== PAUSE TestAccDynamoDBTableReplica_basic
=== RUN   TestAccDynamoDBTableReplica_disappears
=== PAUSE TestAccDynamoDBTableReplica_disappears
=== RUN   TestAccDynamoDBTableReplica_pitr
=== PAUSE TestAccDynamoDBTableReplica_pitr
=== RUN   TestAccDynamoDBTableReplica_tags
=== PAUSE TestAccDynamoDBTableReplica_tags
=== RUN   TestAccDynamoDBTableReplica_tableClass
=== PAUSE TestAccDynamoDBTableReplica_tableClass
=== RUN   TestUpdateDiffGSI
--- PASS: TestUpdateDiffGSI (0.00s)
=== RUN   TestAccDynamoDBTable_basic
=== PAUSE TestAccDynamoDBTable_basic
=== RUN   TestAccDynamoDBTable_disappears
=== PAUSE TestAccDynamoDBTable_disappears
=== RUN   TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
=== PAUSE TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
=== RUN   TestAccDynamoDBTable_extended
=== PAUSE TestAccDynamoDBTable_extended
=== RUN   TestAccDynamoDBTable_enablePITR
=== PAUSE TestAccDynamoDBTable_enablePITR
=== RUN   TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== PAUSE TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== RUN   TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
=== PAUSE TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
=== RUN   TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
=== PAUSE TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
=== RUN   TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
=== PAUSE TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
=== RUN   TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
=== PAUSE TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
=== RUN   TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
=== PAUSE TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
=== RUN   TestAccDynamoDBTable_streamSpecification
=== PAUSE TestAccDynamoDBTable_streamSpecification
=== RUN   TestAccDynamoDBTable_streamSpecificationDiffs
=== PAUSE TestAccDynamoDBTable_streamSpecificationDiffs
=== RUN   TestAccDynamoDBTable_streamSpecificationValidation
=== PAUSE TestAccDynamoDBTable_streamSpecificationValidation
=== RUN   TestAccDynamoDBTable_tags
=== PAUSE TestAccDynamoDBTable_tags
=== RUN   TestAccDynamoDBTable_gsiUpdateCapacity
=== PAUSE TestAccDynamoDBTable_gsiUpdateCapacity
=== RUN   TestAccDynamoDBTable_gsiUpdateOtherAttributes
=== PAUSE TestAccDynamoDBTable_gsiUpdateOtherAttributes
=== RUN   TestAccDynamoDBTable_lsiNonKeyAttributes
=== PAUSE TestAccDynamoDBTable_lsiNonKeyAttributes
=== RUN   TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
=== PAUSE TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
=== RUN   TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
=== PAUSE TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
=== RUN   TestAccDynamoDBTable_TTL_enabled
=== PAUSE TestAccDynamoDBTable_TTL_enabled
=== RUN   TestAccDynamoDBTable_TTL_disabled
=== PAUSE TestAccDynamoDBTable_TTL_disabled
=== RUN   TestAccDynamoDBTable_attributeUpdate
=== PAUSE TestAccDynamoDBTable_attributeUpdate
=== RUN   TestAccDynamoDBTable_lsiUpdate
=== PAUSE TestAccDynamoDBTable_lsiUpdate
=== RUN   TestAccDynamoDBTable_attributeUpdateValidation
=== PAUSE TestAccDynamoDBTable_attributeUpdateValidation
=== RUN   TestAccDynamoDBTable_encryption
=== PAUSE TestAccDynamoDBTable_encryption
=== RUN   TestAccDynamoDBTable_Replica_multiple
=== PAUSE TestAccDynamoDBTable_Replica_multiple
=== RUN   TestAccDynamoDBTable_Replica_single
=== PAUSE TestAccDynamoDBTable_Replica_single
=== RUN   TestAccDynamoDBTable_Replica_singleWithCMK
=== PAUSE TestAccDynamoDBTable_Replica_singleWithCMK
=== RUN   TestAccDynamoDBTable_Replica_pitr
=== PAUSE TestAccDynamoDBTable_Replica_pitr
=== RUN   TestAccDynamoDBTable_Replica_tagsOneOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_tagsOneOfTwo
=== RUN   TestAccDynamoDBTable_Replica_tagsTwoOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_tagsTwoOfTwo
=== RUN   TestAccDynamoDBTable_Replica_tagsNext
=== PAUSE TestAccDynamoDBTable_Replica_tagsNext
=== RUN   TestAccDynamoDBTable_Replica_tagsUpdate
=== PAUSE TestAccDynamoDBTable_Replica_tagsUpdate
=== RUN   TestAccDynamoDBTable_tableClassInfrequentAccess
=== PAUSE TestAccDynamoDBTable_tableClassInfrequentAccess
=== RUN   TestAccDynamoDBTable_backupEncryption
=== PAUSE TestAccDynamoDBTable_backupEncryption
=== RUN   TestAccDynamoDBTable_backup_overrideEncryption
=== PAUSE TestAccDynamoDBTable_backup_overrideEncryption
=== RUN   TestAccDynamoDBTag_basic
=== PAUSE TestAccDynamoDBTag_basic
=== RUN   TestAccDynamoDBTag_disappears
=== PAUSE TestAccDynamoDBTag_disappears
=== RUN   TestAccDynamoDBTag_ResourceARN_tableReplica
=== PAUSE TestAccDynamoDBTag_ResourceARN_tableReplica
=== RUN   TestAccDynamoDBTag_value
=== PAUSE TestAccDynamoDBTag_value
=== CONT  TestAccDynamoDBContributorInsights_basic
=== CONT  TestAccDynamoDBTable_Replica_pitr
=== CONT  TestAccDynamoDBTag_value
=== CONT  TestAccDynamoDBTable_Replica_tagsUpdate
=== CONT  TestAccDynamoDBTable_Replica_tagsTwoOfTwo
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== CONT  TestAccDynamoDBTable_Replica_tagsNext
=== CONT  TestAccDynamoDBTable_tableClassInfrequentAccess
=== CONT  TestAccDynamoDBTable_Replica_singleWithCMK
=== CONT  TestAccDynamoDBTable_Replica_single
=== CONT  TestAccDynamoDBTable_Replica_multiple
=== CONT  TestAccDynamoDBTable_encryption
=== CONT  TestAccDynamoDBTable_attributeUpdateValidation
=== CONT  TestAccDynamoDBTable_lsiUpdate
=== CONT  TestAccDynamoDBTable_attributeUpdate
=== CONT  TestAccDynamoDBTable_TTL_disabled
=== CONT  TestAccDynamoDBTable_TTL_enabled
=== CONT  TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
=== CONT  TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
=== CONT  TestAccDynamoDBTable_backupEncryption
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (37.12s)
=== CONT  TestAccDynamoDBTable_lsiNonKeyAttributes
=== CONT  TestAccDynamoDBTable_gsiUpdateOtherAttributes
--- PASS: TestAccDynamoDBTable_TTL_enabled (118.41s)
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (123.46s)
=== CONT  TestAccDynamoDBTable_gsiUpdateCapacity
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (166.54s)
=== CONT  TestAccDynamoDBTable_tags
--- PASS: TestAccDynamoDBTag_value (186.96s)
=== CONT  TestAccDynamoDBTable_streamSpecificationValidation
--- PASS: TestAccDynamoDBTable_TTL_disabled (191.20s)
=== CONT  TestAccDynamoDBTable_streamSpecificationDiffs
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (196.50s)
=== CONT  TestAccDynamoDBTag_disappears
--- PASS: TestAccDynamoDBTable_lsiUpdate (204.79s)
=== CONT  TestAccDynamoDBTag_ResourceARN_tableReplica
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (19.98s)
=== CONT  TestAccDynamoDBTag_basic
--- PASS: TestAccDynamoDBContributorInsights_basic (219.11s)
=== CONT  TestAccDynamoDBTable_backup_overrideEncryption
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (220.66s)
=== CONT  TestAccDynamoDBTableItem_updateWithRangeKey
--- PASS: TestAccDynamoDBTag_disappears (84.86s)
=== CONT  TestAccDynamoDBTable_enablePITR
--- PASS: TestAccDynamoDBTable_tags (116.00s)
=== CONT  TestAccDynamoDBTable_extended
--- PASS: TestAccDynamoDBTag_basic (96.71s)
=== CONT  TestAccDynamoDBTable_streamSpecification
--- PASS: TestAccDynamoDBTable_gsiUpdateCapacity (165.65s)
=== CONT  TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
=== CONT  TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
--- PASS: TestAccDynamoDBTableItem_updateWithRangeKey (117.38s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
--- PASS: TestAccDynamoDBTable_encryption (346.59s)
--- PASS: TestAccDynamoDBTable_Replica_tagsTwoOfTwo (366.51s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
--- PASS: TestAccDynamoDBTable_Replica_singleWithCMK (368.71s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
--- PASS: TestAccDynamoDBTable_backupEncryption (416.04s)
=== CONT  TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
--- PASS: TestAccDynamoDBTable_enablePITR (143.18s)
=== CONT  TestAccDynamoDBTable_disappears
--- PASS: TestAccDynamoDBTable_streamSpecification (146.25s)
=== CONT  TestAccDynamoDBTableReplica_pitr
--- PASS: TestAccDynamoDBTable_Replica_pitr (465.06s)
=== CONT  TestAccDynamoDBTableReplica_disappears
--- PASS: TestAccDynamoDBTable_extended (197.01s)
=== CONT  TestAccDynamoDBTable_basic
=== CONT  TestAccDynamoDBTableReplica_basic
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (481.59s)
--- PASS: TestAccDynamoDBTag_ResourceARN_tableReplica (282.72s)
=== CONT  TestAccDynamoDBTableReplica_tableClass
=== CONT  TestAccDynamoDBTableItem_disappears
--- PASS: TestAccDynamoDBTable_disappears (87.56s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (183.19s)
=== CONT  TestAccDynamoDBTableReplica_tags
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (174.89s)
=== CONT  TestAccDynamoDBTableDataSource_basic
--- PASS: TestAccDynamoDBTable_basic (100.34s)
=== CONT  TestAccDynamoDBTableItem_withMultipleItems
--- PASS: TestAccDynamoDBTableItem_disappears (76.24s)
=== CONT  TestAccDynamoDBTableItem_rangeKey
--- PASS: TestAccDynamoDBTable_streamSpecificationDiffs (407.20s)
=== CONT  TestAccDynamoDBTableItem_update
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (208.05s)
=== CONT  TestAccDynamoDBTableItem_wonkyItems
--- PASS: TestAccDynamoDBTableDataSource_basic (97.04s)
=== CONT  TestAccDynamoDBKinesisStreamingDestination_basic
--- PASS: TestAccDynamoDBTableItem_withMultipleItems (72.70s)
=== CONT  TestAccDynamoDBKinesisStreamingDestination_Disappears_dynamoDBTable
--- PASS: TestAccDynamoDBTableItem_rangeKey (75.39s)
=== CONT  TestAccDynamoDBKinesisStreamingDestination_disappears
--- PASS: TestAccDynamoDBTable_Replica_single (680.60s)
=== CONT  TestAccDynamoDBGlobalTable_basic
--- PASS: TestAccDynamoDBTableItem_wonkyItems (66.96s)
=== CONT  TestAccDynamoDBGlobalTable_multipleRegions
--- PASS: TestAccDynamoDBTableItem_update (106.15s)
=== CONT  TestAccDynamoDBContributorInsights_disappears
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (710.47s)
=== CONT  TestAccDynamoDBTableItem_basic
=== CONT  TestAccDynamoDBTable_Replica_tagsOneOfTwo
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (501.71s)
--- PASS: TestAccDynamoDBKinesisStreamingDestination_Disappears_dynamoDBTable (97.95s)
--- PASS: TestAccDynamoDBKinesisStreamingDestination_basic (113.60s)
--- PASS: TestAccDynamoDBKinesisStreamingDestination_disappears (94.80s)
--- PASS: TestAccDynamoDBTableItem_basic (64.73s)
--- PASS: TestAccDynamoDBContributorInsights_disappears (75.76s)
--- PASS: TestAccDynamoDBTableReplica_disappears (325.70s)
--- PASS: TestAccDynamoDBGlobalTable_basic (116.64s)
--- PASS: TestAccDynamoDBTable_attributeUpdate (800.74s)
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (687.25s)
--- PASS: TestAccDynamoDBTableReplica_pitr (390.05s)
--- PASS: TestAccDynamoDBTable_Replica_tagsNext (857.75s)
--- PASS: TestAccDynamoDBTable_Replica_multiple (861.92s)
--- PASS: TestAccDynamoDBTableReplica_basic (394.54s)
--- PASS: TestAccDynamoDBGlobalTable_multipleRegions (222.56s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (706.73s)
--- PASS: TestAccDynamoDBTable_Replica_tagsOneOfTwo (358.75s)
--- PASS: TestAccDynamoDBTableReplica_tags (560.88s)
--- PASS: TestAccDynamoDBTableReplica_tableClass (620.81s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (940.10s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (1120.17s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   1469.547s
```
