### PR TITLE
r/aws_ce_cost_category - make `effective_start` an argument

### DIFF
--- a/.changelog/28055.txt
+++ b/.changelog/28055.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_ce_cost_category: Allow setting `effective_start`
+resource/aws_ce_cost_category: Allow configuration of `effective_start` value
 ```

--- a/.changelog/28055.txt
+++ b/.changelog/28055.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ce_cost_category: Allow setting `effective_start`
+```

--- a/internal/service/ce/cost_category.go
+++ b/internal/service/ce/cost_category.go
@@ -48,6 +48,7 @@ func ResourceCostCategory() *schema.Resource {
 			},
 			"effective_start": {
 				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
 			},
 			"name": {
@@ -389,6 +390,10 @@ func resourceCostCategoryCreate(ctx context.Context, d *schema.ResourceData, met
 		input.SplitChargeRules = expandCostCategorySplitChargeRules(v.(*schema.Set).List())
 	}
 
+	if v, ok := d.GetOk("effective_start"); ok {
+		input.EffectiveStart = aws.String(v.(string))
+	}
+
 	if len(tags) > 0 {
 		input.ResourceTags = Tags(tags.IgnoreAWS())
 	}
@@ -472,6 +477,10 @@ func resourceCostCategoryUpdate(ctx context.Context, d *schema.ResourceData, met
 
 		if d.HasChange("split_charge_rule") {
 			input.SplitChargeRules = expandCostCategorySplitChargeRules(d.Get("split_charge_rule").(*schema.Set).List())
+		}
+
+		if d.HasChange("effective_start") {
+			input.EffectiveStart = aws.String(d.Get("effective_start").(string))
 		}
 
 		_, err := conn.UpdateCostCategoryDefinitionWithContext(ctx, input)

--- a/website/docs/r/ce_cost_category.html.markdown
+++ b/website/docs/r/ce_cost_category.html.markdown
@@ -56,6 +56,7 @@ The following arguments are required:
 * `name` - (Required) Unique name for the Cost Category.
 * `rule` - (Required) Configuration block for the Cost Category rules used to categorize costs. See below.
 * `rule_version` - (Required) Rule schema version in this particular Cost Category.
+* `effective_start`- (Optional)  The Cost Category's effective start date. It can only be a billing start date (first day of the month). If the date isn't provided, it's the first day of the current month. Dates can't be before the previous twelve months, or in the future. For example `2022-11-01T00:00:00Z`.
 
 The following arguments are optional:
 
@@ -120,7 +121,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - ARN of the cost category.
 * `effective_end` - Effective end data of your Cost Category.
-* `effective_start` - Effective state data of your Cost Category.
 * `id` - Unique ID of the cost category.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28009

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccCECostCategory_ PKG=ce

--- PASS: TestAccCECostCategory_disappears (31.25s)
--- PASS: TestAccCECostCategory_basic (47.13s)
--- PASS: TestAccCECostCategory_complete (67.70s)
--- PASS: TestAccCECostCategory_effectiveStart (71.30s)
--- PASS: TestAccCECostCategory_splitCharge (72.68s)
--- PASS: TestAccCECostCategory_tags (96.73s)
```
