### PR TITLE
Fix auto_minor_version_upgrade documentation on DocumentDB instances

### DIFF
--- a/website/docs/r/docdb_cluster_instance.html.markdown
+++ b/website/docs/r/docdb_cluster_instance.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `apply_immediately` - (Optional) Specifies whether any database modifications
      are applied immediately, or during the next maintenance window. Default is`false`.
-* `auto_minor_version_upgrade` - (Optional) Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. Default `true`.
+* `auto_minor_version_upgrade` - (Optional) This parameter does not apply to Amazon DocumentDB. Amazon DocumentDB does not perform minor version upgrades regardless of the value set (see [docs](https://docs.aws.amazon.com/documentdb/latest/developerguide/API_DBInstance.html)). Default `true`.
 * `availability_zone` - (Optional, Computed) The EC2 Availability Zone that the DB instance is created in. See [docs](https://docs.aws.amazon.com/documentdb/latest/developerguide/API_CreateDBInstance.html) about the details.
 * `cluster_identifier` - (Required) The identifier of the [`aws_docdb_cluster`](/docs/providers/aws/r/docdb_cluster.html) in which to launch this instance.
 * `enable_performance_insights` - (Optional) A value that indicates whether to enable Performance Insights for the DB Instance. Default `false`. See [docs] (https://docs.aws.amazon.com/documentdb/latest/developerguide/performance-insights.html) about the details.


### PR DESCRIPTION
### Description

According to the [documentation on the actual data type](https://docs.aws.amazon.com/documentdb/latest/developerguide/API_DBInstance.html) - and the [AWS CLI docs confirm this](https://docs.aws.amazon.com/cli/latest/reference/docdb/create-db-instance.html) - the `auto_minor_version_upgrade` settings are not applicable to DocDB instances. The options seem to be there to retain some sort of compatibility to the RDS CLI (maybe), but they have no effect.

Terraformers relying on this documentation might expect, that changing that setting changes something in their cloud setup, but it in fact does not.

This pull request should fix the documentation stating wrong things on this page:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster_instance



### References

* AWS DocumentDB Developer Guide: DBInstances https://docs.aws.amazon.com/documentdb/latest/developerguide/API_DBInstance.html
* AWS CLI reference on `docdb`: https://docs.aws.amazon.com/cli/latest/reference/docdb/create-db-instance.html
* Terraform Documentation stating wrong documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster_instance
