### PR TITLE
[WIP] aws_prometheus_workspace: Adds possibility to find workspace using alias

### DIFF
--- a/internal/service/amp/find.go
+++ b/internal/service/amp/find.go
@@ -76,6 +76,31 @@ func FindRuleGroupNamespaceByARN(ctx context.Context, conn *prometheusservice.Pr
 	return output.RuleGroupsNamespace, nil
 }
 
+func FindWorkspaceByAlias(ctx context.Context, conn *prometheusservice.PrometheusService, alias string) (*prometheusservice.WorkspaceDescription, error) {
+	input := &prometheusservice.ListWorkspacesInput{
+		Alias: aws.String(alias),
+	}
+
+	output, err := conn.ListWorkspacesWithContext(ctx, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output.Workspaces) == 0 {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if len(output.Workspaces) > 1 {
+		return nil, tfresource.NewTooManyResultsError(len(output.Workspaces), input)
+	}
+
+	return FindWorkspaceByID(ctx, conn, *output.Workspaces[0].WorkspaceId)
+}
+
 func FindWorkspaceByID(ctx context.Context, conn *prometheusservice.PrometheusService, id string) (*prometheusservice.WorkspaceDescription, error) {
 	input := &prometheusservice.DescribeWorkspaceInput{
 		WorkspaceId: aws.String(id),

--- a/internal/service/amp/workspace_data_source_test.go
+++ b/internal/service/amp/workspace_data_source_test.go
@@ -26,6 +26,17 @@ func TestAccAMPWorkspaceDataSource_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				Config: testAccWorkspaceDataSourceConfig_workspaceId(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "alias", dataSourceName, "alias"),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "created_date"),
+					resource.TestCheckResourceAttrPair(resourceName, "prometheus_endpoint", dataSourceName, "prometheus_endpoint"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "status"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.%", dataSourceName, "tags.%"),
+				),
+			},
+			{
 				Config: testAccWorkspaceDataSourceConfig_alias(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "alias", dataSourceName, "alias"),
@@ -40,7 +51,7 @@ func TestAccAMPWorkspaceDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccWorkspaceDataSourceConfig_alias(rName string) string {
+func testAccWorkspaceDataSourceConfig_workspaceId(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_prometheus_workspace" "test" {
   alias = %[1]q
@@ -48,6 +59,18 @@ resource "aws_prometheus_workspace" "test" {
 
 data "aws_prometheus_workspace" "test" {
   workspace_id = aws_prometheus_workspace.test.id
+}
+`, rName)
+}
+
+func testAccWorkspaceDataSourceConfig_alias(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_prometheus_workspace" "test" {
+  alias = %[1]q
+}
+
+data "aws_prometheus_workspace" "test" {
+  alias = aws_prometheus_workspace.test.alias
 }
 `, rName)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations

Closes #27039

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
❯ make testacc TESTARGS='-run=TestAccAMPWorkspaceDataSource_' PKG=amp
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/amp/... -v -count 1 -parallel 20  -run=TestAccAMPWorkspaceDataSource_ -timeout 180m
=== RUN   TestAccAMPWorkspaceDataSource_basic
--- PASS: TestAccAMPWorkspaceDataSource_basic (47.88s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/amp	49.702s

...
```
