### PR TITLE
d/aws_sqs_queues: new data source

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -902,7 +902,8 @@ func New(_ context.Context) (*schema.Provider, error) {
 
 			"aws_sns_topic": sns.DataSourceTopic(),
 
-			"aws_sqs_queue": sqs.DataSourceQueue(),
+			"aws_sqs_queue":  sqs.DataSourceQueue(),
+			"aws_sqs_queues": sqs.DataSourceQueues(),
 
 			"aws_ssm_document":            ssm.DataSourceDocument(),
 			"aws_ssm_instances":           ssm.DataSourceInstances(),

--- a/internal/service/sqs/queues_data_source.go
+++ b/internal/service/sqs/queues_data_source.go
@@ -45,7 +45,7 @@ func dataSourceQueuesRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	var queueUrls []string
 
-	err := conn.ListQueuesPages(input, func(page *sqs.ListQueuesOutput, lastPage bool) bool {
+	err := conn.ListQueuesPagesWithContext(ctx, input, func(page *sqs.ListQueuesOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}

--- a/internal/service/sqs/queues_data_source.go
+++ b/internal/service/sqs/queues_data_source.go
@@ -1,0 +1,72 @@
+package sqs
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func DataSourceQueues() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceQueuesRead,
+
+		Schema: map[string]*schema.Schema{
+			"queue_name_prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"queue_urls": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+const (
+	DSNameQueues = "Queues Data Source"
+)
+
+func dataSourceQueuesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).SQSConn
+
+	input := &sqs.ListQueuesInput{}
+
+	if v, ok := d.GetOk("queue_name_prefix"); ok {
+		input.QueueNamePrefix = aws.String(v.(string))
+	}
+
+	var queueUrls []string
+
+	err := conn.ListQueuesPages(input, func(page *sqs.ListQueuesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, queueUrl := range page.QueueUrls {
+			if queueUrl == nil {
+				continue
+			}
+
+			queueUrls = append(queueUrls, aws.StringValue(queueUrl))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return create.DiagError(names.SQS, create.ErrActionReading, DSNameQueues, "", err)
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region)
+	d.Set("queue_urls", queueUrls)
+
+	return nil
+}

--- a/internal/service/sqs/queues_data_source_test.go
+++ b/internal/service/sqs/queues_data_source_test.go
@@ -1,0 +1,50 @@
+package sqs_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/sqs"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccSQSQueuesDataSource_queueNamePrefix(t *testing.T) {
+	var queueAttributes map[string]string
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_sqs_queues.test"
+	resourceName := "aws_sqs_queue.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sqs.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueuesDataSourceConfig_queueNamePrefix(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQueueExists(resourceName, &queueAttributes),
+					resource.TestCheckResourceAttr(dataSourceName, "queue_urls.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "queue_urls.0", resourceName, "url"),
+				),
+			},
+		},
+	})
+}
+
+func testAccQueuesDataSourceConfig_queueNamePrefix(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sqs_queue" "test" {
+  name = %[1]q
+}
+
+resource "aws_sqs_queue" "wrong" {
+  name = "wrong_%[1]s"
+}
+
+data "aws_sqs_queues" "test" {
+  queue_name_prefix = aws_sqs_queue.test.name
+}
+`, rName)
+}

--- a/website/docs/d/sqs_queues.html.markdown
+++ b/website/docs/d/sqs_queues.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "SQS (Simple Queue)"
+layout: "aws"
+page_title: "AWS: aws_sqs_queues"
+description: |-
+  Terraform data source for managing an AWS SQS (Simple Queue) Queues.
+---
+
+# Data Source: aws_sqs_queues
+
+Terraform data source for managing an AWS SQS (Simple Queue) Queues.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_sqs_queues" "example" {
+  queue_name_prefix = "example"
+}
+```
+
+## Argument Reference
+
+The following arguments are optional:
+
+* `queue_name_prefix` - (Optional) A string to use for filtering the list results. Only those queues whose name begins with the specified string are returned. Queue URLs and names are case-sensitive.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `queue_urls` - A list of queue URLs.


### PR DESCRIPTION
### Description

This PR introduces the `aws_sqs_queues` plural data source.

### References
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ListQueues.html

### Output from Acceptance Testing
```
$ make testacc TESTARGS='-run=TestAccSQSQueuesDataSource_queueNamePrefix' PKG=sqs ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sqs/... -v -count 1 -parallel 2  -run=TestAccSQSQueuesDataSource_queueNamePrefix -timeout 180m
=== RUN   TestAccSQSQueuesDataSource_queueNamePrefix
=== PAUSE TestAccSQSQueuesDataSource_queueNamePrefix
=== CONT  TestAccSQSQueuesDataSource_queueNamePrefix
--- PASS: TestAccSQSQueuesDataSource_queueNamePrefix (55.63s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sqs        57.452s
```
