### PR TITLE
Update validation rule in appstream stack resource

### DIFF
--- a/.changelog/27744.txt
+++ b/.changelog/27744.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_appstream_stack: Fix `redirect_url` max character length
+```

--- a/internal/service/appstream/stack.go
+++ b/internal/service/appstream/stack.go
@@ -75,7 +75,7 @@ func ResourceStack() *schema.Resource {
 						"settings_group": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringLenBetween(0, 100),
+							ValidateFunc: validation.StringLenBetween(0, 1000),
 						},
 					},
 				},

--- a/internal/service/appstream/stack.go
+++ b/internal/service/appstream/stack.go
@@ -75,7 +75,7 @@ func ResourceStack() *schema.Resource {
 						"settings_group": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringLenBetween(0, 1000),
+							ValidateFunc: validation.StringLenBetween(0, 100),
 						},
 					},
 				},
@@ -129,7 +129,7 @@ func ResourceStack() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.StringLenBetween(0, 100),
+				ValidateFunc: validation.StringLenBetween(0, 1000),
 			},
 			"storage_connectors": {
 				Type:     schema.TypeSet,


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Increase max length of redirectUrl in appstream stack resource. Docs specify that max length is 1000: https://docs.aws.amazon.com/appstream2/latest/APIReference/API_CreateStack.html#AppStream2-CreateStack-request-RedirectURL

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Fixes --->

Fixes #27743

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
