### PR TITLE
documentation: `price-capacity-optimized` spot allocation strategy

### DIFF
--- a/.changelog/27795.txt
+++ b/.changelog/27795.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_autoscaling_group: Add support for `price-capacity-optimized` `spot_allocation_strategy` value
+```
+
+```release-note:note
+resource/aws_ec2_fleet: Add support for `price-capacity-optimized` `spot_options.allocation_strategy` value
+```
+
+```release-note:note
+resource/aws_spot_fleet_request: Add support for `priceCapacityOptimized` `allocation_strategy` value
+```

--- a/internal/service/ec2/consts.go
+++ b/internal/service/ec2/consts.go
@@ -2,6 +2,7 @@ package ec2
 
 import (
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-provider-aws/internal/slices"
 )
 
 const (
@@ -24,7 +25,7 @@ const (
 
 func FleetOnDemandAllocationStrategy_Values() []string {
 	return append(
-		removeFirstOccurrenceFromStringSlice(ec2.FleetOnDemandAllocationStrategy_Values(), ec2.FleetOnDemandAllocationStrategyLowestPrice),
+		slices.RemoveAll(ec2.FleetOnDemandAllocationStrategy_Values(), ec2.FleetOnDemandAllocationStrategyLowestPrice),
 		FleetOnDemandAllocationStrategyLowestPrice,
 	)
 }
@@ -36,7 +37,7 @@ const (
 
 func SpotAllocationStrategy_Values() []string {
 	return append(
-		removeFirstOccurrenceFromStringSlice(ec2.SpotAllocationStrategy_Values(), ec2.SpotAllocationStrategyLowestPrice),
+		slices.RemoveAll(ec2.SpotAllocationStrategy_Values(), ec2.SpotAllocationStrategyLowestPrice),
 		SpotAllocationStrategyLowestPrice,
 	)
 }
@@ -251,16 +252,6 @@ const (
 const (
 	TargetStorageTierStandard = "standard"
 )
-
-func removeFirstOccurrenceFromStringSlice(slice []string, s string) []string {
-	for i, v := range slice {
-		if v == s {
-			return append(slice[:i], slice[i+1:]...)
-		}
-	}
-
-	return slice
-}
 
 const (
 	OutsideIPAddressTypePrivateIPv4 = "PrivateIpv4"

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -471,7 +471,7 @@ This configuration block supports the following:
 * `on_demand_allocation_strategy` - (Optional) Strategy to use when launching on-demand instances. Valid values: `prioritized`. Default: `prioritized`.
 * `on_demand_base_capacity` - (Optional) Absolute minimum amount of desired capacity that must be fulfilled by on-demand instances. Default: `0`.
 * `on_demand_percentage_above_base_capacity` - (Optional) Percentage split between on-demand and Spot instances above the base on-demand capacity. Default: `100`.
-* `spot_allocation_strategy` - (Optional) How to allocate capacity across the Spot pools. Valid values: `lowest-price`, `capacity-optimized`, `capacity-optimized-prioritized`. Default: `lowest-price`.
+* `spot_allocation_strategy` - (Optional) How to allocate capacity across the Spot pools. Valid values: `lowest-price`, `capacity-optimized`, `capacity-optimized-prioritized`, and `price-capacity-optimized`. Default: `lowest-price`.
 * `spot_instance_pools` - (Optional) Number of Spot pools per availability zone to allocate capacity. EC2 Auto Scaling selects the cheapest Spot pools and evenly allocates Spot capacity across the number of Spot pools that you specify. Only available with `spot_allocation_strategy` set to `lowest-price`. Otherwise it must be set to `0`, if it has been defined before. Default: `2`.
 * `spot_max_price` - (Optional) Maximum price per unit hour that the user is willing to pay for the Spot instances. Default: an empty string which means the on-demand price.
 

--- a/website/docs/r/ec2_fleet.html.markdown
+++ b/website/docs/r/ec2_fleet.html.markdown
@@ -196,7 +196,7 @@ This configuration block supports the following:
 
 ### spot_options
 
-* `allocation_strategy` - (Optional) How to allocate the target capacity across the Spot pools. Valid values: `diversified`, `lowestPrice`, `capacity-optimized` and `capacity-optimized-prioritized`. Default: `lowestPrice`.
+* `allocation_strategy` - (Optional) How to allocate the target capacity across the Spot pools. Valid values: `diversified`, `lowestPrice`, `capacity-optimized`, `capacity-optimized-prioritized` and `price-capacity-optimized`. Default: `lowestPrice`.
 * `instance_interruption_behavior` - (Optional) Behavior when a Spot Instance is interrupted. Valid values: `hibernate`, `stop`, `terminate`. Default: `terminate`.
 * `instance_pools_to_use_count` - (Optional) Number of Spot pools across which to allocate your target Spot capacity. Valid only when Spot `allocation_strategy` is set to `lowestPrice`. Default: `1`.
 * `maintenance_strategies` - (Optional) Nested argument containing maintenance strategies for managing your Spot Instances that are at an elevated risk of being interrupted. Defined below.

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -219,7 +219,7 @@ across different markets and instance types. Conflicts with `launch_template_con
   important to your application workload, such as vCPUs, memory, or I/O.
 * `target_capacity_unit_type` - (Optional) The unit for the target capacity. This can only be done with `instance_requirements` defined
 * `allocation_strategy` - Indicates how to allocate the target capacity across
-  the Spot pools specified by the Spot fleet request. The default is
+  the Spot pools specified by the Spot fleet request. Valid values: `lowestPrice`, `diversified`, `capacityOptimized`, `capacityOptimizedPrioritized`, and `priceCapacityOptimized`. The default is
   `lowestPrice`.
 * `instance_pools_to_use_count` - (Optional; Default: 1)
   The number of Spot pools across which to allocate your target Spot capacity.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Documents the new `price-capacity-optimized` spot allocation strategy.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/27759.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccEC2Fleet_SpotOptions_allocationStrategy' PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2Fleet_SpotOptions_allocationStrategy -timeout 180m
=== RUN   TestAccEC2Fleet_SpotOptions_allocationStrategy
=== PAUSE TestAccEC2Fleet_SpotOptions_allocationStrategy
=== CONT  TestAccEC2Fleet_SpotOptions_allocationStrategy
--- PASS: TestAccEC2Fleet_SpotOptions_allocationStrategy (104.28s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	109.196s
```
