### PR TITLE
r/aws_redshiftserverless_namespace - fix user/pass update

### DIFF
--- a/.changelog/28125.txt
+++ b/.changelog/28125.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_redshiftserverless_namespace: Fix Updating `admin_username` and `admin_user_password`
+```

--- a/.changelog/28125.txt
+++ b/.changelog/28125.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_redshiftserverless_namespace: Fix Updating `admin_username` and `admin_user_password`
+resource/aws_redshiftserverless_namespace: Fix updating `admin_username` and `admin_user_password`
 ```

--- a/internal/service/redshiftserverless/namespace.go
+++ b/internal/service/redshiftserverless/namespace.go
@@ -29,10 +29,6 @@ func ResourceNamespace() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"admin_user_password": {
 				Type:      schema.TypeString,
 				Optional:  true,
@@ -43,6 +39,10 @@ func ResourceNamespace() *schema.Resource {
 				Optional:  true,
 				Sensitive: true,
 				Computed:  true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"db_name": {
 				Type:     schema.TypeString,
@@ -100,8 +100,10 @@ func resourceNamespaceCreate(d *schema.ResourceData, meta interface{}) error {
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
-	input := redshiftserverless.CreateNamespaceInput{
-		NamespaceName: aws.String(d.Get("namespace_name").(string)),
+	name := d.Get("namespace_name").(string)
+	input := &redshiftserverless.CreateNamespaceInput{
+		NamespaceName: aws.String(name),
+		Tags:          Tags(tags.IgnoreAWS()),
 	}
 
 	if v, ok := d.GetOk("admin_user_password"); ok {
@@ -120,27 +122,25 @@ func resourceNamespaceCreate(d *schema.ResourceData, meta interface{}) error {
 		input.DefaultIamRoleArn = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("kms_key_id"); ok {
-		input.KmsKeyId = aws.String(v.(string))
-	}
-
 	if v, ok := d.GetOk("iam_roles"); ok && v.(*schema.Set).Len() > 0 {
 		input.IamRoles = flex.ExpandStringSet(v.(*schema.Set))
+	}
+
+	if v, ok := d.GetOk("kms_key_id"); ok {
+		input.KmsKeyId = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("log_exports"); ok && v.(*schema.Set).Len() > 0 {
 		input.LogExports = flex.ExpandStringSet(v.(*schema.Set))
 	}
 
-	input.Tags = Tags(tags.IgnoreAWS())
-
-	out, err := conn.CreateNamespace(&input)
+	output, err := conn.CreateNamespace(input)
 
 	if err != nil {
-		return fmt.Errorf("error creating Redshift Serverless Namespace : %w", err)
+		return fmt.Errorf("creating Redshift Serverless Namespace (%s): %w", name, err)
 	}
 
-	d.SetId(aws.StringValue(out.Namespace.NamespaceName))
+	d.SetId(aws.StringValue(output.Namespace.NamespaceName))
 
 	return resourceNamespaceRead(d, meta)
 }
@@ -150,7 +150,8 @@ func resourceNamespaceRead(d *schema.ResourceData, meta interface{}) error {
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	out, err := FindNamespaceByName(conn, d.Id())
+	output, err := FindNamespaceByName(conn, d.Id())
+
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Redshift Serverless Namespace (%s) not found, removing from state", d.Id())
 		d.SetId("")
@@ -158,39 +159,39 @@ func resourceNamespaceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error reading Redshift Serverless Namespace (%s): %w", d.Id(), err)
+		return fmt.Errorf("reading Redshift Serverless Namespace (%s): %w", d.Id(), err)
 	}
 
-	arn := aws.StringValue(out.NamespaceArn)
+	arn := aws.StringValue(output.NamespaceArn)
+	d.Set("admin_username", output.AdminUsername)
 	d.Set("arn", arn)
-	d.Set("namespace_name", out.NamespaceName)
-	d.Set("namespace_id", out.NamespaceId)
-	d.Set("kms_key_id", out.KmsKeyId)
-	d.Set("admin_username", out.AdminUsername)
-	d.Set("db_name", out.DbName)
-	d.Set("default_iam_role_arn", out.DefaultIamRoleArn)
-	d.Set("log_exports", flex.FlattenStringSet(out.LogExports))
-	d.Set("iam_roles", flex.FlattenStringSet(out.IamRoles))
+	d.Set("db_name", output.DbName)
+	d.Set("default_iam_role_arn", output.DefaultIamRoleArn)
+	d.Set("iam_roles", aws.StringValueSlice(output.IamRoles))
+	d.Set("kms_key_id", output.KmsKeyId)
+	d.Set("log_exports", aws.StringValueSlice(output.LogExports))
+	d.Set("namespace_id", output.NamespaceId)
+	d.Set("namespace_name", output.NamespaceName)
 
 	tags, err := ListTags(conn, arn)
 
-	if err != nil {
-		if tfawserr.ErrCodeEquals(err, "UnknownOperationException") {
-			return nil
-		}
+	if tfawserr.ErrCodeEquals(err, "UnknownOperationException") {
+		return nil
+	}
 
-		return fmt.Errorf("error listing tags for edshift Serverless Namespace (%s): %w", arn, err)
+	if err != nil {
+		return fmt.Errorf("listing tags for Redshift Serverless Namespace (%s): %w", arn, err)
 	}
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
+		return fmt.Errorf("setting tags: %w", err)
 	}
 
 	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return fmt.Errorf("error setting tags_all: %w", err)
+		return fmt.Errorf("setting tags_all: %w", err)
 	}
 
 	return nil
@@ -204,39 +205,35 @@ func resourceNamespaceUpdate(d *schema.ResourceData, meta interface{}) error {
 			NamespaceName: aws.String(d.Id()),
 		}
 
-		if d.HasChange("kms_key_id") {
-			input.KmsKeyId = aws.String(d.Get("kms_key_id").(string))
+		if d.HasChanges("admin_username", "admin_user_password") {
+			input.AdminUsername = aws.String(d.Get("admin_username").(string))
+			input.AdminUserPassword = aws.String(d.Get("admin_user_password").(string))
 		}
 
 		if d.HasChange("default_iam_role_arn") {
 			input.DefaultIamRoleArn = aws.String(d.Get("default_iam_role_arn").(string))
 		}
 
-		if d.HasChange("admin_username") {
-			input.AdminUsername = aws.String(d.Get("admin_username").(string))
-			input.AdminUserPassword = aws.String(d.Get("admin_user_password").(string))
+		if d.HasChange("iam_roles") {
+			input.IamRoles = flex.ExpandStringSet(d.Get("iam_roles").(*schema.Set))
 		}
 
-		if d.HasChange("admin_user_password") {
-			input.AdminUsername = aws.String(d.Get("admin_username").(string))
-			input.AdminUserPassword = aws.String(d.Get("admin_user_password").(string))
+		if d.HasChange("kms_key_id") {
+			input.KmsKeyId = aws.String(d.Get("kms_key_id").(string))
 		}
 
 		if d.HasChange("log_exports") {
 			input.LogExports = flex.ExpandStringSet(d.Get("log_exports").(*schema.Set))
 		}
 
-		if d.HasChange("iam_roles") {
-			input.IamRoles = flex.ExpandStringSet(d.Get("iam_roles").(*schema.Set))
-		}
-
 		_, err := conn.UpdateNamespace(input)
+
 		if err != nil {
-			return fmt.Errorf("error updating Redshift Serverless Namespace (%s): %w", d.Id(), err)
+			return fmt.Errorf("updating Redshift Serverless Namespace (%s): %w", d.Id(), err)
 		}
 
 		if _, err := waitNamespaceUpdated(conn, d.Id()); err != nil {
-			return fmt.Errorf("error waiting for Redshift Serverless Namespace (%s) to be updated: %w", d.Id(), err)
+			return fmt.Errorf("waiting for Redshift Serverless Namespace (%s) update: %w", d.Id(), err)
 		}
 	}
 
@@ -244,7 +241,7 @@ func resourceNamespaceUpdate(d *schema.ResourceData, meta interface{}) error {
 		o, n := d.GetChange("tags_all")
 
 		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
-			return fmt.Errorf("error updating Redshift Serverless Namespace (%s) tags: %w", d.Get("arn").(string), err)
+			return fmt.Errorf("updating Redshift Serverless Namespace (%s) tags: %w", d.Get("arn").(string), err)
 		}
 	}
 
@@ -269,11 +266,11 @@ func resourceNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting Redshift Serverless Namespace (%s): %w", d.Id(), err)
+		return fmt.Errorf("deleting Redshift Serverless Namespace (%s): %w", d.Id(), err)
 	}
 
 	if _, err := waitNamespaceDeleted(conn, d.Id()); err != nil {
-		return fmt.Errorf("error waiting for Redshift Serverless Namespace (%s) delete: %w", d.Id(), err)
+		return fmt.Errorf("waiting for Redshift Serverless Namespace (%s) delete: %w", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/redshiftserverless/namespace.go
+++ b/internal/service/redshiftserverless/namespace.go
@@ -213,11 +213,13 @@ func resourceNamespaceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if d.HasChange("admin_username") {
-			input.AdminUserPassword = aws.String(d.Get("admin_username").(string))
+			input.AdminUsername = aws.String(d.Get("admin_username").(string))
+			input.AdminUserPassword = aws.String(d.Get("admin_user_password").(string))
 		}
 
 		if d.HasChange("admin_user_password") {
-			input.AdminUsername = aws.String(d.Get("admin_user_password").(string))
+			input.AdminUsername = aws.String(d.Get("admin_username").(string))
+			input.AdminUserPassword = aws.String(d.Get("admin_user_password").(string))
 		}
 
 		if d.HasChange("log_exports") {

--- a/internal/service/redshiftserverless/namespace_test.go
+++ b/internal/service/redshiftserverless/namespace_test.go
@@ -59,6 +59,38 @@ func TestAccRedshiftServerlessNamespace_basic(t *testing.T) {
 	})
 }
 
+func TestAccRedshiftServerlessNamespace_user(t *testing.T) {
+	resourceName := "aws_redshiftserverless_namespace.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, redshiftserverless.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNamespaceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNamespaceExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccNamespaceConfig_user(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNamespaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "admin_user_password", "Password123"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRedshiftServerlessNamespace_tags(t *testing.T) {
 	resourceName := "aws_redshiftserverless_namespace.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -170,6 +202,15 @@ func testAccNamespaceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshiftserverless_namespace" "test" {
   namespace_name = %[1]q
+}
+`, rName)
+}
+
+func testAccNamespaceConfig_user(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_redshiftserverless_namespace" "test" {
+  namespace_name      = %[1]q
+  admin_user_password = "Password123"
 }
 `, rName)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28122

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccRedshiftServerlessNamespace_ PKG=redshiftserverless
--- PASS: TestAccRedshiftServerlessNamespace_disappears (20.45s)
--- PASS: TestAccRedshiftServerlessNamespace_user (47.28s)
--- PASS: TestAccRedshiftServerlessNamespace_basic (51.88s)
--- PASS: TestAccRedshiftServerlessNamespace_tags (62.37s)
```
