### PR TITLE
Fix formatting on `aws_eks_node_group` docs

### DIFF
--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -66,8 +66,8 @@ resource "aws_eks_node_group" "example" {
 You can have the node group track the latest version of the Amazon EKS optimized Amazon Linux AMI for a given EKS version by querying an Amazon provided SSM parameter. Replace `amazon-linux-2` in the parameter name below with `amazon-linux-2-gpu` to retrieve the  accelerated AMI version and `amazon-linux-2-arm64` to retrieve the Arm version.
 
 ```terraform
-data aws_ssm_parameter "eks_ami_release_version" {
-    name = /aws/service/eks/optimized-ami/${aws_eks_cluster.example.version}/amazon-linux-2/recommended/release_version"
+data "aws_ssm_parameter" "eks_ami_release_version" {
+    name = "/aws/service/eks/optimized-ami/${aws_eks_cluster.example.version}/amazon-linux-2/recommended/release_version"
 }
 
 resource "aws_eks_node_group" "example" {

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -65,7 +65,7 @@ resource "aws_eks_node_group" "example" {
 
 You can have the node group track the latest version of the Amazon EKS optimized Amazon Linux AMI for a given EKS version by querying an Amazon provided SSM parameter. Replace `amazon-linux-2` in the parameter name below with `amazon-linux-2-gpu` to retrieve the  accelerated AMI version and `amazon-linux-2-arm64` to retrieve the Arm version.
 
-```
+```terraform
 data aws_ssm_parameter "eks_ami_release_version" {
     name = /aws/service/eks/optimized-ami/${aws_eks_cluster.example.version}/amazon-linux-2/recommended/release_version"
 }

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -67,7 +67,7 @@ You can have the node group track the latest version of the Amazon EKS optimized
 
 ```terraform
 data "aws_ssm_parameter" "eks_ami_release_version" {
-    name = "/aws/service/eks/optimized-ami/${aws_eks_cluster.example.version}/amazon-linux-2/recommended/release_version"
+  name = "/aws/service/eks/optimized-ami/${aws_eks_cluster.example.version}/amazon-linux-2/recommended/release_version"
 }
 
 resource "aws_eks_node_group" "example" {


### PR DESCRIPTION
### Description

There was no language tag, so the formatting on [this section of the docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group#tracking-the-latest-eks-node-group-ami-releases) was a bit ugly to look at.

### Relations

- [Discuss thread](https://discuss.hashicorp.com/t/documentation-formatting-is-messed-up/46385)

### References

N/a

### Output from Acceptance Testing

N/a, docs
