### PR TITLE
r/aws_fsx_ontap_storage_virtual_machine: `subtype` is deprecated

### DIFF
--- a/internal/service/fsx/ontap_storage_virtual_machine.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine.go
@@ -208,8 +208,9 @@ func ResourceOntapStorageVirtualMachine() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(fsx.StorageVirtualMachineRootVolumeSecurityStyle_Values(), false),
 			},
 			"subtype": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: `this trait has been removed from the API`,
 			},
 			"svm_admin_password": {
 				Type:         schema.TypeString,

--- a/website/docs/r/fsx_ontap_storage_virtual_machine.html.markdown
+++ b/website/docs/r/fsx_ontap_storage_virtual_machine.html.markdown
@@ -78,7 +78,7 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - Amazon Resource Name of the storage virtual machine.
 * `endpoints` - The endpoints that are used to access data or to manage the storage virtual machine using the NetApp ONTAP CLI, REST API, or NetApp SnapMirror. See [Endpoints](#endpoints) below.
 * `id` - Identifier of the storage virtual machine, e.g., `svm-12345678`
-* `subtype` - Describes the SVM's subtype, e.g. `DEFAULT`
+* `subtype` (**Deprecated**) - Describes the SVM's subtype, e.g. `DEFAULT`
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `uuid` - The SVM's UUID (universally unique identifier).
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Deprecates the `aws_fsx_ontap_storage_virtual_machine.subtype` attribute.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/28117.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
```
