### PR TITLE
r/sagemaker_user_profile - make user settings updateable + better response on error for sagemaker studio resources

### DIFF
--- a/.changelog/28025.txt
+++ b/.changelog/28025.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sagemaker_user_profile: `user_settings.jupyter_server_app_settings`, `user_settings.kernel_gateway_app_settings`, and `user_settings.tensor_board_app_settings` are updateable 
+```

--- a/internal/service/sagemaker/status.go
+++ b/internal/service/sagemaker/status.go
@@ -143,6 +143,10 @@ func StatusDomain(conn *sagemaker.SageMaker, domainID string) resource.StateRefr
 			return nil, domainStatusNotFound, nil
 		}
 
+		if aws.StringValue(output.Status) == sagemaker.DomainStatusFailed {
+			return output, sagemaker.DomainStatusFailed, fmt.Errorf("%s", aws.StringValue(output.FailureReason))
+		}
+
 		return output, aws.StringValue(output.Status), nil
 	}
 }
@@ -201,6 +205,10 @@ func StatusUserProfile(conn *sagemaker.SageMaker, domainID, userProfileName stri
 			return nil, userProfileStatusNotFound, nil
 		}
 
+		if aws.StringValue(output.Status) == sagemaker.UserProfileStatusFailed {
+			return output, sagemaker.UserProfileStatusFailed, fmt.Errorf("%s", aws.StringValue(output.FailureReason))
+		}
+
 		return output, aws.StringValue(output.Status), nil
 	}
 }
@@ -227,6 +235,10 @@ func StatusApp(conn *sagemaker.SageMaker, domainID, userProfileName, appType, ap
 
 		if output == nil {
 			return nil, appStatusNotFound, nil
+		}
+
+		if aws.StringValue(output.Status) == sagemaker.AppStatusFailed {
+			return output, sagemaker.AppStatusFailed, fmt.Errorf("%s", aws.StringValue(output.FailureReason))
 		}
 
 		return output, aws.StringValue(output.Status), nil

--- a/internal/service/sagemaker/user_profile.go
+++ b/internal/service/sagemaker/user_profile.go
@@ -98,7 +98,6 @@ func ResourceUserProfile() *schema.Resource {
 						"jupyter_server_app_settings": {
 							Type:     schema.TypeList,
 							Optional: true,
-							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -145,7 +144,6 @@ func ResourceUserProfile() *schema.Resource {
 						"kernel_gateway_app_settings": {
 							Type:     schema.TypeList,
 							Optional: true,
-							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -278,7 +276,6 @@ func ResourceUserProfile() *schema.Resource {
 						"sharing_settings": {
 							Type:     schema.TypeList,
 							Optional: true,
-							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -303,7 +300,6 @@ func ResourceUserProfile() *schema.Resource {
 						"tensor_board_app_settings": {
 							Type:     schema.TypeList,
 							Optional: true,
-							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/internal/service/sagemaker/user_profile_test.go
+++ b/internal/service/sagemaker/user_profile_test.go
@@ -136,7 +136,7 @@ func testAccUserProfile_tensorboardAppSettingsWithImage(t *testing.T) {
 		CheckDestroy:             testAccCheckUserProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserProfileConfig_tensorBoardAppSettingsImage(rName),
+				Config: testAccUserProfileConfig_tensorBoardAppSettingsImage(rName, "ml.t3.micro"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserProfileExists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "1"),
@@ -150,6 +150,17 @@ func testAccUserProfile_tensorboardAppSettingsWithImage(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccUserProfileConfig_tensorBoardAppSettingsImage(rName, "ml.t3.small"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserProfileExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.0.tensor_board_app_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.0.tensor_board_app_settings.0.default_resource_spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.0.tensor_board_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.small"),
+					resource.TestCheckResourceAttrPair(resourceName, "user_settings.0.tensor_board_app_settings.0.default_resource_spec.0.sagemaker_image_arn", "aws_sagemaker_image.test", "arn"),
+				),
 			},
 		},
 	})
@@ -455,7 +466,7 @@ resource "aws_sagemaker_user_profile" "test" {
 `, rName))
 }
 
-func testAccUserProfileConfig_tensorBoardAppSettingsImage(rName string) string {
+func testAccUserProfileConfig_tensorBoardAppSettingsImage(rName, instanceType string) string {
 	return acctest.ConfigCompose(testAccUserProfileConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_image" "test" {
   image_name = %[1]q
@@ -471,13 +482,13 @@ resource "aws_sagemaker_user_profile" "test" {
 
     tensor_board_app_settings {
       default_resource_spec {
-        instance_type       = "ml.t3.micro"
+        instance_type       = %[2]q
         sagemaker_image_arn = aws_sagemaker_image.test.arn
       }
     }
   }
 }
-`, rName))
+`, rName, instanceType))
 }
 
 func testAccUserProfileConfig_jupyterServerAppSettings(rName string) string {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #27265

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccSageMaker_serial/UserProfile/tensorboardAppSettingsWithImage
--- PASS: TestAccSageMaker_serial (304.45s)
    --- PASS: TestAccSageMaker_serial/UserProfile (304.45s)
        --- PASS: TestAccSageMaker_serial/UserProfile/tensorboardAppSettingsWithImage (304.45s)
```
