### PR TITLE
RDS: updates Instance, Cluster, and ClusterInstance to use `WithoutTimeout` CRUDI functions

### DIFF
--- a/internal/service/rds/cluster_activity_stream.go
+++ b/internal/service/rds/cluster_activity_stream.go
@@ -71,9 +71,9 @@ func resourceClusterActivityStreamCreate(ctx context.Context, d *schema.Resource
 
 	log.Printf("[DEBUG] RDS Cluster start activity stream input: %s", startActivityStreamInput)
 
-	resp, err := conn.StartActivityStream(startActivityStreamInput)
+	resp, err := conn.StartActivityStreamWithContext(ctx, startActivityStreamInput)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating RDS Cluster Activity Stream: %s", err))
+		return diag.FromErr(fmt.Errorf("creating RDS Cluster Activity Stream: %s", err))
 	}
 
 	log.Printf("[DEBUG]: RDS Cluster start activity stream response: %s", resp)
@@ -92,7 +92,7 @@ func resourceClusterActivityStreamRead(ctx context.Context, d *schema.ResourceDa
 	conn := meta.(*conns.AWSClient).RDSConn
 
 	log.Printf("[DEBUG] Finding DB Cluster (%s)", d.Id())
-	resp, err := FindDBClusterWithActivityStream(conn, d.Id())
+	resp, err := FindDBClusterWithActivityStream(ctx, conn, d.Id())
 
 	if tfresource.NotFound(err) {
 		log.Printf("[WARN] RDS Cluster (%s) not found, removing from state", d.Id())
@@ -101,7 +101,7 @@ func resourceClusterActivityStreamRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error describing RDS Cluster (%s): %s", d.Id(), err))
+		return diag.FromErr(fmt.Errorf("describing RDS Cluster (%s): %s", d.Id(), err))
 	}
 
 	d.Set("resource_arn", resp.DBClusterArn)
@@ -122,9 +122,9 @@ func resourceClusterActivityStreamDelete(ctx context.Context, d *schema.Resource
 
 	log.Printf("[DEBUG] RDS Cluster stop activity stream input: %s", stopActivityStreamInput)
 
-	resp, err := conn.StopActivityStream(stopActivityStreamInput)
+	resp, err := conn.StopActivityStreamWithContext(ctx, stopActivityStreamInput)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error stopping RDS Cluster Activity Stream: %w", err))
+		return diag.FromErr(fmt.Errorf("stopping RDS Cluster Activity Stream: %w", err))
 	}
 
 	log.Printf("[DEBUG] RDS Cluster stop activity stream response: %s", resp)

--- a/internal/service/rds/cluster_activity_stream_test.go
+++ b/internal/service/rds/cluster_activity_stream_test.go
@@ -1,6 +1,7 @@
 package rds_test
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
@@ -99,9 +100,10 @@ func testAccCheckClusterActivityStreamExistsProvider(resourceName string, dbClus
 			return fmt.Errorf("DBCluster ID is not set")
 		}
 
+		ctx := context.Background()
 		conn := provider.Meta().(*conns.AWSClient).RDSConn
 
-		response, err := tfrds.FindDBClusterWithActivityStream(conn, rs.Primary.ID)
+		response, err := tfrds.FindDBClusterWithActivityStream(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -143,6 +145,7 @@ func testAccCheckClusterActivityStreamDestroy(s *terraform.State) error {
 }
 
 func testAccCheckClusterActivityStreamDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {
+	ctx := context.Background()
 	conn := provider.Meta().(*conns.AWSClient).RDSConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -152,7 +155,7 @@ func testAccCheckClusterActivityStreamDestroyWithProvider(s *terraform.State, pr
 
 		var err error
 
-		_, err = tfrds.FindDBClusterWithActivityStream(conn, rs.Primary.ID)
+		_, err = tfrds.FindDBClusterWithActivityStream(ctx, conn, rs.Primary.ID)
 		if err != nil {
 			// Return nil if the cluster is already destroyed
 			if tfresource.NotFound(err) {

--- a/internal/service/rds/cluster_data_source.go
+++ b/internal/service/rds/cluster_data_source.go
@@ -2,17 +2,19 @@ package rds
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
 func DataSourceCluster() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceClusterRead,
+		ReadWithoutTimeout: dataSourceClusterRead,
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
@@ -136,8 +138,8 @@ func DataSourceCluster() *schema.Resource {
 	}
 }
 
-func dataSourceClusterRead(d *schema.ResourceData, meta interface{}) error {
-	ctx := context.TODO()
+func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSConn
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -145,7 +147,7 @@ func dataSourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	dbc, err := FindDBClusterByID(ctx, conn, dbClusterID)
 
 	if err != nil {
-		return fmt.Errorf("reading RDS Cluster (%s): %w", dbClusterID, err)
+		return errs.AppendErrorf(diags, "reading RDS Cluster (%s): %w", dbClusterID, err)
 	}
 
 	d.SetId(aws.StringValue(dbc.DBClusterIdentifier))
@@ -197,15 +199,15 @@ func dataSourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("vpc_security_group_ids", securityGroupIDs)
 
-	tags, err := ListTags(conn, clusterARN)
+	tags, err := ListTagsWithContext(ctx, conn, clusterARN)
 
 	if err != nil {
-		return fmt.Errorf("listing tags for RDS Cluster (%s): %w", d.Id(), err)
+		return errs.AppendErrorf(diags, "listing tags for RDS Cluster (%s): %w", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("setting tags: %w", err)
+		return errs.AppendErrorf(diags, "setting tags: %w", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/rds/cluster_data_source.go
+++ b/internal/service/rds/cluster_data_source.go
@@ -147,7 +147,7 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 	dbc, err := FindDBClusterByID(ctx, conn, dbClusterID)
 
 	if err != nil {
-		return errs.AppendErrorf(diags, "reading RDS Cluster (%s): %w", dbClusterID, err)
+		return errs.AppendErrorf(diags, "reading RDS Cluster (%s): %s", dbClusterID, err)
 	}
 
 	d.SetId(aws.StringValue(dbc.DBClusterIdentifier))
@@ -202,11 +202,11 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 	tags, err := ListTagsWithContext(ctx, conn, clusterARN)
 
 	if err != nil {
-		return errs.AppendErrorf(diags, "listing tags for RDS Cluster (%s): %w", d.Id(), err)
+		return errs.AppendErrorf(diags, "listing tags for RDS Cluster (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return errs.AppendErrorf(diags, "setting tags: %w", err)
+		return errs.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
 	return diags

--- a/internal/service/rds/cluster_data_source.go
+++ b/internal/service/rds/cluster_data_source.go
@@ -1,6 +1,7 @@
 package rds
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -136,11 +137,12 @@ func DataSourceCluster() *schema.Resource {
 }
 
 func dataSourceClusterRead(d *schema.ResourceData, meta interface{}) error {
+	ctx := context.TODO()
 	conn := meta.(*conns.AWSClient).RDSConn
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	dbClusterID := d.Get("cluster_identifier").(string)
-	dbc, err := FindDBClusterByID(conn, dbClusterID)
+	dbc, err := FindDBClusterByID(ctx, conn, dbClusterID)
 
 	if err != nil {
 		return fmt.Errorf("reading RDS Cluster (%s): %w", dbClusterID, err)

--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -325,7 +325,7 @@ func resourceClusterInstanceCreate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("updating RDS Cluster Instance (%s): %w", d.Id(), err)
 		}
 
-		if _, err := waitDBInstanceUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		if _, err := waitDBInstanceAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return fmt.Errorf("waiting for RDS Cluster Instance (%s) update: %w", d.Id(), err)
 		}
 
@@ -337,7 +337,7 @@ func resourceClusterInstanceCreate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("rebooting RDS Cluster Instance (%s): %w", d.Id(), err)
 		}
 
-		if _, err := waitDBInstanceUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		if _, err := waitDBInstanceAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return fmt.Errorf("waiting for RDS Cluster Instance (%s) update: %w", d.Id(), err)
 		}
 	}

--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -1,6 +1,7 @@
 package rds
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -220,6 +221,7 @@ func ResourceClusterInstance() *schema.Resource {
 }
 
 func resourceClusterInstanceCreate(d *schema.ResourceData, meta interface{}) error {
+	ctx := context.TODO()
 	conn := meta.(*conns.AWSClient).RDSConn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
@@ -306,7 +308,7 @@ func resourceClusterInstanceCreate(d *schema.ResourceData, meta interface{}) err
 
 	d.SetId(aws.StringValue(output.DBInstance.DBInstanceIdentifier))
 
-	if _, err := waitDBClusterInstanceCreated(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+	if _, err := waitDBClusterInstanceCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return fmt.Errorf("waiting for RDS Cluster Instance (%s) create: %w", d.Id(), err)
 	}
 
@@ -323,7 +325,7 @@ func resourceClusterInstanceCreate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("updating RDS Cluster Instance (%s): %w", d.Id(), err)
 		}
 
-		if _, err := waitDBInstanceUpdated(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		if _, err := waitDBInstanceUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return fmt.Errorf("waiting for RDS Cluster Instance (%s) update: %w", d.Id(), err)
 		}
 
@@ -335,7 +337,7 @@ func resourceClusterInstanceCreate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("rebooting RDS Cluster Instance (%s): %w", d.Id(), err)
 		}
 
-		if _, err := waitDBInstanceUpdated(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		if _, err := waitDBInstanceUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return fmt.Errorf("waiting for RDS Cluster Instance (%s) update: %w", d.Id(), err)
 		}
 	}
@@ -344,11 +346,12 @@ func resourceClusterInstanceCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceClusterInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	ctx := context.TODO()
 	conn := meta.(*conns.AWSClient).RDSConn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	db, err := FindDBInstanceByID(conn, d.Id())
+	db, err := FindDBInstanceByID(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] RDS Cluster Instance (%s) not found, removing from state", d.Id())
@@ -439,6 +442,7 @@ func resourceClusterInstanceRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceClusterInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
+	ctx := context.TODO()
 	conn := meta.(*conns.AWSClient).RDSConn
 
 	if d.HasChangesExcept("tags", "tags_all") {
@@ -514,7 +518,7 @@ func resourceClusterInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("updating RDS Cluster Instance (%s): %w", d.Id(), err)
 		}
 
-		if _, err := waitDBClusterInstanceUpdated(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		if _, err := waitDBClusterInstanceUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return fmt.Errorf("waiting for RDS Cluster Instance (%s) update: %w", d.Id(), err)
 		}
 	}
@@ -531,6 +535,7 @@ func resourceClusterInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceClusterInstanceDelete(d *schema.ResourceData, meta interface{}) error {
+	ctx := context.TODO()
 	conn := meta.(*conns.AWSClient).RDSConn
 
 	input := &rds.DeleteDBInstanceInput{
@@ -552,7 +557,7 @@ func resourceClusterInstanceDelete(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("deleting RDS Cluster Instance (%s): %w", d.Id(), err)
 	}
 
-	if _, err := waitDBClusterInstanceDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+	if _, err := waitDBClusterInstanceDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 		return fmt.Errorf("waiting for RDS Cluster Instance (%s) delete: %w", d.Id(), err)
 	}
 

--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -2,7 +2,6 @@ package rds
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -10,10 +9,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -21,13 +22,13 @@ import (
 
 func ResourceClusterInstance() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceClusterInstanceCreate,
-		Read:   resourceClusterInstanceRead,
-		Update: resourceClusterInstanceUpdate,
-		Delete: resourceClusterInstanceDelete,
+		CreateWithoutTimeout: resourceClusterInstanceCreate,
+		ReadWithoutTimeout:   resourceClusterInstanceRead,
+		UpdateWithoutTimeout: resourceClusterInstanceUpdate,
+		DeleteWithoutTimeout: resourceClusterInstanceDelete,
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -220,8 +221,8 @@ func ResourceClusterInstance() *schema.Resource {
 	}
 }
 
-func resourceClusterInstanceCreate(d *schema.ResourceData, meta interface{}) error {
-	ctx := context.TODO()
+func resourceClusterInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSConn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
@@ -301,7 +302,7 @@ func resourceClusterInstanceCreate(d *schema.ResourceData, meta interface{}) err
 		errCodeInvalidParameterValue, "IAM role ARN value is invalid or does not include the required permissions")
 
 	if err != nil {
-		return fmt.Errorf("creating RDS Cluster (%s) Instance (%s): %w", clusterID, identifier, err)
+		return errs.AppendErrorf(diags, "creating RDS Cluster (%s) Instance (%s): %s", clusterID, identifier, err)
 	}
 
 	output := outputRaw.(*rds.CreateDBInstanceOutput)
@@ -309,7 +310,7 @@ func resourceClusterInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	d.SetId(aws.StringValue(output.DBInstance.DBInstanceIdentifier))
 
 	if _, err := waitDBClusterInstanceCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return fmt.Errorf("waiting for RDS Cluster Instance (%s) create: %w", d.Id(), err)
+		return errs.AppendErrorf(diags, "waiting for RDS Cluster Instance (%s) create: %s", d.Id(), err)
 	}
 
 	if v, ok := d.GetOk("ca_cert_identifier"); ok && v.(string) != aws.StringValue(output.DBInstance.CACertificateIdentifier) {
@@ -319,60 +320,54 @@ func resourceClusterInstanceCreate(d *schema.ResourceData, meta interface{}) err
 			DBInstanceIdentifier:    aws.String(d.Id()),
 		}
 
-		_, err := conn.ModifyDBInstance(input)
-
-		if err != nil {
-			return fmt.Errorf("updating RDS Cluster Instance (%s): %w", d.Id(), err)
+		if _, err := conn.ModifyDBInstance(input); err != nil {
+			return errs.AppendErrorf(diags, "updating RDS Cluster Instance (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitDBInstanceAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return fmt.Errorf("waiting for RDS Cluster Instance (%s) update: %w", d.Id(), err)
+			return errs.AppendErrorf(diags, "waiting for RDS Cluster Instance (%s) update: %s", d.Id(), err)
 		}
 
 		_, err = conn.RebootDBInstance(&rds.RebootDBInstanceInput{
 			DBInstanceIdentifier: aws.String(d.Id()),
 		})
-
 		if err != nil {
-			return fmt.Errorf("rebooting RDS Cluster Instance (%s): %w", d.Id(), err)
+			return errs.AppendErrorf(diags, "rebooting RDS Cluster Instance (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitDBInstanceAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return fmt.Errorf("waiting for RDS Cluster Instance (%s) update: %w", d.Id(), err)
+			return errs.AppendErrorf(diags, "waiting for RDS Cluster Instance (%s) update: %s", d.Id(), err)
 		}
 	}
 
-	return resourceClusterInstanceRead(d, meta)
+	return append(diags, resourceClusterInstanceRead(ctx, d, meta)...)
 }
 
-func resourceClusterInstanceRead(d *schema.ResourceData, meta interface{}) error {
-	ctx := context.TODO()
+func resourceClusterInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
 	conn := meta.(*conns.AWSClient).RDSConn
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	db, err := FindDBInstanceByID(ctx, conn, d.Id())
-
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] RDS Cluster Instance (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
-
 	if err != nil {
-		return fmt.Errorf("reading RDS Cluster Instance (%s): %w", d.Id(), err)
+		return errs.AppendErrorf(diags, "reading RDS Cluster Instance (%s): %s", d.Id(), err)
 	}
 
 	dbClusterID := aws.StringValue(db.DBClusterIdentifier)
 
 	if dbClusterID == "" {
-		return fmt.Errorf("DBClusterIdentifier is missing from RDS Cluster Instance (%s). The aws_db_instance resource should be used for non-Aurora instances", d.Id())
+		return errs.AppendErrorf(diags, "DBClusterIdentifier is missing from RDS Cluster Instance (%s). The aws_db_instance resource should be used for non-Aurora instances", d.Id())
 	}
 
 	dbc, err := FindDBClusterByID(conn, dbClusterID)
 
 	if err != nil {
-		return fmt.Errorf("reading RDS Cluster (%s): %w", dbClusterID, err)
+		return errs.AppendErrorf(diags, "reading RDS Cluster (%s): %s", dbClusterID, err)
 	}
 
 	for _, m := range dbc.DBClusterMembers {
@@ -424,25 +419,24 @@ func resourceClusterInstanceRead(d *schema.ResourceData, meta interface{}) error
 	tags, err := ListTags(conn, aws.StringValue(db.DBInstanceArn))
 
 	if err != nil {
-		return fmt.Errorf("listing tags for RDS Cluster Instance (%s): %w", d.Id(), err)
+		return errs.AppendErrorf(diags, "listing tags for RDS Cluster Instance (%s): %s", d.Id(), err)
 	}
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return fmt.Errorf("setting tags: %w", err)
+		return errs.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
 	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return fmt.Errorf("setting tags_all: %w", err)
+		return errs.AppendErrorf(diags, "setting tags_all: %s", err)
 	}
 
 	return nil
 }
 
-func resourceClusterInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
-	ctx := context.TODO()
+func resourceClusterInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
 	conn := meta.(*conns.AWSClient).RDSConn
 
 	if d.HasChangesExcept("tags", "tags_all") {
@@ -515,11 +509,11 @@ func resourceClusterInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			errCodeInvalidParameterValue, "IAM role ARN value is invalid or does not include the required permissions")
 
 		if err != nil {
-			return fmt.Errorf("updating RDS Cluster Instance (%s): %w", d.Id(), err)
+			return errs.AppendErrorf(diags, "updating RDS Cluster Instance (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitDBClusterInstanceUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return fmt.Errorf("waiting for RDS Cluster Instance (%s) update: %w", d.Id(), err)
+			return errs.AppendErrorf(diags, "waiting for RDS Cluster Instance (%s) update: %s", d.Id(), err)
 		}
 	}
 
@@ -527,15 +521,14 @@ func resourceClusterInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		o, n := d.GetChange("tags_all")
 
 		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("updating RDS Cluster Instance (%s) tags: %w", d.Id(), err)
+			return errs.AppendErrorf(diags, "updating RDS Cluster Instance (%s) tags: %s", d.Id(), err)
 		}
 	}
 
-	return resourceClusterInstanceRead(d, meta)
+	return append(diags, resourceClusterInstanceRead(ctx, d, meta)...)
 }
 
-func resourceClusterInstanceDelete(d *schema.ResourceData, meta interface{}) error {
-	ctx := context.TODO()
+func resourceClusterInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
 	conn := meta.(*conns.AWSClient).RDSConn
 
 	input := &rds.DeleteDBInstanceInput{
@@ -554,11 +547,11 @@ func resourceClusterInstanceDelete(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if err != nil && !tfawserr.ErrMessageContains(err, rds.ErrCodeInvalidDBInstanceStateFault, "is already being deleted") {
-		return fmt.Errorf("deleting RDS Cluster Instance (%s): %w", d.Id(), err)
+		return errs.AppendErrorf(diags, "deleting RDS Cluster Instance (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitDBClusterInstanceDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return fmt.Errorf("waiting for RDS Cluster Instance (%s) delete: %w", d.Id(), err)
+		return errs.AppendErrorf(diags, "waiting for RDS Cluster Instance (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/rds/cluster_instance_test.go
+++ b/internal/service/rds/cluster_instance_test.go
@@ -1,6 +1,7 @@
 package rds_test
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -1108,9 +1109,10 @@ func testAccCheckClusterInstanceExists(n string, v *rds.DBInstance) resource.Tes
 			return fmt.Errorf("No RDS Cluster Instance ID is set")
 		}
 
+		ctx := context.Background()
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn
 
-		output, err := tfrds.FindDBInstanceByID(conn, rs.Primary.ID)
+		output, err := tfrds.FindDBInstanceByID(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -1123,6 +1125,7 @@ func testAccCheckClusterInstanceExists(n string, v *rds.DBInstance) resource.Tes
 }
 
 func testAccCheckClusterInstanceDestroy(s *terraform.State) error {
+	ctx := context.Background()
 	conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -1130,7 +1133,7 @@ func testAccCheckClusterInstanceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := tfrds.FindDBInstanceByID(conn, rs.Primary.ID)
+		_, err := tfrds.FindDBInstanceByID(ctx, conn, rs.Primary.ID)
 
 		if tfresource.NotFound(err) {
 			continue

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -1,6 +1,7 @@
 package rds_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"regexp"
@@ -2130,6 +2131,7 @@ func testAccCheckClusterDestroy(s *terraform.State) error {
 }
 
 func testAccCheckClusterDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {
+	ctx := context.Background()
 	conn := provider.Meta().(*conns.AWSClient).RDSConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -2137,7 +2139,7 @@ func testAccCheckClusterDestroyWithProvider(s *terraform.State, provider *schema
 			continue
 		}
 
-		_, err := tfrds.FindDBClusterByID(conn, rs.Primary.ID)
+		_, err := tfrds.FindDBClusterByID(ctx, conn, rs.Primary.ID)
 
 		if tfresource.NotFound(err) {
 			continue
@@ -2154,6 +2156,7 @@ func testAccCheckClusterDestroyWithProvider(s *terraform.State, provider *schema
 }
 
 func testAccCheckClusterDestroyWithFinalSnapshot(s *terraform.State) error {
+	ctx := context.Background()
 	conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -2176,7 +2179,7 @@ func testAccCheckClusterDestroyWithFinalSnapshot(s *terraform.State) error {
 			return err
 		}
 
-		_, err = tfrds.FindDBClusterByID(conn, rs.Primary.ID)
+		_, err = tfrds.FindDBClusterByID(ctx, conn, rs.Primary.ID)
 
 		if tfresource.NotFound(err) {
 			continue
@@ -2207,9 +2210,10 @@ func testAccCheckClusterExistsWithProvider(n string, v *rds.DBCluster, providerF
 			return fmt.Errorf("No RDS Cluster ID is set")
 		}
 
+		ctx := context.Background()
 		conn := providerF().Meta().(*conns.AWSClient).RDSConn
 
-		output, err := tfrds.FindDBClusterByID(conn, rs.Primary.ID)
+		output, err := tfrds.FindDBClusterByID(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err

--- a/internal/service/rds/find.go
+++ b/internal/service/rds/find.go
@@ -188,36 +188,6 @@ func FindDBClusterSnapshotByID(conn *rds.RDS, id string) (*rds.DBClusterSnapshot
 	return dbClusterSnapshot, nil
 }
 
-func FindDBInstanceByID(conn *rds.RDS, id string) (*rds.DBInstance, error) {
-	input := &rds.DescribeDBInstancesInput{
-		DBInstanceIdentifier: aws.String(id),
-	}
-
-	output, err := conn.DescribeDBInstances(input)
-
-	if tfawserr.ErrCodeEquals(err, rds.ErrCodeDBInstanceNotFoundFault) {
-		return nil, &resource.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
-		}
-	}
-
-	if output == nil || len(output.DBInstances) == 0 || output.DBInstances[0] == nil {
-		return nil, tfresource.NewEmptyResultError(input)
-	}
-
-	dbInstance := output.DBInstances[0]
-
-	// Eventual consistency check.
-	if aws.StringValue(dbInstance.DBInstanceIdentifier) != id {
-		return nil, &resource.NotFoundError{
-			LastRequest: input,
-		}
-	}
-
-	return dbInstance, nil
-}
-
 func FindDBProxyByName(conn *rds.RDS, name string) (*rds.DBProxy, error) {
 	input := &rds.DescribeDBProxiesInput{
 		DBProxyName: aws.String(name),

--- a/internal/service/rds/find.go
+++ b/internal/service/rds/find.go
@@ -2,7 +2,6 @@ package rds
 
 import (
 	"context"
-	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
@@ -70,7 +69,8 @@ func FindDBProxyEndpoint(conn *rds.RDS, id string) (*rds.DBProxyEndpoint, error)
 }
 
 func FindDBClusterRoleByDBClusterIDAndRoleARN(conn *rds.RDS, dbClusterID, roleARN string) (*rds.DBClusterRole, error) {
-	dbCluster, err := FindDBClusterByID(conn, dbClusterID)
+	ctx := context.TODO()
+	dbCluster, err := FindDBClusterByID(ctx, conn, dbClusterID)
 
 	if err != nil {
 		return nil, err
@@ -91,43 +91,12 @@ func FindDBClusterRoleByDBClusterIDAndRoleARN(conn *rds.RDS, dbClusterID, roleAR
 	return nil, &resource.NotFoundError{}
 }
 
-func FindDBClusterByID(conn *rds.RDS, id string) (*rds.DBCluster, error) {
-	input := &rds.DescribeDBClustersInput{
-		DBClusterIdentifier: aws.String(id),
-	}
-
-	output, err := conn.DescribeDBClusters(input)
-
-	if tfawserr.ErrCodeEquals(err, rds.ErrCodeDBClusterNotFoundFault) {
-		return nil, &resource.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
-		}
-	}
-
-	if output == nil || len(output.DBClusters) == 0 || output.DBClusters[0] == nil {
-		return nil, tfresource.NewEmptyResultError(input)
-	}
-
-	dbCluster := output.DBClusters[0]
-
-	// Eventual consistency check.
-	if aws.StringValue(dbCluster.DBClusterIdentifier) != id {
-		return nil, &resource.NotFoundError{
-			LastRequest: input,
-		}
-	}
-
-	return dbCluster, nil
-}
-
-func FindDBClusterWithActivityStream(conn *rds.RDS, dbClusterArn string) (*rds.DBCluster, error) {
-	log.Printf("[DEBUG] Calling conn.DescribeDBCClusters(input) with DBClusterIdentifier set to %s", dbClusterArn)
+func FindDBClusterWithActivityStream(ctx context.Context, conn *rds.RDS, dbClusterArn string) (*rds.DBCluster, error) {
 	input := &rds.DescribeDBClustersInput{
 		DBClusterIdentifier: aws.String(dbClusterArn),
 	}
 
-	output, err := conn.DescribeDBClusters(input)
+	output, err := conn.DescribeDBClustersWithContext(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, rds.ErrCodeDBClusterNotFoundFault) {
 		return nil, &resource.NotFoundError{
@@ -377,9 +346,9 @@ func findDBInstanceAutomatedBackups(conn *rds.RDS, input *rds.DescribeDBInstance
 	return output, nil
 }
 
-func FindGlobalClusterByDBClusterARN(conn *rds.RDS, dbClusterARN string) (*rds.GlobalCluster, error) {
+func FindGlobalClusterByDBClusterARN(ctx context.Context, conn *rds.RDS, dbClusterARN string) (*rds.GlobalCluster, error) {
 	input := &rds.DescribeGlobalClustersInput{}
-	globalClusters, err := findGlobalClusters(conn, input)
+	globalClusters, err := findGlobalClusters(ctx, conn, input)
 
 	if err != nil {
 		return nil, err
@@ -396,12 +365,12 @@ func FindGlobalClusterByDBClusterARN(conn *rds.RDS, dbClusterARN string) (*rds.G
 	return nil, &resource.NotFoundError{LastRequest: dbClusterARN}
 }
 
-func FindGlobalClusterByID(conn *rds.RDS, id string) (*rds.GlobalCluster, error) {
+func FindGlobalClusterByID(ctx context.Context, conn *rds.RDS, id string) (*rds.GlobalCluster, error) {
 	input := &rds.DescribeGlobalClustersInput{
 		GlobalClusterIdentifier: aws.String(id),
 	}
 
-	output, err := findGlobalCluster(conn, input)
+	output, err := findGlobalCluster(ctx, conn, input)
 
 	if err != nil {
 		return nil, err
@@ -417,8 +386,8 @@ func FindGlobalClusterByID(conn *rds.RDS, id string) (*rds.GlobalCluster, error)
 	return output, nil
 }
 
-func findGlobalCluster(conn *rds.RDS, input *rds.DescribeGlobalClustersInput) (*rds.GlobalCluster, error) {
-	output, err := findGlobalClusters(conn, input)
+func findGlobalCluster(ctx context.Context, conn *rds.RDS, input *rds.DescribeGlobalClustersInput) (*rds.GlobalCluster, error) {
+	output, err := findGlobalClusters(ctx, conn, input)
 
 	if err != nil {
 		return nil, err
@@ -435,10 +404,10 @@ func findGlobalCluster(conn *rds.RDS, input *rds.DescribeGlobalClustersInput) (*
 	return output[0], nil
 }
 
-func findGlobalClusters(conn *rds.RDS, input *rds.DescribeGlobalClustersInput) ([]*rds.GlobalCluster, error) {
+func findGlobalClusters(ctx context.Context, conn *rds.RDS, input *rds.DescribeGlobalClustersInput) ([]*rds.GlobalCluster, error) {
 	var output []*rds.GlobalCluster
 
-	err := conn.DescribeGlobalClustersPages(input, func(page *rds.DescribeGlobalClustersOutput, lastPage bool) bool {
+	err := conn.DescribeGlobalClustersPagesWithContext(ctx, input, func(page *rds.DescribeGlobalClustersOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -1095,7 +1095,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			input.MultiAZ = aws.Bool(false)
 			modifyDbInstanceInput.MultiAZ = aws.Bool(true)
 			requiresModifyDbInstance = true
-			_, err = conn.RestoreDBInstanceFromDBSnapshot(input)
+			_, err = conn.RestoreDBInstanceFromDBSnapshotWithContext(ctx, input)
 		}
 
 		if err != nil {

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -1614,7 +1614,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if !aws.BoolValue(input.ApplyImmediately) {
-			log.Println("[INFO] Only settings updating, instance changes will be applied in next maintenance window")
+			diags = errs.AppendWarningf(diags, "updating RDS DB Instance (%s): changes will be applied during next maintenance window", d.Id())
 		}
 
 		if d.HasChanges("allocated_storage", "iops") {

--- a/internal/service/rds/instance_automated_backups_replication.go
+++ b/internal/service/rds/instance_automated_backups_replication.go
@@ -1,6 +1,7 @@
 package rds
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -118,6 +119,7 @@ func resourceInstanceAutomatedBackupsReplicationRead(d *schema.ResourceData, met
 }
 
 func resourceInstanceAutomatedBackupsReplicationDelete(d *schema.ResourceData, meta interface{}) error {
+	ctx := context.TODO()
 	conn := meta.(*conns.AWSClient).RDSConn
 
 	backup, err := FindDBInstanceAutomatedBackupByARN(conn, d.Id())
@@ -152,7 +154,7 @@ func resourceInstanceAutomatedBackupsReplicationDelete(d *schema.ResourceData, m
 		sourceDatabaseConn = rds.New(meta.(*conns.AWSClient).Session, aws.NewConfig().WithRegion(sourceDatabaseARN.Region))
 	}
 
-	if _, err := waitDBInstanceAutomatedBackupDeleted(sourceDatabaseConn, dbInstanceID, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+	if _, err := waitDBInstanceAutomatedBackupDeleted(ctx, sourceDatabaseConn, dbInstanceID, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return fmt.Errorf("error waiting for DB instance automated backup (%s) delete: %w", d.Id(), err)
 	}
 

--- a/internal/service/rds/instance_data_source.go
+++ b/internal/service/rds/instance_data_source.go
@@ -1,6 +1,7 @@
 package rds
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -184,10 +185,11 @@ func DataSourceInstance() *schema.Resource {
 }
 
 func dataSourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	ctx := context.TODO()
 	conn := meta.(*conns.AWSClient).RDSConn
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	v, err := FindDBInstanceByID(conn, d.Get("db_instance_identifier").(string))
+	v, err := FindDBInstanceByID(ctx, conn, d.Get("db_instance_identifier").(string))
 
 	if err != nil {
 		return tfresource.SingularDataSourceFindError("RDS DB Instance", err)

--- a/internal/service/rds/instance_data_source.go
+++ b/internal/service/rds/instance_data_source.go
@@ -270,11 +270,11 @@ func dataSourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta in
 	tags, err := ListTagsWithContext(ctx, conn, d.Get("db_instance_arn").(string))
 
 	if err != nil {
-		return errs.AppendErrorf(diags, "listing tags for RDS DB Instance (%s): %w", d.Get("db_instance_arn").(string), err)
+		return errs.AppendErrorf(diags, "listing tags for RDS DB Instance (%s): %s", d.Get("db_instance_arn").(string), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return errs.AppendErrorf(diags, "setting tags: %w", err)
+		return errs.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
 	return diags

--- a/internal/service/rds/instance_role_association.go
+++ b/internal/service/rds/instance_role_association.go
@@ -1,6 +1,7 @@
 package rds
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -173,7 +174,8 @@ func InstanceRoleAssociationDecodeID(id string) (string, string, error) {
 }
 
 func DescribeDBInstanceRole(conn *rds.RDS, dbInstanceIdentifier, roleArn string) (*rds.DBInstanceRole, error) {
-	dbInstance, err := FindDBInstanceByID(conn, dbInstanceIdentifier)
+	ctx := context.TODO()
+	dbInstance, err := FindDBInstanceByID(ctx, conn, dbInstanceIdentifier)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -1,6 +1,7 @@
 package rds_test
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -4322,6 +4323,7 @@ func testAccCheckInstanceAutomatedBackups(s *terraform.State) error {
 }
 
 func testAccCheckInstanceDestroy(s *terraform.State) error {
+	ctx := context.Background()
 	conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -4329,7 +4331,7 @@ func testAccCheckInstanceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := tfrds.FindDBInstanceByID(conn, rs.Primary.ID)
+		_, err := tfrds.FindDBInstanceByID(ctx, conn, rs.Primary.ID)
 
 		if tfresource.NotFound(err) {
 			continue
@@ -4427,6 +4429,7 @@ func testAccCheckInstanceReplicaAttributes(source, replica *rds.DBInstance) reso
 // - Tags have been copied to the snapshot
 // The snapshot is deleted.
 func testAccCheckInstanceDestroyWithFinalSnapshot(s *terraform.State) error {
+	ctx := context.Background()
 	conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -4459,7 +4462,7 @@ func testAccCheckInstanceDestroyWithFinalSnapshot(s *terraform.State) error {
 			return err
 		}
 
-		_, err = tfrds.FindDBInstanceByID(conn, rs.Primary.ID)
+		_, err = tfrds.FindDBInstanceByID(ctx, conn, rs.Primary.ID)
 
 		if tfresource.NotFound(err) {
 			continue
@@ -4479,6 +4482,7 @@ func testAccCheckInstanceDestroyWithFinalSnapshot(s *terraform.State) error {
 // - The DBInstance has been destroyed
 // - No DBSnapshot has been produced
 func testAccCheckInstanceDestroyWithoutFinalSnapshot(s *terraform.State) error {
+	ctx := context.Background()
 	conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn
 
 	for _, rs := range s.RootModule().Resources {
@@ -4497,7 +4501,7 @@ func testAccCheckInstanceDestroyWithoutFinalSnapshot(s *terraform.State) error {
 			return fmt.Errorf("RDS DB Snapshot %s exists", finalSnapshotID)
 		}
 
-		_, err = tfrds.FindDBInstanceByID(conn, rs.Primary.ID)
+		_, err = tfrds.FindDBInstanceByID(ctx, conn, rs.Primary.ID)
 
 		if tfresource.NotFound(err) {
 			continue
@@ -4523,6 +4527,7 @@ func testAccCheckInstanceNotRecreated(instance1, instance2 *rds.DBInstance) reso
 }
 
 func testAccCheckInstanceExists(n string, v *rds.DBInstance) resource.TestCheckFunc {
+	ctx := context.Background()
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -4535,7 +4540,7 @@ func testAccCheckInstanceExists(n string, v *rds.DBInstance) resource.TestCheckF
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn
 
-		output, err := tfrds.FindDBInstanceByID(conn, rs.Primary.ID)
+		output, err := tfrds.FindDBInstanceByID(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -704,7 +704,7 @@ func TestAccRDSInstance_finalSnapshotIdentifier(t *testing.T) {
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, rds.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		// testAccCheckInstanceSnapshot verifies a database snapshot is
+		// testAccCheckInstanceDestroyWithFinalSnapshot verifies a database snapshot is
 		// created, and subsequently deletes it
 		CheckDestroy: testAccCheckInstanceDestroyWithFinalSnapshot,
 		Steps: []resource.TestStep{

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -4623,7 +4623,6 @@ resource "aws_db_instance" "test" {
   allocated_storage   = 10
   engine              = data.aws_rds_orderable_db_instance.test.engine
   instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
-  publicly_accessible = true
   skip_final_snapshot = true
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
@@ -4638,7 +4637,6 @@ resource "aws_db_instance" "test" {
   allocated_storage   = 10
   engine              = data.aws_rds_orderable_db_instance.test.engine
   instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
-  publicly_accessible = true
   skip_final_snapshot = true
   password            = "avoid-plaintext-passwords"
   username            = "tfacctest"
@@ -5011,8 +5009,6 @@ resource "aws_db_instance" "test" {
   username                = "tfacctest"
   backup_retention_period = 1
 
-  publicly_accessible = true
-
   parameter_group_name = "default.${data.aws_rds_engine_version.default.parameter_group_family}"
 
   skip_final_snapshot       = true
@@ -5119,7 +5115,6 @@ resource "aws_db_instance" "test" {
   auto_minor_version_upgrade = true
   instance_class             = data.aws_rds_orderable_db_instance.test.instance_class
   db_name                    = "test"
-  publicly_accessible        = false
   password                   = "avoid-plaintext-passwords"
   username                   = "tfacctest"
   backup_retention_period    = 0
@@ -5151,7 +5146,6 @@ resource "aws_db_instance" "test" {
   engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
   instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   db_name                 = "test"
-  publicly_accessible     = true
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
   backup_retention_period = 1

--- a/internal/service/rds/reserved_instance.go
+++ b/internal/service/rds/reserved_instance.go
@@ -194,7 +194,7 @@ func resourceReservedInstanceRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("state", reservation.State)
 	d.Set("usage_price", reservation.UsagePrice)
 
-	tags, err := ListTags(conn, aws.ToString(reservation.ReservedDBInstanceArn))
+	tags, err := ListTagsWithContext(ctx, conn, aws.ToString(reservation.ReservedDBInstanceArn))
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	if err != nil {
@@ -219,7 +219,7 @@ func resourceReservedInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 	if d.HasChange("tags") {
 		o, n := d.GetChange("tags")
 
-		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+		if err := UpdateTagsWithContext(ctx, conn, d.Get("arn").(string), o, n); err != nil {
 			return create.DiagError(names.RDS, create.ErrActionUpdating, ResNameTags, d.Id(), err)
 		}
 	}
@@ -227,7 +227,7 @@ func resourceReservedInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+		if err := UpdateTagsWithContext(ctx, conn, d.Get("arn").(string), o, n); err != nil {
 			return create.DiagError(names.RDS, create.ErrActionUpdating, ResNameTags, d.Id(), err)
 		}
 	}

--- a/internal/service/rds/snapshot_copy.go
+++ b/internal/service/rds/snapshot_copy.go
@@ -218,7 +218,7 @@ func resourceSnapshotCopyRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("target_db_snapshot_identifier", snapshot.DBSnapshotIdentifier)
 	d.Set("vpc_id", snapshot.VpcId)
 
-	tags, err := ListTags(conn, arn)
+	tags, err := ListTagsWithContext(ctx, conn, arn)
 
 	if err != nil {
 		return diag.Errorf("error listing tags for RDS DB Snapshot (%s): %s", arn, err)
@@ -244,7 +244,7 @@ func resourceSnapshotCopyUpdate(ctx context.Context, d *schema.ResourceData, met
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
-		if err := UpdateTags(conn, d.Get("db_snapshot_arn").(string), o, n); err != nil {
+		if err := UpdateTagsWithContext(ctx, conn, d.Get("db_snapshot_arn").(string), o, n); err != nil {
 			return diag.Errorf("error updating RDS DB Snapshot (%s) tags: %s", d.Get("db_snapshot_arn").(string), err)
 		}
 	}

--- a/internal/service/rds/status.go
+++ b/internal/service/rds/status.go
@@ -83,22 +83,6 @@ func statusDBClusterRole(conn *rds.RDS, dbClusterID, roleARN string) resource.St
 	}
 }
 
-func statusDBInstance(conn *rds.RDS, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		output, err := FindDBInstanceByID(conn, id)
-
-		if tfresource.NotFound(err) {
-			return nil, "", nil
-		}
-
-		if err != nil {
-			return nil, "", err
-		}
-
-		return output, aws.StringValue(output.DBInstanceStatus), nil
-	}
-}
-
 func statusDBClusterActivityStream(conn *rds.RDS, dbClusterArn string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindDBClusterWithActivityStream(conn, dbClusterArn)
@@ -137,9 +121,9 @@ func statusDBInstanceAutomatedBackup(conn *rds.RDS, arn string) resource.StateRe
 
 // statusDBInstanceHasAutomatedBackup returns whether or not a database instance has a specified automated backup.
 // The connection must be valid for the database instance's Region.
-func statusDBInstanceHasAutomatedBackup(conn *rds.RDS, dbInstanceID, dbInstanceAutomatedBackupsARN string) resource.StateRefreshFunc {
+func statusDBInstanceHasAutomatedBackup(ctx context.Context, conn *rds.RDS, dbInstanceID, dbInstanceAutomatedBackupsARN string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		output, err := FindDBInstanceByID(conn, dbInstanceID)
+		output, err := FindDBInstanceByID(ctx, conn, dbInstanceID)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil

--- a/internal/service/rds/status.go
+++ b/internal/service/rds/status.go
@@ -51,22 +51,6 @@ func statusDBProxyEndpoint(conn *rds.RDS, id string) resource.StateRefreshFunc {
 	}
 }
 
-func statusDBCluster(conn *rds.RDS, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		output, err := FindDBClusterByID(conn, id)
-
-		if tfresource.NotFound(err) {
-			return nil, "", nil
-		}
-
-		if err != nil {
-			return nil, "", err
-		}
-
-		return output, aws.StringValue(output.Status), nil
-	}
-}
-
 func statusDBClusterRole(conn *rds.RDS, dbClusterID, roleARN string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindDBClusterRoleByDBClusterIDAndRoleARN(conn, dbClusterID, roleARN)
@@ -83,9 +67,9 @@ func statusDBClusterRole(conn *rds.RDS, dbClusterID, roleARN string) resource.St
 	}
 }
 
-func statusDBClusterActivityStream(conn *rds.RDS, dbClusterArn string) resource.StateRefreshFunc {
+func statusDBClusterActivityStream(ctx context.Context, conn *rds.RDS, dbClusterArn string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		output, err := FindDBClusterWithActivityStream(conn, dbClusterArn)
+		output, err := FindDBClusterWithActivityStream(ctx, conn, dbClusterArn)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil

--- a/internal/service/rds/wait.go
+++ b/internal/service/rds/wait.go
@@ -116,83 +116,6 @@ func waitDBProxyEndpointDeleted(conn *rds.RDS, id string, timeout time.Duration)
 	return nil, err
 }
 
-func waitDBClusterCreated(conn *rds.RDS, id string, timeout time.Duration) (*rds.DBCluster, error) {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{
-			ClusterStatusBackingUp,
-			ClusterStatusCreating,
-			ClusterStatusMigrating,
-			ClusterStatusModifying,
-			ClusterStatusPreparingDataMigration,
-			ClusterStatusRebooting,
-			ClusterStatusResettingMasterCredentials,
-		},
-		Target:     []string{ClusterStatusAvailable},
-		Refresh:    statusDBCluster(conn, id),
-		Timeout:    timeout,
-		MinTimeout: 10 * time.Second,
-		Delay:      30 * time.Second,
-	}
-
-	outputRaw, err := stateConf.WaitForState()
-
-	if output, ok := outputRaw.(*rds.DBCluster); ok {
-		return output, err
-	}
-
-	return nil, err
-}
-
-func waitDBClusterDeleted(conn *rds.RDS, id string, timeout time.Duration) (*rds.DBCluster, error) {
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{
-			ClusterStatusAvailable,
-			ClusterStatusBackingUp,
-			ClusterStatusDeleting,
-			ClusterStatusModifying,
-		},
-		Target:     []string{},
-		Refresh:    statusDBCluster(conn, id),
-		Timeout:    timeout,
-		MinTimeout: 10 * time.Second,
-		Delay:      30 * time.Second,
-	}
-
-	outputRaw, err := stateConf.WaitForState()
-
-	if output, ok := outputRaw.(*rds.DBCluster); ok {
-		return output, err
-	}
-
-	return nil, err
-}
-
-func waitDBClusterUpdated(conn *rds.RDS, id string, timeout time.Duration) (*rds.DBCluster, error) { //nolint:unparam
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{
-			ClusterStatusBackingUp,
-			ClusterStatusConfiguringIAMDatabaseAuth,
-			ClusterStatusModifying,
-			ClusterStatusRenaming,
-			ClusterStatusResettingMasterCredentials,
-			ClusterStatusUpgrading,
-		},
-		Target:     []string{ClusterStatusAvailable},
-		Refresh:    statusDBCluster(conn, id),
-		Timeout:    timeout,
-		MinTimeout: 10 * time.Second,
-		Delay:      30 * time.Second,
-	}
-
-	outputRaw, err := stateConf.WaitForState()
-
-	if output, ok := outputRaw.(*rds.DBCluster); ok {
-		return output, err
-	}
-
-	return nil, err
-}
-
 func waitDBClusterRoleAssociationCreated(conn *rds.RDS, dbClusterID, roleARN string) (*rds.DBClusterRole, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{ClusterRoleStatusPending},
@@ -323,7 +246,7 @@ func waitActivityStreamStarted(ctx context.Context, conn *rds.RDS, dbClusterArn 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{rds.ActivityStreamStatusStarting},
 		Target:     []string{rds.ActivityStreamStatusStarted},
-		Refresh:    statusDBClusterActivityStream(conn, dbClusterArn),
+		Refresh:    statusDBClusterActivityStream(ctx, conn, dbClusterArn),
 		Timeout:    dbClusterActivityStreamStartedTimeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
@@ -343,7 +266,7 @@ func waitActivityStreamStopped(ctx context.Context, conn *rds.RDS, dbClusterArn 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{rds.ActivityStreamStatusStopping},
 		Target:     []string{},
-		Refresh:    statusDBClusterActivityStream(conn, dbClusterArn),
+		Refresh:    statusDBClusterActivityStream(ctx, conn, dbClusterArn),
 		Timeout:    dbClusterActivityStreamStoppedTimeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,


### PR DESCRIPTION
updates `aws_db_instance`, `aws_rds_cluster`, and `aws_rds_cluster_instance` to use `WithoutTimeout` CRUD functions and `Context`-aware Import functions.

Also ensures that `Context`-aware functions are used in other resources when `WithoutTimeout` CRUD functions are used.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Acceptance test failures are pre-existing

```
$ make testacc PKG=rds TESTS='TestAccRDSInstance|TestAccRDSSnapshotCopy|TestAccRDSReservedInstance|TestAccRDSCluster' ACCTEST_TIMEOUT=5h

--- SKIP: TestAccRDSCluster_SnapshotIdentifierEngineMode_serverless (0.00s)
--- PASS: TestAccRDSCluster_iamAuth (129.02s)
--- PASS: TestAccRDSCluster_backupsUpdate (225.55s)
--- FAIL: TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID (1.63s)
--- PASS: TestAccRDSCluster_engineVersionWithPrimaryInstance (1185.56s)
--- PASS: TestAccRDSCluster_encrypted (152.97s)
--- PASS: TestAccRDSCluster_copyTagsToSnapshot (217.46s)
--- PASS: TestAccRDSCluster_kmsKey (147.45s)
--- PASS: TestAccRDSCluster_networkType (209.22s)
--- PASS: TestAccRDSCluster_updateIAMRoles (204.51s)
--- PASS: TestAccRDSCluster_identifierPrefix (158.43s)
--- PASS: TestAccRDSCluster_identifierGenerated (168.60s)
--- PASS: TestAccRDSCluster_tags (192.43s)
--- PASS: TestAccRDSCluster_disappears (141.37s)
--- PASS: TestAccRDSCluster_basic (169.06s)
--- FAIL: TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql (14.36s)
--- FAIL: TestAccRDSCluster_iops (7.62s)
--- FAIL: TestAccRDSCluster_allocatedStorage (8.18s)
--- PASS: TestAccRDSCluster_EnabledCloudWatchLogsExports_mySQL (245.97s)
--- FAIL: TestAccRDSCluster_dbClusterInstanceClass (7.79s)
--- PASS: TestAccRDSCluster_missingUserNameCausesError (6.65s)
--- PASS: TestAccRDSCluster_engineVersion (478.73s)
--- PASS: TestAccRDSCluster_engineMode (412.10s)
--- FAIL: TestAccRDSCluster_EngineMode_parallelQuery (9.56s)
--- PASS: TestAccRDSCluster_EngineMode_multiMaster (145.60s)
--- PASS: TestAccRDSCluster_EngineMode_global (201.12s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global (143.41s)
--- PASS: TestAccRDSCluster_deletionProtection (226.57s)
--- PASS: TestAccRDSCluster_takeFinalSnapshot (224.43s)
--- FAIL: TestAccRDSCluster_storageType (8.40s)
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineVersion_different (471.32s)
--- PASS: TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs (456.42s)
--- PASS: TestAccRDSCluster_SnapshotIdentifier_tags (433.32s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm (2578.33s)
--- PASS: TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports (987.45s)
--- PASS: TestAccRDSCluster_dbSubnetGroupName (875.26s)
--- PASS: TestAccRDSCluster_pointInTimeRestore (1075.01s)
--- PASS: TestAccRDSCluster_availabilityZones (1062.05s)
--- PASS: TestAccRDSCluster_SnapshotIdentifier_encryptedRestore (1257.32s)
--- PASS: TestAccRDSCluster_backtrackWindow (1571.75s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgrade (2492.82s)
--- PASS: TestAccRDSCluster_enableHTTPEndpoint (1641.54s)
--- PASS: TestAccRDSCluster_onlyMajorVersion (1884.58s)
--- PASS: TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags (461.69s)
--- FAIL: TestAccRDSCluster_SnapshotIdentifierEngineMode_parallelQuery (6.94s)
--- PASS: TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow (447.67s)
--- PASS: TestAccRDSCluster_port (256.75s)
--- PASS: TestAccRDSCluster_SnapshotIdentifier_masterPassword (398.72s)
--- PASS: TestAccRDSCluster_SnapshotIdentifier_kmsKeyID (429.19s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters (2293.19s)
--- PASS: TestAccRDSCluster_SnapshotIdentifier_deletionProtection (492.44s)
--- FAIL: TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier (1.83s)
--- FAIL: TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters (1.82s)
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned (407.17s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned (142.71s)
--- FAIL: TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding (1.98s)
--- PASS: TestAccRDSCluster_Scaling_defaultMinCapacity (296.56s)
--- FAIL: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add (165.96s)
--- PASS: TestAccRDSCluster_snapshotIdentifier (415.93s)
--- PASS: TestAccRDSCluster_serverlessV2ScalingConfiguration (245.49s)
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal (484.73s)
--- FAIL: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update (195.74s)
--- PASS: TestAccRDSCluster_scaling (363.93s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove (239.32s)
--- PASS: TestAccRDSCluster_SnapshotIdentifier_masterUsername (436.56s)
--- PASS: TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow (436.36s)

--- PASS: TestAccRDSInstance_noDeleteAutomatedBackups (699.85s)
--- SKIP: TestAccRDSInstance_coIPEnabled (0.34s)
--- SKIP: TestAccRDSInstance_CoIPEnabled_snapshotIdentifier (0.36s)
--- SKIP: TestAccRDSInstance_CoIPEnabled_restoreToPointInTime (0.33s)
--- SKIP: TestAccRDSInstance_CoIPEnabled_enabledToDisabled (0.12s)
--- SKIP: TestAccRDSInstance_CoIPEnabled_disabledToEnabled (0.11s)
--- SKIP: TestAccRDSInstance_ReplicateSourceDB_deletionProtection (0.00s)
--- SKIP: TestAccRDSInstance_S3Import_basic (0.00s)
--- SKIP: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameRAMShared (0.70s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_nameGenerated (983.06s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_deletionProtection (1042.03s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved (1107.05s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_availabilityZone (1161.59s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs (1190.67s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow (1196.36s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupWindow (1199.30s)
--- SKIP: TestAccRDSInstance_SnapshotIdentifier_tagsRemove (0.00s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade (1231.69s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName (1258.96s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_monitoring (1302.45s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage (1316.86s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled (1318.35s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_namePrefix (1383.91s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_allocatedStorage (1390.71s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_io1Storage (1472.73s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride (1580.60s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset (1742.51s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_basic (1261.18s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade (2026.28s)
--- PASS: TestAccRDSInstance_caCertificateIdentifier (370.95s)
--- PASS: TestAccRDSInstance_license (1042.81s)
--- PASS: TestAccRDSInstance_NoNationalCharacterSet_oracle (838.62s)
--- PASS: TestAccRDSInstance_NationalCharacterSet_oracle (893.71s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier (1427.20s)
--- PASS: TestAccRDSInstance_performanceInsightsRetentionPeriod (965.75s)
--- PASS: TestAccRDSInstance_performanceInsightsKMSKeyID (966.66s)
--- PASS: TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled (780.51s)
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_postgresql (516.67s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs (1583.86s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_port (1583.02s)
--- PASS: TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled (771.31s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled (1292.39s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica (1683.72s)
--- PASS: TestAccRDSInstance_separateIopsUpdate (705.29s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue (1648.70s)
--- PASS: TestAccRDSInstance_nameDeprecated (539.90s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier (1463.92s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_monitoring (1584.73s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled (1484.93s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceResourceID (1569.36s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_replicaMode (2323.55s)
--- PASS: TestAccRDSInstance_tags (567.13s)
--- PASS: TestAccRDSInstance_identifierGenerated (471.10s)
--- PASS: TestAccRDSInstance_disappears (510.25s)
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_oracle (886.40s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName (2403.08s)
--- SKIP: TestAccRDSInstance_DBSubnetGroupName_ramShared (0.00s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_addLater (1389.32s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_nameGenerated (1466.58s)
--- PASS: TestAccRDSInstance_password (391.98s)
--- PASS: TestAccRDSInstance_deletionProtection (620.65s)
--- PASS: TestAccRDSInstance_optionGroup (555.59s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_availabilityZone (1540.86s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod (1871.51s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allocatedStorage (1366.25s)
--- PASS: TestAccRDSInstance_subnetGroup (758.92s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_namePrefix (1573.29s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade (1393.59s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_basic (1362.82s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade (1495.73s)
--- PASS: TestAccRDSInstance_dbSubnetGroupName (550.42s)
--- PASS: TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs (434.79s)
--- PASS: TestAccRDSInstance_kmsKey (377.59s)
--- PASS: TestAccRDSInstance_networkType (800.89s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops (1602.43s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iops (1437.96s)
--- PASS: TestAccRDSInstance_iamAuth (524.91s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_multiAZ (1766.06s)
--- PASS: TestAccRDSInstance_customIAMInstanceProfile (2729.73s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer (5403.06s)
--- PASS: TestAccRDSInstance_onlyMajorVersion (545.71s)
--- FAIL: TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep (2707.80s)
--- PASS: TestAccRDSInstance_cloudWatchLogsExport (455.02s)
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_msSQL (929.15s)
--- PASS: TestAccRDSInstance_minorVersion (500.13s)
--- PASS: TestAccRDSInstance_basic (512.28s)
--- PASS: TestAccRDSInstance_identifierPrefix (541.72s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_networkType (1143.61s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSameSetOnBoth (1358.95s)
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL (973.55s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth (1952.64s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists (1515.81s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_removedToEnabled (737.48s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled (1261.42s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow (1311.99s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved (828.37s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_multiAZ (1867.78s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring (1790.40s)
--- PASS: TestAccRDSInstance_monitoringInterval (1082.90s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage (1601.95s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled (947.70s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs (1196.42s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags (1105.10s)
--- PASS: TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion (1656.76s)
--- PASS: TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_vpcSecurityGroupIDs (2065.81s)
--- PASS: TestAccRDSInstance_portUpdate (641.99s)
--- SKIP: TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_ramShared (0.07s)
--- PASS: TestAccRDSInstance_MSSQL_domainSnapshotRestore (3317.40s)
--- PASS: TestAccRDSInstance_MSSQL_tz (2063.73s)
--- PASS: TestAccRDSInstance_isAlreadyBeingDeleted (1018.09s)
--- PASS: TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot (883.75s)
--- PASS: TestAccRDSInstance_maxAllocatedStorage (2149.77s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_parameterGroupName (1524.07s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_port (1222.09s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_tags (1355.97s)
--- PASS: TestAccRDSInstance_allowMajorVersionUpgrade (534.86s)
--- PASS: TestAccRDSInstance_MSSQL_domain (4191.94s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_backupWindow (1436.24s)
--- PASS: TestAccRDSInstance_finalSnapshotIdentifier (923.08s)

--- SKIP: TestAccRDSReservedInstance_basic (0.00s)

--- PASS: TestAccRDSInstanceOffering_basic (21.10s)

--- PASS: TestAccRDSSnapshotCopy_disappears (713.71s)
--- PASS: TestAccRDSSnapshotCopy_tags (678.97s)
--- PASS: TestAccRDSSnapshotCopy_basic (706.30s)

--- PASS: TestAccRDSClusterActivityStream_basic (1802.09s)
--- PASS: TestAccRDSClusterActivityStream_disappears (1794.78s)

--- PASS: TestAccRDSClusterParameterGroup_GeneratedName_parameter (17.75s)
--- PASS: TestAccRDSClusterParameterGroup_disappears (12.99s)
--- PASS: TestAccRDSClusterParameterGroup_generatedName (22.18s)
--- PASS: TestAccRDSClusterParameterGroup_NamePrefix_parameter (26.50s)
--- PASS: TestAccRDSClusterParameterGroup_namePrefix (19.51s)
--- PASS: TestAccRDSClusterParameterGroup_withApplyMethod (24.14s)
--- PASS: TestAccRDSClusterParameterGroup_basic (88.08s)
--- PASS: TestAccRDSClusterParameterGroup_updateParameters (40.89s)
--- PASS: TestAccRDSClusterParameterGroup_caseParameters (52.51s)
--- PASS: TestAccRDSClusterParameterGroup_only (38.87s)

--- PASS: TestAccRDSInstanceRoleAssociation_basic (995.04s)
--- PASS: TestAccRDSInstanceRoleAssociation_disappears (816.00s)

--- PASS: TestAccRDSClusterSnapshotDataSource_mostRecent (303.37s)
--- PASS: TestAccRDSClusterSnapshotDataSource_dbClusterIdentifier (873.29s)
--- PASS: TestAccRDSClusterSnapshotDataSource_dbClusterSnapshotIdentifier (1087.92s)

--- PASS: TestAccRDSClusterSnapshot_basic (204.58s)
--- PASS: TestAccRDSClusterSnapshot_tags (257.30s)

--- PASS: TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraPostgresql (816.68s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraPostgresql_defaultKeyToCustomKey (937.68s)
--- PASS: TestAccRDSClusterInstance_MonitoringRoleARN_enabledToDisabled (1221.65s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraMySQL2_defaultKeyToCustomKey (896.65s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraMySQL1_defaultKeyToCustomKey (893.91s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraMySQL2 (913.02s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraMySQL1 (955.39s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraMySQL2 (999.44s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraMySQL1 (924.59s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraPostgresql (1017.37s)
--- PASS: TestAccRDSClusterInstance_performanceInsightsRetentionPeriod (1433.81s)
--- PASS: TestAccRDSClusterInstance_MonitoringRoleARN_removedToEnabled (1942.88s)
--- PASS: TestAccRDSClusterInstance_MonitoringRoleARN_enabledToRemoved (1695.29s)
--- FAIL: TestAccRDSClusterInstance_publiclyAccessible (123.48s)
--- PASS: TestAccRDSClusterInstance_az (1297.10s)
--- PASS: TestAccRDSClusterInstance_caCertificateIdentifier (1068.13s)
--- PASS: TestAccRDSClusterInstance_copyTagsToSnapshot (931.04s)
--- PASS: TestAccRDSClusterInstance_isAlreadyBeingDeleted (1058.44s)
--- PASS: TestAccRDSClusterInstance_disappears (935.33s)
--- PASS: TestAccRDSClusterInstance_monitoringInterval (1642.78s)
--- PASS: TestAccRDSClusterInstance_tags (1123.69s)
--- PASS: TestAccRDSClusterInstance_basic (928.59s)
--- PASS: TestAccRDSClusterInstance_kmsKey (1061.16s)
--- PASS: TestAccRDSClusterInstance_identifierPrefix (965.76s)
--- PASS: TestAccRDSClusterInstance_identifierGenerated (881.94s)

--- PASS: TestAccRDSInstanceDataSource_basic (1250.63s)

--- PASS: TestAccRDSClusterRoleAssociation_Disappears_role (574.90s)
--- PASS: TestAccRDSClusterRoleAssociation_Disappears_cluster (193.34s)
--- PASS: TestAccRDSClusterRoleAssociation_disappears (163.77s)
--- PASS: TestAccRDSClusterRoleAssociation_basic (187.80s)

--- PASS: TestAccRDSInstanceAutomatedBackupsReplication_kmsEncrypted (2141.71s)
--- PASS: TestAccRDSInstanceAutomatedBackupsReplication_retentionPeriod (2040.05s)
--- PASS: TestAccRDSInstanceAutomatedBackupsReplication_basic (2114.45s)

--- PASS: TestAccRDSClusterDataSource_basic (176.27s)

--- PASS: TestAccRDSClusterEndpoint_tags (1776.26s)
--- PASS: TestAccRDSClusterEndpoint_basic (1657.97s)
```
