### PR TITLE
Add support for key_algorithm in `aws_acm_certificate` resource

### DIFF
--- a/.changelog/27781.txt
+++ b/.changelog/27781.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_acm_certificate: Add `key_algorithm` argument
+resource/aws_acm_certificate: Add `key_algorithm` argument in support of [ECDSA TLS certificates](https://docs.aws.amazon.com/acm/latest/userguide/acm-certificate.html#algorithms)
 ```

--- a/.changelog/27781.txt
+++ b/.changelog/27781.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_acm_certificate: Add `key_algorithm` argument
+```

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -443,9 +443,9 @@ func resourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta i
 		keyAlgorithmValue := certificate.KeyAlgorithm
 		// ACM DescribeCertificate returns hyphenated string values instead of underscore separated
 		// This sets the value to the string in the ACM SDK (i.e. underscore separated)
-		for _, str := range acm.KeyAlgorithm_Values() {
-			if strings.ReplaceAll(*keyAlgorithmValue, "-", "_") == strings.ReplaceAll(str, "-", "_") {
-				keyAlgorithmValue = aws.String(str)
+		for _, v := range acm.KeyAlgorithm_Values() {
+			if strings.ReplaceAll(aws.StringValue(keyAlgorithmValue), "-", "_") == strings.ReplaceAll(v, "-", "_") {
+				keyAlgorithmValue = aws.String(v)
 				break
 			}
 		}

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -118,6 +118,14 @@ func ResourceCertificate() *schema.Resource {
 				ValidateDiagFunc: validateHybridDuration,
 				ConflictsWith:    []string{"certificate_body", "certificate_chain", "private_key", "validation_method"},
 			},
+			"key_algorithm": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ValidateFunc:  validation.StringInSlice(acm.KeyAlgorithm_Values(), false),
+				ConflictsWith: []string{"certificate_body", "certificate_chain", "private_key"},
+			},
 			"not_after": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -341,6 +349,10 @@ func resourceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta
 			input.CertificateAuthorityArn = aws.String(v.(string))
 		}
 
+		if v, ok := d.GetOk("key_algorithm"); ok {
+			input.KeyAlgorithm = aws.String(v.(string))
+		}
+
 		if v, ok := d.GetOk("options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 			input.Options = expandCertificateOptions(v.([]interface{})[0].(map[string]interface{}))
 		}
@@ -426,6 +438,18 @@ func resourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("early_renewal_duration", d.Get("early_renewal_duration"))
 	if err := d.Set("domain_validation_options", domainValidationOptions); err != nil {
 		return diag.Errorf("setting domain_validation_options: %s", err)
+	}
+	if certificate.KeyAlgorithm != nil {
+		keyAlgorithmValue := certificate.KeyAlgorithm
+		// ACM DescribeCertificate returns hyphenated string values instead of underscore separated
+		// This sets the value to the string in the ACM SDK (i.e. underscore separated)
+		for _, str := range acm.KeyAlgorithm_Values() {
+			if strings.ReplaceAll(*keyAlgorithmValue, "-", "_") == strings.ReplaceAll(str, "-", "_") {
+				keyAlgorithmValue = aws.String(str)
+				break
+			}
+		}
+		d.Set("key_algorithm", keyAlgorithmValue)
 	}
 	if certificate.NotAfter != nil {
 		d.Set("not_after", aws.TimeValue(certificate.NotAfter).Format(time.RFC3339))

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -144,6 +144,7 @@ The following arguments are supported:
     * `domain_name` - (Required) Domain name for which the certificate should be issued
     * `subject_alternative_names` - (Optional) Set of domains that should be SANs in the issued certificate. To remove all elements of a previously configured list, set this value equal to an empty list (`[]`) or use the [`terraform taint` command](https://www.terraform.io/docs/commands/taint.html) to trigger recreation.
     * `validation_method` - (Required) Which method to use for validation. `DNS` or `EMAIL` are valid, `NONE` can be used for certificates that were imported into ACM and then into Terraform.
+    * `key_algorithm` - (Optional) Specifies the algorithm of the public and private key pair that your Amazon issued certificate uses to encrypt data. See [ACM Certificate characteristics](https://docs.aws.amazon.com/acm/latest/userguide/acm-certificate.html#algorithms) for more details.
     * `options` - (Optional) Configuration block used to set certificate options. Detailed below.
     * `validation_option` - (Optional) Configuration block used to specify information about the initial validation of each domain name. Detailed below.
 * Importing an existing certificate


### PR DESCRIPTION
### Description

Support specifying the key algorithm when requesting ACM certificates. Enables requesting certificates with ECDSA algorithms.

### Relations

Relates #27715 

### References

- https://aws.amazon.com/about-aws/whats-new/2022/11/aws-certificate-manager-elliptic-curve-digital-signature-algorithm-tls-certificates/
- https://docs.aws.amazon.com/acm/latest/userguide/acm-certificate.html#algorithms

### Output from Acceptance Testing

```
$ ACM_CERTIFICATE_ROOT_DOMAIN=beta-env.idv.tw make testacc TESTS='TestAccACMCertificate_(root|keyAlgorithm)' PKG=acm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/acm/... -v -count 1 -parallel 20 -run='TestAccACMCertificate_(root|keyAlgorithm)'  -timeout 180m
=== RUN   TestAccACMCertificate_root
=== PAUSE TestAccACMCertificate_root
=== RUN   TestAccACMCertificate_rootAndWildcardSan
=== PAUSE TestAccACMCertificate_rootAndWildcardSan
=== RUN   TestAccACMCertificate_keyAlgorithm
=== PAUSE TestAccACMCertificate_keyAlgorithm
=== CONT  TestAccACMCertificate_root
=== CONT  TestAccACMCertificate_keyAlgorithm
=== CONT  TestAccACMCertificate_rootAndWildcardSan
--- PASS: TestAccACMCertificate_keyAlgorithm (42.44s)
--- PASS: TestAccACMCertificate_root (43.58s)
--- PASS: TestAccACMCertificate_rootAndWildcardSan (46.25s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/acm	48.472s
```
