### PR TITLE
bugfix: `aws_lightsail_domain_entry` id field update separator to `,` to support `_` in `txt` records

### DIFF
--- a/.changelog/27791.txt
+++ b/.changelog/27791.txt
@@ -1,3 +1,3 @@
-```release-note:bug
+```release-note:breaking-change
 resource/aws_ligthsail_domain_entry: Update `id` separator to use `,` to support txt records with `_` values.
 ```

--- a/.changelog/27791.txt
+++ b/.changelog/27791.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ligthsail_domain_entry: Update `id` separator to use `,` to support txt records with `_` values.
+```

--- a/internal/service/lightsail/domain_entry.go
+++ b/internal/service/lightsail/domain_entry.go
@@ -102,7 +102,7 @@ func resourceDomainEntryCreate(ctx context.Context, d *schema.ResourceData, meta
 		d.Get("target").(string),
 	}
 
-	d.SetId(strings.Join(vars, "_"))
+	d.SetId(strings.Join(vars, ","))
 
 	return resourceDomainEntryRead(ctx, d, meta)
 }
@@ -160,7 +160,7 @@ func resourceDomainEntryDelete(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func expandDomainEntry(id string) *lightsail.DomainEntry {
-	id_parts := strings.SplitN(id, "_", -1)
+	id_parts := strings.SplitN(id, ",", -1)
 	name := id_parts[0]
 	domainName := id_parts[1]
 	recordType := id_parts[2]
@@ -176,7 +176,7 @@ func expandDomainEntry(id string) *lightsail.DomainEntry {
 }
 
 func expandDomainNameFromId(id string) string {
-	id_parts := strings.SplitN(id, "_", -1)
+	id_parts := strings.SplitN(id, ",", -1)
 	domainName := id_parts[1]
 
 	return domainName

--- a/internal/service/lightsail/find.go
+++ b/internal/service/lightsail/find.go
@@ -173,7 +173,7 @@ func FindDiskAttachmentById(ctx context.Context, conn *lightsail.Lightsail, id s
 }
 
 func FindDomainEntryById(ctx context.Context, conn *lightsail.Lightsail, id string) (*lightsail.DomainEntry, error) {
-	id_parts := strings.SplitN(id, "_", -1)
+	id_parts := strings.SplitN(id, ",", -1)
 	domainName := id_parts[1]
 	name := expandDomainEntryName(id_parts[0], domainName)
 	recordType := id_parts[2]

--- a/website/docs/r/lightsail_domain_entry.html.markdown
+++ b/website/docs/r/lightsail_domain_entry.html.markdown
@@ -40,12 +40,12 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - A combination of attributes to create a unique id: `name`\_`domain_name`\_`type`\_`target`
+* `id` - A combination of attributes to create a unique id: `name`,`domain_name`,`type`,`target`
 
 ## Import
 
 `aws_lightsail_domain_entry` can be imported by using the id attribute, e.g.,
 
 ```
-$ terraform import aws_lightsail_domain_entry.example www_mydomain.com_A_127.0.0.1
+$ terraform import aws_lightsail_domain_entry.example www,mydomain.com,A,127.0.0.1
 ```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The current separator used for the custom id field uses `_` as a separator. This causes issues when creating `txt` records which commonly have `_` inside the record. This also updates the separator to be the same as the rest of the lightsail resources.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #27843
Closes: #27927

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$  make testacc TESTARGS='-run=TestAccLightsailDomainEntry' PKG=lightsail
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lightsail/... -v -count 1 -parallel 20  -run=TestAccLightsailDomainEntry -timeout 180m
=== RUN   TestAccLightsailDomainEntry_basic
=== PAUSE TestAccLightsailDomainEntry_basic
=== RUN   TestAccLightsailDomainEntry_disappears
=== PAUSE TestAccLightsailDomainEntry_disappears
=== CONT  TestAccLightsailDomainEntry_basic
=== CONT  TestAccLightsailDomainEntry_disappears
--- PASS: TestAccLightsailDomainEntry_disappears (50.59s)
--- PASS: TestAccLightsailDomainEntry_basic (53.68s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  55.779s

...
```
