### PR TITLE
Fix bug that makes aws_instance ignore iam instance profile of launch template

### DIFF
--- a/.changelog/27972.txt
+++ b/.changelog/27972.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_instance: Fix bug that ignores the iam instance profile set in the launch template
+resource/aws_instance: Change `iam_instance_profile` to `Computed` as the value may configured via a launch template
 ```

--- a/.changelog/27972.txt
+++ b/.changelog/27972.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_instance: Fix bug that ignores the iam instance profile set in the launch template
+```

--- a/.changelog/27972.txt
+++ b/.changelog/27972.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_instance: Change `iam_instance_profile` to `Computed` as the value may configured via a launch template
+resource/aws_instance: Change `iam_instance_profile` to `Computed` as the value may be configured via a launch template
 ```

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -326,6 +326,7 @@ func ResourceInstance() *schema.Resource {
 			"iam_instance_profile": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"instance_initiated_shutdown_behavior": {
 				Type:     schema.TypeString,
@@ -2621,8 +2622,10 @@ func buildInstanceOpts(d *schema.ResourceData, meta interface{}) (*instanceOpts,
 		Enabled: aws.Bool(d.Get("monitoring").(bool)),
 	}
 
-	opts.IAMInstanceProfile = &ec2.IamInstanceProfileSpecification{
-		Name: aws.String(d.Get("iam_instance_profile").(string)),
+	if v := d.Get("iam_instance_profile").(string); v != "" {
+		opts.IAMInstanceProfile = &ec2.IamInstanceProfileSpecification{
+			Name: aws.String(v),
+		}
 	}
 
 	userData := d.Get("user_data").(string)

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -2622,9 +2622,9 @@ func buildInstanceOpts(d *schema.ResourceData, meta interface{}) (*instanceOpts,
 		Enabled: aws.Bool(d.Get("monitoring").(bool)),
 	}
 
-	if v := d.Get("iam_instance_profile").(string); v != "" {
+	if v, ok := d.GetOk("iam_instance_profile"); ok {
 		opts.IAMInstanceProfile = &ec2.IamInstanceProfileSpecification{
-			Name: aws.String(v),
+			Name: aws.String(v.(string)),
 		}
 	}
 

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -3357,6 +3357,30 @@ func TestAccEC2Instance_LaunchTemplate_swapIDAndName(t *testing.T) {
 	})
 }
 
+func TestAccEC2Instance_LaunchTemplate_withIAMInstanceProfile(t *testing.T) {
+	var v ec2.Instance
+	resourceName := "aws_instance.test"
+	launchTemplateResourceName := "aws_launch_template.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_templateWithIAMInstanceProfile(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceExists(resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "launch_template.0.id", launchTemplateResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "iam_instance_profile", launchTemplateResourceName, "iam_instance_profile.0.name"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEC2Instance_LaunchTemplate_spotAndStop(t *testing.T) {
 	var v ec2.Instance
 	resourceName := "aws_instance.test"
@@ -7975,6 +7999,61 @@ resource "aws_launch_template" "test" {
   name          = %[1]q
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+}
+
+resource "aws_instance" "test" {
+  launch_template {
+    name = aws_launch_template.test.name
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccInstanceConfig_templateWithIAMInstanceProfile(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinuxHVMEBSAMI(),
+		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro", "t1.micro", "m1.small"),
+		fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": [
+        "sts:AssumeRole"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.name
+}
+
+resource "aws_launch_template" "test" {
+  name          = %[1]q
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.test.name
+  }
 }
 
 resource "aws_instance" "test" {


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR fixes #27969.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27969


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ AWS_DEFAULT_REGION=ap-northeast-1 make testacc TESTS='^TestAccEC2Instance_(basic|withIAMInstanceProfile|LaunchTemplate_withIamInstanceProfile)$' PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='^TestAccEC2Instance_(basic|withIAMInstanceProfile|LaunchTemplate_withIamInstanceProfile)'  -timeout 180m
=== RUN   TestAccEC2Instance_basic
=== PAUSE TestAccEC2Instance_basic
=== RUN   TestAccEC2Instance_withIAMInstanceProfile
=== PAUSE TestAccEC2Instance_withIAMInstanceProfile
=== RUN   TestAccEC2Instance_withIAMInstanceProfilePath
=== PAUSE TestAccEC2Instance_withIAMInstanceProfilePath
=== RUN   TestAccEC2Instance_LaunchTemplate_withIamInstanceProfile
=== PAUSE TestAccEC2Instance_LaunchTemplate_withIamInstanceProfile
=== CONT  TestAccEC2Instance_basic
=== CONT  TestAccEC2Instance_withIAMInstanceProfilePath
=== CONT  TestAccEC2Instance_LaunchTemplate_withIamInstanceProfile
=== CONT  TestAccEC2Instance_withIAMInstanceProfile
--- PASS: TestAccEC2Instance_LaunchTemplate_withIamInstanceProfile (71.64s)
--- PASS: TestAccEC2Instance_basic (99.66s)
--- PASS: TestAccEC2Instance_withIAMInstanceProfilePath (102.11s)
--- PASS: TestAccEC2Instance_withIAMInstanceProfile (111.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        114.391s
```
