### PR TITLE
d/aws_iam_attached_group_policies: New Data Source

### DIFF
--- a/.changelog/27898.txt
+++ b/.changelog/27898.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_iam_attached_group_policies
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -681,6 +681,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_guardduty_detector": guardduty.DataSourceDetector(),
 
 			"aws_iam_account_alias":           iam.DataSourceAccountAlias(),
+			"aws_iam_attached_group_policies": iam.DataSourceAttachedGroupPolicies(),
 			"aws_iam_group":                   iam.DataSourceGroup(),
 			"aws_iam_instance_profile":        iam.DataSourceInstanceProfile(),
 			"aws_iam_instance_profiles":       iam.DataSourceInstanceProfiles(),

--- a/internal/service/iam/attached_group_policies_data_source.go
+++ b/internal/service/iam/attached_group_policies_data_source.go
@@ -1,0 +1,81 @@
+package iam
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceAttachedGroupPolicies() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAttachedGroupPoliciesRead,
+
+		Schema: map[string]*schema.Schema{
+			"group": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"path_prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "/",
+			},
+			"arns": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"names": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceAttachedGroupPoliciesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).IAMConn
+
+	group := d.Get("group").(string)
+	pathPrefix := d.Get("path_prefix").(string)
+	input := &iam.ListAttachedGroupPoliciesInput{
+		GroupName:  aws.String(group),
+		PathPrefix: aws.String(pathPrefix),
+	}
+
+	var arns, names []string
+
+	log.Printf("[DEBUG] Reading IAM Attached Group Policies: %s", input)
+	err := conn.ListAttachedGroupPoliciesPages(input,
+		func(page *iam.ListAttachedGroupPoliciesOutput, lastPage bool) bool {
+			if page == nil {
+				return !lastPage
+			}
+
+			for _, p := range page.AttachedPolicies {
+				if p == nil {
+					continue
+				}
+
+				arns = append(arns, aws.StringValue(p.PolicyArn))
+				names = append(names, aws.StringValue(p.PolicyName))
+			}
+
+			return !lastPage
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("error getting attached group policies: %w", err)
+	}
+
+	d.SetId(group)
+	d.Set("arns", arns)
+	d.Set("names", names)
+
+	return nil
+}

--- a/internal/service/iam/attached_group_policies_data_source_test.go
+++ b/internal/service/iam/attached_group_policies_data_source_test.go
@@ -1,0 +1,164 @@
+package iam_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/iam"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccIAMAttachedGroupPoliciesDataSource_basic(t *testing.T) {
+	resourceName := "aws_iam_group_policy_attachment.test"
+	dataSourceName := "data.aws_iam_attached_group_policies.test"
+
+	group := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAttachedGroupPoliciesDataSourceConfig_basic(group, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "group", resourceName, "group"),
+					resource.TestCheckResourceAttr(dataSourceName, "path_prefix", "/"),
+					resource.TestCheckResourceAttr(dataSourceName, "names.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "names.0", policyName),
+					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "arns.0", resourceName, "policy_arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIAMAttachedGroupPoliciesDataSource_withPathPrefixMatching(t *testing.T) {
+	resourceName := "aws_iam_group_policy_attachment.test"
+	dataSourceName := "data.aws_iam_attached_group_policies.test"
+
+	group := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyPath := "/test/"
+	pathPrefix := policyPath
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAttachedGroupPoliciesDataSourceConfig_withPathPrefix(group, policyName, policyPath, pathPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "group", resourceName, "group"),
+					resource.TestCheckResourceAttr(dataSourceName, "path_prefix", pathPrefix),
+					resource.TestCheckResourceAttr(dataSourceName, "names.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "names.0", policyName),
+					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "arns.0", resourceName, "policy_arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIAMAttachedGroupPoliciesDataSource_withPathPrefixNotMatching(t *testing.T) {
+	resourceName := "aws_iam_group_policy_attachment.test"
+	dataSourceName := "data.aws_iam_attached_group_policies.test"
+
+	group := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyPath := "/test/"
+	pathPrefix := "/different/"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAttachedGroupPoliciesDataSourceConfig_withPathPrefix(group, policyName, policyPath, pathPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "group", resourceName, "group"),
+					resource.TestCheckResourceAttr(dataSourceName, "path_prefix", pathPrefix),
+					resource.TestCheckResourceAttr(dataSourceName, "names.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAttachedGroupPoliciesDataSourceConfig_basic(name, policyName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_group" "test" {
+  name = "%s"
+}
+
+resource "aws_iam_policy" "test" {
+  name = "%s"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Deny"
+        Action   = "*"
+        Resource = "*"
+      },
+    ],
+  })
+}
+
+resource "aws_iam_group_policy_attachment" "test" {
+  group      = aws_iam_group.test.name
+  policy_arn = aws_iam_policy.test.arn
+}
+
+data "aws_iam_attached_group_policies" "test" {
+  depends_on = [aws_iam_group_policy_attachment.test]
+
+  group = aws_iam_group.test.name
+}
+`, name, policyName)
+}
+
+func testAccAttachedGroupPoliciesDataSourceConfig_withPathPrefix(name, policyName, policyPath, pathPrefix string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_group" "test" {
+  name = "%s"
+}
+
+resource "aws_iam_policy" "test" {
+  name = "%s"
+  path = "%s"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Deny"
+        Action   = "*"
+        Resource = "*"
+      },
+    ],
+  })
+}
+
+resource "aws_iam_group_policy_attachment" "test" {
+  group      = aws_iam_group.test.name
+  policy_arn = aws_iam_policy.test.arn
+}
+
+data "aws_iam_attached_group_policies" "test" {
+  depends_on = [aws_iam_group_policy_attachment.test]
+
+  group       = aws_iam_group.test.name
+  path_prefix = "%s"
+}
+`, name, policyName, policyPath, pathPrefix)
+}

--- a/website/docs/d/iam_attached_group_policies.html.markdown
+++ b/website/docs/d/iam_attached_group_policies.html.markdown
@@ -1,0 +1,63 @@
+---
+subcategory: "IAM (Identity & Access Management)"
+layout: "aws"
+page_title: "AWS: aws_iam_attached_group_policies"
+description: |-
+  Terraform data source that lists all managed policies that are attached to the specified IAM group.
+---
+
+# Data Source: aws_iam_attached_group_policies
+
+Terraform data source that lists all managed policies that are attached to the specified IAM group.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_iam_group" "example" {
+  name = "example"
+}
+
+resource "aws_iam_policy" "example" {
+  name = "example"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "ec2:Describe*"
+        Resource = "*"
+      },
+    ],
+  })
+}
+
+resource "aws_iam_group_policy_attachment" "example" {
+  group      = aws_iam_group.example.name
+  policy_arn = aws_iam_policy.example.arn
+}
+
+data "aws_iam_attached_group_policies" "example" {
+  group       = aws_iam_group.example.name
+  path_prefix = "/"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `group` - (Required) Name (not ARN) of the group to list attached policies for.
+
+The following arguments are optional:
+
+* `path_prefix` - (Optional) Path prefix for filtering results. Defaults to a slash (`/`), which will list all attached policies.
+
+## Attributes Reference
+
+* `arns` - Set of policy ARNs attached to the group.
+* `names` - Set of policy names attached to the group.
+
+[1]: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/list-attached-group-policies.html


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds `aws_iam_attached_group_policies` new data source.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/list-attached-group-policies.html


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccIAMAttachedGroupPoliciesDataSource PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMAttachedGroupPoliciesDataSource'  -timeout 180m
=== RUN   TestAccIAMAttachedGroupPoliciesDataSource_basic
=== PAUSE TestAccIAMAttachedGroupPoliciesDataSource_basic
=== RUN   TestAccIAMAttachedGroupPoliciesDataSource_withPathPrefixMatching
=== PAUSE TestAccIAMAttachedGroupPoliciesDataSource_withPathPrefixMatching
=== RUN   TestAccIAMAttachedGroupPoliciesDataSource_withPathPrefixNotMatching
=== PAUSE TestAccIAMAttachedGroupPoliciesDataSource_withPathPrefixNotMatching
=== CONT  TestAccIAMAttachedGroupPoliciesDataSource_basic
=== CONT  TestAccIAMAttachedGroupPoliciesDataSource_withPathPrefixNotMatching
=== CONT  TestAccIAMAttachedGroupPoliciesDataSource_withPathPrefixMatching
--- PASS: TestAccIAMAttachedGroupPoliciesDataSource_withPathPrefixNotMatching (14.17s)
--- PASS: TestAccIAMAttachedGroupPoliciesDataSource_basic (14.27s)
--- PASS: TestAccIAMAttachedGroupPoliciesDataSource_withPathPrefixMatching (14.43s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	16.287s
...
```
