### PR TITLE
aws_cloudwatch_log_group - Update possible retention policy in days values

### DIFF
--- a/internal/service/logs/group.go
+++ b/internal/service/logs/group.go
@@ -57,7 +57,7 @@ func ResourceGroup() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      0,
-				ValidateFunc: validation.IntInSlice([]int{0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653}),
+				ValidateFunc: validation.IntInSlice([]int{0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 2192, 2557, 2922, 3288, 3653}),
 			},
 			"skip_destroy": {
 				Type:     schema.TypeBool,

--- a/website/docs/r/cloudwatch_log_group.html.markdown
+++ b/website/docs/r/cloudwatch_log_group.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `skip_destroy` - (Optional) Set to true if you do not wish the log group (and any logs it may contain) to be deleted at destroy time, and instead just remove the log group from the Terraform state.
 * `retention_in_days` - (Optional) Specifies the number of days
-  you want to retain log events in the specified log group.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.
+  you want to retain log events in the specified log group.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 2192, 2557, 2922, 3288, 3653, and 0.
   If you select 0, the events in the log group are always retained and never expire.
 * `kms_key_id` - (Optional) The ARN of the KMS Key to use when encrypting log data. Please note, after the AWS KMS CMK is disassociated from the log group,
 AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Updates possible retention policy in days values. The AWS GO SDK does not support a `_Values()` enum for this.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

--->

Closes #28002

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make testacc TESTARGS='-run=TestAccLogsGroup_' PKG=logs 

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/logs/... -v -count 1 -parallel 20  -run=TestAccLogsGroup_ -timeout 180m
=== RUN   TestAccLogsGroup_basic
=== PAUSE TestAccLogsGroup_basic
=== RUN   TestAccLogsGroup_nameGenerate
=== PAUSE TestAccLogsGroup_nameGenerate
=== RUN   TestAccLogsGroup_namePrefix
=== PAUSE TestAccLogsGroup_namePrefix
=== RUN   TestAccLogsGroup_disappears
=== PAUSE TestAccLogsGroup_disappears
=== RUN   TestAccLogsGroup_tags
=== PAUSE TestAccLogsGroup_tags
=== RUN   TestAccLogsGroup_kmsKey
=== PAUSE TestAccLogsGroup_kmsKey
=== RUN   TestAccLogsGroup_retentionPolicy
=== PAUSE TestAccLogsGroup_retentionPolicy
=== RUN   TestAccLogsGroup_multiple
=== PAUSE TestAccLogsGroup_multiple
=== RUN   TestAccLogsGroup_skipDestroy
=== PAUSE TestAccLogsGroup_skipDestroy
=== CONT  TestAccLogsGroup_basic
=== CONT  TestAccLogsGroup_kmsKey
=== CONT  TestAccLogsGroup_skipDestroy
=== CONT  TestAccLogsGroup_disappears
=== CONT  TestAccLogsGroup_tags
=== CONT  TestAccLogsGroup_multiple
=== CONT  TestAccLogsGroup_nameGenerate
=== CONT  TestAccLogsGroup_retentionPolicy
=== CONT  TestAccLogsGroup_namePrefix
--- PASS: TestAccLogsGroup_disappears (17.56s)
--- PASS: TestAccLogsGroup_skipDestroy (20.36s)
--- PASS: TestAccLogsGroup_multiple (21.05s)
--- PASS: TestAccLogsGroup_basic (23.06s)
--- PASS: TestAccLogsGroup_nameGenerate (24.29s)
--- PASS: TestAccLogsGroup_namePrefix (24.32s)
--- PASS: TestAccLogsGroup_retentionPolicy (34.33s)
--- PASS: TestAccLogsGroup_tags (44.59s)
--- PASS: TestAccLogsGroup_kmsKey (48.39s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       52.442s
...
```
