### PR TITLE
r/aws_medialive_channel: start/stop channel

### DIFF
--- a/.changelog/27882.txt
+++ b/.changelog/27882.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_medialive_channel: Add `start_channel` attribute
+```

--- a/internal/enum/validate.go
+++ b/internal/enum/validate.go
@@ -1,10 +1,16 @@
 package enum
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func Validate[T valueser[T]]() schema.SchemaValidateDiagFunc {
 	return validation.ToDiagFunc(validation.StringInSlice(Values[T](), false))
+}
+
+func FrameworkValidate[T valueser[T]]() tfsdk.AttributeValidator {
+	return stringvalidator.OneOf(Values[T]()...)
 }

--- a/internal/service/medialive/channel.go
+++ b/internal/service/medialive/channel.go
@@ -3,6 +3,7 @@ package medialive
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"time"
 
@@ -655,6 +656,11 @@ func ResourceChannel() *schema.Resource {
 				Optional:         true,
 				ValidateDiagFunc: validation.ToDiagFunc(verify.ValidARN),
 			},
+			"start_channel": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"vpc": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -757,6 +763,12 @@ func resourceChannelCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return create.DiagError(names.MediaLive, create.ErrActionWaitingForCreation, ResNameChannel, d.Id(), err)
 	}
 
+	if d.Get("start_channel").(bool) {
+		if err := startChannel(ctx, conn, d.Timeout(schema.TimeoutCreate), d.Id()); err != nil {
+			return create.DiagError(names.MediaLive, create.ErrActionCreating, ResNameChannel, d.Get("name").(string), err)
+		}
+	}
+
 	return resourceChannelRead(ctx, d, meta)
 }
 
@@ -827,7 +839,7 @@ func resourceChannelRead(ctx context.Context, d *schema.ResourceData, meta inter
 func resourceChannelUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).MediaLiveClient
 
-	if d.HasChangesExcept("tags", "tags_all") {
+	if d.HasChangesExcept("tags", "tags_all", "start_channel") {
 		in := &medialive.UpdateChannelInput{
 			ChannelId: aws.String(d.Id()),
 		}
@@ -868,6 +880,18 @@ func resourceChannelUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			in.RoleArn = aws.String(d.Get("role_arn").(string))
 		}
 
+		channel, err := FindChannelByID(ctx, conn, d.Id())
+
+		if err != nil {
+			return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
+		}
+
+		if channel.State == types.ChannelStateRunning {
+			if err := stopChannel(ctx, conn, d.Timeout(schema.TimeoutUpdate), d.Id()); err != nil {
+				return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
+			}
+		}
+
 		log.Printf("[DEBUG] Updating MediaLive Channel (%s): %#v", d.Id(), in)
 		out, err := conn.UpdateChannel(ctx, in)
 		if err != nil {
@@ -879,11 +903,40 @@ func resourceChannelUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 	}
 
+	if d.Get("start_channel").(bool) {
+		if err := startChannel(ctx, conn, d.Timeout(schema.TimeoutUpdate), d.Id()); err != nil {
+			return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Get("name").(string), err)
+		}
+	}
+
 	if d.HasChange("tags_all") {
 		o, n := d.GetChange("tags_all")
 
 		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
 			return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
+		}
+	}
+
+	if d.HasChange("start_channel") {
+		channel, err := FindChannelByID(ctx, conn, d.Id())
+
+		if err != nil {
+			return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
+		}
+
+		switch d.Get("start_channel").(bool) {
+		case true:
+			if channel.State == types.ChannelStateIdle {
+				if err := startChannel(ctx, conn, d.Timeout(schema.TimeoutUpdate), d.Id()); err != nil {
+					return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
+				}
+			}
+		default:
+			if channel.State == types.ChannelStateRunning {
+				if err := stopChannel(ctx, conn, d.Timeout(schema.TimeoutUpdate), d.Id()); err != nil {
+					return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
+				}
+			}
 		}
 	}
 
@@ -910,6 +963,42 @@ func resourceChannelDelete(ctx context.Context, d *schema.ResourceData, meta int
 
 	if _, err := waitChannelDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 		return create.DiagError(names.MediaLive, create.ErrActionWaitingForDeletion, ResNameChannel, d.Id(), err)
+	}
+
+	return nil
+}
+
+func startChannel(ctx context.Context, conn *medialive.Client, timeout time.Duration, id string) error {
+	_, err := conn.StartChannel(ctx, &medialive.StartChannelInput{
+		ChannelId: aws.String(id),
+	})
+
+	if err != nil {
+		return fmt.Errorf("starting Medialive Channel (%s): %s", id, err)
+	}
+
+	_, err = waitChannelStarted(ctx, conn, id, timeout)
+
+	if err != nil {
+		return fmt.Errorf("waiting for Medialive Channel (%s) start: %s", id, err)
+	}
+
+	return nil
+}
+
+func stopChannel(ctx context.Context, conn *medialive.Client, timeout time.Duration, id string) error {
+	_, err := conn.StopChannel(ctx, &medialive.StopChannelInput{
+		ChannelId: aws.String(id),
+	})
+
+	if err != nil {
+		return fmt.Errorf("stopping Medialive Channel (%s): %s", id, err)
+	}
+
+	_, err = waitChannelStopped(ctx, conn, id, timeout)
+
+	if err != nil {
+		return fmt.Errorf("waiting for Medialive Channel (%s) stop: %s", id, err)
 	}
 
 	return nil
@@ -955,6 +1044,38 @@ func waitChannelDeleted(ctx context.Context, conn *medialive.Client, id string, 
 	stateConf := &resource.StateChangeConf{
 		Pending: enum.Slice(types.ChannelStateDeleting),
 		Target:  []string{},
+		Refresh: statusChannel(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*medialive.DescribeChannelOutput); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+func waitChannelStarted(ctx context.Context, conn *medialive.Client, id string, timeout time.Duration) (*medialive.DescribeChannelOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: enum.Slice(types.ChannelStateStarting),
+		Target:  enum.Slice(types.ChannelStateRunning),
+		Refresh: statusChannel(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*medialive.DescribeChannelOutput); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+func waitChannelStopped(ctx context.Context, conn *medialive.Client, id string, timeout time.Duration) (*medialive.DescribeChannelOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: enum.Slice(types.ChannelStateStopping),
+		Target:  enum.Slice(types.ChannelStateIdle),
 		Refresh: statusChannel(ctx, conn, id),
 		Timeout: timeout,
 	}

--- a/internal/service/medialive/channel.go
+++ b/internal/service/medialive/channel.go
@@ -891,7 +891,7 @@ func resourceChannelUpdate(ctx context.Context, d *schema.ResourceData, meta int
 				return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
 			}
 		}
-		
+
 		out, err := conn.UpdateChannel(ctx, in)
 		if err != nil {
 			return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)

--- a/internal/service/medialive/channel.go
+++ b/internal/service/medialive/channel.go
@@ -891,8 +891,7 @@ func resourceChannelUpdate(ctx context.Context, d *schema.ResourceData, meta int
 				return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)
 			}
 		}
-
-		log.Printf("[DEBUG] Updating MediaLive Channel (%s): %#v", d.Id(), in)
+		
 		out, err := conn.UpdateChannel(ctx, in)
 		if err != nil {
 			return create.DiagError(names.MediaLive, create.ErrActionUpdating, ResNameChannel, d.Id(), err)

--- a/internal/service/medialive/channel_test.go
+++ b/internal/service/medialive/channel_test.go
@@ -372,11 +372,11 @@ func testAccCheckChannelStatus(name string, state types.ChannelState) resource.T
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
-			return create.Error(names.MediaLive, "checking status", tfmedialive.ResNameChannel, name, errors.New("not found"))
+			return create.Error(names.MediaLive, create.ErrActionChecking, tfmedialive.ResNameChannel, name, errors.New("not found"))
 		}
 
 		if rs.Primary.ID == "" {
-			return create.Error(names.MediaLive, "checking status", tfmedialive.ResNameChannel, name, errors.New("not set"))
+			return create.Error(names.MediaLive, create.ErrActionChecking, tfmedialive.ResNameChannel, name, errors.New("not set"))
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).MediaLiveClient
@@ -384,11 +384,11 @@ func testAccCheckChannelStatus(name string, state types.ChannelState) resource.T
 		resp, err := tfmedialive.FindChannelByID(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
-			return create.Error(names.MediaLive, create.ErrActionCheckingExistence, tfmedialive.ResNameChannel, rs.Primary.ID, err)
+			return create.Error(names.MediaLive, create.ErrActionChecking, tfmedialive.ResNameChannel, rs.Primary.ID, err)
 		}
 
 		if resp.State != state {
-			return create.Error(names.MediaLive, "checking status", tfmedialive.ResNameChannel, rs.Primary.ID, fmt.Errorf("not (%s) got: %s", state, resp.State))
+			return create.Error(names.MediaLive, create.ErrActionChecking, tfmedialive.ResNameChannel, rs.Primary.ID, fmt.Errorf("not (%s) got: %s", state, resp.State))
 		}
 
 		return nil

--- a/internal/service/medialive/channel_test.go
+++ b/internal/service/medialive/channel_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/medialive"
+	"github.com/aws/aws-sdk-go-v2/service/medialive/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -65,9 +66,10 @@ func TestAccMediaLiveChannel_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"start_channel"},
 			},
 		},
 	})
@@ -118,6 +120,43 @@ func TestAccMediaLiveChannel_hls(t *testing.T) {
 						"name": "test-video-name",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "encoder_settings.0.output_groups.0.outputs.0.output_settings.0.hls_output_settings.0.h265_packaging_type", "HVC1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMediaLiveChannel_status(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var channel medialive.DescribeChannelOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_medialive_channel.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.MediaLiveEndpointID, t)
+			testAccChannelsPreCheck(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccChannelConfig_start(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckChannelExists(resourceName, &channel),
+					testAccCheckChannelStatus(resourceName, types.ChannelStateRunning),
+				),
+			},
+			{
+				Config: testAccChannelConfig_start(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckChannelExists(resourceName, &channel),
+					testAccCheckChannelStatus(resourceName, types.ChannelStateIdle),
 				),
 			},
 		},
@@ -324,6 +363,33 @@ func testAccCheckChannelExists(name string, channel *medialive.DescribeChannelOu
 		}
 
 		*channel = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckChannelStatus(name string, state types.ChannelState) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.MediaLive, "checking status", tfmedialive.ResNameChannel, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.MediaLive, "checking status", tfmedialive.ResNameChannel, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).MediaLiveClient
+		ctx := context.Background()
+		resp, err := tfmedialive.FindChannelByID(ctx, conn, rs.Primary.ID)
+
+		if err != nil {
+			return create.Error(names.MediaLive, create.ErrActionCheckingExistence, tfmedialive.ResNameChannel, rs.Primary.ID, err)
+		}
+
+		if resp.State != state {
+			return create.Error(names.MediaLive, "checking status", tfmedialive.ResNameChannel, rs.Primary.ID, fmt.Errorf("not (%s) got: %s", state, resp.State))
+		}
 
 		return nil
 	}
@@ -601,6 +667,88 @@ resource "aws_medialive_channel" "test" {
   }
 }
 `, rName))
+}
+
+func testAccChannelConfig_start(rName string, start bool) string {
+	return acctest.ConfigCompose(
+		testAccChannelBaseConfig(rName),
+		testAccChannelBaseS3Config(rName),
+		testAccChannelBaseMultiplexConfig(rName),
+		fmt.Sprintf(`
+resource "aws_medialive_channel" "test" {
+  name          = %[1]q
+  channel_class = "STANDARD"
+  role_arn      = aws_iam_role.test.arn
+  start_channel = %[2]t
+
+  input_specification {
+    codec            = "AVC"
+    input_resolution = "HD"
+    maximum_bitrate  = "MAX_20_MBPS"
+  }
+
+  input_attachments {
+    input_attachment_name = "example-input1"
+    input_id              = aws_medialive_input.test.id
+  }
+
+  destinations {
+    id = %[1]q
+
+    settings {
+      url = "s3://${aws_s3_bucket.test1.id}/test1"
+    }
+
+    settings {
+      url = "s3://${aws_s3_bucket.test2.id}/test2"
+    }
+  }
+
+  encoder_settings {
+    timecode_config {
+      source = "EMBEDDED"
+    }
+
+    audio_descriptions {
+      audio_selector_name = %[1]q
+      name                = %[1]q
+    }
+
+    video_descriptions {
+      name = "test-video-name"
+    }
+
+    output_groups {
+      output_group_settings {
+        archive_group_settings {
+          destination {
+            destination_ref_id = %[1]q
+          }
+        }
+      }
+
+      outputs {
+        output_name             = "test-output-name"
+        video_description_name  = "test-video-name"
+        audio_description_names = [%[1]q]
+        output_settings {
+          archive_output_settings {
+            name_modifier = "_1"
+            extension     = "m2ts"
+            container_settings {
+              m2ts_settings {
+                audio_buffer_model = "ATSC"
+                buffer_model       = "MULTIPLEX"
+                rate_mode          = "CBR"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, rName, start))
 }
 
 func testAccChannelConfig_update(rName, codec, inputResolution string) string {

--- a/internal/service/medialive/multiplex_program.go
+++ b/internal/service/medialive/multiplex_program.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/medialive"
 	mltypes "github.com/aws/aws-sdk-go-v2/service/medialive/types"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -18,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	resourceHelper "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -76,7 +76,7 @@ func (m *multiplexProgram) GetSchema(context.Context) (tfsdk.Schema, diag.Diagno
 						Type:     types.StringType,
 						Required: true,
 						Validators: []tfsdk.AttributeValidator{
-							stringvalidator.OneOf(preferredChannelPipelineToSlice(mltypes.PreferredChannelPipeline("").Values())...),
+							enum.FrameworkValidate[mltypes.PreferredChannelPipeline](),
 						},
 					},
 				},
@@ -663,15 +663,6 @@ func flattenVideoSettings(mps *mltypes.MultiplexVideoSettings, stateMuxIsNull bo
 		Elems:    []attr.Value{vals},
 		ElemType: elemType,
 	}
-}
-
-func preferredChannelPipelineToSlice(p []mltypes.PreferredChannelPipeline) []string {
-	s := make([]string, 0)
-
-	for _, v := range p {
-		s = append(s, string(v))
-	}
-	return s
 }
 
 func ParseMultiplexProgramID(id string) (programName string, multiplexId string, err error) {

--- a/website/docs/r/medialive_channel.html.markdown
+++ b/website/docs/r/medialive_channel.html.markdown
@@ -107,6 +107,7 @@ The following arguments are optional:
 * `log_level` - (Optional) The log level to write to Cloudwatch logs.
 * `maintenance` - (Optional) Maintenance settings for this channel. See [Maintenance](#maintenance) for more details.
 * `role_arn` - (Optional) Concise argument description.
+* `start_channel` - (Optional) Whether to start/stop channel. Default: `false`
 * `tags` - (Optional) A map of tags to assign to the channel. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `vpc` - (Optional) Settings for the VPC outputs.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
 
start/stop `aws_medialive_channel`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

--->

Closes #27706

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccMediaLiveChannel_status' PKG=medialive

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/medialive/... -v -count 1 -parallel 20  -run=TestAccMediaLiveChannel_status -timeout 180m
=== RUN   TestAccMediaLiveChannel_status
=== PAUSE TestAccMediaLiveChannel_status
=== CONT  TestAccMediaLiveChannel_status
--- PASS: TestAccMediaLiveChannel_status (203.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	205.829s
...
```
