### PR TITLE
b/fix_dms_task_update_bug_19938: Add required fields to update input 

### DIFF
--- a/.changelog/28047.txt
+++ b/.changelog/28047.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dms_replication_task: Allow updates to `aws_dms_replication_task` even when `migration_type` and `table_mappings` have not changed
+```

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -33,7 +33,7 @@ func ResourceEndpoint() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/internal/service/dms/replication_task.go
+++ b/internal/service/dms/replication_task.go
@@ -227,6 +227,8 @@ func resourceReplicationTaskUpdate(d *schema.ResourceData, meta interface{}) err
 	if d.HasChangesExcept("tags", "tags_all", "start_replication_task") {
 		input := &dms.ModifyReplicationTaskInput{
 			ReplicationTaskArn: aws.String(d.Get("replication_task_arn").(string)),
+			MigrationType:      aws.String(d.Get("migration_type").(string)),
+			TableMappings:      aws.String(d.Get("table_mappings").(string)),
 		}
 
 		if d.HasChange("cdc_start_position") {
@@ -241,16 +243,8 @@ func resourceReplicationTaskUpdate(d *schema.ResourceData, meta interface{}) err
 			input.CdcStartTime = aws.Time(time.Unix(seconds, 0))
 		}
 
-		if d.HasChange("migration_type") {
-			input.MigrationType = aws.String(d.Get("migration_type").(string))
-		}
-
 		if d.HasChange("replication_task_settings") {
 			input.ReplicationTaskSettings = aws.String(d.Get("replication_task_settings").(string))
-		}
-
-		if d.HasChange("table_mappings") {
-			input.TableMappings = aws.String(d.Get("table_mappings").(string))
 		}
 
 		status := d.Get("status").(string)

--- a/internal/service/dms/replication_task_test.go
+++ b/internal/service/dms/replication_task_test.go
@@ -2,6 +2,7 @@ package dms_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	dms "github.com/aws/aws-sdk-go/service/databasemigrationservice"
@@ -56,6 +57,92 @@ func TestAccDMSReplicationTask_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReplicationTaskExists(resourceName),
 				),
+			},
+		},
+	})
+}
+
+func TestAccDMSReplicationTask_update(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_dms_replication_task.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckReplicationTaskDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReplicationTaskConfig_update(rName, "full-load", 1024, "ZedsDead"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckReplicationTaskExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_task_arn"),
+					resource.TestCheckResourceAttr(resourceName, "migration_type", "full-load"),
+					resource.TestMatchResourceAttr(resourceName, "replication_task_settings", regexp.MustCompile("MemoryLimitTotal\":1024")),
+					resource.TestMatchResourceAttr(resourceName, "table_mappings", regexp.MustCompile("rule-name\":\"ZedsDead")),
+				),
+			},
+			{
+				Config: testAccReplicationTaskConfig_update(rName, "full-load", 1024, "EMBRZ"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckReplicationTaskExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "migration_type", "full-load"),
+					resource.TestMatchResourceAttr(resourceName, "replication_task_settings", regexp.MustCompile("MemoryLimitTotal\":1024")),
+					resource.TestMatchResourceAttr(resourceName, "table_mappings", regexp.MustCompile("rule-name\":\"EMBRZ")),
+				),
+			},
+			{
+				Config:             testAccReplicationTaskConfig_update(rName, "full-load", 1024, "EMBRZ"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: testAccReplicationTaskConfig_update(rName, "full-load", 1248, "ZedsDead"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckReplicationTaskExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_task_arn"),
+					resource.TestCheckResourceAttr(resourceName, "migration_type", "full-load"),
+					resource.TestMatchResourceAttr(resourceName, "replication_task_settings", regexp.MustCompile("MemoryLimitTotal\":1248")),
+					resource.TestMatchResourceAttr(resourceName, "table_mappings", regexp.MustCompile("rule-name\":\"ZedsDead")),
+				),
+			},
+			{
+				Config: testAccReplicationTaskConfig_update(rName, "full-load", 1024, "ZedsDead"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckReplicationTaskExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "migration_type", "full-load"),
+					resource.TestMatchResourceAttr(resourceName, "replication_task_settings", regexp.MustCompile("MemoryLimitTotal\":1024")),
+					resource.TestMatchResourceAttr(resourceName, "table_mappings", regexp.MustCompile("rule-name\":\"ZedsDead")),
+				),
+			},
+			{
+				Config:             testAccReplicationTaskConfig_update(rName, "full-load", 1024, "ZedsDead"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: testAccReplicationTaskConfig_update(rName, "full-load", 1248, "ZedsDead"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckReplicationTaskExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "replication_task_arn"),
+					resource.TestCheckResourceAttr(resourceName, "migration_type", "full-load"),
+					resource.TestMatchResourceAttr(resourceName, "replication_task_settings", regexp.MustCompile("MemoryLimitTotal\":1248")),
+					resource.TestMatchResourceAttr(resourceName, "table_mappings", regexp.MustCompile("rule-name\":\"ZedsDead")),
+				),
+			},
+			{
+				Config: testAccReplicationTaskConfig_update(rName, "full-load", 1024, "EMBRZ"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckReplicationTaskExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "migration_type", "full-load"),
+					resource.TestMatchResourceAttr(resourceName, "replication_task_settings", regexp.MustCompile("MemoryLimitTotal\":1024")),
+					resource.TestMatchResourceAttr(resourceName, "table_mappings", regexp.MustCompile("rule-name\":\"EMBRZ")),
+				),
+			},
+			{
+				Config:             testAccReplicationTaskConfig_update(rName, "full-load", 1024, "EMBRZ"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})
@@ -326,6 +413,27 @@ resource "aws_dms_replication_task" "test" {
   target_endpoint_arn = aws_dms_endpoint.target.endpoint_arn
 }
 `, rName, tags))
+}
+
+func testAccReplicationTaskConfig_update(rName, migType string, memLimitTotal int, ruleName string) string {
+	return acctest.ConfigCompose(
+		replicationTaskConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_dms_replication_task" "test" {
+  migration_type            = %[2]q
+  replication_instance_arn  = aws_dms_replication_instance.test.replication_instance_arn
+  replication_task_id       = %[1]q
+  replication_task_settings = "{\"BeforeImageSettings\":null,\"FailTaskWhenCleanTaskResourceFailed\":false,\"ChangeProcessingDdlHandlingPolicy\":{\"HandleSourceTableAltered\":true,\"HandleSourceTableDropped\":true,\"HandleSourceTableTruncated\":true},\"ChangeProcessingTuning\":{\"BatchApplyMemoryLimit\":500,\"BatchApplyPreserveTransaction\":true,\"BatchApplyTimeoutMax\":30,\"BatchApplyTimeoutMin\":1,\"BatchSplitSize\":0,\"CommitTimeout\":1,\"MemoryKeepTime\":60,\"MemoryLimitTotal\":%[3]d,\"MinTransactionSize\":1000,\"StatementCacheSize\":50},\"CharacterSetSettings\":null,\"ControlTablesSettings\":{\"ControlSchema\":\"\",\"FullLoadExceptionTableEnabled\":false,\"HistoryTableEnabled\":false,\"HistoryTimeslotInMinutes\":5,\"StatusTableEnabled\":false,\"SuspendedTablesTableEnabled\":false},\"ErrorBehavior\":{\"ApplyErrorDeletePolicy\":\"IGNORE_RECORD\",\"ApplyErrorEscalationCount\":0,\"ApplyErrorEscalationPolicy\":\"LOG_ERROR\",\"ApplyErrorFailOnTruncationDdl\":false,\"ApplyErrorInsertPolicy\":\"LOG_ERROR\",\"ApplyErrorUpdatePolicy\":\"LOG_ERROR\",\"DataErrorEscalationCount\":0,\"DataErrorEscalationPolicy\":\"SUSPEND_TABLE\",\"DataErrorPolicy\":\"LOG_ERROR\",\"DataTruncationErrorPolicy\":\"LOG_ERROR\",\"EventErrorPolicy\":\"IGNORE\",\"FailOnNoTablesCaptured\":false,\"FailOnTransactionConsistencyBreached\":false,\"FullLoadIgnoreConflicts\":true,\"RecoverableErrorCount\":-1,\"RecoverableErrorInterval\":5,\"RecoverableErrorStopRetryAfterThrottlingMax\":false,\"RecoverableErrorThrottling\":true,\"RecoverableErrorThrottlingMax\":1800,\"TableErrorEscalationCount\":0,\"TableErrorEscalationPolicy\":\"STOP_TASK\",\"TableErrorPolicy\":\"SUSPEND_TABLE\"},\"FullLoadSettings\":{\"CommitRate\":10000,\"CreatePkAfterFullLoad\":false,\"MaxFullLoadSubTasks\":8,\"StopTaskCachedChangesApplied\":false,\"StopTaskCachedChangesNotApplied\":false,\"TargetTablePrepMode\":\"DROP_AND_CREATE\",\"TransactionConsistencyTimeout\":600},\"Logging\":{\"EnableLogging\":false,\"LogComponents\":[{\"Id\":\"TRANSFORMATION\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"SOURCE_UNLOAD\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"IO\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TARGET_LOAD\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"PERFORMANCE\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"SOURCE_CAPTURE\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"SORTER\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"REST_SERVER\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"VALIDATOR_EXT\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TARGET_APPLY\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TASK_MANAGER\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TABLES_MANAGER\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"METADATA_MANAGER\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"FILE_FACTORY\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"COMMON\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"ADDONS\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"DATA_STRUCTURE\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"COMMUNICATION\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"FILE_TRANSFER\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"}]},\"LoopbackPreventionSettings\":null,\"PostProcessingRules\":null,\"StreamBufferSettings\":{\"CtrlStreamBufferSizeInMB\":5,\"StreamBufferCount\":3,\"StreamBufferSizeInMB\":8},\"TargetMetadata\":{\"BatchApplyEnabled\":false,\"FullLobMode\":false,\"InlineLobMaxSize\":0,\"LimitedSizeLobMode\":true,\"LoadMaxFileSize\":0,\"LobChunkSize\":0,\"LobMaxSize\":32,\"ParallelApplyBufferSize\":0,\"ParallelApplyQueuesPerThread\":0,\"ParallelApplyThreads\":0,\"ParallelLoadBufferSize\":0,\"ParallelLoadQueuesPerThread\":0,\"ParallelLoadThreads\":0,\"SupportLobs\":true,\"TargetSchema\":\"\",\"TaskRecoveryTableEnabled\":false},\"TTSettings\":{\"EnableTT\":false,\"TTRecordSettings\":null,\"TTS3Settings\":null}}"
+  source_endpoint_arn       = aws_dms_endpoint.source.endpoint_arn
+  table_mappings            = "{\"rules\":[{\"rule-type\":\"selection\",\"rule-id\":\"1\",\"rule-name\":\"%[4]s\",\"object-locator\":{\"schema-name\":\"%%\",\"table-name\":\"%%\"},\"rule-action\":\"include\"}]}"
+
+  tags = {
+    Name = %[1]q
+  }
+
+  target_endpoint_arn = aws_dms_endpoint.target.endpoint_arn
+}
+`, rName, migType, memLimitTotal, ruleName))
 }
 
 func testAccReplicationTaskConfig_cdcStartPosition(rName, cdcStartPosition string) string {

--- a/internal/service/dms/replication_task_test.go
+++ b/internal/service/dms/replication_task_test.go
@@ -489,7 +489,7 @@ resource "aws_subnet" "test2" {
   }
 }
 
-resource "aws_default_security_group" "test" {
+resource "aws_security_group" "test" {
   vpc_id = aws_vpc.test.id
 
   ingress {
@@ -548,7 +548,7 @@ resource "aws_rds_cluster" "test1" {
   master_username                 = "tftest"
   master_password                 = "mustbeeightcharaters"
   skip_final_snapshot             = true
-  vpc_security_group_ids          = [aws_default_security_group.test.id]
+  vpc_security_group_ids          = [aws_security_group.test.id]
   db_subnet_group_name            = aws_db_subnet_group.test.name
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.test.name
 }
@@ -570,7 +570,7 @@ resource "aws_rds_cluster" "test2" {
   master_username        = "tftest"
   master_password        = "mustbeeightcharaters"
   skip_final_snapshot    = true
-  vpc_security_group_ids = [aws_default_security_group.test.id]
+  vpc_security_group_ids = [aws_security_group.test.id]
   db_subnet_group_name   = aws_db_subnet_group.test.name
 }
 
@@ -619,7 +619,7 @@ resource "aws_dms_replication_instance" "test" {
   preferred_maintenance_window = "sun:00:30-sun:02:30"
   publicly_accessible          = false
   replication_subnet_group_id  = aws_dms_replication_subnet_group.test.replication_subnet_group_id
-  vpc_security_group_ids       = [aws_default_security_group.test.id]
+  vpc_security_group_ids       = [aws_security_group.test.id]
 }
 
 resource "aws_dms_replication_task" "test" {

--- a/internal/service/dms/wait.go
+++ b/internal/service/dms/wait.go
@@ -91,7 +91,7 @@ func waitReplicationTaskRunning(conn *dms.DatabaseMigrationService, id string) e
 
 func waitReplicationTaskStopped(conn *dms.DatabaseMigrationService, id string) error {
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{replicationTaskStatusStopping},
+		Pending:    []string{replicationTaskStatusStopping, replicationTaskStatusRunning},
 		Target:     []string{replicationTaskStatusStopped},
 		Refresh:    statusReplicationTask(conn, id),
 		Timeout:    replicationTaskRunningTimeout,

--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -199,6 +199,13 @@ In addition to all arguments above, the following attributes are exported:
 * `endpoint_arn` - ARN for the endpoint.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `create` - (Default `5m`)
+- `delete` - (Default `10m`)
+
 ## Import
 
 Endpoints can be imported using the `endpoint_id`, e.g.,


### PR DESCRIPTION
### Description
This PR intends to fix the bug [described here](https://github.com/hashicorp/terraform-provider-aws/issues/19938) by including `MigrationType` and `TableMappings` on the update call regardless of whether they have been changed.
That issue is well written and is great for context.

### Relations
Closes #19938

### References
[Readme in this repo for dms](https://github.com/hashicorp/terraform-provider-aws/blob/main/website/docs/r/dms_replication_task.html.markdown) - note: the altered fields are listed as required.
[AWS dms api](https://docs.aws.amazon.com/dms/latest/APIReference/API_ModifyReplicationTask.html)


### Output from Acceptance Testing
I couldn't acceptance test this, hopefully you can run this on your side. I would be surprised if this change caused failures but you never know...
