### PR TITLE
bugfix ec2 launch template associate_public_ip_address bool

### DIFF
--- a/.changelog/27958.txt
+++ b/.changelog/27958.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/ec2_launch_template: Update `associate_public_ip_address` field from type String to Bool to agree with docs.
+```
+
+```release-note:bug
+data-source/ec2_launch_template: Update `associate_public_ip_address` field from type String to Bool to agree with docs.
+```

--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -711,10 +711,8 @@ func ResourceLaunchTemplate() *schema.Resource {
 							ValidateFunc:     verify.ValidTypeStringNullableBoolean,
 						},
 						"associate_public_ip_address": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							DiffSuppressFunc: verify.SuppressEquivalentTypeStringBoolean,
-							ValidateFunc:     verify.ValidTypeStringNullableBoolean,
+							Type:     schema.TypeBool,
+							Optional: true,
 						},
 						"delete_on_termination": {
 							// Use TypeString to allow an "unspecified" value,
@@ -1945,11 +1943,7 @@ func expandLaunchTemplateInstanceNetworkInterfaceSpecificationRequest(tfMap map[
 		apiObject.AssociateCarrierIpAddress = aws.Bool(v)
 	}
 
-	if v, ok := tfMap["associate_public_ip_address"].(string); ok && v != "" {
-		v, _ := strconv.ParseBool(v)
-
-		apiObject.AssociatePublicIpAddress = aws.Bool(v)
-	}
+	apiObject.AssociatePublicIpAddress = aws.Bool(tfMap["associate_public_ip_address"].(bool))
 
 	if v, ok := tfMap["delete_on_termination"].(string); ok && v != "" {
 		v, _ := strconv.ParseBool(v)
@@ -2910,9 +2904,7 @@ func flattenLaunchTemplateInstanceNetworkInterfaceSpecification(apiObject *ec2.L
 		tfMap["associate_carrier_ip_address"] = strconv.FormatBool(aws.BoolValue(v))
 	}
 
-	if v := apiObject.AssociatePublicIpAddress; v != nil {
-		tfMap["associate_public_ip_address"] = strconv.FormatBool(aws.BoolValue(v))
-	}
+	tfMap["associate_public_ip_address"] = aws.BoolValue(apiObject.AssociatePublicIpAddress)
 
 	if v := apiObject.DeleteOnTermination; v != nil {
 		tfMap["delete_on_termination"] = strconv.FormatBool(aws.BoolValue(v))

--- a/internal/service/ec2/ec2_launch_template_data_source.go
+++ b/internal/service/ec2/ec2_launch_template_data_source.go
@@ -571,7 +571,7 @@ func DataSourceLaunchTemplate() *schema.Resource {
 							Computed: true,
 						},
 						"associate_public_ip_address": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeBool,
 							Computed: true,
 						},
 						"delete_on_termination": {


### PR DESCRIPTION
### Description

Corrects implementation of associate_public_ip_address on aws_launch_template resource and data source to be a boolean instead of string as the docs state.


### Relations

Closes [#27716](https://github.com/hashicorp/terraform-provider-aws/issues/27716)


### References


### Output from Acceptance Testing

Note: I wasn't able to run every resource acceptance test because of permission restrictions on the AWS account I ran from. 

```
make testacc TESTS=TestAccEC2LaunchTemplate PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2LaunchTemplate'  -timeout 180m
=== RUN   TestAccEC2LaunchTemplateDataSource_name
=== PAUSE TestAccEC2LaunchTemplateDataSource_name
=== RUN   TestAccEC2LaunchTemplateDataSource_id
=== PAUSE TestAccEC2LaunchTemplateDataSource_id
=== RUN   TestAccEC2LaunchTemplateDataSource_filter
=== PAUSE TestAccEC2LaunchTemplateDataSource_filter
=== RUN   TestAccEC2LaunchTemplateDataSource_tags
=== PAUSE TestAccEC2LaunchTemplateDataSource_tags
=== RUN   TestAccEC2LaunchTemplate_basic
=== PAUSE TestAccEC2LaunchTemplate_basic
=== RUN   TestAccEC2LaunchTemplate_Name_generated
=== PAUSE TestAccEC2LaunchTemplate_Name_generated
=== RUN   TestAccEC2LaunchTemplate_Name_prefix
=== PAUSE TestAccEC2LaunchTemplate_Name_prefix
=== RUN   TestAccEC2LaunchTemplate_disappears
=== PAUSE TestAccEC2LaunchTemplate_disappears
=== RUN   TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs
    ec2_launch_template_test.go:160: TODO: cant do this in managed AWS account.
--- SKIP: TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs (0.00s)
=== RUN   TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_deleteOnTermination
    ec2_launch_template_test.go:192: TODO: cant do this in managed AWS account.
--- SKIP: TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_deleteOnTermination (0.00s)
=== RUN   TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_gp3
    ec2_launch_template_test.go:235: TODO: cant do this in managed AWS account.
--- SKIP: TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_gp3 (0.00s)
=== RUN   TestAccEC2LaunchTemplate_ebsOptimized
=== PAUSE TestAccEC2LaunchTemplate_ebsOptimized
=== RUN   TestAccEC2LaunchTemplate_elasticInferenceAccelerator
=== PAUSE TestAccEC2LaunchTemplate_elasticInferenceAccelerator
=== RUN   TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination
=== PAUSE TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination
=== RUN   TestAccEC2LaunchTemplate_data
=== PAUSE TestAccEC2LaunchTemplate_data
=== RUN   TestAccEC2LaunchTemplate_description
=== PAUSE TestAccEC2LaunchTemplate_description
=== RUN   TestAccEC2LaunchTemplate_update
    ec2_launch_template_test.go:497: TODO: cant do this in managed AWS account.
--- SKIP: TestAccEC2LaunchTemplate_update (0.00s)
=== RUN   TestAccEC2LaunchTemplate_tags
=== PAUSE TestAccEC2LaunchTemplate_tags
=== RUN   TestAccEC2LaunchTemplate_CapacityReservation_preference
=== PAUSE TestAccEC2LaunchTemplate_CapacityReservation_preference
=== RUN   TestAccEC2LaunchTemplate_CapacityReservation_target
    ec2_launch_template_test.go:613: TODO: cant do this in managed AWS account.
--- SKIP: TestAccEC2LaunchTemplate_CapacityReservation_target (0.00s)
=== RUN   TestAccEC2LaunchTemplate_cpuOptions
=== PAUSE TestAccEC2LaunchTemplate_cpuOptions
=== RUN   TestAccEC2LaunchTemplate_CreditSpecification_nonBurstable
=== PAUSE TestAccEC2LaunchTemplate_CreditSpecification_nonBurstable
=== RUN   TestAccEC2LaunchTemplate_CreditSpecification_t2
=== PAUSE TestAccEC2LaunchTemplate_CreditSpecification_t2
=== RUN   TestAccEC2LaunchTemplate_CreditSpecification_t3
=== PAUSE TestAccEC2LaunchTemplate_CreditSpecification_t3
=== RUN   TestAccEC2LaunchTemplate_CreditSpecification_t4g
=== PAUSE TestAccEC2LaunchTemplate_CreditSpecification_t4g
=== RUN   TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock
=== PAUSE TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock
=== RUN   TestAccEC2LaunchTemplate_networkInterface
    ec2_launch_template_test.go:800: TODO: cant do this in managed AWS account.
--- SKIP: TestAccEC2LaunchTemplate_networkInterface (0.00s)
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceAddresses
    ec2_launch_template_test.go:847: TODO: cant do this in managed AWS account.
--- SKIP: TestAccEC2LaunchTemplate_networkInterfaceAddresses (0.00s)
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceType
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceType
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceCardIndex
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceCardIndex
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes
=== RUN   TestAccEC2LaunchTemplate_associatePublicIPAddress
    ec2_launch_template_test.go:1047: TODO: cant do this in managed AWS account.
--- SKIP: TestAccEC2LaunchTemplate_associatePublicIPAddress (0.00s)
=== RUN   TestAccEC2LaunchTemplate_associateCarrierIPAddress
    ec2_launch_template_test.go:1098: TODO: cant do this in managed AWS account.
--- SKIP: TestAccEC2LaunchTemplate_associateCarrierIPAddress (0.00s)
=== RUN   TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN
=== PAUSE TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN
=== RUN   TestAccEC2LaunchTemplate_Placement_partitionNum
=== PAUSE TestAccEC2LaunchTemplate_Placement_partitionNum
=== RUN   TestAccEC2LaunchTemplate_privateDNSNameOptions
=== PAUSE TestAccEC2LaunchTemplate_privateDNSNameOptions
=== RUN   TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses
=== PAUSE TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses
=== RUN   TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount
=== PAUSE TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount
=== RUN   TestAccEC2LaunchTemplate_instanceMarketOptions
    ec2_launch_template_test.go:1296: TODO: cant do this in managed AWS account.
--- SKIP: TestAccEC2LaunchTemplate_instanceMarketOptions (0.00s)
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_bareMetal
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_bareMetal
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_localStorage
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_localStorage
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB
=== RUN   TestAccEC2LaunchTemplate_licenseSpecification
=== PAUSE TestAccEC2LaunchTemplate_licenseSpecification
=== RUN   TestAccEC2LaunchTemplate_metadataOptions
=== PAUSE TestAccEC2LaunchTemplate_metadataOptions
=== RUN   TestAccEC2LaunchTemplate_enclaveOptions
=== PAUSE TestAccEC2LaunchTemplate_enclaveOptions
=== RUN   TestAccEC2LaunchTemplate_hibernation
=== PAUSE TestAccEC2LaunchTemplate_hibernation
=== RUN   TestAccEC2LaunchTemplate_defaultVersion
=== PAUSE TestAccEC2LaunchTemplate_defaultVersion
=== RUN   TestAccEC2LaunchTemplate_updateDefaultVersion
=== PAUSE TestAccEC2LaunchTemplate_updateDefaultVersion
=== CONT  TestAccEC2LaunchTemplateDataSource_name
=== CONT  TestAccEC2LaunchTemplate_privateDNSNameOptions
=== CONT  TestAccEC2LaunchTemplate_updateDefaultVersion
=== CONT  TestAccEC2LaunchTemplate_defaultVersion
=== CONT  TestAccEC2LaunchTemplate_hibernation
=== CONT  TestAccEC2LaunchTemplate_enclaveOptions
=== CONT  TestAccEC2LaunchTemplate_metadataOptions
=== CONT  TestAccEC2LaunchTemplate_licenseSpecification
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_localStorage
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers
=== CONT  TestAccEC2LaunchTemplate_licenseSpecification
    acctest.go:862: skipping tests; missing IAM service-linked role /aws-service-role/license-manager.amazonaws.com. Please create the role and retry
--- SKIP: TestAccEC2LaunchTemplate_licenseSpecification (1.71s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount
--- PASS: TestAccEC2LaunchTemplate_privateDNSNameOptions (88.01s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount
--- PASS: TestAccEC2LaunchTemplateDataSource_name (91.97s)
=== CONT  TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice (105.30s)
=== CONT  TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice (107.84s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes (193.69s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames (196.62s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers (197.27s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps
--- PASS: TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount (109.73s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport (206.58s)
=== CONT  TestAccEC2LaunchTemplate_cpuOptions
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes (209.61s)
=== CONT  TestAccEC2LaunchTemplate_Placement_partitionNum
--- PASS: TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses (114.58s)
=== CONT  TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN
--- PASS: TestAccEC2LaunchTemplate_defaultVersion (243.40s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes
--- PASS: TestAccEC2LaunchTemplate_metadataOptions (254.48s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount
--- PASS: TestAccEC2LaunchTemplate_hibernation (255.52s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes
--- PASS: TestAccEC2LaunchTemplate_enclaveOptions (256.58s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount (294.01s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceCardIndex
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount (300.68s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceType
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount (214.63s)
=== CONT  TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock
--- PASS: TestAccEC2LaunchTemplate_cpuOptions (97.43s)
=== CONT  TestAccEC2LaunchTemplate_CreditSpecification_t4g
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_localStorage (307.63s)
=== CONT  TestAccEC2LaunchTemplate_CreditSpecification_t3
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB (308.16s)
=== CONT  TestAccEC2LaunchTemplate_CreditSpecification_t2
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB (308.28s)
=== CONT  TestAccEC2LaunchTemplate_CreditSpecification_nonBurstable
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU (316.01s)
=== CONT  TestAccEC2LaunchTemplate_ebsOptimized
--- PASS: TestAccEC2LaunchTemplate_updateDefaultVersion (322.14s)
=== CONT  TestAccEC2LaunchTemplate_CapacityReservation_preference
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers (222.08s)
=== CONT  TestAccEC2LaunchTemplate_tags
--- PASS: TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN (121.53s)
=== CONT  TestAccEC2LaunchTemplate_description
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes (110.12s)
=== CONT  TestAccEC2LaunchTemplate_data
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount (110.94s)
=== CONT  TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes (112.20s)
=== CONT  TestAccEC2LaunchTemplate_elasticInferenceAccelerator
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount (116.09s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_bareMetal
--- PASS: TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock (94.19s)
=== CONT  TestAccEC2LaunchTemplate_basic
--- PASS: TestAccEC2LaunchTemplate_Placement_partitionNum (188.86s)
=== CONT  TestAccEC2LaunchTemplate_disappears
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceCardIndex (112.00s)
=== CONT  TestAccEC2LaunchTemplate_Name_prefix
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_t4g (111.09s)
=== CONT  TestAccEC2LaunchTemplate_Name_generated
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes (219.82s)
=== CONT  TestAccEC2LaunchTemplateDataSource_filter
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations (223.37s)
=== CONT  TestAccEC2LaunchTemplateDataSource_tags
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_t2 (109.08s)
=== CONT  TestAccEC2LaunchTemplateDataSource_id
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceType (114.97s)
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_t3 (112.37s)
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_nonBurstable (114.20s)
--- PASS: TestAccEC2LaunchTemplate_CapacityReservation_preference (113.30s)
--- PASS: TestAccEC2LaunchTemplate_disappears (64.27s)
--- PASS: TestAccEC2LaunchTemplate_data (109.31s)
--- PASS: TestAccEC2LaunchTemplate_basic (86.97s)
--- PASS: TestAccEC2LaunchTemplateDataSource_filter (72.35s)
--- PASS: TestAccEC2LaunchTemplateDataSource_tags (72.47s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps (292.68s)
--- PASS: TestAccEC2LaunchTemplateDataSource_id (73.36s)
--- PASS: TestAccEC2LaunchTemplate_Name_prefix (84.83s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance (289.29s)
--- PASS: TestAccEC2LaunchTemplate_Name_generated (78.86s)
--- PASS: TestAccEC2LaunchTemplate_description (153.39s)
--- PASS: TestAccEC2LaunchTemplate_elasticInferenceAccelerator (133.83s)
--- PASS: TestAccEC2LaunchTemplate_tags (181.26s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_bareMetal (167.59s)
--- PASS: TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination (171.96s)
--- PASS: TestAccEC2LaunchTemplate_ebsOptimized (229.12s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        548.014s
...
```
