### PR TITLE
new resource: aws_ivs_recording_configuration

### DIFF
--- a/.changelog/27718.txt
+++ b/.changelog/27718.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_ivs_recording_configuration
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1652,7 +1652,8 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_iot_topic_rule":                 iot.ResourceTopicRule(),
 			"aws_iot_topic_rule_destination":     iot.ResourceTopicRuleDestination(),
 
-			"aws_ivs_playback_key_pair": ivs.ResourcePlaybackKeyPair(),
+			"aws_ivs_playback_key_pair":       ivs.ResourcePlaybackKeyPair(),
+			"aws_ivs_recording_configuration": ivs.ResourceRecordingConfiguration(),
 
 			"aws_msk_cluster":                  kafka.ResourceCluster(),
 			"aws_msk_configuration":            kafka.ResourceConfiguration(),

--- a/internal/service/ivs/find.go
+++ b/internal/service/ivs/find.go
@@ -32,3 +32,26 @@ func FindPlaybackKeyPairByID(ctx context.Context, conn *ivs.IVS, id string) (*iv
 
 	return out.KeyPair, nil
 }
+
+func FindRecordingConfigurationByID(ctx context.Context, conn *ivs.IVS, id string) (*ivs.RecordingConfiguration, error) {
+	in := &ivs.GetRecordingConfigurationInput{
+		Arn: aws.String(id),
+	}
+	out, err := conn.GetRecordingConfigurationWithContext(ctx, in)
+	if tfawserr.ErrCodeEquals(err, ivs.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil || out.RecordingConfiguration == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out.RecordingConfiguration, nil
+}

--- a/internal/service/ivs/recording_configuration.go
+++ b/internal/service/ivs/recording_configuration.go
@@ -1,0 +1,334 @@
+package ivs
+
+import (
+	"context"
+	"errors"
+	"log"
+	"regexp"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ivs"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func ResourceRecordingConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceRecordingConfigurationCreate,
+		ReadWithoutTimeout:   resourceRecordingConfigurationRead,
+		DeleteWithoutTimeout: resourceRecordingConfigurationDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"destination_configuration": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"s3": {
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"bucket_name": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-z0-9-.]{3,63}$`), "must contain only lowercase alphanumeric characters, hyphen, or dot, and between 3 and 63 characters"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9-_]{0,128}$`), "must contain only alphanumeric characters, hyphen, or underscore, and at most 128 characters"),
+			},
+			"recording_reconnect_window_seconds": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntBetween(0, 300),
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags":     tftags.TagsSchemaForceNew(),
+			"tags_all": tftags.TagsSchemaComputed(),
+			"thumbnail_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"recording_mode": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice(ivs.RecordingMode_Values(), false),
+						},
+						"target_interval_seconds": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.IntBetween(5, 60),
+						},
+					},
+				},
+			},
+		},
+
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+const (
+	ResNameRecordingConfiguration = "Recording Configuration"
+)
+
+func resourceRecordingConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).IVSConn
+
+	in := &ivs.CreateRecordingConfigurationInput{
+		DestinationConfiguration: expandDestinationConfiguration(d.Get("destination_configuration").([]interface{})),
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		in.Name = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("recording_reconnect_window_seconds"); ok {
+		in.RecordingReconnectWindowSeconds = aws.Int64(int64(v.(int)))
+	}
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	if len(tags) > 0 {
+		in.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	if v, ok := d.GetOk("thumbnail_configuration"); ok {
+		in.ThumbnailConfiguration = expandThumbnailConfiguration(v.([]interface{}))
+
+		if aws.StringValue(in.ThumbnailConfiguration.RecordingMode) == ivs.RecordingModeDisabled && in.ThumbnailConfiguration.TargetIntervalSeconds != nil {
+			return diag.Errorf("thumbnail configuration target interval cannot be set if recording_mode is \"DISABLED\"")
+		}
+	}
+
+	out, err := conn.CreateRecordingConfigurationWithContext(ctx, in)
+	if err != nil {
+		return create.DiagError(names.IVS, create.ErrActionCreating, ResNameRecordingConfiguration, d.Get("name").(string), err)
+	}
+
+	if out == nil || out.RecordingConfiguration == nil {
+		return create.DiagError(names.IVS, create.ErrActionCreating, ResNameRecordingConfiguration, d.Get("name").(string), errors.New("empty output"))
+	}
+
+	d.SetId(aws.StringValue(out.RecordingConfiguration.Arn))
+
+	if _, err := waitRecordingConfigurationCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return create.DiagError(names.IVS, create.ErrActionWaitingForCreation, ResNameRecordingConfiguration, d.Id(), err)
+	}
+
+	return resourceRecordingConfigurationRead(ctx, d, meta)
+}
+
+func resourceRecordingConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).IVSConn
+
+	out, err := FindRecordingConfigurationByID(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] IVS RecordingConfiguration (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.IVS, create.ErrActionReading, ResNameRecordingConfiguration, d.Id(), err)
+	}
+
+	d.Set("arn", out.Arn)
+
+	if err := d.Set("destination_configuration", flattenDestinationConfiguration(out.DestinationConfiguration)); err != nil {
+		return create.DiagError(names.IVS, create.ErrActionSetting, ResNameRecordingConfiguration, d.Id(), err)
+	}
+
+	d.Set("name", out.Name)
+	d.Set("recording_reconnect_window_seconds", out.RecordingReconnectWindowSeconds)
+	d.Set("state", out.State)
+
+	if err := d.Set("thumbnail_configuration", flattenThumbnailConfiguration(out.ThumbnailConfiguration)); err != nil {
+		return create.DiagError(names.IVS, create.ErrActionSetting, ResNameRecordingConfiguration, d.Id(), err)
+	}
+
+	tags, err := ListTagsWithContext(ctx, conn, d.Id())
+	if err != nil {
+		return create.DiagError(names.IVS, create.ErrActionReading, ResNameRecordingConfiguration, d.Id(), err)
+	}
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return create.DiagError(names.IVS, create.ErrActionSetting, ResNameRecordingConfiguration, d.Id(), err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return create.DiagError(names.IVS, create.ErrActionSetting, ResNameRecordingConfiguration, d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceRecordingConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).IVSConn
+
+	log.Printf("[INFO] Deleting IVS RecordingConfiguration %s", d.Id())
+
+	_, err := conn.DeleteRecordingConfigurationWithContext(ctx, &ivs.DeleteRecordingConfigurationInput{
+		Arn: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, ivs.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.IVS, create.ErrActionDeleting, ResNameRecordingConfiguration, d.Id(), err)
+	}
+
+	if _, err := waitRecordingConfigurationDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+		return create.DiagError(names.IVS, create.ErrActionWaitingForDeletion, ResNameRecordingConfiguration, d.Id(), err)
+	}
+
+	return nil
+}
+
+func flattenDestinationConfiguration(apiObject *ivs.DestinationConfiguration) []interface{} {
+	if apiObject == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{}
+
+	if v := apiObject.S3; v != nil {
+		m["s3"] = flattenS3DestinationConfiguration(v)
+	}
+
+	return []interface{}{m}
+}
+
+func flattenS3DestinationConfiguration(apiObject *ivs.S3DestinationConfiguration) []interface{} {
+	if apiObject == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{}
+
+	if v := apiObject.BucketName; v != nil {
+		m["bucket_name"] = *v
+	}
+
+	return []interface{}{m}
+}
+
+func flattenThumbnailConfiguration(apiObject *ivs.ThumbnailConfiguration) []interface{} {
+	if apiObject == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{}
+
+	if v := apiObject.RecordingMode; v != nil {
+		m["recording_mode"] = *v
+	}
+
+	if v := apiObject.TargetIntervalSeconds; v != nil {
+		m["target_interval_seconds"] = *v
+	}
+
+	return []interface{}{m}
+}
+
+func expandDestinationConfiguration(vSettings []interface{}) *ivs.DestinationConfiguration {
+	if len(vSettings) == 0 || vSettings[0] == nil {
+		return nil
+	}
+	tfMap := vSettings[0].(map[string]interface{})
+	a := &ivs.DestinationConfiguration{}
+
+	if v, ok := tfMap["s3"].([]interface{}); ok && len(v) > 0 {
+		a.S3 = expandS3DestinationConfiguration(v)
+	}
+
+	return a
+}
+
+func expandS3DestinationConfiguration(vSettings []interface{}) *ivs.S3DestinationConfiguration {
+	if len(vSettings) == 0 || vSettings[0] == nil {
+		return nil
+	}
+
+	tfMap := vSettings[0].(map[string]interface{})
+	a := &ivs.S3DestinationConfiguration{}
+
+	if v, ok := tfMap["bucket_name"].(string); ok && v != "" {
+		a.BucketName = aws.String(v)
+	}
+
+	return a
+}
+
+func expandThumbnailConfiguration(vSettings []interface{}) *ivs.ThumbnailConfiguration {
+	if len(vSettings) == 0 || vSettings[0] == nil {
+		return nil
+	}
+	a := &ivs.ThumbnailConfiguration{}
+	tfMap := vSettings[0].(map[string]interface{})
+
+	if v, ok := tfMap["recording_mode"].(string); ok && v != "" {
+		a.RecordingMode = aws.String(v)
+	}
+
+	if v, ok := tfMap["target_interval_seconds"].(int); ok {
+		a.TargetIntervalSeconds = aws.Int64(int64(v))
+	}
+
+	return a
+}

--- a/internal/service/ivs/recording_configuration.go
+++ b/internal/service/ivs/recording_configuration.go
@@ -262,7 +262,7 @@ func flattenS3DestinationConfiguration(apiObject *ivs.S3DestinationConfiguration
 	m := map[string]interface{}{}
 
 	if v := apiObject.BucketName; v != nil {
-		m["bucket_name"] = *v
+		m["bucket_name"] = aws.StringValue(v)
 	}
 
 	return []interface{}{m}
@@ -276,11 +276,11 @@ func flattenThumbnailConfiguration(apiObject *ivs.ThumbnailConfiguration) []inte
 	m := map[string]interface{}{}
 
 	if v := apiObject.RecordingMode; v != nil {
-		m["recording_mode"] = *v
+		m["recording_mode"] = aws.StringValue(v)
 	}
 
 	if v := apiObject.TargetIntervalSeconds; v != nil {
-		m["target_interval_seconds"] = *v
+		m["target_interval_seconds"] = aws.Int64Value(v)
 	}
 
 	return []interface{}{m}

--- a/internal/service/ivs/recording_configuration_test.go
+++ b/internal/service/ivs/recording_configuration_test.go
@@ -290,8 +290,8 @@ func testAccRecordingConfigurationPreCheck(t *testing.T) {
 func testAccRecordingConfigurationConfig_s3Bucket(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
-	bucket        = %[1]q
-	force_destroy = true
+  bucket        = %[1]q
+  force_destroy = true
 }
 `, bucketName)
 }
@@ -301,11 +301,11 @@ func testAccRecordingConfigurationConfig_basic(bucketName string) string {
 		testAccRecordingConfigurationConfig_s3Bucket(bucketName),
 		`
 resource "aws_ivs_recording_configuration" "test" {
-	destination_configuration {
-		s3 {
-			bucket_name = aws_s3_bucket.test.id
-		}
-	}
+  destination_configuration {
+    s3 {
+      bucket_name = aws_s3_bucket.test.id
+    }
+  }
 }
 `)
 }
@@ -315,12 +315,12 @@ func testAccRecordingConfigurationConfig_name(bucketName, rName string) string {
 		testAccRecordingConfigurationConfig_s3Bucket(bucketName),
 		fmt.Sprintf(`
 resource "aws_ivs_recording_configuration" "test" {
-	name = %[1]q
-	destination_configuration {
-		s3 {
-			bucket_name = aws_s3_bucket.test.id
-		}
-	}
+  name = %[1]q
+  destination_configuration {
+    s3 {
+      bucket_name = aws_s3_bucket.test.id
+    }
+  }
 }
 `, rName))
 }
@@ -330,17 +330,17 @@ func testAccRecordingConfigurationConfig_update(bucketName, rName, recordingReco
 		testAccRecordingConfigurationConfig_s3Bucket(bucketName),
 		fmt.Sprintf(`
 resource "aws_ivs_recording_configuration" "test" {
-	name = %[1]q
-	destination_configuration {
-		s3 {
-			bucket_name = aws_s3_bucket.test.id
-		}
-	}
-	recording_reconnect_window_seconds = %[2]s
-	thumbnail_configuration {
-        recording_mode          = %[3]q
-        target_interval_seconds = %[4]s
+  name = %[1]q
+  destination_configuration {
+    s3 {
+      bucket_name = aws_s3_bucket.test.id
     }
+  }
+  recording_reconnect_window_seconds = %[2]s
+  thumbnail_configuration {
+    recording_mode          = %[3]q
+    target_interval_seconds = %[4]s
+  }
 }
 `, rName, recordingReconnectWindowSeconds, recordingMode, targetIntervalSeconds))
 }
@@ -350,14 +350,14 @@ func testAccRecordingConfigurationConfig_tags1(bucketName, tagKey1, tagValue1 st
 		testAccRecordingConfigurationConfig_s3Bucket(bucketName),
 		fmt.Sprintf(`
 resource "aws_ivs_recording_configuration" "test" {
-	destination_configuration {
-		s3 {
-			bucket_name = aws_s3_bucket.test.id
-		}
-	}
-	tags = {
-		%[1]q = %[2]q
-	}
+  destination_configuration {
+    s3 {
+      bucket_name = aws_s3_bucket.test.id
+    }
+  }
+  tags = {
+    %[1]q = %[2]q
+  }
 }
 `, tagKey1, tagValue1))
 }
@@ -367,15 +367,15 @@ func testAccRecordingConfigurationConfig_tags2(bucketName, tagKey1, tagValue1, t
 		testAccRecordingConfigurationConfig_s3Bucket(bucketName),
 		fmt.Sprintf(`
 resource "aws_ivs_recording_configuration" "test" {
-	destination_configuration {
-		s3 {
-			bucket_name = aws_s3_bucket.test.id
-		}
-	}
-	tags = {
-		%[1]q = %[2]q
-		%[3]q = %[4]q
-	}
+  destination_configuration {
+    s3 {
+      bucket_name = aws_s3_bucket.test.id
+    }
+  }
+  tags = {
+    %[1]q = %[2]q
+    %[3]q = %[4]q
+  }
 }
 `, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/internal/service/ivs/recording_configuration_test.go
+++ b/internal/service/ivs/recording_configuration_test.go
@@ -1,0 +1,381 @@
+package ivs_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ivs"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfivs "github.com/hashicorp/terraform-provider-aws/internal/service/ivs"
+	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccIVSRecordingConfiguration_basic(t *testing.T) {
+	var recordingConfiguration ivs.RecordingConfiguration
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ivs_recording_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(ivs.EndpointsID, t)
+			testAccRecordingConfigurationPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ivs.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordingConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecordingConfigurationConfig_basic(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordingConfigurationExists(resourceName, &recordingConfiguration),
+					resource.TestCheckResourceAttr(resourceName, "state", "ACTIVE"),
+					resource.TestCheckResourceAttr(resourceName, "destination_configuration.0.s3.0.bucket_name", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ivs", regexp.MustCompile(`recording-configuration/.+`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIVSRecordingConfiguration_update(t *testing.T) {
+	var v1, v2 ivs.RecordingConfiguration
+	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	bucketName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	bucketName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ivs_recording_configuration.test"
+	recordingReconnectWindowSeconds := "45"
+	recordingMode := "INTERVAL"
+	targetIntervalSeconds := "30"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(ivs.EndpointsID, t)
+			testAccRecordingConfigurationPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ivs.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordingConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecordingConfigurationConfig_name(bucketName1, rName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordingConfigurationExists(resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, "name", rName1),
+					resource.TestCheckResourceAttr(resourceName, "destination_configuration.0.s3.0.bucket_name", bucketName1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRecordingConfigurationConfig_update(bucketName2, rName2, recordingReconnectWindowSeconds, recordingMode, targetIntervalSeconds),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordingConfigurationExists(resourceName, &v2),
+					testAccCheckRecordingConfigurationRecreated(&v1, &v2),
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
+					resource.TestCheckResourceAttr(resourceName, "destination_configuration.0.s3.0.bucket_name", bucketName2),
+					resource.TestCheckResourceAttr(resourceName, "recording_reconnect_window_seconds", recordingReconnectWindowSeconds),
+					resource.TestCheckResourceAttr(resourceName, "thumbnail_configuration.0.recording_mode", recordingMode),
+					resource.TestCheckResourceAttr(resourceName, "thumbnail_configuration.0.target_interval_seconds", targetIntervalSeconds),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIVSRecordingConfiguration_disappears(t *testing.T) {
+	var recordingconfiguration ivs.RecordingConfiguration
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ivs_recording_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(ivs.EndpointsID, t)
+			testAccRecordingConfigurationPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ivs.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordingConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecordingConfigurationConfig_basic(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordingConfigurationExists(resourceName, &recordingconfiguration),
+					acctest.CheckResourceDisappears(acctest.Provider, tfivs.ResourceRecordingConfiguration(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccIVSRecordingConfiguration_disappears_S3Bucket(t *testing.T) {
+	var recordingconfiguration ivs.RecordingConfiguration
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	parentResourceName := "aws_s3_bucket.test"
+	resourceName := "aws_ivs_recording_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(ivs.EndpointsID, t)
+			testAccRecordingConfigurationPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ivs.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordingConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecordingConfigurationConfig_basic(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordingConfigurationExists(resourceName, &recordingconfiguration),
+					acctest.CheckResourceDisappears(acctest.Provider, tfs3.ResourceBucket(), parentResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccIVSRecordingConfiguration_tags(t *testing.T) {
+	var recordingConfiguration ivs.RecordingConfiguration
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ivs_recording_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(ivs.EndpointsID, t)
+			testAccRecordingConfigurationPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ivs.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRecordingConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecordingConfigurationConfig_tags1(bucketName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordingConfigurationExists(resourceName, &recordingConfiguration),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRecordingConfigurationConfig_tags2(bucketName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordingConfigurationExists(resourceName, &recordingConfiguration),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccRecordingConfigurationConfig_tags1(bucketName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRecordingConfigurationExists(resourceName, &recordingConfiguration),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckRecordingConfigurationDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).IVSConn
+	ctx := context.Background()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ivs_recording_configuration" {
+			continue
+		}
+
+		input := &ivs.GetRecordingConfigurationInput{
+			Arn: aws.String(rs.Primary.ID),
+		}
+		_, err := conn.GetRecordingConfigurationWithContext(ctx, input)
+		if err != nil {
+			if tfawserr.ErrCodeEquals(err, ivs.ErrCodeResourceNotFoundException) {
+				return nil
+			}
+			return err
+		}
+
+		return create.Error(names.IVS, create.ErrActionCheckingDestroyed, tfivs.ResNameRecordingConfiguration, rs.Primary.ID, errors.New("not destroyed"))
+	}
+
+	return nil
+}
+
+func testAccCheckRecordingConfigurationExists(name string, recordingconfiguration *ivs.RecordingConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.IVS, create.ErrActionCheckingExistence, tfivs.ResNameRecordingConfiguration, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.IVS, create.ErrActionCheckingExistence, tfivs.ResNameRecordingConfiguration, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).IVSConn
+		ctx := context.Background()
+		resp, err := tfivs.FindRecordingConfigurationByID(ctx, conn, rs.Primary.ID)
+
+		if err != nil {
+			return create.Error(names.IVS, create.ErrActionCheckingExistence, tfivs.ResNameRecordingConfiguration, rs.Primary.ID, err)
+		}
+
+		*recordingconfiguration = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckRecordingConfigurationRecreated(before, after *ivs.RecordingConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if before, after := aws.StringValue(before.Arn), aws.StringValue(after.Arn); before == after {
+			return fmt.Errorf("Expected Recording Configuration IDs to change, %s", before)
+		}
+
+		return nil
+	}
+}
+
+func testAccRecordingConfigurationPreCheck(t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).IVSConn
+	ctx := context.Background()
+
+	input := &ivs.ListRecordingConfigurationsInput{}
+	_, err := conn.ListRecordingConfigurationsWithContext(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccRecordingConfigurationConfig_s3Bucket(bucketName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+	bucket        = %[1]q
+	force_destroy = true
+}
+`, bucketName)
+}
+
+func testAccRecordingConfigurationConfig_basic(bucketName string) string {
+	return acctest.ConfigCompose(
+		testAccRecordingConfigurationConfig_s3Bucket(bucketName),
+		`
+resource "aws_ivs_recording_configuration" "test" {
+	destination_configuration {
+		s3 {
+			bucket_name = aws_s3_bucket.test.id
+		}
+	}
+}
+`)
+}
+
+func testAccRecordingConfigurationConfig_name(bucketName, rName string) string {
+	return acctest.ConfigCompose(
+		testAccRecordingConfigurationConfig_s3Bucket(bucketName),
+		fmt.Sprintf(`
+resource "aws_ivs_recording_configuration" "test" {
+	name = %[1]q
+	destination_configuration {
+		s3 {
+			bucket_name = aws_s3_bucket.test.id
+		}
+	}
+}
+`, rName))
+}
+
+func testAccRecordingConfigurationConfig_update(bucketName, rName, recordingReconnectWindowSeconds, recordingMode, targetIntervalSeconds string) string {
+	return acctest.ConfigCompose(
+		testAccRecordingConfigurationConfig_s3Bucket(bucketName),
+		fmt.Sprintf(`
+resource "aws_ivs_recording_configuration" "test" {
+	name = %[1]q
+	destination_configuration {
+		s3 {
+			bucket_name = aws_s3_bucket.test.id
+		}
+	}
+	recording_reconnect_window_seconds = %[2]s
+	thumbnail_configuration {
+        recording_mode          = %[3]q
+        target_interval_seconds = %[4]s
+    }
+}
+`, rName, recordingReconnectWindowSeconds, recordingMode, targetIntervalSeconds))
+}
+
+func testAccRecordingConfigurationConfig_tags1(bucketName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(
+		testAccRecordingConfigurationConfig_s3Bucket(bucketName),
+		fmt.Sprintf(`
+resource "aws_ivs_recording_configuration" "test" {
+	destination_configuration {
+		s3 {
+			bucket_name = aws_s3_bucket.test.id
+		}
+	}
+	tags = {
+		%[1]q = %[2]q
+	}
+}
+`, tagKey1, tagValue1))
+}
+
+func testAccRecordingConfigurationConfig_tags2(bucketName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(
+		testAccRecordingConfigurationConfig_s3Bucket(bucketName),
+		fmt.Sprintf(`
+resource "aws_ivs_recording_configuration" "test" {
+	destination_configuration {
+		s3 {
+			bucket_name = aws_s3_bucket.test.id
+		}
+	}
+	tags = {
+		%[1]q = %[2]q
+		%[3]q = %[4]q
+	}
+}
+`, tagKey1, tagValue1, tagKey2, tagValue2))
+}

--- a/internal/service/ivs/status.go
+++ b/internal/service/ivs/status.go
@@ -11,9 +11,6 @@ import (
 
 const (
 	statusNormal = "Normal"
-
-	statusActive   = ivs.RecordingConfigurationStateActive
-	statusCreating = ivs.RecordingConfigurationStateCreating
 )
 
 func statusPlaybackKeyPair(ctx context.Context, conn *ivs.IVS, id string) resource.StateRefreshFunc {

--- a/internal/service/ivs/status.go
+++ b/internal/service/ivs/status.go
@@ -3,6 +3,7 @@ package ivs
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ivs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -11,8 +12,8 @@ import (
 const (
 	statusNormal = "Normal"
 
-	statusActive   = "ACTIVE"
-	statusCreating = "CREATING"
+	statusActive   = ivs.RecordingConfigurationStateActive
+	statusCreating = ivs.RecordingConfigurationStateCreating
 )
 
 func statusPlaybackKeyPair(ctx context.Context, conn *ivs.IVS, id string) resource.StateRefreshFunc {
@@ -41,6 +42,6 @@ func statusRecordingConfiguration(ctx context.Context, conn *ivs.IVS, id string)
 			return nil, "", err
 		}
 
-		return out, *out.State, nil
+		return out, aws.StringValue(out.State), nil
 	}
 }

--- a/internal/service/ivs/status.go
+++ b/internal/service/ivs/status.go
@@ -10,6 +10,9 @@ import (
 
 const (
 	statusNormal = "Normal"
+
+	statusActive   = "ACTIVE"
+	statusCreating = "CREATING"
 )
 
 func statusPlaybackKeyPair(ctx context.Context, conn *ivs.IVS, id string) resource.StateRefreshFunc {
@@ -24,5 +27,20 @@ func statusPlaybackKeyPair(ctx context.Context, conn *ivs.IVS, id string) resour
 		}
 
 		return out, statusNormal, nil
+	}
+}
+
+func statusRecordingConfiguration(ctx context.Context, conn *ivs.IVS, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		out, err := FindRecordingConfigurationByID(ctx, conn, id)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return out, *out.State, nil
 	}
 }

--- a/internal/service/ivs/wait.go
+++ b/internal/service/ivs/wait.go
@@ -41,3 +41,37 @@ func waitPlaybackKeyPairDeleted(ctx context.Context, conn *ivs.IVS, id string, t
 
 	return nil, err
 }
+
+func waitRecordingConfigurationCreated(ctx context.Context, conn *ivs.IVS, id string, timeout time.Duration) (*ivs.RecordingConfiguration, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending:                   []string{statusCreating},
+		Target:                    []string{statusActive},
+		Refresh:                   statusRecordingConfiguration(ctx, conn, id),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*ivs.RecordingConfiguration); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+func waitRecordingConfigurationDeleted(ctx context.Context, conn *ivs.IVS, id string, timeout time.Duration) (*ivs.RecordingConfiguration, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{statusActive},
+		Target:  []string{},
+		Refresh: statusRecordingConfiguration(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*ivs.RecordingConfiguration); ok {
+		return out, err
+	}
+
+	return nil, err
+}

--- a/internal/service/ivs/wait.go
+++ b/internal/service/ivs/wait.go
@@ -44,8 +44,8 @@ func waitPlaybackKeyPairDeleted(ctx context.Context, conn *ivs.IVS, id string, t
 
 func waitRecordingConfigurationCreated(ctx context.Context, conn *ivs.IVS, id string, timeout time.Duration) (*ivs.RecordingConfiguration, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending:                   []string{statusCreating},
-		Target:                    []string{statusActive},
+		Pending:                   []string{ivs.RecordingConfigurationStateCreating},
+		Target:                    []string{ivs.RecordingConfigurationStateActive},
 		Refresh:                   statusRecordingConfiguration(ctx, conn, id),
 		Timeout:                   timeout,
 		NotFoundChecks:            20,
@@ -62,7 +62,7 @@ func waitRecordingConfigurationCreated(ctx context.Context, conn *ivs.IVS, id st
 
 func waitRecordingConfigurationDeleted(ctx context.Context, conn *ivs.IVS, id string, timeout time.Duration) (*ivs.RecordingConfiguration, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{statusActive},
+		Pending: []string{ivs.RecordingConfigurationStateActive},
 		Target:  []string{},
 		Refresh: statusRecordingConfiguration(ctx, conn, id),
 		Timeout: timeout,

--- a/website/docs/r/ivs_recording_configuration.html.markdown
+++ b/website/docs/r/ivs_recording_configuration.html.markdown
@@ -1,0 +1,66 @@
+---
+subcategory: "IVS (Interactive Video)"
+layout: "aws"
+page_title: "AWS: aws_ivs_recording_configuration"
+description: |-
+  Terraform resource for managing an AWS IVS (Interactive Video) Recording Configuration.
+---
+
+# Resource: aws_ivs_recording_configuration
+
+Terraform resource for managing an AWS IVS (Interactive Video) Recording Configuration.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_ivs_recording_configuration" "example" {
+  name = "recording_configuration-1"
+  destination_configuration {
+    s3 {
+      bucket_name = "ivs-stream-archive"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `destination_configuration` - Object containing destination configuration for where recorded video will be stored.
+    * `s3` - S3 destination configuration where recorded videos will be stored.
+        * `bucket_name` - S3 bucket name where recorded videos will be stored.
+
+The following arguments are optional:
+
+* `name` - (Optional) Recording Configuration name.
+* `recording_reconnect_window_seconds` - (Optional) If a broadcast disconnects and then reconnects within the specified interval, the multiple streams will be considered a single broadcast and merged together.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `thumbnail_configuration` - (Optional) Object containing information to enable/disable the recording of thumbnails for a live session and modify the interval at which thumbnails are generated for the live session.
+    * `recording_mode` - (Optional) Thumbnail recording mode. Valid values: `DISABLED`, `INTERVAL`.
+    * `target_interval_seconds` (Configurable [and required] only if `recording_mode` is `INTERVAL`) - The targeted thumbnail-generation interval in seconds.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the Recording Configuration.
+* `state` -  The current state of the Recording Configuration.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+
+## Timeouts
+
+[Configuration options](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts):
+
+* `create` - (Default `10m`)
+* `delete` - (Default `10m`)
+
+## Import
+
+IVS (Interactive Video) Recording Configuration can be imported using the ARN, e.g.,
+
+```
+$ terraform import aws_ivs_recording_configuration.example arn:aws:ivs:us-west-2:326937407773:recording-configuration/KAk1sHBl2L47
+```


### PR DESCRIPTION
### Description
Add new resource for AWS IVS Recording Configuration: aws_ivs_recording_configuration. This PR is the second in a set to support the full AWS IVS entities:

1. ~~Playback Key Pair~~
2. Recording Configuration
3. Channel
4. Stream Key

### Relations

Relates #17272

### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccIVSRecordingConfiguration_ PKG=ivs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 /Users/eakevinh/go/bin/go1.18.4 test ./internal/service/ivs/... -v -count 1 -parallel 20 -run='TestAccIVSRecordingConfiguration_'  -timeout 180m
=== RUN   TestAccIVSRecordingConfiguration_basic
=== PAUSE TestAccIVSRecordingConfiguration_basic
=== RUN   TestAccIVSRecordingConfiguration_update
=== PAUSE TestAccIVSRecordingConfiguration_update
=== RUN   TestAccIVSRecordingConfiguration_disappears
=== PAUSE TestAccIVSRecordingConfiguration_disappears
=== RUN   TestAccIVSRecordingConfiguration_disappears_S3Bucket
=== PAUSE TestAccIVSRecordingConfiguration_disappears_S3Bucket
=== RUN   TestAccIVSRecordingConfiguration_tags
=== PAUSE TestAccIVSRecordingConfiguration_tags
=== CONT  TestAccIVSRecordingConfiguration_basic
=== CONT  TestAccIVSRecordingConfiguration_disappears_S3Bucket
=== CONT  TestAccIVSRecordingConfiguration_disappears
=== CONT  TestAccIVSRecordingConfiguration_tags
=== CONT  TestAccIVSRecordingConfiguration_update
--- PASS: TestAccIVSRecordingConfiguration_disappears_S3Bucket (39.73s)
--- PASS: TestAccIVSRecordingConfiguration_disappears (43.56s)
--- PASS: TestAccIVSRecordingConfiguration_basic (49.20s)
--- PASS: TestAccIVSRecordingConfiguration_update (83.09s)
--- PASS: TestAccIVSRecordingConfiguration_tags (108.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ivs        110.759s
```
