### PR TITLE
[New Data Source]: get-spot-placement-scores

### DIFF
--- a/.changelog/27779.txt
+++ b/.changelog/27779.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_ec2_spot_placement_scores
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -569,6 +569,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_ec2_network_insights_path":                  ec2.DataSourceNetworkInsightsPath(),
 			"aws_ec2_serial_console_access":                  ec2.DataSourceSerialConsoleAccess(),
 			"aws_ec2_spot_price":                             ec2.DataSourceSpotPrice(),
+			"aws_ec2_spot_placement_scores":                  ec2.DataSourceSpotPricementScores(),
 			"aws_ec2_transit_gateway":                        ec2.DataSourceTransitGateway(),
 			"aws_ec2_transit_gateway_attachment":             ec2.DataSourceTransitGatewayAttachment(),
 			"aws_ec2_transit_gateway_connect":                ec2.DataSourceTransitGatewayConnect(),

--- a/internal/service/ec2/ec2_spot_placement_scores_data_source.go
+++ b/internal/service/ec2/ec2_spot_placement_scores_data_source.go
@@ -1,0 +1,423 @@
+package ec2
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func DataSourceSpotPricementScores() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceSpotPlacementScoresRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"instance_requirements_with_metadata": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"architecture_types": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringInSlice(ec2.ArchitectureType_Values(), false),
+							},
+						},
+						"instance_requirements": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"accelerator_count": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"max": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntAtLeast(0),
+												},
+												"min": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntAtLeast(1),
+												},
+											},
+										},
+									},
+									"accelerator_manufacturers": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validation.StringInSlice(ec2.AcceleratorManufacturer_Values(), false),
+										},
+									},
+									"accelerator_names": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validation.StringInSlice(ec2.AcceleratorName_Values(), false),
+										},
+									},
+									"accelerator_total_memory_mib": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"max": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntAtLeast(1),
+												},
+												"min": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntAtLeast(1),
+												},
+											},
+										},
+									},
+									"accelerator_types": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validation.StringInSlice(ec2.AcceleratorType_Values(), false),
+										},
+									},
+									"bare_metal": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice(ec2.BareMetal_Values(), false),
+									},
+									"baseline_ebs_bandwidth_mbps": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"max": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntAtLeast(1),
+												},
+												"min": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntAtLeast(1),
+												},
+											},
+										},
+									},
+									"burstable_performance": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice(ec2.BurstablePerformance_Values(), false),
+									},
+									"cpu_manufacturers": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validation.StringInSlice(ec2.CpuManufacturer_Values(), false),
+										},
+									},
+									"excluded_instance_types": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										MaxItems: 400,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"instance_generations": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validation.StringInSlice(ec2.InstanceGeneration_Values(), false),
+										},
+									},
+									"local_storage": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice(ec2.LocalStorage_Values(), false),
+									},
+									"local_storage_types": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validation.StringInSlice(ec2.LocalStorageType_Values(), false),
+										},
+									},
+									"memory_gib_per_vcpu": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"max": {
+													Type:         schema.TypeFloat,
+													Optional:     true,
+													ValidateFunc: verify.FloatGreaterThan(0.0),
+												},
+												"min": {
+													Type:         schema.TypeFloat,
+													Optional:     true,
+													ValidateFunc: verify.FloatGreaterThan(0.0),
+												},
+											},
+										},
+									},
+									"memory_mib": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"max": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntAtLeast(1),
+												},
+												"min": {
+													Type:         schema.TypeInt,
+													Required:     true,
+													ValidateFunc: validation.IntAtLeast(1),
+												},
+											},
+										},
+									},
+									"network_interface_count": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"max": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntAtLeast(1),
+												},
+												"min": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntAtLeast(1),
+												},
+											},
+										},
+									},
+									"on_demand_max_price_percentage_over_lowest_price": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+									"require_hibernate_support": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"spot_max_price_percentage_over_lowest_price": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+									"total_local_storage_gb": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"max": {
+													Type:         schema.TypeFloat,
+													Optional:     true,
+													ValidateFunc: verify.FloatGreaterThan(0.0),
+												},
+												"min": {
+													Type:         schema.TypeFloat,
+													Optional:     true,
+													ValidateFunc: verify.FloatGreaterThan(0.0),
+												},
+											},
+										},
+									},
+									"vcpu_count": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"max": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntAtLeast(1),
+												},
+												"min": {
+													Type:         schema.TypeInt,
+													Required:     true,
+													ValidateFunc: validation.IntAtLeast(1),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"virtualization_types": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringInSlice(ec2.VirtualizationType_Values(), false),
+							},
+						},
+					},
+				},
+			},
+			"instance_types": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"max_results": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(10, 1000),
+			},
+			"region_names": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: verify.ValidRegionName,
+				},
+			},
+			"single_availability_zone": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"target_capacity": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntBetween(1, 2000000000),
+			},
+			"target_capacity_unit_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(ec2.TargetCapacityUnitType_Values(), false),
+			},
+			"spot_placement_score_sets": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"availability_zone_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"score": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceSpotPlacementScoresRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).EC2Conn
+
+	input := &ec2.GetSpotPlacementScoresInput{}
+
+	if v, ok := d.GetOk("instance_types"); ok {
+		instanceTypes := flex.ExpandStringSet(v.(*schema.Set))
+		input.SetInstanceTypes(instanceTypes)
+	}
+
+	if v, ok := d.GetOk("max_results"); ok {
+		input.SetMaxResults(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("region_names"); ok {
+		regionNames := flex.ExpandStringSet(v.(*schema.Set))
+		input.SetRegionNames(regionNames)
+	}
+
+	if v, ok := d.GetOk("single_availability_zone"); ok {
+		input.SetSingleAvailabilityZone(v.(bool))
+	}
+
+	if v, ok := d.GetOk("target_capacity"); ok {
+		input.SetTargetCapacity(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("target_capacity_unit_type"); ok {
+		input.SetTargetCapacityUnitType(v.(string))
+	}
+
+	if v, ok := d.GetOk("instance_requirements_with_metadata"); ok {
+		irwm := expandInstanceRequirementsWithMetadata(v.([]interface{})[0].(map[string]interface{}))
+		input.SetInstanceRequirementsWithMetadata(irwm)
+	}
+
+	getSpotPlacementScoresOutput, err := conn.GetSpotPlacementScores(input)
+	if err != nil {
+		return fmt.Errorf("error reading EC2 Spot Placement Scores: %w", err)
+	}
+
+	var spotPlacementScores []map[string]interface{}
+	for _, spotPlacementScore := range getSpotPlacementScoresOutput.SpotPlacementScores {
+		spotPlacementScores = append(
+			spotPlacementScores,
+			map[string]interface{}{
+				"availability_zone_id": spotPlacementScore.AvailabilityZoneId,
+				"region":               spotPlacementScore.Region,
+				"score":                spotPlacementScore.Score,
+			},
+		)
+	}
+
+	d.Set("spot_placement_score_sets", spotPlacementScores)
+	d.SetId(meta.(*conns.AWSClient).Region)
+
+	return nil
+}
+
+func expandInstanceRequirementsWithMetadata(tflist map[string]interface{}) *ec2.InstanceRequirementsWithMetadataRequest {
+	input := &ec2.InstanceRequirementsWithMetadataRequest{}
+
+	if v, ok := tflist["architecture_types"].(*schema.Set); ok && v.Len() > 0 {
+		input.SetArchitectureTypes(flex.ExpandStringSet(v))
+	}
+
+	if v, ok := tflist["instance_requirements"]; ok {
+		input.SetInstanceRequirements(expandInstanceRequirementsRequest(v.([]interface{})[0].(map[string]interface{})))
+	}
+
+	if v, ok := tflist["virtualization_types"].(*schema.Set); ok && v.Len() > 0 {
+		input.SetVirtualizationTypes(flex.ExpandStringSet(v))
+	}
+
+	return input
+}

--- a/internal/service/ec2/ec2_spot_placement_scores_data_source_test.go
+++ b/internal/service/ec2/ec2_spot_placement_scores_data_source_test.go
@@ -1,0 +1,140 @@
+package ec2_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccEC2SpotPlacementScoresDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_ec2_spot_placement_scores.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEC2SpotPlacementScoresDataSourceConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchTypeSetElemNestedAttrs(
+						dataSourceName,
+						"spot_placement_score_sets.*",
+						map[string]*regexp.Regexp{
+							"region": regexp.MustCompile(`^[a-z1-3\-]*$`),
+							"score":  regexp.MustCompile(`^[1-9]0?$`),
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2SpotPlacementScoresDataSource_singleAz(t *testing.T) {
+	dataSourceName := "data.aws_ec2_spot_placement_scores.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEC2SpotPlacementScoresDataSourceConfig_singleAz(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchTypeSetElemNestedAttrs(
+						dataSourceName,
+						"spot_placement_score_sets.*",
+						map[string]*regexp.Regexp{
+							"availability_zone_id": regexp.MustCompile(`^[a-z1-3\-]*$`),
+							"region":               regexp.MustCompile(`^[a-z1-3\-]*$`),
+							"score":                regexp.MustCompile(`^[1-9]0?$`),
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2SpotPlacementScoresDataSource_withMetadata(t *testing.T) {
+	dataSourceName := "data.aws_ec2_spot_placement_scores.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEC2SpotPlacementScoresDataSourceConfig_withMetadata(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchTypeSetElemNestedAttrs(
+						dataSourceName,
+						"spot_placement_score_sets.*",
+						map[string]*regexp.Regexp{
+							"availability_zone_id": regexp.MustCompile(`^[a-z1-3\-]*$`),
+							"region":               regexp.MustCompile(`^[a-z1-3\-]*$`),
+							"score":                regexp.MustCompile(`^[1-9]0?$`),
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccEC2SpotPlacementScoresDataSourceConfig_basic() string {
+	return acctest.ConfigCompose(`
+data "aws_ec2_spot_placement_scores" "test" {
+  max_results = 10
+  target_capacity = 10
+  instance_types = ["m3.xlarge","t4g.small","p4d.24xlarge"]
+}
+`)
+}
+
+func testAccEC2SpotPlacementScoresDataSourceConfig_singleAz() string {
+	return acctest.ConfigCompose(`
+data "aws_ec2_spot_placement_scores" "test" {
+  max_results = 10
+  single_availability_zone = true
+  target_capacity = 10
+  instance_types = ["m3.xlarge","t4g.small","p4d.24xlarge"]
+}
+`)
+}
+
+func testAccEC2SpotPlacementScoresDataSourceConfig_withMetadata() string {
+	return acctest.ConfigCompose(`
+data "aws_ec2_spot_placement_scores" "test" {
+  max_results = 10
+  single_availability_zone = true
+  target_capacity = 1
+  region_names = ["us-east-1","us-east-2","eu-west-1","eu-west-2"]
+  
+  instance_requirements_with_metadata {
+    architecture_types = ["x86_64","arm64","x86_64_mac"]
+    instance_requirements {
+      vcpu_count {
+        min = 1
+        max = 8
+      }
+
+      memory_mib {
+        min = 100
+        max = 50000
+      }
+
+      instance_generations = ["current"]
+    }
+    virtualization_types = ["paravirtual", "hvm"]
+  }
+}
+`)
+}

--- a/website/docs/d/ec2_spot_placement_scores.html.markdown
+++ b/website/docs/d/ec2_spot_placement_scores.html.markdown
@@ -1,0 +1,208 @@
+---
+subcategory: "EC2 (Elastic Compute Cloud)"
+layout: "aws"
+page_title: "AWS: aws_ec2_spot_placement_scores"
+description: |-
+  Calculates the Spot placement score for a Region or Availability Zone based on the specified target capacity and compute requirements.
+---
+
+# Data Source: aws_ec2_spot_placement_scores
+
+Calculates the Spot placement score for a Region or Availability Zone based on the specified target capacity and compute requirements.
+
+## Example Usage
+
+```terraform
+data "aws_ec2_spot_placement_scores" "test" {
+  max_results = 10
+  target_capacity = 10
+  instance_types = ["m3.xlarge","t4g.small","p4d.24xlarge"]
+}
+```
+
+### Single AZ
+```terraform
+data "aws_ec2_spot_placement_scores" "test" {
+  max_results = 10
+  single_availability_zone = true
+  target_capacity = 10
+  instance_types = ["m3.xlarge","t4g.small","p4d.24xlarge"]
+}
+```
+
+### With Metadata
+```terraform
+data "aws_ec2_spot_placement_scores" "test" {
+  max_results = 10
+  single_availability_zone = true
+  target_capacity = 1
+  
+  instance_requirements_with_metadata {
+    architecture_types = ["x86_64","arm64","x86_64_mac"]
+    instance_requirements {
+      vcpu_count {
+        min = 1
+        max = 8
+      }
+
+      memory_mib {
+        min = 100
+        max = 50000
+      }
+
+      instance_generations = ["current"]
+    }
+    virtualization_types = ["paravirtual", "hvm"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_requirements_with_metadata` - (Optional) The attribute requirements for the type of instance. If present then `instance_types` cannot be present.
+* `instance_types` - Set of The instance types. We recommend that you specify at least three instance types. If you specify one or two instance types, or specify variations of a single instance type (for example, an m3.xlarge with and without instance storage), the returned placement score will always be low. If you specify InstanceTypes, you can't specify `instance_requirements_with_metadata`.
+* `max_results` - (Optional) The maximum number of results to return in a single call. Specify a value between 1 and 1000. The default value is 1000.
+* `region_names` - (Optional) Set of Regions used to narrow down the list of Regions to be scored. Enter the Region code, for example, us-east-1.
+* `single_availability_zone` - (Optional) Specify true so that the response returns a list of scored Availability Zones. Otherwise, the response returns a list of scored Regions.
+* `target_capacity` - (Required) The target capacity. Specify a value between 1 and 2000000000.
+* `target_capacity_unit_type` - (Optional) The unit for the target capacity.
+
+    ```
+    Valid types:
+      * vcpu
+      * memory-mib
+      * units
+    ```
+
+### instance_requirements_with_metadata
+
+* `architecture_types` - (Optional) Set of architecture types.
+
+    ```
+    Valid types:
+      * i386
+      * x86_64
+      * arm64
+      * x86_64_mac
+    ```
+
+* `instance_requirements` - (Optional) The instance requirements. See below.
+* `virtualization_types` - (Optional) Set of virtualization types.
+
+    ```
+    Valid types:
+      * hvm
+      * paravirtual
+    ```
+
+#### instance_requirements
+
+This configuration block supports the following:
+
+~> **NOTE:** Both `memory_mib.min` and `vcpu_count.min` must be specified.
+
+* `accelerator_count` - (Optional) Block describing the minimum and maximum number of accelerators (GPUs, FPGAs, or AWS Inferentia chips). Default is no minimum or maximum.
+    * `min` - (Optional) Minimum.
+    * `max` - (Optional) Maximum. Set to `0` to exclude instance types with accelerators.
+* `accelerator_manufacturers` - (Optional) List of accelerator manufacturer names. Default is any manufacturer.
+
+    ```
+    Valid names:
+      * amazon-web-services
+      * amd
+      * nvidia
+      * xilinx
+    ```
+
+* `accelerator_names` - (Optional) List of accelerator names. Default is any acclerator.
+
+    ```
+    Valid names:
+      * a100            - NVIDIA A100 GPUs
+      * v100            - NVIDIA V100 GPUs
+      * k80             - NVIDIA K80 GPUs
+      * t4              - NVIDIA T4 GPUs
+      * m60             - NVIDIA M60 GPUs
+      * radeon-pro-v520 - AMD Radeon Pro V520 GPUs
+      * vu9p            - Xilinx VU9P FPGAs
+    ```
+
+* `accelerator_total_memory_mib` - (Optional) Block describing the minimum and maximum total memory of the accelerators. Default is no minimum or maximum.
+    * `min` - (Optional) Minimum.
+    * `max` - (Optional) Maximum.
+* `accelerator_types` - (Optional) List of accelerator types. Default is any accelerator type.
+
+    ```
+    Valid types:
+      * fpga
+      * gpu
+      * inference
+    ```
+
+* `bare_metal` - (Optional) Indicate whether bare metal instace types should be `included`, `excluded`, or `required`. Default is `excluded`.
+* `baseline_ebs_bandwidth_mbps` - (Optional) Block describing the minimum and maximum baseline EBS bandwidth, in Mbps. Default is no minimum or maximum.
+    * `min` - (Optional) Minimum.
+    * `max` - (Optional) Maximum.
+* `burstable_performance` - (Optional) Indicate whether burstable performance instance types should be `included`, `excluded`, or `required`. Default is `excluded`.
+* `cpu_manufacturers` (Optional) List of CPU manufacturer names. Default is any manufacturer.
+
+    ~> **NOTE:** Don't confuse the CPU hardware manufacturer with the CPU hardware architecture. Instances will be launched with a compatible CPU architecture based on the Amazon Machine Image (AMI) that you specify in your launch template.
+
+    ```
+    Valid names:
+      * amazon-web-services
+      * amd
+      * intel
+    ```
+
+* `excluded_instance_types` - (Optional) List of instance types to exclude. You can use strings with one or more wild cards, represented by an asterisk (\*). The following are examples: `c5*`, `m5a.*`, `r*`, `*3*`. For example, if you specify `c5*`, you are excluding the entire C5 instance family, which includes all C5a and C5n instance types. If you specify `m5a.*`, you are excluding all the M5a instance types, but not the M5n instance types. Maximum of 400 entries in the list; each entry is limited to 30 characters. Default is no excluded instance types.
+* `instance_generations` - (Optional) List of instance generation names. Default is any generation.
+
+    ```
+    Valid names:
+      * current  - Recommended for best performance.
+      * previous - For existing applications optimized for older instance types.
+    ```
+
+* `local_storage` - (Optional) Indicate whether instance types with local storage volumes are `included`, `excluded`, or `required`. Default is `included`.
+* `local_storage_types` - (Optional) List of local storage type names. Default any storage type.
+
+    ```
+    Value names:
+      * hdd - hard disk drive
+      * ssd - solid state drive
+    ```
+
+* `memory_gib_per_vcpu` - (Optional) Block describing the minimum and maximum amount of memory (GiB) per vCPU. Default is no minimum or maximum.
+    * `min` - (Optional) Minimum. May be a decimal number, e.g. `0.5`.
+    * `max` - (Optional) Maximum. May be a decimal number, e.g. `0.5`.
+* `memory_mib` - (Required) Block describing the minimum and maximum amount of memory (MiB). Default is no maximum.
+    * `min` - (Required) Minimum.
+    * `max` - (Optional) Maximum.
+* `network_interface_count` - (Optional) Block describing the minimum and maximum number of network interfaces. Default is no minimum or maximum.
+    * `min` - (Optional) Minimum.
+    * `max` - (Optional) Maximum.
+* `on_demand_max_price_percentage_over_lowest_price` - (Optional) The price protection threshold for On-Demand Instances. This is the maximum you’ll pay for an On-Demand Instance, expressed as a percentage higher than the cheapest M, C, or R instance type with your specified attributes. When Amazon EC2 Auto Scaling selects instance types with your attributes, we will exclude instance types whose price is higher than your threshold. The parameter accepts an integer, which Amazon EC2 Auto Scaling interprets as a percentage. To turn off price protection, specify a high value, such as 999999. Default is 20.
+
+    If you set DesiredCapacityType to vcpu or memory-mib, the price protection threshold is applied based on the per vCPU or per memory price instead of the per instance price.
+* `require_hibernate_support` - (Optional) Indicate whether instance types must support On-Demand Instance Hibernation, either `true` or `false`. Default is `false`.
+* `spot_max_price_percentage_over_lowest_price` - (Optional) The price protection threshold for Spot Instances. This is the maximum you’ll pay for a Spot Instance, expressed as a percentage higher than the cheapest M, C, or R instance type with your specified attributes. When Amazon EC2 Auto Scaling selects instance types with your attributes, we will exclude instance types whose price is higher than your threshold. The parameter accepts an integer, which Amazon EC2 Auto Scaling interprets as a percentage. To turn off price protection, specify a high value, such as 999999. Default is 100.
+
+    If you set DesiredCapacityType to vcpu or memory-mib, the price protection threshold is applied based on the per vCPU or per memory price instead of the per instance price.
+* `total_local_storage_gb` - (Optional) Block describing the minimum and maximum total local storage (GB). Default is no minimum or maximum.
+    * `min` - (Optional) Minimum. May be a decimal number, e.g. `0.5`.
+    * `max` - (Optional) Maximum. May be a decimal number, e.g. `0.5`.
+* `vcpu_count` - (Required) Block describing the minimum and maximum number of vCPUs. Default is no maximum.
+    * `min` - (Required) Minimum.
+    * `max` - (Optional) Maximum.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `spot_placement_score_sets` - List of spot_placement_score_set.
+  * `spot_placement_score_set.#.availability_zone_id` - The Availability Zone.
+  * `spot_placement_score_set.#.region` - The Region.
+  * `spot_placement_score_set.#.score` - The placement score, on a scale from 1 to 10. A score of 10 indicates that your Spot request is highly likely to succeed in this Region or Availability Zone. A score of 1 indicates that your Spot request is not likely to succeed.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27722

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/ja_jp/AWSEC2/latest/APIReference/API_GetSpotPlacementScores.html
https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.GetSpotPlacementScores


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccEC2SpotPlacementScoresDataSource PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2SpotPlacementScoresDataSource'  -timeout 180m
=== RUN   TestAccEC2SpotPlacementScoresDataSource_basic
=== PAUSE TestAccEC2SpotPlacementScoresDataSource_basic
=== RUN   TestAccEC2SpotPlacementScoresDataSource_singleAz
=== PAUSE TestAccEC2SpotPlacementScoresDataSource_singleAz
=== RUN   TestAccEC2SpotPlacementScoresDataSource_withMetadata
=== PAUSE TestAccEC2SpotPlacementScoresDataSource_withMetadata
=== CONT  TestAccEC2SpotPlacementScoresDataSource_basic
=== CONT  TestAccEC2SpotPlacementScoresDataSource_withMetadata
=== CONT  TestAccEC2SpotPlacementScoresDataSource_singleAz
--- PASS: TestAccEC2SpotPlacementScoresDataSource_basic (44.48s)
--- PASS: TestAccEC2SpotPlacementScoresDataSource_singleAz (46.14s)
--- PASS: TestAccEC2SpotPlacementScoresDataSource_withMetadata (46.28s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        46.672s
```
