### PR TITLE
`hcl/v2` should only be `updated via terraform-plugin-sdk`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     ignore:
+      # hcl/v2 should only be updated via terraform-plugin-sdk
+      - dependency-name: "github.com/hashicorp/hcl/v2"
       # terraform-plugin-go should only be updated via terraform-plugin-framework
       - dependency-name: "github.com/hashicorp/terraform-plugin-go"
       # terraform-plugin-log should only be updated via terraform-plugin-framework


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Ibid.