### PR TITLE
Fix typo in `aws_sesv2_configuration_set` docs

### DIFF
--- a/website/docs/r/sesv2_configuration_set.html.markdown
+++ b/website/docs/r/sesv2_configuration_set.html.markdown
@@ -26,7 +26,7 @@ resource "aws_sesv2_configuration_set" "example" {
     reputation_metrics_enabled = false
   }
 
-  sendig_options {
+  sending_options {
     sending_enabled = true
   }
 


### PR DESCRIPTION
### Description

Just a quick type fix, `sendig` != `sending`.

### Relations

Closes #27727

### References

N/a

### Output from Acceptance Testing

N/a, docs
