### PR TITLE
d/aws_acmpca_certificate_authority - handle exception when retrieving a shared ACM PCA

### DIFF
--- a/.changelog/26868.txt
+++ b/.changelog/26868.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data/aws_acmpca_certificate_authority: Handle `AccessDeniedException` on `acm-pca/GetCertificateAuthorityCsr` when retrieving a shared ACM PCA
+```

--- a/internal/service/acmpca/certificate_authority_data_source.go
+++ b/internal/service/acmpca/certificate_authority_data_source.go
@@ -183,7 +183,7 @@ func dataSourceCertificateAuthorityRead(d *schema.ResourceData, meta interface{}
 
 	getCertificateAuthorityCsrOutput, err := conn.GetCertificateAuthorityCsr(getCertificateAuthorityCsrInput)
 	if err != nil {
-		return fmt.Errorf("reading ACM PCA Certificate Authority Certificate Signing Request: %w", err)
+		log.Printf("[WARN] Error reading ACM PCA Certificate Authority Certificate Signing Request: %w", err)
 	}
 
 	d.Set("certificate_signing_request", "")


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Given that an alternate account shared an ACM PCA with me,
When I tried to retrieve the ACM PCA resource,
I would encounter an `AccessDeniedException` as the default permission does not allow retrieval of the PCA's CSR.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #26868

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

```
2022-11-18T19:11:47.352+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: [DEBUG] Reading ACM PCA Certificate Authority Certificate Signing Request: {
2022-11-18T19:11:47.352+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5:   CertificateAuthorityArn: "arn:aws:acm-pca:ap-southeast-1:<account_id>:certificate-authority/<uuid>"
2022-11-18T19:11:47.352+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: }
2022-11-18T19:11:47.352+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: [DEBUG] [aws-sdk-go] DEBUG: Request acm-pca/GetCertificateAuthorityCsr Details:
2022-11-18T19:11:47.352+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: ---[ REQUEST POST-SIGN ]-----------------------------
2022-11-18T19:11:47.352+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: POST / HTTP/1.1
2022-11-18T19:11:47.352+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: Host: acm-pca.ap-southeast-1.amazonaws.com
2022-11-18T19:11:47.352+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: User-Agent: APN/1.0 HashiCorp/1.0 Terraform/1.3.0 (+https://www.terraform.io) terraform-provider-aws/dev (+https://registry.terraform.io/providers/hashicorp/aws) aws-sdk-go/1.44.139 (go1.19.2; darwin; amd64)
2022-11-18T19:11:47.352+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: Content-Length: 132
2022-11-18T19:11:47.352+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: Authorization: AWS4-HMAC-SHA256 Credential=<access_key>/20221118/ap-southeast-1/acm-pca/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-amz-security-token;x-amz-target, Signature=<signature>
2022-11-18T19:11:47.352+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: Content-Type: application/x-amz-json-1.1
2022-11-18T19:11:47.352+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: X-Amz-Date: 20221118T111147Z
2022-11-18T19:11:47.352+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: X-Amz-Security-Token: <token>
2022-11-18T19:11:47.352+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: X-Amz-Target: ACMPrivateCA.GetCertificateAuthorityCsr
2022-11-18T19:11:47.352+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: Accept-Encoding: gzip
2022-11-18T19:11:47.353+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: 
2022-11-18T19:11:47.353+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: {"CertificateAuthorityArn":"arn:aws:acm-pca:ap-southeast-1:<account_id>:certificate-authority/<uuid>"}
2022-11-18T19:11:47.353+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: -----------------------------------------------------
2022-11-18T19:11:47.433+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: [DEBUG] [aws-sdk-go] DEBUG: Response acm-pca/GetCertificateAuthorityCsr Details:
2022-11-18T19:11:47.433+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: ---[ RESPONSE ]--------------------------------------
2022-11-18T19:11:47.433+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: HTTP/2.0 400 Bad Request
2022-11-18T19:11:47.433+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: Content-Length: 407
2022-11-18T19:11:47.433+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: Content-Type: application/x-amz-json-1.1
2022-11-18T19:11:47.433+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: Date: Fri, 18 Nov 2022 11:11:47 GMT
2022-11-18T19:11:47.433+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: X-Amzn-Requestid: <request_id>
2022-11-18T19:11:47.433+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: 
2022-11-18T19:11:47.433+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: 
2022-11-18T19:11:47.433+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: -----------------------------------------------------
2022-11-18T19:11:47.433+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: [DEBUG] [aws-sdk-go] {"__type":"AccessDeniedException","Message":"User: arn:aws:sts::<sts_account_id>:assumed-role/<role_name>/<role_id> is not authorized to perform: acm-pca:GetCertificateAuthorityCsr on resource: arn:aws:acm-pca:ap-southeast-1:<account_id>:certificate-authority/<uuid> because no resource-based policy allows the acm-pca:GetCertificateAuthorityCsr action"}
2022-11-18T19:11:47.433+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: [DEBUG] [aws-sdk-go] DEBUG: Validate Response acm-pca/GetCertificateAuthorityCsr failed, attempt 0/25, error AccessDeniedException: User: arn:aws:sts::<sts_account_id>:assumed-role/<role_name>/<role_id> is not authorized to perform: acm-pca:GetCertificateAuthorityCsr on resource: arn:aws:acm-pca:ap-southeast-1:<account_id>:certificate-authority/<uuid> because no resource-based policy allows the acm-pca:GetCertificateAuthorityCsr action
2022-11-18T19:11:47.433+0800 [DEBUG] provider.terraform-provider-aws_v4.40.0_x5: 	status code: 400, request id: <request_id>
2022-11-18T19:11:47.433+0800 [ERROR] provider.terraform-provider-aws_v4.40.0_x5: Response contains error diagnostic: diagnostic_severity=ERROR diagnostic_summary="reading ACM PCA Certificate Authority Certificate Signing Request: AccessDeniedException: User: arn:aws:sts::<sts_account_id>:assumed-role/<role_name>/<role_id> is not authorized to perform: acm-pca:GetCertificateAuthorityCsr on resource: arn:aws:acm-pca:ap-southeast-1:<account_id>:certificate-authority/<uuid> because no resource-based policy allows the acm-pca:GetCertificateAuthorityCsr action
	status code: 400, request id: <request_id>" tf_proto_version=5.3 tf_req_id=aff78e9b-bd9a-ab18-6702-f3feb04f109d @module=sdk.proto diagnostic_detail= tf_data_source_type=aws_acmpca_certificate_authority tf_provider_addr=registry.terraform.io/hashicorp/aws tf_rpc=ReadDataSource @caller=github.com/hashicorp/terraform-plugin-go@v0.14.1/tfprotov5/internal/diag/diagnostics.go:55 timestamp=2022-11-18T19:11:47.433+0800
2022-11-18T19:11:47.434+0800 [ERROR] vertex "data.aws_acmpca_certificate_authority.this" error: reading ACM PCA Certificate Authority Certificate Signing Request: AccessDeniedException: User: arn:aws:sts::<sts_account_id>:assumed-role/<role_name>/<role_id> is not authorized to perform: acm-pca:GetCertificateAuthorityCsr on resource: arn:aws:acm-pca:ap-southeast-1:<account_id>:certificate-authority/<uuid> because no resource-based policy allows the acm-pca:GetCertificateAuthorityCsr action
	status code: 400, request id: <request_id>
2022-11-18T19:11:47.435+0800 [ERROR] vertex "data.aws_acmpca_certificate_authority.this" error: reading ACM PCA Certificate Authority Certificate Signing Request: AccessDeniedException: User: arn:aws:sts::<sts_account_id>:assumed-role/<role_name>/<role_id> is not authorized to perform: acm-pca:GetCertificateAuthorityCsr on resource: arn:aws:acm-pca:ap-southeast-1:<account_id>:certificate-authority/<uuid> because no resource-based policy allows the acm-pca:GetCertificateAuthorityCsr action
	status code: 400, request id: <request_id>
2022-11-18T19:11:47.435+0800 [ERROR] vertex "data.aws_acmpca_certificate_authority.this (expand)" error: reading ACM PCA Certificate Authority Certificate Signing Request: AccessDeniedException: User: arn:aws:sts::<sts_account_id>:assumed-role/<role_name>/<role_id> is not authorized to perform: acm-pca:GetCertificateAuthorityCsr on resource: arn:aws:acm-pca:ap-southeast-1:<account_id>:certificate-authority/<uuid> because no resource-based policy allows the acm-pca:GetCertificateAuthorityCsr action
	status code: 400, request id: <request_id>
2022-11-18T19:11:47.435+0800 [INFO]  backend/local: plan operation completed
╷
│ Error: reading ACM PCA Certificate Authority Certificate Signing Request: AccessDeniedException: User: arn:aws:sts::<sts_account_id>:assumed-role/<role_name>/<role_id> is not authorized to perform: acm-pca:GetCertificateAuthorityCsr on resource: arn:aws:acm-pca:ap-southeast-1:<account_id>:certificate-authority/<uuid> because no resource-based policy allows the acm-pca:GetCertificateAuthorityCsr action
│ 	status code: 400, request id: <request_id>
│ 
│   with data.aws_acmpca_certificate_authority.this,
│   on main.tf line 14, in data "aws_acmpca_certificate_authority" "this":
│   14: data "aws_acmpca_certificate_authority" "this" {
│ 
╵
2022-11-18T19:11:47.439+0800 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2022-11-18T19:11:47.451+0800 [DEBUG] provider: plugin process exited: path=.terraform/providers/registry.terraform.io/hashicorp/aws/4.40.0/darwin_amd64/terraform-provider-aws_v4.40.0_x5 pid=18252
2022-11-18T19:11:47.451+0800 [DEBUG] provider: plugin exited
```


### Output from Acceptance Testing

I would need help running this acceptance test.

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccACMPCACertificateAuthorityDataSource_ramShared PKG=acmpca

...
```
