### PR TITLE
aws_memorydb_cluster: add data_tiering attribute and allow more than one snapshot ARN

### DIFF
--- a/.changelog/28022.txt
+++ b/.changelog/28022.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_memorydb_cluster: Add `data_tiering` attribute
+```
+
+```release-note:enhancement
+data-source/aws_memorydb_cluster: Add `data_tiering` attribute
+```
+
+```release-note:bug
+resource/aws_memorydb_cluster: Allow more than one element in `snapshot_arns`
+```

--- a/internal/service/memorydb/cluster.go
+++ b/internal/service/memorydb/cluster.go
@@ -195,7 +195,6 @@ func ResourceCluster() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				ForceNew:      true,
-				MaxItems:      1,
 				ConflictsWith: []string{"snapshot_name"},
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/internal/service/memorydb/cluster.go
+++ b/internal/service/memorydb/cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -56,6 +57,12 @@ func ResourceCluster() *schema.Resource {
 				ForceNew: true,
 			},
 			"cluster_endpoint": endpointSchema(),
+			"data_tiering": {
+				Type:     schema.TypeBool,
+				ForceNew: true,
+				Optional: true,
+				Default:  false,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -275,6 +282,10 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		TLSEnabled:              aws.Bool(d.Get("tls_enabled").(bool)),
 	}
 
+	if v, ok := d.GetOk("data_tiering"); ok {
+		input.DataTiering = aws.Bool(v.(bool))
+	}
+
 	if v, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(v.(string))
 	}
@@ -488,6 +499,15 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if v := cluster.ClusterEndpoint; v != nil {
 		d.Set("cluster_endpoint", flattenEndpoint(v))
 		d.Set("port", v.Port)
+	}
+
+	if v := aws.StringValue(cluster.DataTiering); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return diag.Errorf("error reading data_tiering for MemoryDB Cluster (%s): %s", d.Id(), err)
+		}
+
+		d.Set("data_tiering", b)
 	}
 
 	d.Set("description", cluster.Description)

--- a/internal/service/memorydb/cluster_data_source.go
+++ b/internal/service/memorydb/cluster_data_source.go
@@ -2,6 +2,7 @@ package memorydb
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -30,6 +31,10 @@ func DataSourceCluster() *schema.Resource {
 				Computed: true,
 			},
 			"cluster_endpoint": endpointSchema(),
+			"data_tiering": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -174,6 +179,15 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 	if v := cluster.ClusterEndpoint; v != nil {
 		d.Set("cluster_endpoint", flattenEndpoint(v))
 		d.Set("port", v.Port)
+	}
+
+	if v := aws.StringValue(cluster.DataTiering); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return diag.Errorf("error reading data_tiering for MemoryDB Cluster (%s): %s", d.Id(), err)
+		}
+
+		d.Set("data_tiering", b)
 	}
 
 	d.Set("description", cluster.Description)

--- a/internal/service/memorydb/cluster_data_source_test.go
+++ b/internal/service/memorydb/cluster_data_source_test.go
@@ -28,6 +28,7 @@ func TestAccMemoryDBClusterDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "auto_minor_version_upgrade", resourceName, "auto_minor_version_upgrade"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_endpoint.0.address", resourceName, "cluster_endpoint.0.address"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_endpoint.0.port", resourceName, "cluster_endpoint.0.port"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "data_tiering", resourceName, "data_tiering"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "engine_patch_version", resourceName, "engine_patch_version"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "engine_version", resourceName, "engine_version"),

--- a/internal/service/memorydb/cluster_test.go
+++ b/internal/service/memorydb/cluster_test.go
@@ -35,6 +35,7 @@ func TestAccMemoryDBCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
 					resource.TestMatchResourceAttr(resourceName, "cluster_endpoint.0.address", regexp.MustCompile(`^clustercfg\..*?\.amazonaws\.com$`)),
 					resource.TestCheckResourceAttr(resourceName, "cluster_endpoint.0.port", "6379"),
+					resource.TestCheckResourceAttr(resourceName, "data_tiering", "false"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Managed by Terraform"),
 					resource.TestCheckResourceAttrSet(resourceName, "engine_patch_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
@@ -95,6 +96,7 @@ func TestAccMemoryDBCluster_defaults(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "cluster_endpoint.0.address"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_endpoint.0.port", "6379"),
+					resource.TestCheckResourceAttr(resourceName, "data_tiering", "false"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Managed by Terraform"),
 					resource.TestCheckResourceAttrSet(resourceName, "engine_patch_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
@@ -207,6 +209,32 @@ func TestAccMemoryDBCluster_create_noTLS(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tls_enabled", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccMemoryDBCluster_create_withDataTiering(t *testing.T) {
+	rName := "tf-test-" + sdkacctest.RandString(8)
+	resourceName := "aws_memorydb_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, memorydb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_dataTiering(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "data_tiering", "true"),
 				),
 			},
 			{
@@ -1194,6 +1222,21 @@ resource "aws_memorydb_cluster" "test" {
   subnet_group_name      = aws_memorydb_subnet_group.test.id
 }
 `, rName, aclName),
+	)
+}
+
+func testAccClusterConfig_dataTiering(rName string) string {
+	return acctest.ConfigCompose(
+		testAccClusterConfig_baseNetwork(rName),
+		fmt.Sprintf(`
+resource "aws_memorydb_cluster" "test" {
+  acl_name          = "open-access"
+  data_tiering      = true
+  name              = %[1]q
+  node_type         = "db.r6gd.xlarge"
+  subnet_group_name = aws_memorydb_subnet_group.test.id
+}
+`, rName),
 	)
 }
 

--- a/website/docs/d/memorydb_cluster.html.markdown
+++ b/website/docs/d/memorydb_cluster.html.markdown
@@ -35,6 +35,7 @@ In addition, the following attributes are exported:
 * `cluster_endpoint`
     * `address` - DNS hostname of the cluster configuration endpoint.
     * `port` - Port number that the cluster configuration endpoint is listening on.
+* `data_tiering` - True when data tiering is enabled.
 * `description` - Description for the cluster.
 * `engine_patch_version` - Patch version number of the Redis engine used by the cluster.
 * `engine_version` - Version number of the Redis engine used by the cluster.

--- a/website/docs/r/memorydb_cluster.html.markdown
+++ b/website/docs/r/memorydb_cluster.html.markdown
@@ -36,6 +36,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `auto_minor_version_upgrade` - (Optional, Forces new resource) When set to `true`, the cluster will automatically receive minor engine version upgrades after launch. Defaults to `true`.
+* `data_tiering` - (Optional, Forces new resource) Enables data tiering. This option is not supported by all instance types. For more information, see [Data tiering](https://docs.aws.amazon.com/memorydb/latest/devguide/data-tiering.html).
 * `description` - (Optional) Description for the cluster. Defaults to `"Managed by Terraform"`.
 * `engine_version` - (Optional) Version number of the Redis engine to be used for the cluster. Downgrades are not supported.
 * `final_snapshot_name` - (Optional) Name of the final cluster snapshot to be created when this resource is deleted. If omitted, no final snapshot will be made.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

- Removes the `MaxItems: 1` restriction of the `snapshot_arns` attribute (the API doesn't document a limit).
- Adds the `data_tiering` attribute to the resource and data source (https://aws.amazon.com/about-aws/whats-new/2022/11/amazon-memorydb-redis-data-tiering/).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/25780

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- https://aws.amazon.com/about-aws/whats-new/2022/11/amazon-memorydb-redis-data-tiering/

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccMemoryDBCluster_ PKG=memorydb ACCTEST_TIMEOUT=600m ACCTEST_PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/memorydb/... -v -count 1 -parallel 5 -run='TestAccMemoryDBCluster_'  -timeout 600m
=== RUN   TestAccMemoryDBCluster_basic
=== PAUSE TestAccMemoryDBCluster_basic
=== RUN   TestAccMemoryDBCluster_defaults
=== PAUSE TestAccMemoryDBCluster_defaults
=== RUN   TestAccMemoryDBCluster_disappears
=== PAUSE TestAccMemoryDBCluster_disappears
=== RUN   TestAccMemoryDBCluster_nameGenerated
=== PAUSE TestAccMemoryDBCluster_nameGenerated
=== RUN   TestAccMemoryDBCluster_namePrefix
=== PAUSE TestAccMemoryDBCluster_namePrefix
=== RUN   TestAccMemoryDBCluster_create_noTLS
=== PAUSE TestAccMemoryDBCluster_create_noTLS
=== RUN   TestAccMemoryDBCluster_create_withDataTiering
=== PAUSE TestAccMemoryDBCluster_create_withDataTiering
=== RUN   TestAccMemoryDBCluster_create_withKMS
=== PAUSE TestAccMemoryDBCluster_create_withKMS
=== RUN   TestAccMemoryDBCluster_create_withPort
=== PAUSE TestAccMemoryDBCluster_create_withPort
=== RUN   TestAccMemoryDBCluster_create_fromSnapshot
=== PAUSE TestAccMemoryDBCluster_create_fromSnapshot
=== RUN   TestAccMemoryDBCluster_delete_withFinalSnapshot
=== PAUSE TestAccMemoryDBCluster_delete_withFinalSnapshot
=== RUN   TestAccMemoryDBCluster_Update_aclName
=== PAUSE TestAccMemoryDBCluster_Update_aclName
=== RUN   TestAccMemoryDBCluster_Update_description
=== PAUSE TestAccMemoryDBCluster_Update_description
=== RUN   TestAccMemoryDBCluster_Update_engineVersion
=== PAUSE TestAccMemoryDBCluster_Update_engineVersion
=== RUN   TestAccMemoryDBCluster_Update_maintenanceWindow
=== PAUSE TestAccMemoryDBCluster_Update_maintenanceWindow
=== RUN   TestAccMemoryDBCluster_Update_nodeType
=== PAUSE TestAccMemoryDBCluster_Update_nodeType
=== RUN   TestAccMemoryDBCluster_Update_numShards_scaleUp
=== PAUSE TestAccMemoryDBCluster_Update_numShards_scaleUp
=== RUN   TestAccMemoryDBCluster_Update_numShards_scaleDown
=== PAUSE TestAccMemoryDBCluster_Update_numShards_scaleDown
=== RUN   TestAccMemoryDBCluster_Update_numReplicasPerShard_scaleUp
=== PAUSE TestAccMemoryDBCluster_Update_numReplicasPerShard_scaleUp
=== RUN   TestAccMemoryDBCluster_Update_numReplicasPerShard_scaleDown
=== PAUSE TestAccMemoryDBCluster_Update_numReplicasPerShard_scaleDown
=== RUN   TestAccMemoryDBCluster_Update_parameterGroup
=== PAUSE TestAccMemoryDBCluster_Update_parameterGroup
=== RUN   TestAccMemoryDBCluster_Update_securityGroupIds
=== PAUSE TestAccMemoryDBCluster_Update_securityGroupIds
=== RUN   TestAccMemoryDBCluster_Update_snapshotRetentionLimit
=== PAUSE TestAccMemoryDBCluster_Update_snapshotRetentionLimit
=== RUN   TestAccMemoryDBCluster_Update_snapshotWindow
=== PAUSE TestAccMemoryDBCluster_Update_snapshotWindow
=== RUN   TestAccMemoryDBCluster_Update_snsTopicARN
=== PAUSE TestAccMemoryDBCluster_Update_snsTopicARN
=== RUN   TestAccMemoryDBCluster_Update_tags
=== PAUSE TestAccMemoryDBCluster_Update_tags
=== CONT  TestAccMemoryDBCluster_basic
=== CONT  TestAccMemoryDBCluster_Update_engineVersion
=== CONT  TestAccMemoryDBCluster_Update_parameterGroup
=== CONT  TestAccMemoryDBCluster_Update_numShards_scaleDown
=== CONT  TestAccMemoryDBCluster_create_withKMS
--- PASS: TestAccMemoryDBCluster_create_withKMS (815.33s)
=== CONT  TestAccMemoryDBCluster_Update_description
--- PASS: TestAccMemoryDBCluster_Update_engineVersion (815.59s)
=== CONT  TestAccMemoryDBCluster_Update_aclName
    cluster_test.go:373: Step 1/4 error: Error running apply: exit status 1

        Error: error creating MemoryDB Cluster (tf-test-6aighuv2): RequestError: send request failed
        caused by: Post "https://memory-db.eu-west-1.amazonaws.com/": read tcp 192.168.1.105:55439->52.94.220.13:443: read: connection reset by peer

          with aws_memorydb_cluster.test,
          on terraform_plugin_test.tf line 51, in resource "aws_memorydb_cluster" "test":
          51: resource "aws_memorydb_cluster" "test" {

    testing_new.go:84: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: error deleting MemoryDB ACL (tf-test-6aighuv2): InvalidACLStateFault: ACL tf-test-6aighuv2 can't be deleted because it is still associated with some of the cluster(s).


        Error: error deleting MemoryDB Subnet Group (terraform-20221125121423748200000007): SubnetGroupInUseFault: Subnet group terraform-20221125121423748200000007 is currently in use by a cluster.

--- FAIL: TestAccMemoryDBCluster_Update_aclName (69.33s)
=== CONT  TestAccMemoryDBCluster_delete_withFinalSnapshot
--- PASS: TestAccMemoryDBCluster_Update_parameterGroup (914.72s)
=== CONT  TestAccMemoryDBCluster_create_fromSnapshot
--- PASS: TestAccMemoryDBCluster_basic (923.50s)
=== CONT  TestAccMemoryDBCluster_create_withPort
--- PASS: TestAccMemoryDBCluster_Update_numShards_scaleDown (1979.99s)
=== CONT  TestAccMemoryDBCluster_Update_nodeType
=== CONT  TestAccMemoryDBCluster_Update_numShards_scaleUp
--- PASS: TestAccMemoryDBCluster_Update_description (1229.16s)
--- PASS: TestAccMemoryDBCluster_create_withPort (1122.24s)
=== CONT  TestAccMemoryDBCluster_Update_maintenanceWindow
--- PASS: TestAccMemoryDBCluster_delete_withFinalSnapshot (2213.81s)
=== CONT  TestAccMemoryDBCluster_Update_numReplicasPerShard_scaleDown
--- PASS: TestAccMemoryDBCluster_Update_maintenanceWindow (1254.56s)
=== CONT  TestAccMemoryDBCluster_Update_tags
--- PASS: TestAccMemoryDBCluster_Update_nodeType (2098.77s)
=== CONT  TestAccMemoryDBCluster_namePrefix
--- PASS: TestAccMemoryDBCluster_create_fromSnapshot (3264.66s)
=== CONT  TestAccMemoryDBCluster_create_withDataTiering
--- PASS: TestAccMemoryDBCluster_Update_tags (1150.52s)
=== CONT  TestAccMemoryDBCluster_Update_snapshotWindow
--- PASS: TestAccMemoryDBCluster_Update_numReplicasPerShard_scaleDown (1626.62s)
=== CONT  TestAccMemoryDBCluster_Update_snsTopicARN
--- PASS: TestAccMemoryDBCluster_namePrefix (1107.78s)
=== CONT  TestAccMemoryDBCluster_Update_numReplicasPerShard_scaleUp
--- PASS: TestAccMemoryDBCluster_create_withDataTiering (1234.63s)
=== CONT  TestAccMemoryDBCluster_Update_snapshotRetentionLimit
--- PASS: TestAccMemoryDBCluster_Update_numShards_scaleUp (3371.01s)
=== CONT  TestAccMemoryDBCluster_Update_securityGroupIds
--- PASS: TestAccMemoryDBCluster_Update_snapshotWindow (1180.90s)
=== CONT  TestAccMemoryDBCluster_nameGenerated
--- PASS: TestAccMemoryDBCluster_Update_snsTopicARN (1130.76s)
=== CONT  TestAccMemoryDBCluster_defaults
--- PASS: TestAccMemoryDBCluster_Update_snapshotRetentionLimit (1214.42s)
=== CONT  TestAccMemoryDBCluster_create_noTLS
--- PASS: TestAccMemoryDBCluster_Update_securityGroupIds (1337.63s)
=== CONT  TestAccMemoryDBCluster_disappears
--- PASS: TestAccMemoryDBCluster_nameGenerated (1168.02s)
--- PASS: TestAccMemoryDBCluster_Update_numReplicasPerShard_scaleUp (1689.66s)
--- PASS: TestAccMemoryDBCluster_defaults (1290.65s)
--- PASS: TestAccMemoryDBCluster_create_noTLS (1110.28s)
--- PASS: TestAccMemoryDBCluster_disappears (1715.55s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/memorydb   8470.517s
FAIL
make: *** [testacc] Error 1

$ make testacc TESTS=TestAccMemoryDBCluster_Update_aclName PKG=memorydb ACCTEST_TIMEOUT=600m ACCTEST_PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/memorydb/... -v -count 1 -parallel 5 -run='TestAccMemoryDBCluster_Update_aclName'  -timeout 600m
=== RUN   TestAccMemoryDBCluster_Update_aclName
=== PAUSE TestAccMemoryDBCluster_Update_aclName
=== CONT  TestAccMemoryDBCluster_Update_aclName
--- PASS: TestAccMemoryDBCluster_Update_aclName (1232.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/memorydb   1234.412s

$ make testacc TESTS=TestAccMemoryDBClusterDataSource_ PKG=memorydb ACCTEST_TIMEOUT=600m ACCTEST_PARALLELISM=5
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/memorydb/... -v -count 1 -parallel 5 -run='TestAccMemoryDBClusterDataSource_'  -timeout 600m
=== RUN   TestAccMemoryDBClusterDataSource_basic
=== PAUSE TestAccMemoryDBClusterDataSource_basic
=== CONT  TestAccMemoryDBClusterDataSource_basic
--- PASS: TestAccMemoryDBClusterDataSource_basic (1639.73s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/memorydb   1641.575s
```
