### PR TITLE
Update available codesigning region guards

### DIFF
--- a/.changelog/28008.txt
+++ b/.changelog/28008.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lambda_function: Don't fail resource Create if AWS Signer service is not available in the configured Region
+```

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -903,7 +903,7 @@ func resourceFunctionRead(d *schema.ResourceData, meta interface{}) error {
 	// so we cannot just ignore the error as would typically.
 	// We are hardcoding the region here, because go aws sdk endpoints
 	// package does not support Signer service
-	if region := meta.(*conns.AWSClient).Region; region == endpoints.ApNortheast3RegionID || region == endpoints.MeCentral1RegionID || region == endpoints.ApSoutheast3RegionID {
+	if region := meta.(*conns.AWSClient).Region; region == endpoints.ApNortheast3RegionID || region == endpoints.ApSoutheast3RegionID || region == endpoints.EuCentral2RegionID || region == endpoints.MeCentral1RegionID {
 		return nil
 	}
 

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -898,12 +898,9 @@ func resourceFunctionRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	// Currently, this functionality is not enabled in ap-northeast-3 (Osaka), me-central-1 (UAE) and ap-southeast-3 (Jakarta) region
-	// and returns ambiguous error codes (e.g. AccessDeniedException)
-	// so we cannot just ignore the error as would typically.
-	// We are hardcoding the region here, because go aws sdk endpoints
-	// package does not support Signer service
-	if region := meta.(*conns.AWSClient).Region; region == endpoints.ApNortheast3RegionID || region == endpoints.ApSoutheast3RegionID || region == endpoints.EuCentral2RegionID || region == endpoints.MeCentral1RegionID {
+	// Currently this functionality is not enabled in all Regions and returns ambiguous error codes
+	// (e.g. AccessDeniedException), so we cannot just ignore the error as we would typically.
+	if !SignerServiceIsAvailable(meta.(*conns.AWSClient).Region) {
 		return nil
 	}
 
@@ -1446,6 +1443,36 @@ func waitForFunctionUpdate(conn *lambda.Lambda, functionName string, timeout tim
 	_, err := stateConf.WaitForState()
 
 	return err
+}
+
+// SignerServiceIsAvailable returns whether the AWS Signer service is available in the specified AWS Region.
+// The AWS SDK endpoints package does not support Signer.
+// See https://docs.aws.amazon.com/general/latest/gr/signer.html#signer_lambda_region.
+func SignerServiceIsAvailable(region string) bool {
+	availableRegions := map[string]struct{}{
+		endpoints.UsEast2RegionID:      {},
+		endpoints.UsEast1RegionID:      {},
+		endpoints.UsWest1RegionID:      {},
+		endpoints.UsWest2RegionID:      {},
+		endpoints.AfSouth1RegionID:     {},
+		endpoints.ApSouth1RegionID:     {},
+		endpoints.ApNortheast2RegionID: {},
+		endpoints.ApSoutheast1RegionID: {},
+		endpoints.ApSoutheast2RegionID: {},
+		endpoints.ApNortheast1RegionID: {},
+		endpoints.CaCentral1RegionID:   {},
+		endpoints.EuCentral1RegionID:   {},
+		endpoints.EuWest1RegionID:      {},
+		endpoints.EuWest2RegionID:      {},
+		endpoints.EuSouth1RegionID:     {},
+		endpoints.EuWest3RegionID:      {},
+		endpoints.EuNorth1RegionID:     {},
+		endpoints.MeSouth1RegionID:     {},
+		endpoints.SaEast1RegionID:      {},
+	}
+	_, ok := availableRegions[region]
+
+	return ok
 }
 
 func flattenEnvironment(apiObject *lambda.EnvironmentResponse) []interface{} {

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -206,16 +206,8 @@ func TestAccLambdaFunction_unpublishedCodeUpdate(t *testing.T) {
 }
 
 func TestAccLambdaFunction_codeSigning(t *testing.T) {
-	if got, want := acctest.Partition(), endpoints.AwsUsGovPartitionID; got == want {
-		t.Skipf("Lambda code signing config is not supported in %s partition", got)
-	}
-
-	// We are hardcoding the region here, because go aws sdk endpoints
-	// package does not support Signer service
-	for _, want := range []string{endpoints.ApNortheast3RegionID, endpoints.ApSoutheast3RegionID, endpoints.EuCentral2RegionID, endpoints.MeCentral1RegionID} {
-		if got := acctest.Region(); got == want {
-			t.Skipf("Lambda code signing config is not supported in %s region", got)
-		}
+	if curr := acctest.Region(); !tflambda.SignerServiceIsAvailable(curr) {
+		t.Skipf("Lambda code signing config is not supported in %s region", curr)
 	}
 
 	var conf lambda.GetFunctionOutput

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -212,7 +212,7 @@ func TestAccLambdaFunction_codeSigning(t *testing.T) {
 
 	// We are hardcoding the region here, because go aws sdk endpoints
 	// package does not support Signer service
-	for _, want := range []string{endpoints.ApNortheast3RegionID, endpoints.ApSoutheast3RegionID} {
+	for _, want := range []string{endpoints.ApNortheast3RegionID, endpoints.ApSoutheast3RegionID, endpoints.EuCentral2RegionID, endpoints.MeCentral1RegionID} {
 		if got := acctest.Region(); got == want {
 			t.Skipf("Lambda code signing config is not supported in %s region", got)
 		}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27986 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make testacc TESTARGS='-run=TestAccLambdaFunction_codeSigning\|TestAccLambdaFunction_tracing\|TestAccLambdaFunction_basic' PKG=lambda 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20  -run=TestAccLambdaFunction_codeSigning\|TestAccLambdaFunction_tracing\|TestAccLambdaFunction_basic -timeout 180m
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== RUN   TestAccLambdaFunction_codeSigning
=== PAUSE TestAccLambdaFunction_codeSigning
=== RUN   TestAccLambdaFunction_tracing
=== PAUSE TestAccLambdaFunction_tracing
=== CONT  TestAccLambdaFunction_basic
=== CONT  TestAccLambdaFunction_tracing
=== CONT  TestAccLambdaFunction_codeSigning
--- PASS: TestAccLambdaFunction_basic (46.56s)
--- PASS: TestAccLambdaFunction_codeSigning (66.17s)
--- PASS: TestAccLambdaFunction_tracing (68.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     72.717s
...
```
