### PR TITLE
New Resource: aws_cloudwatch_log_data_protection_policy

### DIFF
--- a/.changelog/28049.txt
+++ b/.changelog/28049.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_cloudwatch_log_data_protection_policy
+```

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
+require github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.17.0 // indirect
+
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.3.11 h1:6cZRymlLEIlDTEB0+5+An6Zj1CK
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.11/go.mod h1:0MR+sS1b/yxsfAPvAESrw8NfwUoxMinDyw6EYR9BS2U=
 github.com/aws/aws-sdk-go-v2/service/auditmanager v1.21.0 h1:3TOMzf1EqvOapVX76yxostIZVe9lpSnQs5n8TNPEgvE=
 github.com/aws/aws-sdk-go-v2/service/auditmanager v1.21.0/go.mod h1:KQ0nmqhPXEsObZkum2BWlzZcPFgnWFUwjkIXheLLYUM=
+github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.17.0 h1:/RFnaZHehAtDteT8Ds9SNpMaNbkyVrKizWQPaMXLI8I=
+github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.17.0/go.mod h1:9feOMWt3rxs46DqBVHco7z1KxRG36bKUqtv306cAtaA=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.19.2 h1:QPZlPIMkaEOOFbz+znqwS5HkomTbNFxEJnKJ8zGOMlQ=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.19.2/go.mod h1:TF15nEFgTfsELGXN/OvQHFa3dIueBisgKGHEwKVityA=
 github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.17.21 h1:7vuzLT8obylMtylazUAcvbwEaCqAkr9v5KMjDt9L9z8=

--- a/internal/conns/awsclient.go
+++ b/internal/conns/awsclient.go
@@ -3,6 +3,7 @@ package conns
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 )
 
@@ -18,6 +19,10 @@ func (client *AWSClient) PartitionHostname(prefix string) string {
 // The prefix should not contain a trailing period.
 func (client *AWSClient) RegionalHostname(prefix string) string {
 	return fmt.Sprintf("%s.%s.%s", prefix, client.Region, client.DNSSuffix)
+}
+
+func (client *AWSClient) LogsClient() *cloudwatchlogs.Client {
+	return client.logsClient.Client()
 }
 
 func (client *AWSClient) SSMClient() *ssm.Client {

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -3,6 +3,7 @@ package conns
 
 import (
 	"github.com/aws/aws-sdk-go-v2/service/auditmanager"
+	cloudwatchlogs_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/comprehend"
 	"github.com/aws/aws-sdk-go-v2/service/computeoptimizer"
 	"github.com/aws/aws-sdk-go-v2/service/fis"
@@ -329,7 +330,8 @@ type AWSClient struct {
 	SupportedPlatforms        []string
 	TerraformVersion          string
 
-	ssmClient lazyClient[*ssm_sdkv2.Client]
+	logsClient lazyClient[*cloudwatchlogs_sdkv2.Client]
+	ssmClient  lazyClient[*ssm_sdkv2.Client]
 
 	ACMConn                          *acm.ACM
 	ACMPCAConn                       *acmpca.ACMPCA

--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/comprehend"
 	"github.com/aws/aws-sdk-go-v2/service/computeoptimizer"
 	"github.com/aws/aws-sdk-go-v2/service/fis"
@@ -289,6 +290,14 @@ func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWS
 		if endpoint := c.Endpoints[names.Transcribe]; endpoint != "" {
 			o.EndpointResolver = transcribe.EndpointResolverFromURL(endpoint)
 		}
+	})
+
+	client.logsClient.init(&cfg, func() *cloudwatchlogs.Client {
+		return cloudwatchlogs.NewFromConfig(cfg, func(o *cloudwatchlogs.Options) {
+			if endpoint := c.Endpoints[names.Logs]; endpoint != "" {
+				o.EndpointResolver = cloudwatchlogs.EndpointResolverFromURL(endpoint)
+			}
+		})
 	})
 
 	client.ssmClient.init(&cfg, func() *ssm.Client {

--- a/internal/generate/awsclient/file.tmpl
+++ b/internal/generate/awsclient/file.tmpl
@@ -5,6 +5,7 @@ import (
 {{ range .Services }}
 	{{ if ne .GoPackageOverride "" }}{{ .GoPackageOverride }}{{ end -}} "github.com/aws/aws-sdk-go{{ if eq .SDKVersion "2" }}-v2{{ end }}/service/{{ .GoPackage }}"
 {{- end }}
+	cloudwatchlogs_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	ssm_sdkv2 "github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/hashicorp/terraform-provider-aws/internal/experimental/intf"
@@ -26,7 +27,8 @@ type AWSClient struct {
 	SupportedPlatforms        []string
 	TerraformVersion          string
 
-	ssmClient lazyClient[*ssm_sdkv2.Client]
+	logsClient lazyClient[*cloudwatchlogs_sdkv2.Client]
+	ssmClient  lazyClient[*ssm_sdkv2.Client]
 
 	{{ range .Services }}
 	{{ .ProviderNameUpper }}{{ if eq .SDKVersion "1" }}Conn{{ else }}Client{{end}} *{{ if ne .GoPackageOverride "" }}{{ .GoPackageOverride }}{{ else }}{{ .GoPackage }}{{ end }}.{{ .ClientTypeName }}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1155,14 +1155,15 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_cloudwatch_event_rule":            events.ResourceRule(),
 			"aws_cloudwatch_event_target":          events.ResourceTarget(),
 
-			"aws_cloudwatch_log_destination":         logs.ResourceDestination(),
-			"aws_cloudwatch_log_destination_policy":  logs.ResourceDestinationPolicy(),
-			"aws_cloudwatch_log_group":               logs.ResourceGroup(),
-			"aws_cloudwatch_log_metric_filter":       logs.ResourceMetricFilter(),
-			"aws_cloudwatch_log_resource_policy":     logs.ResourceResourcePolicy(),
-			"aws_cloudwatch_log_stream":              logs.ResourceStream(),
-			"aws_cloudwatch_log_subscription_filter": logs.ResourceSubscriptionFilter(),
-			"aws_cloudwatch_query_definition":        logs.ResourceQueryDefinition(),
+			"aws_cloudwatch_log_data_protection_policy": logs.ResourceDataProtectionPolicy(),
+			"aws_cloudwatch_log_destination":            logs.ResourceDestination(),
+			"aws_cloudwatch_log_destination_policy":     logs.ResourceDestinationPolicy(),
+			"aws_cloudwatch_log_group":                  logs.ResourceGroup(),
+			"aws_cloudwatch_log_metric_filter":          logs.ResourceMetricFilter(),
+			"aws_cloudwatch_log_resource_policy":        logs.ResourceResourcePolicy(),
+			"aws_cloudwatch_log_stream":                 logs.ResourceStream(),
+			"aws_cloudwatch_log_subscription_filter":    logs.ResourceSubscriptionFilter(),
+			"aws_cloudwatch_query_definition":           logs.ResourceQueryDefinition(),
 
 			"aws_rum_app_monitor": rum.ResourceAppMonitor(),
 

--- a/internal/service/logs/data_protection_policy.go
+++ b/internal/service/logs/data_protection_policy.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-type logsClient interface {
+type LogsClient interface {
 	LogsClient() *cloudwatchlogs.Client
 }
 
@@ -43,7 +43,7 @@ func ResourceDataProtectionPolicy() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
@@ -54,7 +54,7 @@ func ResourceDataProtectionPolicy() *schema.Resource {
 }
 
 func resourceDataProtectionPolicyPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(logsClient).LogsClient()
+	conn := meta.(LogsClient).LogsClient()
 
 	logGroupName := d.Get("log_group_name").(string)
 
@@ -83,7 +83,7 @@ func resourceDataProtectionPolicyPut(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceDataProtectionPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(logsClient).LogsClient()
+	conn := meta.(LogsClient).LogsClient()
 
 	output, err := FindDataProtectionPolicyByID(ctx, conn, d.Id())
 
@@ -117,7 +117,7 @@ func resourceDataProtectionPolicyRead(ctx context.Context, d *schema.ResourceDat
 }
 
 func resourceDataProtectionPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(logsClient).LogsClient()
+	conn := meta.(LogsClient).LogsClient()
 
 	log.Printf("[DEBUG] Deleting CloudWatch Logs Data Protection Policy: %s", d.Id())
 	_, err := conn.DeleteDataProtectionPolicy(ctx, &cloudwatchlogs.DeleteDataProtectionPolicyInput{

--- a/internal/service/logs/data_protection_policy.go
+++ b/internal/service/logs/data_protection_policy.go
@@ -1,0 +1,160 @@
+package logs
+
+import (
+	"context"
+	"errors"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+type logsClient interface {
+	LogsClient() *cloudwatchlogs.Client
+}
+
+func ResourceDataProtectionPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceDataProtectionPolicyPut,
+		ReadWithoutTimeout:   resourceDataProtectionPolicyRead,
+		UpdateWithoutTimeout: resourceDataProtectionPolicyPut,
+		DeleteWithoutTimeout: resourceDataProtectionPolicyDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"log_group_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"policy_document": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateFunc:     validation.StringIsJSON,
+				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
+			},
+		},
+	}
+}
+
+func resourceDataProtectionPolicyPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(logsClient).LogsClient()
+
+	policy, err := structure.NormalizeJsonString(d.Get("policy_document").(string))
+
+	if err != nil {
+		return diag.Errorf("policy (%s) is invalid JSON: %s", policy, err)
+	}
+
+	logGroupID := d.Get("log_group_arn").(string)
+	input := &cloudwatchlogs.PutDataProtectionPolicyInput{
+		LogGroupIdentifier: aws.String(logGroupID),
+		PolicyDocument:     aws.String(policy),
+	}
+
+	_, err = conn.PutDataProtectionPolicy(ctx, input)
+
+	if err != nil {
+		return diag.Errorf("putting CloudWatch Logs Data Protection Policy (%s): %s", logGroupID, err)
+	}
+
+	if d.IsNewResource() {
+		d.SetId(logGroupID)
+	}
+
+	return resourceDataProtectionPolicyRead(ctx, d, meta)
+}
+
+func resourceDataProtectionPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(logsClient).LogsClient()
+
+	output, err := FindDataProtectionPolicyByID(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] CloudWatch Logs Data Protection Policy (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("reading CloudWatch Logs Data Protection Policy (%s): %s", d.Id(), err)
+	}
+
+	d.Set("log_group_arn", output.LogGroupIdentifier)
+
+	policyToSet, err := verify.SecondJSONUnlessEquivalent(d.Get("policy_document").(string), aws.ToString(output.PolicyDocument))
+
+	if err != nil {
+		return diag.Errorf("while setting policy (%s), encountered: %s", policyToSet, err)
+	}
+
+	policyToSet, err = structure.NormalizeJsonString(policyToSet)
+
+	if err != nil {
+		return diag.Errorf("policy (%s) is invalid JSON: %s", policyToSet, err)
+	}
+
+	d.Set("policy_document", policyToSet)
+
+	return nil
+}
+
+func resourceDataProtectionPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(logsClient).LogsClient()
+
+	log.Printf("[DEBUG] Deleting CloudWatch Logs Data Protection Policy: %s", d.Id())
+	_, err := conn.DeleteDataProtectionPolicy(ctx, &cloudwatchlogs.DeleteDataProtectionPolicyInput{
+		LogGroupIdentifier: aws.String(d.Id()),
+	})
+
+	if nfe := (*types.ResourceNotFoundException)(nil); errors.As(err, &nfe) {
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("deleting CloudWatch Logs Data Protection Policy (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func FindDataProtectionPolicyByID(ctx context.Context, conn *cloudwatchlogs.Client, id string) (*cloudwatchlogs.GetDataProtectionPolicyOutput, error) {
+	input := &cloudwatchlogs.GetDataProtectionPolicyInput{
+		LogGroupIdentifier: aws.String(id),
+	}
+
+	output, err := conn.GetDataProtectionPolicy(ctx, input)
+
+	if nfe := (*types.ResourceNotFoundException)(nil); errors.As(err, &nfe) {
+		return nil, &resource.NotFoundError{
+			LastError:   nfe,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
+}

--- a/internal/service/logs/data_protection_policy_test.go
+++ b/internal/service/logs/data_protection_policy_test.go
@@ -1,0 +1,387 @@
+package logs_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tflogs "github.com/hashicorp/terraform-provider-aws/internal/service/logs"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccLogsDataProtectionPolicy_basic(t *testing.T) {
+	var policy cloudwatchlogs.GetDataProtectionPolicyOutput
+	resourceName := "aws_cloudwatch_log_data_protection_policy.test"
+	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchLogsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataProtectionPolicy_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataProtectionPolicyExists(resourceName, &policy),
+					resource.TestCheckResourceAttrPair(resourceName, "log_group_name", "aws_cloudwatch_log_group.test", "name"),
+					acctest.CheckResourceAttrEquivalentJSON(resourceName, "policy_document", fmt.Sprintf(`
+{
+	"Name": "Test",
+	"Version": "2021-06-01",
+	"Statement": [
+		{
+			"Sid": "Audit",
+			"DataIdentifier": [
+				"arn:aws:dataprotection::aws:data-identifier/EmailAddress"
+			],
+			"Operation": {
+				"Audit": {
+					"FindingsDestination": {
+                      "S3": {
+                        "Bucket": %[1]q
+                      }
+                    }
+				}
+			}
+		},
+		{
+			"Sid": "Redact",
+			"DataIdentifier": [
+				"arn:aws:dataprotection::aws:data-identifier/EmailAddress"
+			],
+			"Operation": {
+				"Deidentify": {
+					"MaskConfig": {}
+				}
+			}
+		}
+	]
+}
+`, name)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLogsDataProtectionPolicy_disappears(t *testing.T) {
+	var policy cloudwatchlogs.GetDataProtectionPolicyOutput
+	resourceName := "aws_cloudwatch_log_data_protection_policy.test"
+	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchLogsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataProtectionPolicy_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataProtectionPolicyExists(resourceName, &policy),
+					acctest.CheckResourceDisappears(acctest.Provider, tflogs.ResourceDataProtectionPolicy(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccLogsDataProtectionPolicy_policyDocument(t *testing.T) {
+	var policy cloudwatchlogs.GetDataProtectionPolicyOutput
+	resourceName := "aws_cloudwatch_log_data_protection_policy.test"
+	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchLogsEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataProtectionPolicy_policyDocument1(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataProtectionPolicyExists(resourceName, &policy),
+					acctest.CheckResourceAttrEquivalentJSON(resourceName, "policy_document", `
+{
+	"Name": "Test",
+	"Version": "2021-06-01",
+	"Statement": [
+		{
+			"Sid": "Audit",
+			"DataIdentifier": [
+				"arn:aws:dataprotection::aws:data-identifier/EmailAddress"
+			],
+			"Operation": {
+				"Audit": {
+					"FindingsDestination": {}
+				}
+			}
+		},
+		{
+			"Sid": "Redact",
+			"DataIdentifier": [
+				"arn:aws:dataprotection::aws:data-identifier/EmailAddress"
+			],
+			"Operation": {
+				"Deidentify": {
+					"MaskConfig": {}
+				}
+			}
+		}
+	]
+}
+`),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDataProtectionPolicy_policyDocument2(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataProtectionPolicyExists(resourceName, &policy),
+					acctest.CheckResourceAttrEquivalentJSON(resourceName, "policy_document", fmt.Sprintf(`
+{
+	"Name": "Test",
+	"Version": "2021-06-01",
+	"Statement": [
+		{
+			"Sid": "Audit",
+			"DataIdentifier": [
+				"arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+				"arn:aws:dataprotection::aws:data-identifier/DriversLicense-US"
+			],
+			"Operation": {
+				"Audit": {
+					"FindingsDestination": {
+                      "S3": {
+                        "Bucket": %[1]q
+                      }
+                    }
+				}
+			}
+		},
+		{
+			"Sid": "Redact",
+			"DataIdentifier": [
+				"arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+				"arn:aws:dataprotection::aws:data-identifier/DriversLicense-US"
+			],
+			"Operation": {
+				"Deidentify": {
+					"MaskConfig": {}
+				}
+			}
+		}
+	]
+}
+`, name)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDataProtectionPolicyDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(tflogs.LogsClient).LogsClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_cloudwatch_log_data_protection_policy" {
+			continue
+		}
+
+		_, err := tflogs.FindDataProtectionPolicyByID(context.Background(), conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("CloudWatch Logs Data Protection Policy still exists: %s", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckDataProtectionPolicyExists(n string, v *cloudwatchlogs.GetDataProtectionPolicyOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No CloudWatch Logs Data Protection Policy ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(tflogs.LogsClient).LogsClient()
+
+		output, err := tflogs.FindDataProtectionPolicyByID(context.Background(), conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		*v = *output
+
+		return nil
+	}
+}
+
+func testAccDataProtectionPolicy_basic(name string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_log_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+
+resource "aws_cloudwatch_log_data_protection_policy" "test" {
+  log_group_name = aws_cloudwatch_log_group.test.name
+  policy_document = jsonencode({
+    Name    = "Test"
+    Version = "2021-06-01"
+
+    Statement = [
+      {
+        Sid = "Audit"
+        DataIdentifier = ["arn:aws:dataprotection::aws:data-identifier/EmailAddress"]
+        Operation = {
+          Audit = {
+            FindingsDestination = {
+              S3 = {
+                Bucket = aws_s3_bucket.test.bucket
+              }
+            }
+          }
+        }
+      },
+      {
+        Sid = "Redact"
+        DataIdentifier = ["arn:aws:dataprotection::aws:data-identifier/EmailAddress"]
+        Operation = {
+          Deidentify = {
+            MaskConfig = {}
+          }
+        }
+      }
+    ]
+  })
+}
+`, name)
+}
+
+func testAccDataProtectionPolicy_policyDocument1(name string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_log_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_cloudwatch_log_data_protection_policy" "test" {
+  log_group_name = aws_cloudwatch_log_group.test.name
+  policy_document = jsonencode({
+    Name    = "Test"
+    Version = "2021-06-01"
+
+    Statement = [
+      {
+        Sid = "Audit"
+        DataIdentifier = ["arn:aws:dataprotection::aws:data-identifier/EmailAddress"]
+        Operation = {
+          Audit = {
+            FindingsDestination = {}
+          }
+        }
+      },
+      {
+        Sid = "Redact"
+        DataIdentifier = ["arn:aws:dataprotection::aws:data-identifier/EmailAddress"]
+        Operation = {
+          Deidentify = {
+            MaskConfig = {}
+          }
+        }
+      }
+    ]
+  })
+}
+`, name)
+}
+
+func testAccDataProtectionPolicy_policyDocument2(name string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_log_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+
+resource "aws_cloudwatch_log_data_protection_policy" "test" {
+  log_group_name = aws_cloudwatch_log_group.test.name
+  policy_document = jsonencode({
+    Name    = "Test"
+    Version = "2021-06-01"
+
+    Statement = [
+      {
+        Sid = "Audit"
+        DataIdentifier = [
+          "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+          "arn:aws:dataprotection::aws:data-identifier/DriversLicense-US",
+        ]
+        Operation = {
+          Audit = {
+            FindingsDestination = {
+              S3 = {
+                Bucket = aws_s3_bucket.test.bucket
+              }
+            }
+          }
+        }
+      },
+      {
+        Sid = "Redact"
+        DataIdentifier = [
+          "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+          "arn:aws:dataprotection::aws:data-identifier/DriversLicense-US",
+        ]
+        Operation = {
+          Deidentify = {
+            MaskConfig = {}
+          }
+        }
+      }
+    ]
+  })
+}
+`, name)
+}

--- a/internal/service/logs/data_protection_policy_test.go
+++ b/internal/service/logs/data_protection_policy_test.go
@@ -270,7 +270,7 @@ resource "aws_cloudwatch_log_data_protection_policy" "test" {
 
     Statement = [
       {
-        Sid = "Audit"
+        Sid            = "Audit"
         DataIdentifier = ["arn:aws:dataprotection::aws:data-identifier/EmailAddress"]
         Operation = {
           Audit = {
@@ -283,7 +283,7 @@ resource "aws_cloudwatch_log_data_protection_policy" "test" {
         }
       },
       {
-        Sid = "Redact"
+        Sid            = "Redact"
         DataIdentifier = ["arn:aws:dataprotection::aws:data-identifier/EmailAddress"]
         Operation = {
           Deidentify = {
@@ -311,7 +311,7 @@ resource "aws_cloudwatch_log_data_protection_policy" "test" {
 
     Statement = [
       {
-        Sid = "Audit"
+        Sid            = "Audit"
         DataIdentifier = ["arn:aws:dataprotection::aws:data-identifier/EmailAddress"]
         Operation = {
           Audit = {
@@ -320,7 +320,7 @@ resource "aws_cloudwatch_log_data_protection_policy" "test" {
         }
       },
       {
-        Sid = "Redact"
+        Sid            = "Redact"
         DataIdentifier = ["arn:aws:dataprotection::aws:data-identifier/EmailAddress"]
         Operation = {
           Deidentify = {

--- a/internal/service/logs/data_protection_policy_test.go
+++ b/internal/service/logs/data_protection_policy_test.go
@@ -31,6 +31,7 @@ func TestAccLogsDataProtectionPolicy_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataProtectionPolicyExists(resourceName, &policy),
 					resource.TestCheckResourceAttrPair(resourceName, "log_group_name", "aws_cloudwatch_log_group.test", "name"),
+					//lintignore:AWSAT005
 					acctest.CheckResourceAttrEquivalentJSON(resourceName, "policy_document", fmt.Sprintf(`
 {
 	"Name": "Test",
@@ -114,6 +115,7 @@ func TestAccLogsDataProtectionPolicy_policyDocument(t *testing.T) {
 				Config: testAccDataProtectionPolicy_policyDocument1(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataProtectionPolicyExists(resourceName, &policy),
+					//lintignore:AWSAT005
 					acctest.CheckResourceAttrEquivalentJSON(resourceName, "policy_document", `
 {
 	"Name": "Test",
@@ -155,6 +157,7 @@ func TestAccLogsDataProtectionPolicy_policyDocument(t *testing.T) {
 				Config: testAccDataProtectionPolicy_policyDocument2(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataProtectionPolicyExists(resourceName, &policy),
+					//lintignore:AWSAT005
 					acctest.CheckResourceAttrEquivalentJSON(resourceName, "policy_document", fmt.Sprintf(`
 {
 	"Name": "Test",
@@ -253,6 +256,8 @@ func testAccCheckDataProtectionPolicyExists(n string, v *cloudwatchlogs.GetDataP
 
 func testAccDataProtectionPolicy_basic(name string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_cloudwatch_log_group" "test" {
   name = %[1]q
 }
@@ -271,7 +276,7 @@ resource "aws_cloudwatch_log_data_protection_policy" "test" {
     Statement = [
       {
         Sid            = "Audit"
-        DataIdentifier = ["arn:aws:dataprotection::aws:data-identifier/EmailAddress"]
+        DataIdentifier = ["arn:${data.aws_partition.current.partition}:dataprotection::aws:data-identifier/EmailAddress"]
         Operation = {
           Audit = {
             FindingsDestination = {
@@ -284,7 +289,7 @@ resource "aws_cloudwatch_log_data_protection_policy" "test" {
       },
       {
         Sid            = "Redact"
-        DataIdentifier = ["arn:aws:dataprotection::aws:data-identifier/EmailAddress"]
+        DataIdentifier = ["arn:${data.aws_partition.current.partition}:dataprotection::aws:data-identifier/EmailAddress"]
         Operation = {
           Deidentify = {
             MaskConfig = {}
@@ -299,6 +304,8 @@ resource "aws_cloudwatch_log_data_protection_policy" "test" {
 
 func testAccDataProtectionPolicy_policyDocument1(name string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_cloudwatch_log_group" "test" {
   name = %[1]q
 }
@@ -312,7 +319,7 @@ resource "aws_cloudwatch_log_data_protection_policy" "test" {
     Statement = [
       {
         Sid            = "Audit"
-        DataIdentifier = ["arn:aws:dataprotection::aws:data-identifier/EmailAddress"]
+        DataIdentifier = ["arn:${data.aws_partition.current.partition}:dataprotection::aws:data-identifier/EmailAddress"]
         Operation = {
           Audit = {
             FindingsDestination = {}
@@ -321,7 +328,7 @@ resource "aws_cloudwatch_log_data_protection_policy" "test" {
       },
       {
         Sid            = "Redact"
-        DataIdentifier = ["arn:aws:dataprotection::aws:data-identifier/EmailAddress"]
+        DataIdentifier = ["arn:${data.aws_partition.current.partition}:dataprotection::aws:data-identifier/EmailAddress"]
         Operation = {
           Deidentify = {
             MaskConfig = {}
@@ -336,6 +343,8 @@ resource "aws_cloudwatch_log_data_protection_policy" "test" {
 
 func testAccDataProtectionPolicy_policyDocument2(name string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_cloudwatch_log_group" "test" {
   name = %[1]q
 }
@@ -355,8 +364,8 @@ resource "aws_cloudwatch_log_data_protection_policy" "test" {
       {
         Sid = "Audit"
         DataIdentifier = [
-          "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
-          "arn:aws:dataprotection::aws:data-identifier/DriversLicense-US",
+          "arn:${data.aws_partition.current.partition}:dataprotection::aws:data-identifier/EmailAddress",
+          "arn:${data.aws_partition.current.partition}:dataprotection::aws:data-identifier/DriversLicense-US",
         ]
         Operation = {
           Audit = {
@@ -371,8 +380,8 @@ resource "aws_cloudwatch_log_data_protection_policy" "test" {
       {
         Sid = "Redact"
         DataIdentifier = [
-          "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
-          "arn:aws:dataprotection::aws:data-identifier/DriversLicense-US",
+          "arn:${data.aws_partition.current.partition}:dataprotection::aws:data-identifier/EmailAddress",
+          "arn:${data.aws_partition.current.partition}:dataprotection::aws:data-identifier/DriversLicense-US",
         ]
         Operation = {
           Deidentify = {

--- a/internal/service/logs/destination_policy.go
+++ b/internal/service/logs/destination_policy.go
@@ -63,7 +63,7 @@ func resourceDestinationPolicyPut(ctx context.Context, d *schema.ResourceData, m
 		input.ForceUpdate = aws.Bool(v.(bool))
 	}
 
-	_, err := conn.PutDestinationPolicy(input)
+	_, err := conn.PutDestinationPolicyWithContext(ctx, input)
 
 	if err != nil {
 		return diag.Errorf("putting CloudWatch Logs Destination Policy (%s): %s", name, err)

--- a/names/names.go
+++ b/names/names.go
@@ -23,6 +23,7 @@ import (
 
 // This "should" be defined by the AWS Go SDK v2, but currently isn't.
 const (
+	CloudWatchLogsEndpointID   = "logs"
 	ComprehendEndpointID       = "comprehend"
 	ComputeOptimizerEndpointID = "computeoptimizer"
 	IdentityStoreEndpointID    = "identitystore"

--- a/website/docs/r/cloudwatch_log_data_protection_policy.html.markdown
+++ b/website/docs/r/cloudwatch_log_data_protection_policy.html.markdown
@@ -65,6 +65,10 @@ The following arguments are supported:
 * `log_group_name` - (Required) The name of the log group under which the log stream is to be created.
 * `policy_document` - (Required) Specifies the data protection policy in JSON. Read more at [Data protection policy syntax](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data-start.html#mask-sensitive-log-data-policysyntax).
 
+## Attributes Reference
+
+No additional attributes are exported.
+
 ## Import
 
 This resource can be imported using the `log_group_name`. For example:

--- a/website/docs/r/cloudwatch_log_data_protection_policy.html.markdown
+++ b/website/docs/r/cloudwatch_log_data_protection_policy.html.markdown
@@ -20,7 +20,7 @@ resource "aws_cloudwatch_log_group" "example" {
 }
 
 resource "aws_s3_bucket" "example" {
-  bucket  = "example"
+  bucket = "example"
 }
 
 resource "aws_cloudwatch_log_data_protection_policy" "example" {

--- a/website/docs/r/cloudwatch_log_data_protection_policy.html.markdown
+++ b/website/docs/r/cloudwatch_log_data_protection_policy.html.markdown
@@ -32,7 +32,7 @@ resource "aws_cloudwatch_log_data_protection_policy" "example" {
 
     Statement = [
       {
-        Sid = "Audit"
+        Sid            = "Audit"
         DataIdentifier = ["arn:aws:dataprotection::aws:data-identifier/EmailAddress"]
         Operation = {
           Audit = {
@@ -45,7 +45,7 @@ resource "aws_cloudwatch_log_data_protection_policy" "example" {
         }
       },
       {
-        Sid = "Redact"
+        Sid            = "Redact"
         DataIdentifier = ["arn:aws:dataprotection::aws:data-identifier/EmailAddress"]
         Operation = {
           Deidentify = {

--- a/website/docs/r/cloudwatch_log_data_protection_policy.html.markdown
+++ b/website/docs/r/cloudwatch_log_data_protection_policy.html.markdown
@@ -1,0 +1,74 @@
+---
+subcategory: "CloudWatch Logs"
+layout: "aws"
+page_title: "AWS: aws_cloudwatch_log_data_protection_policy"
+description: |-
+  Provides a CloudWatch Log Data Protection Policy resource.
+---
+
+# Resource: aws_cloudwatch_log_data_protection_policy
+
+Provides a CloudWatch Log Data Protection Policy resource.
+
+Read more about protecting sensitive user data in the [User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html).
+
+## Example Usage
+
+```terraform
+resource "aws_cloudwatch_log_group" "example" {
+  name = "example"
+}
+
+resource "aws_s3_bucket" "example" {
+  bucket  = "example"
+}
+
+resource "aws_cloudwatch_log_data_protection_policy" "example" {
+  log_group_name = aws_cloudwatch_log_group.example.name
+
+  policy_document = jsonencode({
+    Name    = "Example"
+    Version = "2021-06-01"
+
+    Statement = [
+      {
+        Sid = "Audit"
+        DataIdentifier = ["arn:aws:dataprotection::aws:data-identifier/EmailAddress"]
+        Operation = {
+          Audit = {
+            FindingsDestination = {
+              S3 = {
+                Bucket = aws_s3_bucket.example.bucket
+              }
+            }
+          }
+        }
+      },
+      {
+        Sid = "Redact"
+        DataIdentifier = ["arn:aws:dataprotection::aws:data-identifier/EmailAddress"]
+        Operation = {
+          Deidentify = {
+            MaskConfig = {}
+          }
+        }
+      }
+    ]
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `log_group_name` - (Required) The name of the log group under which the log stream is to be created.
+* `policy_document` - (Required) Specifies the data protection policy in JSON. Read more at [Data protection policy syntax](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data-start.html#mask-sensitive-log-data-policysyntax).
+
+## Import
+
+This resource can be imported using the `log_group_name`. For example:
+
+```
+$ terraform import aws_cloudwatch_log_data_protection_policy.example my-log-group
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/pull/28045
Relates https://github.com/hashicorp/terraform-provider-aws/issues/28036

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccLogsDataProtectionPolicy_ PKG=logs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/logs/... -v -count 1 -parallel 20 -run='TestAccLogsDataProtectionPolicy_'  -timeout 180m
=== RUN   TestAccLogsDataProtectionPolicy_basic
=== PAUSE TestAccLogsDataProtectionPolicy_basic
=== RUN   TestAccLogsDataProtectionPolicy_disappears
=== PAUSE TestAccLogsDataProtectionPolicy_disappears
=== RUN   TestAccLogsDataProtectionPolicy_policyDocument
=== PAUSE TestAccLogsDataProtectionPolicy_policyDocument
=== CONT  TestAccLogsDataProtectionPolicy_basic
=== CONT  TestAccLogsDataProtectionPolicy_policyDocument
=== CONT  TestAccLogsDataProtectionPolicy_disappears
--- PASS: TestAccLogsDataProtectionPolicy_disappears (11.99s)
--- PASS: TestAccLogsDataProtectionPolicy_basic (13.48s)
--- PASS: TestAccLogsDataProtectionPolicy_policyDocument (21.90s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       23.744s
```
