### PR TITLE
r/aws_cognito_user: Correct the argument name

### DIFF
--- a/website/docs/r/cognito_user.html.markdown
+++ b/website/docs/r/cognito_user.html.markdown
@@ -67,7 +67,7 @@ resource "aws_cognito_user" "example" {
 The following arguments are required:
 
 * `user_pool_id` - (Required) The user pool ID for the user pool where the user will be created.
-* `user_name` - (Required) The username for the user. Must be unique within the user pool. Must be a UTF-8 string between 1 and 128 characters. After the user is created, the username cannot be changed.
+* `username` - (Required) The username for the user. Must be unique within the user pool. Must be a UTF-8 string between 1 and 128 characters. After the user is created, the username cannot be changed.
 
 The following arguments are optional:
 


### PR DESCRIPTION
### Description
This PR corrects the argument name which should be `username`, not `user_name`.

### Relations
Closes #27808.

### References
https://github.com/hashicorp/terraform-provider-aws/blob/5cae4979cecb8ad61c10bb930cd26d5c241bb47f/internal/service/cognitoidp/user.go#L98-L103

