### PR TITLE
Tech debt: Add `*testing.T` parameter to `acctest` crypto functions

### DIFF
--- a/internal/acctest/crypto.go
+++ b/internal/acctest/crypto.go
@@ -201,15 +201,13 @@ func TLSRSAX509SelfSignedCACertificatePEM(t *testing.T, keyPem string) string {
 	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	publicKeyBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	publicKeyBytesSha1 := sha1.Sum(publicKeyBytes)
@@ -217,8 +215,7 @@ func TLSRSAX509SelfSignedCACertificatePEM(t *testing.T, keyPem string) string {
 	serialNumber, err := rand.Int(rand.Reader, tlsX509CertificateSerialNumberLimit)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	certificate := &x509.Certificate{
@@ -239,8 +236,7 @@ func TLSRSAX509SelfSignedCACertificatePEM(t *testing.T, keyPem string) string {
 	certificateBytes, err := x509.CreateCertificate(rand.Reader, certificate, certificate, &key.PublicKey, key)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	certificateBlock := &pem.Block{

--- a/internal/acctest/crypto.go
+++ b/internal/acctest/crypto.go
@@ -108,21 +108,19 @@ func TLSRSAPrivateKeyPEM(t *testing.T, bits int) string {
 // TLSRSAPublicKeyPEM generates a RSA public key PEM string.
 // Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
 // configurations such as: public_key_pem = "%[1]s"
-func TLSRSAPublicKeyPEM(keyPem string) string {
+func TLSRSAPublicKeyPEM(t *testing.T, keyPem string) string {
 	keyBlock, _ := pem.Decode([]byte(keyPem))
 
 	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	publicKeyBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	block := &pem.Block{

--- a/internal/acctest/crypto.go
+++ b/internal/acctest/crypto.go
@@ -134,14 +134,13 @@ func TLSRSAPublicKeyPEM(t *testing.T, keyPem string) string {
 // TLSRSAX509LocallySignedCertificatePEM generates a local CA x509 certificate PEM string.
 // Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
 // configurations such as: certificate_pem = "%[1]s"
-func TLSRSAX509LocallySignedCertificatePEM(caKeyPem, caCertificatePem, keyPem, commonName string) string {
+func TLSRSAX509LocallySignedCertificatePEM(t *testing.T, caKeyPem, caCertificatePem, keyPem, commonName string) string {
 	caCertificateBlock, _ := pem.Decode([]byte(caCertificatePem))
 
 	caCertificate, err := x509.ParseCertificate(caCertificateBlock.Bytes)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	caKeyBlock, _ := pem.Decode([]byte(caKeyPem))
@@ -149,8 +148,7 @@ func TLSRSAX509LocallySignedCertificatePEM(caKeyPem, caCertificatePem, keyPem, c
 	caKey, err := x509.ParsePKCS1PrivateKey(caKeyBlock.Bytes)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	keyBlock, _ := pem.Decode([]byte(keyPem))
@@ -158,15 +156,13 @@ func TLSRSAX509LocallySignedCertificatePEM(caKeyPem, caCertificatePem, keyPem, c
 	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	serialNumber, err := rand.Int(rand.Reader, tlsX509CertificateSerialNumberLimit)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	certificate := &x509.Certificate{
@@ -185,8 +181,7 @@ func TLSRSAX509LocallySignedCertificatePEM(caKeyPem, caCertificatePem, keyPem, c
 	certificateBytes, err := x509.CreateCertificate(rand.Reader, certificate, caCertificate, &key.PublicKey, caKey)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	certificateBlock := &pem.Block{

--- a/internal/acctest/crypto.go
+++ b/internal/acctest/crypto.go
@@ -354,11 +354,11 @@ func TLSRSAX509SelfSignedCertificatePEM(t *testing.T, keyPem, commonName string)
 // and a RSA private key PEM string.
 // Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
 // configurations such as: certificate_signing_request_pem = "%[1]s" private_key_pem = "%[2]s"
-func TLSRSAX509CertificateRequestPEM(keyBits int, commonName string) (string, string) {
+func TLSRSAX509CertificateRequestPEM(t *testing.T, keyBits int, commonName string) (string, string) {
 	keyBytes, err := rsa.GenerateKey(rand.Reader, keyBits)
+
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	csr := x509.CertificateRequest{
@@ -370,9 +370,9 @@ func TLSRSAX509CertificateRequestPEM(keyBits int, commonName string) (string, st
 	}
 
 	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &csr, keyBytes)
+
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	csrBlock := &pem.Block{

--- a/internal/acctest/crypto.go
+++ b/internal/acctest/crypto.go
@@ -90,12 +90,11 @@ func TLSECDSAPublicKeyPEM(t *testing.T, keyPem string) (string, string) {
 // TLSRSAPrivateKeyPEM generates a RSA private key PEM string.
 // Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
 // configurations such as: private_key_pem = "%[1]s"
-func TLSRSAPrivateKeyPEM(bits int) string {
+func TLSRSAPrivateKeyPEM(t *testing.T, bits int) string {
 	key, err := rsa.GenerateKey(rand.Reader, bits)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	block := &pem.Block{

--- a/internal/acctest/crypto.go
+++ b/internal/acctest/crypto.go
@@ -195,7 +195,7 @@ func TLSRSAX509LocallySignedCertificatePEM(t *testing.T, caKeyPem, caCertificate
 // TLSRSAX509SelfSignedCACertificatePEM generates a x509 CA certificate PEM string.
 // Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
 // configurations such as: root_certificate_pem = "%[1]s"
-func TLSRSAX509SelfSignedCACertificatePEM(keyPem string) string {
+func TLSRSAX509SelfSignedCACertificatePEM(t *testing.T, keyPem string) string {
 	keyBlock, _ := pem.Decode([]byte(keyPem))
 
 	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)

--- a/internal/acctest/crypto.go
+++ b/internal/acctest/crypto.go
@@ -252,21 +252,19 @@ func TLSRSAX509SelfSignedCACertificatePEM(t *testing.T, keyPem string) string {
 // See https://docs.aws.amazon.com/rolesanywhere/latest/userguide/trust-model.html#signature-verification.
 // Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
 // configurations such as: root_certificate_pem = "%[1]s"
-func TLSRSAX509SelfSignedCACertificateForRolesAnywhereTrustAnchorPEM(keyPem string) string {
+func TLSRSAX509SelfSignedCACertificateForRolesAnywhereTrustAnchorPEM(t *testing.T, keyPem string) string {
 	keyBlock, _ := pem.Decode([]byte(keyPem))
 
 	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	publicKeyBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	publicKeyBytesSha1 := sha1.Sum(publicKeyBytes)
@@ -274,8 +272,7 @@ func TLSRSAX509SelfSignedCACertificateForRolesAnywhereTrustAnchorPEM(keyPem stri
 	serialNumber, err := rand.Int(rand.Reader, tlsX509CertificateSerialNumberLimit)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	certificate := &x509.Certificate{
@@ -297,8 +294,7 @@ func TLSRSAX509SelfSignedCACertificateForRolesAnywhereTrustAnchorPEM(keyPem stri
 	certificateBytes, err := x509.CreateCertificate(rand.Reader, certificate, certificate, &key.PublicKey, key)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	certificateBlock := &pem.Block{

--- a/internal/acctest/crypto.go
+++ b/internal/acctest/crypto.go
@@ -308,21 +308,19 @@ func TLSRSAX509SelfSignedCACertificateForRolesAnywhereTrustAnchorPEM(t *testing.
 // TLSRSAX509SelfSignedCertificatePEM generates a x509 certificate PEM string.
 // Wrap with TLSPEMEscapeNewlines() to allow simple fmt.Sprintf()
 // configurations such as: private_key_pem = "%[1]s"
-func TLSRSAX509SelfSignedCertificatePEM(keyPem, commonName string) string {
+func TLSRSAX509SelfSignedCertificatePEM(t *testing.T, keyPem, commonName string) string {
 	keyBlock, _ := pem.Decode([]byte(keyPem))
 
 	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	serialNumber, err := rand.Int(rand.Reader, tlsX509CertificateSerialNumberLimit)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	certificate := &x509.Certificate{
@@ -341,8 +339,7 @@ func TLSRSAX509SelfSignedCertificatePEM(keyPem, commonName string) string {
 	certificateBytes, err := x509.CreateCertificate(rand.Reader, certificate, certificate, &key.PublicKey, key)
 
 	if err != nil {
-		//lintignore:R009
-		panic(err)
+		t.Fatal(err)
 	}
 
 	certificateBlock := &pem.Block{

--- a/internal/acctest/crypto_test.go
+++ b/internal/acctest/crypto_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestTLSRSAPrivateKeyPEM(t *testing.T) {
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 
 	if !strings.Contains(key, acctest.PEMBlockTypeRSAPrivateKey) {
 		t.Errorf("key does not contain RSA PRIVATE KEY: %s", key)
@@ -16,7 +16,7 @@ func TestTLSRSAPrivateKeyPEM(t *testing.T) {
 }
 
 func TestTLSRSAPublicKeyPEM(t *testing.T) {
-	privateKey := acctest.TLSRSAPrivateKeyPEM(2048)
+	privateKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	publicKey := acctest.TLSRSAPublicKeyPEM(privateKey)
 
 	if !strings.Contains(publicKey, acctest.PEMBlockTypePublicKey) {
@@ -25,9 +25,9 @@ func TestTLSRSAPublicKeyPEM(t *testing.T) {
 }
 
 func TestTLSRSAX509LocallySignedCertificatePEM(t *testing.T) {
-	caKey := acctest.TLSRSAPrivateKeyPEM(2048)
+	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(caKey)
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509LocallySignedCertificatePEM(caKey, caCertificate, key, "example.com")
 
 	if !strings.Contains(certificate, acctest.PEMBlockTypeCertificate) {
@@ -36,7 +36,7 @@ func TestTLSRSAX509LocallySignedCertificatePEM(t *testing.T) {
 }
 
 func TestTLSRSAX509SelfSignedCACertificatePEM(t *testing.T) {
-	caKey := acctest.TLSRSAPrivateKeyPEM(2048)
+	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(caKey)
 
 	if !strings.Contains(caCertificate, acctest.PEMBlockTypeCertificate) {
@@ -45,7 +45,7 @@ func TestTLSRSAX509SelfSignedCACertificatePEM(t *testing.T) {
 }
 
 func TestTLSRSAX509SelfSignedCertificatePEM(t *testing.T) {
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 
 	if !strings.Contains(certificate, acctest.PEMBlockTypeCertificate) {

--- a/internal/acctest/crypto_test.go
+++ b/internal/acctest/crypto_test.go
@@ -17,7 +17,7 @@ func TestTLSRSAPrivateKeyPEM(t *testing.T) {
 
 func TestTLSRSAPublicKeyPEM(t *testing.T) {
 	privateKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	publicKey := acctest.TLSRSAPublicKeyPEM(privateKey)
+	publicKey := acctest.TLSRSAPublicKeyPEM(t, privateKey)
 
 	if !strings.Contains(publicKey, acctest.PEMBlockTypePublicKey) {
 		t.Errorf("key does not contain PUBLIC KEY: %s", publicKey)

--- a/internal/acctest/crypto_test.go
+++ b/internal/acctest/crypto_test.go
@@ -54,7 +54,7 @@ func TestTLSRSAX509SelfSignedCertificatePEM(t *testing.T) {
 }
 
 func TestTLSRSAX509CertificateRequestPEM(t *testing.T) {
-	csr, key := acctest.TLSRSAX509CertificateRequestPEM(2048, "example.com")
+	csr, key := acctest.TLSRSAX509CertificateRequestPEM(t, 2048, "example.com")
 
 	if !strings.Contains(csr, acctest.PEMBlockTypeCertificateRequest) {
 		t.Errorf("certificate does not contain CERTIFICATE REQUEST: %s", csr)

--- a/internal/acctest/crypto_test.go
+++ b/internal/acctest/crypto_test.go
@@ -26,7 +26,7 @@ func TestTLSRSAPublicKeyPEM(t *testing.T) {
 
 func TestTLSRSAX509LocallySignedCertificatePEM(t *testing.T) {
 	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(caKey)
+	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(t, caKey)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509LocallySignedCertificatePEM(t, caKey, caCertificate, key, "example.com")
 
@@ -37,7 +37,7 @@ func TestTLSRSAX509LocallySignedCertificatePEM(t *testing.T) {
 
 func TestTLSRSAX509SelfSignedCACertificatePEM(t *testing.T) {
 	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(caKey)
+	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(t, caKey)
 
 	if !strings.Contains(caCertificate, acctest.PEMBlockTypeCertificate) {
 		t.Errorf("CA certificate does not contain CERTIFICATE: %s", caCertificate)

--- a/internal/acctest/crypto_test.go
+++ b/internal/acctest/crypto_test.go
@@ -28,7 +28,7 @@ func TestTLSRSAX509LocallySignedCertificatePEM(t *testing.T) {
 	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(caKey)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509LocallySignedCertificatePEM(caKey, caCertificate, key, "example.com")
+	certificate := acctest.TLSRSAX509LocallySignedCertificatePEM(t, caKey, caCertificate, key, "example.com")
 
 	if !strings.Contains(certificate, acctest.PEMBlockTypeCertificate) {
 		t.Errorf("certificate does not contain CERTIFICATE: %s", certificate)

--- a/internal/acctest/crypto_test.go
+++ b/internal/acctest/crypto_test.go
@@ -46,7 +46,7 @@ func TestTLSRSAX509SelfSignedCACertificatePEM(t *testing.T) {
 
 func TestTLSRSAX509SelfSignedCertificatePEM(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
 	if !strings.Contains(certificate, acctest.PEMBlockTypeCertificate) {
 		t.Errorf("certificate does not contain CERTIFICATE: %s", certificate)

--- a/internal/service/acm/certificate_data_source_test.go
+++ b/internal/service/acm/certificate_data_source_test.go
@@ -208,7 +208,7 @@ func TestAccACMCertificateDataSource_noMatchReturnsError(t *testing.T) {
 func TestAccACMCertificateDataSource_keyTypes(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
 	dataSourceName := "data.aws_acm_certificate.test"
-	key := acctest.TLSRSAPrivateKeyPEM(4096)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 4096)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, acctest.RandomDomain().String())
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 

--- a/internal/service/acm/certificate_data_source_test.go
+++ b/internal/service/acm/certificate_data_source_test.go
@@ -209,7 +209,7 @@ func TestAccACMCertificateDataSource_keyTypes(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
 	dataSourceName := "data.aws_acm_certificate.test"
 	key := acctest.TLSRSAPrivateKeyPEM(t, 4096)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, acctest.RandomDomain().String())
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, acctest.RandomDomain().String())
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -1338,10 +1338,10 @@ func TestAccACMCertificate_Imported_domainName(t *testing.T) {
 	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(caKey)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509LocallySignedCertificatePEM(caKey, caCertificate, key, commonName)
+	certificate := acctest.TLSRSAX509LocallySignedCertificatePEM(t, caKey, caCertificate, key, commonName)
 	newCaKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	newCaCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(newCaKey)
-	newCertificate := acctest.TLSRSAX509LocallySignedCertificatePEM(newCaKey, newCaCertificate, key, commonName)
+	newCertificate := acctest.TLSRSAX509LocallySignedCertificatePEM(t, newCaKey, newCaCertificate, key, commonName)
 	withoutChainDomain := acctest.RandomDomainName()
 	var v1, v2, v3 acm.CertificateDetail
 
@@ -1398,7 +1398,7 @@ func TestAccACMCertificate_Imported_validityDates(t *testing.T) {
 	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(caKey)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509LocallySignedCertificatePEM(caKey, caCertificate, key, commonName)
+	certificate := acctest.TLSRSAX509LocallySignedCertificatePEM(t, caKey, caCertificate, key, commonName)
 
 	var v acm.CertificateDetail
 

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -1335,11 +1335,11 @@ func TestAccACMCertificate_disableCTLogging(t *testing.T) {
 func TestAccACMCertificate_Imported_domainName(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
 	commonName := "example.com"
-	caKey := acctest.TLSRSAPrivateKeyPEM(2048)
+	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(caKey)
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509LocallySignedCertificatePEM(caKey, caCertificate, key, commonName)
-	newCaKey := acctest.TLSRSAPrivateKeyPEM(2048)
+	newCaKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	newCaCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(newCaKey)
 	newCertificate := acctest.TLSRSAX509LocallySignedCertificatePEM(newCaKey, newCaCertificate, key, commonName)
 	withoutChainDomain := acctest.RandomDomainName()
@@ -1395,9 +1395,9 @@ func TestAccACMCertificate_Imported_domainName(t *testing.T) {
 func TestAccACMCertificate_Imported_validityDates(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
 	commonName := "example.com"
-	caKey := acctest.TLSRSAPrivateKeyPEM(2048)
+	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(caKey)
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509LocallySignedCertificatePEM(caKey, caCertificate, key, commonName)
 
 	var v acm.CertificateDetail
@@ -1465,9 +1465,9 @@ func TestAccACMCertificate_Imported_ipAddress(t *testing.T) { // Reference: http
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/15055
 func TestAccACMCertificate_PrivateKey_tags(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
-	key1 := acctest.TLSRSAPrivateKeyPEM(2048)
+	key1 := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate1 := acctest.TLSRSAX509SelfSignedCertificatePEM(key1, "1.2.3.4")
-	key2 := acctest.TLSRSAPrivateKeyPEM(2048)
+	key2 := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate2 := acctest.TLSRSAX509SelfSignedCertificatePEM(key2, "5.6.7.8")
 	var v acm.CertificateDetail
 
@@ -1790,7 +1790,7 @@ resource "aws_acm_certificate" "test" {
 }
 
 func testAccCertificateConfig_privateKeyNoChain(commonName string) string {
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, commonName)
 
 	return fmt.Sprintf(`

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -1336,11 +1336,11 @@ func TestAccACMCertificate_Imported_domainName(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
 	commonName := "example.com"
 	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(caKey)
+	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(t, caKey)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509LocallySignedCertificatePEM(t, caKey, caCertificate, key, commonName)
 	newCaKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	newCaCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(newCaKey)
+	newCaCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(t, newCaKey)
 	newCertificate := acctest.TLSRSAX509LocallySignedCertificatePEM(t, newCaKey, newCaCertificate, key, commonName)
 	withoutChainDomain := acctest.RandomDomainName()
 	var v1, v2, v3 acm.CertificateDetail
@@ -1396,7 +1396,7 @@ func TestAccACMCertificate_Imported_validityDates(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
 	commonName := "example.com"
 	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(caKey)
+	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(t, caKey)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509LocallySignedCertificatePEM(t, caKey, caCertificate, key, commonName)
 

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -1371,7 +1371,7 @@ func TestAccACMCertificate_Imported_domainName(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCertificateConfig_privateKeyNoChain(withoutChainDomain),
+				Config: testAccCertificateConfig_privateKeyNoChain(t, withoutChainDomain),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(resourceName, &v3),
 					testAccCheckCertficateNotRecreated(&v2, &v3),
@@ -1443,7 +1443,7 @@ func TestAccACMCertificate_Imported_ipAddress(t *testing.T) { // Reference: http
 		CheckDestroy:             testAccCheckCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCertificateConfig_privateKeyNoChain("1.2.3.4"),
+				Config: testAccCertificateConfig_privateKeyNoChain(t, "1.2.3.4"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", ""),
@@ -1789,7 +1789,7 @@ resource "aws_acm_certificate" "test" {
 `, domainName, subjectAlternativeNames, validationMethod)
 }
 
-func testAccCertificateConfig_privateKeyNoChain(commonName string) string {
+func testAccCertificateConfig_privateKeyNoChain(t *testing.T, commonName string) string {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, commonName)
 

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -1466,9 +1466,9 @@ func TestAccACMCertificate_Imported_ipAddress(t *testing.T) { // Reference: http
 func TestAccACMCertificate_PrivateKey_tags(t *testing.T) {
 	resourceName := "aws_acm_certificate.test"
 	key1 := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate1 := acctest.TLSRSAX509SelfSignedCertificatePEM(key1, "1.2.3.4")
+	certificate1 := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key1, "1.2.3.4")
 	key2 := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate2 := acctest.TLSRSAX509SelfSignedCertificatePEM(key2, "5.6.7.8")
+	certificate2 := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key2, "5.6.7.8")
 	var v acm.CertificateDetail
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1791,7 +1791,7 @@ resource "aws_acm_certificate" "test" {
 
 func testAccCertificateConfig_privateKeyNoChain(commonName string) string {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, commonName)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, commonName)
 
 	return fmt.Sprintf(`
 resource "aws_acm_certificate" "test" {

--- a/internal/service/acmpca/certificate_test.go
+++ b/internal/service/acmpca/certificate_test.go
@@ -106,7 +106,7 @@ func TestAccACMPCACertificate_endEntityCertificate(t *testing.T) {
 	resourceName := "aws_acmpca_certificate.test"
 
 	csrDomain := acctest.RandomDomainName()
-	csr, _ := acctest.TLSRSAX509CertificateRequestPEM(4096, csrDomain)
+	csr, _ := acctest.TLSRSAX509CertificateRequestPEM(t, 4096, csrDomain)
 	domain := acctest.RandomDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -148,7 +148,7 @@ func TestAccACMPCACertificate_Validity_endDate(t *testing.T) {
 	resourceName := "aws_acmpca_certificate.test"
 
 	csrDomain := acctest.RandomDomainName()
-	csr, _ := acctest.TLSRSAX509CertificateRequestPEM(4096, csrDomain)
+	csr, _ := acctest.TLSRSAX509CertificateRequestPEM(t, 4096, csrDomain)
 	domain := acctest.RandomDomainName()
 	later := time.Now().Add(time.Minute * 10).Format(time.RFC3339)
 
@@ -191,7 +191,7 @@ func TestAccACMPCACertificate_Validity_absolute(t *testing.T) {
 	resourceName := "aws_acmpca_certificate.test"
 
 	csrDomain := acctest.RandomDomainName()
-	csr, _ := acctest.TLSRSAX509CertificateRequestPEM(4096, csrDomain)
+	csr, _ := acctest.TLSRSAX509CertificateRequestPEM(t, 4096, csrDomain)
 	domain := acctest.RandomDomainName()
 	later := time.Now().Add(time.Minute * 10).Unix()
 

--- a/internal/service/apigateway/base_path_mapping_test.go
+++ b/internal/service/apigateway/base_path_mapping_test.go
@@ -72,7 +72,7 @@ func TestAccAPIGatewayBasePathMapping_basic(t *testing.T) {
 	name := acctest.RandomSubdomain()
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, name)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, name)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -102,7 +102,7 @@ func TestAccAPIGatewayBasePathMapping_BasePath_empty(t *testing.T) {
 	name := acctest.RandomSubdomain()
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, name)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, name)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -131,7 +131,7 @@ func TestAccAPIGatewayBasePathMapping_updates(t *testing.T) {
 	name := acctest.RandomSubdomain()
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, name)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, name)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -182,7 +182,7 @@ func TestAccAPIGatewayBasePathMapping_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_base_path_mapping.test"
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, name)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, name)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },

--- a/internal/service/apigateway/base_path_mapping_test.go
+++ b/internal/service/apigateway/base_path_mapping_test.go
@@ -71,7 +71,7 @@ func TestAccAPIGatewayBasePathMapping_basic(t *testing.T) {
 
 	name := acctest.RandomSubdomain()
 
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, name)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -101,7 +101,7 @@ func TestAccAPIGatewayBasePathMapping_BasePath_empty(t *testing.T) {
 
 	name := acctest.RandomSubdomain()
 
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, name)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -130,7 +130,7 @@ func TestAccAPIGatewayBasePathMapping_updates(t *testing.T) {
 	resourceName := "aws_api_gateway_base_path_mapping.test"
 	name := acctest.RandomSubdomain()
 
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, name)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -181,7 +181,7 @@ func TestAccAPIGatewayBasePathMapping_disappears(t *testing.T) {
 	name := acctest.RandomSubdomain()
 	resourceName := "aws_api_gateway_base_path_mapping.test"
 
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, name)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/apigateway/domain_name_data_source_test.go
+++ b/internal/service/apigateway/domain_name_data_source_test.go
@@ -14,7 +14,7 @@ func TestAccAPIGatewayDomainNameDataSource_basic(t *testing.T) {
 	dataSourceName := "data.aws_api_gateway_domain_name.test"
 	rName := acctest.RandomSubdomain()
 
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, rName)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/apigateway/domain_name_data_source_test.go
+++ b/internal/service/apigateway/domain_name_data_source_test.go
@@ -15,7 +15,7 @@ func TestAccAPIGatewayDomainNameDataSource_basic(t *testing.T) {
 	rName := acctest.RandomSubdomain()
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, rName)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },

--- a/internal/service/apigateway/domain_name_test.go
+++ b/internal/service/apigateway/domain_name_test.go
@@ -165,7 +165,7 @@ func TestAccAPIGatewayDomainName_regionalCertificateName(t *testing.T) {
 	rName := fmt.Sprintf("%s.%s", sdkacctest.RandString(8), domain)
 
 	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(caKey)
+	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(t, caKey)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509LocallySignedCertificatePEM(t, caKey, caCertificate, key, domainWildcard)
 

--- a/internal/service/apigateway/domain_name_test.go
+++ b/internal/service/apigateway/domain_name_test.go
@@ -121,7 +121,7 @@ func TestAccAPIGatewayDomainName_regionalCertificateARN(t *testing.T) {
 	rName := acctest.RandomSubdomain()
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, rName)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -200,7 +200,7 @@ func TestAccAPIGatewayDomainName_securityPolicy(t *testing.T) {
 	rName := acctest.RandomSubdomain()
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, rName)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -230,7 +230,7 @@ func TestAccAPIGatewayDomainName_tags(t *testing.T) {
 	rName := acctest.RandomSubdomain()
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, rName)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -278,7 +278,7 @@ func TestAccAPIGatewayDomainName_disappears(t *testing.T) {
 	rName := acctest.RandomSubdomain()
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, rName)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, rName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -347,7 +347,7 @@ func TestAccAPIGatewayDomainName_MutualTLSAuthentication_ownership(t *testing.T)
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
 	domain := fmt.Sprintf("%s.%s", acctest.RandomSubdomain(), rootDomain)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, domain)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domain)
 
 	var v apigateway.DomainName
 	resourceName := "aws_api_gateway_domain_name.test"

--- a/internal/service/apigateway/domain_name_test.go
+++ b/internal/service/apigateway/domain_name_test.go
@@ -120,7 +120,7 @@ func TestAccAPIGatewayDomainName_regionalCertificateARN(t *testing.T) {
 	resourceName := "aws_api_gateway_domain_name.test"
 	rName := acctest.RandomSubdomain()
 
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, rName)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -164,9 +164,9 @@ func TestAccAPIGatewayDomainName_regionalCertificateName(t *testing.T) {
 	domainWildcard := fmt.Sprintf("*.%s", domain)
 	rName := fmt.Sprintf("%s.%s", sdkacctest.RandString(8), domain)
 
-	caKey := acctest.TLSRSAPrivateKeyPEM(2048)
+	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(caKey)
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509LocallySignedCertificatePEM(caKey, caCertificate, key, domainWildcard)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -199,7 +199,7 @@ func TestAccAPIGatewayDomainName_securityPolicy(t *testing.T) {
 	resourceName := "aws_api_gateway_domain_name.test"
 	rName := acctest.RandomSubdomain()
 
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, rName)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -229,7 +229,7 @@ func TestAccAPIGatewayDomainName_tags(t *testing.T) {
 	resourceName := "aws_api_gateway_domain_name.test"
 	rName := acctest.RandomSubdomain()
 
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, rName)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -277,7 +277,7 @@ func TestAccAPIGatewayDomainName_disappears(t *testing.T) {
 	resourceName := "aws_api_gateway_domain_name.test"
 	rName := acctest.RandomSubdomain()
 
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, rName)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -346,7 +346,7 @@ func TestAccAPIGatewayDomainName_MutualTLSAuthentication_basic(t *testing.T) {
 func TestAccAPIGatewayDomainName_MutualTLSAuthentication_ownership(t *testing.T) {
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
 	domain := fmt.Sprintf("%s.%s", acctest.RandomSubdomain(), rootDomain)
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, domain)
 
 	var v apigateway.DomainName

--- a/internal/service/apigateway/domain_name_test.go
+++ b/internal/service/apigateway/domain_name_test.go
@@ -167,7 +167,7 @@ func TestAccAPIGatewayDomainName_regionalCertificateName(t *testing.T) {
 	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	caCertificate := acctest.TLSRSAX509SelfSignedCACertificatePEM(caKey)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509LocallySignedCertificatePEM(caKey, caCertificate, key, domainWildcard)
+	certificate := acctest.TLSRSAX509LocallySignedCertificatePEM(t, caKey, caCertificate, key, domainWildcard)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },

--- a/internal/service/apigatewayv2/api_mapping_test.go
+++ b/internal/service/apigatewayv2/api_mapping_test.go
@@ -158,7 +158,7 @@ func testAccAPIMapping_key(t *testing.T, rName string, certificateArn *string) {
 func testAccCheckAPIMappingCreateCertificate(rName string, certificateArn *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		privateKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-		certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(privateKey, fmt.Sprintf("%s.example.com", rName))
+		certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKey, fmt.Sprintf("%s.example.com", rName))
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ACMConn
 

--- a/internal/service/apigatewayv2/api_mapping_test.go
+++ b/internal/service/apigatewayv2/api_mapping_test.go
@@ -157,7 +157,7 @@ func testAccAPIMapping_key(t *testing.T, rName string, certificateArn *string) {
 
 func testAccCheckAPIMappingCreateCertificate(rName string, certificateArn *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		privateKey := acctest.TLSRSAPrivateKeyPEM(2048)
+		privateKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 		certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(privateKey, fmt.Sprintf("%s.example.com", rName))
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ACMConn

--- a/internal/service/apigatewayv2/api_mapping_test.go
+++ b/internal/service/apigatewayv2/api_mapping_test.go
@@ -54,7 +54,7 @@ func testAccAPIMapping_createCertificate(t *testing.T, rName string, certificate
 			{
 				Config: "# Empty config",
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAPIMappingCreateCertificate(rName, certificateArn),
+					testAccCheckAPIMappingCreateCertificate(t, rName, certificateArn),
 				),
 			},
 		},
@@ -155,7 +155,7 @@ func testAccAPIMapping_key(t *testing.T, rName string, certificateArn *string) {
 	})
 }
 
-func testAccCheckAPIMappingCreateCertificate(rName string, certificateArn *string) resource.TestCheckFunc {
+func testAccCheckAPIMappingCreateCertificate(t *testing.T, rName string, certificateArn *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		privateKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 		certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKey, fmt.Sprintf("%s.example.com", rName))

--- a/internal/service/apigatewayv2/domain_name_test.go
+++ b/internal/service/apigatewayv2/domain_name_test.go
@@ -22,7 +22,7 @@ func TestAccAPIGatewayV2DomainName_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	domainName := fmt.Sprintf("%s.example.com", rName)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, domainName)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domainName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -61,7 +61,7 @@ func TestAccAPIGatewayV2DomainName_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	domainName := fmt.Sprintf("%s.example.com", rName)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, domainName)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domainName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -88,7 +88,7 @@ func TestAccAPIGatewayV2DomainName_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	domainName := fmt.Sprintf("%s.example.com", rName)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, domainName)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domainName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -147,7 +147,7 @@ func TestAccAPIGatewayV2DomainName_updateCertificate(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	domainName := fmt.Sprintf("%s.example.com", rName)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, domainName)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domainName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -333,7 +333,7 @@ func TestAccAPIGatewayV2DomainName_MutualTLSAuthentication_ownership(t *testing.
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
 	domain := acctest.ACMCertificateRandomSubDomain(rootDomain)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, domain)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domain)
 
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"

--- a/internal/service/apigatewayv2/domain_name_test.go
+++ b/internal/service/apigatewayv2/domain_name_test.go
@@ -20,7 +20,7 @@ func TestAccAPIGatewayV2DomainName_basic(t *testing.T) {
 	resourceName := "aws_apigatewayv2_domain_name.test"
 	certResourceName := "aws_acm_certificate.test.0"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	domainName := fmt.Sprintf("%s.example.com", rName)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, domainName)
 
@@ -59,7 +59,7 @@ func TestAccAPIGatewayV2DomainName_disappears(t *testing.T) {
 	var v apigatewayv2.GetDomainNameOutput
 	resourceName := "aws_apigatewayv2_domain_name.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	domainName := fmt.Sprintf("%s.example.com", rName)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, domainName)
 
@@ -86,7 +86,7 @@ func TestAccAPIGatewayV2DomainName_tags(t *testing.T) {
 	resourceName := "aws_apigatewayv2_domain_name.test"
 	certResourceName := "aws_acm_certificate.test.0"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	domainName := fmt.Sprintf("%s.example.com", rName)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, domainName)
 
@@ -145,7 +145,7 @@ func TestAccAPIGatewayV2DomainName_updateCertificate(t *testing.T) {
 	certResourceName0 := "aws_acm_certificate.test.0"
 	certResourceName1 := "aws_acm_certificate.test.1"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	domainName := fmt.Sprintf("%s.example.com", rName)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, domainName)
 
@@ -332,7 +332,7 @@ func TestAccAPIGatewayV2DomainName_MutualTLSAuthentication_noVersion(t *testing.
 func TestAccAPIGatewayV2DomainName_MutualTLSAuthentication_ownership(t *testing.T) {
 	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
 	domain := acctest.ACMCertificateRandomSubDomain(rootDomain)
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, domain)
 
 	var v apigatewayv2.GetDomainNameOutput

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -3575,7 +3575,7 @@ resource "aws_cloudfront_distribution" "test" {
 // CloudFront Distribution ACM Certificates must be created in us-east-1
 func testAccDistributionViewerCertificateACMCertificateARNBaseConfig(commonName string) string {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, commonName)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, commonName)
 
 	return testAccRegionProviderConfig() + fmt.Sprintf(`
 resource "aws_acm_certificate" "test" {

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -3574,7 +3574,7 @@ resource "aws_cloudfront_distribution" "test" {
 
 // CloudFront Distribution ACM Certificates must be created in us-east-1
 func testAccDistributionViewerCertificateACMCertificateARNBaseConfig(commonName string) string {
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, commonName)
 
 	return testAccRegionProviderConfig() + fmt.Sprintf(`

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -1209,13 +1209,13 @@ func TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN(t *testin
 		CheckDestroy:             testAccCheckDistributionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDistributionConfig_viewerCertificateACMCertificateARN(retainOnDelete),
+				Config: testAccDistributionConfig_viewerCertificateACMCertificateARN(t, retainOnDelete),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDistributionExists(resourceName, &distribution),
 				),
 			},
 			{
-				Config:            testAccDistributionConfig_viewerCertificateACMCertificateARN(retainOnDelete),
+				Config:            testAccDistributionConfig_viewerCertificateACMCertificateARN(t, retainOnDelete),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -1241,13 +1241,13 @@ func TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsW
 		CheckDestroy:             testAccCheckDistributionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDistributionConfig_viewerCertificateACMCertificateARNConflictsDefaultCertificate(retainOnDelete),
+				Config: testAccDistributionConfig_viewerCertificateACMCertificateARNConflictsDefaultCertificate(t, retainOnDelete),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDistributionExists(resourceName, &distribution),
 				),
 			},
 			{
-				Config:            testAccDistributionConfig_viewerCertificateACMCertificateARNConflictsDefaultCertificate(retainOnDelete),
+				Config:            testAccDistributionConfig_viewerCertificateACMCertificateARNConflictsDefaultCertificate(t, retainOnDelete),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -3573,7 +3573,7 @@ resource "aws_cloudfront_distribution" "test" {
 }
 
 // CloudFront Distribution ACM Certificates must be created in us-east-1
-func testAccDistributionViewerCertificateACMCertificateARNBaseConfig(commonName string) string {
+func testAccDistributionViewerCertificateACMCertificateARNBaseConfig(t *testing.T, commonName string) string {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, commonName)
 
@@ -3585,11 +3585,11 @@ resource "aws_acm_certificate" "test" {
 `, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key))
 }
 
-func testAccDistributionConfig_viewerCertificateACMCertificateARN(retainOnDelete bool) string {
-	return testAccDistributionViewerCertificateACMCertificateARNBaseConfig("example.com") + fmt.Sprintf(`
+func testAccDistributionConfig_viewerCertificateACMCertificateARN(t *testing.T, retainOnDelete bool) string {
+	return acctest.ConfigCompose(testAccDistributionViewerCertificateACMCertificateARNBaseConfig(t, "example.com"), fmt.Sprintf(`
 resource "aws_cloudfront_distribution" "test" {
   enabled          = false
-  retain_on_delete = %t
+  retain_on_delete = %[1]t
 
   default_cache_behavior {
     allowed_methods        = ["GET", "HEAD"]
@@ -3629,14 +3629,14 @@ resource "aws_cloudfront_distribution" "test" {
     ssl_support_method  = "sni-only"
   }
 }
-`, retainOnDelete)
+`, retainOnDelete))
 }
 
-func testAccDistributionConfig_viewerCertificateACMCertificateARNConflictsDefaultCertificate(retainOnDelete bool) string {
-	return testAccDistributionViewerCertificateACMCertificateARNBaseConfig("example.com") + fmt.Sprintf(`
+func testAccDistributionConfig_viewerCertificateACMCertificateARNConflictsDefaultCertificate(t *testing.T, retainOnDelete bool) string {
+	return acctest.ConfigCompose(testAccDistributionViewerCertificateACMCertificateARNBaseConfig(t, "example.com"), fmt.Sprintf(`
 resource "aws_cloudfront_distribution" "test" {
   enabled          = false
-  retain_on_delete = %t
+  retain_on_delete = %[1]t
 
   default_cache_behavior {
     allowed_methods        = ["GET", "HEAD"]
@@ -3677,7 +3677,7 @@ resource "aws_cloudfront_distribution" "test" {
     ssl_support_method             = "sni-only"
   }
 }
-`, retainOnDelete)
+`, retainOnDelete))
 }
 
 func testAccDistributionConfig_waitForDeployment(enabled, waitForDeployment bool) string {

--- a/internal/service/ec2/vpnclient_authorization_rule_test.go
+++ b/internal/service/ec2/vpnclient_authorization_rule_test.go
@@ -28,7 +28,7 @@ func testAccClientVPNAuthorizationRule_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNAuthorizationRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNAuthorizationRuleConfig_basic(rName),
+				Config: testAccClientVPNAuthorizationRuleConfig_basic(t, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNAuthorizationRuleExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "target_network_cidr", subnetResourceName, "cidr_block"),
@@ -57,7 +57,7 @@ func testAccClientVPNAuthorizationRule_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNAuthorizationRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNAuthorizationRuleConfig_basic(rName),
+				Config: testAccClientVPNAuthorizationRuleConfig_basic(t, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNAuthorizationRuleExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceClientVPNAuthorizationRule(), resourceName),
@@ -80,7 +80,7 @@ func testAccClientVPNAuthorizationRule_Disappears_endpoint(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNAuthorizationRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNAuthorizationRuleConfig_basic(rName),
+				Config: testAccClientVPNAuthorizationRuleConfig_basic(t, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNAuthorizationRuleExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceClientVPNEndpoint(), "aws_ec2_client_vpn_endpoint.test"),
@@ -119,7 +119,7 @@ func testAccClientVPNAuthorizationRule_groups(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNAuthorizationRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNAuthorizationRuleConfig_groups(rName, groups1),
+				Config: testAccClientVPNAuthorizationRuleConfig_groups(t, rName, groups1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNAuthorizationRuleExists(resource1Name, &v),
 					resource.TestCheckResourceAttrPair(resource1Name, "target_network_cidr", subnetResourceName, "cidr_block"),
@@ -133,7 +133,7 @@ func testAccClientVPNAuthorizationRule_groups(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClientVPNAuthorizationRuleConfig_groups(rName, groups2),
+				Config: testAccClientVPNAuthorizationRuleConfig_groups(t, rName, groups2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNAuthorizationRuleExists(resource1Name, &v),
 					resource.TestCheckResourceAttrPair(resource1Name, "target_network_cidr", subnetResourceName, "cidr_block"),
@@ -152,7 +152,7 @@ func testAccClientVPNAuthorizationRule_groups(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClientVPNAuthorizationRuleConfig_groups(rName, groups3),
+				Config: testAccClientVPNAuthorizationRuleConfig_groups(t, rName, groups3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNAuthorizationRuleExists(resource2Name, &v),
 					resource.TestCheckResourceAttrPair(resource2Name, "target_network_cidr", subnetResourceName, "cidr_block"),
@@ -190,7 +190,7 @@ func testAccClientVPNAuthorizationRule_subnets(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNAuthorizationRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNAuthorizationRuleConfig_subnets(rName, subnetCount, case1),
+				Config: testAccClientVPNAuthorizationRuleConfig_subnets(t, rName, subnetCount, case1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNAuthorizationRuleExists(resource1Name, &v),
 					resource.TestCheckResourceAttrPair(resource1Name, "target_network_cidr", fmt.Sprintf("aws_subnet.test.%d", subnetIndex1), "cidr_block"),
@@ -209,7 +209,7 @@ func testAccClientVPNAuthorizationRule_subnets(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClientVPNAuthorizationRuleConfig_subnets(rName, subnetCount, case2),
+				Config: testAccClientVPNAuthorizationRuleConfig_subnets(t, rName, subnetCount, case2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNAuthorizationRuleExists(resource2Name, &v),
 					resource.TestCheckResourceAttrPair(resource2Name, "target_network_cidr", fmt.Sprintf("aws_subnet.test.%d", subnetIndex2), "cidr_block"),
@@ -282,9 +282,9 @@ func testAccCheckClientVPNAuthorizationRuleExists(name string, v *ec2.Authorizat
 	}
 }
 
-func testAccClientVPNAuthorizationRuleConfig_base(rName string, subnetCount int) string {
+func testAccClientVPNAuthorizationRuleConfig_base(t *testing.T, rName string, subnetCount int) string {
 	return acctest.ConfigCompose(
-		testAccClientVPNEndpointConfig_basic(rName),
+		testAccClientVPNEndpointConfig_basic(t, rName),
 		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
 		fmt.Sprintf(`
 resource "aws_vpc" "test" {
@@ -309,8 +309,8 @@ resource "aws_subnet" "test" {
 `, rName, subnetCount))
 }
 
-func testAccClientVPNAuthorizationRuleConfig_basic(rName string) string {
-	return acctest.ConfigCompose(testAccClientVPNAuthorizationRuleConfig_base(rName, 1), `
+func testAccClientVPNAuthorizationRuleConfig_basic(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(testAccClientVPNAuthorizationRuleConfig_base(t, rName, 1), `
 resource "aws_ec2_client_vpn_authorization_rule" "test" {
   client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.test.id
   target_network_cidr    = aws_subnet.test[0].cidr_block
@@ -319,7 +319,7 @@ resource "aws_ec2_client_vpn_authorization_rule" "test" {
 `)
 }
 
-func testAccClientVPNAuthorizationRuleConfig_groups(rName string, groupNames map[string]string) string {
+func testAccClientVPNAuthorizationRuleConfig_groups(t *testing.T, rName string, groupNames map[string]string) string {
 	var b strings.Builder
 	for k, v := range groupNames {
 		fmt.Fprintf(&b, `
@@ -331,10 +331,10 @@ resource "aws_ec2_client_vpn_authorization_rule" %[1]q {
 `, k, v)
 	}
 
-	return acctest.ConfigCompose(testAccClientVPNAuthorizationRuleConfig_base(rName, 1), b.String())
+	return acctest.ConfigCompose(testAccClientVPNAuthorizationRuleConfig_base(t, rName, 1), b.String())
 }
 
-func testAccClientVPNAuthorizationRuleConfig_subnets(rName string, subnetCount int, groupNames map[string]int) string {
+func testAccClientVPNAuthorizationRuleConfig_subnets(t *testing.T, rName string, subnetCount int, groupNames map[string]int) string {
 	var b strings.Builder
 	for k, v := range groupNames {
 		fmt.Fprintf(&b, `
@@ -346,5 +346,5 @@ resource "aws_ec2_client_vpn_authorization_rule" %[1]q {
 `, k, v)
 	}
 
-	return acctest.ConfigCompose(testAccClientVPNAuthorizationRuleConfig_base(rName, subnetCount), b.String())
+	return acctest.ConfigCompose(testAccClientVPNAuthorizationRuleConfig_base(t, rName, subnetCount), b.String())
 }

--- a/internal/service/ec2/vpnclient_endpoint_data_source_test.go
+++ b/internal/service/ec2/vpnclient_endpoint_data_source_test.go
@@ -23,7 +23,7 @@ func testAccClientVPNEndpointDataSource_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNEndpointDataSourceConfig_basic(rName),
+				Config: testAccClientVPNEndpointDataSourceConfig_basic(t, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasource1Name, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(datasource1Name, "authentication_options.#", resourceName, "authentication_options.#"),
@@ -90,8 +90,8 @@ func testAccClientVPNEndpointDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccClientVPNEndpointDataSourceConfig_basic(rName string) string {
-	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_basic(rName), `
+func testAccClientVPNEndpointDataSourceConfig_basic(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_basic(t, rName), `
 data "aws_ec2_client_vpn_endpoint" "by_id" {
   client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.test.id
 }

--- a/internal/service/ec2/vpnclient_endpoint_test.go
+++ b/internal/service/ec2/vpnclient_endpoint_test.go
@@ -100,7 +100,7 @@ func testAccClientVPNEndpoint_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNEndpointConfig_basic(rName),
+				Config: testAccClientVPNEndpointConfig_basic(t, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`client-vpn-endpoint/cvpn-endpoint-.+`)),
@@ -156,7 +156,7 @@ func testAccClientVPNEndpoint_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNEndpointConfig_basic(rName),
+				Config: testAccClientVPNEndpointConfig_basic(t, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceClientVPNEndpoint(), resourceName),
@@ -178,7 +178,7 @@ func testAccClientVPNEndpoint_tags(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNEndpointConfig_tags1("key1", "value1"),
+				Config: testAccClientVPNEndpointConfig_tags1(t, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -191,7 +191,7 @@ func testAccClientVPNEndpoint_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClientVPNEndpointConfig_tags2("key1", "value1updated", "key2", "value2"),
+				Config: testAccClientVPNEndpointConfig_tags2(t, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -200,7 +200,7 @@ func testAccClientVPNEndpoint_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClientVPNEndpointConfig_tags1("key2", "value2"),
+				Config: testAccClientVPNEndpointConfig_tags1(t, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -229,7 +229,7 @@ func testAccClientVPNEndpoint_msADAuth(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNEndpointConfig_microsoftAD(rName, domainName),
+				Config: testAccClientVPNEndpointConfig_microsoftAD(t, rName, domainName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "authentication_options.#", "1"),
@@ -265,7 +265,7 @@ func testAccClientVPNEndpoint_msADAuthAndMutualAuth(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNEndpointConfig_mutualAuthAndMicrosoftAD(rName, domainName),
+				Config: testAccClientVPNEndpointConfig_mutualAuthAndMicrosoftAD(t, rName, domainName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "authentication_options.#", "2"),
@@ -298,7 +298,7 @@ func testAccClientVPNEndpoint_federatedAuth(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNEndpointConfig_federatedAuth(rName, idpEntityID),
+				Config: testAccClientVPNEndpointConfig_federatedAuth(t, rName, idpEntityID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "authentication_options.#", "1"),
@@ -330,7 +330,7 @@ func testAccClientVPNEndpoint_federatedAuthWithSelfServiceProvider(t *testing.T)
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNEndpointConfig_federatedAuthAndSelfServiceSAMLProvider(rName, idpEntityID),
+				Config: testAccClientVPNEndpointConfig_federatedAuthAndSelfServiceSAMLProvider(t, rName, idpEntityID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "authentication_options.#", "1"),
@@ -362,7 +362,7 @@ func testAccClientVPNEndpoint_withClientConnectOptions(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNEndpointConfig_clientConnectOptions(rName, true, 1),
+				Config: testAccClientVPNEndpointConfig_clientConnectOptions(t, rName, true, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "client_connect_options.#", "1"),
@@ -376,7 +376,7 @@ func testAccClientVPNEndpoint_withClientConnectOptions(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClientVPNEndpointConfig_clientConnectOptions(rName, true, 2),
+				Config: testAccClientVPNEndpointConfig_clientConnectOptions(t, rName, true, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "client_connect_options.#", "1"),
@@ -385,7 +385,7 @@ func testAccClientVPNEndpoint_withClientConnectOptions(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClientVPNEndpointConfig_clientConnectOptions(rName, false, 0),
+				Config: testAccClientVPNEndpointConfig_clientConnectOptions(t, rName, false, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "client_connect_options.#", "1"),
@@ -409,7 +409,7 @@ func testAccClientVPNEndpoint_withClientLoginBannerOptions(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNEndpointConfig_clientLoginBannerOptions(rName, true, "Options 1"),
+				Config: testAccClientVPNEndpointConfig_clientLoginBannerOptions(t, rName, true, "Options 1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "client_login_banner_options.#", "1"),
@@ -423,7 +423,7 @@ func testAccClientVPNEndpoint_withClientLoginBannerOptions(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClientVPNEndpointConfig_clientLoginBannerOptions(rName, true, "Options 2"),
+				Config: testAccClientVPNEndpointConfig_clientLoginBannerOptions(t, rName, true, "Options 2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "client_login_banner_options.#", "1"),
@@ -432,7 +432,7 @@ func testAccClientVPNEndpoint_withClientLoginBannerOptions(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClientVPNEndpointConfig_clientLoginBannerOptions(rName, false, ""),
+				Config: testAccClientVPNEndpointConfig_clientLoginBannerOptions(t, rName, false, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "client_login_banner_options.#", "1"),
@@ -459,7 +459,7 @@ func testAccClientVPNEndpoint_withConnectionLogOptions(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNEndpointConfig_connectionLogOptions(rName, 0),
+				Config: testAccClientVPNEndpointConfig_connectionLogOptions(t, rName, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "connection_log_options.#", "1"),
@@ -469,7 +469,7 @@ func testAccClientVPNEndpoint_withConnectionLogOptions(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClientVPNEndpointConfig_connectionLogOptions(rName, 1),
+				Config: testAccClientVPNEndpointConfig_connectionLogOptions(t, rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "connection_log_options.#", "1"),
@@ -484,7 +484,7 @@ func testAccClientVPNEndpoint_withConnectionLogOptions(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClientVPNEndpointConfig_connectionLogOptions(rName, 2),
+				Config: testAccClientVPNEndpointConfig_connectionLogOptions(t, rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "connection_log_options.#", "1"),
@@ -494,7 +494,7 @@ func testAccClientVPNEndpoint_withConnectionLogOptions(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClientVPNEndpointConfig_basic(rName),
+				Config: testAccClientVPNEndpointConfig_basic(t, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "connection_log_options.#", "1"),
@@ -519,7 +519,7 @@ func testAccClientVPNEndpoint_withDNSServers(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNEndpointConfig_dnsServers(rName),
+				Config: testAccClientVPNEndpointConfig_dnsServers(t, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "dns_servers.#", "2"),
@@ -533,7 +533,7 @@ func testAccClientVPNEndpoint_withDNSServers(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClientVPNEndpointConfig_dnsServersUpdated(rName),
+				Config: testAccClientVPNEndpointConfig_dnsServersUpdated(t, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "dns_servers.#", "1"),
@@ -541,7 +541,7 @@ func testAccClientVPNEndpoint_withDNSServers(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClientVPNEndpointConfig_basic(rName),
+				Config: testAccClientVPNEndpointConfig_basic(t, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "dns_servers.#", "0"),
@@ -565,7 +565,7 @@ func testAccClientVPNEndpoint_simpleAttributesUpdate(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNEndpointConfig_simpleAttributes(rName),
+				Config: testAccClientVPNEndpointConfig_simpleAttributes(t, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", "Description1"),
@@ -582,7 +582,7 @@ func testAccClientVPNEndpoint_simpleAttributesUpdate(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClientVPNEndpointConfig_simpleAttributesUpdated(rName),
+				Config: testAccClientVPNEndpointConfig_simpleAttributesUpdated(t, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", "Description2"),
@@ -610,7 +610,7 @@ func testAccClientVPNEndpoint_selfServicePortal(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNEndpointConfig_selfServicePortal(rName, "enabled", idpEntityID),
+				Config: testAccClientVPNEndpointConfig_selfServicePortal(t, rName, "enabled", idpEntityID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "self_service_portal", "enabled"),
@@ -622,7 +622,7 @@ func testAccClientVPNEndpoint_selfServicePortal(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClientVPNEndpointConfig_selfServicePortal(rName, "disabled", idpEntityID),
+				Config: testAccClientVPNEndpointConfig_selfServicePortal(t, rName, "disabled", idpEntityID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "self_service_portal", "disabled"),
@@ -646,7 +646,7 @@ func testAccClientVPNEndpoint_vpcNoSecurityGroups(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNEndpointConfig_securityGroups(rName, 0),
+				Config: testAccClientVPNEndpointConfig_securityGroups(t, rName, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "1"),
@@ -667,8 +667,8 @@ func testAccClientVPNEndpoint_vpcSecurityGroups(t *testing.T) {
 	var v ec2.ClientVpnEndpoint
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
-	securityGroup1ResourceName := "aws_security_group.test1"
-	securityGroup2ResourceName := "aws_security_group.test2"
+	securityGroup1ResourceName := "aws_security_group.test.0"
+	securityGroup2ResourceName := "aws_security_group.test.1"
 	vpcResourceName := "aws_vpc.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -678,7 +678,7 @@ func testAccClientVPNEndpoint_vpcSecurityGroups(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNEndpointConfig_securityGroups(rName, 2),
+				Config: testAccClientVPNEndpointConfig_securityGroups(t, rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "2"),
@@ -693,7 +693,7 @@ func testAccClientVPNEndpoint_vpcSecurityGroups(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccClientVPNEndpointConfig_securityGroups(rName, 1),
+				Config: testAccClientVPNEndpointConfig_securityGroups(t, rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "1"),
@@ -757,7 +757,7 @@ func testAccCheckClientVPNEndpointExists(name string, v *ec2.ClientVpnEndpoint) 
 	}
 }
 
-func testAccClientVPNEndpointConfig_acmCertificateBase(n string) string {
+func testAccClientVPNEndpointConfig_acmCertificateBase(t *testing.T, n string) string {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
@@ -806,43 +806,15 @@ resource "aws_subnet" "test" {
 }
 
 func testAccClientVPNEndpointConfig_vpcBase(rName string) string {
-	return acctest.ConfigCompose(
-		acctest.ConfigAvailableAZsNoOptIn(),
-		fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block = "10.1.0.0/16"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_subnet" "test" {
-  count             = 2
-  availability_zone = data.aws_availability_zones.available.names[count.index]
-  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
-  vpc_id            = aws_vpc.test.id
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
 resource "aws_default_security_group" "test" {
   vpc_id = aws_vpc.test.id
 }
 
-resource "aws_security_group" "test1" {
-  name   = "%[1]s-1"
-  vpc_id = aws_vpc.test.id
+resource "aws_security_group" "test" {
+  count = 2
 
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_security_group" "test2" {
-  name   = "%[1]s-2"
+  name   = "%[1]s-${count.index}"
   vpc_id = aws_vpc.test.id
 
   tags = {
@@ -852,10 +824,8 @@ resource "aws_security_group" "test2" {
 `, rName))
 }
 
-func testAccClientVPNEndpointConfig_basic(rName string) string {
-	return acctest.ConfigCompose(
-		testAccClientVPNEndpointConfig_acmCertificateBase("test"),
-		fmt.Sprintf(`
+func testAccClientVPNEndpointConfig_basic(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase(t, "test"), fmt.Sprintf(`
 resource "aws_ec2_client_vpn_endpoint" "test" {
   server_certificate_arn = aws_acm_certificate.test.arn
   client_cidr_block      = "10.0.0.0/16"
@@ -876,10 +846,10 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 `, rName))
 }
 
-func testAccClientVPNEndpointConfig_clientConnectOptions(rName string, enabled bool, lambdaFunctionIndex int) string {
+func testAccClientVPNEndpointConfig_clientConnectOptions(t *testing.T, rName string, enabled bool, lambdaFunctionIndex int) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLambdaBase(rName, rName, rName),
-		testAccClientVPNEndpointConfig_acmCertificateBase("test"),
+		testAccClientVPNEndpointConfig_acmCertificateBase(t, "test"),
 		fmt.Sprintf(`
 resource "aws_lambda_function" "test1" {
   filename      = "test-fixtures/lambdatest.zip"
@@ -928,8 +898,8 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 `, rName, enabled, lambdaFunctionIndex))
 }
 
-func testAccClientVPNEndpointConfig_clientLoginBannerOptions(rName string, enabled bool, bannerText string) string {
-	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase("test"), fmt.Sprintf(`
+func testAccClientVPNEndpointConfig_clientLoginBannerOptions(t *testing.T, rName string, enabled bool, bannerText string) string {
+	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase(t, "test"), fmt.Sprintf(`
 locals {
   enabled     = %[2]t
   text        = %[3]q
@@ -961,8 +931,8 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 `, rName, enabled, bannerText))
 }
 
-func testAccClientVPNEndpointConfig_connectionLogOptions(rName string, logStreamIndex int) string {
-	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase("test"), fmt.Sprintf(`
+func testAccClientVPNEndpointConfig_connectionLogOptions(t *testing.T, rName string, logStreamIndex int) string {
+	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase(t, "test"), fmt.Sprintf(`
 resource "aws_cloudwatch_log_group" "test" {
   name = %[1]q
 }
@@ -1004,8 +974,8 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 `, rName, logStreamIndex))
 }
 
-func testAccClientVPNEndpointConfig_dnsServers(rName string) string {
-	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase("test"), fmt.Sprintf(`
+func testAccClientVPNEndpointConfig_dnsServers(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase(t, "test"), fmt.Sprintf(`
 resource "aws_ec2_client_vpn_endpoint" "test" {
   server_certificate_arn = aws_acm_certificate.test.arn
   client_cidr_block      = "10.0.0.0/16"
@@ -1028,8 +998,8 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 `, rName))
 }
 
-func testAccClientVPNEndpointConfig_dnsServersUpdated(rName string) string {
-	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase("test"), fmt.Sprintf(`
+func testAccClientVPNEndpointConfig_dnsServersUpdated(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase(t, "test"), fmt.Sprintf(`
 resource "aws_ec2_client_vpn_endpoint" "test" {
   server_certificate_arn = aws_acm_certificate.test.arn
   client_cidr_block      = "10.0.0.0/16"
@@ -1052,9 +1022,9 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 `, rName))
 }
 
-func testAccClientVPNEndpointConfig_microsoftAD(rName, domain string) string {
+func testAccClientVPNEndpointConfig_microsoftAD(t *testing.T, rName, domain string) string {
 	return acctest.ConfigCompose(
-		testAccClientVPNEndpointConfig_acmCertificateBase("test"),
+		testAccClientVPNEndpointConfig_acmCertificateBase(t, "test"),
 		testAccClientVPNEndpointConfig_msADBase(rName, domain),
 		fmt.Sprintf(`
 resource "aws_ec2_client_vpn_endpoint" "test" {
@@ -1077,9 +1047,9 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 `, rName))
 }
 
-func testAccClientVPNEndpointConfig_mutualAuthAndMicrosoftAD(rName, domain string) string {
+func testAccClientVPNEndpointConfig_mutualAuthAndMicrosoftAD(t *testing.T, rName, domain string) string {
 	return acctest.ConfigCompose(
-		testAccClientVPNEndpointConfig_acmCertificateBase("test"),
+		testAccClientVPNEndpointConfig_acmCertificateBase(t, "test"),
 		testAccClientVPNEndpointConfig_msADBase(rName, domain),
 		fmt.Sprintf(`
 resource "aws_ec2_client_vpn_endpoint" "test" {
@@ -1107,9 +1077,9 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 `, rName))
 }
 
-func testAccClientVPNEndpointConfig_federatedAuth(rName, idpEntityID string) string {
+func testAccClientVPNEndpointConfig_federatedAuth(t *testing.T, rName, idpEntityID string) string {
 	return acctest.ConfigCompose(
-		testAccClientVPNEndpointConfig_acmCertificateBase("test"),
+		testAccClientVPNEndpointConfig_acmCertificateBase(t, "test"),
 		fmt.Sprintf(`
 resource "aws_iam_saml_provider" "test" {
   name                   = %[1]q
@@ -1136,8 +1106,8 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 `, rName, idpEntityID))
 }
 
-func testAccClientVPNEndpointConfig_federatedAuthAndSelfServiceSAMLProvider(rName, idpEntityID string) string {
-	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase("test"), fmt.Sprintf(`
+func testAccClientVPNEndpointConfig_federatedAuthAndSelfServiceSAMLProvider(t *testing.T, rName, idpEntityID string) string {
+	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase(t, "test"), fmt.Sprintf(`
 resource "aws_iam_saml_provider" "test1" {
   name                   = %[1]q
   saml_metadata_document = templatefile("./test-fixtures/saml-metadata.xml.tpl", { entity_id = %[2]q })
@@ -1169,8 +1139,8 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 `, rName, idpEntityID))
 }
 
-func testAccClientVPNEndpointConfig_tags1(tagKey1, tagValue1 string) string {
-	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase("test"), fmt.Sprintf(`
+func testAccClientVPNEndpointConfig_tags1(t *testing.T, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase(t, "test"), fmt.Sprintf(`
 resource "aws_ec2_client_vpn_endpoint" "test" {
   server_certificate_arn = aws_acm_certificate.test.arn
   client_cidr_block      = "10.0.0.0/16"
@@ -1191,8 +1161,8 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 `, tagKey1, tagValue1))
 }
 
-func testAccClientVPNEndpointConfig_tags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase("test"), fmt.Sprintf(`
+func testAccClientVPNEndpointConfig_tags2(t *testing.T, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase(t, "test"), fmt.Sprintf(`
 resource "aws_ec2_client_vpn_endpoint" "test" {
   server_certificate_arn = aws_acm_certificate.test.arn
   client_cidr_block      = "10.0.0.0/16"
@@ -1214,10 +1184,10 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 `, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func testAccClientVPNEndpointConfig_simpleAttributes(rName string) string {
+func testAccClientVPNEndpointConfig_simpleAttributes(t *testing.T, rName string) string {
 	return acctest.ConfigCompose(
-		testAccClientVPNEndpointConfig_acmCertificateBase("test1"),
-		testAccClientVPNEndpointConfig_acmCertificateBase("test2"),
+		testAccClientVPNEndpointConfig_acmCertificateBase(t, "test1"),
+		testAccClientVPNEndpointConfig_acmCertificateBase(t, "test2"),
 		fmt.Sprintf(`
 resource "aws_ec2_client_vpn_endpoint" "test" {
   client_cidr_block      = "10.0.0.0/16"
@@ -1244,10 +1214,10 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 `, rName))
 }
 
-func testAccClientVPNEndpointConfig_simpleAttributesUpdated(rName string) string {
+func testAccClientVPNEndpointConfig_simpleAttributesUpdated(t *testing.T, rName string) string {
 	return acctest.ConfigCompose(
-		testAccClientVPNEndpointConfig_acmCertificateBase("test1"),
-		testAccClientVPNEndpointConfig_acmCertificateBase("test2"),
+		testAccClientVPNEndpointConfig_acmCertificateBase(t, "test1"),
+		testAccClientVPNEndpointConfig_acmCertificateBase(t, "test2"),
 		fmt.Sprintf(`
 resource "aws_ec2_client_vpn_endpoint" "test" {
   client_cidr_block      = "10.0.0.0/16"
@@ -1274,8 +1244,8 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 `, rName))
 }
 
-func testAccClientVPNEndpointConfig_selfServicePortal(rName, selfServicePortal, idpEntityID string) string {
-	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase("test"), fmt.Sprintf(`
+func testAccClientVPNEndpointConfig_selfServicePortal(t *testing.T, rName, selfServicePortal, idpEntityID string) string {
+	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase(t, "test"), fmt.Sprintf(`
 resource "aws_iam_saml_provider" "test" {
   name                   = %[1]q
   saml_metadata_document = templatefile("./test-fixtures/saml-metadata.xml.tpl", { entity_id = %[3]q })
@@ -1302,14 +1272,14 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 `, rName, selfServicePortal, idpEntityID))
 }
 
-func testAccClientVPNEndpointConfig_securityGroups(rName string, nSecurityGroups int) string {
+func testAccClientVPNEndpointConfig_securityGroups(t *testing.T, rName string, nSecurityGroups int) string {
 	return acctest.ConfigCompose(
-		testAccClientVPNEndpointConfig_acmCertificateBase("test"),
+		testAccClientVPNEndpointConfig_acmCertificateBase(t, "test"),
 		testAccClientVPNEndpointConfig_vpcBase(rName),
 		fmt.Sprintf(`
 locals {
   security_group_count = %[2]d
-  security_group_ids   = local.security_group_count == 0 ? null : (local.security_group_count == 1 ? [aws_security_group.test1.id] : [aws_security_group.test1.id, aws_security_group.test2.id])
+  security_group_ids   = local.security_group_count == 0 ? null : (local.security_group_count == 1 ? [aws_security_group.test[0].id] : aws_security_group.test[*].id)
 }
 
 resource "aws_ec2_client_vpn_endpoint" "test" {

--- a/internal/service/ec2/vpnclient_endpoint_test.go
+++ b/internal/service/ec2/vpnclient_endpoint_test.go
@@ -759,7 +759,7 @@ func testAccCheckClientVPNEndpointExists(name string, v *ec2.ClientVpnEndpoint) 
 
 func testAccClientVPNEndpointConfig_acmCertificateBase(n string) string {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
 	return fmt.Sprintf(`
 resource "aws_acm_certificate" %[1]q {

--- a/internal/service/ec2/vpnclient_endpoint_test.go
+++ b/internal/service/ec2/vpnclient_endpoint_test.go
@@ -758,7 +758,7 @@ func testAccCheckClientVPNEndpointExists(name string, v *ec2.ClientVpnEndpoint) 
 }
 
 func testAccClientVPNEndpointConfig_acmCertificateBase(n string) string {
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 
 	return fmt.Sprintf(`

--- a/internal/service/ec2/vpnclient_network_association_test.go
+++ b/internal/service/ec2/vpnclient_network_association_test.go
@@ -33,7 +33,7 @@ func testAccClientVPNNetworkAssociation_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNNetworkAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNNetworkAssociationConfig_basic(rName),
+				Config: testAccClientVPNNetworkAssociationConfig_basic(t, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNNetworkAssociationExists(resourceName, &assoc),
 					resource.TestMatchResourceAttr(resourceName, "association_id", regexp.MustCompile("^cvpn-assoc-[a-z0-9]+$")),
@@ -73,7 +73,7 @@ func testAccClientVPNNetworkAssociation_multipleSubnets(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNNetworkAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNNetworkAssociationConfig_multipleSubnets(rName),
+				Config: testAccClientVPNNetworkAssociationConfig_multipleSubnets(t, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNNetworkAssociationExists(resourceNames[0], &assoc),
 					resource.TestMatchResourceAttr(resourceNames[0], "association_id", regexp.MustCompile("^cvpn-assoc-[a-z0-9]+$")),
@@ -116,7 +116,7 @@ func testAccClientVPNNetworkAssociation_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNNetworkAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNNetworkAssociationConfig_basic(rName),
+				Config: testAccClientVPNNetworkAssociationConfig_basic(t, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNNetworkAssociationExists(resourceName, &assoc),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceClientVPNNetworkAssociation(), resourceName),
@@ -142,7 +142,7 @@ func testAccClientVPNNetworkAssociation_securityGroups(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNNetworkAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNNetworkAssociationConfig_twoSecurityGroups(rName),
+				Config: testAccClientVPNNetworkAssociationConfig_twoSecurityGroups(t, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClientVPNNetworkAssociationExists(resourceName, &assoc1),
 					testAccCheckSecurityGroupExists(securityGroup1ResourceName, &group11),
@@ -159,7 +159,7 @@ func testAccClientVPNNetworkAssociation_securityGroups(t *testing.T) {
 				ImportStateIdFunc: testAccClientVPNNetworkAssociationImportStateIdFunc(resourceName),
 			},
 			{
-				Config: testAccClientVPNNetworkAssociationConfig_oneSecurityGroup(rName),
+				Config: testAccClientVPNNetworkAssociationConfig_oneSecurityGroup(t, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClientVPNNetworkAssociationExists(resourceName, &assoc2),
 					testAccCheckSecurityGroupExists(securityGroup1ResourceName, &group21),
@@ -183,7 +183,7 @@ func testAccClientVPNNetworkAssociation_securityGroupsOnEndpoint(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNNetworkAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNNetworkAssociationConfig_twoSecurityGroupsOnEndpoint(rName),
+				Config: testAccClientVPNNetworkAssociationConfig_twoSecurityGroupsOnEndpoint(t, rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClientVPNNetworkAssociationExists(resourceName, &assoc),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "2"),
@@ -266,11 +266,8 @@ func testAccClientVPNNetworkAssociationImportStateIdFunc(resourceName string) re
 	}
 }
 
-func testAccClientVPNNetworkAssociationConfig_base(rName string) string {
-	return acctest.ConfigCompose(
-		testAccClientVPNEndpointConfig_basic(rName),
-		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
-		fmt.Sprintf(`
+func testAccClientVPNNetworkAssociationConfig_base(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), testAccClientVPNEndpointConfig_basic(t, rName), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -307,8 +304,8 @@ resource "aws_subnet" "test2" {
 `, rName))
 }
 
-func testAccClientVPNNetworkAssociationConfig_basic(rName string) string {
-	return acctest.ConfigCompose(testAccClientVPNNetworkAssociationConfig_base(rName), `
+func testAccClientVPNNetworkAssociationConfig_basic(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(testAccClientVPNNetworkAssociationConfig_base(t, rName), `
 resource "aws_ec2_client_vpn_network_association" "test" {
   client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.test.id
   subnet_id              = aws_subnet.test1.id
@@ -316,8 +313,8 @@ resource "aws_ec2_client_vpn_network_association" "test" {
 `)
 }
 
-func testAccClientVPNNetworkAssociationConfig_multipleSubnets(rName string) string {
-	return acctest.ConfigCompose(testAccClientVPNNetworkAssociationConfig_base(rName), `
+func testAccClientVPNNetworkAssociationConfig_multipleSubnets(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(testAccClientVPNNetworkAssociationConfig_base(t, rName), `
 resource "aws_ec2_client_vpn_network_association" "test1" {
   client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.test.id
   subnet_id              = aws_subnet.test1.id
@@ -330,8 +327,8 @@ resource "aws_ec2_client_vpn_network_association" "test2" {
 `)
 }
 
-func testAccClientVPNNetworkAssociationConfig_twoSecurityGroups(rName string) string {
-	return acctest.ConfigCompose(testAccClientVPNNetworkAssociationConfig_base(rName), fmt.Sprintf(`
+func testAccClientVPNNetworkAssociationConfig_twoSecurityGroups(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(testAccClientVPNNetworkAssociationConfig_base(t, rName), fmt.Sprintf(`
 resource "aws_ec2_client_vpn_network_association" "test" {
   client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.test.id
   subnet_id              = aws_subnet.test1.id
@@ -358,8 +355,8 @@ resource "aws_security_group" "test2" {
 `, rName))
 }
 
-func testAccClientVPNNetworkAssociationConfig_oneSecurityGroup(rName string) string {
-	return acctest.ConfigCompose(testAccClientVPNNetworkAssociationConfig_base(rName), fmt.Sprintf(`
+func testAccClientVPNNetworkAssociationConfig_oneSecurityGroup(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(testAccClientVPNNetworkAssociationConfig_base(t, rName), fmt.Sprintf(`
 resource "aws_ec2_client_vpn_network_association" "test" {
   client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.test.id
   subnet_id              = aws_subnet.test1.id
@@ -386,8 +383,8 @@ resource "aws_security_group" "test2" {
 `, rName))
 }
 
-func testAccClientVPNNetworkAssociationConfig_twoSecurityGroupsOnEndpoint(rName string) string {
-	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_securityGroups(rName, 2), `
+func testAccClientVPNNetworkAssociationConfig_twoSecurityGroupsOnEndpoint(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_securityGroups(t, rName, 2), `
 resource "aws_ec2_client_vpn_network_association" "test" {
   client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.test.id
   subnet_id              = aws_subnet.test[0].id

--- a/internal/service/ec2/vpnclient_route_test.go
+++ b/internal/service/ec2/vpnclient_route_test.go
@@ -170,7 +170,7 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  count                   = %[2]d
+  count = %[2]d
 
   availability_zone       = data.aws_availability_zones.available.names[count.index]
   cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)

--- a/internal/service/ec2/vpnclient_route_test.go
+++ b/internal/service/ec2/vpnclient_route_test.go
@@ -28,7 +28,7 @@ func testAccClientVPNRoute_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNRouteConfig_basic(rName),
+				Config: testAccClientVPNRouteConfig_basic(t, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNRouteExists(resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "client_vpn_endpoint_id", endpointResourceName, "id"),
@@ -60,7 +60,7 @@ func testAccClientVPNRoute_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNRouteConfig_basic(rName),
+				Config: testAccClientVPNRouteConfig_basic(t, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNRouteExists(resourceName, &v),
 					acctest.CheckResourceDisappears(acctest.Provider, tfec2.ResourceClientVPNRoute(), resourceName),
@@ -83,7 +83,7 @@ func testAccClientVPNRoute_description(t *testing.T) {
 		CheckDestroy:             testAccCheckClientVPNRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientVPNRouteConfig_description(rName),
+				Config: testAccClientVPNRouteConfig_description(t, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNRouteExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "description", "test client VPN route"),
@@ -159,11 +159,8 @@ func testAccCheckClientVPNRouteExists(name string, v *ec2.ClientVpnRoute) resour
 	}
 }
 
-func testAccClientVPNRouteConfig_base(rName string, subnetCount int) string {
-	return acctest.ConfigCompose(
-		testAccClientVPNEndpointConfig_basic(rName),
-		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
-		fmt.Sprintf(`
+func testAccClientVPNRouteConfig_base(t *testing.T, rName string, subnetCount int) string {
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), testAccClientVPNEndpointConfig_basic(t, rName), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
@@ -174,6 +171,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_subnet" "test" {
   count                   = %[2]d
+
   availability_zone       = data.aws_availability_zones.available.names[count.index]
   cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
   vpc_id                  = aws_vpc.test.id
@@ -186,8 +184,8 @@ resource "aws_subnet" "test" {
 `, rName, subnetCount))
 }
 
-func testAccClientVPNRouteConfig_basic(rName string) string {
-	return acctest.ConfigCompose(testAccClientVPNRouteConfig_base(rName, 1), `
+func testAccClientVPNRouteConfig_basic(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(testAccClientVPNRouteConfig_base(t, rName, 1), `
 resource "aws_ec2_client_vpn_route" "test" {
   client_vpn_endpoint_id = aws_ec2_client_vpn_network_association.test.client_vpn_endpoint_id
   destination_cidr_block = "0.0.0.0/0"
@@ -201,8 +199,8 @@ resource "aws_ec2_client_vpn_network_association" "test" {
 `)
 }
 
-func testAccClientVPNRouteConfig_description(rName string) string {
-	return acctest.ConfigCompose(testAccClientVPNRouteConfig_base(rName, 1), `
+func testAccClientVPNRouteConfig_description(t *testing.T, rName string) string {
+	return acctest.ConfigCompose(testAccClientVPNRouteConfig_base(t, rName, 1), `
 resource "aws_ec2_client_vpn_route" "test" {
   client_vpn_endpoint_id = aws_ec2_client_vpn_network_association.test.client_vpn_endpoint_id
   destination_cidr_block = "0.0.0.0/0"

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -99,7 +99,7 @@ func TestAccElasticsearchDomain_customEndpoint(t *testing.T) {
 	resourceName := "aws_elasticsearch_domain.test"
 	customEndpoint := fmt.Sprintf("%s.example.com", rName)
 	certResourceName := "aws_acm_certificate.test"
-	certKey := acctest.TLSRSAPrivateKeyPEM(2048)
+	certKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(certKey, customEndpoint)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -100,7 +100,7 @@ func TestAccElasticsearchDomain_customEndpoint(t *testing.T) {
 	customEndpoint := fmt.Sprintf("%s.example.com", rName)
 	certResourceName := "aws_acm_certificate.test"
 	certKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(certKey, customEndpoint)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, certKey, customEndpoint)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },

--- a/internal/service/elb/backend_server_policy_test.go
+++ b/internal/service/elb/backend_server_policy_test.go
@@ -21,7 +21,7 @@ func TestAccELBBackendServerPolicy_basic(t *testing.T) {
 	privateKey2 := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	publicKey1 := acctest.TLSRSAPublicKeyPEM(t, privateKey1)
 	publicKey2 := acctest.TLSRSAPublicKeyPEM(t, privateKey2)
-	certificate1 := acctest.TLSRSAX509SelfSignedCertificatePEM(privateKey1, "example.com")
+	certificate1 := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKey1, "example.com")
 	rString := sdkacctest.RandString(8)
 	lbName := fmt.Sprintf("tf-acc-lb-bsp-basic-%s", rString)
 

--- a/internal/service/elb/backend_server_policy_test.go
+++ b/internal/service/elb/backend_server_policy_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 func TestAccELBBackendServerPolicy_basic(t *testing.T) {
-	privateKey1 := acctest.TLSRSAPrivateKeyPEM(2048)
-	privateKey2 := acctest.TLSRSAPrivateKeyPEM(2048)
+	privateKey1 := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	privateKey2 := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	publicKey1 := acctest.TLSRSAPublicKeyPEM(privateKey1)
 	publicKey2 := acctest.TLSRSAPublicKeyPEM(privateKey2)
 	certificate1 := acctest.TLSRSAX509SelfSignedCertificatePEM(privateKey1, "example.com")

--- a/internal/service/elb/backend_server_policy_test.go
+++ b/internal/service/elb/backend_server_policy_test.go
@@ -19,8 +19,8 @@ import (
 func TestAccELBBackendServerPolicy_basic(t *testing.T) {
 	privateKey1 := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	privateKey2 := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	publicKey1 := acctest.TLSRSAPublicKeyPEM(privateKey1)
-	publicKey2 := acctest.TLSRSAPublicKeyPEM(privateKey2)
+	publicKey1 := acctest.TLSRSAPublicKeyPEM(t, privateKey1)
+	publicKey2 := acctest.TLSRSAPublicKeyPEM(t, privateKey2)
 	certificate1 := acctest.TLSRSAX509SelfSignedCertificatePEM(privateKey1, "example.com")
 	rString := sdkacctest.RandString(8)
 	lbName := fmt.Sprintf("tf-acc-lb-bsp-basic-%s", rString)

--- a/internal/service/elb/lb_ssl_negotiation_policy_test.go
+++ b/internal/service/elb/lb_ssl_negotiation_policy_test.go
@@ -21,7 +21,7 @@ func TestAccELBSSLNegotiationPolicy_basic(t *testing.T) {
 	elbResourceName := "aws_elb.test"
 	resourceName := "aws_lb_ssl_negotiation_policy.test"
 
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -47,7 +47,7 @@ func TestAccELBSSLNegotiationPolicy_disappears(t *testing.T) {
 	elbResourceName := "aws_elb.test"
 	resourceName := "aws_lb_ssl_negotiation_policy.test"
 
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/elb/lb_ssl_negotiation_policy_test.go
+++ b/internal/service/elb/lb_ssl_negotiation_policy_test.go
@@ -22,7 +22,7 @@ func TestAccELBSSLNegotiationPolicy_basic(t *testing.T) {
 	resourceName := "aws_lb_ssl_negotiation_policy.test"
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -48,7 +48,7 @@ func TestAccELBSSLNegotiationPolicy_disappears(t *testing.T) {
 	resourceName := "aws_lb_ssl_negotiation_policy.test"
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },

--- a/internal/service/elb/load_balancer_test.go
+++ b/internal/service/elb/load_balancer_test.go
@@ -324,7 +324,7 @@ func TestAccELBLoadBalancer_tags(t *testing.T) {
 
 func TestAccELBLoadBalancer_ListenerSSLCertificateID_iamServerCertificate(t *testing.T) {
 	var conf elb.LoadBalancerDescription
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 	rName := fmt.Sprintf("tf-acctest-%s", sdkacctest.RandString(10))
 	resourceName := "aws_elb.test"

--- a/internal/service/elb/load_balancer_test.go
+++ b/internal/service/elb/load_balancer_test.go
@@ -325,7 +325,7 @@ func TestAccELBLoadBalancer_tags(t *testing.T) {
 func TestAccELBLoadBalancer_ListenerSSLCertificateID_iamServerCertificate(t *testing.T) {
 	var conf elb.LoadBalancerDescription
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 	rName := fmt.Sprintf("tf-acctest-%s", sdkacctest.RandString(10))
 	resourceName := "aws_elb.test"
 

--- a/internal/service/elbv2/listener_certificate_test.go
+++ b/internal/service/elbv2/listener_certificate_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestAccELBV2ListenerCertificate_basic(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 	iamServerCertificateResourceName := "aws_iam_server_certificate.test"
 	lbListenerResourceName := "aws_lb_listener.test"
 	resourceName := "aws_lb_listener_certificate.test"
@@ -50,7 +50,7 @@ func TestAccELBV2ListenerCertificate_basic(t *testing.T) {
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/17639
 func TestAccELBV2ListenerCertificate_CertificateARN_underscores(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 	iamServerCertificateResourceName := "aws_iam_server_certificate.test"
 	lbListenerResourceName := "aws_lb_listener.test"
 	resourceName := "aws_lb_listener_certificate.test"
@@ -84,7 +84,7 @@ func TestAccELBV2ListenerCertificate_multiple(t *testing.T) {
 	certificates := make([]string, 4)
 	for i := 0; i < 4; i++ {
 		keys[i] = acctest.TLSRSAPrivateKeyPEM(t, 2048)
-		certificates[i] = acctest.TLSRSAX509SelfSignedCertificatePEM(keys[i], "example.com")
+		certificates[i] = acctest.TLSRSAX509SelfSignedCertificatePEM(t, keys[i], "example.com")
 	}
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -153,7 +153,7 @@ func TestAccELBV2ListenerCertificate_multiple(t *testing.T) {
 
 func TestAccELBV2ListenerCertificate_disappears(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 	resourceName := "aws_lb_listener_certificate.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 

--- a/internal/service/elbv2/listener_certificate_test.go
+++ b/internal/service/elbv2/listener_certificate_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestAccELBV2ListenerCertificate_basic(t *testing.T) {
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 	iamServerCertificateResourceName := "aws_iam_server_certificate.test"
 	lbListenerResourceName := "aws_lb_listener.test"
@@ -49,7 +49,7 @@ func TestAccELBV2ListenerCertificate_basic(t *testing.T) {
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/17639
 func TestAccELBV2ListenerCertificate_CertificateARN_underscores(t *testing.T) {
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 	iamServerCertificateResourceName := "aws_iam_server_certificate.test"
 	lbListenerResourceName := "aws_lb_listener.test"
@@ -83,7 +83,7 @@ func TestAccELBV2ListenerCertificate_multiple(t *testing.T) {
 	keys := make([]string, 4)
 	certificates := make([]string, 4)
 	for i := 0; i < 4; i++ {
-		keys[i] = acctest.TLSRSAPrivateKeyPEM(2048)
+		keys[i] = acctest.TLSRSAPrivateKeyPEM(t, 2048)
 		certificates[i] = acctest.TLSRSAX509SelfSignedCertificatePEM(keys[i], "example.com")
 	}
 
@@ -152,7 +152,7 @@ func TestAccELBV2ListenerCertificate_multiple(t *testing.T) {
 }
 
 func TestAccELBV2ListenerCertificate_disappears(t *testing.T) {
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 	resourceName := "aws_lb_listener_certificate.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/elbv2/listener_data_source_test.go
+++ b/internal/service/elbv2/listener_data_source_test.go
@@ -80,7 +80,7 @@ func TestAccELBV2ListenerDataSource_backwardsCompatibility(t *testing.T) {
 
 func TestAccELBV2ListenerDataSource_https(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 	dataSourceName := "data.aws_lb_listener.test"
 	dataSourceName2 := "data.aws_lb_listener.from_lb_and_port"

--- a/internal/service/elbv2/listener_data_source_test.go
+++ b/internal/service/elbv2/listener_data_source_test.go
@@ -81,7 +81,7 @@ func TestAccELBV2ListenerDataSource_backwardsCompatibility(t *testing.T) {
 func TestAccELBV2ListenerDataSource_https(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 	dataSourceName := "data.aws_lb_listener.test"
 	dataSourceName2 := "data.aws_lb_listener.from_lb_and_port"
 

--- a/internal/service/elbv2/listener_rule_test.go
+++ b/internal/service/elbv2/listener_rule_test.go
@@ -577,7 +577,7 @@ func TestAccELBV2ListenerRule_priority(t *testing.T) {
 
 func TestAccELBV2ListenerRule_cognito(t *testing.T) {
 	var conf elbv2.Rule
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 	lbName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -621,7 +621,7 @@ func TestAccELBV2ListenerRule_cognito(t *testing.T) {
 
 func TestAccELBV2ListenerRule_oidc(t *testing.T) {
 	var conf elbv2.Rule
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 	lbName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -665,7 +665,7 @@ func TestAccELBV2ListenerRule_oidc(t *testing.T) {
 
 func TestAccELBV2ListenerRule_Action_order(t *testing.T) {
 	var rule elbv2.Rule
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_listener_rule.test"
@@ -692,7 +692,7 @@ func TestAccELBV2ListenerRule_Action_order(t *testing.T) {
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/6171
 func TestAccELBV2ListenerRule_ActionOrder_recreates(t *testing.T) {
 	var rule elbv2.Rule
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_listener_rule.test"

--- a/internal/service/elbv2/listener_rule_test.go
+++ b/internal/service/elbv2/listener_rule_test.go
@@ -578,7 +578,7 @@ func TestAccELBV2ListenerRule_priority(t *testing.T) {
 func TestAccELBV2ListenerRule_cognito(t *testing.T) {
 	var conf elbv2.Rule
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 	lbName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resourceName := "aws_lb_listener_rule.cognito"
@@ -622,7 +622,7 @@ func TestAccELBV2ListenerRule_cognito(t *testing.T) {
 func TestAccELBV2ListenerRule_oidc(t *testing.T) {
 	var conf elbv2.Rule
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 	lbName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resourceName := "aws_lb_listener_rule.oidc"
@@ -666,7 +666,7 @@ func TestAccELBV2ListenerRule_oidc(t *testing.T) {
 func TestAccELBV2ListenerRule_Action_order(t *testing.T) {
 	var rule elbv2.Rule
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_listener_rule.test"
 
@@ -693,7 +693,7 @@ func TestAccELBV2ListenerRule_Action_order(t *testing.T) {
 func TestAccELBV2ListenerRule_ActionOrder_recreates(t *testing.T) {
 	var rule elbv2.Rule
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_listener_rule.test"
 

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -254,7 +254,7 @@ func TestAccELBV2Listener_backwardsCompatibility(t *testing.T) {
 
 func TestAccELBV2Listener_Protocol_https(t *testing.T) {
 	var conf elbv2.Listener
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	resourceName := "aws_lb_listener.test"
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -324,7 +324,7 @@ func TestAccELBV2Listener_LoadBalancerARN_gatewayLoadBalancer(t *testing.T) {
 
 func TestAccELBV2Listener_Protocol_tls(t *testing.T) {
 	var listener1 elbv2.Listener
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_listener.test"
@@ -439,7 +439,7 @@ func TestAccELBV2Listener_fixedResponse(t *testing.T) {
 
 func TestAccELBV2Listener_cognito(t *testing.T) {
 	var conf elbv2.Listener
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	resourceName := "aws_lb_listener.test"
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -483,7 +483,7 @@ func TestAccELBV2Listener_cognito(t *testing.T) {
 
 func TestAccELBV2Listener_oidc(t *testing.T) {
 	var conf elbv2.Listener
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	resourceName := "aws_lb_listener.test"
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -531,7 +531,7 @@ func TestAccELBV2Listener_oidc(t *testing.T) {
 
 func TestAccELBV2Listener_DefaultAction_order(t *testing.T) {
 	var listener elbv2.Listener
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_listener.test"
@@ -564,7 +564,7 @@ func TestAccELBV2Listener_DefaultAction_order(t *testing.T) {
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/6171
 func TestAccELBV2Listener_DefaultAction_orderRecreates(t *testing.T) {
 	var listener elbv2.Listener
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_listener.test"

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -256,7 +256,7 @@ func TestAccELBV2Listener_Protocol_https(t *testing.T) {
 	var conf elbv2.Listener
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	resourceName := "aws_lb_listener.test"
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -325,7 +325,7 @@ func TestAccELBV2Listener_LoadBalancerARN_gatewayLoadBalancer(t *testing.T) {
 func TestAccELBV2Listener_Protocol_tls(t *testing.T) {
 	var listener1 elbv2.Listener
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_listener.test"
 
@@ -441,7 +441,7 @@ func TestAccELBV2Listener_cognito(t *testing.T) {
 	var conf elbv2.Listener
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	resourceName := "aws_lb_listener.test"
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -485,7 +485,7 @@ func TestAccELBV2Listener_oidc(t *testing.T) {
 	var conf elbv2.Listener
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	resourceName := "aws_lb_listener.test"
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -532,7 +532,7 @@ func TestAccELBV2Listener_oidc(t *testing.T) {
 func TestAccELBV2Listener_DefaultAction_order(t *testing.T) {
 	var listener elbv2.Listener
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_listener.test"
 
@@ -565,7 +565,7 @@ func TestAccELBV2Listener_DefaultAction_order(t *testing.T) {
 func TestAccELBV2Listener_DefaultAction_orderRecreates(t *testing.T) {
 	var listener elbv2.Listener
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_listener.test"
 

--- a/internal/service/iam/server_certificate_data_source_test.go
+++ b/internal/service/iam/server_certificate_data_source_test.go
@@ -39,7 +39,7 @@ func TestResourceSortByExpirationDate(t *testing.T) {
 func TestAccIAMServerCertificateDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -85,7 +85,7 @@ func TestAccIAMServerCertificateDataSource_path(t *testing.T) {
 	path := "/test-path/"
 	pathPrefix := "/test-path/"
 
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/iam/server_certificate_data_source_test.go
+++ b/internal/service/iam/server_certificate_data_source_test.go
@@ -40,7 +40,7 @@ func TestAccIAMServerCertificateDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -86,7 +86,7 @@ func TestAccIAMServerCertificateDataSource_path(t *testing.T) {
 	pathPrefix := "/test-path/"
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },

--- a/internal/service/iam/server_certificate_test.go
+++ b/internal/service/iam/server_certificate_test.go
@@ -22,7 +22,7 @@ func TestAccIAMServerCertificate_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -61,7 +61,7 @@ func TestAccIAMServerCertificate_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -111,7 +111,7 @@ func TestAccIAMServerCertificate_Name_prefix(t *testing.T) {
 	resourceName := "aws_iam_server_certificate.test"
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -134,7 +134,7 @@ func TestAccIAMServerCertificate_disappears(t *testing.T) {
 	resourceName := "aws_iam_server_certificate.test"
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -199,7 +199,7 @@ func TestAccIAMServerCertificate_path(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },

--- a/internal/service/iam/server_certificate_test.go
+++ b/internal/service/iam/server_certificate_test.go
@@ -21,7 +21,7 @@ func TestAccIAMServerCertificate_basic(t *testing.T) {
 	resourceName := "aws_iam_server_certificate.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -60,7 +60,7 @@ func TestAccIAMServerCertificate_tags(t *testing.T) {
 	resourceName := "aws_iam_server_certificate.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -110,7 +110,7 @@ func TestAccIAMServerCertificate_Name_prefix(t *testing.T) {
 
 	resourceName := "aws_iam_server_certificate.test"
 
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -133,7 +133,7 @@ func TestAccIAMServerCertificate_disappears(t *testing.T) {
 	var cert iam.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
 
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -198,7 +198,7 @@ func TestAccIAMServerCertificate_path(t *testing.T) {
 	resourceName := "aws_iam_server_certificate.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/iam/signing_certificate_test.go
+++ b/internal/service/iam/signing_certificate_test.go
@@ -19,7 +19,7 @@ func TestAccIAMSigningCertificate_basic(t *testing.T) {
 
 	resourceName := "aws_iam_signing_certificate.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -52,7 +52,7 @@ func TestAccIAMSigningCertificate_status(t *testing.T) {
 
 	resourceName := "aws_iam_signing_certificate.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -96,7 +96,7 @@ func TestAccIAMSigningCertificate_disappears(t *testing.T) {
 	resourceName := "aws_iam_signing_certificate.test"
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/iam/signing_certificate_test.go
+++ b/internal/service/iam/signing_certificate_test.go
@@ -20,7 +20,7 @@ func TestAccIAMSigningCertificate_basic(t *testing.T) {
 	resourceName := "aws_iam_signing_certificate.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -53,7 +53,7 @@ func TestAccIAMSigningCertificate_status(t *testing.T) {
 	resourceName := "aws_iam_signing_certificate.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -97,7 +97,7 @@ func TestAccIAMSigningCertificate_disappears(t *testing.T) {
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },

--- a/internal/service/iam/user_test.go
+++ b/internal/service/iam/user_test.go
@@ -671,7 +671,7 @@ func testAccCheckUserUploadSigningCertificate(getUserOutput *iam.GetUserOutput) 
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn
 
-		key := acctest.TLSRSAPrivateKeyPEM(2048)
+		key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 		certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
 
 		input := &iam.UploadSigningCertificateInput{

--- a/internal/service/iam/user_test.go
+++ b/internal/service/iam/user_test.go
@@ -245,7 +245,7 @@ func TestAccIAMUser_ForceDestroy_signingCertificate(t *testing.T) {
 				Config: testAccUserConfig_forceDestroy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(resourceName, &user),
-					testAccCheckUserUploadSigningCertificate(&user),
+					testAccCheckUserUploadSigningCertificate(t, &user),
 				),
 			},
 			{
@@ -667,7 +667,7 @@ func testAccCheckUserServiceSpecificCredential(getUserOutput *iam.GetUserOutput)
 	}
 }
 
-func testAccCheckUserUploadSigningCertificate(getUserOutput *iam.GetUserOutput) resource.TestCheckFunc {
+func testAccCheckUserUploadSigningCertificate(t *testing.T, getUserOutput *iam.GetUserOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn
 

--- a/internal/service/iam/user_test.go
+++ b/internal/service/iam/user_test.go
@@ -672,7 +672,7 @@ func testAccCheckUserUploadSigningCertificate(getUserOutput *iam.GetUserOutput) 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn
 
 		key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-		certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "example.com")
+		certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
 
 		input := &iam.UploadSigningCertificateInput{
 			CertificateBody: aws.String(certificate),

--- a/internal/service/iot/certificate_test.go
+++ b/internal/service/iot/certificate_test.go
@@ -59,7 +59,7 @@ func TestAccIoTCertificate_Keys_certificate(t *testing.T) {
 
 func TestAccIoTCertificate_Keys_existingCertificate(t *testing.T) {
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "testcert")
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "testcert")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },

--- a/internal/service/iot/certificate_test.go
+++ b/internal/service/iot/certificate_test.go
@@ -58,7 +58,7 @@ func TestAccIoTCertificate_Keys_certificate(t *testing.T) {
 }
 
 func TestAccIoTCertificate_Keys_existingCertificate(t *testing.T) {
-	key := acctest.TLSRSAPrivateKeyPEM(2048)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(key, "testcert")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -152,7 +152,7 @@ func TestAccOpenSearchDomain_customEndpoint(t *testing.T) {
 	resourceName := "aws_opensearch_domain.test"
 	customEndpoint := fmt.Sprintf("%s.example.com", rName)
 	certResourceName := "aws_acm_certificate.test"
-	certKey := acctest.TLSRSAPrivateKeyPEM(2048)
+	certKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(certKey, customEndpoint)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -153,7 +153,7 @@ func TestAccOpenSearchDomain_customEndpoint(t *testing.T) {
 	customEndpoint := fmt.Sprintf("%s.example.com", rName)
 	certResourceName := "aws_acm_certificate.test"
 	certKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(certKey, customEndpoint)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, certKey, customEndpoint)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },

--- a/internal/service/rolesanywhere/trust_anchor_test.go
+++ b/internal/service/rolesanywhere/trust_anchor_test.go
@@ -327,7 +327,7 @@ resource "aws_rolesanywhere_trust_anchor" "test" {
 
 func testAccTrustAnchorConfig_certificateBundle(rName string) string {
 	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	caCertificate := acctest.TLSRSAX509SelfSignedCACertificateForRolesAnywhereTrustAnchorPEM(caKey)
+	caCertificate := acctest.TLSRSAX509SelfSignedCACertificateForRolesAnywhereTrustAnchorPEM(t, caKey)
 
 	return fmt.Sprintf(`
 resource "aws_rolesanywhere_trust_anchor" "test" {
@@ -344,7 +344,7 @@ resource "aws_rolesanywhere_trust_anchor" "test" {
 
 func testAccTrustAnchorConfig_enabled(rName string, enabled bool) string {
 	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
-	caCertificate := acctest.TLSRSAX509SelfSignedCACertificateForRolesAnywhereTrustAnchorPEM(caKey)
+	caCertificate := acctest.TLSRSAX509SelfSignedCACertificateForRolesAnywhereTrustAnchorPEM(t, caKey)
 
 	return fmt.Sprintf(`
 resource "aws_rolesanywhere_trust_anchor" "test" {

--- a/internal/service/rolesanywhere/trust_anchor_test.go
+++ b/internal/service/rolesanywhere/trust_anchor_test.go
@@ -326,7 +326,7 @@ resource "aws_rolesanywhere_trust_anchor" "test" {
 }
 
 func testAccTrustAnchorConfig_certificateBundle(rName string) string {
-	caKey := acctest.TLSRSAPrivateKeyPEM(2048)
+	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	caCertificate := acctest.TLSRSAX509SelfSignedCACertificateForRolesAnywhereTrustAnchorPEM(caKey)
 
 	return fmt.Sprintf(`
@@ -343,7 +343,7 @@ resource "aws_rolesanywhere_trust_anchor" "test" {
 }
 
 func testAccTrustAnchorConfig_enabled(rName string, enabled bool) string {
-	caKey := acctest.TLSRSAPrivateKeyPEM(2048)
+	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	caCertificate := acctest.TLSRSAX509SelfSignedCACertificateForRolesAnywhereTrustAnchorPEM(caKey)
 
 	return fmt.Sprintf(`

--- a/internal/service/rolesanywhere/trust_anchor_test.go
+++ b/internal/service/rolesanywhere/trust_anchor_test.go
@@ -127,7 +127,7 @@ func TestAccRolesAnywhereTrustAnchor_certificateBundle(t *testing.T) {
 		CheckDestroy:             testAccCheckTrustAnchorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrustAnchorConfig_certificateBundle(rName),
+				Config: testAccTrustAnchorConfig_certificateBundle(t, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrustAnchorExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "enabled"),
@@ -157,7 +157,7 @@ func TestAccRolesAnywhereTrustAnchor_enabled(t *testing.T) {
 		CheckDestroy:             testAccCheckTrustAnchorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrustAnchorConfig_enabled(rName, true),
+				Config: testAccTrustAnchorConfig_enabled(t, rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrustAnchorExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
@@ -169,14 +169,14 @@ func TestAccRolesAnywhereTrustAnchor_enabled(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTrustAnchorConfig_enabled(rName, false),
+				Config: testAccTrustAnchorConfig_enabled(t, rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrustAnchorExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
 				),
 			},
 			{
-				Config: testAccTrustAnchorConfig_enabled(rName, true),
+				Config: testAccTrustAnchorConfig_enabled(t, rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTrustAnchorExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
@@ -325,7 +325,7 @@ resource "aws_rolesanywhere_trust_anchor" "test" {
 `, rName, tag1, value1, tag2, value2))
 }
 
-func testAccTrustAnchorConfig_certificateBundle(rName string) string {
+func testAccTrustAnchorConfig_certificateBundle(t *testing.T, rName string) string {
 	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	caCertificate := acctest.TLSRSAX509SelfSignedCACertificateForRolesAnywhereTrustAnchorPEM(t, caKey)
 
@@ -342,7 +342,7 @@ resource "aws_rolesanywhere_trust_anchor" "test" {
 `, rName, acctest.TLSPEMEscapeNewlines(caCertificate))
 }
 
-func testAccTrustAnchorConfig_enabled(rName string, enabled bool) string {
+func testAccTrustAnchorConfig_enabled(t *testing.T, rName string, enabled bool) string {
 	caKey := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	caCertificate := acctest.TLSRSAX509SelfSignedCACertificateForRolesAnywhereTrustAnchorPEM(t, caKey)
 

--- a/internal/service/sesv2/email_identity_test.go
+++ b/internal/service/sesv2/email_identity_test.go
@@ -185,10 +185,10 @@ func TestAccSESV2EmailIdentity_domainSigning(t *testing.T) {
 	rName := acctest.RandomDomainName()
 	resourceName := "aws_sesv2_email_identity.test"
 
-	key1 := verify.Base64Encode([]byte(acctest.TLSRSAPrivateKeyPEM(2048)))
+	key1 := verify.Base64Encode([]byte(acctest.TLSRSAPrivateKeyPEM(t, 2048)))
 	selector1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	key2 := verify.Base64Encode([]byte(acctest.TLSRSAPrivateKeyPEM(2048)))
+	key2 := verify.Base64Encode([]byte(acctest.TLSRSAPrivateKeyPEM(t, 2048)))
 	selector2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds an initial `t *testing.T` parameter to the `acctest` crypto functions.