### PR TITLE
d/aws_rds_clusters: new data source

### DIFF
--- a/.changelog/27891.txt
+++ b/.changelog/27891.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_rds_clusters
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -836,6 +836,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_db_subnet_group":                rds.DataSourceSubnetGroup(),
 			"aws_rds_certificate":                rds.DataSourceCertificate(),
 			"aws_rds_cluster":                    rds.DataSourceCluster(),
+			"aws_rds_clusters":                   rds.DataSourceClusters(),
 			"aws_rds_engine_version":             rds.DataSourceEngineVersion(),
 			"aws_rds_orderable_db_instance":      rds.DataSourceOrderableInstance(),
 			"aws_rds_reserved_instance_offering": rds.DataSourceReservedOffering(),

--- a/internal/service/rds/clusters_data_source.go
+++ b/internal/service/rds/clusters_data_source.go
@@ -1,0 +1,78 @@
+package rds
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/generate/namevaluesfilters"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func DataSourceClusters() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceClustersRead,
+
+		Schema: map[string]*schema.Schema{
+			"cluster_arns": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"cluster_identifiers": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"filter": namevaluesfilters.Schema(),
+		},
+	}
+}
+
+const (
+	DSNameClusters = "Clusters Data Source"
+)
+
+func dataSourceClustersRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).RDSConn
+
+	input := &rds.DescribeDBClustersInput{}
+
+	if v, ok := d.GetOk("filter"); ok {
+		input.Filters = namevaluesfilters.New(v.(*schema.Set)).RDSFilters()
+	}
+
+	var clusterArns []string
+	var clusterIdentifiers []string
+
+	err := conn.DescribeDBClustersPagesWithContext(ctx, input, func(page *rds.DescribeDBClustersOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, dbCluster := range page.DBClusters {
+			if dbCluster == nil {
+				continue
+			}
+
+			clusterArns = append(clusterArns, aws.StringValue(dbCluster.DBClusterArn))
+			clusterIdentifiers = append(clusterIdentifiers, aws.StringValue(dbCluster.DBClusterIdentifier))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return create.DiagError(names.RDS, create.ErrActionReading, DSNameClusters, "", err)
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region)
+	d.Set("cluster_arns", clusterArns)
+	d.Set("cluster_identifiers", clusterIdentifiers)
+
+	return nil
+}

--- a/internal/service/rds/clusters_data_source_test.go
+++ b/internal/service/rds/clusters_data_source_test.go
@@ -39,25 +39,25 @@ func TestAccRDSClustersDataSource_filter(t *testing.T) {
 func testAccClustersDataSourceConfig_filter(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_cluster" "test" {
-  cluster_identifier              = %[1]q
-  database_name                   = "test"
-  master_username                 = "tfacctest"
-  master_password                 = "avoid-plaintext-passwords"
-  skip_final_snapshot             = true
+  cluster_identifier  = %[1]q
+  database_name       = "test"
+  master_username     = "tfacctest"
+  master_password     = "avoid-plaintext-passwords"
+  skip_final_snapshot = true
 }
 
 resource "aws_rds_cluster" "wrong" {
-  cluster_identifier              = "wrong-%[1]s"
-  database_name                   = "test"
-  master_username                 = "tfacctest"
-  master_password                 = "avoid-plaintext-passwords"
-  skip_final_snapshot             = true
+  cluster_identifier  = "wrong-%[1]s"
+  database_name       = "test"
+  master_username     = "tfacctest"
+  master_password     = "avoid-plaintext-passwords"
+  skip_final_snapshot = true
 }
 
 data "aws_rds_clusters" "test" {
   filter {
-	name   = "db-cluster-id"
-	values = [aws_rds_cluster.test.cluster_identifier]
+    name   = "db-cluster-id"
+    values = [aws_rds_cluster.test.cluster_identifier]
   }
 }
 `, rName)

--- a/internal/service/rds/clusters_data_source_test.go
+++ b/internal/service/rds/clusters_data_source_test.go
@@ -1,0 +1,64 @@
+package rds_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/rds"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccRDSClustersDataSource_filter(t *testing.T) {
+	var dbCluster rds.DBCluster
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_rds_clusters.test"
+	resourceName := "aws_rds_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, rds.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClustersDataSourceConfig_filter(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(dataSourceName, "cluster_arns.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_arns.0", resourceName, "arn"),
+					resource.TestCheckResourceAttr(dataSourceName, "cluster_identifiers.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_identifiers.0", resourceName, "cluster_identifier"),
+				),
+			},
+		},
+	})
+}
+
+func testAccClustersDataSourceConfig_filter(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster" "test" {
+  cluster_identifier              = %[1]q
+  database_name                   = "test"
+  master_username                 = "tfacctest"
+  master_password                 = "avoid-plaintext-passwords"
+  skip_final_snapshot             = true
+}
+
+resource "aws_rds_cluster" "wrong" {
+  cluster_identifier              = "wrong-%[1]s"
+  database_name                   = "test"
+  master_username                 = "tfacctest"
+  master_password                 = "avoid-plaintext-passwords"
+  skip_final_snapshot             = true
+}
+
+data "aws_rds_clusters" "test" {
+  filter {
+	name   = "db-cluster-id"
+	values = [aws_rds_cluster.test.cluster_identifier]
+  }
+}
+`, rName)
+}

--- a/website/docs/d/rds_clusters.html.markdown
+++ b/website/docs/d/rds_clusters.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "RDS (Relational Database)"
+layout: "aws"
+page_title: "AWS: aws_rds_clusters"
+description: |-
+  Terraform data source for managing an AWS RDS (Relational Database) Clusters.
+---
+
+# Data Source: aws_rds_clusters
+
+Terraform data source for managing an AWS RDS (Relational Database) Clusters.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_rds_clusters" "example" {
+  filter {
+    name   = "engine"
+    values = ["aurora-postgresql"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are optional:
+
+* `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
+
+### filter Configuration block
+
+The following arguments are supported by the `filter` configuration block:
+
+* `name` - (Required) Name of the filter field. Valid values can be found in the [RDS DescribeDBClusters API Reference](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBClusters.html).
+* `values` - (Required) Set of values that are accepted for the given filter field. Results will be selected if any given value matches.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `cluster_arns` - Set of cluster ARNs of the matched RDS clusters.
+* `cluster_identifiers` - Set of ARNs of cluster identifiers of the matched RDS clusters.


### PR DESCRIPTION
### Description
This PR introduces the `aws_rds_clusters` plural data source.

### References
https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBClusters.html

### Output from Acceptance Testing
```
$ make testacc TESTARGS='-run=TestAccRDSClustersDataSource_filter' PKG=rds ACCTEST_PARALLELISM=2    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 2  -run=TestAccRDSClustersDataSource_filter -timeout 180m
=== RUN   TestAccRDSClustersDataSource_filter
=== PAUSE TestAccRDSClustersDataSource_filter
=== CONT  TestAccRDSClustersDataSource_filter
--- PASS: TestAccRDSClustersDataSource_filter (171.03s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        172.860s
```
