### PR TITLE
Tests: Remove external provider aliases

### DIFF
--- a/internal/service/batch/compute_environment_test.go
+++ b/internal/service/batch/compute_environment_test.go
@@ -1767,21 +1767,15 @@ provider "kubernetes" {
   host                   = aws_eks_cluster.test.endpoint
   cluster_ca_certificate = base64decode(aws_eks_cluster.test.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.cluster.token
-
-  alias = "batch"
 }
 
 resource "kubernetes_namespace" "test" {
-  provider = kubernetes.batch
-
   metadata {
     name = "test"
   }
 }
 
 resource "kubernetes_cluster_role" "test" {
-  provider = kubernetes.batch
-
   metadata {
     name = "aws-batch-cluster-role"
   }
@@ -1812,8 +1806,6 @@ resource "kubernetes_cluster_role" "test" {
 }
 
 resource "kubernetes_cluster_role_binding" "test" {
-  provider = kubernetes.batch
-
   metadata {
     name = "aws-batch-cluster-role-binding"
   }
@@ -1832,8 +1824,6 @@ resource "kubernetes_cluster_role_binding" "test" {
 }
 
 resource "kubernetes_role" "test" {
-  provider = kubernetes.batch
-
   metadata {
     name      = "aws-batch-compute-environment-role"
     namespace = kubernetes_namespace.test.metadata[0].name
@@ -1859,8 +1849,6 @@ resource "kubernetes_role" "test" {
 }
 
 resource "kubernetes_role_binding" "test" {
-  provider = kubernetes.batch
-
   metadata {
     name      = "aws-batch-compute-environment-role-binding"
     namespace = kubernetes_namespace.test.metadata[0].name
@@ -1880,8 +1868,6 @@ resource "kubernetes_role_binding" "test" {
 }
 
 resource "kubernetes_config_map" "aws_auth" {
-  provider = kubernetes.batch
-
   metadata {
     name      = "aws-auth"
     namespace = "kube-system"

--- a/internal/service/emrcontainers/virtual_cluster_test.go
+++ b/internal/service/emrcontainers/virtual_cluster_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestAccEMRContainersVirtualCluster_basic(t *testing.T) {
 	var v emrcontainers.VirtualCluster
-	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_emrcontainers_virtual_cluster.test"
 	testExternalProviders := map[string]resource.ExternalProvider{
 		"kubernetes": {
@@ -72,7 +72,7 @@ func TestAccEMRContainersVirtualCluster_basic(t *testing.T) {
 
 func TestAccEMRContainersVirtualCluster_disappears(t *testing.T) {
 	var v emrcontainers.VirtualCluster
-	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_emrcontainers_virtual_cluster.test"
 	testExternalProviders := map[string]resource.ExternalProvider{
 		"kubernetes": {
@@ -105,7 +105,7 @@ func TestAccEMRContainersVirtualCluster_disappears(t *testing.T) {
 
 func TestAccEMRContainersVirtualCluster_tags(t *testing.T) {
 	var v emrcontainers.VirtualCluster
-	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_emrcontainers_virtual_cluster.test"
 	testExternalProviders := map[string]resource.ExternalProvider{
 		"kubernetes": {

--- a/internal/service/emrcontainers/virtual_cluster_test.go
+++ b/internal/service/emrcontainers/virtual_cluster_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestAccEMRContainersVirtualCluster_basic(t *testing.T) {
 	var v emrcontainers.VirtualCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_emrcontainers_virtual_cluster.test"
 	testExternalProviders := map[string]resource.ExternalProvider{
 		"kubernetes": {
@@ -72,7 +72,7 @@ func TestAccEMRContainersVirtualCluster_basic(t *testing.T) {
 
 func TestAccEMRContainersVirtualCluster_disappears(t *testing.T) {
 	var v emrcontainers.VirtualCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_emrcontainers_virtual_cluster.test"
 	testExternalProviders := map[string]resource.ExternalProvider{
 		"kubernetes": {
@@ -105,7 +105,7 @@ func TestAccEMRContainersVirtualCluster_disappears(t *testing.T) {
 
 func TestAccEMRContainersVirtualCluster_tags(t *testing.T) {
 	var v emrcontainers.VirtualCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_emrcontainers_virtual_cluster.test"
 	testExternalProviders := map[string]resource.ExternalProvider{
 		"kubernetes": {
@@ -378,13 +378,9 @@ provider "kubernetes" {
   host                   = aws_eks_cluster.test.endpoint
   cluster_ca_certificate = base64decode(aws_eks_cluster.test.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.cluster.token
-
-  alias = "emr"
 }
 
 resource "kubernetes_role" "emrcontainers_role" {
-  provider = kubernetes.emr
-
   metadata {
     name      = "emr-containers"
     namespace = "default"
@@ -434,8 +430,6 @@ resource "kubernetes_role" "emrcontainers_role" {
 }
 
 resource "kubernetes_role_binding" "emrcontainers_rolemapping" {
-  provider = kubernetes.emr
-
   metadata {
     name      = "emr-containers"
     namespace = "default"
@@ -455,8 +449,6 @@ resource "kubernetes_role_binding" "emrcontainers_rolemapping" {
 }
 
 resource "kubernetes_config_map" "aws_auth" {
-  provider = kubernetes.emr
-
   metadata {
     name      = "aws-auth"
     namespace = "kube-system"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

https://github.com/hashicorp/terraform-plugin-sdk/pull/1092 removes the need to use external provider aliases in acceptance test configurations.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/27499.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/27615.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/27803.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccEMRContainersVirtualCluster_basic' PKG=emrcontainers
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/emrcontainers/... -v -count 1 -parallel 20  -run=TestAccEMRContainersVirtualCluster_basic -timeout 180m
=== RUN   TestAccEMRContainersVirtualCluster_basic
=== PAUSE TestAccEMRContainersVirtualCluster_basic
=== CONT  TestAccEMRContainersVirtualCluster_basic
--- PASS: TestAccEMRContainersVirtualCluster_basic (1209.44s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/emrcontainers	1216.440s
% make testacc TESTARGS='-run=TestAccBatchComputeEnvironment_eksConfiguration' PKG=batch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/batch/... -v -count 1 -parallel 20  -run=TestAccBatchComputeEnvironment_eksConfiguration -timeout 180m
=== RUN   TestAccBatchComputeEnvironment_eksConfiguration
=== PAUSE TestAccBatchComputeEnvironment_eksConfiguration
=== CONT  TestAccBatchComputeEnvironment_eksConfiguration
--- PASS: TestAccBatchComputeEnvironment_eksConfiguration (778.42s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/batch	783.646s
```
