### PR TITLE
d/aws_identitystore_group: expose all group attributes

### DIFF
--- a/.changelog/27762.txt
+++ b/.changelog/27762.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+data-source/aws_identitystore_group: Add `alternate_identifier` argument and `description` attribute
+```
+
+```release-note:note
+data-source/aws_identitystore_group: The `filter` argument has been deprecated. Use the `alternate_identifier` argument instead
+ ```

--- a/internal/service/identitystore/group_data_source.go
+++ b/internal/service/identitystore/group_data_source.go
@@ -2,6 +2,7 @@ package identitystore
 
 import (
 	"context"
+	"errors"
 	"regexp"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -12,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -20,14 +22,63 @@ func DataSourceGroup() *schema.Resource {
 		ReadContext: dataSourceGroupRead,
 
 		Schema: map[string]*schema.Schema{
+			"alternate_identifier": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"filter", "group_id"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"external_id": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							MaxItems:     1,
+							ExactlyOneOf: []string{"alternate_identifier.0.external_id", "alternate_identifier.0.unique_attribute"},
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"issuer": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"unique_attribute": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							MaxItems:     1,
+							ExactlyOneOf: []string{"alternate_identifier.0.external_id", "alternate_identifier.0.unique_attribute"},
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"attribute_path": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"attribute_value": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"display_name": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"filter": {
-				Type:     schema.TypeSet,
-				Required: true,
+				Deprecated:    "Use the alternate_identifier attribute instead.",
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				AtLeastOneOf:  []string{"alternate_identifier", "filter", "group_id"},
+				ConflictsWith: []string{"alternate_identifier"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"attribute_path": {
@@ -41,17 +92,17 @@ func DataSourceGroup() *schema.Resource {
 					},
 				},
 			},
-
 			"group_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				AtLeastOneOf:  []string{"alternate_identifier", "filter", "group_id"},
+				ConflictsWith: []string{"alternate_identifier"},
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 47),
 					validation.StringMatch(regexp.MustCompile(`^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$`), "must match ([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}"),
 				),
 			},
-
 			"identity_store_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -73,76 +124,61 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	identityStoreId := d.Get("identity_store_id").(string)
 
-	// Filters has been marked as deprecated in favour of GetGroupId, which
-	// allows only a single filter. Keep using it to maintain backwards
-	// compatibility of the data source.
+	var getGroupIdInput *identitystore.GetGroupIdInput
 
-	input := &identitystore.ListGroupsInput{
-		IdentityStoreId: aws.String(identityStoreId),
-		Filters:         expandFilters(d.Get("filter").(*schema.Set).List()),
+	if v, ok := d.GetOk("alternate_identifier"); ok && len(v.([]interface{})) > 0 {
+		getGroupIdInput = &identitystore.GetGroupIdInput{
+			AlternateIdentifier: expandAlternateIdentifier(v.([]interface{})[0].(map[string]interface{})),
+			IdentityStoreId:     aws.String(identityStoreId),
+		}
+	} else if v, ok := d.GetOk("filter"); ok && len(v.([]interface{})) > 0 {
+		getGroupIdInput = &identitystore.GetGroupIdInput{
+			AlternateIdentifier: &types.AlternateIdentifierMemberUniqueAttribute{
+				Value: *expandUniqueAttribute(v.([]interface{})[0].(map[string]interface{})),
+			},
+			IdentityStoreId: aws.String(identityStoreId),
+		}
 	}
 
-	var results []types.Group
+	var groupId string
 
-	paginator := identitystore.NewListGroupsPaginator(conn, input)
-
-	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(ctx)
+	if getGroupIdInput != nil {
+		output, err := conn.GetGroupId(ctx, getGroupIdInput)
 
 		if err != nil {
-			return create.DiagError(names.IdentityStore, create.ErrActionReading, DSNameGroup, identityStoreId, err)
-		}
-
-		for _, group := range page.Groups {
-			if v, ok := d.GetOk("group_id"); ok && v.(string) != aws.ToString(group.GroupId) {
-				continue
+			var e *types.ResourceNotFoundException
+			if errors.As(err, &e) {
+				return diag.Errorf("no Identity Store Group found matching criteria; try different search")
+			} else {
+				return create.DiagError(names.IdentityStore, create.ErrActionReading, DSNameGroup, identityStoreId, err)
 			}
-
-			results = append(results, group)
 		}
+
+		groupId = aws.ToString(output.GroupId)
 	}
 
-	if len(results) == 0 {
-		return diag.Errorf("no Identity Store Group found matching criteria\n%v; try different search", input.Filters)
+	if v, ok := d.GetOk("group_id"); ok && v.(string) != "" {
+		if groupId != "" && groupId != v.(string) {
+			// We were given a filter, and it found a group different to this one.
+			return diag.Errorf("no Identity Store Group found matching criteria; try different search")
+		}
+
+		groupId = v.(string)
 	}
 
-	if len(results) > 1 {
-		return diag.Errorf("multiple Identity Store Groups found matching criteria\n%v; try different search", input.Filters)
-	}
+	group, err := findGroupByID(ctx, conn, identityStoreId, groupId)
 
-	group := results[0]
+	if err != nil {
+		if tfresource.NotFound(err) {
+			return diag.Errorf("no Identity Store Group found matching criteria; try different search")
+		}
+
+		return create.DiagError(names.IdentityStore, create.ErrActionReading, DSNameGroup, identityStoreId, err)
+	}
 
 	d.SetId(aws.ToString(group.GroupId))
 	d.Set("display_name", group.DisplayName)
 	d.Set("group_id", group.GroupId)
 
 	return nil
-}
-
-func expandFilters(l []interface{}) []types.Filter {
-	if len(l) == 0 || l[0] == nil {
-		return nil
-	}
-
-	filters := make([]types.Filter, 0, len(l))
-	for _, v := range l {
-		tfMap, ok := v.(map[string]interface{})
-		if !ok {
-			continue
-		}
-
-		filter := types.Filter{}
-
-		if v, ok := tfMap["attribute_path"].(string); ok && v != "" {
-			filter.AttributePath = aws.String(v)
-		}
-
-		if v, ok := tfMap["attribute_value"].(string); ok && v != "" {
-			filter.AttributeValue = aws.String(v)
-		}
-
-		filters = append(filters, filter)
-	}
-
-	return filters
 }

--- a/internal/service/identitystore/group_data_source.go
+++ b/internal/service/identitystore/group_data_source.go
@@ -68,6 +68,10 @@ func DataSourceGroup() *schema.Resource {
 					},
 				},
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"display_name": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -194,6 +198,7 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	d.SetId(aws.ToString(group.GroupId))
 
+	d.Set("description", group.Description)
 	d.Set("display_name", group.DisplayName)
 	d.Set("group_id", group.GroupId)
 

--- a/internal/service/identitystore/group_data_source.go
+++ b/internal/service/identitystore/group_data_source.go
@@ -72,6 +72,22 @@ func DataSourceGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"external_ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"issuer": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"filter": {
 				Deprecated:    "Use the alternate_identifier attribute instead.",
 				Type:          schema.TypeList,
@@ -177,8 +193,13 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	d.SetId(aws.ToString(group.GroupId))
+
 	d.Set("display_name", group.DisplayName)
 	d.Set("group_id", group.GroupId)
+
+	if err := d.Set("external_ids", flattenExternalIds(group.ExternalIds)); err != nil {
+		return create.DiagError(names.IdentityStore, create.ErrActionSetting, DSNameGroup, d.Id(), err)
+	}
 
 	return nil
 }

--- a/internal/service/identitystore/group_data_source_test.go
+++ b/internal/service/identitystore/group_data_source_test.go
@@ -32,6 +32,7 @@ func TestAccIdentityStoreGroupDataSource_displayName(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "display_name", resourceName, "display_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "group_id", resourceName, "group_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "external_ids.#", "0"),
 				),
 			},
 		},
@@ -57,6 +58,7 @@ func TestAccIdentityStoreGroupDataSource_groupID(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "display_name", resourceName, "display_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "group_id", resourceName, "group_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "external_ids.#", "0"),
 				),
 			},
 		},

--- a/internal/service/identitystore/group_data_source_test.go
+++ b/internal/service/identitystore/group_data_source_test.go
@@ -30,6 +30,7 @@ func TestAccIdentityStoreGroupDataSource_displayName(t *testing.T) {
 			{
 				Config: testAccGroupDataSourceConfig_displayName(name),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "display_name", resourceName, "display_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "group_id", resourceName, "group_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "external_ids.#", "0"),
@@ -56,6 +57,7 @@ func TestAccIdentityStoreGroupDataSource_groupID(t *testing.T) {
 			{
 				Config: testAccGroupDataSourceConfig_id(name),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "display_name", resourceName, "display_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "group_id", resourceName, "group_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "external_ids.#", "0"),
@@ -87,6 +89,7 @@ data "aws_ssoadmin_instances" "test" {}
 resource "aws_identitystore_group" "test" {
   identity_store_id = tolist(data.aws_ssoadmin_instances.test.identity_store_ids)[0]
   display_name      = %[1]q
+  description       = "Acceptance Test"
 }
 
 data "aws_identitystore_group" "test" {
@@ -107,6 +110,7 @@ data "aws_ssoadmin_instances" "test" {}
 resource "aws_identitystore_group" "test" {
   identity_store_id = tolist(data.aws_ssoadmin_instances.test.identity_store_ids)[0]
   display_name      = %[1]q
+  description       = "Acceptance Test"
 }
 
 data "aws_identitystore_group" "test" {

--- a/internal/service/identitystore/group_data_source_test.go
+++ b/internal/service/identitystore/group_data_source_test.go
@@ -321,7 +321,7 @@ data "aws_identitystore_group" "test" {
     attribute_value = aws_identitystore_group.test.display_name
   }
 
-  group_id = aws_identitystore_group.test2.group_id 
+  group_id = aws_identitystore_group.test2.group_id
 }
 `, name2),
 	)

--- a/website/docs/d/identitystore_group.html.markdown
+++ b/website/docs/d/identitystore_group.html.markdown
@@ -83,6 +83,7 @@ The following arguments are supported by the `unique_attribute` configuration bl
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Identifier of the group in the Identity Store.
+* `description` - Description of the specified group.
 * `display_name` - Group's display name value.
 * `external_ids` - List of identifiers issued to this resource by an external identity provider.
   * `id` - The identifier issued to this resource by an external identity provider.

--- a/website/docs/d/identitystore_group.html.markdown
+++ b/website/docs/d/identitystore_group.html.markdown
@@ -33,7 +33,6 @@ output "group_id" {
 
 ## Argument Reference
 
-
 The following arguments are required:
 
 * `identity_store_id` - (Required) Identity Store ID associated with the Single Sign-On Instance.
@@ -86,5 +85,5 @@ In addition to all arguments above, the following attributes are exported:
 * `description` - Description of the specified group.
 * `display_name` - Group's display name value.
 * `external_ids` - List of identifiers issued to this resource by an external identity provider.
-  * `id` - The identifier issued to this resource by an external identity provider.
-  * `issuer` - The issuer for an external identifier.
+    * `id` - The identifier issued to this resource by an external identity provider.
+    * `issuer` - The issuer for an external identifier.

--- a/website/docs/d/identitystore_group.html.markdown
+++ b/website/docs/d/identitystore_group.html.markdown
@@ -18,9 +18,11 @@ data "aws_ssoadmin_instances" "example" {}
 data "aws_identitystore_group" "example" {
   identity_store_id = tolist(data.aws_ssoadmin_instances.example.identity_store_ids)[0]
 
-  filter {
-    attribute_path  = "DisplayName"
-    attribute_value = "ExampleGroup"
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = "ExampleGroup"
+    }
   }
 }
 
@@ -31,17 +33,49 @@ output "group_id" {
 
 ## Argument Reference
 
-The following arguments are supported:
 
-* `filter` - (Required) Configuration block(s) for filtering. Currently, the AWS Identity Store API supports only 1 filter. Detailed below.
-* `group_id` - (Optional)  The identifier for a group in the Identity Store.
+The following arguments are required:
+
 * `identity_store_id` - (Required) Identity Store ID associated with the Single Sign-On Instance.
 
+The following arguments are optional:
+
+* `alternate_identifier` (Optional) A unique identifier for the group that is not the primary identifier. Conflicts with `group_id` and `filter`. Detailed below.
+* `filter` - (Optional, **Deprecated** use the `alternate_identifier` attribute instead) Configuration block for filtering by a unique attribute of the group. Detailed below.
+* `group_id` - (Optional) The identifier for a group in the Identity Store.
+
+-> Exactly one of the above arguments must be provided. Passing both `filter` and `group_id` is allowed for backwards compatibility.
+
+### `alternate_identifier` Configuration Block
+
+The following arguments are supported by the `alternate_identifier` configuration block:
+
+* `external_id` - (Optional) Configuration block for filtering by the identifier issued by an external identity provider. Detailed below.
+* `unique_attribute` - (Optional) An entity attribute that's unique to a specific entity. Detailed below.
+
+-> Exactly one of the above arguments must be provided.
+
+### `external_id` Configuration Block
+
+The following arguments are supported by the `external_id` configuration block:
+
+* `id` - (Required) The identifier issued to this resource by an external identity provider.
+* `issuer` - (Required) The issuer for an external identifier.
+
 ### `filter` Configuration Block
+
+~> The `filter` configuration block has been deprecated. Use `alternate_identifier` instead.
 
 The following arguments are supported by the `filter` configuration block:
 
 * `attribute_path` - (Required) Attribute path that is used to specify which attribute name to search. Currently, `DisplayName` is the only valid attribute path.
+* `attribute_value` - (Required) Value for an attribute.
+
+### `unique_attribute` Configuration Block
+
+The following arguments are supported by the `unique_attribute` configuration block:
+
+* `attribute_path` - (Required) Attribute path that is used to specify which attribute name to search. For example: `DisplayName`. Refer to the [Group data type](https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_Group.html).
 * `attribute_value` - (Required) Value for an attribute.
 
 ## Attributes Reference

--- a/website/docs/d/identitystore_group.html.markdown
+++ b/website/docs/d/identitystore_group.html.markdown
@@ -84,3 +84,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - Identifier of the group in the Identity Store.
 * `display_name` - Group's display name value.
+* `external_ids` - List of identifiers issued to this resource by an external identity provider.
+  * `id` - The identifier issued to this resource by an external identity provider.
+  * `issuer` - The issuer for an external identifier.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

- Refactor data source using the `aws_identitystore_user` resource.
- Refactor resource using the `GetGroupId` and `DescribeGroup` API-s instead of `ListGroups`.
- Expose all attributes of the `Group` data type.
- Deprecates the `filter` attribute in favour of the `alternate_identifier` configuration block in line with [GetGroupId](https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_GetGroupId.html).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/26598
Relates https://github.com/hashicorp/terraform-provider-aws/pull/27053

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccIdentityStoreGroupDataSource_ PKG=identitystore
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/identitystore/... -v -count 1 -parallel 20 -run='TestAccIdentityStoreGroupDataSource_'  -timeout 180m
=== RUN   TestAccIdentityStoreGroupDataSource_filterDisplayName
=== PAUSE TestAccIdentityStoreGroupDataSource_filterDisplayName
=== RUN   TestAccIdentityStoreGroupDataSource_uniqueAttributeDisplayName
=== PAUSE TestAccIdentityStoreGroupDataSource_uniqueAttributeDisplayName
=== RUN   TestAccIdentityStoreGroupDataSource_filterDisplayNameAndGroupId
=== PAUSE TestAccIdentityStoreGroupDataSource_filterDisplayNameAndGroupId
=== RUN   TestAccIdentityStoreGroupDataSource_nonExistent
=== PAUSE TestAccIdentityStoreGroupDataSource_nonExistent
=== RUN   TestAccIdentityStoreGroupDataSource_groupIdFilterMismatch
=== PAUSE TestAccIdentityStoreGroupDataSource_groupIdFilterMismatch
=== RUN   TestAccIdentityStoreGroupDataSource_externalIdConflictsWithUniqueAttribute
=== PAUSE TestAccIdentityStoreGroupDataSource_externalIdConflictsWithUniqueAttribute
=== RUN   TestAccIdentityStoreGroupDataSource_filterConflictsWithUniqueAttribute
=== PAUSE TestAccIdentityStoreGroupDataSource_filterConflictsWithUniqueAttribute
=== RUN   TestAccIdentityStoreGroupDataSource_groupIdConflictsWithUniqueAttribute
=== PAUSE TestAccIdentityStoreGroupDataSource_groupIdConflictsWithUniqueAttribute
=== RUN   TestAccIdentityStoreGroupDataSource_filterConflictsWithExternalId
=== PAUSE TestAccIdentityStoreGroupDataSource_filterConflictsWithExternalId
=== RUN   TestAccIdentityStoreGroupDataSource_groupIdConflictsWithExternalId
=== PAUSE TestAccIdentityStoreGroupDataSource_groupIdConflictsWithExternalId
=== CONT  TestAccIdentityStoreGroupDataSource_filterDisplayName
=== CONT  TestAccIdentityStoreGroupDataSource_groupIdConflictsWithExternalId
=== CONT  TestAccIdentityStoreGroupDataSource_externalIdConflictsWithUniqueAttribute
=== CONT  TestAccIdentityStoreGroupDataSource_nonExistent
=== CONT  TestAccIdentityStoreGroupDataSource_groupIdFilterMismatch
=== CONT  TestAccIdentityStoreGroupDataSource_filterDisplayNameAndGroupId
=== CONT  TestAccIdentityStoreGroupDataSource_uniqueAttributeDisplayName
=== CONT  TestAccIdentityStoreGroupDataSource_groupIdConflictsWithUniqueAttribute
=== CONT  TestAccIdentityStoreGroupDataSource_filterConflictsWithExternalId
=== CONT  TestAccIdentityStoreGroupDataSource_filterConflictsWithUniqueAttribute
--- PASS: TestAccIdentityStoreGroupDataSource_externalIdConflictsWithUniqueAttribute (2.38s)
--- PASS: TestAccIdentityStoreGroupDataSource_filterConflictsWithExternalId (2.44s)
--- PASS: TestAccIdentityStoreGroupDataSource_nonExistent (3.08s)
--- PASS: TestAccIdentityStoreGroupDataSource_filterConflictsWithUniqueAttribute (8.48s)
--- PASS: TestAccIdentityStoreGroupDataSource_groupIdConflictsWithExternalId (8.50s)
--- PASS: TestAccIdentityStoreGroupDataSource_groupIdFilterMismatch (8.50s)
--- PASS: TestAccIdentityStoreGroupDataSource_groupIdConflictsWithUniqueAttribute (8.50s)
--- PASS: TestAccIdentityStoreGroupDataSource_filterDisplayName (12.66s)
--- PASS: TestAccIdentityStoreGroupDataSource_filterDisplayNameAndGroupId (12.92s)
--- PASS: TestAccIdentityStoreGroupDataSource_uniqueAttributeDisplayName (13.08s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/identitystore      14.925s
```
