### PR TITLE
Enable setting of 0 for sampling_rate

### DIFF
--- a/.changelog/27778.txt
+++ b/.changelog/27778.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudfront_response_headers_policy: Allow `server_timing_headers_config.0.sampling_rate` to be `0`
+```

--- a/internal/service/cloudfront/response_headers_policy.go
+++ b/internal/service/cloudfront/response_headers_policy.go
@@ -1114,7 +1114,7 @@ func expandResponseHeadersPolicyServerTimingHeadersConfig(tfMap map[string]inter
 		apiObject.Enabled = aws.Bool(v)
 	}
 
-	if v, ok := tfMap["sampling_rate"].(float64); ok && v != 0 {
+	if v, ok := tfMap["sampling_rate"].(float64); ok {
 		apiObject.SamplingRate = aws.Float64(v)
 	}
 

--- a/internal/service/cloudfront/response_headers_policy_test.go
+++ b/internal/service/cloudfront/response_headers_policy_test.go
@@ -269,7 +269,7 @@ func TestAccCloudFrontResponseHeadersPolicy_ServerTimingHeadersConfig(t *testing
 			{
 				Config: testAccResponseHeadersPolicyConfig_serverTiming(rName, true, 0),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResponseHeadersPolicyExists(resourceName),
+					testAccCheckResponseHeadersPolicyExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "comment", ""),
 					resource.TestCheckResourceAttr(resourceName, "cors_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "custom_headers_config.#", "0"),

--- a/internal/service/cloudfront/response_headers_policy_test.go
+++ b/internal/service/cloudfront/response_headers_policy_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccCloudFrontResponseHeadersPolicy_CorsConfig(t *testing.T) {
+func TestAccCloudFrontResponseHeadersPolicy_cors(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -94,7 +94,7 @@ func TestAccCloudFrontResponseHeadersPolicy_CorsConfig(t *testing.T) {
 	})
 }
 
-func TestAccCloudFrontResponseHeadersPolicy_CustomHeadersConfig(t *testing.T) {
+func TestAccCloudFrontResponseHeadersPolicy_customHeaders(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_cloudfront_response_headers_policy.test"
@@ -139,7 +139,7 @@ func TestAccCloudFrontResponseHeadersPolicy_CustomHeadersConfig(t *testing.T) {
 	})
 }
 
-func TestAccCloudFrontResponseHeadersPolicy_SecurityHeadersConfig(t *testing.T) {
+func TestAccCloudFrontResponseHeadersPolicy_securityHeaders(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_cloudfront_response_headers_policy.test"
@@ -219,7 +219,7 @@ func TestAccCloudFrontResponseHeadersPolicy_SecurityHeadersConfig(t *testing.T) 
 	})
 }
 
-func TestAccCloudFrontResponseHeadersPolicy_ServerTimingHeadersConfig(t *testing.T) {
+func TestAccCloudFrontResponseHeadersPolicy_serverTimingHeaders(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_cloudfront_response_headers_policy.test"

--- a/internal/service/cloudfront/response_headers_policy_test.go
+++ b/internal/service/cloudfront/response_headers_policy_test.go
@@ -267,6 +267,21 @@ func TestAccCloudFrontResponseHeadersPolicy_ServerTimingHeadersConfig(t *testing
 				),
 			},
 			{
+				Config: testAccResponseHeadersPolicyConfig_serverTiming(rName, true, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResponseHeadersPolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "comment", ""),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "custom_headers_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "security_headers_config.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "etag"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "server_timing_headers_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server_timing_headers_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "server_timing_headers_config.0.sampling_rate", "0"),
+				),
+			},
+			{
 				Config: testAccResponseHeadersPolicyConfig_serverTiming(rName, false, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResponseHeadersPolicyExists(ctx, resourceName),


### PR DESCRIPTION
Resource:aws_cloudfront_response_headers_policy.server_timing_headers_config

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Allow 0 for sampling_rate in server_timing_headers_config.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27721

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccCloudFrontResponseHeadersPolicy_ServerTimingHeadersConfig PKG=cloudfront
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontResponseHeadersPolicy_ServerTimingHeadersConfig'  -timeout 180m
=== RUN   TestAccCloudFrontResponseHeadersPolicy_ServerTimingHeadersConfig
=== PAUSE TestAccCloudFrontResponseHeadersPolicy_ServerTimingHeadersConfig
=== CONT  TestAccCloudFrontResponseHeadersPolicy_ServerTimingHeadersConfig
--- PASS: TestAccCloudFrontResponseHeadersPolicy_ServerTimingHeadersConfig (108.71s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 108.802s```
