### PR TITLE
docs: adding missing region_concurrency_type valid values (#27821)

### DIFF
--- a/website/docs/r/cloudformation_stack_set_instance.html.markdown
+++ b/website/docs/r/cloudformation_stack_set_instance.html.markdown
@@ -96,18 +96,18 @@ The following arguments are supported:
 
 The `deployment_targets` configuration block supports the following arguments:
 
-*`organizational_unit_ids` - (Optional) The organization root ID or organizational unit (OU) IDs to which StackSets deploys.
+* `organizational_unit_ids` - (Optional) The organization root ID or organizational unit (OU) IDs to which StackSets deploys.
 
 ### `operation_preferences` Argument Reference
 
 The `operation_preferences` configuration block supports the following arguments:
 
-*`failure_tolerance_count` - (Optional) The number of accounts, per Region, for which this operation can fail before AWS CloudFormation stops the operation in that Region.
-*`failure_tolerance_percentage` - (Optional) The percentage of accounts, per Region, for which this stack operation can fail before AWS CloudFormation stops the operation in that Region.
-*`max_concurrent_count` - (Optional) The maximum number of accounts in which to perform this operation at one time.
-*`max_concurrent_percentage` - (Optional) The maximum percentage of accounts in which to perform this operation at one time.
-*`region_concurrency_type` - (Optional) The concurrency type of deploying StackSets operations in Regions, could be in parallel or one Region at a time.
-*`region_order` - (Optional) The order of the Regions in where you want to perform the stack operation.
+* `failure_tolerance_count` - (Optional) The number of accounts, per Region, for which this operation can fail before AWS CloudFormation stops the operation in that Region.
+* `failure_tolerance_percentage` - (Optional) The percentage of accounts, per Region, for which this stack operation can fail before AWS CloudFormation stops the operation in that Region.
+* `max_concurrent_count` - (Optional) The maximum number of accounts in which to perform this operation at one time.
+* `max_concurrent_percentage` - (Optional) The maximum percentage of accounts in which to perform this operation at one time.
+* `region_concurrency_type` - (Optional) The concurrency type of deploying StackSets operations in Regions, could be in parallel or one Region at a time. Valid values are `SEQUENTIAL` and `PARALLEL`.
+* `region_order` - (Optional) The order of the Regions in where you want to perform the stack operation.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Description

- adding valid values to region_concurrency_type argument in "`operation_preferences` Argument Reference" section
- fixing bullet list format in "`operation_preferences` Argument Reference" section
- fixing bullet list format in "`deployment_targets` Argument Reference" section

### Relations
Closes #27821
