### PR TITLE
adds sybase engine support

### DIFF
--- a/.changelog/27949.txt
+++ b/.changelog/27949.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dms_endpoint: Add `sybase engine` support
+```

--- a/.changelog/27949.txt
+++ b/.changelog/27949.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_dms_endpoint: Add `sybase engine` support
+resource/aws_dms_endpoint: Add ability to use AWS Secrets Manager with the `sybase` engine
 ```

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -869,6 +869,25 @@ func resourceEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 			// Set connection info in top-level namespace as well
 			expandTopLevelConnectionInfo(d, input)
 		}
+	case engineNameSybase:
+		if _, ok := d.GetOk("secrets_manager_arn"); ok {
+			input.SybaseSettings = &dms.SybaseSettings{
+				SecretsManagerAccessRoleArn: aws.String(d.Get("secrets_manager_access_role_arn").(string)),
+				SecretsManagerSecretId:      aws.String(d.Get("secrets_manager_arn").(string)),
+				DatabaseName:                aws.String(d.Get("database_name").(string)),
+			}
+		} else {
+			input.SybaseSettings = &dms.SybaseSettings{
+				Username:     aws.String(d.Get("username").(string)),
+				Password:     aws.String(d.Get("password").(string)),
+				ServerName:   aws.String(d.Get("server_name").(string)),
+				Port:         aws.Int64(int64(d.Get("port").(int))),
+				DatabaseName: aws.String(d.Get("database_name").(string)),
+			}
+
+			// Set connection info in top-level namespace as well
+			expandTopLevelConnectionInfo(d, input)
+		}
 	case engineNameS3:
 		input.S3Settings = expandS3Settings(d.Get("s3_settings").([]interface{})[0].(map[string]interface{}))
 	default:
@@ -1189,6 +1208,30 @@ func resourceEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 					expandTopLevelConnectionInfoModify(d, input)
 				}
 			}
+		case engineNameSybase:
+			if d.HasChanges(
+				"username", "password", "server_name", "port", "database_name", "secrets_manager_access_role_arn",
+				"secrets_manager_arn") {
+				if _, ok := d.GetOk("secrets_manager_arn"); ok {
+					input.SybaseSettings = &dms.SybaseSettings{
+						DatabaseName:                aws.String(d.Get("database_name").(string)),
+						SecretsManagerAccessRoleArn: aws.String(d.Get("secrets_manager_access_role_arn").(string)),
+						SecretsManagerSecretId:      aws.String(d.Get("secrets_manager_arn").(string)),
+					}
+				} else {
+					input.SybaseSettings = &dms.SybaseSettings{
+						Username:     aws.String(d.Get("username").(string)),
+						Password:     aws.String(d.Get("password").(string)),
+						ServerName:   aws.String(d.Get("server_name").(string)),
+						Port:         aws.Int64(int64(d.Get("port").(int))),
+						DatabaseName: aws.String(d.Get("database_name").(string)),
+					}
+					input.EngineName = aws.String(engineName) // Must be included (should be 'postgres')
+
+					// Update connection info in top-level namespace as well
+					expandTopLevelConnectionInfoModify(d, input)
+				}
+			}
 		case engineNameS3:
 			if d.HasChanges("s3_settings") {
 				input.S3Settings = expandS3Settings(d.Get("s3_settings").([]interface{})[0].(map[string]interface{}))
@@ -1404,6 +1447,17 @@ func resourceEndpointSetState(d *schema.ResourceData, endpoint *dms.Endpoint) er
 			d.Set("database_name", endpoint.MicrosoftSQLServerSettings.DatabaseName)
 			d.Set("secrets_manager_access_role_arn", endpoint.MicrosoftSQLServerSettings.SecretsManagerAccessRoleArn)
 			d.Set("secrets_manager_arn", endpoint.MicrosoftSQLServerSettings.SecretsManagerSecretId)
+		} else {
+			flattenTopLevelConnectionInfo(d, endpoint)
+		}
+	case engineNameSybase:
+		if endpoint.SybaseSettings != nil {
+			d.Set("username", endpoint.SybaseSettings.Username)
+			d.Set("server_name", endpoint.SybaseSettings.ServerName)
+			d.Set("port", endpoint.SybaseSettings.Port)
+			d.Set("database_name", endpoint.SybaseSettings.DatabaseName)
+			d.Set("secrets_manager_access_role_arn", endpoint.SybaseSettings.SecretsManagerAccessRoleArn)
+			d.Set("secrets_manager_arn", endpoint.SybaseSettings.SecretsManagerSecretId)
 		} else {
 			flattenTopLevelConnectionInfo(d, endpoint)
 		}

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -284,7 +284,7 @@ func TestAccDMSEndpoint_S3_basic(t *testing.T) {
 				Config: testAccEndpointConfig_s3Update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointExists(resourceName),
-					resource.TestMatchResourceAttr(resourceName, "extra_connection_attributes", regexp.MustCompile(`key=value;`)),
+					resource.TestMatchResourceAttr(resourceName, "extra_connection_attributes", regexp.MustCompile(``)),
 					resource.TestCheckResourceAttr(resourceName, "s3_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.external_table_definition", "new-external_table_definition"),
 					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.csv_row_delimiter", "\\r"),
@@ -895,7 +895,7 @@ func TestAccDMSEndpoint_MySQL_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "password", "tftest-new-password"),
 					resource.TestCheckResourceAttr(resourceName, "database_name", "tftest-new-database_name"),
 					resource.TestCheckResourceAttr(resourceName, "ssl_mode", "none"),
-					resource.TestMatchResourceAttr(resourceName, "extra_connection_attributes", regexp.MustCompile(`key=value;`)),
+					resource.TestMatchResourceAttr(resourceName, "extra_connection_attributes", regexp.MustCompile(`CleanSrcMetadataOnMismatch=false;`)),
 				),
 			},
 			{
@@ -1222,6 +1222,121 @@ func TestAccDMSEndpoint_SQLServer_kmsKey(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfig_sqlserverKey(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDMSEndpoint_Sybase_basic(t *testing.T) {
+	resourceName := "aws_dms_endpoint.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfig_sybase(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func TestAccDMSEndpoint_Sybase_secretID(t *testing.T) {
+	resourceName := "aws_dms_endpoint.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfig_sybaseSecretID(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccDMSEndpoint_Sybase_update(t *testing.T) {
+	resourceName := "aws_dms_endpoint.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfig_sybase(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+				),
+			},
+			{
+				Config: testAccEndpointConfig_sybaseUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "server_name", "tftest-new-server_name"),
+					resource.TestCheckResourceAttr(resourceName, "port", "27018"),
+					resource.TestCheckResourceAttr(resourceName, "username", "tftest-new-username"),
+					resource.TestCheckResourceAttr(resourceName, "password", "tftest-new-password"),
+					resource.TestCheckResourceAttr(resourceName, "database_name", "tftest-new-database_name"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_mode", "none"),
+					resource.TestMatchResourceAttr(resourceName, "extra_connection_attributes", regexp.MustCompile(`key=value;`)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+// https://github.com/hashicorp/terraform-provider-aws/issues/23143
+func TestAccDMSEndpoint_Sybase_kmsKey(t *testing.T) {
+	resourceName := "aws_dms_endpoint.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfig_sybaseKey(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
@@ -2041,7 +2156,7 @@ resource "aws_dms_endpoint" "test" {
   endpoint_type               = "target"
   engine_name                 = "s3"
   ssl_mode                    = "none"
-  extra_connection_attributes = "key=value;"
+  extra_connection_attributes = ""
 
   tags = {
     Name   = %[1]q
@@ -2602,7 +2717,7 @@ resource "aws_dms_endpoint" "test" {
   password                    = "tftest-new-password"
   database_name               = "tftest-new-database_name"
   ssl_mode                    = "none"
-  extra_connection_attributes = "key=value;"
+  extra_connection_attributes = "CleanSrcMetadataOnMismatch=false;"
 
   tags = {
     Name   = %[1]q
@@ -2817,6 +2932,74 @@ resource "aws_dms_endpoint" "test" {
 `, rName))
 }
 
+func testAccEndpointConfig_sybase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dms_endpoint" "test" {
+  endpoint_id                 = %[1]q
+  endpoint_type               = "source"
+  engine_name                 = "sybase"
+  server_name                 = "tftest"
+  port                        = 27017
+  username                    = "tftest"
+  password                    = "tftest"
+  database_name               = "tftest"
+  ssl_mode                    = "none"
+  extra_connection_attributes = ""
+
+  tags = {
+    Name   = %[1]q
+    Update = "to-update"
+    Remove = "to-remove"
+  }
+}
+`, rName)
+}
+
+func testAccEndpointConfig_sybaseUpdate(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dms_endpoint" "test" {
+  endpoint_id                 = %[1]q
+  endpoint_type               = "source"
+  engine_name                 = "sybase"
+  server_name                 = "tftest-new-server_name"
+  port                        = 27018
+  username                    = "tftest-new-username"
+  password                    = "tftest-new-password"
+  database_name               = "tftest-new-database_name"
+  ssl_mode                    = "none"
+  extra_connection_attributes = "key=value;"
+
+  tags = {
+    Name   = %[1]q
+    Update = "updated"
+    Add    = "added"
+  }
+}
+`, rName)
+}
+
+func testAccEndpointConfig_sybaseSecretID(rName string) string {
+	return acctest.ConfigCompose(testAccEndpointConfig_secretBase(rName), fmt.Sprintf(`
+resource "aws_dms_endpoint" "test" {
+  endpoint_id                     = %[1]q
+  endpoint_type                   = "source"
+  engine_name                     = "sybase"
+  secrets_manager_access_role_arn = aws_iam_role.test.arn
+  secrets_manager_arn             = aws_secretsmanager_secret.test.id
+
+  database_name               = "tftest"
+  ssl_mode                    = "none"
+  extra_connection_attributes = ""
+
+  tags = {
+    Name   = %[1]q
+    Update = "to-update"
+    Remove = "to-remove"
+  }
+}
+`, rName))
+}
+
 func testAccEndpointConfig_docDB(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_dms_endpoint" "test" {
@@ -2957,6 +3140,33 @@ resource "aws_dms_endpoint" "test" {
   password                    = "tftest"
   database_name               = "tftest"
   ssl_mode                    = "require"
+  extra_connection_attributes = ""
+  kms_key_arn                 = aws_kms_key.test.arn
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccEndpointConfig_sybaseKey(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+}
+
+resource "aws_dms_endpoint" "test" {
+  endpoint_id                 = %[1]q
+  endpoint_type               = "source"
+  engine_name                 = "sybase"
+  server_name                 = "tftest"
+  port                        = 27018
+  username                    = "tftest"
+  password                    = "tftest"
+  database_name               = "tftest"
+  ssl_mode                    = "none"
   extra_connection_attributes = ""
   kms_key_arn                 = aws_kms_key.test.arn
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

- Bug fix to include Sybase Engine to dms-create-endpoint. Documentation references Sybase engine but code and tests did not include support. 
- S3 and MySQL endpoint tests were updated as AWS API threw errors for improper values. 

### Relations
Closes [#20400](https://github.com/hashicorp/terraform-provider-aws/issues/20400)

### References


### Output from Acceptance Testing

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dms/... -v -count 1 -parallel 20 -run='TestAccDMSEndpoint'  -timeout 180m
=== RUN   TestAccDMSEndpoint_basic
=== PAUSE TestAccDMSEndpoint_basic
=== RUN   TestAccDMSEndpoint_Aurora_basic
=== PAUSE TestAccDMSEndpoint_Aurora_basic
=== RUN   TestAccDMSEndpoint_Aurora_secretID
=== PAUSE TestAccDMSEndpoint_Aurora_secretID
=== RUN   TestAccDMSEndpoint_Aurora_update
=== PAUSE TestAccDMSEndpoint_Aurora_update
=== RUN   TestAccDMSEndpoint_AuroraPostgreSQL_basic
=== PAUSE TestAccDMSEndpoint_AuroraPostgreSQL_basic
=== RUN   TestAccDMSEndpoint_AuroraPostgreSQL_secretID
=== PAUSE TestAccDMSEndpoint_AuroraPostgreSQL_secretID
=== RUN   TestAccDMSEndpoint_AuroraPostgreSQL_update
=== PAUSE TestAccDMSEndpoint_AuroraPostgreSQL_update
=== RUN   TestAccDMSEndpoint_S3_basic
=== PAUSE TestAccDMSEndpoint_S3_basic
=== RUN   TestAccDMSEndpoint_S3_extraConnectionAttributes
=== PAUSE TestAccDMSEndpoint_S3_extraConnectionAttributes
=== RUN   TestAccDMSEndpoint_dynamoDB
=== PAUSE TestAccDMSEndpoint_dynamoDB
=== RUN   TestAccDMSEndpoint_OpenSearch_basic
=== PAUSE TestAccDMSEndpoint_OpenSearch_basic
=== RUN   TestAccDMSEndpoint_OpenSearch_extraConnectionAttributes
=== PAUSE TestAccDMSEndpoint_OpenSearch_extraConnectionAttributes
=== RUN   TestAccDMSEndpoint_OpenSearch_errorRetryDuration
=== PAUSE TestAccDMSEndpoint_OpenSearch_errorRetryDuration
=== RUN   TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage
=== PAUSE TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage
=== RUN   TestAccDMSEndpoint_kafka
=== PAUSE TestAccDMSEndpoint_kafka
=== RUN   TestAccDMSEndpoint_kinesis
=== PAUSE TestAccDMSEndpoint_kinesis
=== RUN   TestAccDMSEndpoint_MongoDB_basic
=== PAUSE TestAccDMSEndpoint_MongoDB_basic
=== RUN   TestAccDMSEndpoint_MongoDB_secretID
=== PAUSE TestAccDMSEndpoint_MongoDB_secretID
=== RUN   TestAccDMSEndpoint_MongoDB_update
=== PAUSE TestAccDMSEndpoint_MongoDB_update
=== RUN   TestAccDMSEndpoint_MariaDB_basic
=== PAUSE TestAccDMSEndpoint_MariaDB_basic
=== RUN   TestAccDMSEndpoint_MariaDB_secretID
=== PAUSE TestAccDMSEndpoint_MariaDB_secretID
=== RUN   TestAccDMSEndpoint_MariaDB_update
=== PAUSE TestAccDMSEndpoint_MariaDB_update
=== RUN   TestAccDMSEndpoint_MySQL_basic
=== PAUSE TestAccDMSEndpoint_MySQL_basic
=== RUN   TestAccDMSEndpoint_MySQL_secretID
=== PAUSE TestAccDMSEndpoint_MySQL_secretID
=== RUN   TestAccDMSEndpoint_MySQL_update
=== PAUSE TestAccDMSEndpoint_MySQL_update
=== RUN   TestAccDMSEndpoint_Oracle_basic
=== PAUSE TestAccDMSEndpoint_Oracle_basic
=== RUN   TestAccDMSEndpoint_Oracle_secretID
=== PAUSE TestAccDMSEndpoint_Oracle_secretID
=== RUN   TestAccDMSEndpoint_Oracle_update
=== PAUSE TestAccDMSEndpoint_Oracle_update
=== RUN   TestAccDMSEndpoint_PostgreSQL_basic
=== PAUSE TestAccDMSEndpoint_PostgreSQL_basic
=== RUN   TestAccDMSEndpoint_PostgreSQL_secretID
=== PAUSE TestAccDMSEndpoint_PostgreSQL_secretID
=== RUN   TestAccDMSEndpoint_PostgreSQL_update
=== PAUSE TestAccDMSEndpoint_PostgreSQL_update
=== RUN   TestAccDMSEndpoint_PostgreSQL_kmsKey
=== PAUSE TestAccDMSEndpoint_PostgreSQL_kmsKey
=== RUN   TestAccDMSEndpoint_SQLServer_basic
=== PAUSE TestAccDMSEndpoint_SQLServer_basic
=== RUN   TestAccDMSEndpoint_SQLServer_secretID
=== PAUSE TestAccDMSEndpoint_SQLServer_secretID
=== RUN   TestAccDMSEndpoint_SQLServer_update
=== PAUSE TestAccDMSEndpoint_SQLServer_update
=== RUN   TestAccDMSEndpoint_SQLServer_kmsKey
=== PAUSE TestAccDMSEndpoint_SQLServer_kmsKey
=== RUN   TestAccDMSEndpoint_Sybase_basic
=== PAUSE TestAccDMSEndpoint_Sybase_basic
=== RUN   TestAccDMSEndpoint_Sybase_secretID
=== PAUSE TestAccDMSEndpoint_Sybase_secretID
=== RUN   TestAccDMSEndpoint_Sybase_update
=== PAUSE TestAccDMSEndpoint_Sybase_update
=== RUN   TestAccDMSEndpoint_Sybase_kmsKey
=== PAUSE TestAccDMSEndpoint_Sybase_kmsKey
=== RUN   TestAccDMSEndpoint_docDB
=== PAUSE TestAccDMSEndpoint_docDB
=== RUN   TestAccDMSEndpoint_db2
=== PAUSE TestAccDMSEndpoint_db2
=== RUN   TestAccDMSEndpoint_redis
=== PAUSE TestAccDMSEndpoint_redis
=== RUN   TestAccDMSEndpoint_Redshift_basic
=== PAUSE TestAccDMSEndpoint_Redshift_basic
=== RUN   TestAccDMSEndpoint_Redshift_secretID
=== PAUSE TestAccDMSEndpoint_Redshift_secretID
=== RUN   TestAccDMSEndpoint_Redshift_update
=== PAUSE TestAccDMSEndpoint_Redshift_update
=== CONT  TestAccDMSEndpoint_basic
=== CONT  TestAccDMSEndpoint_redis
=== CONT  TestAccDMSEndpoint_Sybase_update
=== CONT  TestAccDMSEndpoint_Redshift_secretID
=== CONT  TestAccDMSEndpoint_OpenSearch_errorRetryDuration
=== CONT  TestAccDMSEndpoint_MariaDB_update
=== CONT  TestAccDMSEndpoint_OpenSearch_extraConnectionAttributes
=== CONT  TestAccDMSEndpoint_docDB
=== CONT  TestAccDMSEndpoint_Sybase_kmsKey
=== CONT  TestAccDMSEndpoint_MariaDB_secretID
=== CONT  TestAccDMSEndpoint_MariaDB_basic
=== CONT  TestAccDMSEndpoint_MongoDB_update
=== CONT  TestAccDMSEndpoint_MongoDB_secretID
=== CONT  TestAccDMSEndpoint_MongoDB_basic
=== CONT  TestAccDMSEndpoint_kinesis
=== CONT  TestAccDMSEndpoint_kafka
=== CONT  TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage
=== CONT  TestAccDMSEndpoint_Redshift_update
=== CONT  TestAccDMSEndpoint_PostgreSQL_update
=== CONT  TestAccDMSEndpoint_db2
--- PASS: TestAccDMSEndpoint_Sybase_kmsKey (142.87s)
=== CONT  TestAccDMSEndpoint_Sybase_secretID
--- PASS: TestAccDMSEndpoint_MongoDB_basic (153.04s)
=== CONT  TestAccDMSEndpoint_Sybase_basic
--- PASS: TestAccDMSEndpoint_MongoDB_secretID (155.41s)
=== CONT  TestAccDMSEndpoint_SQLServer_kmsKey
--- PASS: TestAccDMSEndpoint_MariaDB_basic (158.91s)
=== CONT  TestAccDMSEndpoint_SQLServer_update
--- PASS: TestAccDMSEndpoint_Redshift_secretID (165.74s)
=== CONT  TestAccDMSEndpoint_SQLServer_secretID
--- PASS: TestAccDMSEndpoint_MariaDB_secretID (167.20s)
=== CONT  TestAccDMSEndpoint_SQLServer_basic
--- PASS: TestAccDMSEndpoint_redis (173.43s)
=== CONT  TestAccDMSEndpoint_PostgreSQL_kmsKey
--- PASS: TestAccDMSEndpoint_basic (175.09s)
=== CONT  TestAccDMSEndpoint_Redshift_basic
--- PASS: TestAccDMSEndpoint_kafka (175.20s)
=== CONT  TestAccDMSEndpoint_Oracle_secretID
=== CONT  TestAccDMSEndpoint_PostgreSQL_secretID
--- PASS: TestAccDMSEndpoint_db2 (175.53s)
--- PASS: TestAccDMSEndpoint_OpenSearch_errorRetryDuration (179.40s)
=== CONT  TestAccDMSEndpoint_PostgreSQL_basic
--- PASS: TestAccDMSEndpoint_OpenSearch_extraConnectionAttributes (180.68s)
=== CONT  TestAccDMSEndpoint_Oracle_update
--- PASS: TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage (181.89s)
=== CONT  TestAccDMSEndpoint_MySQL_update
--- PASS: TestAccDMSEndpoint_Sybase_update (186.80s)
=== CONT  TestAccDMSEndpoint_Oracle_basic
--- PASS: TestAccDMSEndpoint_MariaDB_update (187.09s)
=== CONT  TestAccDMSEndpoint_MySQL_secretID
--- PASS: TestAccDMSEndpoint_PostgreSQL_update (187.46s)
=== CONT  TestAccDMSEndpoint_MySQL_basic
--- PASS: TestAccDMSEndpoint_docDB (187.57s)
=== CONT  TestAccDMSEndpoint_AuroraPostgreSQL_update
--- PASS: TestAccDMSEndpoint_MongoDB_update (189.02s)
=== CONT  TestAccDMSEndpoint_OpenSearch_basic
--- PASS: TestAccDMSEndpoint_kinesis (199.28s)
=== CONT  TestAccDMSEndpoint_dynamoDB
--- PASS: TestAccDMSEndpoint_SQLServer_kmsKey (118.25s)
=== CONT  TestAccDMSEndpoint_S3_extraConnectionAttributes
--- PASS: TestAccDMSEndpoint_Sybase_secretID (134.23s)
=== CONT  TestAccDMSEndpoint_S3_basic
--- PASS: TestAccDMSEndpoint_Sybase_basic (131.84s)
=== CONT  TestAccDMSEndpoint_Aurora_update
--- PASS: TestAccDMSEndpoint_SQLServer_basic (126.58s)
=== CONT  TestAccDMSEndpoint_AuroraPostgreSQL_secretID
=== CONT  TestAccDMSEndpoint_AuroraPostgreSQL_basic
--- PASS: TestAccDMSEndpoint_PostgreSQL_kmsKey (130.09s)
--- PASS: TestAccDMSEndpoint_SQLServer_secretID (144.24s)
=== CONT  TestAccDMSEndpoint_Aurora_secretID
--- PASS: TestAccDMSEndpoint_PostgreSQL_basic (133.16s)
=== CONT  TestAccDMSEndpoint_Aurora_basic
--- PASS: TestAccDMSEndpoint_Redshift_update (315.20s)
--- PASS: TestAccDMSEndpoint_PostgreSQL_secretID (140.07s)
--- PASS: TestAccDMSEndpoint_Oracle_secretID (140.78s)
--- PASS: TestAccDMSEndpoint_SQLServer_update (161.42s)
--- PASS: TestAccDMSEndpoint_MySQL_basic (134.29s)
--- PASS: TestAccDMSEndpoint_MySQL_secretID (137.05s)
--- PASS: TestAccDMSEndpoint_Oracle_basic (144.71s)
--- PASS: TestAccDMSEndpoint_Oracle_update (154.06s)
--- PASS: TestAccDMSEndpoint_MySQL_update (153.01s)
--- PASS: TestAccDMSEndpoint_OpenSearch_basic (147.91s)
--- PASS: TestAccDMSEndpoint_AuroraPostgreSQL_update (160.81s)
--- PASS: TestAccDMSEndpoint_dynamoDB (163.43s)
--- PASS: TestAccDMSEndpoint_Aurora_update (134.68s)
--- PASS: TestAccDMSEndpoint_S3_extraConnectionAttributes (150.07s)
--- PASS: TestAccDMSEndpoint_AuroraPostgreSQL_secretID (134.83s)
--- PASS: TestAccDMSEndpoint_Aurora_basic (120.01s)
--- PASS: TestAccDMSEndpoint_S3_basic (156.63s)
--- PASS: TestAccDMSEndpoint_Aurora_secretID (124.74s)
--- PASS: TestAccDMSEndpoint_AuroraPostgreSQL_basic (131.33s)
--- PASS: TestAccDMSEndpoint_Redshift_basic (421.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dms	598.672s
```