### PR TITLE
r/aws_sesv2_email_identity_mail_from_attributes: new resource

### DIFF
--- a/.changelog/27672.txt
+++ b/.changelog/27672.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_sesv2_email_identity_mail_from_attributes
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2069,11 +2069,12 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_ses_receipt_rule_set":             ses.ResourceReceiptRuleSet(),
 			"aws_ses_template":                     ses.ResourceTemplate(),
 
-			"aws_sesv2_configuration_set":                  sesv2.ResourceConfigurationSet(),
-			"aws_sesv2_dedicated_ip_assignment":            sesv2.ResourceDedicatedIPAssignment(),
-			"aws_sesv2_dedicated_ip_pool":                  sesv2.ResourceDedicatedIPPool(),
-			"aws_sesv2_email_identity":                     sesv2.ResourceEmailIdentity(),
-			"aws_sesv2_email_identity_feedback_attributes": sesv2.ResourceEmailIdentityFeedbackAttributes(),
+			"aws_sesv2_configuration_set":                   sesv2.ResourceConfigurationSet(),
+			"aws_sesv2_dedicated_ip_assignment":             sesv2.ResourceDedicatedIPAssignment(),
+			"aws_sesv2_dedicated_ip_pool":                   sesv2.ResourceDedicatedIPPool(),
+			"aws_sesv2_email_identity":                      sesv2.ResourceEmailIdentity(),
+			"aws_sesv2_email_identity_feedback_attributes":  sesv2.ResourceEmailIdentityFeedbackAttributes(),
+			"aws_sesv2_email_identity_mail_from_attributes": sesv2.ResourceEmailIdentityMailFromAttributes(),
 
 			"aws_sfn_activity":      sfn.ResourceActivity(),
 			"aws_sfn_state_machine": sfn.ResourceStateMachine(),

--- a/internal/service/sesv2/email_identity_feedback_attributes_test.go
+++ b/internal/service/sesv2/email_identity_feedback_attributes_test.go
@@ -141,7 +141,7 @@ func testAccCheckEmailIdentityFeedbackAttributesExist(name string, emailForwardi
 			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameEmailIdentity, rs.Primary.ID, err)
 		}
 		if out == nil || out.FeedbackForwardingStatus != emailForwardingEnabled {
-			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameEmailIdentityFeedbackAttributes, rs.Primary.ID, err)
+			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameEmailIdentityFeedbackAttributes, rs.Primary.ID, errors.New("feedback attributes not set"))
 		}
 
 		return nil

--- a/internal/service/sesv2/email_identity_mail_from_attributes.go
+++ b/internal/service/sesv2/email_identity_mail_from_attributes.go
@@ -1,0 +1,174 @@
+package sesv2
+
+import (
+	"context"
+	"errors"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sesv2"
+	"github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func ResourceEmailIdentityMailFromAttributes() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceEmailIdentityMailFromAttributesCreate,
+		ReadWithoutTimeout:   resourceEmailIdentityMailFromAttributesRead,
+		UpdateWithoutTimeout: resourceEmailIdentityMailFromAttributesUpdate,
+		DeleteWithoutTimeout: resourceEmailIdentityMailFromAttributesDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"behavior_on_mx_failure": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      string(types.BehaviorOnMxFailureUseDefaultValue),
+				ValidateFunc: validation.StringInSlice(behaviorOnMXFailureValues(types.BehaviorOnMxFailure("").Values()), false),
+			},
+			"email_identity": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"mail_from_domain": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+const (
+	ResNameEmailIdentityMailFromAttributes = "Email Identity Mail From Attributes"
+)
+
+func resourceEmailIdentityMailFromAttributesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).SESV2Client
+
+	in := &sesv2.PutEmailIdentityMailFromAttributesInput{
+		EmailIdentity: aws.String(d.Get("email_identity").(string)),
+	}
+
+	if v, ok := d.GetOk("mail_from_domain"); ok {
+		in.MailFromDomain = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("behavior_on_mx_failure"); ok {
+		in.BehaviorOnMxFailure = types.BehaviorOnMxFailure(v.(string))
+	}
+
+	if in.BehaviorOnMxFailure == types.BehaviorOnMxFailureRejectMessage && in.MailFromDomain == nil {
+		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameEmailIdentityMailFromAttributes, d.Get("email_identity").(string), errors.New("mail from is required if behavior on mx failure is REJECT_MESSAGE"))
+	}
+
+	out, err := conn.PutEmailIdentityMailFromAttributes(ctx, in)
+	if err != nil {
+		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameEmailIdentityMailFromAttributes, d.Get("name").(string), err)
+	}
+
+	if out == nil {
+		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameEmailIdentityMailFromAttributes, d.Get("name").(string), errors.New("empty output"))
+	}
+
+	d.SetId(d.Get("email_identity").(string))
+
+	return resourceEmailIdentityMailFromAttributesRead(ctx, d, meta)
+}
+
+func resourceEmailIdentityMailFromAttributesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).SESV2Client
+
+	out, err := FindEmailIdentityByID(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] SESV2 EmailIdentityMailFromAttributes (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.SESV2, create.ErrActionReading, ResNameEmailIdentityMailFromAttributes, d.Id(), err)
+	}
+
+	d.Set("email_identity", d.Id())
+
+	if out.MailFromAttributes != nil {
+		d.Set("behavior_on_mx_failure", out.MailFromAttributes.BehaviorOnMxFailure)
+		d.Set("mail_from_domain", out.MailFromAttributes.MailFromDomain)
+	} else {
+		d.Set("behavior_on_mx_failure", nil)
+		d.Set("mail_from_domain", nil)
+	}
+
+	return nil
+}
+
+func resourceEmailIdentityMailFromAttributesUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).SESV2Client
+
+	update := false
+
+	in := &sesv2.PutEmailIdentityMailFromAttributesInput{
+		EmailIdentity: aws.String(d.Id()),
+	}
+
+	if d.HasChanges("behavior_on_mx_failure", "mail_from_domain") {
+		in.BehaviorOnMxFailure = types.BehaviorOnMxFailure((d.Get("behavior_on_mx_failure").(string)))
+		in.MailFromDomain = aws.String(d.Get("mail_from_domain").(string))
+
+		update = true
+	}
+
+	if !update {
+		return nil
+	}
+
+	log.Printf("[DEBUG] Updating SESV2 EmailIdentityMailFromAttributes (%s): %#v", d.Id(), in)
+	_, err := conn.PutEmailIdentityMailFromAttributes(ctx, in)
+	if err != nil {
+		return create.DiagError(names.SESV2, create.ErrActionUpdating, ResNameEmailIdentityMailFromAttributes, d.Id(), err)
+	}
+
+	return resourceEmailIdentityMailFromAttributesRead(ctx, d, meta)
+}
+
+func resourceEmailIdentityMailFromAttributesDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).SESV2Client
+
+	log.Printf("[INFO] Deleting SESV2 EmailIdentityMailFromAttributes %s", d.Id())
+
+	_, err := conn.PutEmailIdentityMailFromAttributes(ctx, &sesv2.PutEmailIdentityMailFromAttributesInput{
+		EmailIdentity: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		var nfe *types.NotFoundException
+		if errors.As(err, &nfe) {
+			return nil
+		}
+
+		return create.DiagError(names.SESV2, create.ErrActionDeleting, ResNameEmailIdentityMailFromAttributes, d.Id(), err)
+	}
+
+	return nil
+}
+
+func behaviorOnMXFailureValues(in []types.BehaviorOnMxFailure) []string {
+	var out []string
+
+	for _, v := range in {
+		out = append(out, string(v))
+	}
+
+	return out
+}

--- a/internal/service/sesv2/email_identity_mail_from_attributes.go
+++ b/internal/service/sesv2/email_identity_mail_from_attributes.go
@@ -10,9 +10,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sesv2/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -32,10 +32,10 @@ func ResourceEmailIdentityMailFromAttributes() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"behavior_on_mx_failure": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      string(types.BehaviorOnMxFailureUseDefaultValue),
-				ValidateFunc: validation.StringInSlice(behaviorOnMXFailureValues(types.BehaviorOnMxFailure("").Values()), false),
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          string(types.BehaviorOnMxFailureUseDefaultValue),
+				ValidateDiagFunc: enum.Validate[types.BehaviorOnMxFailure](),
 			},
 			"email_identity": {
 				Type:     schema.TypeString,
@@ -167,14 +167,4 @@ func resourceEmailIdentityMailFromAttributesDelete(ctx context.Context, d *schem
 	}
 
 	return nil
-}
-
-func behaviorOnMXFailureValues(in []types.BehaviorOnMxFailure) []string {
-	var out []string
-
-	for _, v := range in {
-		out = append(out, string(v))
-	}
-
-	return out
 }

--- a/internal/service/sesv2/email_identity_mail_from_attributes.go
+++ b/internal/service/sesv2/email_identity_mail_from_attributes.go
@@ -75,11 +75,11 @@ func resourceEmailIdentityMailFromAttributesCreate(ctx context.Context, d *schem
 
 	out, err := conn.PutEmailIdentityMailFromAttributes(ctx, in)
 	if err != nil {
-		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameEmailIdentityMailFromAttributes, d.Get("name").(string), err)
+		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameEmailIdentityMailFromAttributes, d.Get("email_identity").(string), err)
 	}
 
 	if out == nil {
-		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameEmailIdentityMailFromAttributes, d.Get("name").(string), errors.New("empty output"))
+		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameEmailIdentityMailFromAttributes, d.Get("email_identity").(string), errors.New("empty output"))
 	}
 
 	d.SetId(d.Get("email_identity").(string))

--- a/internal/service/sesv2/email_identity_mail_from_attributes_test.go
+++ b/internal/service/sesv2/email_identity_mail_from_attributes_test.go
@@ -44,8 +44,34 @@ func TestAccSESV2EmailIdentityMailFromAttributes_basic(t *testing.T) {
 }
 
 func TestAccSESV2EmailIdentityMailFromAttributes_disappears(t *testing.T) {
+	domain := acctest.RandomDomain()
+	mailFromDomain := domain.Subdomain("test")
+
+	rName := domain.String()
+	resourceName := "aws_sesv2_email_identity_mail_from_attributes.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEmailIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEmailIdentityMailFromAttributesConfig_behaviorOnMXFailureAndMailFromDomain(rName, string(types.BehaviorOnMxFailureUseDefaultValue), mailFromDomain.String()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEmailIdentityMailFromAttributesExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfsesv2.ResourceEmailIdentityMailFromAttributes(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccSESV2EmailIdentityMailFromAttributes_disappearsEmailIdentity(t *testing.T) {
 	rName := acctest.RandomDomainName()
 	resourceName := "aws_sesv2_email_identity_mail_from_attributes.test"
+	emailIdentityName := "aws_sesv2_email_identity.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -57,7 +83,7 @@ func TestAccSESV2EmailIdentityMailFromAttributes_disappears(t *testing.T) {
 				Config: testAccEmailIdentityMailFromAttributesConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEmailIdentityMailFromAttributesExists(resourceName),
-					acctest.CheckResourceDisappears(acctest.Provider, tfsesv2.ResourceEmailIdentity(), resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfsesv2.ResourceEmailIdentity(), emailIdentityName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/service/sesv2/email_identity_mail_from_attributes_test.go
+++ b/internal/service/sesv2/email_identity_mail_from_attributes_test.go
@@ -184,7 +184,7 @@ func testAccCheckEmailIdentityMailFromAttributesExists(name string) resource.Tes
 		}
 
 		if out == nil || out.MailFromAttributes == nil {
-			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameEmailIdentityMailFromAttributes, rs.Primary.ID, err)
+			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameEmailIdentityMailFromAttributes, rs.Primary.ID, errors.New("mail from attributes not set"))
 		}
 
 		return nil

--- a/internal/service/sesv2/email_identity_mail_from_attributes_test.go
+++ b/internal/service/sesv2/email_identity_mail_from_attributes_test.go
@@ -1,0 +1,192 @@
+package sesv2_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfsesv2 "github.com/hashicorp/terraform-provider-aws/internal/service/sesv2"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccSESV2EmailIdentityMailFromAttributes_basic(t *testing.T) {
+	rName := acctest.RandomDomainName()
+	resourceName := "aws_sesv2_email_identity_mail_from_attributes.test"
+	emailIdentityName := "aws_sesv2_email_identity.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEmailIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEmailIdentityMailFromAttributesConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEmailIdentityMailFromAttributesExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "email_identity", emailIdentityName, "email_identity"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSESV2EmailIdentityMailFromAttributes_disappears(t *testing.T) {
+	rName := acctest.RandomDomainName()
+	resourceName := "aws_sesv2_email_identity_mail_from_attributes.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEmailIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEmailIdentityMailFromAttributesConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEmailIdentityMailFromAttributesExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfsesv2.ResourceEmailIdentity(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccSESV2EmailIdentityMailFromAttributes_behaviorOnMXFailure(t *testing.T) {
+	domain := acctest.RandomDomain()
+	mailFromDomain := domain.Subdomain("test")
+
+	rName := domain.String()
+	resourceName := "aws_sesv2_email_identity_mail_from_attributes.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEmailIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEmailIdentityMailFromAttributesConfig_behaviorOnMXFailureAndMailFromDomain(rName, string(types.BehaviorOnMxFailureUseDefaultValue), mailFromDomain.String()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEmailIdentityMailFromAttributesExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "behavior_on_mx_failure", string(types.BehaviorOnMxFailureUseDefaultValue)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccEmailIdentityMailFromAttributesConfig_behaviorOnMXFailureAndMailFromDomain(rName, string(types.BehaviorOnMxFailureRejectMessage), mailFromDomain.String()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEmailIdentityMailFromAttributesExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "behavior_on_mx_failure", string(types.BehaviorOnMxFailureRejectMessage)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSESV2EmailIdentityMailFromAttributes_mailFromDomain(t *testing.T) {
+	domain := acctest.RandomDomain()
+	mailFromDomain1 := domain.Subdomain("test1")
+	mailFromDomain2 := domain.Subdomain("test2")
+
+	rName := domain.String()
+	resourceName := "aws_sesv2_email_identity_mail_from_attributes.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEmailIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEmailIdentityMailFromAttributesConfig_behaviorOnMXFailureAndMailFromDomain(rName, string(types.BehaviorOnMxFailureUseDefaultValue), mailFromDomain1.String()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEmailIdentityMailFromAttributesExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "mail_from_domain", mailFromDomain1.String()),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccEmailIdentityMailFromAttributesConfig_behaviorOnMXFailureAndMailFromDomain(rName, string(types.BehaviorOnMxFailureUseDefaultValue), mailFromDomain2.String()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEmailIdentityMailFromAttributesExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "mail_from_domain", mailFromDomain2.String()),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckEmailIdentityMailFromAttributesExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameEmailIdentityMailFromAttributes, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameEmailIdentityMailFromAttributes, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SESV2Client
+
+		out, err := tfsesv2.FindEmailIdentityByID(context.Background(), conn, rs.Primary.ID)
+
+		if err != nil {
+			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameEmailIdentityMailFromAttributes, rs.Primary.ID, err)
+		}
+
+		if out == nil || out.MailFromAttributes == nil {
+			return create.Error(names.SESV2, create.ErrActionCheckingExistence, tfsesv2.ResNameEmailIdentityMailFromAttributes, rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccEmailIdentityMailFromAttributesConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sesv2_email_identity" "test" {
+  email_identity = %[1]q
+}
+
+resource "aws_sesv2_email_identity_mail_from_attributes" "test" {
+  email_identity = aws_sesv2_email_identity.test.email_identity
+}
+`, rName)
+}
+
+func testAccEmailIdentityMailFromAttributesConfig_behaviorOnMXFailureAndMailFromDomain(rName, behaviorOnMXFailure, mailFromDomain string) string {
+	return fmt.Sprintf(`
+resource "aws_sesv2_email_identity" "test" {
+  email_identity = %[1]q
+}
+
+resource "aws_sesv2_email_identity_mail_from_attributes" "test" {
+  email_identity         = aws_sesv2_email_identity.test.email_identity
+  behavior_on_mx_failure = %[2]q
+  mail_from_domain       = %[3]q
+}
+`, rName, behaviorOnMXFailure, mailFromDomain)
+}

--- a/website/docs/r/sesv2_email_identity_mail_from_attributes.html.markdown
+++ b/website/docs/r/sesv2_email_identity_mail_from_attributes.html.markdown
@@ -1,0 +1,48 @@
+---
+subcategory: "SESv2 (Simple Email V2)"
+layout: "aws"
+page_title: "AWS: aws_sesv2_email_identity_mail_from_attributes"
+description: |-
+  Terraform resource for managing an AWS SESv2 (Simple Email V2) Email Identity Mail From Attributes.
+---
+
+# Resource: aws_sesv2_email_identity_mail_from_attributes
+
+Terraform resource for managing an AWS SESv2 (Simple Email V2) Email Identity Mail From Attributes.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_sesv2_email_identity" "example" {
+  email_identity = "example.com"
+}
+
+resource "aws_sesv2_email_identity_mail_from_attributes" "example" {
+  email_identity = aws_sesv2_email_identity.example.email_identity
+
+  behavior_on_mx_failure = "REJECT_MESSAGE"
+  mail_from_domain       = "test.${aws_sesv2_email_identity.test.email_identity}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `email_identity` - (Required) The verified email identity.
+* `behavior_on_mx_failure` - (Optional) The action to take if the required MX record isn't found when you send an email. Valid values: `USE_DEFAULT_VALUE`, `REJECT_MESSAGE`.
+* `mail_from_domain` - (Optional) The custom MAIL FROM domain that you want the verified identity to use.
+
+## Attributes Reference
+
+No additional attributes are exported.
+
+## Import
+
+SESv2 (Simple Email V2) Email Identity Mail From Attributes can be imported using the `email_identity`, e.g.,
+
+```
+$ terraform import aws_sesv2_email_identity_mail_from_attributes.example example.com
+```

--- a/website/docs/r/sesv2_email_identity_mail_from_attributes.html.markdown
+++ b/website/docs/r/sesv2_email_identity_mail_from_attributes.html.markdown
@@ -23,7 +23,7 @@ resource "aws_sesv2_email_identity_mail_from_attributes" "example" {
   email_identity = aws_sesv2_email_identity.example.email_identity
 
   behavior_on_mx_failure = "REJECT_MESSAGE"
-  mail_from_domain       = "test.${aws_sesv2_email_identity.test.email_identity}"
+  mail_from_domain       = "subdomain.${aws_sesv2_email_identity.example.email_identity}"
 }
 ```
 

--- a/website/docs/r/sesv2_email_identity_mail_from_attributes.html.markdown
+++ b/website/docs/r/sesv2_email_identity_mail_from_attributes.html.markdown
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 * `email_identity` - (Required) The verified email identity.
 * `behavior_on_mx_failure` - (Optional) The action to take if the required MX record isn't found when you send an email. Valid values: `USE_DEFAULT_VALUE`, `REJECT_MESSAGE`.
-* `mail_from_domain` - (Optional) The custom MAIL FROM domain that you want the verified identity to use.
+* `mail_from_domain` - (Optional) The custom MAIL FROM domain that you want the verified identity to use. Required if `behavior_on_mx_failure` is `REJECT_MESSAGE`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Description
This PR introduces the `aws_sesv2_email_identity_mail_from_attributes` resource.

### Relations
Relates #26796.

### References
https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_PutEmailIdentityMailFromAttributes.html

### Output from Acceptance Testing
```
$ make testacc TESTARGS='-run=TestAccSESV2EmailIdentityMailFromAttributes_' PKG=sesv2 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sesv2/... -v -count 1 -parallel 2  -run=TestAccSESV2EmailIdentityMailFromAttributes_ -timeout 180m
=== RUN   TestAccSESV2EmailIdentityMailFromAttributes_basic
=== PAUSE TestAccSESV2EmailIdentityMailFromAttributes_basic
=== RUN   TestAccSESV2EmailIdentityMailFromAttributes_disappears
=== PAUSE TestAccSESV2EmailIdentityMailFromAttributes_disappears
=== RUN   TestAccSESV2EmailIdentityMailFromAttributes_behaviorOnMXFailure
=== PAUSE TestAccSESV2EmailIdentityMailFromAttributes_behaviorOnMXFailure
=== RUN   TestAccSESV2EmailIdentityMailFromAttributes_mailFromDomain
=== PAUSE TestAccSESV2EmailIdentityMailFromAttributes_mailFromDomain
=== CONT  TestAccSESV2EmailIdentityMailFromAttributes_basic
=== CONT  TestAccSESV2EmailIdentityMailFromAttributes_behaviorOnMXFailure
--- PASS: TestAccSESV2EmailIdentityMailFromAttributes_basic (29.15s)
=== CONT  TestAccSESV2EmailIdentityMailFromAttributes_mailFromDomain
--- PASS: TestAccSESV2EmailIdentityMailFromAttributes_behaviorOnMXFailure (47.77s)
=== CONT  TestAccSESV2EmailIdentityMailFromAttributes_disappears
--- PASS: TestAccSESV2EmailIdentityMailFromAttributes_disappears (19.39s)
--- PASS: TestAccSESV2EmailIdentityMailFromAttributes_mailFromDomain (44.30s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sesv2      75.237s
```
