### PR TITLE
docs: Add skip_matching to autoscaling_group

### DIFF
--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -628,6 +628,7 @@ This configuration block supports the following:
     * `checkpoint_percentages` - (Optional) List of percentages for each checkpoint. Values must be unique and in ascending order. To replace all instances, the final number must be `100`.
     * `instance_warmup` - (Optional) Number of seconds until a newly launched instance is configured and ready to use. Default behavior is to use the Auto Scaling Group's health check grace period.
     * `min_healthy_percentage` - (Optional) Amount of capacity in the Auto Scaling group that must remain healthy during an instance refresh to allow the operation to continue, as a percentage of the desired capacity of the Auto Scaling group. Defaults to `90`.
+    * `skip_matching` - (Optional) Replace instances that already have your desired configuration. Defaults to `false`.
 * `triggers` - (Optional) Set of additional property names that will trigger an Instance Refresh. A refresh will always be triggered by a change in any of `launch_configuration`, `launch_template`, or `mixed_instances_policy`.
 
 ~> **NOTE:** A refresh is started when any of the following Auto Scaling Group properties change: `launch_configuration`, `launch_template`, `mixed_instances_policy`. Additional properties can be specified in the `triggers` property of `instance_refresh`.


### PR DESCRIPTION
### Description

Add `skip_matching` to `aws_autoscaling_group` documentation.


### Relations

Closes #28014 

### References

https://github.com/hashicorp/terraform-provider-aws/pull/23059 added the skip_matching option to the instance_refresh block, closing issue https://github.com/hashicorp/terraform-provider-aws/issues/22554

