### PR TITLE
r/aws_config_rule update name regex to support length of 128 characters

### DIFF
--- a/.changelog/27798.txt
+++ b/.changelog/27798.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_config_config_rule: Update validation regex on name to allow for 128 characters.
+```

--- a/internal/service/configservice/config_rule.go
+++ b/internal/service/configservice/config_rule.go
@@ -35,7 +35,7 @@ func ResourceConfigRule() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringLenBetween(0, 64),
+				ValidateFunc: validation.StringLenBetween(0, 128),
 			},
 			"rule_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Changes the max length of a config_rule name from 64 to 128.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27742

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/config/latest/APIReference/API_ConfigRule.html
