### PR TITLE
correct instances.0.console_url description to indicate this references the consule_url for ActiveMQ and RabbitMQ broker types

### DIFF
--- a/website/docs/r/mq_broker.html.markdown
+++ b/website/docs/r/mq_broker.html.markdown
@@ -157,7 +157,7 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - ARN of the broker.
 * `id` - Unique ID that Amazon MQ generates for the broker.
 * `instances` - List of information about allocated brokers (both active & standby).
-    * `instances.0.console_url` - The URL of the broker's [ActiveMQ Web Console](http://activemq.apache.org/web-console.html).
+    * `instances.0.console_url` - The URL of the [ActiveMQ Web Console](http://activemq.apache.org/web-console.html) or the [RabbitMQ Management UI](https://www.rabbitmq.com/management.html#external-monitoring) depending on `engine_type`.
     * `instances.0.ip_address` - IP Address of the broker.
     * `instances.0.endpoints` - Broker's wire-level protocol endpoints in the following order & format referenceable e.g., as `instances.0.endpoints.0` (SSL):
         * For `ActiveMQ`:


### PR DESCRIPTION
correct `instances.0.console_url` description to indicate this references the `consule_url` for `ActiveMQ` and `RabbitMQ` broker types

I have noticed when reading through the docs for `mq_broker` that the attribute `instances.0.console_url` seems to suggest to users that this is only for the `ActiveMQ Web Console` this could confuse users looking for the `RabbitMQ Management UI` endpoint. The resource provides the URL for both the `ActiveMQ Web Console` and the `RabbitMQ Management UI`. I have updated the docs to reflect this 

