### PR TITLE
Add support for AWS Amplify `WEB_DYNAMIC` platform type

### DIFF
--- a/.changelog/#####.txt
+++ b/.changelog/#####.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_amplify_app: Add support for `WEB_COMPUTE` `platform` value
+```

--- a/.changelog/#####.txt
+++ b/.changelog/#####.txt
@@ -1,3 +1,0 @@
-```release-note:enhancement
-resource/aws_amplify_app: Add support for `WEB_COMPUTE` `platform` value
-```

--- a/.changelog/27925.txt
+++ b/.changelog/27925.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_amplify_app: Add support for `WEB_COMPUTE` `platform` value in support of [Next.js web apps](https://docs.aws.amazon.com/amplify/latest/userguide/ssr-Amplify-support.html)
+```

--- a/website/docs/r/amplify_app.html.markdown
+++ b/website/docs/r/amplify_app.html.markdown
@@ -143,7 +143,7 @@ The following arguments are supported:
 * `environment_variables` - (Optional) Environment variables map for an Amplify app.
 * `iam_service_role_arn` - (Optional) AWS Identity and Access Management (IAM) service role for an Amplify app.
 * `oauth_token` - (Optional) OAuth token for a third-party source control system for an Amplify app. The OAuth token is used to create a webhook and a read-only deploy key. The OAuth token is not stored.
-* `platform` - (Optional) Platform or framework for an Amplify app. Valid values: `WEB`.
+* `platform` - (Optional) Platform or framework for an Amplify app. Valid values: `WEB`, `WEB_COMPUTE`.
 * `repository` - (Optional) Repository for an Amplify app.
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 

--- a/website/docs/r/amplify_app.html.markdown
+++ b/website/docs/r/amplify_app.html.markdown
@@ -143,7 +143,7 @@ The following arguments are supported:
 * `environment_variables` - (Optional) Environment variables map for an Amplify app.
 * `iam_service_role_arn` - (Optional) AWS Identity and Access Management (IAM) service role for an Amplify app.
 * `oauth_token` - (Optional) OAuth token for a third-party source control system for an Amplify app. The OAuth token is used to create a webhook and a read-only deploy key. The OAuth token is not stored.
-* `platform` - (Optional) Platform or framework for an Amplify app. Valid values: `WEB`, `WEB_COMPUTE`.
+* `platform` - (Optional) Platform or framework for an Amplify app. Valid values: `WEB`, `WEB_COMPUTE`. Default value: `WEB`.
 * `repository` - (Optional) Repository for an Amplify app.
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Documents AWS Amplify support for the `WEB_DYNAMIC` platform type.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/27907.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccAmplify_serial/App/basic' PKG=amplify ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/amplify/... -v -count 1 -parallel 3  -run=TestAccAmplify_serial/App/basic -timeout 180m
=== RUN   TestAccAmplify_serial
=== RUN   TestAccAmplify_serial/App
=== RUN   TestAccAmplify_serial/App/basic
--- PASS: TestAccAmplify_serial (25.94s)
    --- PASS: TestAccAmplify_serial/App (25.94s)
        --- PASS: TestAccAmplify_serial/App/basic (25.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/amplify	30.718s
```
