### PR TITLE
r/aws_sesv2_email_identity_feedback_attributes: use the correct attribute as the resource ID in error messages

### DIFF
--- a/.changelog/27784.txt
+++ b/.changelog/27784.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sesv2_email_identity_feedback_attributes: Fix invalid resource ID in error messages when creating the resource
+```

--- a/internal/service/sesv2/email_identity_feedback_attributes.go
+++ b/internal/service/sesv2/email_identity_feedback_attributes.go
@@ -56,11 +56,11 @@ func resourceEmailIdentityFeedbackAttributesCreate(ctx context.Context, d *schem
 
 	out, err := conn.PutEmailIdentityFeedbackAttributes(ctx, in)
 	if err != nil {
-		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameEmailIdentityFeedbackAttributes, d.Get("name").(string), err)
+		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameEmailIdentityFeedbackAttributes, d.Get("email_identity").(string), err)
 	}
 
 	if out == nil {
-		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameEmailIdentityFeedbackAttributes, d.Get("name").(string), errors.New("empty output"))
+		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameEmailIdentityFeedbackAttributes, d.Get("email_identity").(string), errors.New("empty output"))
 	}
 
 	d.SetId(d.Get("email_identity").(string))


### PR DESCRIPTION
### Description
This PR fixes the wrong attribute used in the error messages when creating the `aws_sesv2_feedback_attributes`.

### Relations
Relates #26796.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccSESV2EmailIdentityFeedbackAttributes' PKG=sesv2 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sesv2/... -v -count 1 -parallel 2  -run=TestAccSESV2EmailIdentityFeedbackAttributes -timeout 180m
=== RUN   TestAccSESV2EmailIdentityFeedbackAttributes_basic
=== PAUSE TestAccSESV2EmailIdentityFeedbackAttributes_basic
=== RUN   TestAccSESV2EmailIdentityFeedbackAttributes_disappears
=== PAUSE TestAccSESV2EmailIdentityFeedbackAttributes_disappears
=== RUN   TestAccSESV2EmailIdentityFeedbackAttributes_disappears_emailIdentity
=== PAUSE TestAccSESV2EmailIdentityFeedbackAttributes_disappears_emailIdentity
=== RUN   TestAccSESV2EmailIdentityFeedbackAttributes_emailForwardingEnabled
=== PAUSE TestAccSESV2EmailIdentityFeedbackAttributes_emailForwardingEnabled
=== CONT  TestAccSESV2EmailIdentityFeedbackAttributes_basic
=== CONT  TestAccSESV2EmailIdentityFeedbackAttributes_disappears_emailIdentity
--- PASS: TestAccSESV2EmailIdentityFeedbackAttributes_disappears_emailIdentity (21.27s)
=== CONT  TestAccSESV2EmailIdentityFeedbackAttributes_emailForwardingEnabled
--- PASS: TestAccSESV2EmailIdentityFeedbackAttributes_basic (28.49s)
=== CONT  TestAccSESV2EmailIdentityFeedbackAttributes_disappears
--- PASS: TestAccSESV2EmailIdentityFeedbackAttributes_disappears (22.52s)
--- PASS: TestAccSESV2EmailIdentityFeedbackAttributes_emailForwardingEnabled (44.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sesv2      67.833s
```
