### PR TITLE
Added a full example for `aws_networkmanager_site_to_site_vpn_attachment` documentation

### DIFF
--- a/website/docs/r/networkmanager_site_to_site_vpn_attachment.html.markdown
+++ b/website/docs/r/networkmanager_site_to_site_vpn_attachment.html.markdown
@@ -21,6 +21,79 @@ resource "aws_networkmanager_site_to_site_vpn_attachment" "example" {
 }
 ```
 
+### Full Usage
+
+```terraform
+resource "aws_customer_gateway" "test" {
+  bgp_asn    = 65000
+  ip_address = "172.0.0.1"
+  type       = "ipsec.1"
+}
+resource "aws_vpn_connection" "test" {
+  customer_gateway_id = aws_customer_gateway.test.id
+  type                = "ipsec.1"
+  tags = {
+    Name = "test"
+  }
+}
+resource "aws_networkmanager_global_network" "test" {
+  tags = {
+    Name = "test"
+  }
+}
+resource "awscc_networkmanager_core_network" "test" {
+  global_network_id = aws_networkmanager_global_network.test.id
+  policy_document   = jsonencode(jsondecode(data.aws_networkmanager_core_network_policy_document.test.json))
+}
+data "aws_networkmanager_core_network_policy_document" "test" {
+  core_network_configuration {
+    vpn_ecmp_support = false
+    asn_ranges       = ["64512-64555"]
+    edge_locations {
+      location = data.aws_region.current.name
+      asn      = 64512
+    }
+  }
+  segments {
+    name                          = "shared"
+    description                   = "SegmentForSharedServices"
+    require_attachment_acceptance = true
+  }
+  segment_actions {
+    action     = "share"
+    mode       = "attachment-route"
+    segment    = "shared"
+    share_with = ["*"]
+  }
+  attachment_policies {
+    rule_number     = 1
+    condition_logic = "or"
+    conditions {
+      type     = "tag-value"
+      operator = "equals"
+      key      = "segment"
+      value    = "shared"
+    }
+    action {
+      association_method = "constant"
+      segment            = "shared"
+    }
+  }
+}
+
+resource "aws_networkmanager_site_to_site_vpn_attachment" "test" {
+  core_network_id    = awscc_networkmanager_core_network.test.id
+  vpn_connection_arn = aws_vpn_connection.test.arn
+  tags = {
+    segment = "shared"
+  }
+}
+resource "aws_networkmanager_attachment_accepter" "test" {
+  attachment_id   = aws_networkmanager_site_to_site_vpn_attachment.test.id
+  attachment_type = aws_networkmanager_site_to_site_vpn_attachment.test.attachment_type
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Added a full example for networkmanager_site_to_site_attachment to the documentation
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/27387.