### PR TITLE
new data source: aws_ivs_stream_key

### DIFF
--- a/.changelog/27789.txt
+++ b/.changelog/27789.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_ivs_stream_key
+```

--- a/examples/ivs/README.md
+++ b/examples/ivs/README.md
@@ -1,0 +1,13 @@
+# IVS (Interactive Video Service) Example
+
+This example shows how to deploy an AWS IVS channel using Terraform only. The
+example creates an S3 bucket for recording.
+
+To run, configure your AWS provider as described in https://www.terraform.io/docs/providers/aws/index.html
+
+## Running the example
+
+Run `terraform apply` to see it work.
+
+By default, resources are created in the `us-west-2` region. To override the
+region, set the variable `aws_region` to a different value.

--- a/examples/ivs/main.tf
+++ b/examples/ivs/main.tf
@@ -1,0 +1,26 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "aws_s3_bucket" "example" {
+  bucket_prefix = "tf-ivs-stream-archive"
+  force_destroy = true
+}
+
+resource "aws_ivs_recording_configuration" "example" {
+  name = "tf-ivs-recording-configuration"
+  destination_configuration {
+    s3 {
+        bucket_name = aws_s3_bucket.example.id
+    }
+  }
+}
+
+resource "aws_ivs_channel" "example" {
+  name = "tf-ivs-channel"
+  recording_configuration_arn = aws_ivs_recording_configuration.example.arn
+}
+
+data "aws_ivs_stream_key" "example" {
+  channel_arn = aws_ivs_channel.example.arn
+}

--- a/examples/ivs/main.tf
+++ b/examples/ivs/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 provider "aws" {
   region = var.aws_region
 }
@@ -11,13 +15,13 @@ resource "aws_ivs_recording_configuration" "example" {
   name = "tf-ivs-recording-configuration"
   destination_configuration {
     s3 {
-        bucket_name = aws_s3_bucket.example.id
+      bucket_name = aws_s3_bucket.example.id
     }
   }
 }
 
 resource "aws_ivs_channel" "example" {
-  name = "tf-ivs-channel"
+  name                        = "tf-ivs-channel"
   recording_configuration_arn = aws_ivs_recording_configuration.example.arn
 }
 

--- a/examples/ivs/outputs.tf
+++ b/examples/ivs/outputs.tf
@@ -1,0 +1,11 @@
+output "ingest_endpoint" {
+  value = aws_ivs_channel.example.ingest_endpoint
+}
+
+output "stream_key" {
+  value = data.aws_ivs_stream_key.example.value
+}
+
+output "playback_url" {
+  value = aws_ivs_channel.example.playback_url
+}

--- a/examples/ivs/variables.tf
+++ b/examples/ivs/variables.tf
@@ -1,0 +1,4 @@
+variable "aws_region" {
+  description = "The AWS region to create things in."
+  default     = "us-west-2"
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -716,6 +716,8 @@ func New(_ context.Context) (*schema.Provider, error) {
 
 			"aws_iot_endpoint": iot.DataSourceEndpoint(),
 
+			"aws_ivs_stream_key": ivs.DataSourceStreamKey(),
+
 			"aws_msk_broker_nodes":  kafka.DataSourceBrokerNodes(),
 			"aws_msk_cluster":       kafka.DataSourceCluster(),
 			"aws_msk_configuration": kafka.DataSourceConfiguration(),

--- a/internal/service/ivs/stream_key_data_source.go
+++ b/internal/service/ivs/stream_key_data_source.go
@@ -1,0 +1,64 @@
+package ivs
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func DataSourceStreamKey() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceStreamKeyRead,
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"channel_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+const (
+	DSNameStreamKey = "Stream Key Data Source"
+)
+
+func dataSourceStreamKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).IVSConn
+
+	channelArn := d.Get("channel_arn").(string)
+
+	out, err := FindStreamKeyByChannelID(ctx, conn, channelArn)
+	if err != nil {
+		return create.DiagError(names.IVS, create.ErrActionReading, DSNameStreamKey, channelArn, err)
+	}
+
+	d.SetId(aws.StringValue(out.Arn))
+
+	d.Set("arn", out.Arn)
+	d.Set("channel_arn", out.ChannelArn)
+	d.Set("value", out.Value)
+
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", KeyValueTags(out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return create.DiagError(names.IVS, create.ErrActionSetting, DSNameStreamKey, d.Id(), err)
+	}
+
+	return nil
+}

--- a/internal/service/ivs/stream_key_data_source_test.go
+++ b/internal/service/ivs/stream_key_data_source_test.go
@@ -1,0 +1,59 @@
+package ivs_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ivs"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccIVSStreamKeyDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_ivs_stream_key.test"
+	channelResourceName := "aws_ivs_channel.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ivs.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStreamKeyDataSourceConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStreamKeyDataSource(dataSourceName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "channel_arn", channelResourceName, "id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "value"),
+					acctest.MatchResourceAttrRegionalARN(dataSourceName, "arn", "ivs", regexp.MustCompile(`stream-key/.+`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckStreamKeyDataSource(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find Stream Key data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Stream Key data source ID not set")
+		}
+		return nil
+	}
+}
+
+func testAccStreamKeyDataSourceConfig_basic() string {
+	return `
+resource "aws_ivs_channel" "test" {
+}
+
+data "aws_ivs_stream_key" "test" {
+  channel_arn = aws_ivs_channel.test.arn
+}
+`
+}

--- a/website/docs/d/ivs_stream_key.html.markdown
+++ b/website/docs/d/ivs_stream_key.html.markdown
@@ -1,0 +1,35 @@
+---
+subcategory: "IVS (Interactive Video)"
+layout: "aws"
+page_title: "AWS: aws_ivs_stream_key"
+description: |-
+  Terraform data source for managing an AWS IVS (Interactive Video) Stream Key.
+---
+
+# Data Source: aws_ivs_stream_key
+
+Terraform data source for managing an AWS IVS (Interactive Video) Stream Key.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_ivs_stream_key" "example" {
+  channel_arn = "arn:aws:ivs:us-west-2:326937407773:channel/0Y1lcs4U7jk5"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `channel_arn` - (Required) ARN of the Channel.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the Stream Key.
+* `tags` - Map of tags assigned to the resource.
+* `value` - Stream Key value.


### PR DESCRIPTION
### Description

Add new data source for AWS IVS Stream Key: `aws_ivs_stream_key`. This PR is the last in a set to support the full AWS IVS entities:

1. ~~Playback Key Pair~~
2. ~~Recording Configuration~~
3. ~~Channel~~
4. Stream Key

### Relations

Relates #17272

### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccIVSStreamKeyDataSource_ PKG=ivs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 /Users/eakevinh/go/bin/go1.18.4 test ./internal/service/ivs/... -v -count 1 -parallel 20 -run='TestAccIVSStreamKeyDataSource_'  -timeout 180m
=== RUN   TestAccIVSStreamKeyDataSource_basic
=== PAUSE TestAccIVSStreamKeyDataSource_basic
=== CONT  TestAccIVSStreamKeyDataSource_basic
--- PASS: TestAccIVSStreamKeyDataSource_basic (32.33s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ivs        35.249s
```
