### PR TITLE
Don't force recreation of aws_lb_target_groups on health check modifications

### DIFF
--- a/.changelog/28018.txt
+++ b/.changelog/28018.txt
@@ -3,6 +3,10 @@ resource/aws_lb_target_group: Don't force recreation on `health_check` attribute
 ```
 
 ```release-note:bug
+resource/aws_lb_target_group: Allow `interval` to be updated for TCP health checks
+```
+
+```release-note:bug
 resource/aws_lb_target_group: Allow `timeout` to be set for TCP health checks
 ```
 

--- a/.changelog/28018.txt
+++ b/.changelog/28018.txt
@@ -1,5 +1,11 @@
 ```release-note:bug
-resource/aws_lb_target_group: Don't force recreation on `health_check` attribute changes.
-resource/aws_lb_target_group: Allow `timeout` to be set for TCP health checks.
+resource/aws_lb_target_group: Don't force recreation on `health_check` attribute changes
+```
+
+```release-note:bug
+resource/aws_lb_target_group: Allow `timeout` to be set for TCP health checks
+```
+
+```release-note:bug
 resource/aws_lb_target_group: Allow `healthy_threshold` and `unhealthy_threshold` to be set to different values for TCP health checks.
 ```

--- a/.changelog/28018.txt
+++ b/.changelog/28018.txt
@@ -1,0 +1,5 @@
+```release-note:bug
+resource/aws_lb_target_group: Don't force recreation on `health_check` attribute changes.
+resource/aws_lb_target_group: Allow `timeout` to be set for TCP health checks.
+resource/aws_lb_target_group: Allow `healthy_threshold` and `unhealthy_threshold` to be set to different values for TCP health checks.
+```

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -102,7 +102,11 @@ func ResourceTargetGroup() *schema.Resource {
 							StateFunc: func(v interface{}) string {
 								return strings.ToUpper(v.(string))
 							},
-							ValidateFunc:     validation.StringInSlice(elbv2.ProtocolEnum_Values(), false),
+							ValidateFunc: validation.StringInSlice([]string{
+								elbv2.ProtocolEnumHttp,
+								elbv2.ProtocolEnumHttps,
+								elbv2.ProtocolEnumTcp,
+							}, true),
 							DiffSuppressFunc: suppressIfTargetType(elbv2.TargetTypeEnumLambda),
 						},
 						"timeout": {

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -662,10 +662,11 @@ func resourceTargetGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 			healthCheck := healthChecks[0].(map[string]interface{})
 
 			params = &elbv2.ModifyTargetGroupInput{
-				TargetGroupArn:          aws.String(d.Id()),
-				HealthCheckEnabled:      aws.Bool(healthCheck["enabled"].(bool)),
-				HealthyThresholdCount:   aws.Int64(int64(healthCheck["healthy_threshold"].(int))),
-				UnhealthyThresholdCount: aws.Int64(int64(healthCheck["unhealthy_threshold"].(int))),
+				TargetGroupArn:             aws.String(d.Id()),
+				HealthCheckEnabled:         aws.Bool(healthCheck["enabled"].(bool)),
+				HealthCheckIntervalSeconds: aws.Int64(int64(healthCheck["interval"].(int))),
+				HealthyThresholdCount:      aws.Int64(int64(healthCheck["healthy_threshold"].(int))),
+				UnhealthyThresholdCount:    aws.Int64(int64(healthCheck["unhealthy_threshold"].(int))),
 			}
 
 			t := healthCheck["timeout"].(int)
@@ -686,7 +687,6 @@ func resourceTargetGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 					}
 				}
 				params.HealthCheckPath = aws.String(healthCheck["path"].(string))
-				params.HealthCheckIntervalSeconds = aws.Int64(int64(healthCheck["interval"].(int)))
 			}
 			if d.Get("target_type").(string) != elbv2.TargetTypeEnumLambda {
 				params.HealthCheckPort = aws.String(healthCheck["port"].(string))

--- a/internal/service/elbv2/target_group_test.go
+++ b/internal/service/elbv2/target_group_test.go
@@ -615,7 +615,6 @@ port     = 8081
 protocol = "TCP"
 matcher  = "200"
     `
-
 	healthCheckValid := `
 interval = 10
 port     = 8081

--- a/internal/service/elbv2/target_group_test.go
+++ b/internal/service/elbv2/target_group_test.go
@@ -222,38 +222,6 @@ func TestAccELBV2TargetGroup_ProtocolVersion_grpcUpdate(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_HealthCheck_tcp(t *testing.T) {
-	var targetGroup1, targetGroup2 elbv2.TargetGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_lb_target_group.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, elbv2.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckTargetGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTargetGroupConfig_typeTCPIntervalUpdated(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetGroupExists(resourceName, &targetGroup1),
-					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "TCP"),
-				),
-			},
-			{
-				Config: testAccTargetGroupConfig_typeTCPHTTPHealthCheck(rName, "/", 5),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetGroupExists(resourceName, &targetGroup2),
-					testAccCheckTargetGroupRecreated(&targetGroup1, &targetGroup2),
-					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "HTTPS"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccELBV2TargetGroup_ipAddressType(t *testing.T) {
 	var targetGroup1 elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -647,16 +615,12 @@ port     = 8081
 protocol = "TCP"
 matcher  = "200"
     `
-	healthCheckInvalid3 := `
-interval = 10
-port     = 8081
-protocol = "TCP"
-timeout  = 4
-    `
+
 	healthCheckValid := `
 interval = 10
 port     = 8081
 protocol = "TCP"
+timeout  = 4
     `
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -674,10 +638,6 @@ protocol = "TCP"
 				ExpectError: regexp.MustCompile("health_check.matcher is not supported for target_groups with TCP protocol"),
 			},
 			{
-				Config:      testAccTargetGroupConfig_nlbDefaults(rName, healthCheckInvalid3),
-				ExpectError: regexp.MustCompile("health_check.timeout is not supported for target_groups with TCP protocol"),
-			},
-			{
 				Config: testAccTargetGroupConfig_nlbDefaults(rName, healthCheckValid),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTargetGroupExists(resourceName, &conf),
@@ -692,7 +652,7 @@ protocol = "TCP"
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.interval", "10"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "8081"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "TCP"),
-					resource.TestCheckResourceAttr(resourceName, "health_check.0.timeout", "10"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.timeout", "4"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.healthy_threshold", "3"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -781,8 +741,8 @@ func TestAccELBV2TargetGroup_Name_prefix(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroup_NetworkLB_targetGroup(t *testing.T) {
-	var targetGroup1, targetGroup2, targetGroup3 elbv2.TargetGroup
+func TestAccELBV2TargetGroup_NetworkLB_tcpHealthCheckUpdated(t *testing.T) {
+	var targetGroup1, targetGroup2 elbv2.TargetGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lb_target_group.test"
 
@@ -817,11 +777,7 @@ func TestAccELBV2TargetGroup_NetworkLB_targetGroup(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccTargetGroupConfig_typeTCPInvalidThreshold(rName),
-				ExpectError: regexp.MustCompile(`health_check\.healthy_threshold [0-9]+ and health_check\.unhealthy_threshold [0-9]+ must be the same for target_groups with TCP protocol`),
-			},
-			{
-				Config: testAccTargetGroupConfig_typeTCPThresholdUpdated(rName),
+				Config: testAccTargetGroupConfig_typeTCPHealthCheckUpdated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTargetGroupExists(resourceName, &targetGroup2),
 					testAccCheckTargetGroupNotRecreated(&targetGroup1, &targetGroup2),
@@ -833,21 +789,14 @@ func TestAccELBV2TargetGroup_NetworkLB_targetGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "deregistration_delay", "200"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "health_check.0.interval", "10"),
-					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "traffic-port"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.interval", "20"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.port", "8081"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.protocol", "TCP"),
-					resource.TestCheckResourceAttr(resourceName, "health_check.0.timeout", "10"),
-					resource.TestCheckResourceAttr(resourceName, "health_check.0.healthy_threshold", "5"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.timeout", "15"),
+					resource.TestCheckResourceAttr(resourceName, "health_check.0.healthy_threshold", "4"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "5"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
-				),
-			},
-			{
-				Config: testAccTargetGroupConfig_typeTCPIntervalUpdated(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTargetGroupExists(resourceName, &targetGroup3),
-					testAccCheckTargetGroupRecreated(&targetGroup2, &targetGroup3),
 				),
 			},
 		},
@@ -2913,7 +2862,7 @@ resource "aws_vpc" "test" {
 `, rName)
 }
 
-func testAccTargetGroupConfig_typeTCPIntervalUpdated(rName string) string {
+func testAccTargetGroupConfig_typeTCPHealthCheckUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_lb_target_group" "test" {
   name     = %[1]q
@@ -2924,76 +2873,11 @@ resource "aws_lb_target_group" "test" {
   deregistration_delay = 200
 
   health_check {
-    interval            = 30
-    port                = "traffic-port"
+    interval            = 20
+    port                = "8081"
     protocol            = "TCP"
-    healthy_threshold   = 5
-    unhealthy_threshold = 5
-  }
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-`, rName)
-}
-
-func testAccTargetGroupConfig_typeTCPInvalidThreshold(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_lb_target_group" "test" {
-  name     = %[1]q
-  port     = 8082
-  protocol = "TCP"
-  vpc_id   = aws_vpc.test.id
-
-  deregistration_delay = 200
-
-  health_check {
-    interval            = 10
-    port                = "traffic-port"
-    protocol            = "TCP"
-    healthy_threshold   = 3
-    unhealthy_threshold = 4
-  }
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-`, rName)
-}
-
-func testAccTargetGroupConfig_typeTCPThresholdUpdated(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_lb_target_group" "test" {
-  name     = %[1]q
-  port     = 8082
-  protocol = "TCP"
-  vpc_id   = aws_vpc.test.id
-
-  deregistration_delay = 200
-
-  health_check {
-    interval            = 10
-    port                = "traffic-port"
-    protocol            = "TCP"
-    healthy_threshold   = 5
+    timeout             = 15
+    healthy_threshold   = 4
     unhealthy_threshold = 5
   }
 
@@ -3380,16 +3264,6 @@ func testAccCheckTargetGroupNotRecreated(i, j *elbv2.TargetGroup) resource.TestC
 	return func(s *terraform.State) error {
 		if aws.StringValue(i.TargetGroupArn) != aws.StringValue(j.TargetGroupArn) {
 			return fmt.Errorf("ELBv2 Target Group (%s) unexpectedly recreated (%s)", aws.StringValue(i.TargetGroupArn), aws.StringValue(j.TargetGroupArn))
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckTargetGroupRecreated(i, j *elbv2.TargetGroup) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if aws.StringValue(i.TargetGroupArn) == aws.StringValue(j.TargetGroupArn) {
-			return fmt.Errorf("ELBv2 Target Group (%s) not recreated", aws.StringValue(i.TargetGroupArn))
 		}
 
 		return nil

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -103,14 +103,14 @@ The following arguments are supported:
 ~> **Note:** The Health Check parameters you can set vary by the `protocol` of the Target Group. Many parameters cannot be set to custom values for `network` load balancers at this time. See http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html for a complete reference. Keep in mind, that health checks produce actual requests to the backend. The underlying function is invoked when `target_type` is set to `lambda`.
 
 * `enabled` - (Optional) Whether health checks are enabled. Defaults to `true`.
-* `healthy_threshold` - (Optional) Number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 3.
-* `interval` - (Optional) Approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds. For `lambda` target groups, it needs to be greater as the `timeout` of the underlying `lambda`. Default 30 seconds.
+* `healthy_threshold` - (Optional)  Number of consecutive health check successes required before considering a target healthy. The range is 2-10. Defaults to 3.
+* `interval` - (Optional) Approximate amount of time, in seconds, between health checks of an individual target. The range is 5-300. For `lambda` target groups, it needs to be greater than the timeout of the underlying `lambda`. Defaults to 30.
 * `matcher` (May be required) Response codes to use when checking for a healthy responses from a target. You can specify multiple values (for example, "200,202" for HTTP(s) or "0,12" for GRPC) or a range of values (for example, "200-299" or "0-99"). Required for HTTP/HTTPS/GRPC ALB. Only applies to Application Load Balancers (i.e., HTTP/HTTPS/GRPC) not Network Load Balancers (i.e., TCP).
 * `path` - (May be required) Destination for the health check request. Required for HTTP/HTTPS ALB and HTTP NLB. Only applies to HTTP/HTTPS.
-* `port` - (Optional) Port to use to connect with the target. Valid values are either ports 1-65535, or `traffic-port`. Defaults to `traffic-port`.
+* `port` - (Optional) The port the load balancer uses when performing health checks on targets. Default is traffic-port.
 * `protocol` - (Optional) Protocol to use to connect with the target. Defaults to `HTTP`. Not applicable when `target_type` is `lambda`.
-* `timeout` - (Optional) Amount of time, in seconds, during which no response means a failed health check. For Application Load Balancers, the range is 2 to 120 seconds, and the default is 5 seconds for the `instance` target type and 30 seconds for the `lambda` target type. For Network Load Balancers, you cannot set a custom value, and the default is 10 seconds for TCP and HTTPS health checks and 5 seconds for HTTP health checks.
-* `unhealthy_threshold` - (Optional) Number of consecutive health check failures required before considering the target unhealthy. For Network Load Balancers, this value must be the same as the `healthy_threshold`. Defaults to 3.
+* `timeout` - (optional) Amount of time, in seconds, during which no response from a target means a failed health check. The range is 2–120 seconds. For target groups with a protocol of HTTP, the default is 6 seconds. For target groups with a protocol of TCP, TLS or HTTPS, the default is 10 seconds. For target groups with a protocol of GENEVE, the default is 5 seconds. If the target type is lambda, the default is 30 seconds.
+* `unhealthy_threshold` - (Optional) Number of consecutive health check failures required before considering a target unhealthy. The range is 2-10. Defaults to 3.
 
 ### stickiness
 

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -108,7 +108,7 @@ The following arguments are supported:
 * `matcher` (May be required) Response codes to use when checking for a healthy responses from a target. You can specify multiple values (for example, "200,202" for HTTP(s) or "0,12" for GRPC) or a range of values (for example, "200-299" or "0-99"). Required for HTTP/HTTPS/GRPC ALB. Only applies to Application Load Balancers (i.e., HTTP/HTTPS/GRPC) not Network Load Balancers (i.e., TCP).
 * `path` - (May be required) Destination for the health check request. Required for HTTP/HTTPS ALB and HTTP NLB. Only applies to HTTP/HTTPS.
 * `port` - (Optional) The port the load balancer uses when performing health checks on targets. Default is traffic-port.
-* `protocol` - (Optional) Protocol to use to connect with the target. Defaults to `HTTP`. Not applicable when `target_type` is `lambda`.
+* `protocol` - (Optional) Protocol the load balancer uses when performing health checks on targets. Must be either `TCP`, `HTTP`, or `HTTPS`. The TCP protocol is not supported for health checks if the protocol of the target group is HTTP or HTTPS. Defaults to HTTP.
 * `timeout` - (optional) Amount of time, in seconds, during which no response from a target means a failed health check. The range is 2–120 seconds. For target groups with a protocol of HTTP, the default is 6 seconds. For target groups with a protocol of TCP, TLS or HTTPS, the default is 10 seconds. For target groups with a protocol of GENEVE, the default is 5 seconds. If the target type is lambda, the default is 30 seconds.
 * `unhealthy_threshold` - (Optional) Number of consecutive health check failures required before considering a target unhealthy. The range is 2-10. Defaults to 3.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The elbv2 API permits health checks to be modified in place, so this removes the diff customisation pieces that were forcing recreation. It also removes some additional constraints that the API has removed.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #25338

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/sdk-for-go/api/service/elbv2/#CreateTargetGroupInput

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccELBV2TargetGroup_ PKG=elbv2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 3 -run='TestAccELBV2TargetGroup_'  -timeout 180m
=== RUN   TestAccELBV2TargetGroup_backwardsCompatibility
=== PAUSE TestAccELBV2TargetGroup_backwardsCompatibility
=== RUN   TestAccELBV2TargetGroup_ProtocolVersion_basic
=== PAUSE TestAccELBV2TargetGroup_ProtocolVersion_basic
=== RUN   TestAccELBV2TargetGroup_ProtocolVersion_grpcHealthCheck
=== PAUSE TestAccELBV2TargetGroup_ProtocolVersion_grpcHealthCheck
=== RUN   TestAccELBV2TargetGroup_ProtocolVersion_grpcUpdate
=== PAUSE TestAccELBV2TargetGroup_ProtocolVersion_grpcUpdate
=== RUN   TestAccELBV2TargetGroup_ipAddressType
=== PAUSE TestAccELBV2TargetGroup_ipAddressType
=== RUN   TestAccELBV2TargetGroup_tls
=== PAUSE TestAccELBV2TargetGroup_tls
=== RUN   TestAccELBV2TargetGroup_HealthCheck_tcpHTTPS
=== PAUSE TestAccELBV2TargetGroup_HealthCheck_tcpHTTPS
=== RUN   TestAccELBV2TargetGroup_attrsOnCreate
=== PAUSE TestAccELBV2TargetGroup_attrsOnCreate
=== RUN   TestAccELBV2TargetGroup_basic
=== PAUSE TestAccELBV2TargetGroup_basic
=== RUN   TestAccELBV2TargetGroup_udp
=== PAUSE TestAccELBV2TargetGroup_udp
=== RUN   TestAccELBV2TargetGroup_ForceNew_name
=== PAUSE TestAccELBV2TargetGroup_ForceNew_name
=== RUN   TestAccELBV2TargetGroup_ForceNew_port
=== PAUSE TestAccELBV2TargetGroup_ForceNew_port
=== RUN   TestAccELBV2TargetGroup_ForceNew_protocol
=== PAUSE TestAccELBV2TargetGroup_ForceNew_protocol
=== RUN   TestAccELBV2TargetGroup_ForceNew_vpc
=== PAUSE TestAccELBV2TargetGroup_ForceNew_vpc
=== RUN   TestAccELBV2TargetGroup_Defaults_application
=== PAUSE TestAccELBV2TargetGroup_Defaults_application
=== RUN   TestAccELBV2TargetGroup_Defaults_network
=== PAUSE TestAccELBV2TargetGroup_Defaults_network
=== RUN   TestAccELBV2TargetGroup_HealthCheck_enable
=== PAUSE TestAccELBV2TargetGroup_HealthCheck_enable
=== RUN   TestAccELBV2TargetGroup_Name_generated
=== PAUSE TestAccELBV2TargetGroup_Name_generated
=== RUN   TestAccELBV2TargetGroup_Name_prefix
=== PAUSE TestAccELBV2TargetGroup_Name_prefix
=== RUN   TestAccELBV2TargetGroup_NetworkLB_tcpHealthCheckUpdated
=== PAUSE TestAccELBV2TargetGroup_NetworkLB_tcpHealthCheckUpdated
=== RUN   TestAccELBV2TargetGroup_networkLB_TargetGroupWithConnectionTermination
=== PAUSE TestAccELBV2TargetGroup_networkLB_TargetGroupWithConnectionTermination
=== RUN   TestAccELBV2TargetGroup_NetworkLB_targetGroupWithProxy
=== PAUSE TestAccELBV2TargetGroup_NetworkLB_targetGroupWithProxy
=== RUN   TestAccELBV2TargetGroup_preserveClientIPValid
=== PAUSE TestAccELBV2TargetGroup_preserveClientIPValid
=== RUN   TestAccELBV2TargetGroup_Geneve_basic
=== PAUSE TestAccELBV2TargetGroup_Geneve_basic
=== RUN   TestAccELBV2TargetGroup_Geneve_notSticky
=== PAUSE TestAccELBV2TargetGroup_Geneve_notSticky
=== RUN   TestAccELBV2TargetGroup_Geneve_Sticky
=== PAUSE TestAccELBV2TargetGroup_Geneve_Sticky
=== RUN   TestAccELBV2TargetGroup_Geneve_targetFailover
=== PAUSE TestAccELBV2TargetGroup_Geneve_targetFailover
=== RUN   TestAccELBV2TargetGroup_Stickiness_defaultALB
=== PAUSE TestAccELBV2TargetGroup_Stickiness_defaultALB
=== RUN   TestAccELBV2TargetGroup_Stickiness_defaultNLB
=== PAUSE TestAccELBV2TargetGroup_Stickiness_defaultNLB
=== RUN   TestAccELBV2TargetGroup_Stickiness_invalidALB
=== PAUSE TestAccELBV2TargetGroup_Stickiness_invalidALB
=== RUN   TestAccELBV2TargetGroup_Stickiness_invalidNLB
=== PAUSE TestAccELBV2TargetGroup_Stickiness_invalidNLB
=== RUN   TestAccELBV2TargetGroup_Stickiness_validALB
=== PAUSE TestAccELBV2TargetGroup_Stickiness_validALB
=== RUN   TestAccELBV2TargetGroup_Stickiness_validNLB
=== PAUSE TestAccELBV2TargetGroup_Stickiness_validNLB
=== RUN   TestAccELBV2TargetGroup_tags
=== PAUSE TestAccELBV2TargetGroup_tags
=== RUN   TestAccELBV2TargetGroup_Stickiness_updateAppEnabled
=== PAUSE TestAccELBV2TargetGroup_Stickiness_updateAppEnabled
=== RUN   TestAccELBV2TargetGroup_HealthCheck_update
=== PAUSE TestAccELBV2TargetGroup_HealthCheck_update
=== RUN   TestAccELBV2TargetGroup_Stickiness_updateEnabled
=== PAUSE TestAccELBV2TargetGroup_Stickiness_updateEnabled
=== RUN   TestAccELBV2TargetGroup_HealthCheck_without
=== PAUSE TestAccELBV2TargetGroup_HealthCheck_without
=== RUN   TestAccELBV2TargetGroup_ALBAlias_basic
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_basic
=== RUN   TestAccELBV2TargetGroup_ALBAlias_changeNameForceNew
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_changeNameForceNew
=== RUN   TestAccELBV2TargetGroup_ALBAlias_changePortForceNew
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_changePortForceNew
=== RUN   TestAccELBV2TargetGroup_ALBAlias_changeProtocolForceNew
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_changeProtocolForceNew
=== RUN   TestAccELBV2TargetGroup_ALBAlias_changeVPCForceNew
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_changeVPCForceNew
=== RUN   TestAccELBV2TargetGroup_ALBAlias_generatedName
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_generatedName
=== RUN   TestAccELBV2TargetGroup_ALBAlias_lambda
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_lambda
=== RUN   TestAccELBV2TargetGroup_ALBAlias_lambdaMultiValueHeadersEnabled
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_lambdaMultiValueHeadersEnabled
=== RUN   TestAccELBV2TargetGroup_ALBAlias_missingPortProtocolVPC
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_missingPortProtocolVPC
=== RUN   TestAccELBV2TargetGroup_ALBAlias_namePrefix
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_namePrefix
=== RUN   TestAccELBV2TargetGroup_ALBAlias_setAndUpdateSlowStart
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_setAndUpdateSlowStart
=== RUN   TestAccELBV2TargetGroup_ALBAlias_tags
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_tags
=== RUN   TestAccELBV2TargetGroup_ALBAlias_updateHealthCheck
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_updateHealthCheck
=== RUN   TestAccELBV2TargetGroup_ALBAlias_updateLoadBalancingAlgorithmType
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_updateLoadBalancingAlgorithmType
=== RUN   TestAccELBV2TargetGroup_ALBAlias_updateStickinessEnabled
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_updateStickinessEnabled
=== CONT  TestAccELBV2TargetGroup_backwardsCompatibility
=== CONT  TestAccELBV2TargetGroup_Stickiness_invalidALB
=== CONT  TestAccELBV2TargetGroup_Defaults_network
--- PASS: TestAccELBV2TargetGroup_backwardsCompatibility (15.68s)
=== CONT  TestAccELBV2TargetGroup_ALBAlias_changeProtocolForceNew
--- PASS: TestAccELBV2TargetGroup_Defaults_network (17.85s)
=== CONT  TestAccELBV2TargetGroup_ALBAlias_updateStickinessEnabled
--- PASS: TestAccELBV2TargetGroup_Stickiness_invalidALB (30.93s)
=== CONT  TestAccELBV2TargetGroup_ALBAlias_updateLoadBalancingAlgorithmType
--- PASS: TestAccELBV2TargetGroup_ALBAlias_changeProtocolForceNew (31.46s)
=== CONT  TestAccELBV2TargetGroup_ALBAlias_updateHealthCheck
--- PASS: TestAccELBV2TargetGroup_ALBAlias_updateStickinessEnabled (43.44s)
=== CONT  TestAccELBV2TargetGroup_ALBAlias_tags
--- PASS: TestAccELBV2TargetGroup_ALBAlias_updateLoadBalancingAlgorithmType (43.05s)
=== CONT  TestAccELBV2TargetGroup_ALBAlias_setAndUpdateSlowStart
--- PASS: TestAccELBV2TargetGroup_ALBAlias_updateHealthCheck (30.14s)
=== CONT  TestAccELBV2TargetGroup_ALBAlias_namePrefix
--- PASS: TestAccELBV2TargetGroup_ALBAlias_tags (31.00s)
=== CONT  TestAccELBV2TargetGroup_ALBAlias_missingPortProtocolVPC
--- PASS: TestAccELBV2TargetGroup_ALBAlias_namePrefix (16.60s)
=== CONT  TestAccELBV2TargetGroup_ALBAlias_lambdaMultiValueHeadersEnabled
--- PASS: TestAccELBV2TargetGroup_ALBAlias_setAndUpdateSlowStart (31.06s)
=== CONT  TestAccELBV2TargetGroup_ALBAlias_lambda
--- PASS: TestAccELBV2TargetGroup_ALBAlias_missingPortProtocolVPC (19.31s)
=== CONT  TestAccELBV2TargetGroup_ALBAlias_generatedName
--- PASS: TestAccELBV2TargetGroup_ALBAlias_lambda (18.38s)
=== CONT  TestAccELBV2TargetGroup_ALBAlias_changeVPCForceNew
--- PASS: TestAccELBV2TargetGroup_ALBAlias_generatedName (18.14s)
=== CONT  TestAccELBV2TargetGroup_preserveClientIPValid
--- PASS: TestAccELBV2TargetGroup_ALBAlias_lambdaMultiValueHeadersEnabled (41.91s)
=== CONT  TestAccELBV2TargetGroup_Stickiness_defaultNLB
--- PASS: TestAccELBV2TargetGroup_ALBAlias_changeVPCForceNew (30.30s)
=== CONT  TestAccELBV2TargetGroup_Stickiness_defaultALB
--- PASS: TestAccELBV2TargetGroup_preserveClientIPValid (30.50s)
=== CONT  TestAccELBV2TargetGroup_Geneve_targetFailover
--- PASS: TestAccELBV2TargetGroup_Stickiness_defaultALB (16.71s)
=== CONT  TestAccELBV2TargetGroup_Geneve_Sticky
--- PASS: TestAccELBV2TargetGroup_Stickiness_defaultNLB (45.47s)
=== CONT  TestAccELBV2TargetGroup_Geneve_notSticky
--- PASS: TestAccELBV2TargetGroup_Geneve_targetFailover (36.72s)
=== CONT  TestAccELBV2TargetGroup_Geneve_basic
--- PASS: TestAccELBV2TargetGroup_Geneve_Sticky (31.48s)
=== CONT  TestAccELBV2TargetGroup_NetworkLB_targetGroupWithProxy
--- PASS: TestAccELBV2TargetGroup_Geneve_notSticky (31.84s)
=== CONT  TestAccELBV2TargetGroup_basic
--- PASS: TestAccELBV2TargetGroup_Geneve_basic (20.65s)
=== CONT  TestAccELBV2TargetGroup_Defaults_application
--- PASS: TestAccELBV2TargetGroup_basic (17.16s)
=== CONT  TestAccELBV2TargetGroup_ForceNew_vpc
--- PASS: TestAccELBV2TargetGroup_NetworkLB_targetGroupWithProxy (30.46s)
=== CONT  TestAccELBV2TargetGroup_ForceNew_protocol
--- PASS: TestAccELBV2TargetGroup_Defaults_application (16.80s)
=== CONT  TestAccELBV2TargetGroup_ForceNew_port
--- PASS: TestAccELBV2TargetGroup_ForceNew_vpc (29.91s)
=== CONT  TestAccELBV2TargetGroup_ForceNew_name
--- PASS: TestAccELBV2TargetGroup_ForceNew_protocol (31.40s)
=== CONT  TestAccELBV2TargetGroup_NetworkLB_tcpHealthCheckUpdated
--- PASS: TestAccELBV2TargetGroup_ForceNew_port (31.86s)
=== CONT  TestAccELBV2TargetGroup_networkLB_TargetGroupWithConnectionTermination
--- PASS: TestAccELBV2TargetGroup_ForceNew_name (33.11s)
=== CONT  TestAccELBV2TargetGroup_ipAddressType
--- PASS: TestAccELBV2TargetGroup_NetworkLB_tcpHealthCheckUpdated (30.64s)
=== CONT  TestAccELBV2TargetGroup_udp
--- PASS: TestAccELBV2TargetGroup_networkLB_TargetGroupWithConnectionTermination (31.25s)
=== CONT  TestAccELBV2TargetGroup_HealthCheck_tcpHTTPS
--- PASS: TestAccELBV2TargetGroup_udp (17.57s)
=== CONT  TestAccELBV2TargetGroup_HealthCheck_update
--- PASS: TestAccELBV2TargetGroup_ipAddressType (20.46s)
=== CONT  TestAccELBV2TargetGroup_ALBAlias_changePortForceNew
--- PASS: TestAccELBV2TargetGroup_HealthCheck_tcpHTTPS (31.20s)
=== CONT  TestAccELBV2TargetGroup_ALBAlias_changeNameForceNew
--- PASS: TestAccELBV2TargetGroup_HealthCheck_update (30.98s)
=== CONT  TestAccELBV2TargetGroup_attrsOnCreate
--- PASS: TestAccELBV2TargetGroup_ALBAlias_changePortForceNew (30.94s)
=== CONT  TestAccELBV2TargetGroup_tls
--- PASS: TestAccELBV2TargetGroup_ALBAlias_changeNameForceNew (32.20s)
=== CONT  TestAccELBV2TargetGroup_ProtocolVersion_grpcHealthCheck
--- PASS: TestAccELBV2TargetGroup_tls (17.13s)
=== CONT  TestAccELBV2TargetGroup_ProtocolVersion_grpcUpdate
--- PASS: TestAccELBV2TargetGroup_attrsOnCreate (31.77s)
=== CONT  TestAccELBV2TargetGroup_ALBAlias_basic
--- PASS: TestAccELBV2TargetGroup_ProtocolVersion_grpcHealthCheck (17.96s)
=== CONT  TestAccELBV2TargetGroup_Name_generated
--- PASS: TestAccELBV2TargetGroup_ALBAlias_basic (17.38s)
=== CONT  TestAccELBV2TargetGroup_Name_prefix
--- PASS: TestAccELBV2TargetGroup_ProtocolVersion_grpcUpdate (33.83s)
=== CONT  TestAccELBV2TargetGroup_Stickiness_validNLB
--- PASS: TestAccELBV2TargetGroup_Name_generated (17.82s)
=== CONT  TestAccELBV2TargetGroup_Stickiness_updateAppEnabled
--- PASS: TestAccELBV2TargetGroup_Name_prefix (18.76s)
=== CONT  TestAccELBV2TargetGroup_tags
--- PASS: TestAccELBV2TargetGroup_Stickiness_updateAppEnabled (46.26s)
=== CONT  TestAccELBV2TargetGroup_HealthCheck_without
--- PASS: TestAccELBV2TargetGroup_Stickiness_validNLB (60.64s)
=== CONT  TestAccELBV2TargetGroup_Stickiness_updateEnabled
--- PASS: TestAccELBV2TargetGroup_tags (46.93s)
=== CONT  TestAccELBV2TargetGroup_ProtocolVersion_basic
--- PASS: TestAccELBV2TargetGroup_HealthCheck_without (15.59s)
=== CONT  TestAccELBV2TargetGroup_HealthCheck_enable
--- PASS: TestAccELBV2TargetGroup_ProtocolVersion_basic (17.69s)
=== CONT  TestAccELBV2TargetGroup_Stickiness_validALB
--- PASS: TestAccELBV2TargetGroup_HealthCheck_enable (27.58s)
=== CONT  TestAccELBV2TargetGroup_Stickiness_invalidNLB
--- PASS: TestAccELBV2TargetGroup_Stickiness_updateEnabled (46.69s)
--- PASS: TestAccELBV2TargetGroup_Stickiness_validALB (33.15s)
--- PASS: TestAccELBV2TargetGroup_Stickiness_invalidNLB (27.78s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	514.016s
```
