### PR TITLE
Draft: Fix #27995: Add Cognito User Pool Client ClientId

### DIFF
--- a/internal/service/cognitoidp/user_pool_client.go
+++ b/internal/service/cognitoidp/user_pool_client.go
@@ -121,6 +121,11 @@ func ResourceUserPoolClient() *schema.Resource {
 					),
 				},
 			},
+			"client_id": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: false,
+			},
 			"client_secret": {
 				Type:      schema.TypeString,
 				Computed:  true,
@@ -383,6 +388,7 @@ func resourceUserPoolClientRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("refresh_token_validity", userPoolClient.RefreshTokenValidity)
 	d.Set("access_token_validity", userPoolClient.AccessTokenValidity)
 	d.Set("id_token_validity", userPoolClient.IdTokenValidity)
+	d.Set("client_id", userPoolClient.ClientId)
 	d.Set("client_secret", userPoolClient.ClientSecret)
 	d.Set("allowed_oauth_flows", flex.FlattenStringSet(userPoolClient.AllowedOAuthFlows))
 	d.Set("allowed_oauth_flows_user_pool_client", userPoolClient.AllowedOAuthFlowsUserPoolClient)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This adds the `ClientId` field to the Cognito User Pool Client resource.


### Relations
Closes #27995 

### References
https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateUserPoolClient.html
https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserPoolClientType.html#CognitoUserPools-Type-UserPoolClientType-ClientId

### Output from Acceptance Testing
No tests affected AFAICT.
