### PR TITLE
Tech debt: Migrate `cloudcontrol` to AWS SDK v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.17.1
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.19
 	github.com/aws/aws-sdk-go-v2/service/auditmanager v1.21.0
+	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.10.19
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.17.0
 	github.com/aws/aws-sdk-go-v2/service/comprehend v1.19.2
 	github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.3.11 h1:6cZRymlLEIlDTEB0+5+An6Zj1CK
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.11/go.mod h1:0MR+sS1b/yxsfAPvAESrw8NfwUoxMinDyw6EYR9BS2U=
 github.com/aws/aws-sdk-go-v2/service/auditmanager v1.21.0 h1:3TOMzf1EqvOapVX76yxostIZVe9lpSnQs5n8TNPEgvE=
 github.com/aws/aws-sdk-go-v2/service/auditmanager v1.21.0/go.mod h1:KQ0nmqhPXEsObZkum2BWlzZcPFgnWFUwjkIXheLLYUM=
+github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.10.19 h1:CqkR3MZ3y5V7E0yy5FjoGZRV5xuUoa93M02TKoyrvd8=
+github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.10.19/go.mod h1:6vkpJjJPiLqUFFbON9I6xLkrk4Jil8vAuLhNnxGtaAQ=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.17.0 h1:/RFnaZHehAtDteT8Ds9SNpMaNbkyVrKizWQPaMXLI8I=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.17.0/go.mod h1:9feOMWt3rxs46DqBVHco7z1KxRG36bKUqtv306cAtaA=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.19.2 h1:QPZlPIMkaEOOFbz+znqwS5HkomTbNFxEJnKJ8zGOMlQ=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -3,6 +3,7 @@ package conns
 
 import (
 	"github.com/aws/aws-sdk-go-v2/service/auditmanager"
+	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	cloudwatchlogs_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/comprehend"
 	"github.com/aws/aws-sdk-go-v2/service/computeoptimizer"
@@ -61,7 +62,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/chimesdkmeetings"
 	"github.com/aws/aws-sdk-go/service/chimesdkmessaging"
 	"github.com/aws/aws-sdk-go/service/cloud9"
-	"github.com/aws/aws-sdk-go/service/cloudcontrolapi"
 	"github.com/aws/aws-sdk-go/service/clouddirectory"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
@@ -376,7 +376,7 @@ type AWSClient struct {
 	ChimeSDKMeetingsConn             *chimesdkmeetings.ChimeSDKMeetings
 	ChimeSDKMessagingConn            *chimesdkmessaging.ChimeSDKMessaging
 	Cloud9Conn                       *cloud9.Cloud9
-	CloudControlConn                 *cloudcontrolapi.CloudControlApi
+	CloudControlClient               *cloudcontrol.Client
 	CloudDirectoryConn               *clouddirectory.CloudDirectory
 	CloudFormationConn               *cloudformation.CloudFormation
 	CloudFrontConn                   *cloudfront.CloudFront

--- a/internal/conns/config_gen.go
+++ b/internal/conns/config_gen.go
@@ -4,6 +4,7 @@ package conns
 import (
 	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/auditmanager"
+	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	cloudwatchlogs_sdkv2 "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/comprehend"
 	"github.com/aws/aws-sdk-go-v2/service/computeoptimizer"
@@ -62,7 +63,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/chimesdkmeetings"
 	"github.com/aws/aws-sdk-go/service/chimesdkmessaging"
 	"github.com/aws/aws-sdk-go/service/cloud9"
-	"github.com/aws/aws-sdk-go/service/cloudcontrolapi"
 	"github.com/aws/aws-sdk-go/service/clouddirectory"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
@@ -351,7 +351,6 @@ func (c *Config) sdkv1Conns(client *AWSClient, sess *session.Session) {
 	client.ChimeSDKMeetingsConn = chimesdkmeetings.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ChimeSDKMeetings])}))
 	client.ChimeSDKMessagingConn = chimesdkmessaging.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.ChimeSDKMessaging])}))
 	client.Cloud9Conn = cloud9.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Cloud9])}))
-	client.CloudControlConn = cloudcontrolapi.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudControl])}))
 	client.CloudDirectoryConn = clouddirectory.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudDirectory])}))
 	client.CloudFormationConn = cloudformation.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudFormation])}))
 	client.CloudFrontConn = cloudfront.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.CloudFront])}))
@@ -603,6 +602,11 @@ func (c *Config) sdkv2Conns(client *AWSClient, cfg aws_sdkv2.Config) {
 	client.AuditManagerClient = auditmanager.NewFromConfig(cfg, func(o *auditmanager.Options) {
 		if endpoint := c.Endpoints[names.AuditManager]; endpoint != "" {
 			o.EndpointResolver = auditmanager.EndpointResolverFromURL(endpoint)
+		}
+	})
+	client.CloudControlClient = cloudcontrol.NewFromConfig(cfg, func(o *cloudcontrol.Options) {
+		if endpoint := c.Endpoints[names.CloudControl]; endpoint != "" {
+			o.EndpointResolver = cloudcontrol.EndpointResolverFromURL(endpoint)
 		}
 	})
 	client.ComprehendClient = comprehend.NewFromConfig(cfg, func(o *comprehend.Options) {

--- a/internal/generate/awsclient/main.go
+++ b/internal/generate/awsclient/main.go
@@ -34,7 +34,7 @@ type TemplateData struct {
 func main() {
 	g := common.NewGenerator()
 
-	g.Infof("generating internal/conns/%s", filename)
+	g.Infof("Generating internal/conns/%s", filename)
 
 	data, err := common.ReadAllNamesData(namesDataFile)
 

--- a/internal/generate/awsclient/main.go
+++ b/internal/generate/awsclient/main.go
@@ -34,7 +34,7 @@ type TemplateData struct {
 func main() {
 	g := common.NewGenerator()
 
-	g.Infof("generating internal/conns/%s\n", filename)
+	g.Infof("generating internal/conns/%s", filename)
 
 	data, err := common.ReadAllNamesData(namesDataFile)
 

--- a/internal/generate/clientconfig/main.go
+++ b/internal/generate/clientconfig/main.go
@@ -34,7 +34,7 @@ type TemplateData struct {
 func main() {
 	g := common.NewGenerator()
 
-	g.Infof("generating internal/conns/%s", filename)
+	g.Infof("Generating internal/conns/%s", filename)
 
 	data, err := common.ReadAllNamesData(namesDataFile)
 

--- a/internal/generate/clientconfig/main.go
+++ b/internal/generate/clientconfig/main.go
@@ -34,7 +34,7 @@ type TemplateData struct {
 func main() {
 	g := common.NewGenerator()
 
-	g.Infof("generating internal/conns/%s\n", filename)
+	g.Infof("generating internal/conns/%s", filename)
 
 	data, err := common.ReadAllNamesData(namesDataFile)
 

--- a/internal/service/cloudcontrol/resource_data_source.go
+++ b/internal/service/cloudcontrol/resource_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"regexp"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -42,7 +42,7 @@ func DataSourceResource() *schema.Resource {
 }
 
 func dataSourceResourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).CloudControlConn
+	conn := meta.(*conns.AWSClient).CloudControlClient
 
 	identifier := d.Get("identifier").(string)
 	typeName := d.Get("type_name").(string)
@@ -57,7 +57,7 @@ func dataSourceResourceRead(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("reading Cloud Control API (%s) Resource (%s): %s", typeName, identifier, err)
 	}
 
-	d.SetId(aws.StringValue(resourceDescription.Identifier))
+	d.SetId(aws.ToString(resourceDescription.Identifier))
 
 	d.Set("properties", resourceDescription.Properties)
 

--- a/internal/service/cloudcontrol/resource_test.go
+++ b/internal/service/cloudcontrol/resource_test.go
@@ -499,7 +499,7 @@ func TestAccCloudControlResource_lambdaFunction(t *testing.T) {
 }
 
 func testAccCheckResourceDestroy(s *terraform.State) error {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).CloudControlConn
+	conn := acctest.Provider.Meta().(*conns.AWSClient).CloudControlClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_cloudcontrolapi_resource" {

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -48,7 +48,7 @@ s3,s3,,,,,,,,,,,,,,,,CLI High-level S3 commands,AWS,x,,,,CLI only
 history,history,,,,,,,,,,,,,,,,CLI History of commands,AWS,x,,,,CLI only
 importexport,importexport,,,,,,,,,,,,,,,,CLI Import/Export,AWS,x,,,,CLI only
 cli-dev,clidev,,,,,,,,,,,,,,,,CLI Internal commands for development,AWS,x,,,,CLI only
-cloudcontrol,cloudcontrol,cloudcontrolapi,cloudcontrol,,cloudcontrol,,cloudcontrolapi,CloudControl,CloudControlApi,,1,,aws_cloudcontrolapi_,aws_cloudcontrol_,,cloudcontrolapi_,Cloud Control API,AWS,,,,,
+cloudcontrol,cloudcontrol,cloudcontrolapi,cloudcontrol,,cloudcontrol,,cloudcontrolapi,CloudControl,CloudControlApi,,,2,aws_cloudcontrolapi_,aws_cloudcontrol_,,cloudcontrolapi_,Cloud Control API,AWS,,,,,
 ,,,,,,,,,,,,,,,,,Cloud Digital Interface SDK,AWS,x,,,,No SDK support
 clouddirectory,clouddirectory,clouddirectory,clouddirectory,,clouddirectory,,,CloudDirectory,CloudDirectory,,1,,,aws_clouddirectory_,,clouddirectory_,Cloud Directory,Amazon,,,,,
 servicediscovery,servicediscovery,servicediscovery,servicediscovery,,servicediscovery,,,ServiceDiscovery,ServiceDiscovery,,1,,aws_service_discovery_,aws_servicediscovery_,,service_discovery_,Cloud Map,AWS,,,,,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Migrates the `cloudcontrol` service resource and data source to AWS SDK for Go v2.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccCloudControlResource_' PKG=cloudcontrol ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudcontrol/... -v -count 1 -parallel 2  -run=TestAccCloudControlResource_ -timeout 180m
=== RUN   TestAccCloudControlResource_basic
=== PAUSE TestAccCloudControlResource_basic
=== RUN   TestAccCloudControlResource_disappears
=== PAUSE TestAccCloudControlResource_disappears
=== RUN   TestAccCloudControlResource_DesiredState_booleanValueAdded
=== PAUSE TestAccCloudControlResource_DesiredState_booleanValueAdded
=== RUN   TestAccCloudControlResource_DesiredState_booleanValueRemoved
=== PAUSE TestAccCloudControlResource_DesiredState_booleanValueRemoved
=== RUN   TestAccCloudControlResource_DesiredState_booleanValueUpdate
=== PAUSE TestAccCloudControlResource_DesiredState_booleanValueUpdate
=== RUN   TestAccCloudControlResource_DesiredState_createOnly
=== PAUSE TestAccCloudControlResource_DesiredState_createOnly
=== RUN   TestAccCloudControlResource_DesiredState_integerValueAdded
=== PAUSE TestAccCloudControlResource_DesiredState_integerValueAdded
=== RUN   TestAccCloudControlResource_DesiredState_integerValueRemoved
=== PAUSE TestAccCloudControlResource_DesiredState_integerValueRemoved
=== RUN   TestAccCloudControlResource_DesiredState_integerValueUpdate
=== PAUSE TestAccCloudControlResource_DesiredState_integerValueUpdate
=== RUN   TestAccCloudControlResource_DesiredState_invalidPropertyName
=== PAUSE TestAccCloudControlResource_DesiredState_invalidPropertyName
=== RUN   TestAccCloudControlResource_DesiredState_invalidPropertyValue
=== PAUSE TestAccCloudControlResource_DesiredState_invalidPropertyValue
=== RUN   TestAccCloudControlResource_DesiredState_objectValueAdded
=== PAUSE TestAccCloudControlResource_DesiredState_objectValueAdded
=== RUN   TestAccCloudControlResource_DesiredState_objectValueRemoved
=== PAUSE TestAccCloudControlResource_DesiredState_objectValueRemoved
=== RUN   TestAccCloudControlResource_DesiredState_objectValueUpdate
=== PAUSE TestAccCloudControlResource_DesiredState_objectValueUpdate
=== RUN   TestAccCloudControlResource_DesiredState_stringValueAdded
=== PAUSE TestAccCloudControlResource_DesiredState_stringValueAdded
=== RUN   TestAccCloudControlResource_DesiredState_stringValueRemoved
=== PAUSE TestAccCloudControlResource_DesiredState_stringValueRemoved
=== RUN   TestAccCloudControlResource_DesiredState_stringValueUpdate
=== PAUSE TestAccCloudControlResource_DesiredState_stringValueUpdate
=== RUN   TestAccCloudControlResource_resourceSchema
=== PAUSE TestAccCloudControlResource_resourceSchema
=== RUN   TestAccCloudControlResource_lambdaFunction
=== PAUSE TestAccCloudControlResource_lambdaFunction
=== CONT  TestAccCloudControlResource_basic
=== CONT  TestAccCloudControlResource_DesiredState_invalidPropertyValue
--- PASS: TestAccCloudControlResource_DesiredState_invalidPropertyValue (7.76s)
=== CONT  TestAccCloudControlResource_DesiredState_createOnly
--- PASS: TestAccCloudControlResource_basic (18.08s)
=== CONT  TestAccCloudControlResource_DesiredState_invalidPropertyName
--- PASS: TestAccCloudControlResource_DesiredState_invalidPropertyName (2.24s)
=== CONT  TestAccCloudControlResource_DesiredState_integerValueUpdate
--- PASS: TestAccCloudControlResource_DesiredState_createOnly (31.22s)
=== CONT  TestAccCloudControlResource_DesiredState_integerValueRemoved
--- PASS: TestAccCloudControlResource_DesiredState_integerValueUpdate (29.77s)
=== CONT  TestAccCloudControlResource_DesiredState_integerValueAdded
--- PASS: TestAccCloudControlResource_DesiredState_integerValueRemoved (29.97s)
=== CONT  TestAccCloudControlResource_DesiredState_stringValueRemoved
--- PASS: TestAccCloudControlResource_DesiredState_integerValueAdded (29.62s)
=== CONT  TestAccCloudControlResource_lambdaFunction
--- PASS: TestAccCloudControlResource_DesiredState_stringValueRemoved (35.53s)
=== CONT  TestAccCloudControlResource_resourceSchema
--- PASS: TestAccCloudControlResource_resourceSchema (17.33s)
=== CONT  TestAccCloudControlResource_DesiredState_stringValueUpdate
--- PASS: TestAccCloudControlResource_DesiredState_stringValueUpdate (31.93s)
=== CONT  TestAccCloudControlResource_DesiredState_objectValueUpdate
--- PASS: TestAccCloudControlResource_lambdaFunction (107.19s)
=== CONT  TestAccCloudControlResource_DesiredState_stringValueAdded
--- PASS: TestAccCloudControlResource_DesiredState_objectValueUpdate (46.65s)
=== CONT  TestAccCloudControlResource_DesiredState_objectValueRemoved
--- PASS: TestAccCloudControlResource_DesiredState_stringValueAdded (36.28s)
=== CONT  TestAccCloudControlResource_DesiredState_booleanValueRemoved
--- PASS: TestAccCloudControlResource_DesiredState_objectValueRemoved (34.71s)
=== CONT  TestAccCloudControlResource_DesiredState_booleanValueUpdate
--- PASS: TestAccCloudControlResource_DesiredState_booleanValueRemoved (31.48s)
=== CONT  TestAccCloudControlResource_DesiredState_booleanValueAdded
--- PASS: TestAccCloudControlResource_DesiredState_booleanValueUpdate (30.70s)
=== CONT  TestAccCloudControlResource_DesiredState_objectValueAdded
--- PASS: TestAccCloudControlResource_DesiredState_booleanValueAdded (29.02s)
=== CONT  TestAccCloudControlResource_disappears
--- PASS: TestAccCloudControlResource_disappears (15.18s)
--- PASS: TestAccCloudControlResource_DesiredState_objectValueAdded (34.32s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudcontrol	305.128s
```
