### PR TITLE
auditmanager: Use v2 AWS SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.137
 	github.com/aws/aws-sdk-go-v2 v1.17.1
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.19
+	github.com/aws/aws-sdk-go-v2/service/auditmanager v1.20.11
 	github.com/aws/aws-sdk-go-v2/service/comprehend v1.19.2
 	github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.17.21
 	github.com/aws/aws-sdk-go-v2/service/fis v1.13.3

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.19 h1:oRHDrwCTVT8ZXi4sr9
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.19/go.mod h1:6Q0546uHDp421okhmmGfbxzq2hBqbXFNpi4k+Q1JnQA=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.11 h1:6cZRymlLEIlDTEB0+5+An6Zj1CKt6rSE69tOmFeu1nk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.11/go.mod h1:0MR+sS1b/yxsfAPvAESrw8NfwUoxMinDyw6EYR9BS2U=
+github.com/aws/aws-sdk-go-v2/service/auditmanager v1.20.11 h1:8uIuRNb6ZtD4k0QY82WXvQFmqDqpzHze/nwC3E+31vY=
+github.com/aws/aws-sdk-go-v2/service/auditmanager v1.20.11/go.mod h1:KQ0nmqhPXEsObZkum2BWlzZcPFgnWFUwjkIXheLLYUM=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.19.2 h1:QPZlPIMkaEOOFbz+znqwS5HkomTbNFxEJnKJ8zGOMlQ=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.19.2/go.mod h1:TF15nEFgTfsELGXN/OvQHFa3dIueBisgKGHEwKVityA=
 github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.17.21 h1:7vuzLT8obylMtylazUAcvbwEaCqAkr9v5KMjDt9L9z8=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -2,6 +2,7 @@
 package conns
 
 import (
+	"github.com/aws/aws-sdk-go-v2/service/auditmanager"
 	"github.com/aws/aws-sdk-go-v2/service/comprehend"
 	"github.com/aws/aws-sdk-go-v2/service/computeoptimizer"
 	"github.com/aws/aws-sdk-go-v2/service/fis"
@@ -43,7 +44,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/appstream"
 	"github.com/aws/aws-sdk-go/service/appsync"
 	"github.com/aws/aws-sdk-go/service/athena"
-	"github.com/aws/aws-sdk-go/service/auditmanager"
 	"github.com/aws/aws-sdk-go/service/augmentedairuntime"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscalingplans"
@@ -355,7 +355,7 @@ type AWSClient struct {
 	ApplicationCostProfilerConn      *applicationcostprofiler.ApplicationCostProfiler
 	ApplicationInsightsConn          *applicationinsights.ApplicationInsights
 	AthenaConn                       *athena.Athena
-	AuditManagerConn                 *auditmanager.AuditManager
+	AuditManagerClient               *auditmanager.Client
 	AutoScalingConn                  *autoscaling.AutoScaling
 	AutoScalingPlansConn             *autoscalingplans.AutoScalingPlans
 	BackupConn                       *backup.Backup

--- a/internal/conns/config_gen.go
+++ b/internal/conns/config_gen.go
@@ -29,7 +29,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/appstream"
 	"github.com/aws/aws-sdk-go/service/appsync"
 	"github.com/aws/aws-sdk-go/service/athena"
-	"github.com/aws/aws-sdk-go/service/auditmanager"
 	"github.com/aws/aws-sdk-go/service/augmentedairuntime"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscalingplans"
@@ -317,7 +316,6 @@ func (c *Config) clientConns(client *AWSClient, sess *session.Session) {
 	client.ApplicationCostProfilerConn = applicationcostprofiler.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ApplicationCostProfiler])}))
 	client.ApplicationInsightsConn = applicationinsights.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ApplicationInsights])}))
 	client.AthenaConn = athena.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Athena])}))
-	client.AuditManagerConn = auditmanager.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AuditManager])}))
 	client.AutoScalingConn = autoscaling.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AutoScaling])}))
 	client.AutoScalingPlansConn = autoscalingplans.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AutoScalingPlans])}))
 	client.BackupConn = backup.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Backup])}))

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -26,7 +26,7 @@ appstream,appstream,appstream,appstream,,appstream,,,AppStream,AppStream,,1,,,aw
 appsync,appsync,appsync,appsync,,appsync,,,AppSync,AppSync,,1,,,aws_appsync_,,appsync_,AppSync,AWS,,,,,
 ,,,,,,,,,,,,,,,,,Artifact,AWS,x,,,,No SDK support
 athena,athena,athena,athena,,athena,,,Athena,Athena,,1,,,aws_athena_,,athena_,Athena,Amazon,,,,,
-auditmanager,auditmanager,auditmanager,auditmanager,,auditmanager,,,AuditManager,AuditManager,,1,,,aws_auditmanager_,,auditmanager_,Audit Manager,AWS,,,,,
+auditmanager,auditmanager,auditmanager,auditmanager,,auditmanager,,,AuditManager,AuditManager,,,2,,aws_auditmanager_,,auditmanager_,Audit Manager,AWS,,,,,
 autoscaling,autoscaling,autoscaling,autoscaling,,autoscaling,,,AutoScaling,AutoScaling,,1,,aws_(autoscaling_|launch_configuration),aws_autoscaling_,,autoscaling_;launch_configuration,Auto Scaling,,,,,,
 autoscaling-plans,autoscalingplans,autoscalingplans,autoscalingplans,,autoscalingplans,,,AutoScalingPlans,AutoScalingPlans,,1,,,aws_autoscalingplans_,,autoscalingplans_,Auto Scaling Plans,,,,,,
 ,,,,,,,,,,,,,,,,,Backint Agent for SAP HANA,AWS,x,,,,No SDK support


### PR DESCRIPTION
### Description
Switches the `auditmanager` client to the v2 AWS Go SDK.

### Relations
Relates #17981
Relates #18071