### PR TITLE
r/emrserverlesss_application - add  architecture argument

### DIFF
--- a/.changelog/28027.txt
+++ b/.changelog/28027.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_emrserverless_application: Add `architecture` argument
 ```
+
+```release-note:enhancement
+resource/aws_emrserverless_application: Mark `maximum_capacity` and `maximum_capacity.disk` as Computed, preventing spurious resource diffs
+```

--- a/.changelog/28027.txt
+++ b/.changelog/28027.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_emrserverless_application: Add `architecture` argument
+```

--- a/internal/service/emrserverless/application.go
+++ b/internal/service/emrserverless/application.go
@@ -31,6 +31,11 @@ func ResourceApplication() *schema.Resource {
 		CustomizeDiff: verify.SetTagsDiff,
 
 		Schema: map[string]*schema.Schema{
+			"architecture": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(emrserverless.Architecture_Values(), false),
+			},
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -203,6 +208,10 @@ func resourceApplicationCreate(d *schema.ResourceData, meta interface{}) error {
 		Type:         aws.String(d.Get("type").(string)),
 	}
 
+	if v, ok := d.GetOk("architecture"); ok {
+		input.Architecture = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("auto_start_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		input.AutoStartConfiguration = expandAutoStartConfig(v.([]interface{})[0].(map[string]interface{}))
 	}
@@ -260,6 +269,7 @@ func resourceApplicationRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("reading EMR Serverless Application (%s): %w", d.Id(), err)
 	}
 
+	d.Set("architecture", application.Architecture)
 	d.Set("arn", application.Arn)
 	d.Set("name", application.Name)
 	d.Set("release_label", application.ReleaseLabel)
@@ -306,6 +316,10 @@ func resourceApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
 		input := &emrserverless.UpdateApplicationInput{
 			ApplicationId: aws.String(d.Id()),
 			ClientToken:   aws.String(resource.UniqueId()),
+		}
+
+		if v, ok := d.GetOk("architecture"); ok {
+			input.Architecture = aws.String(v.(string))
 		}
 
 		if v, ok := d.GetOk("auto_start_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {

--- a/internal/service/emrserverless/application.go
+++ b/internal/service/emrserverless/application.go
@@ -142,6 +142,7 @@ func ResourceApplication() *schema.Resource {
 						"disk": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"memory": {
 							Type:     schema.TypeString,

--- a/internal/service/emrserverless/application.go
+++ b/internal/service/emrserverless/application.go
@@ -34,6 +34,7 @@ func ResourceApplication() *schema.Resource {
 			"architecture": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Default:      emrserverless.ArchitectureX8664,
 				ValidateFunc: validation.StringInSlice(emrserverless.Architecture_Values(), false),
 			},
 			"arn": {

--- a/internal/service/emrserverless/application.go
+++ b/internal/service/emrserverless/application.go
@@ -129,6 +129,7 @@ func ResourceApplication() *schema.Resource {
 			"maximum_capacity": {
 				Type:             schema.TypeList,
 				Optional:         true,
+				Computed:         true,
 				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
 				MaxItems:         1,
 				Elem: &schema.Resource{

--- a/internal/service/emrserverless/application_test.go
+++ b/internal/service/emrserverless/application_test.go
@@ -52,6 +52,40 @@ func TestAccEMRServerlessApplication_basic(t *testing.T) {
 	})
 }
 
+func TestAccEMRServerlessApplication_arch(t *testing.T) {
+	var application emrserverless.Application
+	resourceName := "aws_emrserverless_application.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, emrserverless.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationConfig_arch(rName, "ARM64"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationExists(resourceName, &application),
+					resource.TestCheckResourceAttr(resourceName, "architecture", "ARM64"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccApplicationConfig_arch(rName, "X86_64"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationExists(resourceName, &application),
+					resource.TestCheckResourceAttr(resourceName, "architecture", "X86_64"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEMRServerlessApplication_initialCapacity(t *testing.T) {
 	var application emrserverless.Application
 	resourceName := "aws_emrserverless_application.test"
@@ -388,4 +422,15 @@ resource "aws_emrserverless_application" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccApplicationConfig_arch(rName, arch string) string {
+	return fmt.Sprintf(`
+resource "aws_emrserverless_application" "test" {
+  name          = %[1]q
+  release_label = "emr-6.6.0"
+  type          = "hive"
+  architecture  = %[2]q
+}
+`, rName, arch)
 }

--- a/internal/service/emrserverless/application_test.go
+++ b/internal/service/emrserverless/application_test.go
@@ -33,6 +33,7 @@ func TestAccEMRServerlessApplication_basic(t *testing.T) {
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "emr-serverless", regexp.MustCompile(`/applications/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "hive"),
+					resource.TestCheckResourceAttr(resourceName, "architecture", "X86_64"),
 					resource.TestCheckResourceAttr(resourceName, "release_label", "emr-6.6.0"),
 					resource.TestCheckResourceAttr(resourceName, "auto_start_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "auto_start_configuration.0.enabled", "true"),

--- a/website/docs/r/emrserverless_application.markdown
+++ b/website/docs/r/emrserverless_application.markdown
@@ -63,7 +63,7 @@ resource "aws_emrserverless_application" "example" {
 
 The following arguments are required:
 
-* `architecture` – (Optional) The CPU architecture of an application. Valid values are `ARM64` or `X86_64`.
+* `architecture` – (Optional) The CPU architecture of an application. Valid values are `ARM64` or `X86_64`. Default value is `X86_64`.
 * `auto_start_configuration` – (Optional) The configuration for an application to automatically start on job submission.
 * `auto_stop_configuration` – (Optional) The configuration for an application to automatically stop after a certain amount of time being idle.
 * `initial_capacity` – (Optional) The capacity to initialize when the application is created.

--- a/website/docs/r/emrserverless_application.markdown
+++ b/website/docs/r/emrserverless_application.markdown
@@ -63,6 +63,7 @@ resource "aws_emrserverless_application" "example" {
 
 The following arguments are required:
 
+* `architecture` – (Optional) The CPU architecture of an application. Valid values are `ARM64` or `X86_64`.
 * `auto_start_configuration` – (Optional) The configuration for an application to automatically start on job submission.
 * `auto_stop_configuration` – (Optional) The configuration for an application to automatically stop after a certain amount of time being idle.
 * `initial_capacity` – (Optional) The capacity to initialize when the application is created.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27999

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$  make testacc TESTS=TestAccEMRServerlessApplication_arch  PKG=emrserverless
--- PASS: TestAccEMRServerlessApplication_basic (99.03s)
--- PASS: TestAccEMRServerlessApplication_network (113.05s)
--- PASS: TestAccEMRServerlessApplication_disappears (117.02s)
--- PASS: TestAccEMRServerlessApplication_arch (119.54s)
--- PASS: TestAccEMRServerlessApplication_maxCapacity (120.41s)
--- PASS: TestAccEMRServerlessApplication_initialCapacity (120.55s)
--- PASS: TestAccEMRServerlessApplication_tags (141.68s)
```
