### PR TITLE
Adding import documentation for control tower controls

### DIFF
--- a/website/docs/r/controltower_control.html.markdown
+++ b/website/docs/r/controltower_control.html.markdown
@@ -43,3 +43,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ARN of the organizational unit.
+
+## Import
+
+Control Tower Controls can be imported using their `organizational_unit_arn/control_identifier`, e.g.,
+
+```
+$ terraform import aws_controltower_control.example arn:aws:organizations::123456789101:ou/o-qqaejywet/ou-qg5o-ufbhdtv3,arn:aws:controltower:us-east-1::control/WTDSMKDKDNLE
+```


### PR DESCRIPTION
### Description
This is adding import documentation for a control tower control. 
https://github.com/hashicorp/terraform-provider-aws/issues/28020


### Relations
Closes #28020


### References
NA


### Output from Acceptance Testing
NA
