### PR TITLE
New Resources: `aws_appconfig_extension` and `aws_appconfig_extension_association`

### DIFF
--- a/.changelog/27860.txt
+++ b/.changelog/27860.txt
@@ -1,0 +1,7 @@
+```release-note:new-resource
+aws_appconfig_extension
+```
+
+```release-note:new-resource
+aws_appconfig_extension_association
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -996,6 +996,8 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_appconfig_configuration_profile":        appconfig.ResourceConfigurationProfile(),
 			"aws_appconfig_deployment":                   appconfig.ResourceDeployment(),
 			"aws_appconfig_deployment_strategy":          appconfig.ResourceDeploymentStrategy(),
+			"aws_appconfig_extension":                    appconfig.ResourceExtension(),
+			"aws_appconfig_extension_association":        appconfig.ResourceExtensionAssociation(),
 			"aws_appconfig_environment":                  appconfig.ResourceEnvironment(),
 			"aws_appconfig_hosted_configuration_version": appconfig.ResourceHostedConfigurationVersion(),
 

--- a/internal/service/appconfig/extension.go
+++ b/internal/service/appconfig/extension.go
@@ -191,7 +191,6 @@ func resourceExtensionRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	if err := d.Set("tags_all", tags.Map()); err != nil {
 		return create.DiagError(names.Lightsail, create.ErrActionReading, ResExtension, d.Id(), errors.New("Error setting tags_all"))
-
 	}
 
 	return nil
@@ -310,7 +309,6 @@ func expandExtensionParameters(rawParameters []interface{}) map[string]*appconfi
 }
 
 func flattenExtensionActions(actions []*appconfig.Action) []interface{} {
-
 	var rawActions []interface{}
 	for _, action := range actions {
 		rawAction := map[string]interface{}{

--- a/internal/service/appconfig/extension.go
+++ b/internal/service/appconfig/extension.go
@@ -1,0 +1,408 @@
+package appconfig
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appconfig"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+const (
+	ResExtension = "Extension"
+)
+
+func ResourceExtension() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceExtensionCreate,
+		ReadWithoutTimeout:   resourceExtensionRead,
+		UpdateWithoutTimeout: resourceExtensionUpdate,
+		DeleteWithoutTimeout: resourceExtensionDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"action_point": {
+				Type:     schema.TypeSet,
+				Required: true,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"point": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(appconfig.ActionPoint_Values(), false),
+						},
+						"action": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MinItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"description": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"role_arn": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"uri": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"parameter": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"required": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"tags":     tftags.TagsSchemaForceNew(),
+			"tags_all": tftags.TagsSchemaComputed(),
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+func resourceExtensionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppConfigConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	actions, expandErr := expandExtensionActionPoints(d.Get("action_point").(*schema.Set).List())
+
+	if expandErr != nil {
+		return create.DiagError(names.AppConfig, create.ErrActionCreating, ResExtension, d.Get("name").(string), expandErr)
+	}
+
+	in := appconfig.CreateExtensionInput{
+		Actions: actions,
+		Name:    aws.String(d.Get("name").(string)),
+		Tags:    Tags(tags.IgnoreAWS()),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		in.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("parameter"); ok && v.(*schema.Set).Len() > 0 {
+		in.Parameters = expandExtensionParameters(v.(*schema.Set).List())
+	}
+
+	out, err := conn.CreateExtensionWithContext(ctx, &in)
+
+	if err != nil {
+		return create.DiagError(names.AppConfig, create.ErrActionCreating, ResExtension, d.Get("name").(string), err)
+	}
+
+	if out == nil {
+		return create.DiagError(names.AppConfig, create.ErrActionCreating, ResExtension, d.Get("name").(string), errors.New("No Extension returned with create request."))
+	}
+
+	d.SetId(aws.StringValue(out.Id))
+
+	return resourceExtensionRead(ctx, d, meta)
+}
+
+func resourceExtensionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppConfigConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	out, err := FindExtensionById(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		create.LogNotFoundRemoveState(names.AppConfig, create.ErrActionReading, ResExtension, d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.AppConfig, create.ErrActionReading, ResExtension, d.Id(), err)
+	}
+
+	d.Set("arn", out.Arn)
+	d.Set("action_point", flattenExtensionActionPoints(out.Actions))
+	d.Set("description", out.Description)
+	d.Set("parameter", flattenExtensionParameters(out.Parameters))
+	d.Set("name", out.Name)
+	d.Set("version", out.VersionNumber)
+
+	tags, err := ListTags(conn, *out.Arn)
+
+	if err != nil {
+		return create.DiagError(names.AppConfig, create.ErrActionReading, ResExtension, d.Get("name").(string), errors.New("error listing tags for AppConfig Extension"))
+	}
+
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return create.DiagError(names.Lightsail, create.ErrActionReading, ResExtension, d.Id(), errors.New("Error setting tags"))
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return create.DiagError(names.Lightsail, create.ErrActionReading, ResExtension, d.Id(), errors.New("Error setting tags_all"))
+
+	}
+
+	return nil
+}
+
+func resourceExtensionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppConfigConn
+	requestUpdate := false
+
+	in := &appconfig.UpdateExtensionInput{
+		ExtensionIdentifier: aws.String(d.Id()),
+	}
+
+	if d.HasChange("description") {
+		in.Description = aws.String(d.Get("description").(string))
+		requestUpdate = true
+	}
+
+	if d.HasChange("action_point") {
+		actions, expandErr := expandExtensionActionPoints(d.Get("action_point").(*schema.Set).List())
+
+		if expandErr != nil {
+			return create.DiagError(names.AppConfig, create.ErrActionCreating, ResExtension, d.Get("name").(string), expandErr)
+		}
+
+		in.Actions = actions
+		requestUpdate = true
+	}
+
+	if d.HasChange("parameter") {
+		in.Parameters = expandExtensionParameters(d.Get("parameter").(*schema.Set).List())
+		requestUpdate = true
+	}
+
+	if requestUpdate {
+		out, err := conn.UpdateExtensionWithContext(ctx, in)
+
+		if err != nil {
+			return create.DiagError(names.AppConfig, create.ErrActionWaitingForUpdate, ResExtension, d.Get("name").(string), err)
+		}
+
+		if out == nil {
+			return create.DiagError(names.AppConfig, create.ErrActionWaitingForUpdate, ResExtension, d.Get("name").(string), errors.New("No Extension returned with update request."))
+		}
+	}
+
+	return resourceExtensionRead(ctx, d, meta)
+}
+
+func resourceExtensionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppConfigConn
+
+	_, err := conn.DeleteExtensionWithContext(ctx, &appconfig.DeleteExtensionInput{
+		ExtensionIdentifier: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		return create.DiagError(names.AppConfig, create.ErrActionDeleting, ResExtension, d.Id(), err)
+	}
+
+	return nil
+}
+
+func expandExtensionActions(actionsListRaw interface{}) []*appconfig.Action {
+	var actions []*appconfig.Action
+	for _, actionRaw := range actionsListRaw.(*schema.Set).List() {
+		actionMap, ok := actionRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		action := &appconfig.Action{
+			Description: aws.String(actionMap["description"].(string)),
+			Name:        aws.String(actionMap["name"].(string)),
+			RoleArn:     aws.String(actionMap["role_arn"].(string)),
+			Uri:         aws.String(actionMap["uri"].(string)),
+		}
+
+		actions = append(actions, action)
+	}
+
+	return actions
+}
+
+func expandExtensionActionPoints(actionsPointListRaw []interface{}) (map[string][]*appconfig.Action, error) {
+	if len(actionsPointListRaw) == 0 {
+		return map[string][]*appconfig.Action{}, nil
+	}
+
+	actionsMap := make(map[string][]*appconfig.Action)
+	pointList := make([]string, len(actionsPointListRaw))
+	for _, actionPointRaw := range actionsPointListRaw {
+		actionPointMap, ok := actionPointRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		if _, ok := actionsMap[actionPointMap["point"].(string)]; ok {
+			return nil, errors.New("Error expanding Actions. You cannot define duplicate action_points.")
+		}
+		pointList = append(pointList, actionPointMap["point"].(string))
+
+		actionsMap[actionPointMap["point"].(string)] = expandExtensionActions(actionPointMap["action"])
+	}
+
+	return actionsMap, nil
+}
+
+func expandExtensionParameters(rawParameters []interface{}) map[string]*appconfig.Parameter {
+	if rawParameters == nil {
+		return nil
+	}
+
+	parameters := make(map[string]*appconfig.Parameter)
+
+	for _, rawParameterMap := range rawParameters {
+		parameterMap, ok := rawParameterMap.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		parameter := &appconfig.Parameter{
+			Description: aws.String(parameterMap["description"].(string)),
+			Required:    aws.Bool(parameterMap["required"].(bool)),
+		}
+		parameters[parameterMap["name"].(string)] = parameter
+	}
+
+	return parameters
+}
+
+func flattenExtensionActions(actions []*appconfig.Action) []interface{} {
+
+	var rawActions []interface{}
+	for _, action := range actions {
+		rawAction := map[string]interface{}{
+			"name":        aws.StringValue(action.Name),
+			"description": aws.StringValue(action.Description),
+			"role_arn":    aws.StringValue(action.RoleArn),
+			"uri":         aws.StringValue(action.Uri),
+		}
+		rawActions = append(rawActions, rawAction)
+	}
+	return rawActions
+}
+
+func flattenExtensionActionPoints(actionPointsMap map[string][]*appconfig.Action) []interface{} {
+	if len(actionPointsMap) == 0 {
+		return nil
+	}
+
+	var rawActionPoints []interface{}
+	for actionPoint, actions := range actionPointsMap {
+		rawActionPoint := map[string]interface{}{
+			"point":  actionPoint,
+			"action": flattenExtensionActions(actions),
+		}
+		rawActionPoints = append(rawActionPoints, rawActionPoint)
+	}
+
+	return rawActionPoints
+}
+
+func flattenExtensionParameters(parameters map[string]*appconfig.Parameter) []interface{} {
+	if len(parameters) == 0 {
+		return nil
+	}
+
+	var rawParameters []interface{}
+	for key, parameter := range parameters {
+		rawParameter := map[string]interface{}{
+			"name":        key,
+			"description": aws.StringValue(parameter.Description),
+			"required":    aws.BoolValue(parameter.Required),
+		}
+
+		rawParameters = append(rawParameters, rawParameter)
+	}
+
+	return rawParameters
+}
+
+// func extensionParameterSchema() *schema.Schema {
+// 	return &schema.Schema{
+// 		Type:     schema.TypeSet,
+// 		Optional: true,
+// 		Computed: true,
+// 		Elem: &schema.Resource{
+// 			Schema: map[string]*schema.Schema{
+// 				"name": {
+// 					Type:     schema.TypeString,
+// 					Required: true,
+// 				},
+// 				"description": {
+// 					Type:     schema.TypeString,
+// 					Optional: true,
+// 				},
+// 				"required": {
+// 					Type:     schema.TypeBool,
+// 					Optional: true,
+// 				},
+// 			},
+// 		},
+// 	}
+// }

--- a/internal/service/appconfig/extension_association.go
+++ b/internal/service/appconfig/extension_association.go
@@ -1,0 +1,152 @@
+package appconfig
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appconfig"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+const (
+	ResExtensionAssociation = "ExtensionAssociation"
+)
+
+func ResourceExtensionAssociation() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceExtensionAssociationCreate,
+		ReadWithoutTimeout:   resourceExtensionAssociationRead,
+		UpdateWithoutTimeout: resourceExtensionAssociationUpdate,
+		DeleteWithoutTimeout: resourceExtensionAssociationDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"extension_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"parameters": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"resource_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"extension_version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceExtensionAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppConfigConn
+
+	in := appconfig.CreateExtensionAssociationInput{
+		ExtensionIdentifier: aws.String(d.Get("extension_arn").(string)),
+		ResourceIdentifier:  aws.String(d.Get("resource_arn").(string)),
+	}
+
+	if v, ok := d.GetOk("parameters"); ok {
+		in.Parameters = flex.ExpandStringMap(v.(map[string]interface{}))
+	}
+
+	out, err := conn.CreateExtensionAssociationWithContext(ctx, &in)
+
+	if err != nil {
+		return create.DiagError(names.AppConfig, create.ErrActionCreating, ResExtensionAssociation, d.Get("name").(string), err)
+	}
+
+	if out == nil {
+		return create.DiagError(names.AppConfig, create.ErrActionCreating, ResExtensionAssociation, d.Get("name").(string), errors.New("No Extension Association returned with create request."))
+	}
+
+	d.SetId(aws.StringValue(out.Id))
+
+	return resourceExtensionAssociationRead(ctx, d, meta)
+}
+
+func resourceExtensionAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppConfigConn
+
+	out, err := FindExtensionAssociationById(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		create.LogNotFoundRemoveState(names.AppConfig, create.ErrActionReading, ResExtensionAssociation, d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.AppConfig, create.ErrActionReading, ResExtensionAssociation, d.Id(), err)
+	}
+
+	d.Set("arn", out.Arn)
+	d.Set("extension_arn", out.ExtensionArn)
+	d.Set("parameters", out.Parameters)
+	d.Set("resource_arn", out.ResourceArn)
+	d.Set("extension_version", out.ExtensionVersionNumber)
+
+	return nil
+}
+
+func resourceExtensionAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppConfigConn
+	requestUpdate := false
+
+	in := &appconfig.UpdateExtensionAssociationInput{
+		ExtensionAssociationId: aws.String(d.Id()),
+	}
+
+	if d.HasChange("parameters") {
+		in.Parameters = flex.ExpandStringMap(d.Get("parameters").(map[string]interface{}))
+		requestUpdate = true
+	}
+
+	if requestUpdate {
+		out, err := conn.UpdateExtensionAssociationWithContext(ctx, in)
+
+		if err != nil {
+			return create.DiagError(names.AppConfig, create.ErrActionWaitingForUpdate, ResExtensionAssociation, d.Get("name").(string), err)
+		}
+
+		if out == nil {
+			return create.DiagError(names.AppConfig, create.ErrActionWaitingForUpdate, ResExtensionAssociation, d.Get("name").(string), errors.New("No ExtensionAssociation returned with update request."))
+		}
+	}
+
+	return resourceExtensionAssociationRead(ctx, d, meta)
+}
+
+func resourceExtensionAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).AppConfigConn
+
+	_, err := conn.DeleteExtensionAssociationWithContext(ctx, &appconfig.DeleteExtensionAssociationInput{
+		ExtensionAssociationId: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		return create.DiagError(names.AppConfig, create.ErrActionDeleting, ResExtensionAssociation, d.Id(), err)
+	}
+
+	return nil
+}

--- a/internal/service/appconfig/extension_test.go
+++ b/internal/service/appconfig/extension_test.go
@@ -27,7 +27,7 @@ func TestAccAppConfigExtension_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckExtensionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExtensionConfigName(rName),
+				Config: testAccExtensionConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionExists(resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "appconfig", regexp.MustCompile(`extension/*`)),
@@ -57,7 +57,7 @@ func TestAccAppConfigExtension_ActionPoint(t *testing.T) {
 		CheckDestroy:             testAccCheckExtensionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExtensionConfigName(rName),
+				Config: testAccExtensionConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "action_point.#", "1"),
@@ -75,7 +75,7 @@ func TestAccAppConfigExtension_ActionPoint(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccExtensionConfigActionPoint2(rName),
+				Config: testAccExtensionConfig_actionPoint2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "action_point.#", "2"),
@@ -94,7 +94,7 @@ func TestAccAppConfigExtension_ActionPoint(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExtensionConfigName(rName),
+				Config: testAccExtensionConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "action_point.#", "1"),
@@ -127,7 +127,7 @@ func TestAccAppConfigExtension_Parameter(t *testing.T) {
 		CheckDestroy:             testAccCheckExtensionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExtensionConfigParameter1(rName, pName1, pDescription1, pRequiredTrue),
+				Config: testAccExtensionConfig_parameter1(rName, pName1, pDescription1, pRequiredTrue),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
@@ -144,7 +144,7 @@ func TestAccAppConfigExtension_Parameter(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccExtensionConfigParameter2(rName),
+				Config: testAccExtensionConfig_parameter2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "2"),
@@ -161,7 +161,7 @@ func TestAccAppConfigExtension_Parameter(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExtensionConfigParameter1(rName, pName2, pDescription2, pRequiredFalse),
+				Config: testAccExtensionConfig_parameter1(rName, pName2, pDescription2, pRequiredFalse),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
@@ -188,7 +188,7 @@ func TestAccAppConfigExtension_Name(t *testing.T) {
 		CheckDestroy:             testAccCheckExtensionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExtensionConfigName(rName),
+				Config: testAccExtensionConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -200,7 +200,7 @@ func TestAccAppConfigExtension_Name(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccExtensionConfigName(rName2),
+				Config: testAccExtensionConfig_name(rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName2),
@@ -224,7 +224,7 @@ func TestAccAppConfigExtension_Description(t *testing.T) {
 		CheckDestroy:             testAccCheckExtensionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExtensionConfigDescription(rName, rDescription),
+				Config: testAccExtensionConfig_description(rName, rDescription),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "description", rDescription),
@@ -236,7 +236,7 @@ func TestAccAppConfigExtension_Description(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccExtensionConfigDescription(rName, rDescription2),
+				Config: testAccExtensionConfig_description(rName, rDescription2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "description", rDescription2),
@@ -257,7 +257,7 @@ func TestAccAppConfigExtension_tags(t *testing.T) {
 		CheckDestroy:             testAccCheckExtensionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExtensionConfigTags1(rName, "key1", "value1"),
+				Config: testAccExtensionConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -270,7 +270,7 @@ func TestAccAppConfigExtension_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccExtensionConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccExtensionConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
@@ -279,7 +279,7 @@ func TestAccAppConfigExtension_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExtensionConfigTags1(rName, "key2", "value2"),
+				Config: testAccExtensionConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -301,7 +301,7 @@ func TestAccAppConfigExtension_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckExtensionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExtensionConfigName(rName),
+				Config: testAccExtensionConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfappconfig.ResourceExtension(), resourceName),
@@ -396,7 +396,7 @@ resource "aws_iam_role" "test" {
   `, rName)
 }
 
-func testAccExtensionConfigName(rName string) string {
+func testAccExtensionConfig_name(rName string) string {
 	return acctest.ConfigCompose(
 		testAccExtensionConfigBase(rName),
 		fmt.Sprintf(`
@@ -415,7 +415,7 @@ resource "aws_appconfig_extension" "test" {
 `, rName))
 }
 
-func testAccExtensionConfigDescription(rName string, rDescription string) string {
+func testAccExtensionConfig_description(rName string, rDescription string) string {
 	return acctest.ConfigCompose(
 		testAccExtensionConfigBase(rName),
 		fmt.Sprintf(`
@@ -434,7 +434,7 @@ resource "aws_appconfig_extension" "test" {
 `, rName, rDescription))
 }
 
-func testAccExtensionConfigTags1(rName string, tagKey1 string, tagValue1 string) string {
+func testAccExtensionConfig_tags1(rName string, tagKey1 string, tagValue1 string) string {
 	return acctest.ConfigCompose(
 		testAccExtensionConfigBase(rName),
 		fmt.Sprintf(`
@@ -455,7 +455,7 @@ resource "aws_appconfig_extension" "test" {
 `, rName, tagKey1, tagValue1))
 }
 
-func testAccExtensionConfigTags2(rName string, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
+func testAccExtensionConfig_tags2(rName string, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
 	return acctest.ConfigCompose(
 		testAccExtensionConfigBase(rName),
 		fmt.Sprintf(`
@@ -477,7 +477,7 @@ resource "aws_appconfig_extension" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
-func testAccExtensionConfigActionPoint2(rName string) string {
+func testAccExtensionConfig_actionPoint2(rName string) string {
 	return acctest.ConfigCompose(
 		testAccExtensionConfigBase(rName),
 		fmt.Sprintf(`
@@ -503,7 +503,7 @@ resource "aws_appconfig_extension" "test" {
 `, rName))
 }
 
-func testAccExtensionConfigParameter1(rName string, pName string, pDescription string, pRequired string) string {
+func testAccExtensionConfig_parameter1(rName string, pName string, pDescription string, pRequired string) string {
 	return acctest.ConfigCompose(
 		testAccExtensionConfigBase(rName),
 		fmt.Sprintf(`
@@ -526,7 +526,7 @@ resource "aws_appconfig_extension" "test" {
 `, rName, pName, pDescription, pRequired))
 }
 
-func testAccExtensionConfigParameter2(rName string) string {
+func testAccExtensionConfig_parameter2(rName string) string {
 	return acctest.ConfigCompose(
 		testAccExtensionConfigBase(rName),
 		fmt.Sprintf(`

--- a/internal/service/appconfig/extension_test.go
+++ b/internal/service/appconfig/extension_test.go
@@ -1,0 +1,555 @@
+package appconfig_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appconfig"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfappconfig "github.com/hashicorp/terraform-provider-aws/internal/service/appconfig"
+)
+
+func TestAccAppConfigExtension_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_appconfig_extension.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, appconfig.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExtensionConfigName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionExists(resourceName),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "appconfig", regexp.MustCompile(`extension/*`)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "action_point.0.point", "ON_DEPLOYMENT_COMPLETE"),
+					resource.TestCheckResourceAttr(resourceName, "action_point.0.action.0.name", "test"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAppConfigExtension_ActionPoint(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_appconfig_extension.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, appconfig.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExtensionConfigName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "action_point.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "action_point.*", map[string]string{
+						"point": "ON_DEPLOYMENT_COMPLETE",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "action_point.*.action.*", map[string]string{
+						"name": "test",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccExtensionConfigActionPoint2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "action_point.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "action_point.*", map[string]string{
+						"point": "ON_DEPLOYMENT_COMPLETE",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "action_point.*", map[string]string{
+						"point": "ON_DEPLOYMENT_ROLLED_BACK",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "action_point.*.action.*", map[string]string{
+						"name": "test",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "action_point.*.action.*", map[string]string{
+						"name": "test2",
+					}),
+				),
+			},
+			{
+				Config: testAccExtensionConfigName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "action_point.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "action_point.*", map[string]string{
+						"point": "ON_DEPLOYMENT_COMPLETE",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "action_point.*.action.*", map[string]string{
+						"name": "test",
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAppConfigExtension_Parameter(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_appconfig_extension.test"
+	pName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	pDescription1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	pRequiredTrue := "true"
+	pName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	pDescription2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	pRequiredFalse := "false"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, appconfig.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExtensionConfigParameter1(rName, pName1, pDescription1, pRequiredTrue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":        pName1,
+						"description": pDescription1,
+						"required":    pRequiredTrue,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccExtensionConfigParameter2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "parameter.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":        "parameter1",
+						"description": "description1",
+						"required":    "true",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":        "parameter2",
+						"description": "description2",
+						"required":    "false",
+					}),
+				),
+			},
+			{
+				Config: testAccExtensionConfigParameter1(rName, pName2, pDescription2, pRequiredFalse),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						"name":        pName2,
+						"description": pDescription2,
+						"required":    pRequiredFalse,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAppConfigExtension_Name(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_appconfig_extension.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, appconfig.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExtensionConfigName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccExtensionConfigName(rName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAppConfigExtension_Description(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rDescription := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rDescription2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resourceName := "aws_appconfig_extension.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, appconfig.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExtensionConfigDescription(rName, rDescription),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", rDescription),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccExtensionConfigDescription(rName, rDescription2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", rDescription2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAppConfigExtension_tags(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_appconfig_extension.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, appconfig.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExtensionConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccExtensionConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccExtensionConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAppConfigExtension_disappears(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_appconfig_extension.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, appconfig.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExtensionConfigName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfappconfig.ResourceExtension(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckExtensionDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).AppConfigConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_appconfig_environment" {
+			continue
+		}
+
+		input := &appconfig.GetExtensionInput{
+			ExtensionIdentifier: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.GetExtension(input)
+
+		if tfawserr.ErrCodeEquals(err, appconfig.ErrCodeResourceNotFoundException) {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("error reading AppConfig Extension (%s): %w", rs.Primary.ID, err)
+		}
+
+		if output != nil {
+			return fmt.Errorf("AppConfig Extension (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckExtensionExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Resource not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Resource (%s) ID not set", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AppConfigConn
+
+		in := &appconfig.GetExtensionInput{
+			ExtensionIdentifier: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.GetExtension(in)
+
+		if err != nil {
+			return fmt.Errorf("error reading AppConfig Extension (%s): %w", rs.Primary.ID, err)
+		}
+
+		if output == nil {
+			return fmt.Errorf("AppConfig Extension (%s) not found", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccExtensionConfigBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sns_topic" "test" {
+  name = %[1]q
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["appconfig.amazonaws.com"]
+    }
+  }
+}
+resource "aws_iam_role" "test" {
+  name               = %[1]q
+  assume_role_policy = data.aws_iam_policy_document.test.json
+}
+  `, rName)
+}
+
+func testAccExtensionConfigName(rName string) string {
+	return acctest.ConfigCompose(
+		testAccExtensionConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_appconfig_extension" "test" {
+  name        = %[1]q
+  description = "test description"
+  action_point {
+    point = "ON_DEPLOYMENT_COMPLETE"
+    action {
+      name     = "test"
+      role_arn = aws_iam_role.test.arn
+      uri      = aws_sns_topic.test.arn
+    }
+  }
+}
+`, rName))
+}
+
+func testAccExtensionConfigDescription(rName string, rDescription string) string {
+	return acctest.ConfigCompose(
+		testAccExtensionConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_appconfig_extension" "test" {
+  name        = %[1]q
+  description = %[2]q
+  action_point {
+    point = "ON_DEPLOYMENT_COMPLETE"
+    action {
+      name     = "test"
+      role_arn = aws_iam_role.test.arn
+      uri      = aws_sns_topic.test.arn
+    }
+  }
+}
+`, rName, rDescription))
+}
+
+func testAccExtensionConfigTags1(rName string, tagKey1 string, tagValue1 string) string {
+	return acctest.ConfigCompose(
+		testAccExtensionConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_appconfig_extension" "test" {
+  name = %[1]q
+  action_point {
+    point = "ON_DEPLOYMENT_COMPLETE"
+    action {
+      name     = "test"
+      role_arn = aws_iam_role.test.arn
+      uri      = aws_sns_topic.test.arn
+    }
+  }
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1))
+}
+
+func testAccExtensionConfigTags2(rName string, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
+	return acctest.ConfigCompose(
+		testAccExtensionConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_appconfig_extension" "test" {
+  name = %[1]q
+  action_point {
+    point = "ON_DEPLOYMENT_COMPLETE"
+    action {
+      name     = "test"
+      role_arn = aws_iam_role.test.arn
+      uri      = aws_sns_topic.test.arn
+    }
+  }
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
+}
+
+func testAccExtensionConfigActionPoint2(rName string) string {
+	return acctest.ConfigCompose(
+		testAccExtensionConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_appconfig_extension" "test" {
+  name = %[1]q
+  action_point {
+    point = "ON_DEPLOYMENT_COMPLETE"
+    action {
+      name     = "test"
+      role_arn = aws_iam_role.test.arn
+      uri      = aws_sns_topic.test.arn
+    }
+  }
+  action_point {
+    point = "ON_DEPLOYMENT_ROLLED_BACK"
+    action {
+      name     = "test2"
+      role_arn = aws_iam_role.test.arn
+      uri      = aws_sns_topic.test.arn
+    }
+  }
+}
+`, rName))
+}
+
+func testAccExtensionConfigParameter1(rName string, pName string, pDescription string, pRequired string) string {
+	return acctest.ConfigCompose(
+		testAccExtensionConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_appconfig_extension" "test" {
+  name = %[1]q
+  action_point {
+    point = "ON_DEPLOYMENT_COMPLETE"
+    action {
+      name     = "test"
+      role_arn = aws_iam_role.test.arn
+      uri      = aws_sns_topic.test.arn
+    }
+  }
+  parameter {
+    name        = %[2]q
+    description = %[3]q
+    required    = %[4]s
+  }
+}
+`, rName, pName, pDescription, pRequired))
+}
+
+func testAccExtensionConfigParameter2(rName string) string {
+	return acctest.ConfigCompose(
+		testAccExtensionConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_appconfig_extension" "test" {
+  name = %[1]q
+  action_point {
+    point = "ON_DEPLOYMENT_COMPLETE"
+    action {
+      name     = "test"
+      role_arn = aws_iam_role.test.arn
+      uri      = aws_sns_topic.test.arn
+    }
+  }
+  parameter {
+    name        = "parameter1"
+    description = "description1"
+    required    = true
+  }
+  parameter {
+    name        = "parameter2"
+    description = "description2"
+    required    = false
+  }
+}
+`, rName))
+}

--- a/internal/service/appconfig/extenstion_association_test.go
+++ b/internal/service/appconfig/extenstion_association_test.go
@@ -27,7 +27,7 @@ func TestAccAppConfigExtensionAssociation_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckExtensionAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExtensionAssociationConfigName(rName),
+				Config: testAccExtensionAssociationConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionAssociationExists(resourceName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "extension_arn", "appconfig", regexp.MustCompile(`extension/*`)),
@@ -62,7 +62,7 @@ func TestAccAppConfigExtensionAssociation_Parameters(t *testing.T) {
 		CheckDestroy:             testAccCheckExtensionAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExtensionAssociationConfigParameter1(rName, pName1, pDescription1, pRequiredTrue, pValue1),
+				Config: testAccExtensionAssociationConfig_parameters1(rName, pName1, pDescription1, pRequiredTrue, pValue1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
@@ -75,7 +75,7 @@ func TestAccAppConfigExtensionAssociation_Parameters(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccExtensionAssociationConfigParameter2(rName),
+				Config: testAccExtensionAssociationConfig_parameters2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "2"),
@@ -84,7 +84,7 @@ func TestAccAppConfigExtensionAssociation_Parameters(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExtensionAssociationConfigParameter1(rName, pName2, pDescription2, pRequiredFalse, pValue2),
+				Config: testAccExtensionAssociationConfig_parameters1(rName, pName2, pDescription2, pRequiredFalse, pValue2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
@@ -92,7 +92,7 @@ func TestAccAppConfigExtensionAssociation_Parameters(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccExtensionAssociationConfigParameterNotRequired(rName, pName2, pDescription2, pRequiredFalse, pValue2),
+				Config: testAccExtensionAssociationConfig_parametersNotRequired(rName, pName2, pDescription2, pRequiredFalse, pValue2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
@@ -113,7 +113,7 @@ func TestAccAppConfigExtensionAssociation_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckExtensionAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExtensionAssociationConfigName(rName),
+				Config: testAccExtensionAssociationConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExtensionAssociationExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfappconfig.ResourceExtensionAssociation(), resourceName),
@@ -195,7 +195,7 @@ resource "aws_appconfig_application" "test" {
 `, rName))
 }
 
-func testAccExtensionAssociationConfigName(rName string) string {
+func testAccExtensionAssociationConfig_name(rName string) string {
 	return acctest.ConfigCompose(
 		testAccExtensionAssociationConfigBase(rName),
 		fmt.Sprintf(`
@@ -218,7 +218,7 @@ resource "aws_appconfig_extension_association" "test" {
 `, rName))
 }
 
-func testAccExtensionAssociationConfigParameter1(rName string, pName string, pDescription string, pRequired string, pValue string) string {
+func testAccExtensionAssociationConfig_parameters1(rName string, pName string, pDescription string, pRequired string, pValue string) string {
 	return acctest.ConfigCompose(
 		testAccExtensionAssociationConfigBase(rName),
 		fmt.Sprintf(`
@@ -248,7 +248,7 @@ resource "aws_appconfig_extension_association" "test" {
 `, rName, pName, pDescription, pRequired, pValue))
 }
 
-func testAccExtensionAssociationConfigParameter2(rName string) string {
+func testAccExtensionAssociationConfig_parameters2(rName string) string {
 	return acctest.ConfigCompose(
 		testAccExtensionAssociationConfigBase(rName),
 		fmt.Sprintf(`
@@ -284,7 +284,7 @@ resource "aws_appconfig_extension_association" "test" {
 `, rName))
 }
 
-func testAccExtensionAssociationConfigParameterNotRequired(rName string, pName string, pDescription string, pRequired string, pValue string) string {
+func testAccExtensionAssociationConfig_parametersNotRequired(rName string, pName string, pDescription string, pRequired string, pValue string) string {
 	return acctest.ConfigCompose(
 		testAccExtensionAssociationConfigBase(rName),
 		fmt.Sprintf(`

--- a/internal/service/appconfig/extenstion_association_test.go
+++ b/internal/service/appconfig/extenstion_association_test.go
@@ -1,0 +1,312 @@
+package appconfig_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appconfig"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfappconfig "github.com/hashicorp/terraform-provider-aws/internal/service/appconfig"
+)
+
+func TestAccAppConfigExtensionAssociation_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_appconfig_extension_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, appconfig.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExtensionAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExtensionAssociationConfigName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionAssociationExists(resourceName),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "extension_arn", "appconfig", regexp.MustCompile(`extension/*`)),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "resource_arn", "appconfig", regexp.MustCompile(`application/*`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAppConfigExtensionAssociation_Parameters(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_appconfig_extension_association.test"
+	pName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	pDescription1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	pRequiredTrue := "true"
+	pValue1 := "ParameterValue1"
+	pName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	pDescription2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	pRequiredFalse := "false"
+	pValue2 := "ParameterValue2"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, appconfig.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExtensionAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExtensionAssociationConfigParameter1(rName, pName1, pDescription1, pRequiredTrue, pValue1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionAssociationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf("parameters.%s", pName1), pValue1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccExtensionAssociationConfigParameter2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionAssociationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.parameter1", pValue1),
+					resource.TestCheckResourceAttr(resourceName, "parameters.parameter2", pValue2),
+				),
+			},
+			{
+				Config: testAccExtensionAssociationConfigParameter1(rName, pName2, pDescription2, pRequiredFalse, pValue2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionAssociationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf("parameters.%s", pName2), pValue2),
+				),
+			},
+			{
+				Config: testAccExtensionAssociationConfigParameterNotRequired(rName, pName2, pDescription2, pRequiredFalse, pValue2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionAssociationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAppConfigExtensionAssociation_disappears(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_appconfig_extension_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, appconfig.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExtensionAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExtensionAssociationConfigName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExtensionAssociationExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfappconfig.ResourceExtensionAssociation(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckExtensionAssociationDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).AppConfigConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_appconfig_environment" {
+			continue
+		}
+
+		input := &appconfig.GetExtensionAssociationInput{
+			ExtensionAssociationId: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.GetExtensionAssociation(input)
+
+		if tfawserr.ErrCodeEquals(err, appconfig.ErrCodeResourceNotFoundException) {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("error reading AppConfig ExtensionAssociation (%s): %w", rs.Primary.ID, err)
+		}
+
+		if output != nil {
+			return fmt.Errorf("AppConfig ExtensionAssociation (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckExtensionAssociationExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Resource not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Resource (%s) ID not set", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AppConfigConn
+
+		in := &appconfig.GetExtensionAssociationInput{
+			ExtensionAssociationId: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.GetExtensionAssociation(in)
+
+		if err != nil {
+			return fmt.Errorf("error reading AppConfig ExtensionAssociation (%s): %w", rs.Primary.ID, err)
+		}
+
+		if output == nil {
+			return fmt.Errorf("AppConfig ExtensionAssociation (%s) not found", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccExtensionAssociationConfigBase(rName string) string {
+	return acctest.ConfigCompose(
+		testAccExtensionConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_appconfig_application" "test" {
+  name = %[1]q
+}
+`, rName))
+}
+
+func testAccExtensionAssociationConfigName(rName string) string {
+	return acctest.ConfigCompose(
+		testAccExtensionAssociationConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_appconfig_extension" "test" {
+  name        = %[1]q
+  description = "test description"
+  action_point {
+    point = "ON_DEPLOYMENT_COMPLETE"
+    action {
+      name     = "test"
+      role_arn = aws_iam_role.test.arn
+      uri      = aws_sns_topic.test.arn
+    }
+  }
+}
+resource "aws_appconfig_extension_association" "test" {
+  extension_arn = aws_appconfig_extension.test.arn
+  resource_arn  = aws_appconfig_application.test.arn
+}
+`, rName))
+}
+
+func testAccExtensionAssociationConfigParameter1(rName string, pName string, pDescription string, pRequired string, pValue string) string {
+	return acctest.ConfigCompose(
+		testAccExtensionAssociationConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_appconfig_extension" "test" {
+  name = %[1]q
+  action_point {
+    point = "ON_DEPLOYMENT_COMPLETE"
+    action {
+      name     = "test"
+      role_arn = aws_iam_role.test.arn
+      uri      = aws_sns_topic.test.arn
+    }
+  }
+  parameter {
+    name        = %[2]q
+    description = %[3]q
+    required    = %[4]s
+  }
+}
+resource "aws_appconfig_extension_association" "test" {
+  extension_arn = aws_appconfig_extension.test.arn
+  resource_arn  = aws_appconfig_application.test.arn
+  parameters = {
+    %[2]s = %[5]q
+  }
+}
+`, rName, pName, pDescription, pRequired, pValue))
+}
+
+func testAccExtensionAssociationConfigParameter2(rName string) string {
+	return acctest.ConfigCompose(
+		testAccExtensionAssociationConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_appconfig_extension" "test" {
+  name = %[1]q
+  action_point {
+    point = "ON_DEPLOYMENT_COMPLETE"
+    action {
+      name     = "test"
+      role_arn = aws_iam_role.test.arn
+      uri      = aws_sns_topic.test.arn
+    }
+  }
+  parameter {
+    name        = "parameter1"
+    description = "description1"
+    required    = true
+  }
+  parameter {
+    name        = "parameter2"
+    description = "description2"
+    required    = false
+  }
+}
+resource "aws_appconfig_extension_association" "test" {
+  extension_arn = aws_appconfig_extension.test.arn
+  resource_arn  = aws_appconfig_application.test.arn
+  parameters = {
+    parameter1 = "ParameterValue1"
+    parameter2 = "ParameterValue2"
+  }
+}
+`, rName))
+}
+
+func testAccExtensionAssociationConfigParameterNotRequired(rName string, pName string, pDescription string, pRequired string, pValue string) string {
+	return acctest.ConfigCompose(
+		testAccExtensionAssociationConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_appconfig_extension" "test" {
+  name = %[1]q
+  action_point {
+    point = "ON_DEPLOYMENT_COMPLETE"
+    action {
+      name     = "test"
+      role_arn = aws_iam_role.test.arn
+      uri      = aws_sns_topic.test.arn
+    }
+  }
+  parameter {
+    name        = %[2]q
+    description = %[3]q
+    required    = %[4]s
+  }
+}
+resource "aws_appconfig_extension_association" "test" {
+  extension_arn = aws_appconfig_extension.test.arn
+  resource_arn  = aws_appconfig_application.test.arn
+}
+`, rName, pName, pDescription, pRequired, pValue))
+}

--- a/internal/service/appconfig/find.go
+++ b/internal/service/appconfig/find.go
@@ -1,0 +1,55 @@
+package appconfig
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appconfig"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func FindExtensionById(ctx context.Context, conn *appconfig.AppConfig, id string) (*appconfig.GetExtensionOutput, error) {
+	in := &appconfig.GetExtensionInput{ExtensionIdentifier: aws.String(id)}
+	out, err := conn.GetExtensionWithContext(ctx, in)
+
+	if tfawserr.ErrCodeEquals(err, appconfig.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}
+
+func FindExtensionAssociationById(ctx context.Context, conn *appconfig.AppConfig, id string) (*appconfig.GetExtensionAssociationOutput, error) {
+	in := &appconfig.GetExtensionAssociationInput{ExtensionAssociationId: aws.String(id)}
+	out, err := conn.GetExtensionAssociationWithContext(ctx, in)
+
+	if tfawserr.ErrCodeEquals(err, appconfig.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}

--- a/website/docs/r/appconfig_extension.html.markdown
+++ b/website/docs/r/appconfig_extension.html.markdown
@@ -76,6 +76,14 @@ The `action` configuration block supports configuring any number of the followin
 * `uri` - (Required) The extension URI associated to the action point in the extension definition. The URI can be an Amazon Resource Name (ARN) for one of the following: an Lambda function, an Amazon Simple Queue Service queue, an Amazon Simple Notification Service topic, or the Amazon EventBridge default event bus.
 * `description` - (Optional) Information about the action.
 
+#### `parameter`
+
+The `parameter` configuration block supports configuring any number of the following arguments:
+
+* `name` - (Required) The parameter name.
+* `required` - (Required) Determines if a parameter value must be specified in the extension association.
+* `description` - (Optional) Information about the parameter.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/website/docs/r/appconfig_extension.html.markdown
+++ b/website/docs/r/appconfig_extension.html.markdown
@@ -1,0 +1,93 @@
+---
+subcategory: "AppConfig"
+layout: "aws"
+page_title: "AWS: aws_appconfig_extension"
+description: |-
+  Provides an AppConfig Extension resource.
+---
+
+# Resource: aws_appconfig_extension
+
+Provides an AppConfig Extension resource.
+
+## Example Usage
+
+```terraform
+resource "aws_sns_topic" "test" {
+  name = "test"
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["appconfig.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name               = "test"
+  assume_role_policy = data.aws_iam_policy_document.test.json
+}
+
+resource "aws_appconfig_extension" "test" {
+  name        = "test"
+  description = "test description"
+  action_point {
+    point = "ON_DEPLOYMENT_COMPLETE"
+    action {
+      name     = "test"
+      role_arn = aws_iam_role.test.arn
+      uri      = aws_sns_topic.test.arn
+    }
+  }
+  tags = {
+    Type = "AppConfig Extension"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A name for the extension. Each extension name in your account must be unique. Extension versions use the same name.
+* `description` - (Optional) Information about the extension.
+* `action_point` - (Required) The action points defined in the extension. [Detailed below](#action_point).
+* `parameter` - (Optional) The parameters accepted by the extension. You specify parameter values when you associate the extension to an AppConfig resource by using the CreateExtensionAssociation API action. For Lambda extension actions, these parameters are included in the Lambda request object. [Detailed below](#parameter).
+* `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### `action_point`
+
+Defines the actions the extension performs during the AppConfig workflow and at which point those actions are performed. The `action_point` configuration block supports the following arguments:
+
+* `point` - (Required) The point at which to perform the defined actions. Valid points are `PRE_CREATE_HOSTED_CONFIGURATION_VERSION`, `PRE_START_DEPLOYMENT`, `ON_DEPLOYMENT_START`, `ON_DEPLOYMENT_STEP`, `ON_DEPLOYMENT_BAKING`, `ON_DEPLOYMENT_COMPLETE`, `ON_DEPLOYMENT_ROLLED_BACK`.
+* `action` - (Required) An action defines the tasks the extension performs during the AppConfig workflow. [Detailed below](#action).
+
+#### `action`
+
+The `action` configuration block supports configuring any number of the following arguments:
+
+* `name` - (Required) The action name.
+* `role_arn` - (Required) An Amazon Resource Name (ARN) for an Identity and Access Management assume role.
+* `uri` - (Required) The extension URI associated to the action point in the extension definition. The URI can be an Amazon Resource Name (ARN) for one of the following: an Lambda function, an Amazon Simple Queue Service queue, an Amazon Simple Notification Service topic, or the Amazon EventBridge default event bus.
+* `description` - (Optional) Information about the action.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the AppConfig Extension.
+* `id` - AppConfig Extension ID.
+* `version` - The version number for the extension.
+
+## Import
+
+AppConfig Extensions can be imported using their extension ID, e.g.,
+
+```
+$ terraform import aws_appconfig_extension.example 71rxuzt
+```

--- a/website/docs/r/appconfig_extension_association.html.markdown
+++ b/website/docs/r/appconfig_extension_association.html.markdown
@@ -1,0 +1,84 @@
+---
+subcategory: "AppConfig"
+layout: "aws"
+page_title: "AWS: aws_appconfig_extension_association"
+description: |-
+  Associates an AppConfig Extension with a Resource.
+---
+
+# Resource: aws_appconfig_extension_association
+
+Associates an AppConfig Extension with a Resource.
+
+## Example Usage
+
+```terraform
+resource "aws_sns_topic" "test" {
+  name = "test"
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["appconfig.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name               = "test"
+  assume_role_policy = data.aws_iam_policy_document.test.json
+}
+
+resource "aws_appconfig_extension" "test" {
+  name        = "test"
+  description = "test description"
+  action_point {
+    point = "ON_DEPLOYMENT_COMPLETE"
+    action {
+      name     = "test"
+      role_arn = aws_iam_role.test.arn
+      uri      = aws_sns_topic.test.arn
+    }
+  }
+  tags = {
+    Type = "AppConfig Extension"
+  }
+}
+
+resource "aws_appconfig_application" "test" {
+  name = "test"
+}
+
+resource "aws_appconfig_extension_association" "test" {
+  extension_arn = aws_appconfig_extension.test.arn
+  resource_arn  = aws_appconfig_application.test.arn
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `extension_arn` - (Required) The ARN of the extension defined in the association.
+* `resource_arn` - (Optional) The ARN of the application, configuration profile, or environment to associate with the extension.
+* `parameters` - (Optional) The parameter names and values defined for the association.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the AppConfig Extension Association.
+* `id` - AppConfig Extension Association ID.
+* `extension_version` - The version number for the extension defined in the association.
+
+## Import
+
+AppConfig Extension Associations can be imported using their extension association ID, e.g.,
+
+```
+$ terraform import aws_appconfig_extension_association.example 71rxuzt
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This implements the `aws_appconfig_extension` and `aws_appconfig_extension_association` resources. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.amazonaws.cn/en_us/appconfig/latest/userguide/working-with-appconfig-extensions-about.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccAppConfigExtension' PKG=appconfig
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appconfig/... -v -count 1 -parallel 20  -run=TestAccAppConfigExtension -timeout 180m
=== RUN   TestAccAppConfigExtension_basic
=== PAUSE TestAccAppConfigExtension_basic
=== RUN   TestAccAppConfigExtension_ActionPoint
=== PAUSE TestAccAppConfigExtension_ActionPoint
=== RUN   TestAccAppConfigExtension_Parameter
=== PAUSE TestAccAppConfigExtension_Parameter
=== RUN   TestAccAppConfigExtension_Name
=== PAUSE TestAccAppConfigExtension_Name
=== RUN   TestAccAppConfigExtension_Description
=== PAUSE TestAccAppConfigExtension_Description
=== RUN   TestAccAppConfigExtension_tags
=== PAUSE TestAccAppConfigExtension_tags
=== RUN   TestAccAppConfigExtension_disappears
=== PAUSE TestAccAppConfigExtension_disappears
=== RUN   TestAccAppConfigExtensionAssociation_basic
=== PAUSE TestAccAppConfigExtensionAssociation_basic
=== RUN   TestAccAppConfigExtensionAssociation_Parameters
=== PAUSE TestAccAppConfigExtensionAssociation_Parameters
=== RUN   TestAccAppConfigExtensionAssociation_disappears
=== PAUSE TestAccAppConfigExtensionAssociation_disappears
=== CONT  TestAccAppConfigExtension_basic
=== CONT  TestAccAppConfigExtension_tags
=== CONT  TestAccAppConfigExtension_Name
=== CONT  TestAccAppConfigExtension_Description
=== CONT  TestAccAppConfigExtensionAssociation_disappears
=== CONT  TestAccAppConfigExtensionAssociation_Parameters
=== CONT  TestAccAppConfigExtensionAssociation_basic
=== CONT  TestAccAppConfigExtension_disappears
=== CONT  TestAccAppConfigExtension_Parameter
=== CONT  TestAccAppConfigExtension_ActionPoint
--- PASS: TestAccAppConfigExtensionAssociation_disappears (25.62s)
--- PASS: TestAccAppConfigExtension_disappears (27.38s)
--- PASS: TestAccAppConfigExtension_basic (30.73s)
--- PASS: TestAccAppConfigExtensionAssociation_basic (32.25s)
--- PASS: TestAccAppConfigExtension_Description (44.47s)
--- PASS: TestAccAppConfigExtension_Name (45.22s)
--- PASS: TestAccAppConfigExtension_Parameter (55.93s)
--- PASS: TestAccAppConfigExtension_tags (56.60s)
--- PASS: TestAccAppConfigExtension_ActionPoint (58.29s)
--- PASS: TestAccAppConfigExtensionAssociation_Parameters (65.88s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appconfig  67.871s

...
```
