### PR TITLE
Change parameter to optional and add test

### DIFF
--- a/.changelog/27693.txt
+++ b/.changelog/27693.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpn_connection: Configuring exactly one of `transit_gateway_id` or `vpn_gateway_id` is not required
+```

--- a/internal/service/ec2/vpnsite_connection.go
+++ b/internal/service/ec2/vpnsite_connection.go
@@ -128,9 +128,9 @@ func ResourceVPNConnection() *schema.Resource {
 				Computed: true,
 			},
 			"transit_gateway_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ExactlyOneOf: []string{"transit_gateway_id", "vpn_gateway_id"},
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"vpn_gateway_id"},
 			},
 			"transport_transit_gateway_attachment_id": {
 				Type:     schema.TypeString,
@@ -608,9 +608,9 @@ func ResourceVPNConnection() *schema.Resource {
 				},
 			},
 			"vpn_gateway_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ExactlyOneOf: []string{"transit_gateway_id", "vpn_gateway_id"},
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"transit_gateway_id"},
 			},
 		},
 

--- a/internal/service/ec2/vpnsite_connection_test.go
+++ b/internal/service/ec2/vpnsite_connection_test.go
@@ -241,6 +241,99 @@ func TestAccSiteVPNConnection_basic(t *testing.T) {
 	})
 }
 
+func TestAccSiteVPNConnection_withoutTGWorVGW(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
+	resourceName := "aws_vpn_connection.test"
+	var vpn ec2.VpnConnection
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccVPNConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSiteVPNConnectionConfig_withoutTGWorVGW(rName, rBgpAsn),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVPNConnectionExists(resourceName, &vpn),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`vpn-connection/vpn-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "core_network_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "core_network_attachment_arn", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "customer_gateway_configuration"),
+					resource.TestCheckResourceAttr(resourceName, "enable_acceleration", "false"),
+					resource.TestCheckResourceAttr(resourceName, "local_ipv4_network_cidr", "0.0.0.0/0"),
+					resource.TestCheckResourceAttr(resourceName, "local_ipv6_network_cidr", ""),
+					resource.TestCheckResourceAttr(resourceName, "outside_ip_address_type", "PublicIpv4"),
+					resource.TestCheckResourceAttr(resourceName, "remote_ipv4_network_cidr", "0.0.0.0/0"),
+					resource.TestCheckResourceAttr(resourceName, "remote_ipv6_network_cidr", ""),
+					resource.TestCheckResourceAttr(resourceName, "routes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "static_routes_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_attachment_id", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel1_address"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_bgp_holdtime", "30"),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel1_cgw_inside_address"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_dpd_timeout_action", ""),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_dpd_timeout_seconds", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel1_ike_versions"),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel1_inside_cidr"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_inside_ipv6_cidr", ""),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_log_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_log_options.0.cloudwatch_log_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_log_options.0.cloudwatch_log_options.0.log_enabled", "false"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel1_phase1_dh_group_numbers"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel1_phase1_encryption_algorithms"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel1_phase1_integrity_algorithms"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_phase1_lifetime_seconds", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel1_phase2_dh_group_numbers"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel1_phase2_encryption_algorithms"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel1_phase2_integrity_algorithms"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_phase2_lifetime_seconds", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel1_preshared_key"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_rekey_fuzz_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_rekey_margin_time_seconds", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_replay_window_size", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel1_startup_action", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel1_vgw_inside_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel2_address"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_bgp_holdtime", "30"),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel2_cgw_inside_address"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_dpd_timeout_action", ""),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_dpd_timeout_seconds", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel2_ike_versions"),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel2_inside_cidr"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_inside_ipv6_cidr", ""),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_log_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_log_options.0.cloudwatch_log_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_log_options.0.cloudwatch_log_options.0.log_enabled", "false"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel2_phase1_dh_group_numbers"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel2_phase1_encryption_algorithms"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel2_phase1_integrity_algorithms"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_phase1_lifetime_seconds", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel2_phase2_dh_group_numbers"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel2_phase2_encryption_algorithms"),
+					resource.TestCheckNoResourceAttr(resourceName, "tunnel2_phase2_integrity_algorithms"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_phase2_lifetime_seconds", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel2_preshared_key"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_rekey_fuzz_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_rekey_margin_time_seconds", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_replay_window_size", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel2_startup_action", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "tunnel2_vgw_inside_address"),
+					resource.TestCheckResourceAttr(resourceName, "tunnel_inside_ip_version", "ipv4"),
+					resource.TestCheckResourceAttr(resourceName, "vgw_telemetry.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccSiteVPNConnection_cloudWatchLogOptions(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
@@ -1620,6 +1713,25 @@ resource "aws_customer_gateway" "test" {
 
 resource "aws_vpn_connection" "test" {
   vpn_gateway_id      = aws_vpn_gateway.test.id
+  customer_gateway_id = aws_customer_gateway.test.id
+  type                = "ipsec.1"
+}
+`, rName, rBgpAsn)
+}
+
+func testAccSiteVPNConnectionConfig_withoutTGWorVGW(rName string, rBgpAsn int) string {
+	return fmt.Sprintf(`
+resource "aws_customer_gateway" "test" {
+  bgp_asn    = %[2]d
+  ip_address = "178.0.0.1"
+  type       = "ipsec.1"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpn_connection" "test" {
   customer_gateway_id = aws_customer_gateway.test.id
   type                = "ipsec.1"
 }

--- a/website/docs/r/vpn_connection.html.markdown
+++ b/website/docs/r/vpn_connection.html.markdown
@@ -121,18 +121,12 @@ resource "aws_vpn_connection" "example" {
 
 ## Argument Reference
 
-The following arguments are required:
+The following arguments are supported:
 
 * `customer_gateway_id` - (Required) The ID of the customer gateway.
 * `type` - (Required) The type of VPN connection. The only type AWS supports at this time is "ipsec.1".
-
-One of the following arguments is required:
-
 * `transit_gateway_id` - (Optional) The ID of the EC2 Transit Gateway.
 * `vpn_gateway_id` - (Optional) The ID of the Virtual Private Gateway.
-
-Other arguments:
-
 * `static_routes_only` - (Optional, Default `false`) Whether the VPN connection uses static routes exclusively. Static routes must be used for devices that don't support BGP.
 * `enable_acceleration` - (Optional, Default `false`) Indicate whether to enable acceleration for the VPN connection. Supports only EC2 Transit Gateway.
 * `tags` - (Optional) Tags to apply to the connection. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Change VPN connection parameters "transit_gateway_id" and "vpn_gateway_id" to optional. Before, one of these was required but AWS VPN API documentation states that these are optional and conflicting. 

### Relations
Relates #27387 


### References
AWS VPN API documentation https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVpnConnection.html.


### Output from Acceptance Testing

```
-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_basic          
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_basic'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_basic
=== PAUSE TestAccSiteVPNConnection_basic
=== CONT  TestAccSiteVPNConnection_basic
--- PASS: TestAccSiteVPNConnection_basic (207.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        212.027s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_withoutTGWorVGW
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_withoutTGWorVGW'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_withoutTGWorVGW
=== PAUSE TestAccSiteVPNConnection_withoutTGWorVGW
=== CONT  TestAccSiteVPNConnection_withoutTGWorVGW
--- PASS: TestAccSiteVPNConnection_withoutTGWorVGW (61.09s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        69.091s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_transitGatewayID
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_transitGatewayID'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_transitGatewayID
=== PAUSE TestAccSiteVPNConnection_transitGatewayID
=== RUN   TestAccSiteVPNConnection_transitGatewayIDToVPNGatewayID
=== PAUSE TestAccSiteVPNConnection_transitGatewayIDToVPNGatewayID
=== CONT  TestAccSiteVPNConnection_transitGatewayID
=== CONT  TestAccSiteVPNConnection_transitGatewayIDToVPNGatewayID
--- PASS: TestAccSiteVPNConnection_transitGatewayID (401.38s)
--- PASS: TestAccSiteVPNConnection_transitGatewayIDToVPNGatewayID (672.13s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        677.662s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_tunnel1PreSharedKey
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_tunnel1PreSharedKey'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_tunnel1PreSharedKey
=== PAUSE TestAccSiteVPNConnection_tunnel1PreSharedKey
=== CONT  TestAccSiteVPNConnection_tunnel1PreSharedKey
--- PASS: TestAccSiteVPNConnection_tunnel1PreSharedKey (203.45s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        208.050s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_outsideAddressTypePrivate
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_outsideAddressTypePrivate'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_outsideAddressTypePrivate
=== PAUSE TestAccSiteVPNConnection_outsideAddressTypePrivate
=== CONT  TestAccSiteVPNConnection_outsideAddressTypePrivate

--- PASS: TestAccSiteVPNConnection_outsideAddressTypePrivate (2140.24s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        2147.108s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_tunnelOptionsLesser
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_tunnelOptionsLesser'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_tunnelOptionsLesser
=== PAUSE TestAccSiteVPNConnection_tunnelOptionsLesser
=== CONT  TestAccSiteVPNConnection_tunnelOptionsLesser
--- PASS: TestAccSiteVPNConnection_tunnelOptionsLesser (1283.78s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2 1289.030s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_tags
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_tags'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_tags
=== PAUSE TestAccSiteVPNConnection_tags
=== CONT  TestAccSiteVPNConnection_tags
--- PASS: TestAccSiteVPNConnection_tags (242.17s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        246.408s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_specifyIPv4
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_specifyIPv4'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_specifyIPv4
=== PAUSE TestAccSiteVPNConnection_specifyIPv4
=== CONT  TestAccSiteVPNConnection_specifyIPv4
--- PASS: TestAccSiteVPNConnection_specifyIPv4 (517.28s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        524.372s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_updateCustomerGatewayID
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_updateCustomerGatewayID'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_updateCustomerGatewayID
=== PAUSE TestAccSiteVPNConnection_updateCustomerGatewayID
=== CONT  TestAccSiteVPNConnection_updateCustomerGatewayID
--- PASS: TestAccSiteVPNConnection_updateCustomerGatewayID (497.89s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        502.665s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_updateVPNGatewayID     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_updateVPNGatewayID'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_updateVPNGatewayID
=== PAUSE TestAccSiteVPNConnection_updateVPNGatewayID
=== CONT  TestAccSiteVPNConnection_updateVPNGatewayID
--- PASS: TestAccSiteVPNConnection_updateVPNGatewayID (496.59s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        504.180s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_vpnGatewayIDToTransitGatewayID
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_vpnGatewayIDToTransitGatewayID'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_vpnGatewayIDToTransitGatewayID
=== PAUSE TestAccSiteVPNConnection_vpnGatewayIDToTransitGatewayID
=== CONT  TestAccSiteVPNConnection_vpnGatewayIDToTransitGatewayID
--- PASS: TestAccSiteVPNConnection_vpnGatewayIDToTransitGatewayID (677.75s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        682.061s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_cloudWatchLogOptions
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_cloudWatchLogOptions'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_cloudWatchLogOptions
=== PAUSE TestAccSiteVPNConnection_cloudWatchLogOptions
=== CONT  TestAccSiteVPNConnection_cloudWatchLogOptions
--- PASS: TestAccSiteVPNConnection_cloudWatchLogOptions (543.04s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        547.612s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_tunnel1InsideCIDR   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_tunnel1InsideCIDR'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_tunnel1InsideCIDR
=== PAUSE TestAccSiteVPNConnection_tunnel1InsideCIDR
=== CONT  TestAccSiteVPNConnection_tunnel1InsideCIDR
--- PASS: TestAccSiteVPNConnection_tunnel1InsideCIDR (204.85s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        210.193s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR                         
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR
=== PAUSE TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR
=== CONT  TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR
--- PASS: TestAccSiteVPNConnection_tunnel1InsideIPv6CIDR (487.91s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        492.806s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_tunnelOptions        
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_tunnelOptions'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_tunnelOptions
=== PAUSE TestAccSiteVPNConnection_tunnelOptions
=== RUN   TestAccSiteVPNConnection_tunnelOptionsLesser
=== PAUSE TestAccSiteVPNConnection_tunnelOptionsLesser
=== CONT  TestAccSiteVPNConnection_tunnelOptions
=== CONT  TestAccSiteVPNConnection_tunnelOptionsLesser
--- PASS: TestAccSiteVPNConnection_tunnelOptions (211.63s)
--- PASS: TestAccSiteVPNConnection_tunnelOptionsLesser (1200.51s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        1204.786s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_staticRoutes 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_staticRoutes'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_staticRoutes
=== PAUSE TestAccSiteVPNConnection_staticRoutes
=== CONT  TestAccSiteVPNConnection_staticRoutes
--- PASS: TestAccSiteVPNConnection_staticRoutes (206.21s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        210.550s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_outsideAddressTypePublic
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_outsideAddressTypePublic'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_outsideAddressTypePublic
=== PAUSE TestAccSiteVPNConnection_outsideAddressTypePublic
=== CONT  TestAccSiteVPNConnection_outsideAddressTypePublic
--- PASS: TestAccSiteVPNConnection_outsideAddressTypePublic (208.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        213.003s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_enableAcceleration      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_enableAcceleration'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_enableAcceleration
=== PAUSE TestAccSiteVPNConnection_enableAcceleration
=== CONT  TestAccSiteVPNConnection_enableAcceleration
--- PASS: TestAccSiteVPNConnection_enableAcceleration (482.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        486.924s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_ipv6              
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_ipv6'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_ipv6
=== PAUSE TestAccSiteVPNConnection_ipv6
=== CONT  TestAccSiteVPNConnection_ipv6

--- PASS: TestAccSiteVPNConnection_ipv6 (2051.78s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        2056.236s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_specifyIPv6
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_specifyIPv6'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_specifyIPv6
=== PAUSE TestAccSiteVPNConnection_specifyIPv6
=== CONT  TestAccSiteVPNConnection_specifyIPv6
--- PASS: TestAccSiteVPNConnection_specifyIPv6 (459.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        463.819s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_disappears 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_disappears'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_disappears
=== PAUSE TestAccSiteVPNConnection_disappears
=== CONT  TestAccSiteVPNConnection_disappears
--- PASS: TestAccSiteVPNConnection_disappears (203.11s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        210.480s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_updateTransitGatewayID
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_updateTransitGatewayID'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_updateTransitGatewayID
=== PAUSE TestAccSiteVPNConnection_updateTransitGatewayID
=== CONT  TestAccSiteVPNConnection_updateTransitGatewayID
--- PASS: TestAccSiteVPNConnection_updateTransitGatewayID (873.93s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        878.767s

-> % make testacc PKG=ec2 TESTS=TestAccSiteVPNConnection_transitGatewayIDToVPNGatewayID
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_transitGatewayIDToVPNGatewayID'  -timeout 180m
=== RUN   TestAccSiteVPNConnection_transitGatewayIDToVPNGatewayID
=== PAUSE TestAccSiteVPNConnection_transitGatewayIDToVPNGatewayID
=== CONT  TestAccSiteVPNConnection_transitGatewayIDToVPNGatewayID
--- PASS: TestAccSiteVPNConnection_transitGatewayIDToVPNGatewayID (629.89s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        634.183s

...
```
