### PR TITLE
redshift serverless creds data source

### DIFF
--- a/.changelog/28026.txt
+++ b/.changelog/28026.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_redshiftserverless_credentials
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -848,6 +848,8 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_redshift_service_account":     redshift.DataSourceServiceAccount(),
 			"aws_redshift_subnet_group":        redshift.DataSourceSubnetGroup(),
 
+			"aws_redshiftserverless_credentials": redshiftserverless.DataSourceCredentials(),
+
 			"aws_resourcegroupstaggingapi_resources": resourcegroupstaggingapi.DataSourceResources(),
 
 			"aws_route53_delegation_set":          route53.DataSourceDelegationSet(),

--- a/internal/service/redshiftserverless/credentials_data_source.go
+++ b/internal/service/redshiftserverless/credentials_data_source.go
@@ -1,0 +1,76 @@
+package redshiftserverless
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/redshiftserverless"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func DataSourceCredentials() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceCredentialsRead,
+
+		Schema: map[string]*schema.Schema{
+			"workgroup_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"db_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"db_password": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"db_user": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"duration_seconds": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      900,
+				ValidateFunc: validation.IntBetween(900, 3600),
+			},
+			"expiration": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceCredentialsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).RedshiftServerlessConn
+
+	workgroupName := d.Get("workgroup_name").(string)
+	input := &redshiftserverless.GetCredentialsInput{
+		WorkgroupName:   aws.String(workgroupName),
+		DurationSeconds: aws.Int64(int64(d.Get("duration_seconds").(int))),
+	}
+
+	if v, ok := d.GetOk("db_name"); ok {
+		input.DbName = aws.String(v.(string))
+	}
+
+	creds, err := conn.GetCredentials(input)
+
+	if err != nil {
+		return fmt.Errorf("reading Redshift Serverless Credentials for Workgroup (%s): %w", workgroupName, err)
+	}
+
+	d.SetId(workgroupName)
+
+	d.Set("db_password", creds.DbPassword)
+	d.Set("db_user", creds.DbUser)
+	d.Set("expiration", aws.TimeValue(creds.Expiration).Format(time.RFC3339))
+
+	return nil
+}

--- a/internal/service/redshiftserverless/credentials_data_source_test.go
+++ b/internal/service/redshiftserverless/credentials_data_source_test.go
@@ -1,0 +1,50 @@
+package redshiftserverless_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/redshiftserverless"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccRedshiftServerlessCredentialsDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_redshiftserverless_credentials.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, redshiftserverless.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterCredentialsDataSourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "workgroup_name", "aws_redshiftserverless_workgroup.test", "workgroup_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "db_password"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "db_user"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "expiration"),
+				),
+			},
+		},
+	})
+}
+
+func testAccClusterCredentialsDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_redshiftserverless_namespace" "test" {
+  namespace_name = %[1]q
+}
+
+resource "aws_redshiftserverless_workgroup" "test" {
+  namespace_name = aws_redshiftserverless_namespace.test.namespace_name
+  workgroup_name = %[1]q
+}
+
+data "aws_redshiftserverless_credentials" "test" {
+  workgroup_name = aws_redshiftserverless_workgroup.test.workgroup_name
+}
+`, rName)
+}

--- a/website/docs/d/redshift_cluster_credentials.html.markdown
+++ b/website/docs/d/redshift_cluster_credentials.html.markdown
@@ -8,13 +8,14 @@ description: |-
 
 # Data Source: aws_redshift_cluster_credentials
 
-Provides redshift subnet group.
+Provides redshift cluster temporary credentials.
 
 ## Example Usage
 
 ```terraform
 data "aws_redshift_cluster_credentials" "example" {
-  name = aws_redshift_cluster_credentials.example.name
+  cluster_identifier = aws_redshift_cluster.example.cluster_identifier
+  db_user            = aws_redshift_cluster.example.master_username
 }
 ```
 
@@ -27,7 +28,7 @@ The following arguments are supported:
 * `db_name` - (Optional) Name of a database that DbUser is authorized to log on to. If `db_name` is not specified, `db_user` can log on to any existing database.
 * `db_user` - (Required) Name of a database user. If a user name matching `db_user` exists in the database, the temporary user credentials have the same permissions as the  existing user. If `db_user` doesn't exist in the database and `auto_create` is `True`, a new user is created using the value for `db_user` with `PUBLIC` permissions.  If a database user matching the value for `db_user` doesn't exist and `not` is `False`, then the command succeeds but the connection attempt will fail because the user doesn't exist in the database.
 * `db_groups` - (Optional) List of the names of existing database groups that the user named in `db_user` will join for the current session, in addition to any group memberships for an existing user. If not specified, a new user is added only to `PUBLIC`.
-* `duration_seconds` - (Optional)  The number of seconds until the returned temporary password expires. Valid values are between `900` and `3600`. Default value is `900`.
+* `duration_seconds` - (Optional) The number of seconds until the returned temporary password expires. Valid values are between `900` and `3600`. Default value is `900`.
 
 ## Attribute Reference
 

--- a/website/docs/d/redshiftserverless_credentials.html.markdown
+++ b/website/docs/d/redshiftserverless_credentials.html.markdown
@@ -1,14 +1,14 @@
 ---
-subcategory: "Redshift"
+subcategory: "Redshift Serverless"
 layout: "aws"
 page_title: "AWS: aws_redshiftserverless_credentials"
 description: |-
-  Provides redshift cluster credentials
+  Provides redshift serverless credentials
 ---
 
 # Data Source: aws_redshiftserverless_credentials
 
-Provides redshift subnet group.
+Provides redshift serverless temporary credentials for a workgroup.
 
 ## Example Usage
 

--- a/website/docs/d/redshiftserverless_credentials.html.markdown
+++ b/website/docs/d/redshiftserverless_credentials.html.markdown
@@ -1,0 +1,35 @@
+---
+subcategory: "Redshift"
+layout: "aws"
+page_title: "AWS: aws_redshiftserverless_credentials"
+description: |-
+  Provides redshift cluster credentials
+---
+
+# Data Source: aws_redshiftserverless_credentials
+
+Provides redshift subnet group.
+
+## Example Usage
+
+```terraform
+data "aws_redshiftserverless_credentials" "example" {
+  workgroup_name = aws_redshiftserverless_workgroup.example.workgroup_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `workgroup_name` - (Required) The name of the workgroup associated with the database.
+* `db_name` - (Optional) The name of the database to get temporary authorization to log on to.
+* `duration_seconds` - (Optional) The number of seconds until the returned temporary password expires. The minimum is 900 seconds, and the maximum is 3600 seconds.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `db_password` - Temporary password that authorizes the user name returned by `db_user` to log on to the database `db_name`.
+* `db_user` - A database user name that is authorized to log on to the database `db_name` using the password `db_password` . If the specified `db_user` exists in the database, the new user name has the same database privileges as the the user named in `db_user` . By default, the user is added to PUBLIC. the user doesn't exist in the database.
+* `expiration` - Date and time the password in `db_password` expires.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccRedshiftServerlessCredentialsDataSource_basic  PKG=redshiftserverless

--- PASS: TestAccRedshiftServerlessCredentialsDataSource_basic (625.34s)
```
