### PR TITLE
workspace will create a logging configuration if one does not exist d…

### DIFF
--- a/.changelog/27472.txt
+++ b/.changelog/27472.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/amp: Fix issue where amp workspace fails to create logging configuration during workspace update.
+```

--- a/internal/service/amp/workspace.go
+++ b/internal/service/amp/workspace.go
@@ -206,14 +206,14 @@ func resourceWorkspaceUpdate(ctx context.Context, d *schema.ResourceData, meta i
 					}
 					_, err := conn.CreateLoggingConfigurationWithContext(ctx, input)
 					if err != nil {
-						return diag.Errorf("Decribing Prometheus Workspace Logging configuration create (%s)", err)
+						return diag.Errorf("describing Prometheus Workspace Logging configuration create (%s)", err)
 					}
 					_, err2 := waitLoggingConfigurationCreated(ctx, conn, *aws.String(d.Id()))
 					if err2 != nil {
-						return diag.Errorf("Waiting on Logging Configuration creation (%s)", err)
+						return diag.Errorf("waiting on Logging Configuration creation (%s)", err)
 					}
 				} else {
-					return diag.Errorf("Decribing Prometheus Workspace Logging configuration (%s)", Describeerr)
+					return diag.Errorf("describing Prometheus Workspace Logging configuration (%s)", err)
 				}
 
 			} else {

--- a/internal/service/amp/workspace.go
+++ b/internal/service/amp/workspace.go
@@ -204,35 +204,31 @@ func resourceWorkspaceUpdate(ctx context.Context, d *schema.ResourceData, meta i
 						LogGroupArn: aws.String(tfMap["log_group_arn"].(string)),
 						WorkspaceId: aws.String(d.Id()),
 					}
-					_, err := conn.CreateLoggingConfigurationWithContext(ctx, input)
-					if err != nil {
+
+					if _, err := conn.CreateLoggingConfigurationWithContext(ctx, input); err != nil {
 						return diag.Errorf("describing Prometheus Workspace Logging configuration create (%s)", err)
 					}
-					_, err2 := waitLoggingConfigurationCreated(ctx, conn, *aws.String(d.Id()))
-					if err2 != nil {
+
+					if _, err := waitLoggingConfigurationCreated(ctx, conn, *aws.String(d.Id())); err != nil {
 						return diag.Errorf("waiting on Logging Configuration creation (%s)", err)
 					}
 				} else {
 					return diag.Errorf("describing Prometheus Workspace Logging configuration (%s)", err)
 				}
-
 			} else {
 				input := &prometheusservice.UpdateLoggingConfigurationInput{
 					LogGroupArn: aws.String(tfMap["log_group_arn"].(string)),
 					WorkspaceId: aws.String(d.Id()),
 				}
-				_, err := conn.UpdateLoggingConfigurationWithContext(ctx, input)
 
-				if err != nil {
+				if _, err := conn.UpdateLoggingConfigurationWithContext(ctx, input); err != nil {
 					return diag.Errorf("updating Prometheus Workspace (%s) logging configuration: %s", d.Id(), err)
 				}
 
 				if _, err := waitLoggingConfigurationUpdated(ctx, conn, d.Id()); err != nil {
 					return diag.Errorf("waiting for Prometheus Workspace (%s) logging configuration update: %s", d.Id(), err)
 				}
-
 			}
-
 		} else {
 			_, err := conn.DeleteLoggingConfigurationWithContext(ctx, &prometheusservice.DeleteLoggingConfigurationInput{
 				WorkspaceId: aws.String(d.Id()),

--- a/internal/service/amp/workspace_test.go
+++ b/internal/service/amp/workspace_test.go
@@ -73,15 +73,10 @@ func TestAccAMPWorkspace_addLoggingConfig(t *testing.T) {
 					testAccCheckWorkspaceExists(resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "alias", ""),
 					resource.TestCheckResourceAttrSet(resourceName, "arn"),
-					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "prometheus_endpoint"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/service/amp/workspace_test.go
+++ b/internal/service/amp/workspace_test.go
@@ -46,6 +46,47 @@ func TestAccAMPWorkspace_basic(t *testing.T) {
 	})
 }
 
+func TestAccAMPWorkspace_addLoggingConfig(t *testing.T) {
+	var v prometheusservice.WorkspaceDescription
+	resourceName := "aws_prometheus_workspace.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(prometheusservice.EndpointsID, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, prometheusservice.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkspaceConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkspaceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "alias", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "prometheus_endpoint"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				Config: testAccWorkspaceConfig_loggingConfiguration(resourceName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkspaceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "alias", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "prometheus_endpoint"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAMPWorkspace_disappears(t *testing.T) {
 	var v prometheusservice.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This pull request will change the functionality of the Amazon Managed Prometheus service. Right now there will be an error if a Amazon Managed Prometheus workspace is created without a logging configuration, then during an update of the workspace a logging configuration is added. After this change, during a workspace update a logging configuration will be created if one doesn't exist.

Closes #27472 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ AWS_PROFILE=default TF_ACC=1 go test ./internal/service/amp/... -parallel 8
ok      github.com/hashicorp/terraform-provider-aws/internal/service/amp        336.806s
```
