### PR TITLE
Add import support for aws_network_interface_sg_attachment resource

### DIFF
--- a/.changelog/27785.txt
+++ b/.changelog/27785.txt
@@ -1,0 +1,3 @@
+```release-note: enhancement
+resource/aws_network_interface_sg_attachment: Add import support
+```

--- a/internal/service/ec2/vpc_network_interface_sg_attachment_test.go
+++ b/internal/service/ec2/vpc_network_interface_sg_attachment_test.go
@@ -34,6 +34,12 @@ func TestAccVPCNetworkInterfaceSgAttachment_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_id", securityGroupResourceName, "id"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccVPCNetworkInterfaceSGAttachmentImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -304,4 +310,22 @@ resource "aws_network_interface_sg_attachment" "test" {
   security_group_id    = aws_security_group.test[count.index].id
 }
 `, rName)
+}
+
+func testAccVPCNetworkInterfaceSGAttachmentImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		var networkInterfaceID string
+		var securityGroupID string
+
+		networkInterfaceID = rs.Primary.Attributes["network_interface_id"]
+		securityGroupID = rs.Primary.Attributes["security_group_id"]
+
+		return fmt.Sprintf("%s_%s", networkInterfaceID, securityGroupID), nil
+	}
 }

--- a/website/docs/r/network_interface_sg_attachment.html.markdown
+++ b/website/docs/r/network_interface_sg_attachment.html.markdown
@@ -92,3 +92,13 @@ resource "aws_network_interface_sg_attachment" "sg_attachment" {
 ## Attributes Reference
 
 No additional attributes are exported.
+
+## Import
+
+Network Interface Security Group attachments can be imported using the associated network interface ID and security group ID, separated by an underscore (`_`).
+
+For example:
+
+```
+$ terraform import aws_network_interface_sg_attachment.sg_attachment eni-1234567890abcdef0_sg-1234567890abcdef0
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This PR adds support for importing existing [aws_network_interface_sg_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface_sg_attachment) resources.


### Relations
Closes #27076


### References
_None_

### Output from Acceptance Testing
```
$ make testacc TESTS=TestAccVPCNetworkInterfaceSgAttachment PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNetworkInterfaceSgAttachment'  -timeout 180m
=== RUN   TestAccVPCNetworkInterfaceSgAttachment_basic
=== PAUSE TestAccVPCNetworkInterfaceSgAttachment_basic
=== RUN   TestAccVPCNetworkInterfaceSgAttachment_disappears
=== PAUSE TestAccVPCNetworkInterfaceSgAttachment_disappears
=== RUN   TestAccVPCNetworkInterfaceSgAttachment_instance
=== PAUSE TestAccVPCNetworkInterfaceSgAttachment_instance
=== RUN   TestAccVPCNetworkInterfaceSgAttachment_multiple
=== PAUSE TestAccVPCNetworkInterfaceSgAttachment_multiple
=== CONT  TestAccVPCNetworkInterfaceSgAttachment_basic
=== CONT  TestAccVPCNetworkInterfaceSgAttachment_instance
=== CONT  TestAccVPCNetworkInterfaceSgAttachment_multiple
=== CONT  TestAccVPCNetworkInterfaceSgAttachment_disappears
--- PASS: TestAccVPCNetworkInterfaceSgAttachment_disappears (67.99s)
--- PASS: TestAccVPCNetworkInterfaceSgAttachment_basic (72.75s)
--- PASS: TestAccVPCNetworkInterfaceSgAttachment_multiple (74.74s)
--- PASS: TestAccVPCNetworkInterfaceSgAttachment_instance (163.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        167.087s
```
