### PR TITLE
Upgrade to v0.16.0 of Terraform Plugin Framework

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.15.0
 	github.com/hashicorp/terraform-plugin-framework v0.16.0
-	github.com/hashicorp/terraform-plugin-framework-validators v0.5.0
+	github.com/hashicorp/terraform-plugin-framework-validators v0.6.0
 	github.com/hashicorp/terraform-plugin-go v0.14.1
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-mux v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl/v2 v2.15.0
-	github.com/hashicorp/terraform-plugin-framework v0.14.0
+	github.com/hashicorp/terraform-plugin-framework v0.16.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.5.0
 	github.com/hashicorp/terraform-plugin-go v0.14.1
 	github.com/hashicorp/terraform-plugin-log v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,8 @@ github.com/hashicorp/terraform-exec v0.17.3 h1:MX14Kvnka/oWGmIkyuyvL6POx25ZmKrjl
 github.com/hashicorp/terraform-exec v0.17.3/go.mod h1:+NELG0EqQekJzhvikkeQsOAZpsw0cv/03rbeQJqscAI=
 github.com/hashicorp/terraform-json v0.14.0 h1:sh9iZ1Y8IFJLx+xQiKHGud6/TSUCM0N8e17dKDpqV7s=
 github.com/hashicorp/terraform-json v0.14.0/go.mod h1:5A9HIWPkk4e5aeeXIBbkcOvaZbIYnAIkEyqP2pNSckM=
-github.com/hashicorp/terraform-plugin-framework v0.14.0 h1:Mwj55u+Jc/QGM6fLBPCe1P+ZF3cuYs6wbCdB15lx/Dg=
-github.com/hashicorp/terraform-plugin-framework v0.14.0/go.mod h1:wcZdk4+Uef6Ng+BiBJjGAcIPlIs5bhlEV/TA1k6Xkq8=
+github.com/hashicorp/terraform-plugin-framework v0.16.0 h1:kEHh0d6dp5Ig/ey6PYXkWDZPMLIW8Me41T/Oa7bpO4s=
+github.com/hashicorp/terraform-plugin-framework v0.16.0/go.mod h1:Vk5MuIJoE1qksHZawAZr6psx6YXsQBFIKDrWbROrwus=
 github.com/hashicorp/terraform-plugin-framework-validators v0.5.0 h1:eD79idhnJOBajkUMEbm0c8dOyOb/F49STbUEVojT6F4=
 github.com/hashicorp/terraform-plugin-framework-validators v0.5.0/go.mod h1:NfGgclDM3FZqvNVppPKE2aHI1JAyT002ypPRya7ch3I=
 github.com/hashicorp/terraform-plugin-go v0.14.1 h1:cwZzPYla82XwAqpLhSzdVsOMU+6H29tczAwrB0z9Zek=

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/hashicorp/terraform-json v0.14.0 h1:sh9iZ1Y8IFJLx+xQiKHGud6/TSUCM0N8e
 github.com/hashicorp/terraform-json v0.14.0/go.mod h1:5A9HIWPkk4e5aeeXIBbkcOvaZbIYnAIkEyqP2pNSckM=
 github.com/hashicorp/terraform-plugin-framework v0.16.0 h1:kEHh0d6dp5Ig/ey6PYXkWDZPMLIW8Me41T/Oa7bpO4s=
 github.com/hashicorp/terraform-plugin-framework v0.16.0/go.mod h1:Vk5MuIJoE1qksHZawAZr6psx6YXsQBFIKDrWbROrwus=
-github.com/hashicorp/terraform-plugin-framework-validators v0.5.0 h1:eD79idhnJOBajkUMEbm0c8dOyOb/F49STbUEVojT6F4=
-github.com/hashicorp/terraform-plugin-framework-validators v0.5.0/go.mod h1:NfGgclDM3FZqvNVppPKE2aHI1JAyT002ypPRya7ch3I=
+github.com/hashicorp/terraform-plugin-framework-validators v0.6.0 h1:j8GlgzuTjbbkMnsbiOXerwJTW8Us4saQwo4FfJKd2I0=
+github.com/hashicorp/terraform-plugin-framework-validators v0.6.0/go.mod h1:iOYhZQinlZ0R/M3Q3nCXS4dikZ7P41d5b7ezpe9uoIw=
 github.com/hashicorp/terraform-plugin-go v0.14.1 h1:cwZzPYla82XwAqpLhSzdVsOMU+6H29tczAwrB0z9Zek=
 github.com/hashicorp/terraform-plugin-go v0.14.1/go.mod h1:Bc/K6K26BQ2FHqIELPbpKtt2CzzbQou+0UQF3/0NsCQ=
 github.com/hashicorp/terraform-plugin-log v0.7.0 h1:SDxJUyT8TwN4l5b5/VkiTIaQgY6R+Y2BQ0sRZftGKQs=

--- a/internal/flex/framework.go
+++ b/internal/flex/framework.go
@@ -130,6 +130,16 @@ func StringSliceFromFramework(_ context.Context, v types.String) []*string {
 	return aws.StringSlice([]string{v.ValueString()})
 }
 
+// BoolToFramework converts a bool pointer to a Framework Bool value.
+// A nil bool pointer is converted to a null Bool.
+func BoolToFramework(_ context.Context, v *bool) types.Bool {
+	if v == nil {
+		return types.BoolNull()
+	}
+
+	return types.BoolValue(aws.ToBool(v))
+}
+
 // Int64ToFramework converts an int64 pointer to a Framework Int64 value.
 // A nil int64 pointer is converted to a null Int64.
 func Int64ToFramework(_ context.Context, v *int64) types.Int64 {

--- a/internal/flex/framework.go
+++ b/internal/flex/framework.go
@@ -100,6 +100,26 @@ func FlattenFrameworkStringValueMap(_ context.Context, m map[string]string) type
 	return types.MapValueMust(types.StringType, elems)
 }
 
+// FromFrameworkString converts a Framework String value to a string pointer.
+// A null String is converted to a nil string pointer.
+func FromFrameworkInt64(_ context.Context, v types.Int64) *int64 {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+
+	return aws.Int64(v.ValueInt64())
+}
+
+// FromFrameworkString converts a Framework String value to a string pointer.
+// A null String is converted to a nil string pointer.
+func FromFrameworkString(_ context.Context, v types.String) *string {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+
+	return aws.String(v.ValueString())
+}
+
 // ToFrameworkInt64Value converts an int64 pointer to a Framework Int64 value.
 // A nil int64 pointer is converted to a null Int64.
 func ToFrameworkInt64Value(_ context.Context, v *int64) types.Int64 {
@@ -107,7 +127,7 @@ func ToFrameworkInt64Value(_ context.Context, v *int64) types.Int64 {
 		return types.Int64Null()
 	}
 
-	return types.Int64Value(*v)
+	return types.Int64Value(aws.ToInt64(v))
 }
 
 // ToFrameworkStringValue converts a string pointer to a Framework String value.
@@ -117,7 +137,7 @@ func ToFrameworkStringValue(_ context.Context, v *string) types.String {
 		return types.StringNull()
 	}
 
-	return types.StringValue(*v)
+	return types.StringValue(aws.ToString(v))
 }
 
 // ToFrameworkStringValueWithTransform converts a string pointer to a Framework String value.
@@ -128,5 +148,5 @@ func ToFrameworkStringValueWithTransform(_ context.Context, v *string, f func(st
 		return types.StringNull()
 	}
 
-	return types.StringValue(f(*v))
+	return types.StringValue(f(aws.ToString(v)))
 }

--- a/internal/flex/framework.go
+++ b/internal/flex/framework.go
@@ -58,10 +58,10 @@ func FlattenFrameworkStringList(_ context.Context, vs []*string) types.List {
 	elems := make([]attr.Value, len(vs))
 
 	for i, v := range vs {
-		elems[i] = types.String{Value: aws.ToString(v)}
+		elems[i] = types.StringValue(aws.ToString(v))
 	}
 
-	return types.List{ElemType: types.StringType, Elems: elems}
+	return types.ListValueMust(types.StringType, elems)
 }
 
 // FlattenFrameworkStringValueList is the Plugin Framework variant of FlattenStringValueList.
@@ -70,10 +70,10 @@ func FlattenFrameworkStringValueList(_ context.Context, vs []string) types.List 
 	elems := make([]attr.Value, len(vs))
 
 	for i, v := range vs {
-		elems[i] = types.String{Value: v}
+		elems[i] = types.StringValue(v)
 	}
 
-	return types.List{ElemType: types.StringType, Elems: elems}
+	return types.ListValueMust(types.StringType, elems)
 }
 
 // FlattenFrameworkStringValueSet is the Plugin Framework variant of FlattenStringValueSet.
@@ -82,10 +82,10 @@ func FlattenFrameworkStringValueSet(_ context.Context, vs []string) types.Set {
 	elems := make([]attr.Value, len(vs))
 
 	for i, v := range vs {
-		elems[i] = types.String{Value: v}
+		elems[i] = types.StringValue(v)
 	}
 
-	return types.Set{ElemType: types.StringType, Elems: elems}
+	return types.SetValueMust(types.StringType, elems)
 }
 
 // FlattenFrameworkStringValueMap has no Plugin SDK equivalent as schema.ResourceData.Set can be passed string value maps directly.
@@ -94,30 +94,30 @@ func FlattenFrameworkStringValueMap(_ context.Context, m map[string]string) type
 	elems := make(map[string]attr.Value, len(m))
 
 	for k, v := range m {
-		elems[k] = types.String{Value: v}
+		elems[k] = types.StringValue(v)
 	}
 
-	return types.Map{ElemType: types.StringType, Elems: elems}
+	return types.MapValueMust(types.StringType, elems)
 }
 
 // ToFrameworkInt64Value converts an int64 pointer to a Framework Int64 value.
 // A nil int64 pointer is converted to a null Int64.
 func ToFrameworkInt64Value(_ context.Context, v *int64) types.Int64 {
 	if v == nil {
-		return types.Int64{Null: true}
+		return types.Int64Null()
 	}
 
-	return types.Int64{Value: *v}
+	return types.Int64Value(*v)
 }
 
 // ToFrameworkStringValue converts a string pointer to a Framework String value.
 // A nil string pointer is converted to a null String.
 func ToFrameworkStringValue(_ context.Context, v *string) types.String {
 	if v == nil {
-		return types.String{Null: true}
+		return types.StringNull()
 	}
 
-	return types.String{Value: *v}
+	return types.StringValue(*v)
 }
 
 // ToFrameworkStringValueWithTransform converts a string pointer to a Framework String value.
@@ -125,8 +125,8 @@ func ToFrameworkStringValue(_ context.Context, v *string) types.String {
 // A non-nil string pointer has its value transformed by `f`.
 func ToFrameworkStringValueWithTransform(_ context.Context, v *string, f func(string) string) types.String {
 	if v == nil {
-		return types.String{Null: true}
+		return types.StringNull()
 	}
 
-	return types.String{Value: f(*v)}
+	return types.StringValue(f(*v))
 }

--- a/internal/flex/framework.go
+++ b/internal/flex/framework.go
@@ -100,6 +100,16 @@ func FlattenFrameworkStringValueMap(_ context.Context, m map[string]string) type
 	return types.MapValueMust(types.StringType, elems)
 }
 
+// BoolFromFramework converts a Framework Bool value to a bool pointer.
+// A null Bool is converted to a nil bool pointer.
+func BoolFromFramework(_ context.Context, v types.Bool) *bool {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+
+	return aws.Bool(v.ValueBool())
+}
+
 // Int64FromFramework converts a Framework Int64 value to an int64 pointer.
 // A null Int64 is converted to a nil int64 pointer.
 func Int64FromFramework(_ context.Context, v types.Int64) *int64 {

--- a/internal/flex/framework.go
+++ b/internal/flex/framework.go
@@ -140,6 +140,12 @@ func BoolToFramework(_ context.Context, v *bool) types.Bool {
 	return types.BoolValue(aws.ToBool(v))
 }
 
+// BoolToFrameworkLegacy converts a bool pointer to a Framework Bool value.
+// A nil bool pointer is converted to a false Bool.
+func BoolToFrameworkLegacy(_ context.Context, v *bool) types.Bool {
+	return types.BoolValue(aws.ToBool(v))
+}
+
 // Int64ToFramework converts an int64 pointer to a Framework Int64 value.
 // A nil int64 pointer is converted to a null Int64.
 func Int64ToFramework(_ context.Context, v *int64) types.Int64 {
@@ -150,6 +156,12 @@ func Int64ToFramework(_ context.Context, v *int64) types.Int64 {
 	return types.Int64Value(aws.ToInt64(v))
 }
 
+// Int64ToFramework converts an int64 pointer to a Framework Int64 value.
+// A nil int64 pointer is converted to a zero Int64.
+func Int64ToFrameworkLegacy(_ context.Context, v *int64) types.Int64 {
+	return types.Int64Value(aws.ToInt64(v))
+}
+
 // StringToFramework converts a string pointer to a Framework String value.
 // A nil string pointer is converted to a null String.
 func StringToFramework(_ context.Context, v *string) types.String {
@@ -157,6 +169,12 @@ func StringToFramework(_ context.Context, v *string) types.String {
 		return types.StringNull()
 	}
 
+	return types.StringValue(aws.ToString(v))
+}
+
+// StringToFrameworkLegacy converts a string pointer to a Framework String value.
+// A nil string pointer is converted to an empty String.
+func StringToFrameworkLegacy(_ context.Context, v *string) types.String {
 	return types.StringValue(aws.ToString(v))
 }
 

--- a/internal/flex/framework.go
+++ b/internal/flex/framework.go
@@ -100,9 +100,9 @@ func FlattenFrameworkStringValueMap(_ context.Context, m map[string]string) type
 	return types.MapValueMust(types.StringType, elems)
 }
 
-// FromFrameworkString converts a Framework String value to a string pointer.
-// A null String is converted to a nil string pointer.
-func FromFrameworkInt64(_ context.Context, v types.Int64) *int64 {
+// Int64FromFramework converts a Framework Int64 value to an int64 pointer.
+// A null Int64 is converted to a nil int64 pointer.
+func Int64FromFramework(_ context.Context, v types.Int64) *int64 {
 	if v.IsNull() || v.IsUnknown() {
 		return nil
 	}
@@ -110,9 +110,9 @@ func FromFrameworkInt64(_ context.Context, v types.Int64) *int64 {
 	return aws.Int64(v.ValueInt64())
 }
 
-// FromFrameworkString converts a Framework String value to a string pointer.
+// StringFromFramework converts a Framework String value to a string pointer.
 // A null String is converted to a nil string pointer.
-func FromFrameworkString(_ context.Context, v types.String) *string {
+func StringFromFramework(_ context.Context, v types.String) *string {
 	if v.IsNull() || v.IsUnknown() {
 		return nil
 	}
@@ -120,9 +120,9 @@ func FromFrameworkString(_ context.Context, v types.String) *string {
 	return aws.String(v.ValueString())
 }
 
-// ToFrameworkInt64Value converts an int64 pointer to a Framework Int64 value.
+// Int64ToFramework converts an int64 pointer to a Framework Int64 value.
 // A nil int64 pointer is converted to a null Int64.
-func ToFrameworkInt64Value(_ context.Context, v *int64) types.Int64 {
+func Int64ToFramework(_ context.Context, v *int64) types.Int64 {
 	if v == nil {
 		return types.Int64Null()
 	}
@@ -130,9 +130,9 @@ func ToFrameworkInt64Value(_ context.Context, v *int64) types.Int64 {
 	return types.Int64Value(aws.ToInt64(v))
 }
 
-// ToFrameworkStringValue converts a string pointer to a Framework String value.
+// StringToFramework converts a string pointer to a Framework String value.
 // A nil string pointer is converted to a null String.
-func ToFrameworkStringValue(_ context.Context, v *string) types.String {
+func StringToFramework(_ context.Context, v *string) types.String {
 	if v == nil {
 		return types.StringNull()
 	}
@@ -140,10 +140,10 @@ func ToFrameworkStringValue(_ context.Context, v *string) types.String {
 	return types.StringValue(aws.ToString(v))
 }
 
-// ToFrameworkStringValueWithTransform converts a string pointer to a Framework String value.
+// StringToFrameworkWithTransform converts a string pointer to a Framework String value.
 // A nil string pointer is converted to a null String.
 // A non-nil string pointer has its value transformed by `f`.
-func ToFrameworkStringValueWithTransform(_ context.Context, v *string, f func(string) string) types.String {
+func StringToFrameworkWithTransform(_ context.Context, v *string, f func(string) string) types.String {
 	if v == nil {
 		return types.StringNull()
 	}

--- a/internal/flex/framework.go
+++ b/internal/flex/framework.go
@@ -120,6 +120,16 @@ func StringFromFramework(_ context.Context, v types.String) *string {
 	return aws.String(v.ValueString())
 }
 
+// StringFromFramework converts a single Framework String value to a string pointer slice.
+// A null String is converted to a nil slice.
+func StringSliceFromFramework(_ context.Context, v types.String) []*string {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+
+	return aws.StringSlice([]string{v.ValueString()})
+}
+
 // Int64ToFramework converts an int64 pointer to a Framework Int64 value.
 // A nil int64 pointer is converted to a null Int64.
 func Int64ToFramework(_ context.Context, v *int64) types.Int64 {

--- a/internal/flex/framework_test.go
+++ b/internal/flex/framework_test.go
@@ -20,20 +20,20 @@ func TestExpandFrameworkStringSet(t *testing.T) {
 	}
 	tests := map[string]testCase{
 		"two elements": {
-			input: types.Set{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "GET"},
-				types.String{Value: "HEAD"},
-			}},
+			input: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
 			expected: []*string{aws.String("GET"), aws.String("HEAD")},
 		},
 		"zero elements": {
-			input:    types.Set{ElemType: types.StringType, Elems: []attr.Value{}},
+			input:    types.SetValueMust(types.StringType, []attr.Value{}),
 			expected: []*string{},
 		},
 		"invalid element type": {
-			input: types.Set{ElemType: types.Int64Type, Elems: []attr.Value{
-				types.Int64{Value: 42},
-			}},
+			input: types.SetValueMust(types.Int64Type, []attr.Value{
+				types.Int64Value(42),
+			}),
 			expected: nil,
 		},
 	}
@@ -59,20 +59,20 @@ func TestExpandFrameworkStringValueSet(t *testing.T) {
 	}
 	tests := map[string]testCase{
 		"two elements": {
-			input: types.Set{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "GET"},
-				types.String{Value: "HEAD"},
-			}},
+			input: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
 			expected: []string{"GET", "HEAD"},
 		},
 		"zero elements": {
-			input:    types.Set{ElemType: types.StringType, Elems: []attr.Value{}},
+			input:    types.SetValueMust(types.StringType, []attr.Value{}),
 			expected: []string{},
 		},
 		"invalid element type": {
-			input: types.Set{ElemType: types.Int64Type, Elems: []attr.Value{
-				types.Int64{Value: 42},
-			}},
+			input: types.SetValueMust(types.Int64Type, []attr.Value{
+				types.Int64Value(42),
+			}),
 			expected: nil,
 		},
 	}
@@ -98,24 +98,23 @@ func TestExpandFrameworkStringValueMap(t *testing.T) {
 	}
 	tests := map[string]testCase{
 		"two elements": {
-			input: types.Map{ElemType: types.StringType, Elems: map[string]attr.Value{
-				"one": types.String{Value: "GET"},
-				"two": types.String{Value: "HEAD"},
-			}},
+			input: types.MapValueMust(types.StringType, map[string]attr.Value{
+				"one": types.StringValue("GET"),
+				"two": types.StringValue("HEAD"),
+			}),
 			expected: map[string]string{
 				"one": "GET",
 				"two": "HEAD",
 			},
 		},
 		"zero elements": {
-			input:    types.Map{ElemType: types.StringType, Elems: map[string]attr.Value{}},
+			input:    types.MapValueMust(types.StringType, map[string]attr.Value{}),
 			expected: map[string]string{},
 		},
 		"invalid element type": {
-			input: types.Map{ElemType: types.BoolType, Elems: map[string]attr.Value{
-				"one": types.Bool{Value: true},
-				"two": types.Bool{Value: false},
-			}},
+			input: types.MapValueMust(types.BoolType, map[string]attr.Value{
+				"one": types.BoolValue(true),
+			}),
 			expected: nil,
 		},
 	}
@@ -142,18 +141,18 @@ func TestFlattenFrameworkStringList(t *testing.T) {
 	tests := map[string]testCase{
 		"two elements": {
 			input: []*string{aws.String("GET"), aws.String("HEAD")},
-			expected: types.List{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "GET"},
-				types.String{Value: "HEAD"},
-			}},
+			expected: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
 		},
 		"zero elements": {
 			input:    []*string{},
-			expected: types.List{ElemType: types.StringType, Elems: []attr.Value{}},
+			expected: types.ListValueMust(types.StringType, []attr.Value{}),
 		},
 		"nil array": {
 			input:    nil,
-			expected: types.List{ElemType: types.StringType, Elems: []attr.Value{}},
+			expected: types.ListValueMust(types.StringType, []attr.Value{}),
 		},
 	}
 
@@ -179,18 +178,18 @@ func TestFlattenFrameworkStringValueList(t *testing.T) {
 	tests := map[string]testCase{
 		"two elements": {
 			input: []string{"GET", "HEAD"},
-			expected: types.List{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "GET"},
-				types.String{Value: "HEAD"},
-			}},
+			expected: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
 		},
 		"zero elements": {
 			input:    []string{},
-			expected: types.List{ElemType: types.StringType, Elems: []attr.Value{}},
+			expected: types.ListValueMust(types.StringType, []attr.Value{}),
 		},
 		"nil array": {
 			input:    nil,
-			expected: types.List{ElemType: types.StringType, Elems: []attr.Value{}},
+			expected: types.ListValueMust(types.StringType, []attr.Value{}),
 		},
 	}
 
@@ -216,18 +215,18 @@ func TestFlattenFrameworkStringValueSet(t *testing.T) {
 	tests := map[string]testCase{
 		"two elements": {
 			input: []string{"GET", "HEAD"},
-			expected: types.Set{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "GET"},
-				types.String{Value: "HEAD"},
-			}},
+			expected: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
 		},
 		"zero elements": {
 			input:    []string{},
-			expected: types.Set{ElemType: types.StringType, Elems: []attr.Value{}},
+			expected: types.SetValueMust(types.StringType, []attr.Value{}),
 		},
 		"nil array": {
 			input:    nil,
-			expected: types.Set{ElemType: types.StringType, Elems: []attr.Value{}},
+			expected: types.SetValueMust(types.StringType, []attr.Value{}),
 		},
 	}
 
@@ -256,18 +255,18 @@ func TestFlattenFrameworkStringValueMap(t *testing.T) {
 				"one": "GET",
 				"two": "HEAD",
 			},
-			expected: types.Map{ElemType: types.StringType, Elems: map[string]attr.Value{
-				"one": types.String{Value: "GET"},
-				"two": types.String{Value: "HEAD"},
-			}},
+			expected: types.MapValueMust(types.StringType, map[string]attr.Value{
+				"one": types.StringValue("GET"),
+				"two": types.StringValue("HEAD"),
+			}),
 		},
 		"zero elements": {
 			input:    map[string]string{},
-			expected: types.Map{ElemType: types.StringType, Elems: map[string]attr.Value{}},
+			expected: types.MapValueMust(types.StringType, map[string]attr.Value{}),
 		},
 		"nil map": {
 			input:    nil,
-			expected: types.Map{ElemType: types.StringType, Elems: map[string]attr.Value{}},
+			expected: types.MapValueMust(types.StringType, map[string]attr.Value{}),
 		},
 	}
 
@@ -293,15 +292,15 @@ func TestToFrameworkInt64Value(t *testing.T) {
 	tests := map[string]testCase{
 		"valid int64": {
 			input:    aws.Int64(42),
-			expected: types.Int64{Value: 42},
+			expected: types.Int64Value(42),
 		},
 		"zero int64": {
 			input:    aws.Int64(0),
-			expected: types.Int64{Value: 0},
+			expected: types.Int64Value(0),
 		},
 		"nil string": {
 			input:    nil,
-			expected: types.Int64{Null: true},
+			expected: types.Int64Null(),
 		},
 	}
 
@@ -327,15 +326,15 @@ func TestToFrameworkStringValue(t *testing.T) {
 	tests := map[string]testCase{
 		"valid string": {
 			input:    aws.String("TEST"),
-			expected: types.String{Value: "TEST"},
+			expected: types.StringValue("TEST"),
 		},
 		"empty string": {
 			input:    aws.String(""),
-			expected: types.String{Value: ""},
+			expected: types.StringValue(""),
 		},
 		"nil string": {
 			input:    nil,
-			expected: types.String{Null: true},
+			expected: types.StringNull(),
 		},
 	}
 
@@ -361,15 +360,15 @@ func TestToFrameworkStringValueWithTransform(t *testing.T) {
 	tests := map[string]testCase{
 		"valid string": {
 			input:    aws.String("TEST"),
-			expected: types.String{Value: "test"},
+			expected: types.StringValue("test"),
 		},
 		"empty string": {
 			input:    aws.String(""),
-			expected: types.String{Value: ""},
+			expected: types.StringValue(""),
 		},
 		"nil string": {
 			input:    nil,
-			expected: types.String{Null: true},
+			expected: types.StringNull(),
 		},
 	}
 

--- a/internal/flex/framework_test.go
+++ b/internal/flex/framework_test.go
@@ -282,6 +282,82 @@ func TestFlattenFrameworkStringValueMap(t *testing.T) {
 	}
 }
 
+func TestFromFrameworkInt64(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    types.Int64
+		expected *int64
+	}
+	tests := map[string]testCase{
+		"valid int64": {
+			input:    types.Int64Value(42),
+			expected: aws.Int64(42),
+		},
+		"zero int64": {
+			input:    types.Int64Value(0),
+			expected: aws.Int64(0),
+		},
+		"null int64": {
+			input:    types.Int64Null(),
+			expected: nil,
+		},
+		"unknown int64": {
+			input:    types.Int64Unknown(),
+			expected: nil,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			got := FromFrameworkInt64(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestFromFrameworkString(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    types.String
+		expected *string
+	}
+	tests := map[string]testCase{
+		"valid string": {
+			input:    types.StringValue("TEST"),
+			expected: aws.String("TEST"),
+		},
+		"empty string": {
+			input:    types.StringValue(""),
+			expected: aws.String(""),
+		},
+		"null string": {
+			input:    types.StringNull(),
+			expected: nil,
+		},
+		"unknown string": {
+			input:    types.StringUnknown(),
+			expected: nil,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			got := FromFrameworkString(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
 func TestToFrameworkInt64Value(t *testing.T) {
 	t.Parallel()
 
@@ -298,7 +374,7 @@ func TestToFrameworkInt64Value(t *testing.T) {
 			input:    aws.Int64(0),
 			expected: types.Int64Value(0),
 		},
-		"nil string": {
+		"nil int64": {
 			input:    nil,
 			expected: types.Int64Null(),
 		},

--- a/internal/flex/framework_test.go
+++ b/internal/flex/framework_test.go
@@ -282,6 +282,40 @@ func TestFlattenFrameworkStringValueMap(t *testing.T) {
 	}
 }
 
+func TestBoolFromFramework(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    types.Bool
+		expected *bool
+	}
+	tests := map[string]testCase{
+		"valid bool": {
+			input:    types.BoolValue(true),
+			expected: aws.Bool(true),
+		},
+		"null bool": {
+			input:    types.BoolNull(),
+			expected: nil,
+		},
+		"unknown bool": {
+			input:    types.BoolUnknown(),
+			expected: nil,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			got := BoolFromFramework(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
 func TestInt64FromFramework(t *testing.T) {
 	t.Parallel()
 

--- a/internal/flex/framework_test.go
+++ b/internal/flex/framework_test.go
@@ -358,6 +358,36 @@ func TestStringFromFramework(t *testing.T) {
 	}
 }
 
+func TestBoolToFramework(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    *bool
+		expected types.Bool
+	}
+	tests := map[string]testCase{
+		"valid bool": {
+			input:    aws.Bool(true),
+			expected: types.BoolValue(true),
+		},
+		"nil bool": {
+			input:    nil,
+			expected: types.BoolNull(),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			got := BoolToFramework(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
 func TestInt64ToFramework(t *testing.T) {
 	t.Parallel()
 

--- a/internal/flex/framework_test.go
+++ b/internal/flex/framework_test.go
@@ -282,7 +282,7 @@ func TestFlattenFrameworkStringValueMap(t *testing.T) {
 	}
 }
 
-func TestFromFrameworkInt64(t *testing.T) {
+func TestInt64FromFramework(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
@@ -311,7 +311,7 @@ func TestFromFrameworkInt64(t *testing.T) {
 	for name, test := range tests {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
-			got := FromFrameworkInt64(context.Background(), test.input)
+			got := Int64FromFramework(context.Background(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
@@ -320,7 +320,7 @@ func TestFromFrameworkInt64(t *testing.T) {
 	}
 }
 
-func TestFromFrameworkString(t *testing.T) {
+func TestStringFromFramework(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
@@ -349,7 +349,7 @@ func TestFromFrameworkString(t *testing.T) {
 	for name, test := range tests {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
-			got := FromFrameworkString(context.Background(), test.input)
+			got := StringFromFramework(context.Background(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
@@ -358,7 +358,7 @@ func TestFromFrameworkString(t *testing.T) {
 	}
 }
 
-func TestToFrameworkInt64Value(t *testing.T) {
+func TestInt64ToFramework(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
@@ -383,7 +383,7 @@ func TestToFrameworkInt64Value(t *testing.T) {
 	for name, test := range tests {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
-			got := ToFrameworkInt64Value(context.Background(), test.input)
+			got := Int64ToFramework(context.Background(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
@@ -392,7 +392,7 @@ func TestToFrameworkInt64Value(t *testing.T) {
 	}
 }
 
-func TestToFrameworkStringValue(t *testing.T) {
+func TestStringToFramework(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
@@ -417,7 +417,7 @@ func TestToFrameworkStringValue(t *testing.T) {
 	for name, test := range tests {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
-			got := ToFrameworkStringValue(context.Background(), test.input)
+			got := StringToFramework(context.Background(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
@@ -426,7 +426,7 @@ func TestToFrameworkStringValue(t *testing.T) {
 	}
 }
 
-func TestToFrameworkStringValueWithTransform(t *testing.T) {
+func TestStringToFrameworkWithTransform(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
@@ -451,7 +451,7 @@ func TestToFrameworkStringValueWithTransform(t *testing.T) {
 	for name, test := range tests {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
-			got := ToFrameworkStringValueWithTransform(context.Background(), test.input, strings.ToLower)
+			got := StringToFrameworkWithTransform(context.Background(), test.input, strings.ToLower)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)

--- a/internal/flex/framework_test.go
+++ b/internal/flex/framework_test.go
@@ -388,6 +388,36 @@ func TestBoolToFramework(t *testing.T) {
 	}
 }
 
+func TestBoolToFrameworkLegacy(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    *bool
+		expected types.Bool
+	}
+	tests := map[string]testCase{
+		"valid bool": {
+			input:    aws.Bool(true),
+			expected: types.BoolValue(true),
+		},
+		"nil bool": {
+			input:    nil,
+			expected: types.BoolValue(false),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			got := BoolToFrameworkLegacy(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
 func TestInt64ToFramework(t *testing.T) {
 	t.Parallel()
 
@@ -422,6 +452,40 @@ func TestInt64ToFramework(t *testing.T) {
 	}
 }
 
+func TestInt64ToFrameworkLegacy(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    *int64
+		expected types.Int64
+	}
+	tests := map[string]testCase{
+		"valid int64": {
+			input:    aws.Int64(42),
+			expected: types.Int64Value(42),
+		},
+		"zero int64": {
+			input:    aws.Int64(0),
+			expected: types.Int64Value(0),
+		},
+		"nil int64": {
+			input:    nil,
+			expected: types.Int64Value(0),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			got := Int64ToFrameworkLegacy(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
 func TestStringToFramework(t *testing.T) {
 	t.Parallel()
 
@@ -448,6 +512,40 @@ func TestStringToFramework(t *testing.T) {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			got := StringToFramework(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestStringToFrameworkLegacy(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    *string
+		expected types.String
+	}
+	tests := map[string]testCase{
+		"valid string": {
+			input:    aws.String("TEST"),
+			expected: types.StringValue("TEST"),
+		},
+		"empty string": {
+			input:    aws.String(""),
+			expected: types.StringValue(""),
+		},
+		"nil string": {
+			input:    nil,
+			expected: types.StringValue(""),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			got := StringToFrameworkLegacy(context.Background(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)

--- a/internal/framework/planmodifiers/default_value.go
+++ b/internal/framework/planmodifiers/default_value.go
@@ -21,7 +21,7 @@ func DefaultValue(value attr.Value) tfsdk.AttributePlanModifier {
 }
 
 func DefaultStringValue(value string) tfsdk.AttributePlanModifier {
-	return DefaultValue(types.String{Value: value})
+	return DefaultValue(types.StringValue(value))
 }
 
 func (m defaultValue) Description(context.Context) string {

--- a/internal/framework/planmodifiers/default_value_test.go
+++ b/internal/framework/planmodifiers/default_value_test.go
@@ -24,246 +24,230 @@ func TestDefaultValue(t *testing.T) {
 	}
 	tests := map[string]testCase{
 		"non-default non-Null string": {
-			plannedValue:  types.String{Value: "gamma"},
-			currentValue:  types.String{Value: "beta"},
-			defaultValue:  types.String{Value: "alpha"},
-			expectedValue: types.String{Value: "gamma"},
+			plannedValue:  types.StringValue("gamma"),
+			currentValue:  types.StringValue("beta"),
+			defaultValue:  types.StringValue("alpha"),
+			expectedValue: types.StringValue("gamma"),
 		},
 		"non-default non-Null string, current Null": {
-			plannedValue:  types.String{Value: "gamma"},
-			currentValue:  types.String{Null: true},
-			defaultValue:  types.String{Value: "alpha"},
-			expectedValue: types.String{Value: "gamma"},
+			plannedValue:  types.StringValue("gamma"),
+			currentValue:  types.StringNull(),
+			defaultValue:  types.StringValue("alpha"),
+			expectedValue: types.StringValue("gamma"),
 		},
 		"non-default Null string, current Null": {
-			plannedValue:  types.String{Null: true},
-			currentValue:  types.String{Value: "beta"},
-			defaultValue:  types.String{Value: "alpha"},
-			expectedValue: types.String{Value: "alpha"},
+			plannedValue:  types.StringNull(),
+			currentValue:  types.StringValue("beta"),
+			defaultValue:  types.StringValue("alpha"),
+			expectedValue: types.StringValue("alpha"),
 		},
 		"default string": {
-			plannedValue:  types.String{Null: true},
-			currentValue:  types.String{Value: "alpha"},
-			defaultValue:  types.String{Value: "alpha"},
-			expectedValue: types.String{Value: "alpha"},
+			plannedValue:  types.StringNull(),
+			currentValue:  types.StringValue("alpha"),
+			defaultValue:  types.StringValue("alpha"),
+			expectedValue: types.StringValue("alpha"),
 		},
 		"default string on create": {
-			plannedValue:  types.String{Null: true},
-			currentValue:  types.String{Null: true},
-			defaultValue:  types.String{Value: "alpha"},
-			expectedValue: types.String{Value: "alpha"},
+			plannedValue:  types.StringNull(),
+			currentValue:  types.StringNull(),
+			defaultValue:  types.StringValue("alpha"),
+			expectedValue: types.StringValue("alpha"),
 		},
 		"non-default non-Null number": {
-			plannedValue:  types.Number{Value: big.NewFloat(30)},
-			currentValue:  types.Number{Value: big.NewFloat(10)},
-			defaultValue:  types.Number{Value: big.NewFloat(-10)},
-			expectedValue: types.Number{Value: big.NewFloat(30)},
+			plannedValue:  types.NumberValue(big.NewFloat(30)),
+			currentValue:  types.NumberValue(big.NewFloat(10)),
+			defaultValue:  types.NumberValue(big.NewFloat(-10)),
+			expectedValue: types.NumberValue(big.NewFloat(30)),
 		},
 		"non-default non-Null number, current Null": {
-			plannedValue:  types.Number{Value: big.NewFloat(30)},
-			currentValue:  types.Number{Null: true},
-			defaultValue:  types.Number{Value: big.NewFloat(-10)},
-			expectedValue: types.Number{Value: big.NewFloat(30)},
+			plannedValue:  types.NumberValue(big.NewFloat(30)),
+			currentValue:  types.NumberNull(),
+			defaultValue:  types.NumberValue(big.NewFloat(-10)),
+			expectedValue: types.NumberValue(big.NewFloat(30)),
 		},
 		"non-default Null number, current Null": {
-			plannedValue:  types.Number{Null: true},
-			currentValue:  types.Number{Value: big.NewFloat(10)},
-			defaultValue:  types.Number{Value: big.NewFloat(-10)},
-			expectedValue: types.Number{Value: big.NewFloat(-10)},
+			plannedValue:  types.NumberNull(),
+			currentValue:  types.NumberValue(big.NewFloat(10)),
+			defaultValue:  types.NumberValue(big.NewFloat(-10)),
+			expectedValue: types.NumberValue(big.NewFloat(-10)),
 		},
 		"default number": {
-			plannedValue:  types.Number{Null: true},
-			currentValue:  types.Number{Value: big.NewFloat(-10)},
-			defaultValue:  types.Number{Value: big.NewFloat(-10)},
-			expectedValue: types.Number{Value: big.NewFloat(-10)},
+			plannedValue:  types.NumberNull(),
+			currentValue:  types.NumberValue(big.NewFloat(-10)),
+			defaultValue:  types.NumberValue(big.NewFloat(-10)),
+			expectedValue: types.NumberValue(big.NewFloat(-10)),
 		},
 		"non-default string list": {
-			plannedValue: types.List{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "POST"},
-			}},
-			currentValue: types.List{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "PUT"},
-			}},
-			defaultValue: types.List{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "GET"},
-				types.String{Value: "HEAD"},
-			}},
-			expectedValue: types.List{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "POST"},
-			}},
+			plannedValue: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("POST"),
+			}),
+			currentValue: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("PUT"),
+			}),
+			defaultValue: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
+			expectedValue: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("POST"),
+			}),
 		},
 		"non-default string list, current out of order": {
-			plannedValue: types.List{ElemType: types.StringType, Null: true},
-			currentValue: types.List{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "HEAD"},
-				types.String{Value: "GET"},
-			}},
-			defaultValue: types.List{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "GET"},
-				types.String{Value: "HEAD"},
-			}},
-			expectedValue: types.List{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "GET"},
-				types.String{Value: "HEAD"},
-			}},
+			plannedValue: types.ListNull(types.StringType),
+			currentValue: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("HEAD"),
+				types.StringValue("GET"),
+			}),
+			defaultValue: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
+			expectedValue: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
 		},
 		"default string list": {
-			plannedValue: types.List{ElemType: types.StringType, Null: true},
-			currentValue: types.List{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "GET"},
-				types.String{Value: "HEAD"},
-			}},
-			defaultValue: types.List{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "GET"},
-				types.String{Value: "HEAD"},
-			}},
-			expectedValue: types.List{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "GET"},
-				types.String{Value: "HEAD"},
-			}},
+			plannedValue: types.ListNull(types.StringType),
+			currentValue: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
+			defaultValue: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
+			expectedValue: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
 		},
 		"non-default string set": {
-			plannedValue: types.Set{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "POST"},
-			}},
-			currentValue: types.Set{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "PUT"},
-			}},
-			defaultValue: types.Set{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "GET"},
-				types.String{Value: "HEAD"},
-			}},
-			expectedValue: types.Set{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "POST"},
-			}},
+			plannedValue: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("POST"),
+			}),
+			currentValue: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("PUT"),
+			}),
+			defaultValue: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
+			expectedValue: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("POST"),
+			}),
 		},
 		"default string set, current out of order": {
-			plannedValue: types.Set{ElemType: types.StringType, Null: true},
-			currentValue: types.Set{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "HEAD"},
-				types.String{Value: "GET"},
-			}},
-			defaultValue: types.Set{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "GET"},
-				types.String{Value: "HEAD"},
-			}},
-			expectedValue: types.Set{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "HEAD"},
-				types.String{Value: "GET"},
-			}},
+			plannedValue: types.SetNull(types.StringType),
+			currentValue: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("HEAD"),
+				types.StringValue("GET"),
+			}),
+			defaultValue: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
+			expectedValue: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("HEAD"),
+				types.StringValue("GET"),
+			}),
 		},
 		"default string set": {
-			plannedValue: types.Set{ElemType: types.StringType, Null: true},
-			currentValue: types.Set{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "GET"},
-				types.String{Value: "HEAD"},
-			}},
-			defaultValue: types.Set{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "GET"},
-				types.String{Value: "HEAD"},
-			}},
-			expectedValue: types.Set{ElemType: types.StringType, Elems: []attr.Value{
-				types.String{Value: "GET"},
-				types.String{Value: "HEAD"},
-			}},
+			plannedValue: types.SetNull(types.StringType),
+			currentValue: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
+			defaultValue: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
+			expectedValue: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
 		},
 		"non-default object": {
-			plannedValue: types.Object{
-				AttrTypes: map[string]attr.Type{
-					"value": types.StringType,
-				},
-				Attrs: map[string]attr.Value{
-					"value": types.String{Value: "gamma"},
-				},
+			plannedValue: types.ObjectValueMust(map[string]attr.Type{
+				"value": types.StringType,
 			},
-			currentValue: types.Object{
-				AttrTypes: map[string]attr.Type{
-					"value": types.StringType,
+				map[string]attr.Value{
+					"value": types.StringValue("gamma"),
 				},
-				Attrs: map[string]attr.Value{
-					"value": types.String{Value: "beta"},
-				},
+			),
+			currentValue: types.ObjectValueMust(map[string]attr.Type{
+				"value": types.StringType,
 			},
-			defaultValue: types.Object{
-				AttrTypes: map[string]attr.Type{
-					"value": types.StringType,
+				map[string]attr.Value{
+					"value": types.StringValue("beta"),
 				},
-				Attrs: map[string]attr.Value{
-					"value": types.String{Value: "alpha"},
-				},
+			),
+			defaultValue: types.ObjectValueMust(map[string]attr.Type{
+				"value": types.StringType,
 			},
-			expectedValue: types.Object{
-				AttrTypes: map[string]attr.Type{
-					"value": types.StringType,
+				map[string]attr.Value{
+					"value": types.StringValue("alpha"),
 				},
-				Attrs: map[string]attr.Value{
-					"value": types.String{Value: "gamma"},
-				},
+			),
+			expectedValue: types.ObjectValueMust(map[string]attr.Type{
+				"value": types.StringType,
 			},
+				map[string]attr.Value{
+					"value": types.StringValue("gamma"),
+				},
+			),
 		},
 		"non-default object, different value": {
-			plannedValue: types.Object{
-				AttrTypes: map[string]attr.Type{
-					"value": types.StringType,
-				},
-				Null: true,
+			plannedValue: types.ObjectNull(map[string]attr.Type{
+				"value": types.StringType,
+			}),
+			currentValue: types.ObjectValueMust(map[string]attr.Type{
+				"value": types.StringType,
 			},
-			currentValue: types.Object{
-				AttrTypes: map[string]attr.Type{
-					"value": types.StringType,
+				map[string]attr.Value{
+					"value": types.StringValue("beta"),
 				},
-				Attrs: map[string]attr.Value{
-					"value": types.String{Value: "beta"},
-				},
+			),
+			defaultValue: types.ObjectValueMust(map[string]attr.Type{
+				"value": types.StringType,
 			},
-			defaultValue: types.Object{
-				AttrTypes: map[string]attr.Type{
-					"value": types.StringType,
+				map[string]attr.Value{
+					"value": types.StringValue("alpha"),
 				},
-				Attrs: map[string]attr.Value{
-					"value": types.String{Value: "alpha"},
-				},
+			),
+			expectedValue: types.ObjectValueMust(map[string]attr.Type{
+				"value": types.StringType,
 			},
-			expectedValue: types.Object{
-				AttrTypes: map[string]attr.Type{
-					"value": types.StringType,
+				map[string]attr.Value{
+					"value": types.StringValue("alpha"),
 				},
-				Attrs: map[string]attr.Value{
-					"value": types.String{Value: "alpha"},
-				},
-			},
+			),
 		},
 		"default object": {
-			plannedValue: types.Object{
-				AttrTypes: map[string]attr.Type{
-					"value": types.StringType,
-				},
-				Null: true,
+			plannedValue: types.ObjectNull(map[string]attr.Type{
+				"value": types.StringType,
+			}),
+			currentValue: types.ObjectValueMust(map[string]attr.Type{
+				"value": types.StringType,
 			},
-			currentValue: types.Object{
-				AttrTypes: map[string]attr.Type{
-					"value": types.StringType,
+				map[string]attr.Value{
+					"value": types.StringValue("alpha"),
 				},
-				Attrs: map[string]attr.Value{
-					"value": types.String{Value: "alpha"},
-				},
+			),
+			defaultValue: types.ObjectValueMust(map[string]attr.Type{
+				"value": types.StringType,
 			},
-			defaultValue: types.Object{
-				AttrTypes: map[string]attr.Type{
-					"value": types.StringType,
+				map[string]attr.Value{
+					"value": types.StringValue("alpha"),
 				},
-				Attrs: map[string]attr.Value{
-					"value": types.String{Value: "alpha"},
-				},
+			),
+			expectedValue: types.ObjectValueMust(map[string]attr.Type{
+				"value": types.StringType,
 			},
-			expectedValue: types.Object{
-				AttrTypes: map[string]attr.Type{
-					"value": types.StringType,
+				map[string]attr.Value{
+					"value": types.StringValue("alpha"),
 				},
-				Attrs: map[string]attr.Value{
-					"value": types.String{Value: "alpha"},
-				},
-			},
+			),
 		},
 	}
 

--- a/internal/framework/types/arn.go
+++ b/internal/framework/types/arn.go
@@ -28,21 +28,27 @@ func (t arnType) TerraformType(_ context.Context) tftypes.Type {
 
 func (t arnType) ValueFromTerraform(_ context.Context, in tftypes.Value) (attr.Value, error) {
 	if !in.IsKnown() {
-		return ARN{Unknown: true}, nil
+		return ARNUnknown(), nil
 	}
+
 	if in.IsNull() {
-		return ARN{Null: true}, nil
+		return ARNNull(), nil
 	}
+
 	var s string
 	err := in.As(&s)
+
 	if err != nil {
 		return nil, err
 	}
-	a, err := arn.Parse(s)
+
+	v, err := arn.Parse(s)
+
 	if err != nil {
 		return nil, err
 	}
-	return ARN{Value: a}, nil
+
+	return ARNValue(v), nil
 }
 
 func (t arnType) ValueType(context.Context) attr.Value {
@@ -112,10 +118,32 @@ func (t arnType) Description() string {
 	return `An Amazon Resource Name.`
 }
 
+func ARNNull() ARN {
+	return ARN{
+		state: attr.ValueStateNull,
+	}
+}
+
+func ARNUnknown() ARN {
+	return ARN{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func ARNValue(value arn.ARN) ARN {
+	return ARN{
+		state: attr.ValueStateKnown,
+		value: value,
+	}
+}
+
 type ARN struct {
-	Unknown bool
-	Null    bool
-	Value   arn.ARN
+	// state represents whether the value is null, unknown, or known. The
+	// zero-value is null.
+	state attr.ValueState
+
+	// value contains the known value, if not null or unknown.
+	value arn.ARN
 }
 
 func (a ARN) Type(_ context.Context) attr.Type {
@@ -124,38 +152,50 @@ func (a ARN) Type(_ context.Context) attr.Type {
 
 func (a ARN) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
 	t := ARNType.TerraformType(ctx)
-	if a.Null {
+
+	switch a.state {
+	case attr.ValueStateKnown:
+		if err := tftypes.ValidateValue(tftypes.Number, a.value); err != nil {
+			return tftypes.NewValue(t, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(t, a.value.String()), nil
+	case attr.ValueStateNull:
 		return tftypes.NewValue(t, nil), nil
-	}
-	if a.Unknown {
+	case attr.ValueStateUnknown:
 		return tftypes.NewValue(t, tftypes.UnknownValue), nil
+	default:
+		return tftypes.NewValue(t, tftypes.UnknownValue), fmt.Errorf("unhandled ARN state in ToTerraformValue: %s", a.state)
 	}
-	return tftypes.NewValue(t, a.Value.String()), nil
 }
 
 // Equal returns true if `other` is a *ARN and has the same value as `a`.
 func (a ARN) Equal(other attr.Value) bool {
 	o, ok := other.(ARN)
+
 	if !ok {
 		return false
 	}
-	if a.Unknown != o.Unknown {
+
+	if a.state != o.state {
 		return false
 	}
-	if a.Null != o.Null {
-		return false
+
+	if a.state != attr.ValueStateKnown {
+		return true
 	}
-	return a.Value == o.Value
+
+	return a.value == o.value
 }
 
 // IsNull returns true if the Value is not set, or is explicitly set to null.
 func (a ARN) IsNull() bool {
-	return a.Null
+	return a.state == attr.ValueStateNull
 }
 
 // IsUnknown returns true if the Value is not yet known.
 func (a ARN) IsUnknown() bool {
-	return a.Unknown
+	return a.state == attr.ValueStateUnknown
 }
 
 // String returns a summary representation of either the underlying Value,
@@ -174,5 +214,10 @@ func (a ARN) String() string {
 		return attr.NullValueString
 	}
 
-	return a.Value.String()
+	return a.value.String()
+}
+
+// ARNValue returns the known arn value. If ARN is null or unknown, returns {}.
+func (a ARN) ARNValue() arn.ARN {
+	return a.value
 }

--- a/internal/framework/types/arn.go
+++ b/internal/framework/types/arn.go
@@ -155,7 +155,7 @@ func (a ARN) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
 
 	switch a.state {
 	case attr.ValueStateKnown:
-		if err := tftypes.ValidateValue(tftypes.Number, a.value); err != nil {
+		if err := tftypes.ValidateValue(t, a.value.String()); err != nil {
 			return tftypes.NewValue(t, tftypes.UnknownValue), err
 		}
 

--- a/internal/framework/types/arn_test.go
+++ b/internal/framework/types/arn_test.go
@@ -22,21 +22,21 @@ func TestARNTypeValueFromTerraform(t *testing.T) {
 	}{
 		"null value": {
 			val:      tftypes.NewValue(tftypes.String, nil),
-			expected: fwtypes.ARN{Null: true},
+			expected: fwtypes.ARNNull(),
 		},
 		"unknown value": {
 			val:      tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
-			expected: fwtypes.ARN{Unknown: true},
+			expected: fwtypes.ARNUnknown(),
 		},
 		"valid ARN": {
 			val: tftypes.NewValue(tftypes.String, "arn:aws:rds:us-east-1:123456789012:db:test"), // lintignore:AWSAT003,AWSAT005
-			expected: fwtypes.ARN{Value: arn.ARN{
+			expected: fwtypes.ARNValue(arn.ARN{
 				Partition: "aws",
 				Service:   "rds",
 				Region:    "us-east-1", // lintignore:AWSAT003
 				AccountID: "123456789012",
 				Resource:  "db:test",
-			}},
+			}),
 		},
 		"invalid duration": {
 			val:         tftypes.NewValue(tftypes.String, "not ok"),

--- a/internal/framework/types/duration.go
+++ b/internal/framework/types/duration.go
@@ -160,7 +160,7 @@ func (d Duration) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
 
 	switch d.state {
 	case attr.ValueStateKnown:
-		if err := tftypes.ValidateValue(tftypes.Number, d.value); err != nil {
+		if err := tftypes.ValidateValue(t, d.value); err != nil {
 			return tftypes.NewValue(t, tftypes.UnknownValue), err
 		}
 

--- a/internal/framework/types/duration.go
+++ b/internal/framework/types/duration.go
@@ -28,21 +28,27 @@ func (d durationType) TerraformType(_ context.Context) tftypes.Type {
 
 func (d durationType) ValueFromTerraform(_ context.Context, in tftypes.Value) (attr.Value, error) {
 	if !in.IsKnown() {
-		return Duration{Unknown: true}, nil
+		return DurationUnknown(), nil
 	}
+
 	if in.IsNull() {
-		return Duration{Null: true}, nil
+		return DurationNull(), nil
 	}
+
 	var s string
 	err := in.As(&s)
+
 	if err != nil {
 		return nil, err
 	}
-	dur, err := time.ParseDuration(s)
+
+	v, err := time.ParseDuration(s)
+
 	if err != nil {
 		return nil, err
 	}
-	return Duration{Value: dur}, nil
+
+	return DurationValue(v), nil
 }
 
 func (d durationType) ValueType(context.Context) attr.Value {
@@ -113,17 +119,32 @@ func (d durationType) Description() string {
 	return `A sequence of numbers with a unit suffix, "h" for hour, "m" for minute, and "s" for second.`
 }
 
+func DurationNull() Duration {
+	return Duration{
+		state: attr.ValueStateNull,
+	}
+}
+
+func DurationUnknown() Duration {
+	return Duration{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func DurationValue(value time.Duration) Duration {
+	return Duration{
+		state: attr.ValueStateKnown,
+		value: value,
+	}
+}
+
 type Duration struct {
-	// Unknown will be true if the value is not yet known.
-	Unknown bool
+	// state represents whether the value is null, unknown, or known. The
+	// zero-value is null.
+	state attr.ValueState
 
-	// Null will be true if the value was not set, or was explicitly set to
-	// null.
-	Null bool
-
-	// Value contains the set value, as long as Unknown and Null are both
-	// false.
-	Value time.Duration
+	// value contains the known value, if not null or unknown.
+	value time.Duration
 }
 
 // Type returns a DurationType.
@@ -136,41 +157,50 @@ func (d Duration) Type(_ context.Context) attr.Type {
 // returns nil.
 func (d Duration) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
 	t := DurationType.TerraformType(ctx)
-	if d.Null {
+
+	switch d.state {
+	case attr.ValueStateKnown:
+		if err := tftypes.ValidateValue(tftypes.Number, d.value); err != nil {
+			return tftypes.NewValue(t, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(t, d.value), nil
+	case attr.ValueStateNull:
 		return tftypes.NewValue(t, nil), nil
-	}
-	if d.Unknown {
+	case attr.ValueStateUnknown:
 		return tftypes.NewValue(t, tftypes.UnknownValue), nil
+	default:
+		return tftypes.NewValue(t, tftypes.UnknownValue), fmt.Errorf("unhandled Duration state in ToTerraformValue: %s", d.state)
 	}
-	if err := tftypes.ValidateValue(tftypes.Number, d.Value); err != nil {
-		return tftypes.NewValue(t, tftypes.UnknownValue), err
-	}
-	return tftypes.NewValue(t, d.Value), nil
 }
 
 // Equal returns true if `other` is a *Duration and has the same value as `d`.
 func (d Duration) Equal(other attr.Value) bool {
 	o, ok := other.(Duration)
+
 	if !ok {
 		return false
 	}
-	if d.Unknown != o.Unknown {
+
+	if d.state != o.state {
 		return false
 	}
-	if d.Null != o.Null {
-		return false
+
+	if d.state != attr.ValueStateKnown {
+		return true
 	}
-	return d.Value == o.Value
+
+	return d.value == o.value
 }
 
 // IsNull returns true if the Value is not set, or is explicitly set to null.
 func (d Duration) IsNull() bool {
-	return d.Null
+	return d.state == attr.ValueStateNull
 }
 
 // IsUnknown returns true if the Value is not yet known.
 func (d Duration) IsUnknown() bool {
-	return d.Unknown
+	return d.state == attr.ValueStateUnknown
 }
 
 // String returns a summary representation of either the underlying Value,
@@ -189,5 +219,10 @@ func (d Duration) String() string {
 		return attr.NullValueString
 	}
 
-	return d.Value.String()
+	return d.value.String()
+}
+
+// DurationValue returns the known duration value. If Duration is null or unknown, returns 0.
+func (d Duration) DurationValue() time.Duration {
+	return d.value
 }

--- a/internal/framework/types/duration_test.go
+++ b/internal/framework/types/duration_test.go
@@ -22,15 +22,15 @@ func TestDurationTypeValueFromTerraform(t *testing.T) {
 	}{
 		"null value": {
 			val:      tftypes.NewValue(tftypes.String, nil),
-			expected: fwtypes.Duration{Null: true},
+			expected: fwtypes.DurationNull(),
 		},
 		"unknown value": {
 			val:      tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
-			expected: fwtypes.Duration{Unknown: true},
+			expected: fwtypes.DurationUnknown(),
 		},
 		"valid duration": {
 			val:      tftypes.NewValue(tftypes.String, "2h"),
-			expected: fwtypes.Duration{Value: 2 * time.Hour},
+			expected: fwtypes.DurationValue(2 * time.Hour),
 		},
 		"invalid duration": {
 			val:         tftypes.NewValue(tftypes.String, "not ok"),

--- a/internal/framework/validators/cidr_test.go
+++ b/internal/framework/validators/cidr_test.go
@@ -20,28 +20,28 @@ func TestIPv4CIDRNetworkAddressValidator(t *testing.T) {
 	}
 	tests := map[string]testCase{
 		"not a String": {
-			val:         types.Bool{Value: true},
+			val:         types.BoolValue(true),
 			expectError: true,
 		},
 		"unknown String": {
-			val: types.String{Unknown: true},
+			val: types.StringUnknown(),
 		},
 		"null String": {
-			val: types.String{Null: true},
+			val: types.StringNull(),
 		},
 		"invalid String": {
-			val:         types.String{Value: "test-value"},
+			val:         types.StringValue("test-value"),
 			expectError: true,
 		},
 		"valid IPv4 CIDR": {
-			val: types.String{Value: "10.2.2.0/24"},
+			val: types.StringValue("10.2.2.0/24"),
 		},
 		"invalid IPv4 CIDR": {
-			val:         types.String{Value: "10.2.2.2/24"},
+			val:         types.StringValue("10.2.2.2/24"),
 			expectError: true,
 		},
 		"valid IPv6 CIDR": {
-			val:         types.String{Value: "2001:db8::/122"},
+			val:         types.StringValue("2001:db8::/122"),
 			expectError: true,
 		},
 	}
@@ -77,28 +77,28 @@ func TestIPv6CIDRNetworkAddressValidator(t *testing.T) {
 	}
 	tests := map[string]testCase{
 		"not a String": {
-			val:         types.Bool{Value: true},
+			val:         types.BoolValue(true),
 			expectError: true,
 		},
 		"unknown String": {
-			val: types.String{Unknown: true},
+			val: types.StringUnknown(),
 		},
 		"null String": {
-			val: types.String{Null: true},
+			val: types.StringNull(),
 		},
 		"invalid String": {
-			val:         types.String{Value: "test-value"},
+			val:         types.StringValue("test-value"),
 			expectError: true,
 		},
 		"valid IPv6 CIDR": {
-			val: types.String{Value: "2001:db8::/122"},
+			val: types.StringValue("2001:db8::/122"),
 		},
 		"invalid IPv6 CIDR": {
-			val:         types.String{Value: "2001::/15"},
+			val:         types.StringValue("2001::/15"),
 			expectError: true,
 		},
 		"valid IPv4 CIDR": {
-			val:         types.String{Value: "10.2.2.0/24"},
+			val:         types.StringValue("10.2.2.0/24"),
 			expectError: true,
 		},
 	}

--- a/internal/framework/validators/int64string_test.go
+++ b/internal/framework/validators/int64string_test.go
@@ -22,48 +22,48 @@ func TestBetweenValidator(t *testing.T) {
 	}
 	tests := map[string]testCase{
 		"not a String": {
-			val:         types.Bool{Value: true},
+			val:         types.BoolValue(true),
 			expectError: true,
 		},
 		"unknown String": {
-			val: types.String{Unknown: true},
+			val: types.StringUnknown(),
 			min: 1,
 			max: 3,
 		},
 		"null String": {
-			val: types.String{Null: true},
+			val: types.StringNull(),
 			min: 1,
 			max: 3,
 		},
 		"invalid String": {
-			val:         types.String{Value: "test-value"},
+			val:         types.StringValue("test-value"),
 			min:         1,
 			max:         3,
 			expectError: true,
 		},
 		"valid string": {
-			val: types.String{Value: "2"},
+			val: types.StringValue("2"),
 			min: 1,
 			max: 3,
 		},
 		"valid string min": {
-			val: types.String{Value: "1"},
+			val: types.StringValue("1"),
 			min: 1,
 			max: 3,
 		},
 		"valid string max": {
-			val: types.String{Value: "3"},
+			val: types.StringValue("3"),
 			min: 1,
 			max: 3,
 		},
 		"too small string": {
-			val:         types.String{Value: "-1"},
+			val:         types.StringValue("-1"),
 			min:         1,
 			max:         3,
 			expectError: true,
 		},
 		"too large string": {
-			val:         types.String{Value: "42"},
+			val:         types.StringValue("42"),
 			min:         1,
 			max:         3,
 			expectError: true,

--- a/internal/framework/validators/type_validation.go
+++ b/internal/framework/validators/type_validation.go
@@ -49,5 +49,5 @@ func validateString(ctx context.Context, request tfsdk.ValidateAttributeRequest,
 		return "", false
 	}
 
-	return s.Value, true
+	return s.ValueString(), true
 }

--- a/internal/framework/validators/type_validation_test.go
+++ b/internal/framework/validators/type_validation_test.go
@@ -20,7 +20,7 @@ func TestValidateInt64String(t *testing.T) {
 	}{
 		"invalid-type": {
 			request: tfsdk.ValidateAttributeRequest{
-				AttributeConfig:         types.Bool{Value: true},
+				AttributeConfig:         types.BoolValue(true),
 				AttributePath:           path.Root("test"),
 				AttributePathExpression: path.MatchRoot("test"),
 			},
@@ -29,7 +29,7 @@ func TestValidateInt64String(t *testing.T) {
 		},
 		"string-null": {
 			request: tfsdk.ValidateAttributeRequest{
-				AttributeConfig:         types.Int64{Null: true},
+				AttributeConfig:         types.Int64Null(),
 				AttributePath:           path.Root("test"),
 				AttributePathExpression: path.MatchRoot("test"),
 			},
@@ -38,7 +38,7 @@ func TestValidateInt64String(t *testing.T) {
 		},
 		"string-valid-value": {
 			request: tfsdk.ValidateAttributeRequest{
-				AttributeConfig:         types.String{Value: "43"},
+				AttributeConfig:         types.StringValue("43"),
 				AttributePath:           path.Root("test"),
 				AttributePathExpression: path.MatchRoot("test"),
 			},
@@ -47,7 +47,7 @@ func TestValidateInt64String(t *testing.T) {
 		},
 		"string-invalid-value": {
 			request: tfsdk.ValidateAttributeRequest{
-				AttributeConfig:         types.String{Value: "test-value"},
+				AttributeConfig:         types.StringValue("test-value"),
 				AttributePath:           path.Root("test"),
 				AttributePathExpression: path.MatchRoot("test"),
 			},
@@ -56,7 +56,7 @@ func TestValidateInt64String(t *testing.T) {
 		},
 		"string-unknown": {
 			request: tfsdk.ValidateAttributeRequest{
-				AttributeConfig:         types.Int64{Unknown: true},
+				AttributeConfig:         types.Int64Unknown(),
 				AttributePath:           path.Root("test"),
 				AttributePathExpression: path.MatchRoot("test"),
 			},
@@ -94,7 +94,7 @@ func TestValidateString(t *testing.T) {
 	}{
 		"invalid-type": {
 			request: tfsdk.ValidateAttributeRequest{
-				AttributeConfig:         types.Bool{Value: true},
+				AttributeConfig:         types.BoolValue(true),
 				AttributePath:           path.Root("test"),
 				AttributePathExpression: path.MatchRoot("test"),
 			},
@@ -103,7 +103,7 @@ func TestValidateString(t *testing.T) {
 		},
 		"string-null": {
 			request: tfsdk.ValidateAttributeRequest{
-				AttributeConfig:         types.Int64{Null: true},
+				AttributeConfig:         types.Int64Null(),
 				AttributePath:           path.Root("test"),
 				AttributePathExpression: path.MatchRoot("test"),
 			},
@@ -112,7 +112,7 @@ func TestValidateString(t *testing.T) {
 		},
 		"string-value": {
 			request: tfsdk.ValidateAttributeRequest{
-				AttributeConfig:         types.String{Value: "test-value"},
+				AttributeConfig:         types.StringValue("test-value"),
 				AttributePath:           path.Root("test"),
 				AttributePathExpression: path.MatchRoot("test"),
 			},
@@ -121,7 +121,7 @@ func TestValidateString(t *testing.T) {
 		},
 		"string-unknown": {
 			request: tfsdk.ValidateAttributeRequest{
-				AttributeConfig:         types.Int64{Unknown: true},
+				AttributeConfig:         types.Int64Unknown(),
 				AttributePath:           path.Root("test"),
 				AttributePathExpression: path.MatchRoot("test"),
 			},

--- a/internal/service/ec2/filters.go
+++ b/internal/service/ec2/filters.go
@@ -171,7 +171,7 @@ func BuildCustomFilters(ctx context.Context, filterSet types.Set) []*ec2.Filter 
 
 	var filters []*ec2.Filter
 
-	for _, v := range filterSet.Elems {
+	for _, v := range filterSet.Elements() {
 		var data customFilterData
 
 		if tfsdk.ValueAs(ctx, v, &data).HasError() {
@@ -184,7 +184,7 @@ func BuildCustomFilters(ctx context.Context, filterSet types.Set) []*ec2.Filter 
 
 		if v := flex.ExpandFrameworkStringSet(ctx, data.Values); v != nil {
 			filters = append(filters, &ec2.Filter{
-				Name:   aws.String(data.Name.Value),
+				Name:   flex.StringFromFramework(ctx, data.Name),
 				Values: v,
 			})
 		}

--- a/internal/service/ec2/vpc_security_group_egress_rule.go
+++ b/internal/service/ec2/vpc_security_group_egress_rule.go
@@ -53,7 +53,7 @@ func (r *resourceSecurityGroupEgressRule) createSecurityGroupRule(ctx context.Co
 	conn := r.Meta().EC2Conn
 
 	input := &ec2.AuthorizeSecurityGroupEgressInput{
-		GroupId:       aws.String(data.SecurityGroupID.Value),
+		GroupId:       flex.StringFromFramework(ctx, data.SecurityGroupID),
 		IpPermissions: []*ec2.IpPermission{r.expandIPPermission(ctx, data)},
 	}
 
@@ -71,7 +71,7 @@ func (r *resourceSecurityGroupEgressRule) deleteSecurityGroupRule(ctx context.Co
 
 	_, err := conn.RevokeSecurityGroupEgressWithContext(ctx, &ec2.RevokeSecurityGroupEgressInput{
 		GroupId:              flex.StringFromFramework(ctx, data.SecurityGroupID),
-		SecurityGroupRuleIds: aws.StringSlice([]string{data.ID.Value}),
+		SecurityGroupRuleIds: flex.StringSliceFromFramework(ctx, data.ID),
 	})
 
 	return err

--- a/internal/service/ec2/vpc_security_group_egress_rule.go
+++ b/internal/service/ec2/vpc_security_group_egress_rule.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 )
 
 func init() {
@@ -69,7 +70,7 @@ func (r *resourceSecurityGroupEgressRule) deleteSecurityGroupRule(ctx context.Co
 	conn := r.Meta().EC2Conn
 
 	_, err := conn.RevokeSecurityGroupEgressWithContext(ctx, &ec2.RevokeSecurityGroupEgressInput{
-		GroupId:              aws.String(data.SecurityGroupID.Value),
+		GroupId:              flex.StringFromFramework(ctx, data.SecurityGroupID),
 		SecurityGroupRuleIds: aws.StringSlice([]string{data.ID.Value}),
 	})
 

--- a/internal/service/ec2/vpc_security_group_ingress_rule.go
+++ b/internal/service/ec2/vpc_security_group_ingress_rule.go
@@ -404,25 +404,25 @@ func (r *resourceSecurityGroupRule) read(ctx context.Context, request resource.R
 	}
 
 	data.ARN = r.arn(ctx, data.ID.Value)
-	data.CIDRIPv4 = flex.ToFrameworkStringValue(ctx, output.CidrIpv4)
-	data.CIDRIPv6 = flex.ToFrameworkStringValue(ctx, output.CidrIpv6)
-	data.Description = flex.ToFrameworkStringValue(ctx, output.Description)
-	data.IPProtocol = flex.ToFrameworkStringValue(ctx, output.IpProtocol)
-	data.PrefixListID = flex.ToFrameworkStringValue(ctx, output.PrefixListId)
+	data.CIDRIPv4 = flex.StringToFramework(ctx, output.CidrIpv4)
+	data.CIDRIPv6 = flex.StringToFramework(ctx, output.CidrIpv6)
+	data.Description = flex.StringToFramework(ctx, output.Description)
+	data.IPProtocol = flex.StringToFramework(ctx, output.IpProtocol)
+	data.PrefixListID = flex.StringToFramework(ctx, output.PrefixListId)
 	data.ReferencedSecurityGroupID = r.flattenReferencedSecurityGroup(ctx, output.ReferencedGroupInfo)
-	data.SecurityGroupID = flex.ToFrameworkStringValue(ctx, output.GroupId)
-	data.SecurityGroupRuleID = flex.ToFrameworkStringValue(ctx, output.SecurityGroupRuleId)
+	data.SecurityGroupID = flex.StringToFramework(ctx, output.GroupId)
+	data.SecurityGroupRuleID = flex.StringToFramework(ctx, output.SecurityGroupRuleId)
 
 	// If planned from_port or to_port are null and values of -1 are returned, propagate null.
 	if v := aws.Int64Value(output.FromPort); v == -1 && data.FromPort.IsNull() {
 		data.FromPort = types.Int64{Null: true}
 	} else {
-		data.FromPort = flex.ToFrameworkInt64Value(ctx, output.FromPort)
+		data.FromPort = flex.Int64ToFramework(ctx, output.FromPort)
 	}
 	if v := aws.Int64Value(output.ToPort); v == -1 && data.ToPort.IsNull() {
 		data.ToPort = types.Int64{Null: true}
 	} else {
-		data.ToPort = flex.ToFrameworkInt64Value(ctx, output.ToPort)
+		data.ToPort = flex.Int64ToFramework(ctx, output.ToPort)
 	}
 
 	tags := KeyValueTags(output.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
@@ -556,7 +556,7 @@ func (r *resourceSecurityGroupRule) flattenReferencedSecurityGroup(ctx context.C
 	}
 
 	if apiObject.UserId == nil || aws.StringValue(apiObject.UserId) == r.Meta().AccountID {
-		return flex.ToFrameworkStringValue(ctx, apiObject.GroupId)
+		return flex.StringToFramework(ctx, apiObject.GroupId)
 	}
 
 	// [UserID/]GroupID.
@@ -635,7 +635,7 @@ func (m normalizeIPProtocol) Modify(ctx context.Context, request tfsdk.ModifyAtt
 		return
 	}
 
-	if ProtocolForValue(current.Value) == ProtocolForValue(planned.Value) {
+	if ProtocolForValue(current.ValueString()) == ProtocolForValue(planned.ValueString()) {
 		response.AttributePlan = request.AttributeState
 
 		return

--- a/internal/service/ec2/vpc_security_group_ingress_rule.go
+++ b/internal/service/ec2/vpc_security_group_ingress_rule.go
@@ -68,7 +68,7 @@ func (r *resourceSecurityGroupIngressRule) createSecurityGroupRule(ctx context.C
 	conn := r.Meta().EC2Conn
 
 	input := &ec2.AuthorizeSecurityGroupIngressInput{
-		GroupId:       aws.String(data.SecurityGroupID.Value),
+		GroupId:       flex.StringFromFramework(ctx, data.SecurityGroupID),
 		IpPermissions: []*ec2.IpPermission{r.expandIPPermission(ctx, data)},
 	}
 
@@ -85,8 +85,8 @@ func (r *resourceSecurityGroupIngressRule) deleteSecurityGroupRule(ctx context.C
 	conn := r.Meta().EC2Conn
 
 	_, err := conn.RevokeSecurityGroupIngressWithContext(ctx, &ec2.RevokeSecurityGroupIngressInput{
-		GroupId:              aws.String(data.SecurityGroupID.Value),
-		SecurityGroupRuleIds: aws.StringSlice([]string{data.ID.Value}),
+		GroupId:              flex.StringFromFramework(ctx, data.SecurityGroupID),
+		SecurityGroupRuleIds: flex.StringSliceFromFramework(ctx, data.ID),
 	})
 
 	return err
@@ -219,25 +219,25 @@ func (r *resourceSecurityGroupRule) Update(ctx context.Context, request resource
 		!new.ReferencedSecurityGroupID.Equal(old.ReferencedSecurityGroupID) ||
 		!new.ToPort.Equal(old.ToPort) {
 		input := &ec2.ModifySecurityGroupRulesInput{
-			GroupId: aws.String(new.SecurityGroupID.Value),
+			GroupId: flex.StringFromFramework(ctx, new.SecurityGroupID),
 			SecurityGroupRules: []*ec2.SecurityGroupRuleUpdate{{
 				SecurityGroupRule:   r.expandSecurityGroupRuleRequest(ctx, &new),
-				SecurityGroupRuleId: aws.String(new.ID.Value),
+				SecurityGroupRuleId: flex.StringFromFramework(ctx, new.ID),
 			}},
 		}
 
 		_, err := conn.ModifySecurityGroupRulesWithContext(ctx, input)
 
 		if err != nil {
-			response.Diagnostics.AddError(fmt.Sprintf("updating VPC Security Group Rule (%s)", new.ID.Value), err.Error())
+			response.Diagnostics.AddError(fmt.Sprintf("updating VPC Security Group Rule (%s)", new.ID.ValueString()), err.Error())
 
 			return
 		}
 	}
 
 	if !new.TagsAll.Equal(old.TagsAll) {
-		if err := UpdateTagsWithContext(ctx, conn, new.ID.Value, old.TagsAll, new.TagsAll); err != nil {
-			response.Diagnostics.AddError(fmt.Sprintf("updating VPC Security Group Rule (%s) tags", new.ID.Value), err.Error())
+		if err := UpdateTagsWithContext(ctx, conn, new.ID.ValueString(), old.TagsAll, new.TagsAll); err != nil {
+			response.Diagnostics.AddError(fmt.Sprintf("updating VPC Security Group Rule (%s) tags", new.ID.ValueString()), err.Error())
 
 			return
 		}
@@ -326,7 +326,7 @@ func (r *resourceSecurityGroupRule) create(ctx context.Context, request resource
 		return
 	}
 
-	data.ID = types.String{Value: securityGroupRuleID}
+	data.ID = types.StringValue(securityGroupRuleID)
 
 	conn := r.Meta().EC2Conn
 	defaultTagsConfig := r.Meta().DefaultTagsConfig
@@ -334,8 +334,8 @@ func (r *resourceSecurityGroupRule) create(ctx context.Context, request resource
 	tags := defaultTagsConfig.MergeTags(tftags.New(data.Tags))
 
 	if len(tags) > 0 {
-		if err := UpdateTagsWithContext(ctx, conn, data.ID.Value, nil, tags); err != nil {
-			response.Diagnostics.AddError(fmt.Sprintf("adding VPC Security Group Rule (%s) tags", data.ID.Value), err.Error())
+		if err := UpdateTagsWithContext(ctx, conn, data.ID.ValueString(), nil, tags); err != nil {
+			response.Diagnostics.AddError(fmt.Sprintf("adding VPC Security Group Rule (%s) tags", data.ID.ValueString()), err.Error())
 
 			return
 		}
@@ -343,7 +343,7 @@ func (r *resourceSecurityGroupRule) create(ctx context.Context, request resource
 
 	// Set values for unknowns.
 	data.ARN = r.arn(ctx, securityGroupRuleID)
-	data.SecurityGroupRuleID = types.String{Value: securityGroupRuleID}
+	data.SecurityGroupRuleID = types.StringValue(securityGroupRuleID)
 	data.TagsAll = flex.FlattenFrameworkStringValueMap(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
@@ -359,7 +359,7 @@ func (r *resourceSecurityGroupRule) delete(ctx context.Context, request resource
 	}
 
 	tflog.Debug(ctx, "deleting VPC Security Group Rule", map[string]interface{}{
-		"id": data.ID.Value,
+		"id": data.ID.ValueString(),
 	})
 	err := f(ctx, &data)
 
@@ -368,7 +368,7 @@ func (r *resourceSecurityGroupRule) delete(ctx context.Context, request resource
 	}
 
 	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("deleting VPC Security Group Rule (%s)", data.ID.Value), err.Error())
+		response.Diagnostics.AddError(fmt.Sprintf("deleting VPC Security Group Rule (%s)", data.ID.ValueString()), err.Error())
 
 		return
 	}
@@ -386,11 +386,11 @@ func (r *resourceSecurityGroupRule) read(ctx context.Context, request resource.R
 	defaultTagsConfig := r.Meta().DefaultTagsConfig
 	ignoreTagsConfig := r.Meta().IgnoreTagsConfig
 
-	output, err := f(ctx, data.ID.Value)
+	output, err := f(ctx, data.ID.ValueString())
 
 	if tfresource.NotFound(err) {
 		tflog.Warn(ctx, "VPC Security Group Rule not found, removing from state", map[string]interface{}{
-			"id": data.ID.Value,
+			"id": data.ID.ValueString(),
 		})
 		response.State.RemoveResource(ctx)
 
@@ -398,12 +398,12 @@ func (r *resourceSecurityGroupRule) read(ctx context.Context, request resource.R
 	}
 
 	if err != nil {
-		response.Diagnostics.AddError(fmt.Sprintf("reading VPC Security Group Rule (%s)", data.ID.Value), err.Error())
+		response.Diagnostics.AddError(fmt.Sprintf("reading VPC Security Group Rule (%s)", data.ID.ValueString()), err.Error())
 
 		return
 	}
 
-	data.ARN = r.arn(ctx, data.ID.Value)
+	data.ARN = r.arn(ctx, data.ID.ValueString())
 	data.CIDRIPv4 = flex.StringToFramework(ctx, output.CidrIpv4)
 	data.CIDRIPv6 = flex.StringToFramework(ctx, output.CidrIpv6)
 	data.Description = flex.StringToFramework(ctx, output.Description)
@@ -415,12 +415,12 @@ func (r *resourceSecurityGroupRule) read(ctx context.Context, request resource.R
 
 	// If planned from_port or to_port are null and values of -1 are returned, propagate null.
 	if v := aws.Int64Value(output.FromPort); v == -1 && data.FromPort.IsNull() {
-		data.FromPort = types.Int64{Null: true}
+		data.FromPort = types.Int64Null()
 	} else {
 		data.FromPort = flex.Int64ToFramework(ctx, output.FromPort)
 	}
 	if v := aws.Int64Value(output.ToPort); v == -1 && data.ToPort.IsNull() {
-		data.ToPort = types.Int64{Null: true}
+		data.ToPort = types.Int64Null()
 	} else {
 		data.ToPort = flex.Int64ToFramework(ctx, output.ToPort)
 	}
@@ -445,106 +445,64 @@ func (r *resourceSecurityGroupRule) arn(_ context.Context, id string) types.Stri
 		AccountID: r.Meta().AccountID,
 		Resource:  fmt.Sprintf("security-group-rule/%s", id),
 	}.String()
-	return types.String{Value: arn}
+	return types.StringValue(arn)
 }
 
-func (r *resourceSecurityGroupRule) expandIPPermission(_ context.Context, data *resourceSecurityGroupRuleData) *ec2.IpPermission {
-	apiObject := &ec2.IpPermission{}
+func (r *resourceSecurityGroupRule) expandIPPermission(ctx context.Context, data *resourceSecurityGroupRuleData) *ec2.IpPermission {
+	apiObject := &ec2.IpPermission{
+		FromPort:   flex.Int64FromFramework(ctx, data.FromPort),
+		IpProtocol: flex.StringFromFramework(ctx, data.IPProtocol),
+		ToPort:     flex.Int64FromFramework(ctx, data.ToPort),
+	}
 
 	if !data.CIDRIPv4.IsNull() {
 		apiObject.IpRanges = []*ec2.IpRange{{
-			CidrIp: aws.String(data.CIDRIPv4.Value),
+			CidrIp:      flex.StringFromFramework(ctx, data.CIDRIPv4),
+			Description: flex.StringFromFramework(ctx, data.Description),
 		}}
-
-		if !data.Description.IsNull() {
-			apiObject.IpRanges[0].Description = aws.String(data.Description.Value)
-		}
 	}
 
 	if !data.CIDRIPv6.IsNull() {
 		apiObject.Ipv6Ranges = []*ec2.Ipv6Range{{
-			CidrIpv6: aws.String(data.CIDRIPv6.Value),
+			CidrIpv6:    flex.StringFromFramework(ctx, data.CIDRIPv6),
+			Description: flex.StringFromFramework(ctx, data.Description),
 		}}
-
-		if !data.Description.IsNull() {
-			apiObject.IpRanges[0].Description = aws.String(data.Description.Value)
-		}
-	}
-
-	if !data.FromPort.IsNull() {
-		apiObject.FromPort = aws.Int64(data.FromPort.Value)
-	}
-
-	if !data.IPProtocol.IsNull() {
-		apiObject.IpProtocol = aws.String(data.IPProtocol.Value)
 	}
 
 	if !data.PrefixListID.IsNull() {
 		apiObject.PrefixListIds = []*ec2.PrefixListId{{
-			PrefixListId: aws.String(data.PrefixListID.Value),
+			PrefixListId: flex.StringFromFramework(ctx, data.PrefixListID),
+			Description:  flex.StringFromFramework(ctx, data.Description),
 		}}
-
-		if !data.Description.IsNull() {
-			apiObject.PrefixListIds[0].Description = aws.String(data.Description.Value)
-		}
 	}
 
 	if !data.ReferencedSecurityGroupID.IsNull() {
-		apiObject.UserIdGroupPairs = []*ec2.UserIdGroupPair{{}}
+		apiObject.UserIdGroupPairs = []*ec2.UserIdGroupPair{{
+			Description: flex.StringFromFramework(ctx, data.Description),
+		}}
 
 		// [UserID/]GroupID.
-		if parts := strings.Split(data.ReferencedSecurityGroupID.Value, "/"); len(parts) == 2 {
+		if parts := strings.Split(data.ReferencedSecurityGroupID.ValueString(), "/"); len(parts) == 2 {
 			apiObject.UserIdGroupPairs[0].GroupId = aws.String(parts[1])
 			apiObject.UserIdGroupPairs[0].UserId = aws.String(parts[0])
 		} else {
-			apiObject.UserIdGroupPairs[0].GroupId = aws.String(data.ReferencedSecurityGroupID.Value)
+			apiObject.UserIdGroupPairs[0].GroupId = flex.StringFromFramework(ctx, data.ReferencedSecurityGroupID)
 		}
-
-		if !data.Description.IsNull() {
-			apiObject.UserIdGroupPairs[0].Description = aws.String(data.Description.Value)
-		}
-	}
-
-	if !data.ToPort.IsNull() {
-		apiObject.ToPort = aws.Int64(data.ToPort.Value)
 	}
 
 	return apiObject
 }
 
-func (r *resourceSecurityGroupRule) expandSecurityGroupRuleRequest(_ context.Context, data *resourceSecurityGroupRuleData) *ec2.SecurityGroupRuleRequest {
-	apiObject := &ec2.SecurityGroupRuleRequest{}
-
-	if !data.CIDRIPv4.IsNull() {
-		apiObject.CidrIpv4 = aws.String(data.CIDRIPv4.Value)
-	}
-
-	if !data.CIDRIPv6.IsNull() {
-		apiObject.CidrIpv6 = aws.String(data.CIDRIPv6.Value)
-	}
-
-	if !data.Description.IsNull() {
-		apiObject.Description = aws.String(data.Description.Value)
-	}
-
-	if !data.FromPort.IsNull() {
-		apiObject.FromPort = aws.Int64(data.FromPort.Value)
-	}
-
-	if !data.IPProtocol.IsNull() {
-		apiObject.IpProtocol = aws.String(data.IPProtocol.Value)
-	}
-
-	if !data.PrefixListID.IsNull() {
-		apiObject.PrefixListId = aws.String(data.PrefixListID.Value)
-	}
-
-	if !data.ReferencedSecurityGroupID.IsNull() {
-		apiObject.ReferencedGroupId = aws.String(data.ReferencedSecurityGroupID.Value)
-	}
-
-	if !data.ToPort.IsNull() {
-		apiObject.ToPort = aws.Int64(data.ToPort.Value)
+func (r *resourceSecurityGroupRule) expandSecurityGroupRuleRequest(ctx context.Context, data *resourceSecurityGroupRuleData) *ec2.SecurityGroupRuleRequest {
+	apiObject := &ec2.SecurityGroupRuleRequest{
+		CidrIpv4:          flex.StringFromFramework(ctx, data.CIDRIPv4),
+		CidrIpv6:          flex.StringFromFramework(ctx, data.CIDRIPv6),
+		Description:       flex.StringFromFramework(ctx, data.Description),
+		FromPort:          flex.Int64FromFramework(ctx, data.FromPort),
+		IpProtocol:        flex.StringFromFramework(ctx, data.IPProtocol),
+		PrefixListId:      flex.StringFromFramework(ctx, data.PrefixListID),
+		ReferencedGroupId: flex.StringFromFramework(ctx, data.ReferencedSecurityGroupID),
+		ToPort:            flex.Int64FromFramework(ctx, data.ToPort),
 	}
 
 	return apiObject
@@ -552,7 +510,7 @@ func (r *resourceSecurityGroupRule) expandSecurityGroupRuleRequest(_ context.Con
 
 func (r *resourceSecurityGroupRule) flattenReferencedSecurityGroup(ctx context.Context, apiObject *ec2.ReferencedSecurityGroup) types.String {
 	if apiObject == nil {
-		return types.String{Null: true}
+		return types.StringNull()
 	}
 
 	if apiObject.UserId == nil || aws.StringValue(apiObject.UserId) == r.Meta().AccountID {
@@ -560,7 +518,7 @@ func (r *resourceSecurityGroupRule) flattenReferencedSecurityGroup(ctx context.C
 	}
 
 	// [UserID/]GroupID.
-	return types.String{Value: strings.Join([]string{aws.StringValue(apiObject.UserId), aws.StringValue(apiObject.GroupId)}, "/")}
+	return types.StringValue(strings.Join([]string{aws.StringValue(apiObject.UserId), aws.StringValue(apiObject.GroupId)}, "/"))
 }
 
 type resourceSecurityGroupRuleData struct {

--- a/internal/service/ec2/vpc_security_group_ingress_rule_test.go
+++ b/internal/service/ec2/vpc_security_group_ingress_rule_test.go
@@ -34,19 +34,19 @@ func TestNormalizeIPProtocol(t *testing.T) {
 	}
 	tests := map[string]testCase{
 		"planned name, current number (equivalent)": {
-			plannedValue:  types.String{Value: "icmp"},
-			currentValue:  types.String{Value: "1"},
-			expectedValue: types.String{Value: "1"},
+			plannedValue:  types.StringValue("icmp"),
+			currentValue:  types.StringValue("1"),
+			expectedValue: types.StringValue("1"),
 		},
 		"planned number, current name (equivalent)": {
-			plannedValue:  types.String{Value: "1"},
-			currentValue:  types.String{Value: "icmp"},
-			expectedValue: types.String{Value: "icmp"},
+			plannedValue:  types.StringValue("1"),
+			currentValue:  types.StringValue("icmp"),
+			expectedValue: types.StringValue("icmp"),
 		},
 		"planned name, current number (not equivalent)": {
-			plannedValue:  types.String{Value: "icmp"},
-			currentValue:  types.String{Value: "2"},
-			expectedValue: types.String{Value: "icmp"},
+			plannedValue:  types.StringValue("icmp"),
+			currentValue:  types.StringValue("2"),
+			expectedValue: types.StringValue("icmp"),
 		},
 	}
 

--- a/internal/service/globalaccelerator/accelerator_data_source.go
+++ b/internal/service/globalaccelerator/accelerator_data_source.go
@@ -122,7 +122,7 @@ func (d *dataSourceAccelerator) Read(ctx context.Context, request datasource.Rea
 				continue
 			}
 
-			if !data.ARN.IsNull() && data.ARN.Value.String() != aws.StringValue(accelerator.AcceleratorArn) {
+			if !data.ARN.IsNull() && data.ARN.ARNValue().String() != aws.StringValue(accelerator.AcceleratorArn) {
 				continue
 			}
 
@@ -157,7 +157,7 @@ func (d *dataSourceAccelerator) Read(ctx context.Context, request datasource.Rea
 	if v, err := arn.Parse(acceleratorARN); err != nil {
 		response.Diagnostics.AddError("parsing ARN", err.Error())
 	} else {
-		data.ARN = fwtypes.ARN{Value: v}
+		data.ARN = fwtypes.ARNValue(v)
 	}
 	data.DnsName = flex.StringToFrameworkLegacy(ctx, accelerator.DnsName)
 	data.Enabled = flex.BoolToFrameworkLegacy(ctx, accelerator.Enabled)

--- a/internal/service/medialive/multiplex_program.go
+++ b/internal/service/medialive/multiplex_program.go
@@ -190,8 +190,8 @@ func (m *multiplexProgram) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	multiplexId := plan.MultiplexID.Value
-	programName := plan.ProgramName.Value
+	multiplexId := plan.MultiplexID.ValueString()
+	programName := plan.ProgramName.ValueString()
 
 	in := &medialive.CreateMultiplexProgramInput{
 		MultiplexId: aws.String(multiplexId),
@@ -226,9 +226,9 @@ func (m *multiplexProgram) Create(ctx context.Context, req resource.CreateReques
 
 	var result resourceMultiplexProgramData
 
-	result.ID = types.String{Value: fmt.Sprintf("%s/%s", programName, multiplexId)}
-	result.ProgramName = types.String{Value: aws.ToString(out.MultiplexProgram.ProgramName)}
-	result.MultiplexID = types.String{Value: plan.MultiplexID.Value}
+	result.ID = types.StringValue(fmt.Sprintf("%s/%s", programName, multiplexId))
+	result.ProgramName = types.StringValue(aws.ToString(out.MultiplexProgram.ProgramName))
+	result.MultiplexID = types.StringValue(plan.MultiplexID.ValueString())
 	result.MultiplexProgramSettings = flattenMultiplexProgramSettings(out.MultiplexProgram.MultiplexProgramSettings, isStateMuxSet)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
@@ -248,7 +248,7 @@ func (m *multiplexProgram) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	programName, multiplexId, err := ParseMultiplexProgramID(state.ID.Value)
+	programName, multiplexId, err := ParseMultiplexProgramID(state.ID.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -289,12 +289,12 @@ func (m *multiplexProgram) Read(ctx context.Context, req resource.ReadRequest, r
 
 	var stateMuxIsNull bool
 	if len(sm) > 0 {
-		if len(sm[0].StatemuxSettings.Elems) == 0 {
+		if len(sm[0].StatemuxSettings.Elements()) == 0 {
 			stateMuxIsNull = true
 		}
 	}
 	state.MultiplexProgramSettings = flattenMultiplexProgramSettings(out.MultiplexProgramSettings, stateMuxIsNull)
-	state.ProgramName = types.String{Value: aws.ToString(out.ProgramName)}
+	state.ProgramName = types.StringValue(aws.ToString(out.ProgramName))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 
@@ -313,7 +313,7 @@ func (m *multiplexProgram) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	programName, multiplexId, err := ParseMultiplexProgramID(plan.ID.Value)
+	programName, multiplexId, err := ParseMultiplexProgramID(plan.ID.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -378,7 +378,7 @@ func (m *multiplexProgram) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
-	programName, multiplexId, err := ParseMultiplexProgramID(state.ID.Value)
+	programName, multiplexId, err := ParseMultiplexProgramID(state.ID.ValueString())
 
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -423,15 +423,15 @@ func (m *multiplexProgram) ValidateConfig(ctx context.Context, req resource.Vali
 		return
 	}
 
-	if len(mps[0].VideoSettings.Elems) > 0 || !mps[0].VideoSettings.IsNull() {
+	if len(mps[0].VideoSettings.Elements()) > 0 || !mps[0].VideoSettings.IsNull() {
 		vs := make([]videoSettings, 1)
 		resp.Diagnostics.Append(mps[0].VideoSettings.ElementsAs(ctx, &vs, false)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
 
-		statMuxSet := len(vs[0].StatmuxSettings.Elems) > 0
-		stateMuxSet := len(vs[0].StatemuxSettings.Elems) > 0
+		statMuxSet := len(vs[0].StatmuxSettings.Elements()) > 0
+		stateMuxSet := len(vs[0].StatemuxSettings.Elements()) > 0
 
 		if statMuxSet && stateMuxSet {
 			resp.Diagnostics.AddAttributeError(
@@ -477,11 +477,11 @@ func expandMultiplexProgramSettings(ctx context.Context, mps []multiplexProgramS
 	data := mps[0]
 
 	l := &mltypes.MultiplexProgramSettings{
-		ProgramNumber:            int32(data.ProgramNumber.Value),
-		PreferredChannelPipeline: mltypes.PreferredChannelPipeline(data.PreferredChannelPipeline.Value),
+		ProgramNumber:            int32(data.ProgramNumber.ValueInt64()),
+		PreferredChannelPipeline: mltypes.PreferredChannelPipeline(data.PreferredChannelPipeline.ValueString()),
 	}
 
-	if len(data.ServiceDescriptor.Elems) > 0 && !data.ServiceDescriptor.IsNull() {
+	if len(data.ServiceDescriptor.Elements()) > 0 && !data.ServiceDescriptor.IsNull() {
 		sd := make([]serviceDescriptor, 1)
 		err := data.ServiceDescriptor.ElementsAs(ctx, &sd, false)
 		if err.HasError() {
@@ -489,12 +489,12 @@ func expandMultiplexProgramSettings(ctx context.Context, mps []multiplexProgramS
 		}
 
 		l.ServiceDescriptor = &mltypes.MultiplexProgramServiceDescriptor{
-			ProviderName: aws.String(sd[0].ProviderName.Value),
-			ServiceName:  aws.String(sd[0].ServiceName.Value),
+			ProviderName: aws.String(sd[0].ProviderName.ValueString()),
+			ServiceName:  aws.String(sd[0].ServiceName.ValueString()),
 		}
 	}
 
-	if len(data.VideoSettings.Elems) > 0 && !data.VideoSettings.IsNull() {
+	if len(data.VideoSettings.Elements()) > 0 && !data.VideoSettings.IsNull() {
 		vs := make([]videoSettings, 1)
 		err := data.VideoSettings.ElementsAs(ctx, &vs, false)
 		if err.HasError() {
@@ -502,11 +502,11 @@ func expandMultiplexProgramSettings(ctx context.Context, mps []multiplexProgramS
 		}
 
 		l.VideoSettings = &mltypes.MultiplexVideoSettings{
-			ConstantBitrate: int32(vs[0].ConstantBitrate.Value),
+			ConstantBitrate: int32(vs[0].ConstantBitrate.ValueInt64()),
 		}
 
 		// Deprecated: will be removed in the next major version
-		if len(vs[0].StatemuxSettings.Elems) > 0 && !vs[0].StatemuxSettings.IsNull() {
+		if len(vs[0].StatemuxSettings.Elements()) > 0 && !vs[0].StatemuxSettings.IsNull() {
 			sms := make([]statmuxSettings, 1)
 			err := vs[0].StatemuxSettings.ElementsAs(ctx, &sms, false)
 			if err.HasError() {
@@ -514,13 +514,13 @@ func expandMultiplexProgramSettings(ctx context.Context, mps []multiplexProgramS
 			}
 
 			l.VideoSettings.StatmuxSettings = &mltypes.MultiplexStatmuxVideoSettings{
-				MinimumBitrate: int32(sms[0].MinimumBitrate.Value),
-				MaximumBitrate: int32(sms[0].MaximumBitrate.Value),
-				Priority:       int32(sms[0].Priority.Value),
+				MinimumBitrate: int32(sms[0].MinimumBitrate.ValueInt64()),
+				MaximumBitrate: int32(sms[0].MaximumBitrate.ValueInt64()),
+				Priority:       int32(sms[0].Priority.ValueInt64()),
 			}
 		}
 
-		if len(vs[0].StatmuxSettings.Elems) > 0 && !vs[0].StatmuxSettings.IsNull() {
+		if len(vs[0].StatmuxSettings.Elements()) > 0 && !vs[0].StatmuxSettings.IsNull() {
 			stateMuxIsNull = true
 			sms := make([]statmuxSettings, 1)
 			err := vs[0].StatmuxSettings.ElementsAs(ctx, &sms, false)
@@ -529,9 +529,9 @@ func expandMultiplexProgramSettings(ctx context.Context, mps []multiplexProgramS
 			}
 
 			l.VideoSettings.StatmuxSettings = &mltypes.MultiplexStatmuxVideoSettings{
-				MinimumBitrate: int32(sms[0].MinimumBitrate.Value),
-				MaximumBitrate: int32(sms[0].MaximumBitrate.Value),
-				Priority:       int32(sms[0].Priority.Value),
+				MinimumBitrate: int32(sms[0].MinimumBitrate.ValueInt64()),
+				MaximumBitrate: int32(sms[0].MaximumBitrate.ValueInt64()),
+				Priority:       int32(sms[0].Priority.ValueInt64()),
 			}
 		}
 	}
@@ -568,101 +568,75 @@ var (
 func flattenMultiplexProgramSettings(mps *mltypes.MultiplexProgramSettings, stateMuxIsNull bool) types.List {
 	elemType := types.ObjectType{AttrTypes: multiplexProgramSettingsAttrs}
 
-	vals := types.Object{AttrTypes: multiplexProgramSettingsAttrs}
-	attrs := map[string]attr.Value{}
-
 	if mps == nil {
-		return types.List{ElemType: elemType, Elems: []attr.Value{}}
+		return types.ListValueMust(elemType, []attr.Value{})
 	}
 
-	attrs["program_number"] = types.Int64{Value: int64(mps.ProgramNumber)}
-	attrs["preferred_channel_pipeline"] = types.String{Value: string(mps.PreferredChannelPipeline)}
+	attrs := map[string]attr.Value{}
+	attrs["program_number"] = types.Int64Value(int64(mps.ProgramNumber))
+	attrs["preferred_channel_pipeline"] = types.StringValue(string(mps.PreferredChannelPipeline))
 	attrs["service_descriptor"] = flattenServiceDescriptor(mps.ServiceDescriptor)
 	attrs["video_settings"] = flattenVideoSettings(mps.VideoSettings, stateMuxIsNull)
 
-	vals.Attrs = attrs
+	vals := types.ObjectValueMust(multiplexProgramSettingsAttrs, attrs)
 
-	return types.List{
-		Elems:    []attr.Value{vals},
-		ElemType: elemType,
-	}
+	return types.ListValueMust(elemType, []attr.Value{vals})
 }
 
 func flattenServiceDescriptor(sd *mltypes.MultiplexProgramServiceDescriptor) types.List {
 	elemType := types.ObjectType{AttrTypes: serviceDescriptorAttrs}
 
-	vals := types.Object{AttrTypes: serviceDescriptorAttrs}
-	attrs := map[string]attr.Value{}
-
 	if sd == nil {
-		return types.List{ElemType: elemType, Elems: []attr.Value{}}
+		return types.ListValueMust(elemType, []attr.Value{})
 	}
 
-	attrs["provider_name"] = types.String{Value: aws.ToString(sd.ProviderName)}
-	attrs["service_name"] = types.String{Value: aws.ToString(sd.ServiceName)}
+	attrs := map[string]attr.Value{}
+	attrs["provider_name"] = types.StringValue(aws.ToString(sd.ProviderName))
+	attrs["service_name"] = types.StringValue(aws.ToString(sd.ServiceName))
 
-	vals.Attrs = attrs
+	vals := types.ObjectValueMust(serviceDescriptorAttrs, attrs)
 
-	return types.List{
-		Elems:    []attr.Value{vals},
-		ElemType: elemType,
-	}
+	return types.ListValueMust(elemType, []attr.Value{vals})
 }
 
 func flattenStatMuxSettings(mps *mltypes.MultiplexStatmuxVideoSettings) types.List {
 	elemType := types.ObjectType{AttrTypes: statmuxAttrs}
 
-	vals := types.Object{AttrTypes: statmuxAttrs}
-
 	if mps == nil {
-		return types.List{ElemType: elemType, Elems: []attr.Value{}}
+		return types.ListValueMust(elemType, []attr.Value{})
 	}
 
 	attrs := map[string]attr.Value{}
-	attrs["minimum_bitrate"] = types.Int64{Value: int64(mps.MinimumBitrate)}
-	attrs["maximum_bitrate"] = types.Int64{Value: int64(mps.MaximumBitrate)}
-	attrs["priority"] = types.Int64{Value: int64(mps.Priority)}
+	attrs["minimum_bitrate"] = types.Int64Value(int64(mps.MinimumBitrate))
+	attrs["maximum_bitrate"] = types.Int64Value(int64(mps.MaximumBitrate))
+	attrs["priority"] = types.Int64Value(int64(mps.Priority))
 
-	vals.Attrs = attrs
+	vals := types.ObjectValueMust(statmuxAttrs, attrs)
 
-	return types.List{
-		Elems:    []attr.Value{vals},
-		ElemType: elemType,
-	}
+	return types.ListValueMust(elemType, []attr.Value{vals})
 }
 
 func flattenVideoSettings(mps *mltypes.MultiplexVideoSettings, stateMuxIsNull bool) types.List {
 	elemType := types.ObjectType{AttrTypes: videoSettingsAttrs}
 
-	vals := types.Object{AttrTypes: videoSettingsAttrs}
-	attrs := map[string]attr.Value{}
-
 	if mps == nil {
-		return types.List{ElemType: elemType, Elems: []attr.Value{}}
+		return types.ListValueMust(elemType, []attr.Value{})
 	}
 
-	attrs["constant_bitrate"] = types.Int64{Value: int64(mps.ConstantBitrate)}
+	attrs := map[string]attr.Value{}
+	attrs["constant_bitrate"] = types.Int64Value(int64(mps.ConstantBitrate))
 
 	if stateMuxIsNull {
 		attrs["statmux_settings"] = flattenStatMuxSettings(mps.StatmuxSettings)
-		attrs["statemux_settings"] = types.List{
-			Elems:    []attr.Value{},
-			ElemType: types.ObjectType{AttrTypes: statmuxAttrs},
-		}
+		attrs["statemux_settings"] = types.ListValueMust(types.ObjectType{AttrTypes: statmuxAttrs}, []attr.Value{})
 	} else {
-		attrs["statmux_settings"] = types.List{
-			Elems:    []attr.Value{},
-			ElemType: types.ObjectType{AttrTypes: statmuxAttrs},
-		}
+		attrs["statmux_settings"] = types.ListValueMust(types.ObjectType{AttrTypes: statmuxAttrs}, []attr.Value{})
 		attrs["statemux_settings"] = flattenStatMuxSettings(mps.StatmuxSettings)
 	}
 
-	vals.Attrs = attrs
+	vals := types.ObjectValueMust(videoSettingsAttrs, attrs)
 
-	return types.List{
-		Elems:    []attr.Value{vals},
-		ElemType: elemType,
-	}
+	return types.ListValueMust(elemType, []attr.Value{vals})
 }
 
 func preferredChannelPipelineToSlice(p []mltypes.PreferredChannelPipeline) []string {

--- a/internal/service/meta/arn_data_source.go
+++ b/internal/service/meta/arn_data_source.go
@@ -82,7 +82,7 @@ func (d *dataSourceARN) Read(ctx context.Context, request datasource.ReadRequest
 		return
 	}
 
-	arn := &data.ARN.Value
+	arn := data.ARN.ARNValue()
 
 	data.Account = types.StringValue(arn.AccountID)
 	data.ID = types.StringValue(arn.String())

--- a/internal/service/meta/arn_data_source.go
+++ b/internal/service/meta/arn_data_source.go
@@ -84,12 +84,12 @@ func (d *dataSourceARN) Read(ctx context.Context, request datasource.ReadRequest
 
 	arn := &data.ARN.Value
 
-	data.Account = types.String{Value: arn.AccountID}
-	data.ID = types.String{Value: arn.String()}
-	data.Partition = types.String{Value: arn.Partition}
-	data.Region = types.String{Value: arn.Region}
-	data.Resource = types.String{Value: arn.Resource}
-	data.Service = types.String{Value: arn.Service}
+	data.Account = types.StringValue(arn.AccountID)
+	data.ID = types.StringValue(arn.String())
+	data.Partition = types.StringValue(arn.Partition)
+	data.Region = types.StringValue(arn.Region)
+	data.Resource = types.StringValue(arn.Resource)
+	data.Service = types.StringValue(arn.Service)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }

--- a/internal/service/meta/billing_service_account_data_source.go
+++ b/internal/service/meta/billing_service_account_data_source.go
@@ -70,8 +70,8 @@ func (d *dataSourceBillingServiceAccount) Read(ctx context.Context, request data
 		Resource:  "root",
 	}
 
-	data.ARN = types.String{Value: arn.String()}
-	data.ID = types.String{Value: billingAccountID}
+	data.ARN = types.StringValue(arn.String())
+	data.ID = types.StringValue(billingAccountID)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }

--- a/internal/service/meta/default_tags_data_source.go
+++ b/internal/service/meta/default_tags_data_source.go
@@ -64,7 +64,7 @@ func (d *dataSourceDefaultTags) Read(ctx context.Context, request datasource.Rea
 	ignoreTagsConfig := d.Meta().IgnoreTagsConfig
 	tags := defaultTagsConfig.GetTags()
 
-	data.ID = types.String{Value: d.Meta().Partition}
+	data.ID = types.StringValue(d.Meta().Partition)
 	data.Tags = flex.FlattenFrameworkStringValueMap(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)

--- a/internal/service/meta/ip_ranges_data_source.go
+++ b/internal/service/meta/ip_ranges_data_source.go
@@ -100,7 +100,7 @@ func (d *dataSourceIPRanges) Read(ctx context.Context, request datasource.ReadRe
 		// Data sources make no use of AttributePlanModifiers to set default values.
 		url = "https://ip-ranges.amazonaws.com/ip-ranges.json"
 	} else {
-		url = data.URL.Value
+		url = data.URL.ValueString()
 	}
 
 	bytes, err := readAll(ctx, url)
@@ -156,12 +156,12 @@ func (d *dataSourceIPRanges) Read(ctx context.Context, request datasource.ReadRe
 
 	sort.Strings(ipv6Prefixes)
 
-	data.CreateDate = types.String{Value: ipRanges.CreateDate}
-	data.ID = types.String{Value: ipRanges.SyncToken}
+	data.CreateDate = types.StringValue(ipRanges.CreateDate)
+	data.ID = types.StringValue(ipRanges.SyncToken)
 	data.IPv4CIDRBlocks = flex.FlattenFrameworkStringValueList(ctx, ipv4Prefixes)
 	data.IPv6CIDRBlocks = flex.FlattenFrameworkStringValueList(ctx, ipv6Prefixes)
-	data.SyncToken = types.Int64{Value: int64(syncToken)}
-	data.URL = types.String{Value: url}
+	data.SyncToken = types.Int64Value(int64(syncToken))
+	data.URL = types.StringValue(url)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }

--- a/internal/service/meta/partition_data_source.go
+++ b/internal/service/meta/partition_data_source.go
@@ -67,10 +67,10 @@ func (d *dataSourcePartition) Read(ctx context.Context, request datasource.ReadR
 		return
 	}
 
-	data.DNSSuffix = types.String{Value: d.Meta().DNSSuffix}
-	data.ID = types.String{Value: d.Meta().Partition}
-	data.Partition = types.String{Value: d.Meta().Partition}
-	data.ReverseDNSPrefix = types.String{Value: d.Meta().ReverseDNSPrefix}
+	data.DNSSuffix = types.StringValue(d.Meta().DNSSuffix)
+	data.ID = types.StringValue(d.Meta().Partition)
+	data.Partition = types.StringValue(d.Meta().Partition)
+	data.ReverseDNSPrefix = types.StringValue(d.Meta().ReverseDNSPrefix)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }

--- a/internal/service/meta/region_data_source.go
+++ b/internal/service/meta/region_data_source.go
@@ -75,7 +75,7 @@ func (d *dataSourceRegion) Read(ctx context.Context, request datasource.ReadRequ
 	var region *endpoints.Region
 
 	if !data.Endpoint.IsNull() {
-		matchingRegion, err := FindRegionByEndpoint(data.Endpoint.Value)
+		matchingRegion, err := FindRegionByEndpoint(data.Endpoint.ValueString())
 
 		if err != nil {
 			response.Diagnostics.AddError("finding Region by endpoint", err.Error())
@@ -87,7 +87,7 @@ func (d *dataSourceRegion) Read(ctx context.Context, request datasource.ReadRequ
 	}
 
 	if !data.Name.IsNull() {
-		matchingRegion, err := FindRegionByName(data.Name.Value)
+		matchingRegion, err := FindRegionByName(data.Name.ValueString())
 
 		if err != nil {
 			response.Diagnostics.AddError("finding Region by name", err.Error())
@@ -125,10 +125,10 @@ func (d *dataSourceRegion) Read(ctx context.Context, request datasource.ReadRequ
 		return
 	}
 
-	data.Description = types.String{Value: region.Description()}
-	data.Endpoint = types.String{Value: strings.TrimPrefix(regionEndpointEC2.URL, "https://")}
-	data.ID = types.String{Value: region.ID()}
-	data.Name = types.String{Value: region.ID()}
+	data.Description = types.StringValue(region.Description())
+	data.Endpoint = types.StringValue(strings.TrimPrefix(regionEndpointEC2.URL, "https://"))
+	data.ID = types.StringValue(region.ID())
+	data.Name = types.StringValue(region.ID())
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }

--- a/internal/service/meta/regions_data_source.go
+++ b/internal/service/meta/regions_data_source.go
@@ -73,11 +73,8 @@ func (d *dataSourceRegions) Read(ctx context.Context, request datasource.ReadReq
 	conn := d.Meta().EC2Conn
 
 	input := &ec2.DescribeRegionsInput{
-		Filters: tfec2.BuildCustomFilters(ctx, data.Filters),
-	}
-
-	if !data.AllRegions.IsNull() {
-		input.AllRegions = aws.Bool(data.AllRegions.Value)
+		AllRegions: flex.BoolFromFramework(ctx, data.AllRegions),
+		Filters:    tfec2.BuildCustomFilters(ctx, data.Filters),
 	}
 
 	output, err := conn.DescribeRegionsWithContext(ctx, input)
@@ -93,7 +90,7 @@ func (d *dataSourceRegions) Read(ctx context.Context, request datasource.ReadReq
 		names = append(names, aws.StringValue(v.RegionName))
 	}
 
-	data.ID = types.String{Value: d.Meta().Partition}
+	data.ID = types.StringValue(d.Meta().Partition)
 	data.Names = flex.FlattenFrameworkStringValueSet(ctx, names)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)

--- a/internal/service/meta/service_data_source.go
+++ b/internal/service/meta/service_data_source.go
@@ -93,7 +93,7 @@ func (d *dataSourceService) Read(ctx context.Context, request datasource.ReadReq
 	}
 
 	if !data.ReverseDNSName.IsNull() {
-		v := data.ReverseDNSName.Value
+		v := data.ReverseDNSName.ValueString()
 		serviceParts := strings.Split(v, ".")
 		n := len(serviceParts)
 
@@ -103,13 +103,13 @@ func (d *dataSourceService) Read(ctx context.Context, request datasource.ReadReq
 			return
 		}
 
-		data.Region = types.String{Value: serviceParts[n-2]}
-		data.ReverseDNSPrefix = types.String{Value: strings.Join(serviceParts[0:n-2], ".")}
-		data.ServiceID = types.String{Value: serviceParts[n-1]}
+		data.Region = types.StringValue(serviceParts[n-2])
+		data.ReverseDNSPrefix = types.StringValue(strings.Join(serviceParts[0:n-2], "."))
+		data.ServiceID = types.StringValue(serviceParts[n-1])
 	}
 
 	if !data.DNSName.IsNull() {
-		v := data.DNSName.Value
+		v := data.DNSName.ValueString()
 		serviceParts := slices.Reverse(strings.Split(v, "."))
 		n := len(serviceParts)
 
@@ -119,13 +119,13 @@ func (d *dataSourceService) Read(ctx context.Context, request datasource.ReadReq
 			return
 		}
 
-		data.Region = types.String{Value: serviceParts[n-2]}
-		data.ReverseDNSPrefix = types.String{Value: strings.Join(serviceParts[0:n-2], ".")}
-		data.ServiceID = types.String{Value: serviceParts[n-1]}
+		data.Region = types.StringValue(serviceParts[n-2])
+		data.ReverseDNSPrefix = types.StringValue(strings.Join(serviceParts[0:n-2], "."))
+		data.ServiceID = types.StringValue(serviceParts[n-1])
 	}
 
 	if data.Region.IsNull() {
-		data.Region = types.String{Value: d.Meta().Region}
+		data.Region = types.StringValue(d.Meta().Region)
 	}
 
 	if data.ServiceID.IsNull() {
@@ -136,25 +136,25 @@ func (d *dataSourceService) Read(ctx context.Context, request datasource.ReadReq
 
 	if data.ReverseDNSPrefix.IsNull() {
 		dnsParts := strings.Split(d.Meta().DNSSuffix, ".")
-		data.ReverseDNSPrefix = types.String{Value: strings.Join(slices.Reverse(dnsParts), ".")}
+		data.ReverseDNSPrefix = types.StringValue(strings.Join(slices.Reverse(dnsParts), "."))
 	}
 
-	reverseDNSName := fmt.Sprintf("%s.%s.%s", data.ReverseDNSPrefix.Value, data.Region.Value, data.ServiceID.Value)
-	data.ReverseDNSName = types.String{Value: reverseDNSName}
-	data.DNSName = types.String{Value: strings.ToLower(strings.Join(slices.Reverse(strings.Split(reverseDNSName, ".")), "."))}
+	reverseDNSName := fmt.Sprintf("%s.%s.%s", data.ReverseDNSPrefix.ValueString(), data.Region.ValueString(), data.ServiceID.ValueString())
+	data.ReverseDNSName = types.StringValue(reverseDNSName)
+	data.DNSName = types.StringValue(strings.ToLower(strings.Join(slices.Reverse(strings.Split(reverseDNSName, ".")), ".")))
 
-	data.Supported = types.Bool{Value: true}
-	if partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), data.Region.Value); ok {
-		data.Partition = types.String{Value: partition.ID()}
+	data.Supported = types.BoolValue(true)
+	if partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), data.Region.ValueString()); ok {
+		data.Partition = types.StringValue(partition.ID())
 
-		if _, ok := partition.Services()[data.ServiceID.Value]; !ok {
-			data.Supported.Value = false
+		if _, ok := partition.Services()[data.ServiceID.ValueString()]; !ok {
+			data.Supported = types.BoolValue(false)
 		}
 	} else {
-		data.Partition = types.String{Null: true}
+		data.Partition = types.StringNull()
 	}
 
-	data.ID = types.String{Value: reverseDNSName}
+	data.ID = types.StringValue(reverseDNSName)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }

--- a/internal/service/sts/caller_identity_data_source.go
+++ b/internal/service/sts/caller_identity_data_source.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 )
 
@@ -79,10 +80,10 @@ func (d *dataSourceCallerIdentity) Read(ctx context.Context, request datasource.
 	}
 
 	accountID := aws.StringValue(output.Account)
-	data.AccountID = types.String{Value: accountID}
-	data.ARN = types.String{Value: aws.StringValue(output.Arn)}
-	data.ID = types.String{Value: accountID}
-	data.UserID = types.String{Value: aws.StringValue(output.UserId)}
+	data.AccountID = types.StringValue(accountID)
+	data.ARN = flex.StringToFrameworkLegacy(ctx, output.Arn)
+	data.ID = types.StringValue(accountID)
+	data.UserID = flex.StringToFrameworkLegacy(ctx, output.UserId)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }

--- a/internal/tags/framework.go
+++ b/internal/tags/framework.go
@@ -22,6 +22,6 @@ func TagsAttributeComputedOnly() tfsdk.Attribute {
 }
 
 var (
-	Null    = types.Map{ElemType: types.StringType, Null: true}
-	Unknown = types.Map{ElemType: types.StringType, Unknown: true}
+	Null    = types.MapNull(types.StringType)
+	Unknown = types.MapUnknown(types.StringType)
 )

--- a/internal/tags/key_value_tags_test.go
+++ b/internal/tags/key_value_tags_test.go
@@ -2273,7 +2273,7 @@ func TestNew(t *testing.T) {
 		},
 		{
 			name:   "empty_typesMap",
-			source: types.Map{ElemType: types.StringType, Elems: map[string]attr.Value{}},
+			source: types.MapValueMust(types.StringType, map[string]attr.Value{}),
 			want:   map[string]string{},
 		},
 		{
@@ -2364,10 +2364,10 @@ func TestNew(t *testing.T) {
 		},
 		{
 			name: "non_empty_typesMap",
-			source: types.Map{ElemType: types.StringType, Elems: map[string]attr.Value{
-				"key1": types.String{Value: ""},
-				"key2": types.String{Value: "value2"},
-			}},
+			source: types.MapValueMust(types.StringType, map[string]attr.Value{
+				"key1": types.StringValue(""),
+				"key2": types.StringValue("value2"),
+			}),
 			want: map[string]string{
 				"key1": "",
 				"key2": "value2",


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Upgrades to **v0.16.0** of [`terraform-plugin-framework`](https://github.com/hashicorp/terraform-plugin-framework)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccMeta' PKG=meta ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/meta/... -v -count 1 -parallel 3  -run=TestAccMeta -timeout 180m
=== RUN   TestAccMetaARNDataSource_basic
=== PAUSE TestAccMetaARNDataSource_basic
=== RUN   TestAccMetaARNDataSource_s3Bucket
=== PAUSE TestAccMetaARNDataSource_s3Bucket
=== RUN   TestAccMetaBillingServiceAccountDataSource_basic
=== PAUSE TestAccMetaBillingServiceAccountDataSource_basic
=== RUN   TestAccMetaDefaultTagsDataSource_basic
=== PAUSE TestAccMetaDefaultTagsDataSource_basic
=== RUN   TestAccMetaDefaultTagsDataSource_empty
=== PAUSE TestAccMetaDefaultTagsDataSource_empty
=== RUN   TestAccMetaDefaultTagsDataSource_multiple
=== PAUSE TestAccMetaDefaultTagsDataSource_multiple
=== RUN   TestAccMetaDefaultTagsDataSource_ignore
=== PAUSE TestAccMetaDefaultTagsDataSource_ignore
=== RUN   TestAccMetaIPRangesDataSource_basic
=== PAUSE TestAccMetaIPRangesDataSource_basic
=== RUN   TestAccMetaIPRangesDataSource_none
=== PAUSE TestAccMetaIPRangesDataSource_none
=== RUN   TestAccMetaIPRangesDataSource_url
=== PAUSE TestAccMetaIPRangesDataSource_url
=== RUN   TestAccMetaIPRangesDataSource_uppercase
=== PAUSE TestAccMetaIPRangesDataSource_uppercase
=== RUN   TestAccMetaPartitionDataSource_basic
=== PAUSE TestAccMetaPartitionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_basic
=== PAUSE TestAccMetaRegionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_endpoint
=== PAUSE TestAccMetaRegionDataSource_endpoint
=== RUN   TestAccMetaRegionDataSource_endpointAndName
=== PAUSE TestAccMetaRegionDataSource_endpointAndName
=== RUN   TestAccMetaRegionDataSource_name
=== PAUSE TestAccMetaRegionDataSource_name
=== RUN   TestAccMetaRegionsDataSource_basic
=== PAUSE TestAccMetaRegionsDataSource_basic
=== RUN   TestAccMetaRegionsDataSource_filter
=== PAUSE TestAccMetaRegionsDataSource_filter
=== RUN   TestAccMetaRegionsDataSource_allRegions
=== PAUSE TestAccMetaRegionsDataSource_allRegions
=== RUN   TestAccMetaRegionsDataSource_nonExistentRegion
=== PAUSE TestAccMetaRegionsDataSource_nonExistentRegion
=== RUN   TestAccMetaService_basic
=== PAUSE TestAccMetaService_basic
=== RUN   TestAccMetaService_byReverseDNSName
=== PAUSE TestAccMetaService_byReverseDNSName
=== RUN   TestAccMetaService_byDNSName
=== PAUSE TestAccMetaService_byDNSName
=== RUN   TestAccMetaService_byParts
=== PAUSE TestAccMetaService_byParts
=== RUN   TestAccMetaService_unsupported
=== PAUSE TestAccMetaService_unsupported
=== CONT  TestAccMetaARNDataSource_basic
=== CONT  TestAccMetaService_unsupported
=== CONT  TestAccMetaService_byParts
--- PASS: TestAccMetaService_byParts (14.08s)
=== CONT  TestAccMetaService_byDNSName
--- PASS: TestAccMetaService_unsupported (14.08s)
=== CONT  TestAccMetaService_byReverseDNSName
--- PASS: TestAccMetaARNDataSource_basic (14.31s)
=== CONT  TestAccMetaService_basic
--- PASS: TestAccMetaService_byReverseDNSName (12.92s)
=== CONT  TestAccMetaRegionsDataSource_nonExistentRegion
--- PASS: TestAccMetaService_byDNSName (12.95s)
=== CONT  TestAccMetaRegionsDataSource_allRegions
--- PASS: TestAccMetaService_basic (12.99s)
=== CONT  TestAccMetaRegionsDataSource_filter
--- PASS: TestAccMetaRegionsDataSource_nonExistentRegion (13.72s)
=== CONT  TestAccMetaRegionsDataSource_basic
--- PASS: TestAccMetaRegionsDataSource_allRegions (13.72s)
=== CONT  TestAccMetaRegionDataSource_name
--- PASS: TestAccMetaRegionsDataSource_filter (13.61s)
=== CONT  TestAccMetaRegionDataSource_endpointAndName
--- PASS: TestAccMetaRegionDataSource_name (14.07s)
=== CONT  TestAccMetaRegionDataSource_endpoint
--- PASS: TestAccMetaRegionsDataSource_basic (14.16s)
=== CONT  TestAccMetaRegionDataSource_basic
--- PASS: TestAccMetaRegionDataSource_endpointAndName (14.07s)
=== CONT  TestAccMetaPartitionDataSource_basic
--- PASS: TestAccMetaRegionDataSource_basic (13.38s)
=== CONT  TestAccMetaIPRangesDataSource_uppercase
--- PASS: TestAccMetaPartitionDataSource_basic (13.31s)
=== CONT  TestAccMetaIPRangesDataSource_url
--- PASS: TestAccMetaRegionDataSource_endpoint (14.35s)
=== CONT  TestAccMetaIPRangesDataSource_none
--- PASS: TestAccMetaIPRangesDataSource_url (14.68s)
=== CONT  TestAccMetaIPRangesDataSource_basic
--- PASS: TestAccMetaIPRangesDataSource_uppercase (15.45s)
=== CONT  TestAccMetaDefaultTagsDataSource_ignore
--- PASS: TestAccMetaIPRangesDataSource_none (14.91s)
=== CONT  TestAccMetaDefaultTagsDataSource_multiple
--- PASS: TestAccMetaDefaultTagsDataSource_multiple (8.79s)
=== CONT  TestAccMetaDefaultTagsDataSource_empty
--- PASS: TestAccMetaIPRangesDataSource_basic (14.67s)
=== CONT  TestAccMetaDefaultTagsDataSource_basic
--- PASS: TestAccMetaDefaultTagsDataSource_ignore (19.72s)
=== CONT  TestAccMetaBillingServiceAccountDataSource_basic
--- PASS: TestAccMetaDefaultTagsDataSource_empty (12.29s)
=== CONT  TestAccMetaARNDataSource_s3Bucket
--- PASS: TestAccMetaDefaultTagsDataSource_basic (8.27s)
--- PASS: TestAccMetaBillingServiceAccountDataSource_basic (12.00s)
--- PASS: TestAccMetaARNDataSource_s3Bucket (12.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	123.872s
% make testacc TESTARGS='-run=TestAccSTSCallerIdentityDataSource_' PKG=sts
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sts/... -v -count 1 -parallel 20  -run=TestAccSTSCallerIdentityDataSource_ -timeout 180m
=== RUN   TestAccSTSCallerIdentityDataSource_basic
=== PAUSE TestAccSTSCallerIdentityDataSource_basic
=== CONT  TestAccSTSCallerIdentityDataSource_basic
--- PASS: TestAccSTSCallerIdentityDataSource_basic (12.19s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sts	16.606s
% make testacc TESTARGS='-run=TestAccGlobalAcceleratorAcceleratorDataSource_' PKG=globalaccelerator
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/globalaccelerator/... -v -count 1 -parallel 20  -run=TestAccGlobalAcceleratorAcceleratorDataSource_ -timeout 180m
=== RUN   TestAccGlobalAcceleratorAcceleratorDataSource_basic
=== PAUSE TestAccGlobalAcceleratorAcceleratorDataSource_basic
=== CONT  TestAccGlobalAcceleratorAcceleratorDataSource_basic
--- PASS: TestAccGlobalAcceleratorAcceleratorDataSource_basic (134.72s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator	139.333s
% make testacc TESTARGS='-run=TestAccSimpleDBDomain_' PKG=simpledb
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/simpledb/... -v -count 1 -parallel 20  -run=TestAccSimpleDBDomain_ -timeout 180m
=== RUN   TestAccSimpleDBDomain_basic
=== PAUSE TestAccSimpleDBDomain_basic
=== RUN   TestAccSimpleDBDomain_disappears
=== PAUSE TestAccSimpleDBDomain_disappears
=== RUN   TestAccSimpleDBDomain_MigrateFromPluginSDK
=== PAUSE TestAccSimpleDBDomain_MigrateFromPluginSDK
=== CONT  TestAccSimpleDBDomain_basic
=== CONT  TestAccSimpleDBDomain_MigrateFromPluginSDK
=== CONT  TestAccSimpleDBDomain_disappears
--- PASS: TestAccSimpleDBDomain_disappears (17.96s)
--- PASS: TestAccSimpleDBDomain_basic (21.51s)
--- PASS: TestAccSimpleDBDomain_MigrateFromPluginSDK (58.48s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/simpledb	62.668s
% make testacc TESTARGS='-run=TestAccMediaLive_serial/MultiplexProgram' PKG=medialive
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/medialive/... -v -count 1 -parallel 20  -run=TestAccMediaLive_serial/MultiplexProgram -timeout 180m
=== RUN   TestAccMediaLive_serial
=== RUN   TestAccMediaLive_serial/MultiplexProgram
=== RUN   TestAccMediaLive_serial/MultiplexProgram/basic
=== RUN   TestAccMediaLive_serial/MultiplexProgram/update
=== RUN   TestAccMediaLive_serial/MultiplexProgram/disappears
--- PASS: TestAccMediaLive_serial (196.57s)
    --- PASS: TestAccMediaLive_serial/MultiplexProgram (196.57s)
        --- PASS: TestAccMediaLive_serial/MultiplexProgram/basic (62.62s)
        --- PASS: TestAccMediaLive_serial/MultiplexProgram/update (73.97s)
        --- PASS: TestAccMediaLive_serial/MultiplexProgram/disappears (59.98s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	201.486s
```
