### PR TITLE
DOC: Added missing "domain" attr to ses_domain_identity

### DIFF
--- a/website/docs/r/ses_domain_identity.html.markdown
+++ b/website/docs/r/ses_domain_identity.html.markdown
@@ -20,6 +20,8 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `domain` - Name of the domain.
+
 * `arn` - The ARN of the domain identity.
 
 * `verification_token` - A code which when added to the domain as a TXT record

--- a/website/docs/r/ses_domain_identity.html.markdown
+++ b/website/docs/r/ses_domain_identity.html.markdown
@@ -10,29 +10,17 @@ description: |-
 
 Provides an SES domain identity resource
 
-## Argument Reference
-
-The following arguments are supported:
-
-* `domain` - (Required) The domain name to assign to SES
-
-## Attributes Reference
-
-In addition to all arguments above, the following attributes are exported:
-
-* `domain` - Name of the domain.
-
-* `arn` - The ARN of the domain identity.
-
-* `verification_token` - A code which when added to the domain as a TXT record
-  will signal to SES that the owner of the domain has authorised SES to act on
-  their behalf. The domain identity will be in state "verification pending"
-  until this is done. See below for an example of how this might be achieved
-  when the domain is hosted in Route 53 and managed by Terraform.  Find out
-  more about verifying domains in Amazon SES in the [AWS SES
-  docs](http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-domains.html).
-
 ## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_ses_domain_identity" "example" {
+  domain = "example.com"
+}
+```
+
+### With Route53 Record
 
 ```terraform
 resource "aws_ses_domain_identity" "example" {
@@ -47,6 +35,26 @@ resource "aws_route53_record" "example_amazonses_verification_record" {
   records = [aws_ses_domain_identity.example.verification_token]
 }
 ```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain` - (Required) The domain name to assign to SES
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the domain identity.
+* `verification_token` - A code which when added to the domain as a TXT record
+  will signal to SES that the owner of the domain has authorised SES to act on
+  their behalf. The domain identity will be in state "verification pending"
+  until this is done. See the [With Route53 Record](#with-route53-record) example
+  for how this might be achieved when the domain is hosted in Route 53 and
+  managed by Terraform.  Find out more about verifying domains in Amazon
+  SES in the [AWS SES
+  docs](http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-domains.html).
 
 ## Import
 

--- a/website/docs/r/ses_email_identity.html.markdown
+++ b/website/docs/r/ses_email_identity.html.markdown
@@ -14,7 +14,7 @@ Provides an SES email identity resource
 
 The following arguments are supported:
 
-* `email` - (Required) The email address to assign to SES
+* `email` - (Required) The email address to assign to SES.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Looking at the source code at: 

https://github.com/hashicorp/terraform-provider-aws/blob/d481be15e66cff7cf9d95f9f1258c148ef63c1cb/internal/service/ses/domain_identity.go#L67

And at the docs of [ses_domain_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_domain_identity):

![2022-11-14-132753_1895x1032_scrot](https://user-images.githubusercontent.com/50263213/201648839-732a57d2-ef05-44dc-b2bc-0f8240a22db2.png)

---

#### P.S.

093a697 is just adding a dot at the and of the line, I can revert this commit if it's out of scope.