### PR TITLE
r/glue_classfier - `custom_datatype_configured` and `custom_datatypes`

### DIFF
--- a/.changelog/28048.txt
+++ b/.changelog/28048.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_glue_classifier: Add `custom_datatypes` and `custom_datatype_configured` Arguments
+```

--- a/.changelog/28048.txt
+++ b/.changelog/28048.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_glue_classifier: Add `custom_datatypes` and `custom_datatype_configured` Arguments
+resource/aws_glue_classifier: Add `custom_datatypes` and `custom_datatype_configured` arguments
 ```

--- a/internal/service/glue/classifier.go
+++ b/internal/service/glue/classifier.go
@@ -337,11 +337,9 @@ func expandCSVClassifierCreate(name string, m map[string]interface{}) *glue.Crea
 	}
 
 	if v, ok := m["custom_datatypes"].([]interface{}); ok && len(v) > 0 {
-
 		if confV, confOk := m["custom_datatype_configured"].(bool); confOk {
 			csvClassifier.CustomDatatypeConfigured = aws.Bool(confV)
 		}
-
 		csvClassifier.CustomDatatypes = flex.ExpandStringList(v)
 	}
 
@@ -366,11 +364,9 @@ func expandCSVClassifierUpdate(name string, m map[string]interface{}) *glue.Upda
 	}
 
 	if v, ok := m["custom_datatypes"].([]interface{}); ok && len(v) > 0 {
-
 		if confV, confOk := m["custom_datatype_configured"].(bool); confOk {
 			csvClassifier.CustomDatatypeConfigured = aws.Bool(confV)
 		}
-
 		csvClassifier.CustomDatatypes = flex.ExpandStringList(v)
 	}
 

--- a/internal/service/glue/classifier.go
+++ b/internal/service/glue/classifier.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func ResourceClassifier() *schema.Resource {
@@ -72,6 +73,30 @@ func ResourceClassifier() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice(glue.CsvHeaderOption_Values(), false),
+						},
+						"custom_datatype_configured": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"custom_datatypes": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{
+									"BINARY",
+									"BOOLEAN",
+									"DATE",
+									"DECIMAL",
+									"DOUBLE",
+									"FLOAT",
+									"INT",
+									"LONG",
+									"SHORT",
+									"STRING",
+									"TIMESTAMP",
+								}, false),
+							},
 						},
 						"delimiter": {
 							Type:     schema.TypeString,
@@ -200,34 +225,23 @@ func resourceClassifierCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceClassifierRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).GlueConn
 
-	input := &glue.GetClassifierInput{
-		Name: aws.String(d.Id()),
-	}
-
-	log.Printf("[DEBUG] Reading Glue Classifier: %s", input)
-	output, err := conn.GetClassifier(input)
-	if err != nil {
-		if tfawserr.ErrCodeEquals(err, glue.ErrCodeEntityNotFoundException) {
-			log.Printf("[WARN] Glue Classifier (%s) not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("error reading Glue Classifier (%s): %s", d.Id(), err)
-	}
-
-	classifier := output.Classifier
-	if classifier == nil {
+	classifier, err := FindClassifierByName(conn, d.Id())
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Glue Classifier (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
+	if err != nil {
+		return fmt.Errorf("error reading Glue Classifier (%s): %w", d.Id(), err)
+	}
+
 	if err := d.Set("csv_classifier", flattenCSVClassifier(classifier.CsvClassifier)); err != nil {
-		return fmt.Errorf("error setting match_criteria: %s", err)
+		return fmt.Errorf("error setting csv_classifier: %s", err)
 	}
 
 	if err := d.Set("grok_classifier", flattenGrokClassifier(classifier.GrokClassifier)); err != nil {
-		return fmt.Errorf("error setting match_criteria: %s", err)
+		return fmt.Errorf("error setting grok_classifier: %s", err)
 	}
 
 	if err := d.Set("json_classifier", flattenJSONClassifier(classifier.JsonClassifier)); err != nil {
@@ -322,6 +336,15 @@ func expandCSVClassifierCreate(name string, m map[string]interface{}) *glue.Crea
 		csvClassifier.Header = flex.ExpandStringList(v)
 	}
 
+	if v, ok := m["custom_datatypes"].([]interface{}); ok && len(v) > 0 {
+
+		if confV, confOk := m["custom_datatype_configured"].(bool); confOk {
+			csvClassifier.CustomDatatypeConfigured = aws.Bool(confV)
+		}
+
+		csvClassifier.CustomDatatypes = flex.ExpandStringList(v)
+	}
+
 	return csvClassifier
 }
 
@@ -340,6 +363,15 @@ func expandCSVClassifierUpdate(name string, m map[string]interface{}) *glue.Upda
 
 	if v, ok := m["header"].([]interface{}); ok {
 		csvClassifier.Header = flex.ExpandStringList(v)
+	}
+
+	if v, ok := m["custom_datatypes"].([]interface{}); ok && len(v) > 0 {
+
+		if confV, confOk := m["custom_datatype_configured"].(bool); confOk {
+			csvClassifier.CustomDatatypeConfigured = aws.Bool(confV)
+		}
+
+		csvClassifier.CustomDatatypes = flex.ExpandStringList(v)
 	}
 
 	return csvClassifier
@@ -421,12 +453,14 @@ func flattenCSVClassifier(csvClassifier *glue.CsvClassifier) []map[string]interf
 	}
 
 	m := map[string]interface{}{
-		"allow_single_column":    aws.BoolValue(csvClassifier.AllowSingleColumn),
-		"contains_header":        aws.StringValue(csvClassifier.ContainsHeader),
-		"delimiter":              aws.StringValue(csvClassifier.Delimiter),
-		"disable_value_trimming": aws.BoolValue(csvClassifier.DisableValueTrimming),
-		"header":                 aws.StringValueSlice(csvClassifier.Header),
-		"quote_symbol":           aws.StringValue(csvClassifier.QuoteSymbol),
+		"allow_single_column":        aws.BoolValue(csvClassifier.AllowSingleColumn),
+		"contains_header":            aws.StringValue(csvClassifier.ContainsHeader),
+		"delimiter":                  aws.StringValue(csvClassifier.Delimiter),
+		"disable_value_trimming":     aws.BoolValue(csvClassifier.DisableValueTrimming),
+		"header":                     aws.StringValueSlice(csvClassifier.Header),
+		"quote_symbol":               aws.StringValue(csvClassifier.QuoteSymbol),
+		"custom_datatype_configured": aws.BoolValue(csvClassifier.CustomDatatypeConfigured),
+		"custom_datatypes":           aws.StringValueSlice(csvClassifier.CustomDatatypes),
 	}
 
 	return []map[string]interface{}{m}

--- a/internal/service/glue/classifier_test.go
+++ b/internal/service/glue/classifier_test.go
@@ -4,15 +4,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/glue"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfglue "github.com/hashicorp/terraform-provider-aws/internal/service/glue"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccGlueClassifier_csvClassifier(t *testing.T) {
@@ -96,6 +95,47 @@ func TestAccGlueClassifier_CSVClassifier_quoteSymbol(t *testing.T) {
 					testAccCheckClassifierExists(resourceName, &classifier),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "csv_classifier.0.quote_symbol", "'"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccGlueClassifier_CSVClassifier_custom(t *testing.T) {
+	var classifier glue.Classifier
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_glue_classifier.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, glue.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClassifierDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClassifierConfig_csvCustom(rName, "BINARY"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClassifierExists(resourceName, &classifier),
+					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "csv_classifier.0.custom_datatypes.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "csv_classifier.0.custom_datatypes.0", "BINARY"),
+					resource.TestCheckResourceAttr(resourceName, "csv_classifier.0.custom_datatypes.1", "SHORT"),
+				),
+			},
+			{
+				Config: testAccClassifierConfig_csvCustom(rName, "BOOLEAN"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClassifierExists(resourceName, &classifier),
+					resource.TestCheckResourceAttr(resourceName, "csv_classifier.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "csv_classifier.0.custom_datatypes.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "csv_classifier.0.custom_datatypes.0", "BOOLEAN"),
+					resource.TestCheckResourceAttr(resourceName, "csv_classifier.0.custom_datatypes.1", "SHORT"),
 				),
 			},
 			{
@@ -403,18 +443,13 @@ func testAccCheckClassifierExists(resourceName string, classifier *glue.Classifi
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).GlueConn
 
-		output, err := conn.GetClassifier(&glue.GetClassifierInput{
-			Name: aws.String(rs.Primary.ID),
-		})
+		output, err := tfglue.FindClassifierByName(conn, rs.Primary.ID)
+
 		if err != nil {
 			return err
 		}
 
-		if output.Classifier == nil {
-			return fmt.Errorf("Glue Classifier (%s) not found", rs.Primary.ID)
-		}
-
-		*classifier = *output.Classifier
+		*classifier = *output
 		return nil
 	}
 }
@@ -427,22 +462,17 @@ func testAccCheckClassifierDestroy(s *terraform.State) error {
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).GlueConn
 
-		output, err := conn.GetClassifier(&glue.GetClassifierInput{
-			Name: aws.String(rs.Primary.ID),
-		})
+		_, err := tfglue.FindClassifierByName(conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
 
 		if err != nil {
-			if tfawserr.ErrCodeEquals(err, glue.ErrCodeEntityNotFoundException) {
-				return nil
-			}
+			return err
 		}
 
-		classifier := output.Classifier
-		if classifier != nil {
-			return fmt.Errorf("Glue Classifier %s still exists", rs.Primary.ID)
-		}
-
-		return err
+		return fmt.Errorf("Glue Classifier %s still exists", rs.Primary.ID)
 	}
 
 	return nil
@@ -478,6 +508,23 @@ resource "aws_glue_classifier" "test" {
   }
 }
 `, rName, symbol)
+}
+
+func testAccClassifierConfig_csvCustom(rName, customType string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_classifier" "test" {
+  name = %[1]q
+
+  csv_classifier {
+    allow_single_column        = false
+    contains_header            = "PRESENT"
+    delimiter                  = ","
+    header                     = ["header_column1", "header_column2"]
+	custom_datatype_configured = true
+	custom_datatypes           = ["%[2]s", "SHORT"]
+  }
+}
+`, rName, customType)
 }
 
 func testAccClassifierConfig_grok(rName, classification, grokPattern string) string {

--- a/internal/service/glue/classifier_test.go
+++ b/internal/service/glue/classifier_test.go
@@ -520,8 +520,8 @@ resource "aws_glue_classifier" "test" {
     contains_header            = "PRESENT"
     delimiter                  = ","
     header                     = ["header_column1", "header_column2"]
-	custom_datatype_configured = true
-	custom_datatypes           = ["%[2]s", "SHORT"]
+    custom_datatype_configured = true
+    custom_datatypes           = ["%[2]s", "SHORT"]
   }
 }
 `, rName, customType)

--- a/internal/service/glue/find.go
+++ b/internal/service/glue/find.go
@@ -237,3 +237,27 @@ func FindPartitionIndexByName(conn *glue.Glue, id string) (*glue.PartitionIndexD
 
 	return result, nil
 }
+
+func FindClassifierByName(conn *glue.Glue, name string) (*glue.Classifier, error) {
+	input := &glue.GetClassifierInput{
+		Name: aws.String(name),
+	}
+
+	output, err := conn.GetClassifier(input)
+	if tfawserr.ErrCodeEquals(err, glue.ErrCodeEntityNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Classifier == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.Classifier, nil
+}

--- a/internal/service/glue/sweep.go
+++ b/internal/service/glue/sweep.go
@@ -151,7 +151,11 @@ func sweepClassifiers(region string) error {
 			}
 
 			log.Printf("[INFO] Deleting Glue Classifier: %s", name)
-			err := DeleteClassifier(conn, name)
+			r := ResourceClassifier()
+			d := r.Data(nil)
+			d.SetId(name)
+
+			err := r.Delete(d, client)
 			if err != nil {
 				log.Printf("[ERROR] Failed to delete Glue Classifier %s: %s", name, err)
 			}

--- a/website/docs/r/glue_classifier.html.markdown
+++ b/website/docs/r/glue_classifier.html.markdown
@@ -83,6 +83,8 @@ The following arguments are supported:
 
 * `allow_single_column` - (Optional) Enables the processing of files that contain only one column.
 * `contains_header` - (Optional) Indicates whether the CSV file contains a header. This can be one of "ABSENT", "PRESENT", or "UNKNOWN".
+* `custom_datatype_configured` - (Optional) A custom symbol to denote what combines content into a single column value. It must be different from the column delimiter.
+* `custom_datatypes` - (Optional) A list of supported custom datatypes. Valid values are `BINARY`, `BOOLEAN`, `DATE`, `DECIMAL`, `DOUBLE`, `FLOAT`, `INT`, `LONG`, `SHORT`, `STRING`, `TIMESTAMP`.
 * `delimiter` - (Optional) The delimiter used in the Csv to separate columns.
 * `disable_value_trimming` - (Optional) Specifies whether to trim column values.
 * `header` - (Optional) A list of strings representing column names.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27971

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccGlueClassifier_  PKG=glue

--- PASS: TestAccGlueClassifier_disappears (36.49s)
--- PASS: TestAccGlueClassifier_CSVClassifier_quoteSymbol (76.01s)
--- PASS: TestAccGlueClassifier_CSVClassifier_custom (76.80s)
--- PASS: TestAccGlueClassifier_csvClassifier (76.80s)
--- PASS: TestAccGlueClassifier_jsonClassifier (77.05s)
--- PASS: TestAccGlueClassifier_grokClassifier (77.84s)
--- PASS: TestAccGlueClassifier_GrokClassifier_customPatterns (77.85s)
--- PASS: TestAccGlueClassifier_xmlClassifier (77.89s)
--- PASS: TestAccGlueClassifier_typeChange (118.30s)
```
