### PR TITLE
dms: New resource aws_dms_s3_endpoint

### DIFF
--- a/.changelog/28130.txt
+++ b/.changelog/28130.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_dms_s3_endpoint
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1308,6 +1308,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_dms_replication_instance":     dms.ResourceReplicationInstance(),
 			"aws_dms_replication_subnet_group": dms.ResourceReplicationSubnetGroup(),
 			"aws_dms_replication_task":         dms.ResourceReplicationTask(),
+			"aws_dms_s3_endpoint":              dms.ResourceS3Endpoint(),
 
 			"aws_docdb_cluster":                 docdb.ResourceCluster(),
 			"aws_docdb_cluster_instance":        docdb.ResourceClusterInstance(),

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -1294,7 +1294,7 @@ func resourceEndpointDelete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("deleting DMS Endpoint (%s): %w", d.Id(), err)
 	}
 
-	if _, err = waitEndpointDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+	if err = waitEndpointDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 		return fmt.Errorf("waiting for DMS Endpoint (%s) delete: %w", d.Id(), err)
 	}
 

--- a/internal/service/dms/s3_endpoint.go
+++ b/internal/service/dms/s3_endpoint.go
@@ -560,8 +560,7 @@ func resourceS3EndpointDelete(d *schema.ResourceData, meta interface{}) error {
 		return create.Error(names.DMS, create.ErrActionDeleting, ResNameS3Endpoint, d.Id(), err)
 	}
 
-	_, err = waitEndpointDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete))
-	if err != nil {
+	if err = waitEndpointDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 		return create.Error(names.DMS, create.ErrActionWaitingForDeletion, ResNameS3Endpoint, d.Id(), err)
 	}
 

--- a/internal/service/dms/s3_endpoint.go
+++ b/internal/service/dms/s3_endpoint.go
@@ -420,11 +420,6 @@ func resourceS3EndpointRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("cdc_max_batch_interval", s3settings.CdcMaxBatchInterval)
 	d.Set("cdc_min_file_size", s3settings.CdcMinFileSize)
 	d.Set("cdc_path", s3settings.CdcPath)
-
-	if (d.Get("compression_type").(string) != dms.CompressionTypeValueNone || aws.StringValue(s3settings.CompressionType) != "") &&
-		(d.Get("compression_type").(string) != "" || aws.StringValue(s3settings.CompressionType) != dms.CompressionTypeValueNone) {
-
-	}
 	d.Set("compression_type", s3settings.CompressionType)
 	d.Set("csv_delimiter", s3settings.CsvDelimiter)
 	d.Set("csv_no_sup_value", s3settings.CsvNoSupValue)

--- a/internal/service/dms/s3_endpoint.go
+++ b/internal/service/dms/s3_endpoint.go
@@ -1,0 +1,740 @@
+package dms
+
+import (
+	"errors"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	dms "github.com/aws/aws-sdk-go/service/databasemigrationservice"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func ResourceS3Endpoint() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceS3EndpointCreate,
+		Read:   resourceS3EndpointRead,
+		Update: resourceS3EndpointUpdate,
+		Delete: resourceS3EndpointDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"certificate_arn": {
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"endpoint_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"endpoint_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validEndpointID,
+			},
+			"endpoint_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(dms.ReplicationEndpointTypeValue_Values(), false),
+			},
+			"engine_display_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"external_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"kms_key_arn": {
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"ssl_mode": {
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(dms.DmsSslModeValue_Values(), false),
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+
+			/////// S3-Specific Settings
+			"add_column_name": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"add_trailing_padding_character": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"bucket_folder": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"bucket_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"canned_acl_for_objects": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(dms.CannedAclForObjectsValue_Values(), true),
+				StateFunc: func(v interface{}) string {
+					return strings.ToLower(v.(string))
+				},
+			},
+			"cdc_inserts_and_updates": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"cdc_inserts_only": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"cdc_max_batch_interval": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+			"cdc_min_file_size": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+			"cdc_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"compression_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(dms.CompressionTypeValue_Values(), true),
+				Default:      strings.ToUpper(dms.CompressionTypeValueNone),
+				StateFunc: func(v interface{}) string {
+					return strings.ToUpper(v.(string))
+				},
+			},
+			"csv_delimiter": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  ",",
+			},
+			"csv_no_sup_value": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"csv_null_value": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"csv_row_delimiter": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "\\n",
+			},
+			"data_format": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(dms.DataFormatValue_Values(), false),
+			},
+			"data_page_size": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+			"date_partition_delimiter": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(dms.DatePartitionDelimiterValue_Values(), true),
+				StateFunc: func(v interface{}) string {
+					return strings.ToUpper(v.(string))
+				},
+			},
+			"date_partition_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"date_partition_sequence": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(dms.DatePartitionSequenceValue_Values(), true),
+				StateFunc: func(v interface{}) string {
+					return strings.ToLower(v.(string))
+				},
+			},
+			"date_partition_timezone": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"dict_page_size_limit": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+			"enable_statistics": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"encoding_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(dms.EncodingTypeValue_Values(), false),
+			},
+			"encryption_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(encryptionMode_Values(), false),
+			},
+			"expected_bucket_owner": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: verify.ValidAccountID,
+			},
+			"external_table_definition": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsJSON,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
+			},
+			"ignore_header_rows": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntInSlice([]int{0, 1}),
+			},
+			"include_op_for_full_load": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"max_file_size": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(1, 1048576),
+			},
+			"parquet_timestamp_in_millisecond": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"parquet_version": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(dms.ParquetVersionValue_Values(), false),
+			},
+			"preserve_transactions": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"rfc_4180": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"row_group_length": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+			"server_side_encryption_kms_key_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"service_access_role_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"timestamp_column_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"use_csv_no_sup_value": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"use_task_start_time_for_full_load_timestamp": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+const (
+	ResNameS3Endpoint = "S3 Endpoint"
+)
+
+func resourceS3EndpointCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DMSConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	input := &dms.CreateEndpointInput{
+		EndpointIdentifier: aws.String(d.Get("endpoint_id").(string)),
+		EndpointType:       aws.String(d.Get("endpoint_type").(string)),
+		EngineName:         aws.String("s3"),
+		Tags:               Tags(tags.IgnoreAWS()),
+	}
+
+	if v, ok := d.GetOk("certificate_arn"); ok {
+		input.CertificateArn = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("kms_key_arn"); ok {
+		input.KmsKeyId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("ssl_mode"); ok {
+		input.SslMode = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("service_access_role_arn"); ok {
+		input.ServiceAccessRoleArn = aws.String(v.(string))
+	}
+
+	input.S3Settings = s3Settings(d, d.Get("endpoint_type").(string) == dms.ReplicationEndpointTypeValueTarget)
+
+	log.Println("[DEBUG] DMS create endpoint:", input)
+
+	var out *dms.CreateEndpointOutput
+	err := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		var err error
+		out, err = conn.CreateEndpoint(input)
+
+		if tfawserr.ErrCodeEquals(err, "AccessDeniedFault") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if tfresource.TimedOut(err) {
+		out, err = conn.CreateEndpoint(input)
+	}
+
+	if err != nil || out == nil || out.Endpoint == nil {
+		return create.Error(names.DMS, create.ErrActionCreating, ResNameS3Endpoint, d.Get("endpoint_id").(string), err)
+	}
+
+	d.SetId(d.Get("endpoint_id").(string))
+	d.Set("endpoint_arn", out.Endpoint.EndpointArn)
+
+	// AWS bug? ssekki is ignored on create but sets on update
+	if _, ok := d.GetOk("server_side_encryption_kms_key_id"); ok {
+		return resourceS3EndpointUpdate(d, meta)
+	}
+
+	return resourceS3EndpointRead(d, meta)
+}
+
+func resourceS3EndpointRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DMSConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	endpoint, err := FindEndpointByID(conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] DMS Endpoint (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.Error(names.DMS, create.ErrActionReading, ResNameS3Endpoint, d.Id(), err)
+	}
+
+	if endpoint.S3Settings == nil {
+		return create.Error(names.DMS, create.ErrActionReading, ResNameS3Endpoint, d.Id(), errors.New("no settings returned"))
+	}
+
+	d.Set("endpoint_arn", endpoint.EndpointArn)
+
+	d.Set("certificate_arn", endpoint.CertificateArn)
+	d.Set("endpoint_id", endpoint.EndpointIdentifier)
+	d.Set("endpoint_type", strings.ToLower(*endpoint.EndpointType)) // For some reason the AWS API only accepts lowercase type but returns it as uppercase
+	d.Set("engine_display_name", endpoint.EngineDisplayName)
+	d.Set("external_id", endpoint.ExternalId)
+	// d.Set("external_table_definition", endpoint.ExternalTableDefinition) // set from s3 settings
+	d.Set("kms_key_arn", endpoint.KmsKeyId)
+	// d.Set("service_access_role_arn", endpoint.ServiceAccessRoleArn) // set from s3 settings
+	d.Set("ssl_mode", endpoint.SslMode)
+	d.Set("status", endpoint.Status)
+
+	s3settings := endpoint.S3Settings
+	d.Set("add_column_name", s3settings.AddColumnName)
+	d.Set("add_trailing_padding_character", s3settings.AddTrailingPaddingCharacter)
+	d.Set("bucket_folder", s3settings.BucketFolder)
+	d.Set("bucket_name", s3settings.BucketName)
+	d.Set("canned_acl_for_objects", s3settings.CannedAclForObjects)
+	d.Set("cdc_inserts_and_updates", s3settings.CdcInsertsAndUpdates)
+	d.Set("cdc_inserts_only", s3settings.CdcInsertsOnly)
+	d.Set("cdc_max_batch_interval", s3settings.CdcMaxBatchInterval)
+	d.Set("cdc_min_file_size", s3settings.CdcMinFileSize)
+	d.Set("cdc_path", s3settings.CdcPath)
+
+	if (d.Get("compression_type").(string) != dms.CompressionTypeValueNone || aws.StringValue(s3settings.CompressionType) != "") &&
+		(d.Get("compression_type").(string) != "" || aws.StringValue(s3settings.CompressionType) != dms.CompressionTypeValueNone) {
+
+	}
+	d.Set("compression_type", s3settings.CompressionType)
+	d.Set("csv_delimiter", s3settings.CsvDelimiter)
+	d.Set("csv_no_sup_value", s3settings.CsvNoSupValue)
+	d.Set("csv_null_value", s3settings.CsvNullValue)
+	d.Set("csv_row_delimiter", s3settings.CsvRowDelimiter)
+	d.Set("data_format", s3settings.DataFormat)
+	d.Set("data_page_size", s3settings.DataPageSize)
+	d.Set("date_partition_delimiter", strings.ToUpper(aws.StringValue(s3settings.DatePartitionDelimiter)))
+	d.Set("date_partition_enabled", s3settings.DatePartitionEnabled)
+	d.Set("date_partition_sequence", s3settings.DatePartitionSequence)
+	d.Set("date_partition_timezone", s3settings.DatePartitionTimezone)
+	d.Set("dict_page_size_limit", s3settings.DictPageSizeLimit)
+	d.Set("enable_statistics", s3settings.EnableStatistics)
+	d.Set("encoding_type", s3settings.EncodingType)
+	d.Set("encryption_mode", s3settings.EncryptionMode)
+	d.Set("expected_bucket_owner", s3settings.ExpectedBucketOwner)
+	d.Set("ignore_header_rows", s3settings.IgnoreHeaderRows)
+	d.Set("include_op_for_full_load", s3settings.IncludeOpForFullLoad)
+	d.Set("max_file_size", s3settings.MaxFileSize)
+	d.Set("parquet_timestamp_in_millisecond", s3settings.ParquetTimestampInMillisecond)
+	d.Set("parquet_version", s3settings.ParquetVersion)
+	d.Set("preserve_transactions", s3settings.PreserveTransactions)
+	d.Set("rfc_4180", s3settings.Rfc4180)
+	d.Set("row_group_length", s3settings.RowGroupLength)
+	d.Set("server_side_encryption_kms_key_id", s3settings.ServerSideEncryptionKmsKeyId)
+	d.Set("service_access_role_arn", s3settings.ServiceAccessRoleArn)
+	d.Set("timestamp_column_name", s3settings.TimestampColumnName)
+	d.Set("use_csv_no_sup_value", s3settings.UseCsvNoSupValue)
+	d.Set("use_task_start_time_for_full_load_timestamp", s3settings.UseTaskStartTimeForFullLoadTimestamp)
+
+	p, err := structure.NormalizeJsonString(aws.StringValue(s3settings.ExternalTableDefinition))
+	if err != nil {
+		return create.Error(names.DMS, create.ErrActionSetting, ResNameS3Endpoint, d.Id(), err)
+	}
+
+	d.Set("external_table_definition", p)
+
+	tags, err := ListTags(conn, d.Get("endpoint_arn").(string))
+	if err != nil {
+		return create.Error(names.DMS, create.ErrActionReading, ResNameS3Endpoint, d.Id(), err)
+	}
+
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return create.Error(names.DMS, create.ErrActionReading, ResNameS3Endpoint, d.Id(), err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return create.Error(names.DMS, create.ErrActionReading, ResNameS3Endpoint, d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceS3EndpointUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DMSConn
+
+	if d.HasChangesExcept("tags", "tags_all") {
+		input := &dms.ModifyEndpointInput{
+			EndpointArn: aws.String(d.Get("endpoint_arn").(string)),
+		}
+
+		if d.HasChange("certificate_arn") {
+			input.CertificateArn = aws.String(d.Get("certificate_arn").(string))
+		}
+
+		if d.HasChange("endpoint_type") {
+			input.EndpointType = aws.String(d.Get("endpoint_type").(string))
+		}
+
+		input.EngineName = aws.String(engineNameS3)
+
+		if d.HasChange("ssl_mode") {
+			input.SslMode = aws.String(d.Get("ssl_mode").(string))
+		}
+
+		if d.HasChangesExcept(
+			"certificate_arn",
+			"endpoint_type",
+			"ssl_mode",
+		) {
+			input.S3Settings = s3Settings(d, d.Get("endpoint_type").(string) == dms.ReplicationEndpointTypeValueTarget)
+			input.ServiceAccessRoleArn = aws.String(d.Get("service_access_role_arn").(string))
+		}
+
+		log.Println("[DEBUG] DMS update endpoint:", input)
+
+		err := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+			_, err := conn.ModifyEndpoint(input)
+
+			if tfawserr.ErrCodeEquals(err, "AccessDeniedFault") {
+				return resource.RetryableError(err)
+			}
+
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+
+			return nil
+		})
+
+		if tfresource.TimedOut(err) {
+			_, err = conn.ModifyEndpoint(input)
+		}
+
+		if err != nil {
+			return create.Error(names.DMS, create.ErrActionUpdating, ResNameS3Endpoint, d.Id(), err)
+		}
+	}
+
+	if d.HasChange("tags_all") {
+		arn := d.Get("endpoint_arn").(string)
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(conn, arn, o, n); err != nil {
+			return create.Error(names.DMS, create.ErrActionUpdating, ResNameS3Endpoint, d.Id(), err)
+		}
+	}
+
+	return resourceS3EndpointRead(d, meta)
+}
+
+func resourceS3EndpointDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).DMSConn
+
+	log.Printf("[DEBUG] Deleting DMS Endpoint: (%s)", d.Id())
+	_, err := conn.DeleteEndpoint(&dms.DeleteEndpointInput{
+		EndpointArn: aws.String(d.Get("endpoint_arn").(string)),
+	})
+
+	if tfawserr.ErrCodeEquals(err, dms.ErrCodeResourceNotFoundFault) {
+		return nil
+	}
+
+	if err != nil {
+		return create.Error(names.DMS, create.ErrActionDeleting, ResNameS3Endpoint, d.Id(), err)
+	}
+
+	_, err = waitEndpointDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return create.Error(names.DMS, create.ErrActionWaitingForDeletion, ResNameS3Endpoint, d.Id(), err)
+	}
+
+	return err
+}
+
+func s3Settings(d *schema.ResourceData, target bool) *dms.S3Settings {
+	s3s := &dms.S3Settings{}
+
+	if v, ok := d.Get("add_column_name").(bool); ok { // likely only useful for target
+		s3s.AddColumnName = aws.Bool(v)
+	}
+
+	if v, ok := d.Get("add_trailing_padding_character").(bool); ok && target { // target
+		s3s.AddTrailingPaddingCharacter = aws.Bool(v)
+	}
+
+	if v, ok := d.GetOk("bucket_folder"); ok {
+		s3s.BucketFolder = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("bucket_name"); ok {
+		s3s.BucketName = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("canned_acl_for_objects"); ok { // likely only useful for target
+		s3s.CannedAclForObjects = aws.String(v.(string))
+	}
+
+	if v, ok := d.Get("cdc_inserts_and_updates").(bool); ok { // likely only useful for target
+		s3s.CdcInsertsAndUpdates = aws.Bool(v)
+	}
+
+	if v, ok := d.Get("cdc_inserts_only").(bool); ok { // likely only useful for target
+		s3s.CdcInsertsOnly = aws.Bool(v)
+	}
+
+	if v, ok := d.GetOk("cdc_max_batch_interval"); ok { // likely only useful for target
+		s3s.CdcMaxBatchInterval = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("cdc_min_file_size"); ok { // likely only useful for target
+		s3s.CdcMinFileSize = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("cdc_path"); ok {
+		s3s.CdcPath = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("compression_type"); ok { // likely only useful for target
+		s3s.CompressionType = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("csv_delimiter"); ok {
+		s3s.CsvDelimiter = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("csv_no_sup_value"); ok && target { // target
+		s3s.CsvNoSupValue = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("csv_null_value"); ok { // likely only useful for target
+		s3s.CsvNullValue = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("csv_row_delimiter"); ok {
+		s3s.CsvRowDelimiter = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("data_format"); ok && target { // target
+		s3s.DataFormat = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("data_page_size"); ok { // likely only useful for target
+		s3s.DataPageSize = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("date_partition_delimiter"); ok && target { // target
+		s3s.DatePartitionDelimiter = aws.String(v.(string))
+	}
+
+	if v, ok := d.Get("date_partition_enabled").(bool); ok { // likely only useful for target
+		s3s.DatePartitionEnabled = aws.Bool(v)
+	}
+
+	if v, ok := d.GetOk("date_partition_sequence"); ok && target { // target
+		s3s.DatePartitionSequence = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("date_partition_timezone"); ok && target { // target
+		s3s.DatePartitionTimezone = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("dict_page_size_limit"); ok { // likely only useful for target
+		s3s.DictPageSizeLimit = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.Get("enable_statistics").(bool); ok { // likely only useful for target
+		s3s.EnableStatistics = aws.Bool(v)
+	}
+
+	if v, ok := d.GetOk("encoding_type"); ok { // likely only useful for target
+		s3s.EncodingType = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("encryption_mode"); ok && target { // target
+		s3s.EncryptionMode = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("expected_bucket_owner"); ok { // likely only useful for target
+		s3s.ExpectedBucketOwner = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("external_table_definition"); ok {
+		s3s.ExternalTableDefinition = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("ignore_header_rows"); ok {
+		s3s.IgnoreHeaderRows = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.Get("include_op_for_full_load").(bool); ok { // likely only useful for target
+		s3s.IncludeOpForFullLoad = aws.Bool(v)
+	}
+
+	if v, ok := d.GetOk("max_file_size"); ok { // likely only useful for target
+		s3s.MaxFileSize = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.Get("parquet_timestamp_in_millisecond").(bool); ok && target { // target
+		s3s.ParquetTimestampInMillisecond = aws.Bool(v)
+	}
+
+	if v, ok := d.GetOk("parquet_version"); ok && target { // target
+		s3s.ParquetVersion = aws.String(v.(string))
+	}
+
+	if v, ok := d.Get("preserve_transactions").(bool); ok && target { // target
+		s3s.PreserveTransactions = aws.Bool(v)
+	}
+
+	if v, ok := d.Get("rfc_4180").(bool); ok {
+		s3s.Rfc4180 = aws.Bool(v)
+	}
+
+	if v, ok := d.GetOk("row_group_length"); ok { // likely only useful for target
+		s3s.RowGroupLength = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("server_side_encryption_kms_key_id"); ok && target { // target
+		s3s.ServerSideEncryptionKmsKeyId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("service_access_role_arn"); ok {
+		s3s.ServiceAccessRoleArn = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("timestamp_column_name"); ok { // likely only useful for target
+		s3s.TimestampColumnName = aws.String(v.(string))
+	}
+
+	if v, ok := d.Get("use_csv_no_sup_value").(bool); ok && target { // target
+		s3s.UseCsvNoSupValue = aws.Bool(v)
+	}
+
+	if v, ok := d.Get("use_task_start_time_for_full_load_timestamp").(bool); ok { // likely only useful for target
+		s3s.UseTaskStartTimeForFullLoadTimestamp = aws.Bool(v)
+	}
+
+	return s3s
+}

--- a/internal/service/dms/s3_endpoint_test.go
+++ b/internal/service/dms/s3_endpoint_test.go
@@ -627,7 +627,7 @@ resource "aws_dms_s3_endpoint" "test" {
         ColumnType     = "INT8"
         ColumnNullable = "false"
         ColumnIsPk     = "true"
-      },{
+        }, {
         ColumnName   = "LastName"
         ColumnType   = "STRING"
         ColumnLength = "20"
@@ -668,7 +668,7 @@ resource "aws_dms_s3_endpoint" "test" {
         ColumnType     = "INT8"
         ColumnNullable = "false"
         ColumnIsPk     = "true"
-      },{
+        }, {
         ColumnName   = "LastName"
         ColumnType   = "STRING"
         ColumnLength = "20"

--- a/internal/service/dms/s3_endpoint_test.go
+++ b/internal/service/dms/s3_endpoint_test.go
@@ -1,0 +1,760 @@
+package dms_test
+
+import (
+	"fmt"
+	"testing"
+
+	dms "github.com/aws/aws-sdk-go/service/databasemigrationservice"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccDMSS3Endpoint_basic(t *testing.T) {
+	resourceName := "aws_dms_s3_endpoint.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccS3EndpointConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "add_column_name", "true"),
+					resource.TestCheckResourceAttr(resourceName, "add_trailing_padding_character", "false"),
+					resource.TestCheckResourceAttr(resourceName, "bucket_folder", "folder"),
+					resource.TestCheckResourceAttr(resourceName, "bucket_name", "bucket_name"),
+					resource.TestCheckResourceAttr(resourceName, "canned_acl_for_objects", "private"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_inserts_and_updates", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_inserts_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_max_batch_interval", "100"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_min_file_size", "16"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_path", "cdc/path"),
+					resource.TestCheckResourceAttr(resourceName, "compression_type", "GZIP"),
+					resource.TestCheckResourceAttr(resourceName, "csv_delimiter", ";"),
+					resource.TestCheckResourceAttr(resourceName, "csv_no_sup_value", "x"),
+					resource.TestCheckResourceAttr(resourceName, "csv_null_value", "?"),
+					resource.TestCheckResourceAttr(resourceName, "csv_row_delimiter", "\\r\\n"),
+					resource.TestCheckResourceAttr(resourceName, "data_format", "parquet"),
+					resource.TestCheckResourceAttr(resourceName, "data_page_size", "1100000"),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_delimiter", "UNDERSCORE"),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_sequence", "yyyymmddhh"),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_timezone", "Asia/Seoul"),
+					resource.TestCheckResourceAttr(resourceName, "dict_page_size_limit", "1000000"),
+					resource.TestCheckResourceAttr(resourceName, "enable_statistics", "false"),
+					resource.TestCheckResourceAttr(resourceName, "encoding_type", "plain"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_mode", "SSE_S3"),
+					resource.TestCheckResourceAttrPair(resourceName, "expected_bucket_owner", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "ignore_header_rows", "1"),
+					resource.TestCheckResourceAttr(resourceName, "include_op_for_full_load", "true"),
+					resource.TestCheckResourceAttr(resourceName, "max_file_size", "1000000"),
+					resource.TestCheckResourceAttr(resourceName, "parquet_timestamp_in_millisecond", "true"),
+					resource.TestCheckResourceAttr(resourceName, "parquet_version", "parquet-2-0"),
+					resource.TestCheckResourceAttr(resourceName, "preserve_transactions", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rfc_4180", "false"),
+					resource.TestCheckResourceAttr(resourceName, "row_group_length", "11000"),
+					resource.TestCheckResourceAttrPair(resourceName, "server_side_encryption_kms_key_id", "aws_kms_key.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_access_role_arn", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "timestamp_column_name", "tx_commit_time"),
+					resource.TestCheckResourceAttr(resourceName, "use_csv_no_sup_value", "false"),
+					resource.TestCheckResourceAttr(resourceName, "use_task_start_time_for_full_load_timestamp", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccDMSS3Endpoint_update(t *testing.T) {
+	resourceName := "aws_dms_s3_endpoint.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccS3EndpointConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "add_column_name", "true"),
+					resource.TestCheckResourceAttr(resourceName, "add_trailing_padding_character", "false"),
+					resource.TestCheckResourceAttr(resourceName, "bucket_folder", "folder"),
+					resource.TestCheckResourceAttr(resourceName, "bucket_name", "bucket_name"),
+					resource.TestCheckResourceAttr(resourceName, "canned_acl_for_objects", "private"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_inserts_and_updates", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_max_batch_interval", "100"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_min_file_size", "16"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_path", "cdc/path"),
+					resource.TestCheckResourceAttr(resourceName, "compression_type", "GZIP"),
+					resource.TestCheckResourceAttr(resourceName, "csv_delimiter", ";"),
+					resource.TestCheckResourceAttr(resourceName, "csv_no_sup_value", "x"),
+					resource.TestCheckResourceAttr(resourceName, "csv_null_value", "?"),
+					resource.TestCheckResourceAttr(resourceName, "csv_row_delimiter", "\\r\\n"),
+					resource.TestCheckResourceAttr(resourceName, "data_format", "parquet"),
+					resource.TestCheckResourceAttr(resourceName, "data_page_size", "1100000"),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_delimiter", "UNDERSCORE"),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_sequence", "yyyymmddhh"),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_timezone", "Asia/Seoul"),
+					resource.TestCheckResourceAttr(resourceName, "dict_page_size_limit", "1000000"),
+					resource.TestCheckResourceAttr(resourceName, "enable_statistics", "false"),
+					resource.TestCheckResourceAttr(resourceName, "encoding_type", "plain"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_mode", "SSE_S3"),
+					resource.TestCheckResourceAttrPair(resourceName, "expected_bucket_owner", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "ignore_header_rows", "1"),
+					resource.TestCheckResourceAttr(resourceName, "include_op_for_full_load", "true"),
+					resource.TestCheckResourceAttr(resourceName, "max_file_size", "1000000"),
+					resource.TestCheckResourceAttr(resourceName, "parquet_timestamp_in_millisecond", "true"),
+					resource.TestCheckResourceAttr(resourceName, "parquet_version", "parquet-2-0"),
+					resource.TestCheckResourceAttr(resourceName, "preserve_transactions", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rfc_4180", "false"),
+					resource.TestCheckResourceAttr(resourceName, "row_group_length", "11000"),
+					resource.TestCheckResourceAttrPair(resourceName, "server_side_encryption_kms_key_id", "aws_kms_key.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_access_role_arn", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "timestamp_column_name", "tx_commit_time"),
+					resource.TestCheckResourceAttr(resourceName, "use_csv_no_sup_value", "false"),
+					resource.TestCheckResourceAttr(resourceName, "use_task_start_time_for_full_load_timestamp", "true"),
+				),
+			},
+			{
+				Config: testAccS3EndpointConfig_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "add_column_name", "false"),
+					resource.TestCheckResourceAttr(resourceName, "add_trailing_padding_character", "true"),
+					resource.TestCheckResourceAttr(resourceName, "bucket_folder", "folder2"),
+					resource.TestCheckResourceAttr(resourceName, "bucket_name", "updated_name"),
+					resource.TestCheckResourceAttr(resourceName, "canned_acl_for_objects", "private"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_inserts_and_updates", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_inserts_only", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_max_batch_interval", "105"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_min_file_size", "17"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_path", "cdc/path"),
+					resource.TestCheckResourceAttr(resourceName, "compression_type", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "csv_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "csv_no_sup_value", "U"),
+					resource.TestCheckResourceAttr(resourceName, "csv_null_value", "-"),
+					resource.TestCheckResourceAttr(resourceName, "csv_row_delimiter", "\\n"),
+					resource.TestCheckResourceAttr(resourceName, "data_format", "parquet"),
+					resource.TestCheckResourceAttr(resourceName, "data_page_size", "1100000"),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_delimiter", "SLASH"),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_sequence", "yyyymmddhh"),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_timezone", "Europe/Paris"),
+					resource.TestCheckResourceAttr(resourceName, "dict_page_size_limit", "1000000"),
+					resource.TestCheckResourceAttr(resourceName, "enable_statistics", "true"),
+					resource.TestCheckResourceAttr(resourceName, "encoding_type", "plain"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_mode", "SSE_S3"),
+					resource.TestCheckResourceAttrPair(resourceName, "expected_bucket_owner", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "ignore_header_rows", "1"),
+					resource.TestCheckResourceAttr(resourceName, "include_op_for_full_load", "false"),
+					resource.TestCheckResourceAttr(resourceName, "max_file_size", "900000"),
+					resource.TestCheckResourceAttr(resourceName, "parquet_timestamp_in_millisecond", "true"),
+					resource.TestCheckResourceAttr(resourceName, "parquet_version", "parquet-2-0"),
+					resource.TestCheckResourceAttr(resourceName, "preserve_transactions", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rfc_4180", "true"),
+					resource.TestCheckResourceAttr(resourceName, "row_group_length", "13000"),
+					resource.TestCheckResourceAttrPair(resourceName, "server_side_encryption_kms_key_id", "aws_kms_key.test2", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_access_role_arn", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "timestamp_column_name", "tx_commit_time2"),
+					resource.TestCheckResourceAttr(resourceName, "use_csv_no_sup_value", "true"),
+					resource.TestCheckResourceAttr(resourceName, "use_task_start_time_for_full_load_timestamp", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDMSS3Endpoint_simple(t *testing.T) {
+	resourceName := "aws_dms_s3_endpoint.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccS3EndpointConfig_simple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "add_column_name", "false"),
+					resource.TestCheckResourceAttr(resourceName, "add_trailing_padding_character", "false"),
+					resource.TestCheckResourceAttr(resourceName, "bucket_folder", ""),
+					resource.TestCheckResourceAttr(resourceName, "bucket_name", "beckut_name"),
+					resource.TestCheckResourceAttr(resourceName, "canned_acl_for_objects", ""),
+					resource.TestCheckResourceAttr(resourceName, "cdc_inserts_and_updates", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_inserts_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_max_batch_interval", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_min_file_size", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_path", ""),
+					resource.TestCheckResourceAttr(resourceName, "compression_type", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "csv_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "csv_no_sup_value", ""),
+					resource.TestCheckResourceAttr(resourceName, "csv_null_value", ""),
+					resource.TestCheckResourceAttr(resourceName, "csv_row_delimiter", "\\n"),
+					resource.TestCheckResourceAttr(resourceName, "data_format", ""),
+					resource.TestCheckResourceAttr(resourceName, "data_page_size", "0"),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_delimiter", ""),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_sequence", ""),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_timezone", ""),
+					resource.TestCheckResourceAttr(resourceName, "dict_page_size_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "enable_statistics", "true"),
+					resource.TestCheckResourceAttr(resourceName, "encoding_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "encryption_mode", ""),
+					resource.TestCheckResourceAttr(resourceName, "expected_bucket_owner", ""),
+					resource.TestCheckResourceAttr(resourceName, "ignore_header_rows", "0"),
+					resource.TestCheckResourceAttr(resourceName, "include_op_for_full_load", "false"),
+					resource.TestCheckResourceAttr(resourceName, "max_file_size", "0"),
+					resource.TestCheckResourceAttr(resourceName, "parquet_timestamp_in_millisecond", "false"),
+					resource.TestCheckResourceAttr(resourceName, "parquet_version", ""),
+					resource.TestCheckResourceAttr(resourceName, "preserve_transactions", "false"),
+					resource.TestCheckResourceAttr(resourceName, "rfc_4180", "true"),
+					resource.TestCheckResourceAttr(resourceName, "row_group_length", "0"),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption_kms_key_id", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "service_access_role_arn", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "timestamp_column_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "use_csv_no_sup_value", "false"),
+					resource.TestCheckResourceAttr(resourceName, "use_task_start_time_for_full_load_timestamp", "false"),
+				),
+			},
+			{
+				Config:   testAccS3EndpointConfig_simple(rName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccDMSS3Endpoint_sourceSimple(t *testing.T) {
+	resourceName := "aws_dms_s3_endpoint.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccS3EndpointConfig_sourceSimple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "add_column_name", "false"),
+					resource.TestCheckResourceAttr(resourceName, "bucket_folder", ""),
+					resource.TestCheckResourceAttr(resourceName, "bucket_name", "beckut_name"),
+					resource.TestCheckResourceAttr(resourceName, "canned_acl_for_objects", ""),
+					resource.TestCheckResourceAttr(resourceName, "cdc_inserts_and_updates", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_inserts_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_max_batch_interval", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_min_file_size", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_path", ""),
+					resource.TestCheckResourceAttr(resourceName, "compression_type", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "csv_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "csv_null_value", ""),
+					resource.TestCheckResourceAttr(resourceName, "csv_row_delimiter", "\\n"),
+					resource.TestCheckResourceAttr(resourceName, "data_page_size", "0"),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "dict_page_size_limit", "0"),
+					resource.TestCheckResourceAttr(resourceName, "enable_statistics", "true"),
+					resource.TestCheckResourceAttr(resourceName, "encoding_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_id", rName),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_type", "source"),
+					resource.TestCheckResourceAttr(resourceName, "expected_bucket_owner", ""),
+					resource.TestCheckResourceAttr(resourceName, "external_table_definition", "{\"TableCount\":1,\"Tables\":[{\"TableColumns\":[{\"ColumnIsPk\":\"true\",\"ColumnName\":\"ID\",\"ColumnNullable\":\"false\",\"ColumnType\":\"INT8\"},{\"ColumnLength\":\"20\",\"ColumnName\":\"LastName\",\"ColumnType\":\"STRING\"}],\"TableColumnsTotal\":\"2\",\"TableName\":\"employee\",\"TableOwner\":\"hr\",\"TablePath\":\"hr/employee/\"}]}"),
+					resource.TestCheckResourceAttr(resourceName, "ignore_header_rows", "0"),
+					resource.TestCheckResourceAttr(resourceName, "include_op_for_full_load", "false"),
+					resource.TestCheckResourceAttr(resourceName, "max_file_size", "0"),
+					resource.TestCheckResourceAttr(resourceName, "rfc_4180", "true"),
+					resource.TestCheckResourceAttr(resourceName, "row_group_length", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_access_role_arn", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_mode", "none"),
+					resource.TestCheckResourceAttr(resourceName, "timestamp_column_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "use_task_start_time_for_full_load_timestamp", "false"),
+				),
+			},
+			{
+				Config:   testAccS3EndpointConfig_sourceSimple(rName),
+				PlanOnly: true,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccDMSS3Endpoint_source(t *testing.T) {
+	resourceName := "aws_dms_s3_endpoint.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccS3EndpointConfig_source(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "bucket_folder", "folder"),
+					resource.TestCheckResourceAttr(resourceName, "bucket_name", "bucket_name"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_path", "cdc/path"),
+					resource.TestCheckResourceAttr(resourceName, "csv_delimiter", ";"),
+					resource.TestCheckResourceAttr(resourceName, "csv_row_delimiter", "\\r\\n"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_id", rName),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_type", "source"),
+					resource.TestCheckResourceAttr(resourceName, "ignore_header_rows", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rfc_4180", "false"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_access_role_arn", "aws_iam_role.test", "arn"),
+
+					resource.TestCheckResourceAttr(resourceName, "add_column_name", "true"),
+					resource.TestCheckResourceAttr(resourceName, "canned_acl_for_objects", "private"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_inserts_and_updates", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_max_batch_interval", "100"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_min_file_size", "16"),
+					resource.TestCheckResourceAttr(resourceName, "compression_type", "GZIP"),
+					resource.TestCheckResourceAttr(resourceName, "csv_null_value", "?"),
+					resource.TestCheckResourceAttr(resourceName, "data_page_size", "1100000"),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "dict_page_size_limit", "1000000"),
+					resource.TestCheckResourceAttr(resourceName, "enable_statistics", "false"),
+					resource.TestCheckResourceAttr(resourceName, "encoding_type", "plain"),
+					resource.TestCheckResourceAttrPair(resourceName, "expected_bucket_owner", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "external_table_definition", "{\"TableCount\":1,\"Tables\":[{\"TableColumns\":[{\"ColumnIsPk\":\"true\",\"ColumnName\":\"ID\",\"ColumnNullable\":\"false\",\"ColumnType\":\"INT8\"},{\"ColumnLength\":\"20\",\"ColumnName\":\"LastName\",\"ColumnType\":\"STRING\"}],\"TableColumnsTotal\":\"2\",\"TableName\":\"employee\",\"TableOwner\":\"hr\",\"TablePath\":\"hr/employee/\"}]}"),
+					resource.TestCheckResourceAttr(resourceName, "include_op_for_full_load", "true"),
+					resource.TestCheckResourceAttr(resourceName, "max_file_size", "1000000"),
+					resource.TestCheckResourceAttr(resourceName, "row_group_length", "11000"),
+					resource.TestCheckResourceAttr(resourceName, "timestamp_column_name", "tx_commit_time"),
+					resource.TestCheckResourceAttr(resourceName, "use_task_start_time_for_full_load_timestamp", "true"),
+				),
+			},
+			{
+				Config: testAccS3EndpointConfig_sourceUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "bucket_folder", "folder2"),
+					resource.TestCheckResourceAttr(resourceName, "bucket_name", "beckut_name"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_path", "cdc/path2"),
+					resource.TestCheckResourceAttr(resourceName, "csv_delimiter", ","),
+					resource.TestCheckResourceAttr(resourceName, "csv_row_delimiter", "\\n"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_id", rName),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_type", "source"),
+					resource.TestCheckResourceAttr(resourceName, "ignore_header_rows", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rfc_4180", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_access_role_arn", "aws_iam_role.test", "arn"),
+
+					resource.TestCheckResourceAttr(resourceName, "add_column_name", "false"),
+					resource.TestCheckResourceAttr(resourceName, "canned_acl_for_objects", "authenticated-read"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_inserts_and_updates", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_inserts_only", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_max_batch_interval", "101"),
+					resource.TestCheckResourceAttr(resourceName, "cdc_min_file_size", "17"),
+					resource.TestCheckResourceAttr(resourceName, "compression_type", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "csv_null_value", "0"),
+					resource.TestCheckResourceAttr(resourceName, "data_page_size", "1000000"),
+					resource.TestCheckResourceAttr(resourceName, "date_partition_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "dict_page_size_limit", "830000"),
+					resource.TestCheckResourceAttr(resourceName, "enable_statistics", "true"),
+					resource.TestCheckResourceAttr(resourceName, "encoding_type", "plain-dictionary"),
+					resource.TestCheckResourceAttrPair(resourceName, "expected_bucket_owner", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "external_table_definition", "{\"TableCount\":1,\"Tables\":[{\"TableColumns\":[{\"ColumnIsPk\":\"true\",\"ColumnName\":\"ID\",\"ColumnNullable\":\"false\",\"ColumnType\":\"INT8\"}],\"TableColumnsTotal\":\"1\",\"TableName\":\"employee\",\"TableOwner\":\"hr\",\"TablePath\":\"hr/employee/\"}]}"),
+					resource.TestCheckResourceAttr(resourceName, "include_op_for_full_load", "false"),
+					resource.TestCheckResourceAttr(resourceName, "max_file_size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "row_group_length", "10000"),
+					resource.TestCheckResourceAttr(resourceName, "timestamp_column_name", "tx_commit_time2"),
+					resource.TestCheckResourceAttr(resourceName, "use_task_start_time_for_full_load_timestamp", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccS3EndpointConfig_base(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "dms.${data.aws_partition.current.dns_suffix}"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:CreateBucket",
+        "s3:ListBucket",
+        "s3:DeleteBucket",
+        "s3:GetBucketLocation",
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:GetObjectVersion",
+        "s3:GetBucketPolicy",
+        "s3:PutBucketPolicy",
+        "s3:DeleteBucketPolicy"
+      ]
+      Resource = "*"
+    }]
+  })
+}
+`, rName)
+}
+
+func testAccS3EndpointConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccS3EndpointConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description = %[1]q
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = %[1]q
+    Statement = [{
+      Sid    = %[1]q
+      Effect = "Allow"
+      Principal = {
+        AWS = "*"
+      }
+      Action   = "kms:*"
+      Resource = "*"
+    }]
+  })
+}
+
+resource "aws_dms_s3_endpoint" "test" {
+  endpoint_id   = %[1]q
+  endpoint_type = "target"
+  ssl_mode      = "none"
+
+  tags = {
+    Name   = %[1]q
+    Update = "to-update"
+    Remove = "to-remove"
+  }
+
+  add_column_name                             = true
+  add_trailing_padding_character              = false
+  bucket_folder                               = "folder"
+  bucket_name                                 = "bucket_name"
+  canned_acl_for_objects                      = "private"
+  cdc_inserts_and_updates                     = true
+  cdc_inserts_only                            = false
+  cdc_max_batch_interval                      = 100
+  cdc_min_file_size                           = 16
+  cdc_path                                    = "cdc/path"
+  compression_type                            = "GZIP"
+  csv_delimiter                               = ";"
+  csv_no_sup_value                            = "x"
+  csv_null_value                              = "?"
+  csv_row_delimiter                           = "\\r\\n"
+  data_format                                 = "parquet"
+  data_page_size                              = 1100000
+  date_partition_delimiter                    = "UNDERSCORE"
+  date_partition_enabled                      = true
+  date_partition_sequence                     = "yyyymmddhh"
+  date_partition_timezone                     = "Asia/Seoul"
+  dict_page_size_limit                        = 1000000
+  enable_statistics                           = false
+  encoding_type                               = "plain"
+  encryption_mode                             = "SSE_S3"
+  expected_bucket_owner                       = data.aws_caller_identity.current.account_id
+  ignore_header_rows                          = 1
+  include_op_for_full_load                    = true
+  max_file_size                               = 1000000
+  parquet_timestamp_in_millisecond            = true
+  parquet_version                             = "parquet-2-0"
+  preserve_transactions                       = false
+  rfc_4180                                    = false
+  row_group_length                            = 11000
+  server_side_encryption_kms_key_id           = aws_kms_key.test.arn
+  service_access_role_arn                     = aws_iam_role.test.arn
+  timestamp_column_name                       = "tx_commit_time"
+  use_csv_no_sup_value                        = false
+  use_task_start_time_for_full_load_timestamp = true
+
+  depends_on = [aws_iam_role_policy.test]
+}
+`, rName))
+}
+
+func testAccS3EndpointConfig_update(rName string) string {
+	return acctest.ConfigCompose(
+		testAccS3EndpointConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_kms_key" "test2" {
+  description = %[1]q
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = %[1]q
+    Statement = [{
+      Sid    = %[1]q
+      Effect = "Allow"
+      Principal = {
+        AWS = "*"
+      }
+      Action   = "kms:*"
+      Resource = "*"
+    }]
+  })
+}
+
+resource "aws_dms_s3_endpoint" "test" {
+  endpoint_id   = %[1]q
+  endpoint_type = "target"
+  ssl_mode      = "none"
+
+  tags = {
+    Name   = %[1]q
+    Update = "to-update"
+    Remove = "to-remove"
+  }
+
+  add_column_name                             = false
+  add_trailing_padding_character              = true
+  bucket_folder                               = "folder2"
+  bucket_name                                 = "updated_name"
+  canned_acl_for_objects                      = "private"
+  cdc_inserts_and_updates                     = false
+  cdc_inserts_only                            = true
+  cdc_max_batch_interval                      = 105
+  cdc_min_file_size                           = 17
+  cdc_path                                    = "cdc/path"
+  compression_type                            = "NONE"
+  csv_delimiter                               = ","
+  csv_no_sup_value                            = "U"
+  csv_null_value                              = "-"
+  csv_row_delimiter                           = "\\n"
+  data_format                                 = "parquet"
+  data_page_size                              = 1100000
+  date_partition_delimiter                    = "SLASH"
+  date_partition_enabled                      = true
+  date_partition_sequence                     = "yyyymmddhh"
+  date_partition_timezone                     = "Europe/Paris"
+  dict_page_size_limit                        = 1000000
+  enable_statistics                           = true
+  encoding_type                               = "plain"
+  encryption_mode                             = "SSE_S3"
+  expected_bucket_owner                       = data.aws_caller_identity.current.account_id
+  ignore_header_rows                          = 1
+  include_op_for_full_load                    = false
+  max_file_size                               = 900000
+  parquet_timestamp_in_millisecond            = true
+  parquet_version                             = "parquet-2-0"
+  preserve_transactions                       = false
+  rfc_4180                                    = true
+  row_group_length                            = 13000
+  server_side_encryption_kms_key_id           = aws_kms_key.test2.arn
+  service_access_role_arn                     = aws_iam_role.test.arn
+  timestamp_column_name                       = "tx_commit_time2"
+  use_csv_no_sup_value                        = true
+  use_task_start_time_for_full_load_timestamp = false
+
+  depends_on = [aws_iam_role_policy.test]
+}
+`, rName))
+}
+
+func testAccS3EndpointConfig_simple(rName string) string {
+	return acctest.ConfigCompose(
+		testAccS3EndpointConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_dms_s3_endpoint" "test" {
+  endpoint_id             = %[1]q
+  endpoint_type           = "target"
+  bucket_name             = "beckut_name"
+  service_access_role_arn = aws_iam_role.test.arn
+
+  depends_on = [aws_iam_role_policy.test]
+}
+`, rName))
+}
+
+func testAccS3EndpointConfig_sourceSimple(rName string) string {
+	return acctest.ConfigCompose(
+		testAccS3EndpointConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_dms_s3_endpoint" "test" {
+  bucket_name             = "beckut_name"
+  endpoint_id             = %[1]q
+  endpoint_type           = "source"
+  service_access_role_arn = aws_iam_role.test.arn
+
+  external_table_definition = jsonencode({
+    TableCount = 1
+    Tables = [{
+      TableName  = "employee"
+      TablePath  = "hr/employee/"
+      TableOwner = "hr"
+      TableColumns = [{
+        ColumnName     = "ID"
+        ColumnType     = "INT8"
+        ColumnNullable = "false"
+        ColumnIsPk     = "true"
+      },{
+        ColumnName   = "LastName"
+        ColumnType   = "STRING"
+        ColumnLength = "20"
+      }]
+      TableColumnsTotal = "2"
+    }]
+  })
+
+  depends_on = [aws_iam_role_policy.test]
+}
+`, rName))
+}
+
+func testAccS3EndpointConfig_source(rName string) string {
+	return acctest.ConfigCompose(
+		testAccS3EndpointConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_dms_s3_endpoint" "test" {
+  bucket_folder           = "folder"
+  bucket_name             = "bucket_name"
+  cdc_path                = "cdc/path"
+  csv_delimiter           = ";"
+  csv_row_delimiter       = "\\r\\n"
+  endpoint_id             = %[1]q
+  endpoint_type           = "source"
+  ignore_header_rows      = 1
+  rfc_4180                = false
+  service_access_role_arn = aws_iam_role.test.arn
+
+  external_table_definition = jsonencode({
+    TableCount = 1
+    Tables = [{
+      TableName  = "employee"
+      TablePath  = "hr/employee/"
+      TableOwner = "hr"
+      TableColumns = [{
+        ColumnName     = "ID"
+        ColumnType     = "INT8"
+        ColumnNullable = "false"
+        ColumnIsPk     = "true"
+      },{
+        ColumnName   = "LastName"
+        ColumnType   = "STRING"
+        ColumnLength = "20"
+      }]
+      TableColumnsTotal = "2"
+    }]
+  })
+
+  add_column_name                             = true
+  canned_acl_for_objects                      = "private"
+  cdc_inserts_and_updates                     = true
+  cdc_inserts_only                            = false
+  cdc_max_batch_interval                      = 100
+  cdc_min_file_size                           = 16
+  compression_type                            = "GZIP"
+  csv_null_value                              = "?"
+  data_page_size                              = 1100000
+  date_partition_enabled                      = true
+  dict_page_size_limit                        = 1000000
+  enable_statistics                           = false
+  encoding_type                               = "plain"
+  expected_bucket_owner                       = data.aws_caller_identity.current.account_id
+  include_op_for_full_load                    = true
+  max_file_size                               = 1000000
+  row_group_length                            = 11000
+  timestamp_column_name                       = "tx_commit_time"
+  use_task_start_time_for_full_load_timestamp = true
+
+  depends_on = [aws_iam_role_policy.test]
+}
+`, rName))
+}
+
+func testAccS3EndpointConfig_sourceUpdated(rName string) string {
+	return acctest.ConfigCompose(
+		testAccS3EndpointConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_dms_s3_endpoint" "test" {
+  bucket_folder           = "folder2"
+  bucket_name             = "beckut_name"
+  cdc_path                = "cdc/path2"
+  csv_delimiter           = ","
+  csv_row_delimiter       = "\\n"
+  endpoint_id             = %[1]q
+  endpoint_type           = "source"
+  ignore_header_rows      = 1
+  rfc_4180                = true
+  service_access_role_arn = aws_iam_role.test.arn
+
+  external_table_definition = jsonencode({
+    TableCount = 1
+    Tables = [{
+      TableName  = "employee"
+      TablePath  = "hr/employee/"
+      TableOwner = "hr"
+      TableColumns = [{
+        ColumnName     = "ID"
+        ColumnType     = "INT8"
+        ColumnNullable = "false"
+        ColumnIsPk     = "true"
+      }]
+      TableColumnsTotal = "1"
+    }]
+  })
+
+  add_column_name                             = false
+  canned_acl_for_objects                      = "authenticated-read"
+  cdc_inserts_and_updates                     = false
+  cdc_inserts_only                            = true
+  cdc_max_batch_interval                      = 101
+  cdc_min_file_size                           = 17
+  compression_type                            = "NONE"
+  csv_null_value                              = "0"
+  data_page_size                              = 1000000
+  date_partition_enabled                      = false
+  dict_page_size_limit                        = 830000
+  enable_statistics                           = true
+  encoding_type                               = "plain-dictionary"
+  expected_bucket_owner                       = data.aws_caller_identity.current.account_id
+  include_op_for_full_load                    = false
+  max_file_size                               = 100
+  row_group_length                            = 10000
+  timestamp_column_name                       = "tx_commit_time2"
+  use_task_start_time_for_full_load_timestamp = false
+
+  depends_on = [aws_iam_role_policy.test]
+}
+`, rName))
+}

--- a/internal/service/dms/wait.go
+++ b/internal/service/dms/wait.go
@@ -12,7 +12,7 @@ const (
 	replicationTaskRunningTimeout = 5 * time.Minute
 )
 
-func waitEndpointDeleted(conn *dms.DatabaseMigrationService, id string, timeout time.Duration) (*dms.Endpoint, error) {
+func waitEndpointDeleted(conn *dms.DatabaseMigrationService, id string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{endpointStatusDeleting},
 		Target:  []string{},
@@ -20,13 +20,9 @@ func waitEndpointDeleted(conn *dms.DatabaseMigrationService, id string, timeout 
 		Timeout: timeout,
 	}
 
-	outputRaw, err := stateConf.WaitForState()
+	_, err := stateConf.WaitForState()
 
-	if output, ok := outputRaw.(*dms.Endpoint); ok {
-		return output, err
-	}
-
-	return nil, err
+	return err
 }
 
 func waitReplicationTaskDeleted(conn *dms.DatabaseMigrationService, id string, timeout time.Duration) error {

--- a/website/docs/r/dms_s3_endpoint.html.markdown
+++ b/website/docs/r/dms_s3_endpoint.html.markdown
@@ -1,0 +1,170 @@
+---
+subcategory: "DMS (Database Migration)"
+layout: "aws"
+page_title: "AWS: aws_dms_s3_endpoint"
+description: |-
+  Provides a DMS (Data Migration Service) S3 endpoint resource.
+---
+
+# Resource: aws_dms_s3_endpoint
+
+Provides a DMS (Data Migration Service) S3 endpoint resource. DMS S3 endpoints can be created, updated, deleted, and imported.
+
+~> **Note:** AWS is deprecating `extra_connection_attributes`, such as used with `aws_dms_endpoint`. This resource is an alternative to `aws_dms_endpoint` and does not use `extra_connection_attributes`. (AWS currently includes `extra_connection_attributes` in the raw responses to the AWS Provider requests and so they may be visible in Terraform logs.)
+
+~> **Note:** Some of this resource's arguments have default values that come from the AWS Provider. Other default values are provided by AWS and subject to change without notice. When relying on AWS defaults, the Terraform state will often have a zero value. For example, the AWS Provider does not provide a default for `cdc_max_batch_interval` but the AWS default is `60` (seconds). However, the Terraform state will show `0` since this is the value return by AWS when no value is present. Below, we aim to flag the defaults that come from AWS (_e.g._, "AWS default...").
+
+## Example Usage
+
+### Minimal Configuration
+
+This is the minimal configuration for an `aws_dms_s3_endpoint`. This endpoint will rely on the AWS Provider and AWS defaults.
+
+```terraform
+resource "aws_dms_s3_endpoint" "example" {
+  endpoint_id             = "donnedtipi"
+  endpoint_type           = "target"
+  bucket_name             = "beckut_name"
+  service_access_role_arn = aws_iam_role.example.arn
+
+  depends_on = [aws_iam_role_policy.example]
+}
+```
+
+### Complete Configuration
+
+```terraform
+resource "aws_dms_s3_endpoint" "example" {
+  endpoint_id   = "donnedtipi"
+  endpoint_type = "target"
+  ssl_mode      = "none"
+
+  tags = {
+    Name   = "donnedtipi"
+    Update = "to-update"
+    Remove = "to-remove"
+  }
+
+  add_column_name                             = true
+  add_trailing_padding_character              = false
+  bucket_folder                               = "folder"
+  bucket_name                                 = "bucket_name"
+  canned_acl_for_objects                      = "private"
+  cdc_inserts_and_updates                     = true
+  cdc_inserts_only                            = false
+  cdc_max_batch_interval                      = 100
+  cdc_min_file_size                           = 16
+  cdc_path                                    = "cdc/path"
+  compression_type                            = "GZIP"
+  csv_delimiter                               = ";"
+  csv_no_sup_value                            = "x"
+  csv_null_value                              = "?"
+  csv_row_delimiter                           = "\\r\\n"
+  data_format                                 = "parquet"
+  data_page_size                              = 1100000
+  date_partition_delimiter                    = "UNDERSCORE"
+  date_partition_enabled                      = true
+  date_partition_sequence                     = "yyyymmddhh"
+  date_partition_timezone                     = "Asia/Seoul"
+  dict_page_size_limit                        = 1000000
+  enable_statistics                           = false
+  encoding_type                               = "plain"
+  encryption_mode                             = "SSE_S3"
+  expected_bucket_owner                       = data.aws_caller_identity.current.account_id
+  external_table_definition                   = "etd"
+  ignore_header_rows                          = 1
+  include_op_for_full_load                    = true
+  max_file_size                               = 1000000
+  parquet_timestamp_in_millisecond            = true
+  parquet_version                             = "parquet-2-0"
+  preserve_transactions                       = false
+  rfc_4180                                    = false
+  row_group_length                            = 11000
+  server_side_encryption_kms_key_id           = aws_kms_key.example.arn
+  service_access_role_arn                     = aws_iam_role.example.arn
+  timestamp_column_name                       = "tx_commit_time"
+  use_csv_no_sup_value                        = false
+  use_task_start_time_for_full_load_timestamp = true
+
+  depends_on = [aws_iam_role_policy.example]
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `bucket_name` - (Required) S3 bucket name.
+* `cdc_path` - (Required for CDC; otherwise, Optional) Folder path of CDC files. If `cdc_path` is set, AWS DMS reads CDC files from this path and replicates the data changes to the target endpoint. Supported in AWS DMS versions 3.4.2 and later.
+* `endpoint_id` - (Required) Database endpoint identifier. Identifiers must contain from 1 to 255 alphanumeric characters or hyphens, begin with a letter, contain only ASCII letters, digits, and hyphens, not end with a hyphen, and not contain two consecutive hyphens.
+* `endpoint_type` - (Required) Type of endpoint. Valid values are `source`, `target`.
+* `external_table_definition` - (Required for `source` endpoints; otherwise, Optional) JSON document that describes how AWS DMS should interpret the data.
+* `service_access_role_arn` - (Required) ARN of the IAM role with permissions to the S3 Bucket.
+
+The following arguments are optional:
+
+* `add_column_name` - (Optional) Whether to add column name information to the .csv output file. Default is `false`.
+* `add_trailing_padding_character` - (Optional) Whether to add padding. Default is `false`. (Ignored for source endpoints.)
+* `bucket_folder` - (Optional) S3 object prefix.
+* `canned_acl_for_objects` - (Optional) Predefined (canned) access control list for objects created in an S3 bucket. Valid values include `NONE`, `PRIVATE`, `PUBLIC_READ`, `PUBLIC_READ_WRITE`, `AUTHENTICATED_READ`, `AWS_EXEC_READ`, `BUCKET_OWNER_READ`, and `BUCKET_OWNER_FULL_CONTROL`. (AWS default is `NONE`.)
+* `cdc_inserts_and_updates` - (Optional) Whether to write insert and update operations to .csv or .parquet output files. Default is `false`.
+* `cdc_inserts_only` - (Optional) Whether to write insert operations to .csv or .parquet output files. Default is `false`.
+* `cdc_max_batch_interval` - (Optional) Maximum length of the interval, defined in seconds, after which to output a file to Amazon S3. (AWS default is `60`.)
+* `cdc_min_file_size` - (Optional) Minimum file size, defined in kilobytes, to reach for a file output. (AWS default is 32 MB.)
+* `certificate_arn` - (Optional, Default: empty string) ARN for the certificate.
+* `compression_type` - (Optional) Set to compress target files. Valid values are `GZIP` and `NONE`. Default is `NONE`.
+* `csv_delimiter` - (Optional) Delimiter used to separate columns in the source files. Default is `,`.
+* `csv_no_sup_value` - (Optional) Only applies if output files for a CDC load are written in .csv format. If `use_csv_no_sup_value` is set to `true`, string to use for all columns not included in the supplemental log. If you do not specify a string value, DMS uses the null value for these columns regardless of `use_csv_no_sup_value`. (Ignored for source endpoints.)
+* `csv_null_value` - (Optional) String to as null when writing to the target. (AWS default is `NULL`.)
+* `csv_row_delimiter` - (Optional) Delimiter used to separate rows in the source files. Default is newline (_i.e._, `\n`).
+* `data_format` - (Optional) Output format for the files that AWS DMS uses to create S3 objects. Valid values are `csv` and `parquet`.  (Ignored for source endpoints -- only `csv` is valid.)
+* `data_page_size` - (Optional) Size of one data page in bytes. (AWS default is 1 MiB, _i.e._, `1048576`.)
+* `date_partition_delimiter` - (Optional) Date separating delimiter to use during folder partitioning. Valid values are `SLASH`, `UNDERSCORE`, `DASH`, and `NONE`. (AWS default is `SLASH`.) (Ignored for source endpoints.)
+* `date_partition_enabled` - (Optional) Partition S3 bucket folders based on transaction commit dates. Default is `false`.
+* `date_partition_sequence` - (Optional) Date format to use during folder partitioning. Use this parameter when `date_partition_enabled` is set to true. Valid values are `YYYYMMDD`, `YYYYMMDDHH`, `YYYYMM`, `MMYYYYDD`, and `DDMMYYYY`. (AWS default is `YYYYMMDD`.) (Ignored for source endpoints.)
+* `date_partition_timezone` - (Optional) Convert the current UTC time to a timezone. The conversion occurs when a date partition folder is created and a CDC filename is generated. The timezone format is Area/Location (_e.g._, `Europe/Paris`). Use this when `date_partition_enabled` is `true`. (Ignored for source endpoints.)
+* `dict_page_size_limit` - (Optional) Maximum size in bytes of an encoded dictionary page of a column. (AWS default is 1 MiB, _i.e._, `1048576`.)
+* `enable_statistics` - (Optional) Whether to enable statistics for Parquet pages and row groups. Default is `true`.
+* `encoding_type` - (Optional) Type of encoding to use. Value values are `rle_dictionary`, `plain`, and `plain_dictionary`. (AWS default is `rle_dictionary`.)
+* `encryption_mode` - (Optional) Server-side encryption mode that you want to encrypt your .csv or .parquet object files copied to S3. Valid values are `SSE_S3` and `SSE_KMS`. (AWS default is `SSE_S3`.) (Ignored for source endpoints -- only `SSE_S3` is valid.)
+* `expected_bucket_owner` - (Optional) Bucket owner to prevent sniping. Value is an AWS account ID.
+* `ignore_headers_row` - (Optional, Force New) When this value is set to `1`, DMS ignores the first row header in a .csv file. (AWS default is `0`.)
+* `include_op_for_full_load` - (Optional) Whether to enable a full load to write INSERT operations to the .csv output files only to indicate how the rows were added to the source database. Default is `false`.
+* `kms_key_arn` - (Optional) ARN for the KMS key that will be used to encrypt the connection parameters. If you do not specify a value for `kms_key_arn`, then AWS DMS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS region.
+* `max_file_size` - (Optional) Maximum size (in KB) of any .csv file to be created while migrating to an S3 target during full load. Valid values are from `1` to `1048576`. (AWS default is 1 GB, _i.e._, `1048576`.)
+* `parquet_timestamp_in_millisecond` - (Optional) - Specifies the precision of any TIMESTAMP column values written to an S3 object file in .parquet format. Default is `false`. (Ignored for source endpoints.)
+* `parquet_version` - (Optional) Version of the .parquet file format. Valid values are `parquet-1-0` and `parquet-2-0`. (AWS default is `parquet-1-0`.) (Ignored for source endpoints.)
+* `preserve_transactions` - (Optional) Whether DMS saves the transaction order for a CDC load on the S3 target specified by `cdc_path`. Default is `false`. (Ignored for source endpoints.)
+* `rfc_4180` - (Optional) For an S3 source, whether each leading double quotation mark has to be followed by an ending double quotation mark. Default is `true`.
+* `row_group_length` - (Optional) Number of rows in a row group. (AWS default is `10000`.)
+* `server_side_encryption_kms_key_id` - (Optional) When `encryption_mode` is `SSE_KMS`, ARN for the AWS KMS key. (Ignored for source endpoints -- only `SSE_S3` is valid.)
+* `ssl_mode` - (Optional) SSL mode to use for the connection. Valid values are `none`, `require`, `verify-ca`, `verify-full`. (AWS default is `none`.)
+* `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `timestamp_column_name` - (Optional) Column to add with timestamp information to the endpoint data for an Amazon S3 target.
+* `use_csv_no_sup_value` - (Optional) Whether to use `csv_no_sup_value` for columns not included in the supplemental log. (Ignored for source endpoints.)
+* `use_task_start_time_for_full_load_timestamp` - (Optional) When set to `true`, uses the task start time as the timestamp column value instead of the time data is written to target. For full load, when set to `true`, each row of the timestamp column contains the task start time. For CDC loads, each row of the timestamp column contains the transaction commit time.When set to false, the full load timestamp in the timestamp column increments with the time data arrives at the target. Default is `false`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `endpoint_arn` - ARN for the endpoint.
+* `engine_display_name` - Expanded name for the engine name.
+* `external_id` - Can be used for cross-account validation. Use it in another account with `aws_dms_s3_endpoint` to create the endpoint cross-account.
+* `status` - Status of the endpoint.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `create` - (Default `5m`)
+- `delete` - (Default `5m`)
+
+## Import
+
+Endpoints can be imported using the `endpoint_id`, e.g.,
+
+```
+$ terraform import aws_dms_s3_endpoint.example example-dms-endpoint-tf
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR addresses at least 3 challenges currently swirling around DMS endpoints.

1. **Extra connection attributes** aren't scaling well for AWS and all the endpoint types available. Correspondingly, the `aws_dms_endpoint` resource is not well suited to handling the many endpoint types, and their unique attributes, without the use of **extra connection attributes**.  The resource is stretched thin (read it's a mess) already with attempts to handle so many endpoints and all the variious edge cases associated with each.
1. As AWS moves closer to deprecating **extra connection attributes**, it appears that they are dropping support for some attributes, like `compression_type`. You _can_ still use `compression_type` but not through **extra connection attributes**.
2. AWS seems to have tightened up some validation rules. For example, previously, including `data_partition_delimiter` in a request to create a `source` endpoint did not cause problems. Now, it causes an error.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27852
Closes #27980 
Relates #23507 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
