### PR TITLE
enhancement resource/aws_rds_cluster: Add seconds_before_timeout to scaling_configuration block

### DIFF
--- a/.changelog/27946.txt
+++ b/.changelog/27946.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+ resource/aws_rds_cluster: Add `seconds_before_timeout` attribute in the `scaling_configuration` configuration block
+ ```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -385,6 +385,12 @@ func ResourceCluster() *schema.Resource {
 							Optional: true,
 							Default:  clusterScalingConfiguration_DefaultMinCapacity,
 						},
+						"seconds_before_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      300,
+							ValidateFunc: validation.IntBetween(60, 600),
+						},
 						"seconds_until_auto_pause": {
 							Type:         schema.TypeInt,
 							Optional:     true,

--- a/internal/service/rds/flex.go
+++ b/internal/service/rds/flex.go
@@ -28,6 +28,10 @@ func expandScalingConfiguration(tfMap map[string]interface{}) *rds.ScalingConfig
 		apiObject.MinCapacity = aws.Int64(int64(v))
 	}
 
+	if v, ok := tfMap["seconds_before_timeout"].(int); ok {
+		apiObject.SecondsBeforeTimeout = aws.Int64(int64(v))
+	}
+
 	if v, ok := tfMap["seconds_until_auto_pause"].(int); ok {
 		apiObject.SecondsUntilAutoPause = aws.Int64(int64(v))
 	}
@@ -60,6 +64,10 @@ func flattenScalingConfigurationInfo(apiObject *rds.ScalingConfigurationInfo) ma
 
 	if v := apiObject.MinCapacity; v != nil {
 		tfMap["min_capacity"] = aws.Int64Value(v)
+	}
+
+	if v := apiObject.SecondsBeforeTimeout; v != nil {
+		tfMap["seconds_before_timeout"] = aws.Int64Value(v)
 	}
 
 	if v := apiObject.SecondsUntilAutoPause; v != nil {

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -268,6 +268,7 @@ resource "aws_rds_cluster" "example" {
     auto_pause               = true
     max_capacity             = 256
     min_capacity             = 2
+    seconds_before_timeout   = 300
     seconds_until_auto_pause = 300
     timeout_action           = "ForceApplyCapacityChange"
   }
@@ -277,6 +278,7 @@ resource "aws_rds_cluster" "example" {
 * `auto_pause` - (Optional) Whether to enable automatic pause. A DB cluster can be paused only when it's idle (it has no connections). If a DB cluster is paused for more than seven days, the DB cluster might be backed up with a snapshot. In this case, the DB cluster is restored when there is a request to connect to it. Defaults to `true`.
 * `max_capacity` - (Optional) The maximum capacity for an Aurora DB cluster in `serverless` DB engine mode. The maximum capacity must be greater than or equal to the minimum capacity. Valid Aurora MySQL capacity values are `1`, `2`, `4`, `8`, `16`, `32`, `64`, `128`, `256`. Valid Aurora PostgreSQL capacity values are (`2`, `4`, `8`, `16`, `32`, `64`, `192`, and `384`). Defaults to `16`.
 * `min_capacity` - (Optional) The minimum capacity for an Aurora DB cluster in `serverless` DB engine mode. The minimum capacity must be lesser than or equal to the maximum capacity. Valid Aurora MySQL capacity values are `1`, `2`, `4`, `8`, `16`, `32`, `64`, `128`, `256`. Valid Aurora PostgreSQL capacity values are (`2`, `4`, `8`, `16`, `32`, `64`, `192`, and `384`). Defaults to `1`.
+* `seconds_before_timeout` - (Optional) The time, in seconds, that Aurora DB cluster tries to find a scaling point to perform seamless scaling before enforcing the timeout action. Valid values are `60` through `600`. Defaults to `300`.
 * `seconds_until_auto_pause` - (Optional) The time, in seconds, before an Aurora DB cluster in serverless mode is paused. Valid values are `300` through `86400`. Defaults to `300`.
 * `timeout_action` - (Optional) The action to take when the timeout is reached. Valid values: `ForceApplyCapacityChange`, `RollbackCapacityChange`. Defaults to `RollbackCapacityChange`. See [documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.how-it-works.html#aurora-serverless.how-it-works.timeout-action).
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This adds the seconds_before_timeout attribute in the scaling_configuration configuration block to the aws_rds_cluster resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #22292

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

<img width="1022" alt="image" src="https://user-images.githubusercontent.com/17902029/203307201-ca6f8fc7-fc4a-4e21-8205-3c2aa48e4dbb.png">

