### PR TITLE
d/aws_iam_attached_role_policies: New Data Source

### DIFF
--- a/.changelog/27896.txt
+++ b/.changelog/27896.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_iam_attached_role_policies
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -681,6 +681,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_guardduty_detector": guardduty.DataSourceDetector(),
 
 			"aws_iam_account_alias":           iam.DataSourceAccountAlias(),
+			"aws_iam_attached_role_policies":  iam.DataSourceAttachedRolePolicies(),
 			"aws_iam_group":                   iam.DataSourceGroup(),
 			"aws_iam_instance_profile":        iam.DataSourceInstanceProfile(),
 			"aws_iam_instance_profiles":       iam.DataSourceInstanceProfiles(),
@@ -695,7 +696,6 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_iam_user":                    iam.DataSourceUser(),
 			"aws_iam_user_ssh_key":            iam.DataSourceUserSSHKey(),
 			"aws_iam_users":                   iam.DataSourceUsers(),
-			"aws_iam_attached_role_policies":  iam.DataSourceAttachedRolePolicies(),
 
 			"aws_identitystore_group": identitystore.DataSourceGroup(),
 			"aws_identitystore_user":  identitystore.DataSourceUser(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -695,6 +695,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_iam_user":                    iam.DataSourceUser(),
 			"aws_iam_user_ssh_key":            iam.DataSourceUserSSHKey(),
 			"aws_iam_users":                   iam.DataSourceUsers(),
+			"aws_iam_attached_role_policies":  iam.DataSourceAttachedRolePolicies(),
 
 			"aws_identitystore_group": identitystore.DataSourceGroup(),
 			"aws_identitystore_user":  identitystore.DataSourceUser(),

--- a/internal/service/iam/attached_role_policies_data_source.go
+++ b/internal/service/iam/attached_role_policies_data_source.go
@@ -1,0 +1,81 @@
+package iam
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceAttachedRolePolicies() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAttachedRolePoliciesRead,
+
+		Schema: map[string]*schema.Schema{
+			"role": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"path_prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "/",
+			},
+			"arns": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"names": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceAttachedRolePoliciesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).IAMConn
+
+	role := d.Get("role").(string)
+	pathPrefix := d.Get("path_prefix").(string)
+	input := &iam.ListAttachedRolePoliciesInput{
+		RoleName:   aws.String(role),
+		PathPrefix: aws.String(pathPrefix),
+	}
+
+	var arns, names []string
+
+	log.Printf("[DEBUG] Reading IAM Attached Role Policies: %s", input)
+	err := conn.ListAttachedRolePoliciesPages(input,
+		func(page *iam.ListAttachedRolePoliciesOutput, lastPage bool) bool {
+			if page == nil {
+				return !lastPage
+			}
+
+			for _, p := range page.AttachedPolicies {
+				if p == nil {
+					continue
+				}
+
+				arns = append(arns, aws.StringValue(p.PolicyArn))
+				names = append(names, aws.StringValue(p.PolicyName))
+			}
+
+			return !lastPage
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("error getting attached role policies: %w", err)
+	}
+
+	d.SetId(role)
+	d.Set("arns", arns)
+	d.Set("names", names)
+
+	return nil
+}

--- a/internal/service/iam/attached_role_policies_data_source_test.go
+++ b/internal/service/iam/attached_role_policies_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccAttachedRolePoliciesDataSource_basic(t *testing.T) {
+func TestAccIAMAttachedRolePoliciesDataSource_basic(t *testing.T) {
 	resourceName := "aws_iam_role_policy_attachment.test"
 	dataSourceName := "data.aws_iam_attached_role_policies.test"
 
@@ -37,7 +37,7 @@ func TestAccAttachedRolePoliciesDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccAttachedRolePoliciesDataSource_withPathPrefixWithResults(t *testing.T) {
+func TestAccIAMAttachedRolePoliciesDataSource_withPathPrefixWithResults(t *testing.T) {
 	resourceName := "aws_iam_role_policy_attachment.test"
 	dataSourceName := "data.aws_iam_attached_role_policies.test"
 

--- a/internal/service/iam/attached_role_policies_data_source_test.go
+++ b/internal/service/iam/attached_role_policies_data_source_test.go
@@ -66,7 +66,7 @@ func TestAccIAMAttachedRolePoliciesDataSource_withPathPrefixWithResults(t *testi
 	})
 }
 
-func TestAccAttachedRolePoliciesDataSource_withPathPrefixWithoutResults(t *testing.T) {
+func TestAccIAMAttachedRolePoliciesDataSource_withPathPrefixWithoutResults(t *testing.T) {
 	resourceName := "aws_iam_role_policy_attachment.test"
 	dataSourceName := "data.aws_iam_attached_role_policies.test"
 

--- a/internal/service/iam/attached_role_policies_data_source_test.go
+++ b/internal/service/iam/attached_role_policies_data_source_test.go
@@ -1,0 +1,190 @@
+package iam_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/iam"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccAttachedRolePoliciesDataSource_basic(t *testing.T) {
+	resourceName := "aws_iam_role_policy_attachment.test"
+	dataSourceName := "data.aws_iam_attached_role_policies.test"
+
+	role := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAttachedRolePoliciesDataSourceConfig_basic(role, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "role", resourceName, "role"),
+					resource.TestCheckResourceAttr(dataSourceName, "path_prefix", "/"),
+					resource.TestCheckResourceAttr(dataSourceName, "names.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "names.0", policyName),
+					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "arns.0", resourceName, "policy_arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAttachedRolePoliciesDataSource_withPathPrefixWithResults(t *testing.T) {
+	resourceName := "aws_iam_role_policy_attachment.test"
+	dataSourceName := "data.aws_iam_attached_role_policies.test"
+
+	role := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := role
+	policyPath := "/test/"
+	pathPrefix := policyPath
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAttachedRolePoliciesDataSourceConfig_withPathPrefix(role, policyName, policyPath, pathPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "role", resourceName, "role"),
+					resource.TestCheckResourceAttr(dataSourceName, "path_prefix", pathPrefix),
+					resource.TestCheckResourceAttr(dataSourceName, "names.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "names.0", policyName),
+					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "arns.0", resourceName, "policy_arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAttachedRolePoliciesDataSource_withPathPrefixWithoutResults(t *testing.T) {
+	resourceName := "aws_iam_role_policy_attachment.test"
+	dataSourceName := "data.aws_iam_attached_role_policies.test"
+
+	role := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := role
+	policyPath := "/test/"
+	pathPrefix := "/different/"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAttachedRolePoliciesDataSourceConfig_withPathPrefix(role, policyName, policyPath, pathPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "role", resourceName, "role"),
+					resource.TestCheckResourceAttr(dataSourceName, "path_prefix", pathPrefix),
+					resource.TestCheckResourceAttr(dataSourceName, "names.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAttachedRolePoliciesDataSourceConfig_basic(name, policyName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = "%s"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "test" {
+  name = "%s"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Deny"
+        Action   = "*"
+        Resource = "*"
+      },
+    ],
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = aws_iam_policy.test.arn
+}
+
+data "aws_iam_attached_role_policies" "test" {
+  depends_on = [aws_iam_role_policy_attachment.test]
+
+  role = aws_iam_role.test.name
+}
+`, name, policyName)
+}
+
+func testAccAttachedRolePoliciesDataSourceConfig_withPathPrefix(name, policyName, policyPath, pathPrefix string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = "%s"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "test" {
+  name = "%s"
+  path = "%s"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Deny"
+        Action   = "*"
+        Resource = "*"
+      },
+    ],
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = aws_iam_policy.test.arn
+}
+
+data "aws_iam_attached_role_policies" "test" {
+  depends_on = [aws_iam_role_policy_attachment.test]
+
+  role        = aws_iam_role.test.name
+  path_prefix = "%s"
+}
+`, name, policyName, policyPath, pathPrefix)
+}

--- a/internal/service/iam/attached_role_policies_data_source_test.go
+++ b/internal/service/iam/attached_role_policies_data_source_test.go
@@ -37,12 +37,12 @@ func TestAccIAMAttachedRolePoliciesDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccIAMAttachedRolePoliciesDataSource_withPathPrefixWithResults(t *testing.T) {
+func TestAccIAMAttachedRolePoliciesDataSource_withPathPrefixMatching(t *testing.T) {
 	resourceName := "aws_iam_role_policy_attachment.test"
 	dataSourceName := "data.aws_iam_attached_role_policies.test"
 
 	role := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName := role
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyPath := "/test/"
 	pathPrefix := policyPath
 
@@ -66,12 +66,12 @@ func TestAccIAMAttachedRolePoliciesDataSource_withPathPrefixWithResults(t *testi
 	})
 }
 
-func TestAccIAMAttachedRolePoliciesDataSource_withPathPrefixWithoutResults(t *testing.T) {
+func TestAccIAMAttachedRolePoliciesDataSource_withPathPrefixNotMatching(t *testing.T) {
 	resourceName := "aws_iam_role_policy_attachment.test"
 	dataSourceName := "data.aws_iam_attached_role_policies.test"
 
 	role := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policyName := role
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	policyPath := "/test/"
 	pathPrefix := "/different/"
 

--- a/website/docs/d/iam_attached_role_policies.html.markdown
+++ b/website/docs/d/iam_attached_role_policies.html.markdown
@@ -1,0 +1,76 @@
+---
+subcategory: "IAM (Identity & Access Management)"
+layout: "aws"
+page_title: "AWS: aws_iam_attached_role_policies"
+description: |-
+  Terraform data source that lists all managed policies that are attached to the specified IAM role.
+---
+
+# Data Source: aws_iam_attached_role_policies
+
+Terraform data source that lists all managed policies that are attached to the specified IAM role.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_iam_role" "example" {
+  name = "example"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "example" {
+  name = "example"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "ec2:Describe*"
+        Resource = "*"
+      },
+    ],
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "example" {
+  role       = aws_iam_role.example.name
+  policy_arn = aws_iam_policy.example.arn
+}
+
+data "aws_iam_attached_role_policies" "example" {
+  role        = aws_iam_role.example.name
+  path_prefix = "/"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `role` - (Required) Name (not ARN) of the role to list attached policies for.
+
+The following arguments are optional:
+
+* `path_prefix` - (Optional) Path prefix for filtering results. Defaults to a slash (`/`), which will list all attached policies.
+
+## Attributes Reference
+
+* `arns` - Set of policy ARNs attached to the role.
+* `names` - Set of policy names attached to the role.
+
+[1]: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/list-attached-role-policies.html


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds `aws_iam_attached_role_policies` data source.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #26769

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/list-attached-role-policies.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccIAMAttachedRolePoliciesDataSource PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMAttachedRolePoliciesDataSource'  -timeout 180m
=== RUN   TestAccIAMAttachedRolePoliciesDataSource_basic
=== PAUSE TestAccIAMAttachedRolePoliciesDataSource_basic
=== RUN   TestAccIAMAttachedRolePoliciesDataSource_withPathPrefixWithResults
=== PAUSE TestAccIAMAttachedRolePoliciesDataSource_withPathPrefixWithResults
=== RUN   TestAccIAMAttachedRolePoliciesDataSource_withPathPrefixWithoutResults
=== PAUSE TestAccIAMAttachedRolePoliciesDataSource_withPathPrefixWithoutResults
=== CONT  TestAccIAMAttachedRolePoliciesDataSource_basic
=== CONT  TestAccIAMAttachedRolePoliciesDataSource_withPathPrefixWithoutResults
=== CONT  TestAccIAMAttachedRolePoliciesDataSource_withPathPrefixWithResults
--- PASS: TestAccIAMAttachedRolePoliciesDataSource_withPathPrefixWithoutResults (15.55s)
--- PASS: TestAccIAMAttachedRolePoliciesDataSource_withPathPrefixWithResults (15.64s)
--- PASS: TestAccIAMAttachedRolePoliciesDataSource_basic (15.74s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	17.616s
...
```
