### PR TITLE
s3 datasource aws_s3_object can read application/xml

### DIFF
--- a/.changelog/27704.txt
+++ b/.changelog/27704.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+data-source/aws_s3_object: Expand content types that can be read from S3 to some human-readable application types (e.g., `application/xml`, `application/atom+xml`)
+```
+
+```release-note:enhancement
+data-source/aws_s3_bucket_object: Expand content types that can be read from S3 to some human-readable application types (e.g., `application/xml`, `application/atom+xml`)
+```

--- a/.changelog/27704.txt
+++ b/.changelog/27704.txt
@@ -1,7 +1,7 @@
 ```release-note:enhancement
-data-source/aws_s3_object: Expand content types that can be read from S3 to some human-readable application types (e.g., `application/xml`, `application/atom+xml`)
+data-source/aws_s3_object: Expand content types that can be read from S3 to include some human-readable application types (e.g., `application/xml`, `application/atom+xml`)
 ```
 
 ```release-note:enhancement
-data-source/aws_s3_bucket_object: Expand content types that can be read from S3 to some human-readable application types (e.g., `application/xml`, `application/atom+xml`)
+data-source/aws_s3_bucket_object: Expand content types that can be read from S3 to include some human-readable application types (e.g., `application/xml`, `application/atom+xml`)
 ```

--- a/internal/service/s3/object_data_source.go
+++ b/internal/service/s3/object_data_source.go
@@ -258,6 +258,7 @@ func isContentTypeAllowed(contentType *string) bool {
 	allowedContentTypes := []*regexp.Regexp{
 		regexp.MustCompile("^text/.+"),
 		regexp.MustCompile("^application/json$"),
+		regexp.MustCompile("^application/xml$"),
 	}
 
 	for _, r := range allowedContentTypes {

--- a/internal/service/s3/object_data_source.go
+++ b/internal/service/s3/object_data_source.go
@@ -256,9 +256,15 @@ func isContentTypeAllowed(contentType *string) bool {
 	}
 
 	allowedContentTypes := []*regexp.Regexp{
-		regexp.MustCompile("^text/.+"),
-		regexp.MustCompile("^application/json$"),
-		regexp.MustCompile("^application/xml$"),
+		regexp.MustCompile(`^application/atom\+xml$`),
+		regexp.MustCompile(`^application/json$`),
+		regexp.MustCompile(`^application/ld\+json$`),
+		regexp.MustCompile(`^application/x-csh$`),
+		regexp.MustCompile(`^application/x-httpd-php$`),
+		regexp.MustCompile(`^application/x-sh$`),
+		regexp.MustCompile(`^application/xhtml\+xml$`),
+		regexp.MustCompile(`^application/xml$`),
+		regexp.MustCompile(`^text/.+`),
 	}
 
 	for _, r := range allowedContentTypes {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This fix allows datasource aws_s3_object to read application/xml.
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27697

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccS3ObjectDataSource PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3ObjectDataSource'  -timeout 180m
=== RUN   TestAccS3ObjectDataSource_basic
=== PAUSE TestAccS3ObjectDataSource_basic
=== RUN   TestAccS3ObjectDataSource_basicViaAccessPoint
=== PAUSE TestAccS3ObjectDataSource_basicViaAccessPoint
=== RUN   TestAccS3ObjectDataSource_readableBody
=== PAUSE TestAccS3ObjectDataSource_readableBody
=== RUN   TestAccS3ObjectDataSource_kmsEncrypted
=== PAUSE TestAccS3ObjectDataSource_kmsEncrypted
=== RUN   TestAccS3ObjectDataSource_bucketKeyEnabled
=== PAUSE TestAccS3ObjectDataSource_bucketKeyEnabled
=== RUN   TestAccS3ObjectDataSource_allParams
=== PAUSE TestAccS3ObjectDataSource_allParams
=== RUN   TestAccS3ObjectDataSource_objectLockLegalHoldOff
=== PAUSE TestAccS3ObjectDataSource_objectLockLegalHoldOff
=== RUN   TestAccS3ObjectDataSource_objectLockLegalHoldOn
=== PAUSE TestAccS3ObjectDataSource_objectLockLegalHoldOn
=== RUN   TestAccS3ObjectDataSource_leadingSlash
=== PAUSE TestAccS3ObjectDataSource_leadingSlash
=== RUN   TestAccS3ObjectDataSource_multipleSlashes
=== PAUSE TestAccS3ObjectDataSource_multipleSlashes
=== RUN   TestAccS3ObjectDataSource_singleSlashAsKey
=== PAUSE TestAccS3ObjectDataSource_singleSlashAsKey
=== CONT  TestAccS3ObjectDataSource_basic
=== CONT  TestAccS3ObjectDataSource_objectLockLegalHoldOff
=== CONT  TestAccS3ObjectDataSource_kmsEncrypted
=== CONT  TestAccS3ObjectDataSource_bucketKeyEnabled
=== CONT  TestAccS3ObjectDataSource_readableBody
=== CONT  TestAccS3ObjectDataSource_multipleSlashes
=== CONT  TestAccS3ObjectDataSource_singleSlashAsKey
=== CONT  TestAccS3ObjectDataSource_leadingSlash
=== CONT  TestAccS3ObjectDataSource_objectLockLegalHoldOn
=== CONT  TestAccS3ObjectDataSource_allParams
=== CONT  TestAccS3ObjectDataSource_basicViaAccessPoint
--- PASS: TestAccS3ObjectDataSource_singleSlashAsKey (47.73s)
--- PASS: TestAccS3ObjectDataSource_readableBody (49.47s)
--- PASS: TestAccS3ObjectDataSource_basic (49.62s)
--- PASS: TestAccS3ObjectDataSource_bucketKeyEnabled (50.22s)
--- PASS: TestAccS3ObjectDataSource_kmsEncrypted (51.79s)
--- PASS: TestAccS3ObjectDataSource_basicViaAccessPoint (52.13s)
--- PASS: TestAccS3ObjectDataSource_allParams (54.36s)
--- PASS: TestAccS3ObjectDataSource_objectLockLegalHoldOn (54.50s)
--- PASS: TestAccS3ObjectDataSource_objectLockLegalHoldOff (54.61s)
--- PASS: TestAccS3ObjectDataSource_multipleSlashes (77.38s)
--- PASS: TestAccS3ObjectDataSource_leadingSlash (78.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 78.097s
```
