### PR TITLE
add documenation for tags argument for pages that are missing it

### DIFF
--- a/website/docs/r/appstream_stack.html.markdown
+++ b/website/docs/r/appstream_stack.html.markdown
@@ -73,6 +73,7 @@ The following arguments are optional:
   See [`storage_connectors`](#storage_connectors) below.
 * `user_settings` - (Optional) Configuration block for the actions that are enabled or disabled for users during their streaming sessions. By default, these actions are enabled.
   See [`user_settings`](#user_settings) below.
+* `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### `access_endpoints`
 

--- a/website/docs/r/vpc_ipam_scope.html.markdown
+++ b/website/docs/r/vpc_ipam_scope.html.markdown
@@ -35,6 +35,7 @@ The following arguments are supported:
 
 * `ipam_id` - The ID of the IPAM for which you're creating this scope.
 * `description` - (Optional) A description for the scope you're creating.
+* `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change adds the documentation for the `tags` arguments for resources that support the argument. It makes the same pattern as the other resources support the `tags` argument.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27667

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

Used this script to help discover the pages that were missing the documentation

https://github.com/frek818/random_scripts/blob/master/supports_tagging/run.sh

### Output from Acceptance Testing

Nothing to test.