### PR TITLE
r/aws_sesv2: make use of enum.Validate

### DIFF
--- a/internal/service/sesv2/configuration_set.go
+++ b/internal/service/sesv2/configuration_set.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -56,9 +57,9 @@ func ResourceConfigurationSet() *schema.Resource {
 							Optional: true,
 						},
 						"tls_policy": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice(tlsPolicyValues(types.TlsPolicy("").Values()), false),
+							Type:             schema.TypeString,
+							Optional:         true,
+							ValidateDiagFunc: enum.Validate[types.TlsPolicy](),
 						},
 					},
 				},
@@ -108,8 +109,8 @@ func ResourceConfigurationSet() *schema.Resource {
 							Optional: true,
 							MinItems: 1,
 							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								ValidateFunc: validation.StringInSlice(suppressionListReasonValues(types.SuppressionListReason("").Values()), false),
+								Type:             schema.TypeString,
+								ValidateDiagFunc: enum.Validate[types.SuppressionListReason](),
 							},
 						},
 					},
@@ -603,24 +604,4 @@ func expandTrackingOptions(tfMap map[string]interface{}) *types.TrackingOptions 
 	}
 
 	return a
-}
-
-func tlsPolicyValues(in []types.TlsPolicy) []string {
-	var out []string
-
-	for _, v := range in {
-		out = append(out, string(v))
-	}
-
-	return out
-}
-
-func suppressionListReasonValues(in []types.SuppressionListReason) []string {
-	var out []string
-
-	for _, v := range in {
-		out = append(out, string(v))
-	}
-
-	return out
 }

--- a/internal/service/sesv2/email_identity.go
+++ b/internal/service/sesv2/email_identity.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -83,11 +84,11 @@ func ResourceEmailIdentity() *schema.Resource {
 							Computed: true,
 						},
 						"next_signing_key_length": {
-							Type:          schema.TypeString,
-							Optional:      true,
-							Computed:      true,
-							ConflictsWith: []string{"dkim_signing_attributes.0.domain_signing_private_key", "dkim_signing_attributes.0.domain_signing_selector"},
-							ValidateFunc:  validation.StringInSlice(dkimSigningKeyLengthValues(types.DkimSigningKeyLength("").Values()), false),
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							ConflictsWith:    []string{"dkim_signing_attributes.0.domain_signing_private_key", "dkim_signing_attributes.0.domain_signing_selector"},
+							ValidateDiagFunc: enum.Validate[types.DkimSigningKeyLength](),
 						},
 						"signing_attributes_origin": {
 							Type:     schema.TypeString,
@@ -385,14 +386,4 @@ func flattenDKIMAttributes(apiObject *types.DkimAttributes) map[string]interface
 	}
 
 	return m
-}
-
-func dkimSigningKeyLengthValues(in []types.DkimSigningKeyLength) []string {
-	var out []string
-
-	for _, v := range in {
-		out = append(out, string(v))
-	}
-
-	return out
 }


### PR DESCRIPTION
### Description
This PR makes use of the `enum.Validate` validator and removes the redundant functions for converting AWS SDK v2 enum types.

### Relations
Relates #26796.


### Output from Acceptance Testing

```
$ make testacc TESTARGS='-run="TestAccSESV2ConfigurationSet_|TestAccSESV2EmailIdentity_"' PKG=sesv2 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
/bin/sh: line 0: [: missing `]'
/bin/sh: TestAccSESV2EmailIdentity_: command not found
TF_ACC=1 go test ./internal/service/sesv2/... -v -count 1 -parallel 2  -run="TestAccSESV2ConfigurationSet_|TestAccSESV2EmailIdentity_" -timeout 180m
=== RUN   TestAccSESV2ConfigurationSet_basic
=== PAUSE TestAccSESV2ConfigurationSet_basic
=== RUN   TestAccSESV2ConfigurationSet_disappears
=== PAUSE TestAccSESV2ConfigurationSet_disappears
=== RUN   TestAccSESV2ConfigurationSet_tlsPolicy
=== PAUSE TestAccSESV2ConfigurationSet_tlsPolicy
=== RUN   TestAccSESV2ConfigurationSet_reputationMetricsEnabled
=== PAUSE TestAccSESV2ConfigurationSet_reputationMetricsEnabled
=== RUN   TestAccSESV2ConfigurationSet_sendingEnabled
=== PAUSE TestAccSESV2ConfigurationSet_sendingEnabled
=== RUN   TestAccSESV2ConfigurationSet_suppressedReasons
=== PAUSE TestAccSESV2ConfigurationSet_suppressedReasons
=== RUN   TestAccSESV2ConfigurationSet_tags
=== PAUSE TestAccSESV2ConfigurationSet_tags
=== RUN   TestAccSESV2EmailIdentity_basic_emailAddress
=== PAUSE TestAccSESV2EmailIdentity_basic_emailAddress
=== RUN   TestAccSESV2EmailIdentity_basic_domain
=== PAUSE TestAccSESV2EmailIdentity_basic_domain
=== RUN   TestAccSESV2EmailIdentity_disappears
=== PAUSE TestAccSESV2EmailIdentity_disappears
=== RUN   TestAccSESV2EmailIdentity_configurationSetName
=== PAUSE TestAccSESV2EmailIdentity_configurationSetName
=== RUN   TestAccSESV2EmailIdentity_nextSigningKeyLength
=== PAUSE TestAccSESV2EmailIdentity_nextSigningKeyLength
=== RUN   TestAccSESV2EmailIdentity_domainSigning
=== PAUSE TestAccSESV2EmailIdentity_domainSigning
=== RUN   TestAccSESV2EmailIdentity_tags
=== PAUSE TestAccSESV2EmailIdentity_tags
=== CONT  TestAccSESV2ConfigurationSet_basic
=== CONT  TestAccSESV2EmailIdentity_basic_emailAddress
--- PASS: TestAccSESV2EmailIdentity_basic_emailAddress (28.14s)
=== CONT  TestAccSESV2ConfigurationSet_sendingEnabled
--- PASS: TestAccSESV2ConfigurationSet_basic (28.14s)
=== CONT  TestAccSESV2ConfigurationSet_tags
--- PASS: TestAccSESV2ConfigurationSet_sendingEnabled (44.20s)
=== CONT  TestAccSESV2ConfigurationSet_tlsPolicy
--- PASS: TestAccSESV2ConfigurationSet_tags (62.12s)
=== CONT  TestAccSESV2ConfigurationSet_suppressedReasons
--- PASS: TestAccSESV2ConfigurationSet_tlsPolicy (42.55s)
=== CONT  TestAccSESV2ConfigurationSet_reputationMetricsEnabled
--- PASS: TestAccSESV2ConfigurationSet_suppressedReasons (42.38s)
=== CONT  TestAccSESV2ConfigurationSet_disappears
--- PASS: TestAccSESV2ConfigurationSet_disappears (17.30s)
=== CONT  TestAccSESV2EmailIdentity_disappears
--- PASS: TestAccSESV2ConfigurationSet_reputationMetricsEnabled (42.12s)
=== CONT  TestAccSESV2EmailIdentity_configurationSetName
--- PASS: TestAccSESV2EmailIdentity_disappears (17.52s)
=== CONT  TestAccSESV2EmailIdentity_nextSigningKeyLength
--- PASS: TestAccSESV2EmailIdentity_configurationSetName (45.59s)
=== CONT  TestAccSESV2EmailIdentity_tags
--- PASS: TestAccSESV2EmailIdentity_nextSigningKeyLength (44.30s)
=== CONT  TestAccSESV2EmailIdentity_basic_domain
--- PASS: TestAccSESV2EmailIdentity_basic_domain (26.18s)
=== CONT  TestAccSESV2EmailIdentity_domainSigning
--- PASS: TestAccSESV2EmailIdentity_tags (61.16s)
--- PASS: TestAccSESV2EmailIdentity_domainSigning (42.93s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sesv2      282.713s
```
