### PR TITLE
Add elasticache ip discovery

### DIFF
--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -142,10 +142,11 @@ func ResourceCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"ip_discovery"{
-				Type:	  schema.TypeString,
-				Optional: true,
-				Computed: false,
+			"ip_discovery": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(elasticache.IpDiscovery_Values(), false),
 			},
 			"log_delivery_configuration": {
 				Type:     schema.TypeSet,
@@ -593,6 +594,11 @@ func resourceClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("parameter_group_name") {
 		req.CacheParameterGroupName = aws.String(d.Get("parameter_group_name").(string))
+		requestUpdate = true
+	}
+
+	if d.HasChange("ip_discovery") {
+		req.IpDiscovery = aws.String(d.Get("ip_discovery").(string))
 		requestUpdate = true
 	}
 

--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -142,6 +142,11 @@ func ResourceCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"ip_discovery"{
+				Type:	  schema.TypeString,
+				Optional: true,
+				Computed: false,
+			},
 			"log_delivery_configuration": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -422,6 +427,10 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 		req.PreferredAvailabilityZones = flex.ExpandStringList(v.([]interface{}))
 	}
 
+	if v, ok := d.GetOk("ip_discovery"); ok {
+		req.IpDiscovery = aws.String(v.(string))
+	}
+
 	id, arn, err := createCacheCluster(conn, req)
 	if err != nil {
 		return fmt.Errorf("error creating ElastiCache Cache Cluster: %w", err)
@@ -507,6 +516,8 @@ func resourceClusterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("arn", c.ARN)
+
+	d.Set("ip_discovery", c.IpDiscovery)
 
 	tags, err := ListTags(conn, aws.StringValue(c.ARN))
 

--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -119,6 +119,7 @@ The following arguments are optional:
   Otherwise, specify the full version desired, e.g., `5.0.6`.
   The actual engine version used is returned in the attribute `engine_version_actual`, see [Attributes Reference](#attributes-reference) below.
 * `final_snapshot_identifier` - (Optional, Redis only) Name of your final cluster snapshot. If omitted, no final snapshot will be made.
+* `ip_discovery` - (Optional) The network type for the cache cluster, either `ipv4` or `ipv6`. IPv6 is supported with Redis engine `6.2` onword or Memcached version `1.6.6` for all [Nitro system](https://aws.amazon.com/ec2/nitro/) instances
 * `log_delivery_configuration` - (Optional, Redis only) Specifies the destination and format of Redis [SLOWLOG](https://redis.io/commands/slowlog) or Redis [Engine Log](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Log_Delivery.html#Log_contents-engine-log). See the documentation on [Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Log_Delivery.html). See [Log Delivery Configuration](#log-delivery-configuration) below for more details.
 * `maintenance_window` – (Optional) Specifies the weekly time range for when maintenance
 on the cache cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H Clock UTC).

--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -119,7 +119,7 @@ The following arguments are optional:
   Otherwise, specify the full version desired, e.g., `5.0.6`.
   The actual engine version used is returned in the attribute `engine_version_actual`, see [Attributes Reference](#attributes-reference) below.
 * `final_snapshot_identifier` - (Optional, Redis only) Name of your final cluster snapshot. If omitted, no final snapshot will be made.
-* `ip_discovery` - (Optional) The network type for the cache cluster, either `ipv4` or `ipv6`. IPv6 is supported with Redis engine `6.2` onword or Memcached version `1.6.6` for all [Nitro system](https://aws.amazon.com/ec2/nitro/) instances
+* `ip_discovery` - (Optional) The network type for the cache cluster. IPv6 is supported with Redis engine `6.2` onword or Memcached version `1.6.6` for all [Nitro system](https://aws.amazon.com/ec2/nitro/) instances. Valid values are `ipv4` or `ipv6`.
 * `log_delivery_configuration` - (Optional, Redis only) Specifies the destination and format of Redis [SLOWLOG](https://redis.io/commands/slowlog) or Redis [Engine Log](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Log_Delivery.html#Log_contents-engine-log). See the documentation on [Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Log_Delivery.html). See [Log Delivery Configuration](#log-delivery-configuration) below for more details.
 * `maintenance_window` – (Optional) Specifies the weekly time range for when maintenance
 on the cache cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H Clock UTC).


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Adds the `ip_discovery` parameter to elasticache cluster creation that is now supported on Redis 6.2 and Memcached engine version 1.6.6 on all instances built on the [Nitro system](https://aws.amazon.com/ec2/nitro/).

Also seen in the official announcement here: https://aws.amazon.com/about-aws/whats-new/2022/11/amazon-elasticache-supports-ipv6/
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27700

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

Announcement: https://aws.amazon.com/about-aws/whats-new/2022/11/amazon-elasticache-supports-ipv6/
API: https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateCacheCluster.html


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
