### PR TITLE
r/aws_sns_topic_subscription: add filter_policy_scope attribute

### DIFF
--- a/.changelog/28004.txt
+++ b/.changelog/28004.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sns_topic_subscription: Add `filter_policy_scope` attribute
+```

--- a/.changelog/28004.txt
+++ b/.changelog/28004.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_sns_topic_subscription: Add `filter_policy_scope` attribute
+resource/aws_sns_topic_subscription: Add `filter_policy_scope` argument in support of [SNS message filtering](https://docs.aws.amazon.com/sns/latest/dg/sns-message-filtering.html)
 ```

--- a/internal/service/sns/consts.go
+++ b/internal/service/sns/consts.go
@@ -58,6 +58,7 @@ const (
 	SubscriptionAttributeNameDeliveryPolicy               = "DeliveryPolicy"
 	SubscriptionAttributeNameEndpoint                     = "Endpoint"
 	SubscriptionAttributeNameFilterPolicy                 = "FilterPolicy"
+	SubscriptionAttributeNameFilterPolicyScope            = "FilterPolicyScope"
 	SubscriptionAttributeNameOwner                        = "Owner"
 	SubscriptionAttributeNamePendingConfirmation          = "PendingConfirmation"
 	SubscriptionAttributeNameProtocol                     = "Protocol"
@@ -97,3 +98,15 @@ const (
 const (
 	propagationTimeout = 2 * time.Minute
 )
+
+const (
+	SubscriptionFilterPolicyScopeMessageAttributes = "MessageAttributes"
+	SubscriptionFilterPolicyScopeMessageBody       = "MessageBody"
+)
+
+func SubscriptionFilterPolicyScope_Values() []string {
+	return []string{
+		SubscriptionFilterPolicyScopeMessageAttributes,
+		SubscriptionFilterPolicyScopeMessageBody,
+	}
+}

--- a/internal/service/sns/topic_subscription_test.go
+++ b/internal/service/sns/topic_subscription_test.go
@@ -86,6 +86,7 @@ func TestAccSNSTopicSubscription_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "delivery_policy", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "endpoint", "aws_sqs_queue.test", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "filter_policy", ""),
+					resource.TestCheckResourceAttr(resourceName, "filter_policy_scope", ""),
 					resource.TestCheckResourceAttr(resourceName, "pending_confirmation", "false"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "sqs"),
 					resource.TestCheckResourceAttr(resourceName, "raw_message_delivery", "false"),
@@ -123,6 +124,7 @@ func TestAccSNSTopicSubscription_filterPolicy(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "filter_policy", filterPolicy1),
+					resource.TestCheckResourceAttr(resourceName, "filter_policy_scope", "MessageAttributes"),
 				),
 			},
 			{
@@ -140,6 +142,7 @@ func TestAccSNSTopicSubscription_filterPolicy(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "filter_policy", filterPolicy2),
+					resource.TestCheckResourceAttr(resourceName, "filter_policy_scope", "MessageAttributes"),
 				),
 			},
 			// Test attribute removal
@@ -148,7 +151,145 @@ func TestAccSNSTopicSubscription_filterPolicy(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
 					resource.TestCheckResourceAttr(resourceName, "filter_policy", ""),
+					resource.TestCheckResourceAttr(resourceName, "filter_policy_scope", ""),
 				),
+			},
+		},
+	})
+}
+
+func TestAccSNSTopicSubscription_filterPolicyScope(t *testing.T) {
+	var attributes map[string]string
+	resourceName := "aws_sns_topic_subscription.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sns.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTopicSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTopicSubscriptionConfig_filterPolicyScope(rName, strconv.Quote("MessageBody")),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
+					resource.TestCheckResourceAttr(resourceName, "filter_policy_scope", "MessageBody"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"confirmation_timeout_in_minutes",
+					"endpoint_auto_confirms",
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"confirmation_timeout_in_minutes",
+					"endpoint_auto_confirms",
+				},
+			},
+			{
+				Config: testAccTopicSubscriptionConfig_filterPolicyScope(rName, strconv.Quote("MessageAttributes")),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
+					resource.TestCheckResourceAttr(resourceName, "filter_policy_scope", "MessageAttributes"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"confirmation_timeout_in_minutes",
+					"endpoint_auto_confirms",
+				},
+			},
+			{
+				Config: testAccTopicSubscriptionConfig_filterPolicyScope(rName, strconv.Quote("MessageBody")),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
+					resource.TestCheckResourceAttr(resourceName, "filter_policy_scope", "MessageBody"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"confirmation_timeout_in_minutes",
+					"endpoint_auto_confirms",
+				},
+			},
+			{
+				Config: testAccTopicSubscriptionConfig_filterPolicyScope(rName, "null"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
+					resource.TestCheckResourceAttr(resourceName, "filter_policy_scope", "MessageAttributes"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"confirmation_timeout_in_minutes",
+					"endpoint_auto_confirms",
+				},
+			},
+			{
+				Config: testAccTopicSubscriptionConfig_filterPolicyScope(rName, strconv.Quote("MessageBody")),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
+					resource.TestCheckResourceAttr(resourceName, "filter_policy_scope", "MessageBody"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"confirmation_timeout_in_minutes",
+					"endpoint_auto_confirms",
+				},
+			},
+			{
+				Config: testAccTopicSubscriptionConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTopicSubscriptionExists(resourceName, &attributes),
+					resource.TestCheckResourceAttr(resourceName, "filter_policy_scope", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"confirmation_timeout_in_minutes",
+					"endpoint_auto_confirms",
+				},
+			},
+		},
+	})
+}
+
+func TestAccSNSTopicSubscription_filterPolicyScope_policyNotSet(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sns.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTopicSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTopicSubscriptionConfig_filterPolicyScope_policyNotSet(rName),
+				ExpectError: regexp.MustCompile(`filter_policy is required when filter_policy_scope is set`),
 			},
 		},
 	})
@@ -627,6 +768,49 @@ resource "aws_sns_topic_subscription" "test" {
   filter_policy = %[2]s
 }
 `, rName, policy)
+}
+
+func testAccTopicSubscriptionConfig_filterPolicyScope(rName, scope string) string {
+	return fmt.Sprintf(`
+resource "aws_sns_topic" "test" {
+  name = %[1]q
+}
+
+resource "aws_sqs_queue" "test" {
+  name = %[1]q
+
+  sqs_managed_sse_enabled = true
+}
+
+resource "aws_sns_topic_subscription" "test" {
+  topic_arn           = aws_sns_topic.test.arn
+  protocol            = "sqs"
+  endpoint            = aws_sqs_queue.test.arn
+  filter_policy       = jsonencode({ key1 = ["value1"] })
+  filter_policy_scope = %[2]s
+}
+`, rName, scope)
+}
+
+func testAccTopicSubscriptionConfig_filterPolicyScope_policyNotSet(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sns_topic" "test" {
+  name = %[1]q
+}
+
+resource "aws_sqs_queue" "test" {
+  name = %[1]q
+
+  sqs_managed_sse_enabled = true
+}
+
+resource "aws_sns_topic_subscription" "test" {
+  topic_arn           = aws_sns_topic.test.arn
+  protocol            = "sqs"
+  endpoint            = aws_sqs_queue.test.arn
+  filter_policy_scope = "MessageBody"
+}
+`, rName)
 }
 
 func testAccTopicSubscriptionConfig_deliveryPolicy(rName, policy string) string {

--- a/website/docs/r/sns_topic_subscription.html.markdown
+++ b/website/docs/r/sns_topic_subscription.html.markdown
@@ -240,6 +240,7 @@ The following arguments are optional:
 * `delivery_policy` - (Optional) JSON String with the delivery policy (retries, backoff, etc.) that will be used in the subscription - this only applies to HTTP/S subscriptions. Refer to the [SNS docs](https://docs.aws.amazon.com/sns/latest/dg/DeliveryPolicies.html) for more details.
 * `endpoint_auto_confirms` - (Optional) Whether the endpoint is capable of [auto confirming subscription](http://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.html#SendMessageToHttp.prepare) (e.g., PagerDuty). Default is `false`.
 * `filter_policy` - (Optional) JSON String with the filter policy that will be used in the subscription to filter messages seen by the target resource. Refer to the [SNS docs](https://docs.aws.amazon.com/sns/latest/dg/message-filtering.html) for more details.
+* `filter_policy_scope` - (Optional) Whether the `filter_policy` applies to `MessageAttributes` (default) or `MessageBody`.
 * `raw_message_delivery` - (Optional) Whether to enable raw message delivery (the original message is directly passed, not wrapped in JSON with the original message in the message property). Default is `false`.
 * `redrive_policy` - (Optional) JSON String with the redrive policy that will be used in the subscription. Refer to the [SNS docs](https://docs.aws.amazon.com/sns/latest/dg/sns-dead-letter-queues.html#how-messages-moved-into-dead-letter-queue) for more details.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/27997

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccSNSTopicSubscription_ PKG=sns
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sns/... -v -count 1 -parallel 20 -run='TestAccSNSTopicSubscription_'  -timeout 180m
=== RUN   TestAccSNSTopicSubscription_basic
=== PAUSE TestAccSNSTopicSubscription_basic
=== RUN   TestAccSNSTopicSubscription_filterPolicy
=== PAUSE TestAccSNSTopicSubscription_filterPolicy
=== RUN   TestAccSNSTopicSubscription_filterPolicyScope
=== PAUSE TestAccSNSTopicSubscription_filterPolicyScope
=== RUN   TestAccSNSTopicSubscription_filterPolicyScope_policyNotSet
=== PAUSE TestAccSNSTopicSubscription_filterPolicyScope_policyNotSet
=== RUN   TestAccSNSTopicSubscription_deliveryPolicy
=== PAUSE TestAccSNSTopicSubscription_deliveryPolicy
=== RUN   TestAccSNSTopicSubscription_redrivePolicy
=== PAUSE TestAccSNSTopicSubscription_redrivePolicy
=== RUN   TestAccSNSTopicSubscription_rawMessageDelivery
=== PAUSE TestAccSNSTopicSubscription_rawMessageDelivery
=== RUN   TestAccSNSTopicSubscription_autoConfirmingEndpoint
=== PAUSE TestAccSNSTopicSubscription_autoConfirmingEndpoint
=== RUN   TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== PAUSE TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== RUN   TestAccSNSTopicSubscription_email
=== PAUSE TestAccSNSTopicSubscription_email
=== RUN   TestAccSNSTopicSubscription_firehose
=== PAUSE TestAccSNSTopicSubscription_firehose
=== RUN   TestAccSNSTopicSubscription_disappears
=== PAUSE TestAccSNSTopicSubscription_disappears
=== RUN   TestAccSNSTopicSubscription_Disappears_topic
=== PAUSE TestAccSNSTopicSubscription_Disappears_topic
=== CONT  TestAccSNSTopicSubscription_basic
=== CONT  TestAccSNSTopicSubscription_autoConfirmingEndpoint
=== CONT  TestAccSNSTopicSubscription_Disappears_topic
=== CONT  TestAccSNSTopicSubscription_email
=== CONT  TestAccSNSTopicSubscription_deliveryPolicy
=== CONT  TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== CONT  TestAccSNSTopicSubscription_firehose
=== CONT  TestAccSNSTopicSubscription_filterPolicyScope
=== CONT  TestAccSNSTopicSubscription_filterPolicyScope_policyNotSet
=== CONT  TestAccSNSTopicSubscription_filterPolicy
=== CONT  TestAccSNSTopicSubscription_disappears
=== CONT  TestAccSNSTopicSubscription_rawMessageDelivery
=== CONT  TestAccSNSTopicSubscription_redrivePolicy
--- PASS: TestAccSNSTopicSubscription_filterPolicyScope_policyNotSet (4.03s)
--- PASS: TestAccSNSTopicSubscription_email (15.85s)
--- PASS: TestAccSNSTopicSubscription_rawMessageDelivery (96.73s)
--- PASS: TestAccSNSTopicSubscription_deliveryPolicy (98.89s)
--- PASS: TestAccSNSTopicSubscription_filterPolicy (99.06s)
--- PASS: TestAccSNSTopicSubscription_Disappears_topic (99.11s)
--- PASS: TestAccSNSTopicSubscription_basic (100.82s)
--- PASS: TestAccSNSTopicSubscription_autoConfirmingEndpoint (103.64s)
--- PASS: TestAccSNSTopicSubscription_disappears (107.75s)
--- PASS: TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint (139.05s)
--- PASS: TestAccSNSTopicSubscription_redrivePolicy (140.50s)
--- PASS: TestAccSNSTopicSubscription_filterPolicyScope (143.17s)
--- PASS: TestAccSNSTopicSubscription_firehose (160.29s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sns        162.159s
```
