### PR TITLE
[WIP] Add ability to add features to existing feature groups in Sagemaker

### DIFF
--- a/internal/service/sagemaker/feature_group.go
+++ b/internal/service/sagemaker/feature_group.go
@@ -333,7 +333,9 @@ func resourceFeatureGroupUpdate(d *schema.ResourceData, meta interface{}) error 
 	var featureDefinitionsNew = expandFeatureGroupFeatureDefinition(n.([]interface{}))
 
 	if !checkIfDefinitionsUnchanged(featureDefinitionsOld, featureDefinitionsNew) {
-		return fmt.Errorf("feature definition")
+		return fmt.Errorf("existing feature definitions should remain unchanged. Only additions of nes feature"+
+			"definitions allowed. Expected:\n%v,\ngot:\n%v",
+			featureDefinitionsOld, featureDefinitionsNew)
 	}
 
 	if d.HasChange("tags_all") {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This leverages newly added [UpdateFeatureGroupRequest](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_UpdateFeatureGroup.html#API_UpdateFeatureGroup_RequestSyntax) in order to introduce adding new features to feature groups.

**NOTE:** in order to enable feature additions, I have had to remove `ForceNew` attribute from `feature_definition` field in order to disable recreation of the feature group when the size changes, but replaced it with `CustomizeDiff`. However, I was not able to simultaneously force creating the new feature group in case if the existing feature groups change, it will only force feature groups recreation when the new size of feature definitions is smaller. The reason for not being able to detect change of existing feature definitions seems to be the improper handling of `CustomizeDiff` attribute for `TypeList` fields. I have added an [issue](https://github.com/hashicorp/terraform-plugin-sdk/issues/1103) into Terraform SDK Plugin repo in order to address this. However, while resolving this definitely might take some time, I have fallen back to the solution on returning an error in case if the existing feature groups change upon applying the plan.

At this time, as I have tried quite a bit of different approaches, as seen in the issue above, and I would largely appreciate suggestions on any alternatives, I will gladly try to apply worthwhile suggestions

Some of the potential alternatives on the plate include:
- Set feature definitions field as computed, try to utilize `ComputedIf` and/or `SetNew` in case if undesired feature groups change are introduced.
- Rework Feature group service as the one using Terraform Framework rather than Terraform SDK. This may be usefuls as [PlanModifiers](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#Attribute.PlanModifiers) may potentially be helpful in resolving the issue. 

However, from what I see from my experience with `TypeList` and `CustomizeDiff` function, it may happen that those changes won't bring the required effect. Specifically, redesigning a service to use Terraform Framework rather than SDK may be quite a big change, especially given relatively small impact.

Therefore, the second thing beyond discussing alternative solutions would be to determine the plausibility of a fallback option I introudced. Woud largely appreciate a feedback on this

TODO:
- [ ] Explore additional ways to force changes prior to attempting applying the update
- [ ] Acceptance tests

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes [#26809](https://github.com/hashicorp/terraform-provider-aws/issues/26809)

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
