### PR TITLE
fdt-lakeformation-data-cells-filter

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1710,6 +1710,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_kms_replica_key":          kms.ResourceReplicaKey(),
 
 			"aws_lakeformation_data_lake_settings": lakeformation.ResourceDataLakeSettings(),
+			"aws_lakeformation_data_cells_filter":  lakeformation.ResourceDataCellsFilter(),
 			"aws_lakeformation_lf_tag":             lakeformation.ResourceLFTag(),
 			"aws_lakeformation_permissions":        lakeformation.ResourcePermissions(),
 			"aws_lakeformation_resource":           lakeformation.ResourceResource(),

--- a/internal/service/lakeformation/data_cells_filter.go
+++ b/internal/service/lakeformation/data_cells_filter.go
@@ -1,0 +1,416 @@
+package lakeformation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lakeformation"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func ResourceDataCellsFilter() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDataCellsFilterCreate,
+		ReadContext:   resourceDataCellsFilterRead,
+		//There is no update api. Create and Deleta only
+		DeleteContext: resourceDataCellsFilterDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		// Don't use timeouts. There is no single data cells filter retrieval api.
+
+		Schema: map[string]*schema.Schema{
+			"table_catalog_id": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: verify.ValidAccountID,
+			},
+			"database_name": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validateLFSingleLineString(),
+			},
+			"table_name": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validateLFSingleLineString(),
+			},
+			"name": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validateLFSingleLineString(),
+			},
+			"column_names": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				ForceNew: true,
+				Optional: true,
+				Set:      schema.HashString,
+				AtLeastOneOf: []string{
+					"column_names",
+					"column_wildcard",
+				},
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.NoZeroValues,
+				},
+			},
+			"column_wildcard": {
+				Type:     schema.TypeList,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				AtLeastOneOf: []string{
+					"column_names",
+					"column_wildcard",
+				},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"excluded_column_names": {
+							Type:     schema.TypeSet,
+							ForceNew: true,
+							Optional: true,
+							Set:      schema.HashString,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.NoZeroValues,
+							},
+						},
+					},
+				},
+			},
+			"row_filter": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				ForceNew: true,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"filter_expression": {
+							Type:         schema.TypeString,
+							ForceNew:     true,
+							Optional:     true,
+							ValidateFunc: validateLFMultiLineURIString(),
+							AtLeastOneOf: []string{
+								"row_filter.0.filter_expression",
+								"row_filter.0.all_rows_wildcard",
+							},
+						},
+						"all_rows_wildcard": {
+							Type:     schema.TypeBool,
+							Default:  false,
+							ForceNew: true,
+							Optional: true,
+							AtLeastOneOf: []string{
+								"row_filter.0.filter_expression",
+								"row_filter.0.all_rows_wildcard",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+const (
+	ResDataCellFilters = "Data Cells Filter"
+)
+
+func resourceDataCellsFilterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LakeFormationConn
+
+	in := &lakeformation.CreateDataCellsFilterInput{
+		TableData: &lakeformation.DataCellsFilter{
+			DatabaseName: aws.String(d.Get("database_name").(string)),
+			TableName:    aws.String(d.Get("table_name").(string)),
+			Name:         aws.String(d.Get("name").(string)),
+			ColumnNames:  flex.ExpandStringSet(d.Get("column_names").(*schema.Set)),
+		},
+	}
+
+	var catalogID string
+	if v, ok := d.GetOk("table_catalog_id"); ok {
+		catalogID = v.(string)
+	} else {
+		catalogID = meta.(*conns.AWSClient).AccountID
+	}
+	in.TableData.TableCatalogId = aws.String(catalogID)
+
+	if v, ok := d.GetOk("row_filter"); ok && len(v.([]interface{})) > 0 {
+		in.TableData.RowFilter = expandRowFilter(v.([]interface{}))
+
+	}
+
+	if v, ok := d.GetOk("column_wildcard"); ok && len(v.([]interface{})) > 0 {
+		in.TableData.ColumnWildcard = expandColumnWildcard(v.([]interface{}))
+	}
+
+	// no tags on data cells filter
+
+	out, err := conn.CreateDataCellsFilter(in)
+	if err != nil {
+		return create.DiagError(names.LakeFormation, create.ErrActionCreating, ResDataCellFilters, d.Get("name").(string), err)
+	}
+
+	if out == nil {
+		return create.DiagError(names.LakeFormation, create.ErrActionCreating, ResDataCellFilters, d.Get("name").(string), errors.New("empty output"))
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s:%s:%s", catalogID, d.Get("database_name").(string), d.Get("table_name").(string), d.Get("name").(string)))
+
+	return resourceDataCellsFilterRead(ctx, d, meta)
+}
+
+// there is no api to get a single data cell filter. the only option is to iterate through a list and attempt to match
+func resourceDataCellsFilterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LakeFormationConn
+
+	catalogID, databaseName, tableName, dataCellsFilterName, err := ReadDataCellsFilterID(d.Id())
+
+	if err != nil {
+		log.Printf("[WARN] Data Cells Filter %s not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	inDCFId := fmt.Sprintf("%s:%s:%s:%s", catalogID, databaseName, tableName, dataCellsFilterName)
+
+	//fmt.Printf("[INFO] Find Lake Formation data cells CatalogId:Database:Table:dataCellFilter %s", inDCFId)
+
+	//accept default MaxResults
+	//const maxResults int64 = 1000
+
+	in := &lakeformation.ListDataCellsFilterInput{
+		Table: &lakeformation.TableResource{
+			CatalogId:    aws.String(catalogID),
+			DatabaseName: aws.String(databaseName),
+			Name:         aws.String(tableName),
+			//Table.TableWildcard
+		},
+		//MaxResults: aws.Int64(maxResults),
+	}
+
+	foundDCF := &lakeformation.DataCellsFilter{}
+	bMatch := false
+	continueIteration := true
+	pageNum := 0
+	//recNum := 0
+	errList := conn.ListDataCellsFilterPagesWithContext(ctx, in, func(page *lakeformation.ListDataCellsFilterOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		pageNum++
+
+		for recNum, dcf := range page.DataCellsFilters {
+			//recNum++
+			outDCFId := fmt.Sprintf("%s:%s:%s:%s", *dcf.TableCatalogId, *dcf.DatabaseName, *dcf.TableName, *dcf.Name)
+			if inDCFId == outDCFId {
+				bMatch = true
+				foundDCF = dcf
+				continueIteration = false
+				log.Printf("[INFO] Found DCF in Lake Formation data cells filter output. item: %v on page: %v", recNum, pageNum)
+				break
+			}
+		}
+
+		// return false to stop the function from iterating through pages
+		return continueIteration
+	})
+
+	if bMatch {
+		d.Set("table_catalog_id", foundDCF.TableCatalogId)
+		d.Set("database_name", foundDCF.DatabaseName)
+		d.Set("table_name", foundDCF.TableName)
+		d.Set("name", foundDCF.Name)
+
+		if err := d.Set("column_names", flex.FlattenStringList(foundDCF.ColumnNames)); err != nil {
+			return create.DiagError(names.LakeFormation, create.ErrActionSetting, ResDataCellFilters, d.Id(), err)
+		}
+		if err := d.Set("column_wildcard", flattenColumnWildcard(foundDCF.ColumnWildcard)); err != nil {
+			return create.DiagError(names.LakeFormation, create.ErrActionSetting, ResDataCellFilters, d.Id(), err)
+		}
+		if err := d.Set("row_filter", flattenRowFilter(foundDCF.RowFilter)); err != nil {
+			return create.DiagError(names.LakeFormation, create.ErrActionSetting, ResDataCellFilters, d.Id(), err)
+		}
+	} else {
+		log.Printf("[WARN] Data Cells Filter %s not found, removing from state. ErrList: %v", d.Id(), errList)
+		d.SetId("")
+		return nil
+		//return create.DiagError(names.LakeFormation, create.ErrActionSetting, ResDataCellFilters, d.Id(), errList)
+	}
+
+	return nil
+}
+
+// no api available for data cells filter update
+//func resourceDataCellsFilterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+func resourceDataCellsFilterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LakeFormationConn
+
+	catalogID, databaseName, tableName, dataCellsFilterName, err := ReadDataCellsFilterID(d.Id())
+	if err != nil {
+		log.Printf("[WARN] Data Cells Filter %s not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	in := &lakeformation.DeleteDataCellsFilterInput{
+		TableCatalogId: aws.String(catalogID),
+		DatabaseName:   aws.String(databaseName),
+		TableName:      aws.String(tableName),
+		Name:           aws.String(dataCellsFilterName),
+	}
+
+	_, err = conn.DeleteDataCellsFilterWithContext(ctx, in)
+	if err != nil {
+
+		if tfawserr.ErrCodeEquals(err, "ResourceNotFoundException") {
+			return nil
+		}
+
+		return create.DiagError(names.LakeFormation, create.ErrActionSetting, ResDataCellFilters, d.Id(), err)
+	}
+
+	return nil
+}
+
+// no waiting ... no api to lookup a single data cells filter for confirmation
+
+func ReadDataCellsFilterID(id string) (catalogID string, databaseName string, tableName string, dataCellFilter string, err error) {
+	idParts := strings.Split(id, ":")
+	if len(idParts) != 4 {
+		return "", "", "", "", fmt.Errorf("unexpected format of ID (%q), expected CATALOG-ID:DATABASE:TABLE:DATA-CELL-FILTER", id)
+	}
+	return idParts[0], idParts[1], idParts[2], idParts[3], nil
+}
+
+func expandRowFilter(l []interface{}) *lakeformation.RowFilter {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	apiObject := &lakeformation.RowFilter{}
+
+	if v, ok := m["filter_expression"]; ok {
+		if len(v.(string)) > 0 {
+			apiObject.FilterExpression = aws.String(v.(string))
+		}
+	}
+
+	if v, ok := m["all_rows_wildcard"].(bool); ok && v {
+		apiObject.AllRowsWildcard = &lakeformation.AllRowsWildcard{}
+	}
+
+	return apiObject
+}
+
+// to push true and false pointer values in flatten function
+func newTrue() *bool {
+	b := true
+	return &b
+}
+func newFalse() *bool {
+	b := false
+	return &b
+}
+
+func flattenRowFilter(apiObject *lakeformation.RowFilter) []interface{} {
+	if apiObject == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{}
+
+	if v := apiObject.FilterExpression; v != nil {
+		// api returns "TRUE" for filter_expression when AllRowsWildcard = True, so bypass TRUE
+		if aws.StringValue(v) != "TRUE" {
+			m["filter_expression"] = aws.StringValue(v)
+		}
+	}
+
+	if v := apiObject.AllRowsWildcard; v != nil {
+		m["all_rows_wildcard"] = aws.BoolValue(newTrue())
+	} else {
+		m["all_rows_wildcard"] = aws.BoolValue(newFalse())
+	}
+
+	return []interface{}{m}
+}
+
+func expandColumnWildcard(l []interface{}) *lakeformation.ColumnWildcard {
+	if len(l) == 0 {
+		return nil
+	}
+
+	apiObject := &lakeformation.ColumnWildcard{}
+
+	if l[0] == nil {
+		// return empty ColumnWildcard
+		return apiObject
+	} else {
+		m := l[0].(map[string]interface{})
+
+		if v, ok := m["excluded_column_names"]; ok {
+			if v, ok := v.(*schema.Set); ok && v.Len() > 0 {
+				apiObject.ExcludedColumnNames = flex.ExpandStringSet(v)
+			}
+		}
+	}
+
+	return apiObject
+}
+
+func flattenColumnWildcard(apiObject *lakeformation.ColumnWildcard) []interface{} {
+	if apiObject == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"excluded_column_names": flex.FlattenStringSet(apiObject.ExcludedColumnNames),
+	}
+
+	return []interface{}{m}
+}
+
+//URI address single and multi-line string pattern
+// AWS surrogate pair and low surrogate UTF-16: [\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\t]
+// GOLANG without surrogate pair UTF-8:         [\x{0020}-\x{D800}\x{E000}-\x{FFFD}\x{DBFF}-\x{DC00}\x{DFFF}\t]
+func validateLFSingleLineString() schema.SchemaValidateFunc {
+	return validation.All(
+		validation.StringLenBetween(1, 255),
+		validation.StringMatch(regexp.MustCompile(`[\x{0020}-\x{D800}\x{E000}-\x{FFFD}\x{DBFF}-\x{DC00}\x{DFFF}\t]*`), ""),
+	)
+}
+
+func validateLFMultiLineURIString() schema.SchemaValidateFunc {
+	return validation.All(
+		validation.StringLenBetween(1, 2048),
+		validation.StringMatch(regexp.MustCompile(`[\x{0020}-\x{D800}\x{E000}-\x{FFFD}\x{DBFF}-\x{DC00}\x{DFFF}\r\n\t]*`), ""),
+	)
+}

--- a/internal/service/lakeformation/data_cells_filter_test.go
+++ b/internal/service/lakeformation/data_cells_filter_test.go
@@ -1,0 +1,553 @@
+package lakeformation_test
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lakeformation"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tflakeformation "github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation"
+)
+
+func testAccResourceDataCellsFilter_basic(t *testing.T) {
+	resourceName := "aws_lakeformation_data_cells_filter.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	filterExpression := fmt.Sprintf("event = '%s'", rName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(lakeformation.EndpointsID, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, lakeformation.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataCellFiltersDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:  testAccResourceDataCellFiltersConfig_basic(rName, rName, filterExpression),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataCellFiltersExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "row_filter.0.filter_expression", filterExpression),
+					acctest.CheckResourceAttrAccountID(resourceName, "table_catalog_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccResourceDataCellsFilter_disappears(t *testing.T) {
+	resourceName := "aws_lakeformation_data_cells_filter.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	filterExpression := fmt.Sprintf("event = '%s'", rName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(lakeformation.EndpointsID, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, lakeformation.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataCellFiltersDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceDataCellFiltersConfig_basic(rName, rName, filterExpression),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataCellFiltersExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tflakeformation.ResourceDataCellsFilter(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccResourceDataCellsFilter_excludeColumns(t *testing.T) {
+	resourceName := "aws_lakeformation_data_cells_filter.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	filterExpression := fmt.Sprintf("event = '%s'", rName)
+	excludeColumn := "timestamp"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(lakeformation.EndpointsID, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, lakeformation.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataCellFiltersDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:  testAccResourceDataCellFiltersConfig_excludeColumns(rName, rName, filterExpression, excludeColumn),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataCellFiltersExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "column_names.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "column_wildcard.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "column_wildcard.0.excluded_column_names.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "column_wildcard.0.excluded_column_names.0", excludeColumn),
+					acctest.CheckResourceAttrAccountID(resourceName, "table_catalog_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccResourceDataCellsFilter_includeColumns(t *testing.T) {
+	resourceName := "aws_lakeformation_data_cells_filter.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	filterExpression := fmt.Sprintf("event = '%s'", rName)
+	includeColumns := []string{"event", "timestamp"}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(lakeformation.EndpointsID, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, lakeformation.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataCellFiltersDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:  testAccResourceDataCellFiltersConfig_includeColumns(rName, rName, filterExpression, includeColumns),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataCellFiltersExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "column_names.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "column_names.0", "event"),
+					resource.TestCheckResourceAttr(resourceName, "column_names.1", "timestamp"),
+					resource.TestCheckResourceAttr(resourceName, "column_wildcard.#", "0"),
+					acctest.CheckResourceAttrAccountID(resourceName, "table_catalog_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccResourceDataCellsFilter_allRowsExcludeColumns(t *testing.T) {
+	resourceName := "aws_lakeformation_data_cells_filter.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	excludeColumn := "timestamp"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(lakeformation.EndpointsID, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, lakeformation.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataCellFiltersDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:  testAccResourceDataCellFiltersConfig_allRowsExcludeColumns(rName, rName, excludeColumn),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataCellFiltersExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "column_names.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "column_wildcard.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "column_wildcard.0.excluded_column_names.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "column_wildcard.0.excluded_column_names.0", excludeColumn),
+					resource.TestCheckResourceAttr(resourceName, "row_filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "row_filter.0.all_rows_wildcard", "true"),
+					acctest.CheckResourceAttrAccountID(resourceName, "table_catalog_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDataCellFiltersDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).LakeFormationConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_lakeformation_data_cells_filter" {
+			continue
+		}
+
+		catalogID, databaseName, tableName, dataCellsFilterName, err := tflakeformation.ReadDataCellsFilterID(rs.Primary.ID)
+		if err != nil {
+			return err
+
+		}
+
+		// there is no api to get a single data cell filter. the only option is to iterate through a list
+		inDCFId := fmt.Sprintf("%s:%s:%s:%s", catalogID, databaseName, tableName, dataCellsFilterName)
+
+		in := &lakeformation.ListDataCellsFilterInput{
+			Table: &lakeformation.TableResource{
+				CatalogId:    aws.String(catalogID),
+				DatabaseName: aws.String(databaseName),
+				Name:         aws.String(tableName),
+				//Table.TableWildcard
+			},
+			//MaxResults: aws.Int64(maxResults),
+		}
+
+		bMatch := false
+		continueIteration := true
+		pageNum := 0
+		//recNum := 0
+		errList := conn.ListDataCellsFilterPages(in, func(page *lakeformation.ListDataCellsFilterOutput, lastPage bool) bool {
+			if page == nil {
+				return !lastPage
+			}
+
+			pageNum++
+
+			for recNum, dcf := range page.DataCellsFilters {
+				recNum++
+				outDCFId := fmt.Sprintf("%s:%s:%s:%s", *dcf.TableCatalogId, *dcf.DatabaseName, *dcf.TableName, *dcf.Name)
+				if inDCFId == outDCFId {
+					bMatch = true
+					continueIteration = false
+					log.Printf("[INFO] testAccCheckDataCellFiltersDestroy Matched DCF. item: %v on page: %v", recNum, pageNum)
+					break
+				}
+			}
+
+			// return false to stop the function from iterating through pages
+			return continueIteration
+		})
+
+		if tfawserr.ErrCodeEquals(errList, lakeformation.ErrCodeEntityNotFoundException) {
+			continue
+		}
+
+		if tfawserr.ErrMessageContains(errList, lakeformation.ErrCodeInvalidInputException, "not found") {
+			continue
+		}
+
+		// If the lake formation admin has been revoked, there will be access denied instead of entity not found
+		if tfawserr.ErrCodeEquals(errList, lakeformation.ErrCodeAccessDeniedException) {
+			continue
+		}
+
+		if bMatch {
+			return fmt.Errorf("Lake Formation Resource Data Cell Filter (%s) still exists", rs.Primary.ID)
+		} else {
+			log.Printf("[INFO] testAccCheckDataCellFiltersDestroy found no resource")
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckDataCellFiltersExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("acceptance test: resource not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		catalogID, databaseName, tableName, dataCellsFilterName, err := tflakeformation.ReadDataCellsFilterID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LakeFormationConn
+
+		// there is no api to get a single data cell filter. the only option is to iterate through a list
+		inDCFId := fmt.Sprintf("%s:%s:%s:%s", catalogID, databaseName, tableName, dataCellsFilterName)
+
+		in := &lakeformation.ListDataCellsFilterInput{
+			Table: &lakeformation.TableResource{
+				CatalogId:    aws.String(catalogID),
+				DatabaseName: aws.String(databaseName),
+				Name:         aws.String(tableName),
+				//Table.TableWildcard
+			},
+			//MaxResults: aws.Int64(maxResults),
+		}
+
+		bMatch := false
+		continueIteration := true
+		pageNum := 0
+		errList := conn.ListDataCellsFilterPages(in, func(page *lakeformation.ListDataCellsFilterOutput, lastPage bool) bool {
+			if page == nil {
+				return !lastPage
+			}
+
+			pageNum++
+
+			for recNum, dcf := range page.DataCellsFilters {
+				recNum++
+				outDCFId := fmt.Sprintf("%s:%s:%s:%s", *dcf.TableCatalogId, *dcf.DatabaseName, *dcf.TableName, *dcf.Name)
+				if inDCFId == outDCFId {
+					bMatch = true
+					continueIteration = false
+					break
+				}
+			}
+
+			// return false to stop the function from iterating through pages
+			return continueIteration
+		})
+
+		if bMatch {
+			log.Printf("[INFO] testAccCheckDataCellFiltersExists errList %v", errList)
+			return nil
+		} else {
+			return fmt.Errorf("Lake Formation Resource Data Cell Filter (%s) does not exist", rs.Primary.ID)
+		}
+	}
+}
+
+// copied glue configuration from resource_lf_tags_test
+func testAccResourceDataCellFiltersConfig_basic(rName string, dcfName string, filterExpression string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_session_context" "current" {
+  arn = data.aws_caller_identity.current.arn
+}
+
+resource "aws_lakeformation_data_lake_settings" "test" {
+  admins = [data.aws_iam_session_context.current.issuer_arn]
+}
+
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test" {
+	name          = %[1]q
+	database_name = aws_glue_catalog_database.test.name
+  
+	storage_descriptor {
+	  columns {
+		name = "event"
+		type = "string"
+	  }
+  
+	  columns {
+		name = "timestamp"
+		type = "date"
+	  }
+  
+	  columns {
+		name = "value"
+		type = "double"
+	  }
+	}
+}
+
+resource "aws_lakeformation_data_cells_filter" "test" {
+	table_catalog_id = data.aws_caller_identity.current.account_id
+	database_name    = aws_glue_catalog_database.test.name
+	table_name       = aws_glue_catalog_table.test.name
+	name             = %[2]q
+
+	row_filter {
+		filter_expression = %[3]q
+	}
+
+	column_wildcard {}
+
+	# for consistency, ensure that admins are setup before testing
+	# depends_on = [aws_lakeformation_data_lake_settings.test]
+}
+
+`, rName, dcfName, filterExpression)
+}
+
+func testAccResourceDataCellFiltersConfig_excludeColumns(rName string, dcfName string, filterExpression string, excludeColumns string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_session_context" "current" {
+	arn = data.aws_caller_identity.current.arn
+}
+
+resource "aws_lakeformation_data_lake_settings" "test" {
+	admins = [data.aws_iam_session_context.current.issuer_arn]
+}
+
+resource "aws_glue_catalog_database" "test" {
+	name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test" {
+	name          = %[1]q
+	database_name = aws_glue_catalog_database.test.name
+	
+	storage_descriptor {
+		columns {
+		name = "event"
+		type = "string"
+		}
+	
+		columns {
+		name = "timestamp"
+		type = "date"
+		}
+	
+		columns {
+		name = "value"
+		type = "double"
+		}
+	}
+}
+
+resource "aws_lakeformation_data_cells_filter" "test" {
+  table_catalog_id = data.aws_caller_identity.current.account_id
+  database_name    = aws_glue_catalog_database.test.name
+  table_name       = aws_glue_catalog_table.test.name
+  name             = %[2]q
+
+  row_filter {
+    filter_expression = %[3]q
+  }
+
+  column_wildcard {
+    excluded_column_names = [ %[4]q ]
+  }
+
+  # for consistency, ensure that admins are setup before testing
+  depends_on = [aws_lakeformation_data_lake_settings.test]
+}
+
+`, rName, dcfName, filterExpression, excludeColumns)
+}
+
+func testAccResourceDataCellFiltersConfig_includeColumns(rName string, dcfName string, filterExpression string, includeColumns []string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_session_context" "current" {
+	arn = data.aws_caller_identity.current.arn
+}
+
+resource "aws_lakeformation_data_lake_settings" "test" {
+	admins = [data.aws_iam_session_context.current.issuer_arn]
+}
+
+resource "aws_glue_catalog_database" "test" {
+	name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test" {
+	name          = %[1]q
+	database_name = aws_glue_catalog_database.test.name
+	
+	storage_descriptor {
+		columns {
+		name = "event"
+		type = "string"
+		}
+	
+		columns {
+		name = "timestamp"
+		type = "date"
+		}
+	
+		columns {
+		name = "value"
+		type = "double"
+		}
+	}
+}
+
+resource "aws_lakeformation_data_cells_filter" "test" {
+  table_catalog_id = data.aws_caller_identity.current.account_id
+  database_name    = aws_glue_catalog_database.test.name
+  table_name       = aws_glue_catalog_table.test.name
+  name             = %[2]q
+
+  row_filter {
+    filter_expression = %[3]q
+  }
+
+  column_names  = [ %[4]s ]
+
+  # for consistency, ensure that admins are setup before testing
+  depends_on = [aws_lakeformation_data_lake_settings.test]
+}
+
+`, rName, dcfName, filterExpression, fmt.Sprintf(`"%s"`, strings.Join(includeColumns, `", "`)))
+}
+
+func testAccResourceDataCellFiltersConfig_allRowsExcludeColumns(rName string, dcfName string, excludeColumns string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_session_context" "current" {
+	arn = data.aws_caller_identity.current.arn
+}
+
+resource "aws_lakeformation_data_lake_settings" "test" {
+	admins = [data.aws_iam_session_context.current.issuer_arn]
+}
+
+resource "aws_glue_catalog_database" "test" {
+	name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test" {
+	name          = %[1]q
+	database_name = aws_glue_catalog_database.test.name
+	
+	storage_descriptor {
+		columns {
+		name = "event"
+		type = "string"
+		}
+	
+		columns {
+		name = "timestamp"
+		type = "date"
+		}
+	
+		columns {
+		name = "value"
+		type = "double"
+		}
+	}
+}
+
+resource "aws_lakeformation_data_cells_filter" "test" {
+  table_catalog_id = data.aws_caller_identity.current.account_id
+  database_name    = aws_glue_catalog_database.test.name
+  table_name       = aws_glue_catalog_table.test.name
+  name             = %[2]q
+
+  row_filter {
+    all_rows_wildcard = "true"
+  }
+
+  column_wildcard {
+    excluded_column_names = [ %[3]q ]
+  }
+
+  # for consistency, ensure that admins are setup before testing
+  depends_on = [aws_lakeformation_data_lake_settings.test]
+}
+
+`, rName, dcfName, excludeColumns)
+}

--- a/internal/service/lakeformation/lakeformation_test.go
+++ b/internal/service/lakeformation/lakeformation_test.go
@@ -61,6 +61,13 @@ func TestAccLakeFormation_serial(t *testing.T) {
 			"table":            testAccResourceLFTags_table,
 			"tableWithColumns": testAccResourceLFTags_tableWithColumns,
 		},
+		"DataCellsFilter": {
+			"basic":                 testAccResourceDataCellsFilter_basic,
+			"disappears":            testAccResourceDataCellsFilter_disappears,
+			"inludeColumns":         testAccResourceDataCellsFilter_includeColumns,
+			"excludeColumns":        testAccResourceDataCellsFilter_excludeColumns,
+			"allRowsExcludeColumns": testAccResourceDataCellsFilter_allRowsExcludeColumns,
+		},
 	}
 
 	for group, m := range testCases {

--- a/website/docs/r/lakeformation_data_cells_filter.html.markdown
+++ b/website/docs/r/lakeformation_data_cells_filter.html.markdown
@@ -1,0 +1,134 @@
+---
+subcategory: "Lake Formation"
+layout: "aws"
+page_title: "AWS: aws_lakeformation_data_cells_filter"
+description: |-
+  Terraform resource for managing an AWS Lake Formation Data Cells Filter.
+---
+
+# Resource: aws_lakeformation_data_cells_filter
+
+Provides a Lake Formation Data Cells Filter resource. (In the AWS Console, this resource is sometimes referred to as "Data Filters"). A Data Cells Filter is applied to a single Glue Database Table. 
+
+"Column-level security" is provided when a Data Cells Filter is configured to include or exclude columns in a Table.  "Row-level security" is provided when a Data Cells Filter is configured to filter (remove) rows in a Table with a Row Filter Expression.  "Cell-level security" combines row filtering and column filtering.
+
+~> **NOTE on Lake Formation Data Cell Filters ID:** AWS does not offer an API to get a single Data Cells Filter object.  Instead, a ListDataCellsFilterPages API is provided.  This API lists all Data Cells Filters for a single Table. The Data Cells Filter resource must iterate through the results of the List API to reference the Data Cells Filter's attributes.  If there are many Data Cells Filters configured for a Table, this may result in slowness.
+
+~> **NOTE on Lake Formation Data Cell Filters Maintenance:** AWS does not offer an API to update a single Data Cells Filter.  Instead, any changes to a Data Cells Filter will delete the existing Data Cells Filter and create a new one.
+
+## Example Usage
+
+### Column-level security - Filter (Exclude) some Columns and allow all Row values
+
+```terraform
+resource "aws_lakeformation_data_cells_filter" "animal_dog_exclude_birthdate" {
+  table_catalog_id = "111111111111"
+  database_name    = "animal"
+  table_name       = "dog"
+  name             = "animal_dog_exclude_birthdate"
+
+  row_filter {
+    all_rows_wildcard = "true"
+  }
+
+  column_wildcard {
+    excluded_column_names = ["birthdate"]
+  }
+}
+```
+
+### Column-level security - Filter (Include) some Columns and allow all Row values
+
+```terraform
+resource "aws_lakeformation_data_cells_filter" "animal_dog_include_fourcolumns" {
+  table_catalog_id = "111111111111"
+  database_name    = "animal"
+  table_name       = "dog"
+  name             = "animal_dog_include_fourcolumns"
+
+  row_filter {
+    all_rows_wildcard = "true"
+  }
+
+  column_names = ["id","name","hair","lastupdate"]
+  
+}
+```
+
+### Row-level security - Include all Columns and filter specific Row values
+
+```terraform
+resource "aws_lakeformation_data_cells_filter" "animal_dog_hair_short" {
+  table_catalog_id = "111111111111"
+  database_name    = "animal"
+  table_name       = "dog"
+  name             = "animal_dog_hair_short"
+
+  row_filter {
+    filter_expression = "hair = 'short'"
+  }
+
+  column_wildcard {}
+
+}
+```
+
+### Cell-level security - Filter (Include) some Columns and filter specific Row values
+
+```terraform
+resource "aws_lakeformation_data_cells_filter" "animal_dog_hair_short_include_fourcolumns" {
+  table_catalog_id = "111111111111"
+  database_name    = "animal"
+  table_name       = "dog"
+  name             = "animal_dog_hair_short_include_fourcolumns"
+
+  row_filter {
+    filter_expression = "hair = 'short'"
+  }
+
+  column_names = ["id","name","hair","lastupdate"]
+
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `database_name` - (Required) Name of the database resource. Unique to the Data Catalog.
+
+* `table_name` - (Required) Name of the table resource. Unique to the database.
+
+* `name` - (Required) Name of the data cells filter resource. Unique to the Data Catalog.
+
+* `row_filter`- (Required) Configuration block for table row filtering.  See below.
+
+Exactly one of the following is required:
+
+* `column_names` - (Optional) Set of column names in the table to INCLUDE.
+
+* `column_wildcard` - (Optional) Configuration block for column names in the table to EXCLUDE. See below.
+
+~> **NOTE include EMPTY column_wildcard if there is no Column-level security needed:** set `column_wildcard` to `{}` 
+
+The following arguments are optional:
+
+* `table_catalog_id` - (Optional) Identifier for the Data Catalog. By default, it is the account ID of the caller.
+
+### row_filter
+
+One of the following arguments are required:
+
+* `filter_expression` - (Required, at least one of `all_rows_wildcard` or `filter_expression`). "WHERE clause" to filter table rows
+
+* `all_rows_wildcard` - (Required, at least one of `all_rows_wildcard` or `filter_expression`). Boolean value. `true` = returns all rows (used in combination with `column_names` or `column_wildcard` to provide Column-level security only).  The default value = "false"
+
+### column_wildcard
+
+The following arguments are optional:
+
+* `excluded_column_names` - (Optional) Set of column names in the table to exclude.
+
+## Attributes Reference
+
+No additional attributes are exported.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Add the resource Data Cells Filter to Lake Formation

Adds acceptance testing and website documentation for the resource.

Does not add a Data Source for Data Cells Filter.  Concerns with the lack of an individual "Get" API for Data Cells Filter.  Forced to use a List API + iteration to retrieve Data Cells Filter attributes.  Potential for performance issues due to this gap in API capability.

This PR does not update permissions to allow permissions to apply to Data Cells Filter.  That would be too much change in 1 PR.  But that is next.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #27677
Relates #26687
Relates https://github.com/hashicorp/terraform-provider-awscc/issues/719

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

```
PS C:\Users\x\workspace\terraform-provider-aws> go test ./internal/service/lakeformation/... -v -count 1 -parallel 20 -run='TestAccLakeFormation_' -timeout 60m
=== RUN   TestAccLakeFormation_serial
=== RUN   TestAccLakeFormation_serial/PermissionsDataSource
=== RUN   TestAccLakeFormation_serial/PermissionsDataSource/database
=== RUN   TestAccLakeFormation_serial/PermissionsDataSource/dataLocation
=== RUN   TestAccLakeFormation_serial/PermissionsDataSource/lfTag
=== RUN   TestAccLakeFormation_serial/PermissionsDataSource/lfTagPolicy
=== RUN   TestAccLakeFormation_serial/PermissionsDataSource/table
=== RUN   TestAccLakeFormation_serial/PermissionsDataSource/tableWithColumns
=== RUN   TestAccLakeFormation_serial/PermissionsDataSource/basic
=== RUN   TestAccLakeFormation_serial/PermissionsTable
=== RUN   TestAccLakeFormation_serial/PermissionsTable/selectOnly
=== RUN   TestAccLakeFormation_serial/PermissionsTable/selectPlus
=== RUN   TestAccLakeFormation_serial/PermissionsTable/wildcardNoSelect
=== RUN   TestAccLakeFormation_serial/PermissionsTable/wildcardSelectPlus
=== RUN   TestAccLakeFormation_serial/PermissionsTable/basic
=== RUN   TestAccLakeFormation_serial/PermissionsTable/multipleRoles
=== RUN   TestAccLakeFormation_serial/PermissionsTable/wildcardSelectOnly
=== RUN   TestAccLakeFormation_serial/PermissionsTable/iamAllowed
=== RUN   TestAccLakeFormation_serial/PermissionsTable/implicit
=== RUN   TestAccLakeFormation_serial/PermissionsTableWithColumns
=== RUN   TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardExcludedColumns
=== RUN   TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardSelectOnly
=== RUN   TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardSelectPlus
=== RUN   TestAccLakeFormation_serial/PermissionsTableWithColumns/basic
=== RUN   TestAccLakeFormation_serial/PermissionsTableWithColumns/implicit
=== RUN   TestAccLakeFormation_serial/LFTags
=== RUN   TestAccLakeFormation_serial/LFTags/basic
=== RUN   TestAccLakeFormation_serial/LFTags/disappears
=== RUN   TestAccLakeFormation_serial/LFTags/values
=== RUN   TestAccLakeFormation_serial/ResourceLFTags
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/table
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/tableWithColumns
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/basic
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/database
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/databaseMultiple
=== RUN   TestAccLakeFormation_serial/DataCellsFilter
=== RUN   TestAccLakeFormation_serial/DataCellsFilter/inludeColumns
=== RUN   TestAccLakeFormation_serial/DataCellsFilter/excludeColumns
=== RUN   TestAccLakeFormation_serial/DataCellsFilter/allRowsExcludeColumns
=== RUN   TestAccLakeFormation_serial/DataCellsFilter/basic
=== RUN   TestAccLakeFormation_serial/DataCellsFilter/disappears
=== RUN   TestAccLakeFormation_serial/DataLakeSettings
=== RUN   TestAccLakeFormation_serial/DataLakeSettings/basic
=== RUN   TestAccLakeFormation_serial/DataLakeSettings/dataSource
=== RUN   TestAccLakeFormation_serial/DataLakeSettings/disappears
=== RUN   TestAccLakeFormation_serial/DataLakeSettings/withoutCatalogId
=== RUN   TestAccLakeFormation_serial/PermissionsBasic
=== RUN   TestAccLakeFormation_serial/PermissionsBasic/databaseMultiple
=== RUN   TestAccLakeFormation_serial/PermissionsBasic/dataLocation
=== RUN   TestAccLakeFormation_serial/PermissionsBasic/disappears
=== RUN   TestAccLakeFormation_serial/PermissionsBasic/lfTag
=== RUN   TestAccLakeFormation_serial/PermissionsBasic/lfTagPolicy
=== RUN   TestAccLakeFormation_serial/PermissionsBasic/basic
=== RUN   TestAccLakeFormation_serial/PermissionsBasic/database
=== RUN   TestAccLakeFormation_serial/PermissionsBasic/databaseIAMAllowed
--- PASS: TestAccLakeFormation_serial (1418.60s)
    --- PASS: TestAccLakeFormation_serial/PermissionsDataSource (210.67s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/database (30.98s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/dataLocation (31.49s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/lfTag (31.71s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/lfTagPolicy (28.66s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/table (27.96s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/tableWithColumns (30.47s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/basic (29.41s)
    --- PASS: TestAccLakeFormation_serial/PermissionsTable (281.78s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/selectOnly (29.44s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/selectPlus (29.24s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/wildcardNoSelect (26.47s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/wildcardSelectPlus (29.58s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/basic (30.81s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/multipleRoles (29.46s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/wildcardSelectOnly (28.99s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/iamAllowed (47.95s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/implicit (29.85s)
    --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns (195.88s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardExcludedColumns (29.85s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardSelectOnly (29.84s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardSelectPlus (29.68s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/basic (76.52s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/implicit (29.99s)
    --- PASS: TestAccLakeFormation_serial/LFTags (76.19s)
        --- PASS: TestAccLakeFormation_serial/LFTags/basic (19.10s)
        --- PASS: TestAccLakeFormation_serial/LFTags/disappears (19.26s)
        --- PASS: TestAccLakeFormation_serial/LFTags/values (37.83s)
    --- PASS: TestAccLakeFormation_serial/ResourceLFTags (162.93s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/table (37.09s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/tableWithColumns (37.61s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/basic (17.42s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/database (35.57s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/databaseMultiple (35.25s)
    --- PASS: TestAccLakeFormation_serial/DataCellsFilter (111.21s)
        --- PASS: TestAccLakeFormation_serial/DataCellsFilter/inludeColumns (23.87s)
        --- PASS: TestAccLakeFormation_serial/DataCellsFilter/excludeColumns (23.99s)
        --- PASS: TestAccLakeFormation_serial/DataCellsFilter/allRowsExcludeColumns (21.20s)
        --- PASS: TestAccLakeFormation_serial/DataCellsFilter/basic (23.12s)
        --- PASS: TestAccLakeFormation_serial/DataCellsFilter/disappears (19.02s)
    --- PASS: TestAccLakeFormation_serial/DataLakeSettings (75.14s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettings/basic (18.96s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettings/dataSource (20.51s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettings/disappears (16.74s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettings/withoutCatalogId (18.93s)
    --- PASS: TestAccLakeFormation_serial/PermissionsBasic (304.79s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/databaseMultiple (26.50s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/dataLocation (29.41s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/disappears (91.68s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/lfTag (25.96s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/lfTagPolicy (28.02s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/basic (28.13s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/database (28.21s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/databaseIAMAllowed (46.88s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation      1425.060s
...
```
