### PR TITLE
d/aws_cloudwatch_event_rule: new data source

### DIFF
--- a/.changelog/27780.txt
+++ b/.changelog/27780.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_cloudwatch_event_source
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -484,6 +484,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_cloudwatch_event_bus":        events.DataSourceBus(),
 			"aws_cloudwatch_event_connection": events.DataSourceConnection(),
 			"aws_cloudwatch_event_source":     events.DataSourceSource(),
+			"aws_cloudwatch_event_rule":       events.DataSourceRule(),
 
 			"aws_cloudwatch_log_group":  logs.DataSourceGroup(),
 			"aws_cloudwatch_log_groups": logs.DataSourceGroups(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -483,8 +483,8 @@ func New(_ context.Context) (*schema.Provider, error) {
 
 			"aws_cloudwatch_event_bus":        events.DataSourceBus(),
 			"aws_cloudwatch_event_connection": events.DataSourceConnection(),
-			"aws_cloudwatch_event_source":     events.DataSourceSource(),
 			"aws_cloudwatch_event_rule":       events.DataSourceRule(),
+			"aws_cloudwatch_event_source":     events.DataSourceSource(),
 
 			"aws_cloudwatch_log_group":  logs.DataSourceGroup(),
 			"aws_cloudwatch_log_groups": logs.DataSourceGroups(),

--- a/internal/service/events/rule_data_source.go
+++ b/internal/service/events/rule_data_source.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eventbridge"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -110,7 +110,7 @@ func dataSourceRuleRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error setting tags: %w", err)
 	}
 
-	d.SetId(*output.Arn)
+	d.SetId(aws.StringValue(output.Arn))
 
 	return nil
 }

--- a/internal/service/events/rule_data_source.go
+++ b/internal/service/events/rule_data_source.go
@@ -20,16 +20,33 @@ func DataSourceRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"event_bus_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"tags": tftags.TagsSchemaComputed(),
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"created_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"event_bus_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"event_pattern": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"managed_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"role_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 				Optional: true,
@@ -43,24 +60,7 @@ func DataSourceRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"description": {
-				Type:     schema.TypeString,
-				Computed: true,
-				Optional: true,
-			},
-			"created_by": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"managed_by": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"role_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-				Optional: true,
-			},
+			"tags": tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -92,15 +92,15 @@ func dataSourceRuleRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Found EventBridge rule: %#v", *output)
 
 	d.Set("arn", output.Arn)
-	d.Set("name", output.Name)
-	d.Set("state", output.State)
 	d.Set("created_by", output.CreatedBy)
 	d.Set("description", output.Description)
-	d.Set("managed_by", output.ManagedBy)
-	d.Set("role_arn", output.RoleArn)
-	d.Set("event_pattern", output.EventPattern)
-	d.Set("schedule_expression", output.ScheduleExpression)
 	d.Set("event_bus_name", output.EventBusName)
+	d.Set("event_pattern", output.EventPattern)
+	d.Set("managed_by", output.ManagedBy)
+	d.Set("name", output.Name)
+	d.Set("role_arn", output.RoleArn)
+	d.Set("schedule_expression", output.ScheduleExpression)
+	d.Set("state", output.State)
 
 	tags, err := ListTags(conn, *output.Arn)
 	if err != nil {

--- a/internal/service/events/rule_data_source.go
+++ b/internal/service/events/rule_data_source.go
@@ -1,0 +1,116 @@
+package events
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/service/eventbridge"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+)
+
+func DataSourceRule() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceRuleRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"event_bus_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"event_pattern": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"schedule_expression": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"created_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"managed_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"role_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceRuleRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).EventsConn
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	name := d.Get("name").(string)
+
+	input := &eventbridge.DescribeRuleInput{
+		Name: aws.String(name),
+	}
+
+	if v, ok := d.GetOk("event_bus_name"); ok {
+		input.EventBusName = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Reading EventBridge rule (%s)", d.Id())
+	output, err := conn.DescribeRule(input)
+	if err != nil {
+		return fmt.Errorf("error getting EventBridge rule (%s): %w", d.Id(), err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error getting EventBridge rule (%s): empty response", d.Id())
+	}
+
+	log.Printf("[DEBUG] Found EventBridge rule: %#v", *output)
+
+	d.Set("arn", output.Arn)
+	d.Set("name", output.Name)
+	d.Set("state", output.State)
+	d.Set("created_by", output.CreatedBy)
+	d.Set("description", output.Description)
+	d.Set("managed_by", output.ManagedBy)
+	d.Set("role_arn", output.RoleArn)
+	d.Set("event_pattern", output.EventPattern)
+	d.Set("schedule_expression", output.ScheduleExpression)
+	d.Set("event_bus_name", output.EventBusName)
+
+	tags, err := ListTags(conn, *output.Arn)
+	if err != nil {
+		return fmt.Errorf("error listing tags for rule (%s): %w", name, err)
+	}
+	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return fmt.Errorf("error setting tags: %w", err)
+	}
+
+	d.SetId(*output.Arn)
+
+	return nil
+}

--- a/internal/service/events/rule_data_source_test.go
+++ b/internal/service/events/rule_data_source_test.go
@@ -1,0 +1,62 @@
+package events_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccEventsRuleDataSource_basic(t *testing.T) {
+
+	ruleName := fmt.Sprintf("test_rule-%d", sdkacctest.RandInt())
+	busName := fmt.Sprintf("test_bus-%d", sdkacctest.RandInt())
+
+	resourceName := "aws_cloudwatch_event_rule.test"
+	dataSourceName := "data.aws_cloudwatch_event_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuleDataSourceConfig_basic(ruleName, busName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRuleDataSourceConfig_basic(ruleName, busName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_event_bus" "test" {
+  name = %[1]q
+}
+
+resource "aws_cloudwatch_event_rule" "test" {
+  name = %[2]q
+  event_pattern = <<EOF
+  {
+	"detail-type": [
+	  "AWS Console Sign In via CloudTrail"
+	]
+  }
+EOF
+  event_bus_name = resource.aws_cloudwatch_event_bus.test.name
+}
+
+data "aws_cloudwatch_event_rule" "test" {
+  name = %[2]q
+  event_bus_name = resource.aws_cloudwatch_event_bus.test.name
+
+  depends_on = [aws_cloudwatch_event_rule.test]
+}
+`, busName, ruleName)
+}

--- a/internal/service/events/rule_data_source_test.go
+++ b/internal/service/events/rule_data_source_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestAccEventsRuleDataSource_basic(t *testing.T) {
 
-	ruleName := fmt.Sprintf("test_rule-%d", sdkacctest.RandInt())
-	busName := fmt.Sprintf("test_bus-%d", sdkacctest.RandInt())
+	ruleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	busName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resourceName := "aws_cloudwatch_event_rule.test"
 	dataSourceName := "data.aws_cloudwatch_event_rule.test"

--- a/website/docs/d/cloudwatch_event_rule.html.markdown
+++ b/website/docs/d/cloudwatch_event_rule.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "EventBridge"
+layout: "aws"
+page_title: "AWS: aws_cloudwatch_event_rule"
+description: |-
+  Get information on an EventBridge (Cloudwatch) rule.
+---
+
+# Data Source: aws_cloudwatch_event_rule
+
+Use this data source to get information about an EventBridge rule. 
+
+~> **Note:** EventBridge was formerly known as CloudWatch Events. The functionality is identical.
+
+## Example Usage
+
+```terraform
+data "aws_cloudwatch_event_rule" "examplerule" {
+  name = "examplerule"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the rule
+* `event_bus_name` - (Optional) The name or ARN of the event bus associated with the rule. If you omit this, the default event bus is used
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name (ARN) of the rule
+* `event_pattern` - The event pattern
+* `schedule_expression` - The scheduling expression
+* `state` - Specifies whether the rule is enabled or disabled
+* `description` - The description of the rule
+* `created_by` - The account ID of the user that created the rule. If you use PutRule to put a rule on an event bus in another account, the other account is the owner of the rule, and the rule ARN includes the account ID for that account. However, the value for CreatedBy is the account ID as the account that created the rule in the other account
+* `managed_by` - If this is a managed rule, created by an Amazon Web Services service on your behalf, this field displays the principal name of the Amazon Web Services service that created the rule
+* `role_arn` - The Amazon Resource Name (ARN) of the IAM role associated with the rule


### PR DESCRIPTION
### Description

New data source for `aws_cloudwatch_event_rule`.


### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccEventsRuleDataSource PKG=events
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsRuleDataSource'  -timeout 180m
=== RUN   TestAccEventsRuleDataSource_basic
=== PAUSE TestAccEventsRuleDataSource_basic
=== CONT  TestAccEventsRuleDataSource_basic
--- PASS: TestAccEventsRuleDataSource_basic (33.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/events     40.836s
...
```
