### PR TITLE
r/sagemaker_space - new resource

### DIFF
--- a/.changelog/28154.txt
+++ b/.changelog/28154.txt
@@ -13,3 +13,7 @@ resource/aws_sagemaker_user_profle: Add `user_settings.jupyter_server_app_settin
 ```release-note:enhancement
 resource/aws_sagemaker_app: Add `space_name` argument
 ```
+
+```release-note:enhancement
+resource/aws_sagemaker_app: Make `user_profile_name` optional
+```

--- a/.changelog/28154.txt
+++ b/.changelog/28154.txt
@@ -1,0 +1,15 @@
+```release-note:new-resource
+aws_sagemaker_space
+```
+
+```release-note:enhancement
+resource/aws_sagemaker_domain: Add `default_space_settings` and `default_user_settings.jupyter_server_app_settings.code_repository` arguments
+```
+
+```release-note:enhancement
+resource/aws_sagemaker_user_profle: Add `user_settings.jupyter_server_app_settings.code_repository` argument
+```
+
+```release-note:enhancement
+resource/aws_sagemaker_app: Add `space_name` argument
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2047,6 +2047,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_sagemaker_notebook_instance":                         sagemaker.ResourceNotebookInstance(),
 			"aws_sagemaker_notebook_instance_lifecycle_configuration": sagemaker.ResourceNotebookInstanceLifeCycleConfiguration(),
 			"aws_sagemaker_project":                                   sagemaker.ResourceProject(),
+			"aws_sagemaker_space":                                     sagemaker.ResourceSpace(),
 			"aws_sagemaker_servicecatalog_portfolio_status":           sagemaker.ResourceServicecatalogPortfolioStatus(),
 			"aws_sagemaker_studio_lifecycle_config":                   sagemaker.ResourceStudioLifecycleConfig(),
 			"aws_sagemaker_user_profile":                              sagemaker.ResourceUserProfile(),

--- a/internal/service/sagemaker/app.go
+++ b/internal/service/sagemaker/app.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -84,12 +85,19 @@ func ResourceApp() *schema.Resource {
 					},
 				},
 			},
+			"space_name": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				ExactlyOneOf: []string{"space_name", "user_profile_name"},
+			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 			"user_profile_name": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				ExactlyOneOf: []string{"space_name", "user_profile_name"},
 			},
 		},
 
@@ -103,10 +111,17 @@ func resourceAppCreate(d *schema.ResourceData, meta interface{}) error {
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
 	input := &sagemaker.CreateAppInput{
-		AppName:         aws.String(d.Get("app_name").(string)),
-		AppType:         aws.String(d.Get("app_type").(string)),
-		DomainId:        aws.String(d.Get("domain_id").(string)),
-		UserProfileName: aws.String(d.Get("user_profile_name").(string)),
+		AppName:  aws.String(d.Get("app_name").(string)),
+		AppType:  aws.String(d.Get("app_type").(string)),
+		DomainId: aws.String(d.Get("domain_id").(string)),
+	}
+
+	if v, ok := d.GetOk("user_profile_name"); ok {
+		input.UserProfileName = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("space_name"); ok {
+		input.SpaceName = aws.String(v.(string))
 	}
 
 	if len(tags) > 0 {
@@ -124,14 +139,14 @@ func resourceAppCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	appArn := aws.StringValue(output.AppArn)
-	domainID, userProfileName, appType, appName, err := decodeAppID(appArn)
+	domainID, userProfileOrSpaceName, appType, appName, err := decodeAppID(appArn)
 	if err != nil {
 		return err
 	}
 
 	d.SetId(appArn)
 
-	if _, err := WaitAppInService(conn, domainID, userProfileName, appType, appName); err != nil {
+	if _, err := WaitAppInService(conn, domainID, userProfileOrSpaceName, appType, appName); err != nil {
 		return fmt.Errorf("waiting for SageMaker App (%s) to create: %w", d.Id(), err)
 	}
 
@@ -143,25 +158,19 @@ func resourceAppRead(d *schema.ResourceData, meta interface{}) error {
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	domainID, userProfileName, appType, appName, err := decodeAppID(d.Id())
+	domainID, userProfileOrSpaceName, appType, appName, err := decodeAppID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	app, err := FindAppByName(conn, domainID, userProfileName, appType, appName)
+	app, err := FindAppByName(conn, domainID, userProfileOrSpaceName, appType, appName)
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+		if !d.IsNewResource() && tfresource.NotFound(err) {
 			d.SetId("")
-			log.Printf("[WARN] Unable to find SageMaker App (%s), removing from state", d.Id())
+			log.Printf("[WARN] Unable to find SageMaker App (%s); removing from state", d.Id())
 			return nil
 		}
 		return fmt.Errorf("reading SageMaker App (%s): %w", d.Id(), err)
-	}
-
-	if aws.StringValue(app.Status) == sagemaker.AppStatusDeleted {
-		d.SetId("")
-		log.Printf("[WARN] Unable to find SageMaker App (%s), removing from state", d.Id())
-		return nil
 	}
 
 	arn := aws.StringValue(app.AppArn)
@@ -170,6 +179,7 @@ func resourceAppRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("arn", arn)
 	d.Set("domain_id", app.DomainId)
 	d.Set("user_profile_name", app.UserProfileName)
+	d.Set("space_name", app.SpaceName)
 
 	if err := d.Set("resource_spec", flattenDomainDefaultResourceSpec(app.ResourceSpec)); err != nil {
 		return fmt.Errorf("setting resource_spec for SageMaker App (%s): %w", d.Id(), err)
@@ -215,13 +225,22 @@ func resourceAppDelete(d *schema.ResourceData, meta interface{}) error {
 	appName := d.Get("app_name").(string)
 	appType := d.Get("app_type").(string)
 	domainID := d.Get("domain_id").(string)
-	userProfileName := d.Get("user_profile_name").(string)
+	userProfileOrSpaceName := ""
 
 	input := &sagemaker.DeleteAppInput{
-		AppName:         aws.String(appName),
-		AppType:         aws.String(appType),
-		DomainId:        aws.String(domainID),
-		UserProfileName: aws.String(userProfileName),
+		AppName:  aws.String(appName),
+		AppType:  aws.String(appType),
+		DomainId: aws.String(domainID),
+	}
+
+	if v, ok := d.GetOk("user_profile_name"); ok {
+		input.UserProfileName = aws.String(v.(string))
+		userProfileOrSpaceName = v.(string)
+	}
+
+	if v, ok := d.GetOk("space_name"); ok {
+		input.SpaceName = aws.String(v.(string))
+		userProfileOrSpaceName = v.(string)
 	}
 
 	if _, err := conn.DeleteApp(input); err != nil {
@@ -235,7 +254,7 @@ func resourceAppDelete(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if _, err := WaitAppDeleted(conn, domainID, userProfileName, appType, appName); err != nil {
+	if _, err := WaitAppDeleted(conn, domainID, userProfileOrSpaceName, appType, appName); err != nil {
 		if !tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
 			return fmt.Errorf("waiting for SageMaker App (%s) to delete: %w", d.Id(), err)
 		}
@@ -254,11 +273,11 @@ func decodeAppID(id string) (string, string, string, string, error) {
 	parts := strings.Split(appResourceName, "/")
 
 	if len(parts) != 4 {
-		return "", "", "", "", fmt.Errorf("Unexpected format of ID (%q), expected DOMAIN-ID/USER-PROFILE-NAME/APP-TYPE/APP-NAME", appResourceName)
+		return "", "", "", "", fmt.Errorf("unexpected format of ID (%q), expected DOMAIN-ID/USER-PROFILE-NAME OR PROFILE-NAME/APP-TYPE/APP-NAME", appResourceName)
 	}
 
 	domainID := parts[0]
-	userProfileName := parts[1]
+	userProfileOrSpaceName := parts[1]
 	appType := parts[2]
 
 	if appType == "jupyterserver" {
@@ -267,9 +286,13 @@ func decodeAppID(id string) (string, string, string, string, error) {
 		appType = sagemaker.AppTypeKernelGateway
 	} else if appType == "tensorboard" {
 		appType = sagemaker.AppTypeTensorBoard
+	} else if appType == "rstudioserverpro" {
+		appType = sagemaker.AppTypeRstudioServerPro
+	} else if appType == "rsessiongateway" {
+		appType = sagemaker.AppTypeRsessionGateway
 	}
 
 	appName := parts[3]
 
-	return domainID, userProfileName, appType, appName, nil
+	return domainID, userProfileOrSpaceName, appType, appName, nil
 }

--- a/internal/service/sagemaker/app_test.go
+++ b/internal/service/sagemaker/app_test.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfsagemaker "github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func testAccApp_basic(t *testing.T) {
@@ -43,6 +43,38 @@ func testAccApp_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "resource_spec.0.sagemaker_image_arn"),
 					resource.TestCheckResourceAttr(resourceName, "resource_spec.0.instance_type", "system"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccApp_space(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var app sagemaker.DescribeAppOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_app.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sagemaker.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppConfig_space(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAppExists(resourceName, &app),
+					resource.TestCheckResourceAttr(resourceName, "app_name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "space_name", "aws_sagemaker_space.test", "space_name"),
 				),
 			},
 			{
@@ -208,14 +240,22 @@ func testAccCheckAppDestroy(s *terraform.State) error {
 			continue
 		}
 
+		userProfileOrSpaceName := ""
 		domainID := rs.Primary.Attributes["domain_id"]
-		userProfileName := rs.Primary.Attributes["user_profile_name"]
 		appType := rs.Primary.Attributes["app_type"]
 		appName := rs.Primary.Attributes["app_name"]
 
-		app, err := tfsagemaker.FindAppByName(conn, domainID, userProfileName, appType, appName)
+		if v, ok := rs.Primary.Attributes["user_profile_name"]; ok {
+			userProfileOrSpaceName = v
+		}
 
-		if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+		if v, ok := rs.Primary.Attributes["space_name"]; ok {
+			userProfileOrSpaceName = v
+		}
+
+		app, err := tfsagemaker.FindAppByName(conn, domainID, userProfileOrSpaceName, appType, appName)
+
+		if tfresource.NotFound(err) {
 			continue
 		}
 
@@ -223,9 +263,8 @@ func testAccCheckAppDestroy(s *terraform.State) error {
 			return fmt.Errorf("reading SageMaker App (%s): %w", rs.Primary.ID, err)
 		}
 
-		appArn := aws.StringValue(app.AppArn)
-		if appArn == rs.Primary.ID && aws.StringValue(app.Status) != sagemaker.AppStatusDeleted {
-			return fmt.Errorf("SageMaker App %q still exists", rs.Primary.ID)
+		if aws.StringValue(app.AppArn) == rs.Primary.ID {
+			return fmt.Errorf("sagemaker App %q still exists", rs.Primary.ID)
 		}
 	}
 
@@ -244,12 +283,20 @@ func testAccCheckAppExists(n string, app *sagemaker.DescribeAppOutput) resource.
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).SageMakerConn
+		userProfileOrSpaceName := ""
 		domainID := rs.Primary.Attributes["domain_id"]
-		userProfileName := rs.Primary.Attributes["user_profile_name"]
 		appType := rs.Primary.Attributes["app_type"]
 		appName := rs.Primary.Attributes["app_name"]
 
-		resp, err := tfsagemaker.FindAppByName(conn, domainID, userProfileName, appType, appName)
+		if v, ok := rs.Primary.Attributes["user_profile_name"]; ok {
+			userProfileOrSpaceName = v
+		}
+
+		if v, ok := rs.Primary.Attributes["space_name"]; ok {
+			userProfileOrSpaceName = v
+		}
+
+		resp, err := tfsagemaker.FindAppByName(conn, domainID, userProfileOrSpaceName, appType, appName)
 		if err != nil {
 			return err
 		}
@@ -261,36 +308,7 @@ func testAccCheckAppExists(n string, app *sagemaker.DescribeAppOutput) resource.
 }
 
 func testAccAppBaseConfig(rName string) string {
-	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  # SageMaker compute resources are not available at usw2-az4.
-  exclude_zone_ids = ["usw2-az4"]
-  state            = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_subnet" "test" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  vpc_id            = aws_vpc.test.id
-  cidr_block        = "10.0.1.0/24"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name               = %[1]q
   path               = "/"
@@ -312,9 +330,13 @@ resource "aws_sagemaker_domain" "test" {
   domain_name = %[1]q
   auth_mode   = "IAM"
   vpc_id      = aws_vpc.test.id
-  subnet_ids  = [aws_subnet.test.id]
+  subnet_ids  = aws_subnet.test[*].id
 
   default_user_settings {
+    execution_role = aws_iam_role.test.arn
+  }
+
+  default_space_settings {
     execution_role = aws_iam_role.test.arn
   }
 
@@ -327,7 +349,7 @@ resource "aws_sagemaker_user_profile" "test" {
   domain_id         = aws_sagemaker_domain.test.id
   user_profile_name = %[1]q
 }
-`, rName)
+`, rName))
 }
 
 func testAccAppConfig_basic(rName string) string {
@@ -337,6 +359,22 @@ resource "aws_sagemaker_app" "test" {
   user_profile_name = aws_sagemaker_user_profile.test.user_profile_name
   app_name          = %[1]q
   app_type          = "JupyterServer"
+}
+`, rName)
+}
+
+func testAccAppConfig_space(rName string) string {
+	return testAccAppBaseConfig(rName) + fmt.Sprintf(`
+resource "aws_sagemaker_space" "test" {
+  domain_id  = aws_sagemaker_domain.test.id
+  space_name = "%[1]s-space"
+}
+
+resource "aws_sagemaker_app" "test" {
+  domain_id  = aws_sagemaker_domain.test.id
+  app_name   = %[1]q
+  app_type   = "JupyterServer"
+  space_name = aws_sagemaker_space.test.space_name
 }
 `, rName)
 }

--- a/internal/service/sagemaker/app_test.go
+++ b/internal/service/sagemaker/app_test.go
@@ -307,7 +307,7 @@ func testAccCheckAppExists(n string, app *sagemaker.DescribeAppOutput) resource.
 	}
 }
 
-func testAccAppBaseConfig(rName string) string {
+func testAccAppConfig_base(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
 resource "aws_iam_role" "test" {
   name               = %[1]q
@@ -353,18 +353,18 @@ resource "aws_sagemaker_user_profile" "test" {
 }
 
 func testAccAppConfig_basic(rName string) string {
-	return testAccAppBaseConfig(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccAppConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_app" "test" {
   domain_id         = aws_sagemaker_domain.test.id
   user_profile_name = aws_sagemaker_user_profile.test.user_profile_name
   app_name          = %[1]q
   app_type          = "JupyterServer"
 }
-`, rName)
+`, rName))
 }
 
 func testAccAppConfig_space(rName string) string {
-	return testAccAppBaseConfig(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccAppConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_space" "test" {
   domain_id  = aws_sagemaker_domain.test.id
   space_name = "%[1]s-space"
@@ -376,11 +376,11 @@ resource "aws_sagemaker_app" "test" {
   app_type   = "JupyterServer"
   space_name = aws_sagemaker_space.test.space_name
 }
-`, rName)
+`, rName))
 }
 
 func testAccAppConfig_tags1(rName, tagKey1, tagValue1 string) string {
-	return testAccAppBaseConfig(rName) + fmt.Sprintf(`
+	return tacctest.ConfigCompose(testAccAppConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_app" "test" {
   domain_id         = aws_sagemaker_domain.test.id
   user_profile_name = aws_sagemaker_user_profile.test.user_profile_name
@@ -391,11 +391,11 @@ resource "aws_sagemaker_app" "test" {
     %[2]q = %[3]q
   }
 }
-`, rName, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
 func testAccAppConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccAppBaseConfig(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccAppConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_app" "test" {
   domain_id         = aws_sagemaker_domain.test.id
   user_profile_name = aws_sagemaker_user_profile.test.user_profile_name
@@ -407,11 +407,11 @@ resource "aws_sagemaker_app" "test" {
     %[4]q = %[5]q
   }
 }
-`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
 func testAccAppConfig_resourceSpec(rName string) string {
-	return testAccAppBaseConfig(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccAppConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_app" "test" {
   domain_id         = aws_sagemaker_domain.test.id
   user_profile_name = aws_sagemaker_user_profile.test.user_profile_name
@@ -422,11 +422,11 @@ resource "aws_sagemaker_app" "test" {
     instance_type = "system"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccAppConfig_resourceSpecLifecycle(rName, uName string) string {
-	return testAccAppBaseConfig(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccAppConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_studio_lifecycle_config" "test" {
   studio_lifecycle_config_name     = %[1]q
   studio_lifecycle_config_app_type = "JupyterServer"
@@ -462,5 +462,5 @@ resource "aws_sagemaker_app" "test" {
     lifecycle_config_arn = aws_sagemaker_studio_lifecycle_config.test.arn
   }
 }
-`, rName, uName)
+`, rName, uName))
 }

--- a/internal/service/sagemaker/app_test.go
+++ b/internal/service/sagemaker/app_test.go
@@ -380,7 +380,7 @@ resource "aws_sagemaker_app" "test" {
 }
 
 func testAccAppConfig_tags1(rName, tagKey1, tagValue1 string) string {
-	return tacctest.ConfigCompose(testAccAppConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccAppConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_app" "test" {
   domain_id         = aws_sagemaker_domain.test.id
   user_profile_name = aws_sagemaker_user_profile.test.user_profile_name

--- a/internal/service/sagemaker/domain.go
+++ b/internal/service/sagemaker/domain.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -645,12 +646,12 @@ func resourceDomainRead(d *schema.ResourceData, meta interface{}) error {
 
 	domain, err := FindDomainByName(conn, d.Id())
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+		if !d.IsNewResource() && tfresource.NotFound(err) {
 			d.SetId("")
-			log.Printf("[WARN] Unable to find SageMaker domain (%s), removing from state", d.Id())
+			log.Printf("[WARN] Unable to find SageMaker Domain (%s); removing from state", d.Id())
 			return nil
 		}
-		return fmt.Errorf("reading SageMaker domain (%s): %w", d.Id(), err)
+		return fmt.Errorf("reading SageMaker Domain (%s): %w", d.Id(), err)
 	}
 
 	arn := aws.StringValue(domain.DomainArn)

--- a/internal/service/sagemaker/domain.go
+++ b/internal/service/sagemaker/domain.go
@@ -52,6 +52,153 @@ func ResourceDomain() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringInSlice(sagemaker.AuthMode_Values(), false),
 			},
+			"default_space_settings": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"execution_role": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: verify.ValidARN,
+						},
+						"jupyter_server_app_settings": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"code_repository": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										MaxItems: 10,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"repository_url": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringLenBetween(1, 1024),
+												},
+											},
+										},
+									},
+									"default_resource_spec": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"instance_type": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(sagemaker.AppInstanceType_Values(), false),
+												},
+												"lifecycle_config_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: verify.ValidARN,
+												},
+												"sagemaker_image_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: verify.ValidARN,
+												},
+												"sagemaker_image_version_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: verify.ValidARN,
+												},
+											},
+										},
+									},
+									"lifecycle_config_arns": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: verify.ValidARN,
+										},
+									},
+								},
+							},
+						},
+						"kernel_gateway_app_settings": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"default_resource_spec": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"instance_type": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(sagemaker.AppInstanceType_Values(), false),
+												},
+												"lifecycle_config_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: verify.ValidARN,
+												},
+												"sagemaker_image_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: verify.ValidARN,
+												},
+												"sagemaker_image_version_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: verify.ValidARN,
+												},
+											},
+										},
+									},
+									"lifecycle_config_arns": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: verify.ValidARN,
+										},
+									},
+									"custom_image": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 30,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"app_image_config_name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"image_name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"image_version_number": {
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"security_groups": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							MaxItems: 5,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
 			"default_user_settings": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -97,6 +244,20 @@ func ResourceDomain() *schema.Resource {
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"code_repository": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										MaxItems: 10,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"repository_url": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringLenBetween(1, 1024),
+												},
+											},
+										},
+									},
 									"default_resource_spec": {
 										Type:     schema.TypeList,
 										Optional: true,
@@ -444,6 +605,10 @@ func resourceDomainCreate(d *schema.ResourceData, meta interface{}) error {
 		input.DomainSettings = expandDomainSettings(v.([]interface{}))
 	}
 
+	if v, ok := d.GetOk("default_space_settings"); ok && len(v.([]interface{})) > 0 {
+		input.DefaultSpaceSettings = expanDefaultSpaceSettings(v.([]interface{}))
+	}
+
 	if v, ok := d.GetOk("kms_key_id"); ok {
 		input.KmsKeyId = aws.String(v.(string))
 	}
@@ -509,6 +674,10 @@ func resourceDomainRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("setting default_user_settings for SageMaker Domain (%s): %w", d.Id(), err)
 	}
 
+	if err := d.Set("default_space_settings", flattenDefaultSpaceSettings(domain.DefaultSpaceSettings)); err != nil {
+		return fmt.Errorf("setting default_space_settings for SageMaker Domain (%s): %w", d.Id(), err)
+	}
+
 	if err := d.Set("domain_settings", flattenDomainSettings(domain.DomainSettings)); err != nil {
 		return fmt.Errorf("setting domain_settings for SageMaker Domain (%s): %w", d.Id(), err)
 	}
@@ -538,12 +707,19 @@ func resourceDomainUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChangesExcept("tags", "tags_all") {
 		input := &sagemaker.UpdateDomainInput{
-			DomainId:            aws.String(d.Id()),
-			DefaultUserSettings: expandDomainDefaultUserSettings(d.Get("default_user_settings").([]interface{})),
+			DomainId: aws.String(d.Id()),
+		}
+
+		if v, ok := d.GetOk("default_user_settings"); ok && len(v.([]interface{})) > 0 {
+			input.DefaultUserSettings = expandDomainDefaultUserSettings(v.([]interface{}))
 		}
 
 		if v, ok := d.GetOk("domain_settings"); ok && len(v.([]interface{})) > 0 {
 			input.DomainSettingsForUpdate = expandDomainSettingsUpdate(v.([]interface{}))
+		}
+
+		if v, ok := d.GetOk("default_space_settings"); ok && len(v.([]interface{})) > 0 {
+			input.DefaultSpaceSettings = expanDefaultSpaceSettings(v.([]interface{}))
 		}
 
 		log.Printf("[DEBUG] sagemaker domain update config: %#v", *input)
@@ -698,6 +874,10 @@ func expandDomainJupyterServerAppSettings(l []interface{}) *sagemaker.JupyterSer
 	m := l[0].(map[string]interface{})
 
 	config := &sagemaker.JupyterServerAppSettings{}
+
+	if v, ok := m["code_repository"].(*schema.Set); ok && v.Len() > 0 {
+		config.CodeRepositories = expandCodeRepositories(v.List())
+	}
 
 	if v, ok := m["default_resource_spec"].([]interface{}); ok && len(v) > 0 {
 		config.DefaultResourceSpec = expandDomainDefaultResourceSpec(v)
@@ -964,6 +1144,10 @@ func flattenDomainJupyterServerAppSettings(config *sagemaker.JupyterServerAppSet
 
 	m := map[string]interface{}{}
 
+	if config.CodeRepositories != nil {
+		m["code_repository"] = flattenCodeRepositories(config.CodeRepositories)
+	}
+
 	if config.DefaultResourceSpec != nil {
 		m["default_resource_spec"] = flattenDomainDefaultResourceSpec(config.DefaultResourceSpec)
 	}
@@ -1100,4 +1284,128 @@ func DecodeDomainID(id string) (string, error) {
 
 	domainName := strings.TrimPrefix(domainArn.Resource, "domain/")
 	return domainName, nil
+}
+
+func expanDefaultSpaceSettings(l []interface{}) *sagemaker.DefaultSpaceSettings {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.DefaultSpaceSettings{}
+
+	if v, ok := m["execution_role"].(string); ok && v != "" {
+		config.ExecutionRole = aws.String(v)
+	}
+
+	if v, ok := m["jupyter_server_app_settings"].([]interface{}); ok && len(v) > 0 {
+		config.JupyterServerAppSettings = expandDomainJupyterServerAppSettings(v)
+	}
+
+	if v, ok := m["kernel_gateway_app_settings"].([]interface{}); ok && len(v) > 0 {
+		config.KernelGatewayAppSettings = expandDomainKernelGatewayAppSettings(v)
+	}
+
+	if v, ok := m["security_groups"].(*schema.Set); ok && v.Len() > 0 {
+		config.SecurityGroups = flex.ExpandStringSet(v)
+	}
+
+	return config
+}
+
+func flattenDefaultSpaceSettings(config *sagemaker.DefaultSpaceSettings) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{}
+
+	if config.ExecutionRole != nil {
+		m["execution_role"] = aws.StringValue(config.ExecutionRole)
+	}
+
+	if config.JupyterServerAppSettings != nil {
+		m["jupyter_server_app_settings"] = flattenDomainJupyterServerAppSettings(config.JupyterServerAppSettings)
+	}
+
+	if config.KernelGatewayAppSettings != nil {
+		m["kernel_gateway_app_settings"] = flattenDomainKernelGatewayAppSettings(config.KernelGatewayAppSettings)
+	}
+
+	if config.SecurityGroups != nil {
+		m["security_groups"] = flex.FlattenStringSet(config.SecurityGroups)
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func expandCodeRepository(tfMap map[string]interface{}) *sagemaker.CodeRepository {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &sagemaker.CodeRepository{
+		RepositoryUrl: aws.String(tfMap["repository_url"].(string)),
+	}
+
+	return apiObject
+}
+
+func expandCodeRepositories(tfList []interface{}) []*sagemaker.CodeRepository {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []*sagemaker.CodeRepository
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		apiObject := expandCodeRepository(tfMap)
+
+		if apiObject == nil {
+			continue
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}
+
+func flattenCodeRepository(apiObject *sagemaker.CodeRepository) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if apiObject.RepositoryUrl != nil {
+		tfMap["repository_url"] = aws.StringValue(apiObject.RepositoryUrl)
+	}
+
+	return tfMap
+}
+
+func flattenCodeRepositories(apiObjects []*sagemaker.CodeRepository) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		tfList = append(tfList, flattenCodeRepository(apiObject))
+	}
+
+	return tfList
 }

--- a/internal/service/sagemaker/domain_test.go
+++ b/internal/service/sagemaker/domain_test.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfsagemaker "github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func testAccDomain_basic(t *testing.T) {
@@ -706,7 +706,7 @@ func testAccCheckDomainDestroy(s *terraform.State) error {
 
 		domain, err := tfsagemaker.FindDomainByName(conn, rs.Primary.ID)
 
-		if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+		if tfresource.NotFound(err) {
 			continue
 		}
 

--- a/internal/service/sagemaker/domain_test.go
+++ b/internal/service/sagemaker/domain_test.go
@@ -36,6 +36,7 @@ func testAccDomain_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "auth_mode", "IAM"),
 					resource.TestCheckResourceAttr(resourceName, "app_network_access_type", "PublicInternetOnly"),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_space_settings.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "default_user_settings.0.execution_role", "aws_iam_role.test", "arn"),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "sagemaker", regexp.MustCompile(`domain/.+`)),
@@ -533,6 +534,41 @@ func testAccDomain_jupyterServerAppSettings(t *testing.T) {
 	})
 }
 
+func testAccDomain_jupyterServerAppSettings_code(t *testing.T) {
+	var domain sagemaker.DescribeDomainOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_domain.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sagemaker.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_jupyterServerAppSettingsCode(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.jupyter_server_app_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.jupyter_server_app_settings.0.default_resource_spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.jupyter_server_app_settings.0.default_resource_spec.0.instance_type", "system"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.jupyter_server_app_settings.0.code_repository.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "default_user_settings.0.jupyter_server_app_settings.0.code_repository.*", map[string]string{
+						"repository_url": "https://github.com/hashicorp/terraform-provider-aws.git",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_policy"},
+			},
+		},
+	})
+}
+
 func testAccDomain_disappears(t *testing.T) {
 	var domain sagemaker.DescribeDomainOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -606,6 +642,55 @@ func testAccDomain_defaultUserSettingsUpdated(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"retention_policy"},
+			},
+		},
+	})
+}
+
+func testAccDomain_spaceSettingsKernelGatewayAppSettings(t *testing.T) {
+	var domain sagemaker.DescribeDomainOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_domain.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sagemaker.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_defaultSpaceKernelGatewayAppSettings(rName, "ml.t3.micro"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.kernel_gateway_app_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.kernel_gateway_app_settings.0.default_resource_spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.kernel_gateway_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.micro"),
+					resource.TestCheckResourceAttr(resourceName, "default_space_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_space_settings.0.kernel_gateway_app_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_space_settings.0.kernel_gateway_app_settings.0.default_resource_spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_space_settings.0.kernel_gateway_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.micro"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_policy"},
+			},
+			{
+				Config: testAccDomainConfig_defaultSpaceKernelGatewayAppSettings(rName, "ml.t3.small"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.kernel_gateway_app_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.kernel_gateway_app_settings.0.default_resource_spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.kernel_gateway_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.small"),
+					resource.TestCheckResourceAttr(resourceName, "default_space_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_space_settings.0.kernel_gateway_app_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_space_settings.0.kernel_gateway_app_settings.0.default_resource_spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_space_settings.0.kernel_gateway_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.small"),
+				),
 			},
 		},
 	})
@@ -1010,6 +1095,35 @@ resource "aws_sagemaker_domain" "test" {
 `, rName))
 }
 
+func testAccDomainConfig_jupyterServerAppSettingsCode(rName string) string {
+	return acctest.ConfigCompose(testAccDomainConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_domain" "test" {
+  domain_name = %[1]q
+  auth_mode   = "IAM"
+  vpc_id      = aws_vpc.test.id
+  subnet_ids  = aws_subnet.test[*].id
+
+  default_user_settings {
+    execution_role = aws_iam_role.test.arn
+
+    jupyter_server_app_settings {
+      code_repository {
+        repository_url = "https://github.com/hashicorp/terraform-provider-aws.git"
+      }
+
+      default_resource_spec {
+        instance_type = "system"
+      }
+    }
+  }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
+  }
+}
+`, rName))
+}
+
 func testAccDomainConfig_rSessionAppSettings(rName string) string {
 	return acctest.ConfigCompose(testAccDomainConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_domain" "test" {
@@ -1058,6 +1172,41 @@ resource "aws_sagemaker_domain" "test" {
   }
 }
 `, rName))
+}
+
+func testAccDomainConfig_defaultSpaceKernelGatewayAppSettings(rName, instance string) string {
+	return acctest.ConfigCompose(testAccDomainConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_domain" "test" {
+  domain_name = %[1]q
+  auth_mode   = "IAM"
+  vpc_id      = aws_vpc.test.id
+  subnet_ids  = aws_subnet.test[*].id
+
+  default_user_settings {
+    execution_role = aws_iam_role.test.arn
+
+    kernel_gateway_app_settings {
+      default_resource_spec {
+        instance_type = %[2]q
+      }
+    }
+  }
+
+  default_space_settings {
+    execution_role = aws_iam_role.test.arn
+
+    kernel_gateway_app_settings {
+      default_resource_spec {
+        instance_type = %[2]q
+      }
+    }
+  }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
+  }
+}
+`, rName, instance))
 }
 
 func testAccDomainConfig_kernelGatewayAppSettingsLifecycle(rName string) string {

--- a/internal/service/sagemaker/find.go
+++ b/internal/service/sagemaker/find.go
@@ -271,7 +271,6 @@ func listAppsByName(conn *sagemaker.SageMaker, domainID, userProfileOrSpaceName,
 
 	var foundApp *sagemaker.AppDetails
 	for _, app := range output.Apps {
-
 		if aws.StringValue(app.AppName) == appName &&
 			aws.StringValue(app.AppType) == appType &&
 			(aws.StringValue(app.SpaceName) == userProfileOrSpaceName ||

--- a/internal/service/sagemaker/find.go
+++ b/internal/service/sagemaker/find.go
@@ -177,12 +177,19 @@ func FindDomainByName(conn *sagemaker.SageMaker, domainID string) (*sagemaker.De
 
 	output, err := conn.DescribeDomain(input)
 
+	if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
 	if err != nil {
 		return nil, err
 	}
 
 	if output == nil {
-		return nil, nil
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	return output, nil

--- a/internal/service/sagemaker/find.go
+++ b/internal/service/sagemaker/find.go
@@ -230,12 +230,19 @@ func FindUserProfileByName(conn *sagemaker.SageMaker, domainID, userProfileName 
 
 	output, err := conn.DescribeUserProfile(input)
 
+	if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
 	if err != nil {
 		return nil, err
 	}
 
 	if output == nil {
-		return nil, nil
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
 	return output, nil

--- a/internal/service/sagemaker/sagemaker_test.go
+++ b/internal/service/sagemaker/sagemaker_test.go
@@ -30,6 +30,7 @@ func TestAccSageMaker_serial(t *testing.T) {
 			"tags":                  testAccApp_tags,
 			"resourceSpec":          testAccApp_resourceSpec,
 			"resourceSpecLifecycle": testAccApp_resourceSpecLifecycle,
+			"space":                 testAccApp_space,
 		},
 		"Domain": {
 			"basic":                                    testAccDomain_basic,
@@ -49,6 +50,8 @@ func TestAccSageMaker_serial(t *testing.T) {
 			"canvas":                                                 testAccDomain_canvasAppSettings,
 			"domainSettings":                                         testAccDomain_domainSettings,
 			"rSessionAppSettings":                                    testAccDomain_rSessionAppSettings,
+			"spaceSettingsKernelGatewayAppSettings":                  testAccDomain_spaceSettingsKernelGatewayAppSettings,
+			"code":                                                   testAccDomain_jupyterServerAppSettings_code,
 		},
 		"FlowDefinition": {
 			"basic":                          testAccFlowDefinition_basic,
@@ -56,6 +59,15 @@ func TestAccSageMaker_serial(t *testing.T) {
 			"HumanLoopConfigPublicWorkforce": testAccFlowDefinition_humanLoopConfig_publicWorkforce,
 			"HumanLoopRequestSource":         testAccFlowDefinition_humanLoopRequestSource,
 			"Tags":                           testAccFlowDefinition_tags,
+		},
+		"Space": {
+			"basic":                    testAccSpace_basic,
+			"disappears":               testAccSpace_tags,
+			"tags":                     testAccSpace_disappears,
+			"kernelGatewayAppSettings": testAccSpace_kernelGatewayAppSettings,
+			"kernelGatewayAppSettings_lifecycleConfig": testAccSpace_kernelGatewayAppSettings_lifecycleconfig,
+			"kernelGatewayAppSettings_imageConfig":     testAccSpace_kernelGatewayAppSettings_imageconfig,
+			"jupyterServerAppSettings":                 testAccSpace_jupyterServerAppSettings,
 		},
 		"UserProfile": {
 			"basic":                           testAccUserProfile_basic,

--- a/internal/service/sagemaker/space.go
+++ b/internal/service/sagemaker/space.go
@@ -1,0 +1,398 @@
+package sagemaker
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceSpace() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSpaceCreate,
+		Read:   resourceSpaceRead,
+		Update: resourceSpaceUpdate,
+		Delete: resourceSpaceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"space_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 63),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](-*[a-zA-Z0-9]){0,62}`), "Valid characters are a-z, A-Z, 0-9, and - (hyphen)."),
+				),
+			},
+			"domain_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"space_settings": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"jupyter_server_app_settings": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"code_repository": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										MaxItems: 10,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"repository_url": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringLenBetween(1, 1024),
+												},
+											},
+										},
+									},
+									"default_resource_spec": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"instance_type": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(sagemaker.AppInstanceType_Values(), false),
+												},
+												"lifecycle_config_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: verify.ValidARN,
+												},
+												"sagemaker_image_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: verify.ValidARN,
+												},
+												"sagemaker_image_version_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: verify.ValidARN,
+												},
+											},
+										},
+									},
+									"lifecycle_config_arns": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: verify.ValidARN,
+										},
+									},
+								},
+							},
+						},
+						"kernel_gateway_app_settings": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"default_resource_spec": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"instance_type": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(sagemaker.AppInstanceType_Values(), false),
+												},
+												"lifecycle_config_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: verify.ValidARN,
+												},
+												"sagemaker_image_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: verify.ValidARN,
+												},
+												"sagemaker_image_version_arn": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: verify.ValidARN,
+												},
+											},
+										},
+									},
+									"lifecycle_config_arns": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: verify.ValidARN,
+										},
+									},
+									"custom_image": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 30,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"app_image_config_name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"image_name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"image_version_number": {
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+			"home_efs_file_system_uid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+func resourceSpaceCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).SageMakerConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+
+	domainId := d.Get("domain_id").(string)
+	spaceName := d.Get("space_name").(string)
+	input := &sagemaker.CreateSpaceInput{
+		SpaceName: aws.String(spaceName),
+		DomainId:  aws.String(domainId),
+	}
+
+	if v, ok := d.GetOk("space_settings"); ok && len(v.([]interface{})) > 0 {
+		input.SpaceSettings = expandSpaceSettings(v.([]interface{}))
+	}
+
+	if len(tags) > 0 {
+		input.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	log.Printf("[DEBUG] SageMaker Space create config: %#v", *input)
+	out, err := conn.CreateSpace(input)
+	if err != nil {
+		return fmt.Errorf("creating SageMaker Space: %w", err)
+	}
+
+	d.SetId(aws.StringValue(out.SpaceArn))
+
+	if _, err := WaitSpaceInService(conn, domainId, spaceName); err != nil {
+		return fmt.Errorf("waiting for SageMaker Space (%s) to create: %w", d.Id(), err)
+	}
+
+	return resourceSpaceRead(d, meta)
+}
+
+func resourceSpaceRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).SageMakerConn
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	domainID, name, err := decodeSpaceName(d.Id())
+	if err != nil {
+		return err
+	}
+
+	Space, err := FindSpaceByName(conn, domainID, name)
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+			d.SetId("")
+			log.Printf("[WARN] Unable to find SageMaker Space (%s), removing from state", d.Id())
+			return nil
+		}
+		return fmt.Errorf("reading SageMaker Space (%s): %w", d.Id(), err)
+	}
+
+	arn := aws.StringValue(Space.SpaceArn)
+	d.Set("space_name", Space.SpaceName)
+	d.Set("domain_id", Space.DomainId)
+	d.Set("arn", arn)
+	d.Set("home_efs_file_system_uid", Space.HomeEfsFileSystemUid)
+
+	if err := d.Set("space_settings", flattenSpaceSettings(Space.SpaceSettings)); err != nil {
+		return fmt.Errorf("setting space_settings for SageMaker Space (%s): %w", d.Id(), err)
+	}
+
+	tags, err := ListTags(conn, arn)
+
+	if err != nil {
+		return fmt.Errorf("listing tags for SageMaker Space (%s): %w", d.Id(), err)
+	}
+
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return fmt.Errorf("setting tags: %w", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return fmt.Errorf("setting tags_all: %w", err)
+	}
+
+	return nil
+}
+
+func resourceSpaceUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).SageMakerConn
+
+	if d.HasChange("space_settings") {
+		domainID := d.Get("domain_id").(string)
+		name := d.Get("space_name").(string)
+
+		input := &sagemaker.UpdateSpaceInput{
+			SpaceName:     aws.String(name),
+			DomainId:      aws.String(domainID),
+			SpaceSettings: expandSpaceSettings(d.Get("space_settings").([]interface{})),
+		}
+
+		log.Printf("[DEBUG] SageMaker Space update config: %#v", *input)
+		_, err := conn.UpdateSpace(input)
+		if err != nil {
+			return fmt.Errorf("updating SageMaker Space: %w", err)
+		}
+
+		if _, err := WaitSpaceInService(conn, domainID, name); err != nil {
+			return fmt.Errorf("waiting for SageMaker Space (%s) to update: %w", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("tags_all") {
+		o, n := d.GetChange("tags_all")
+
+		if err := UpdateTags(conn, d.Get("arn").(string), o, n); err != nil {
+			return fmt.Errorf("updating SageMaker Space (%s) tags: %w", d.Id(), err)
+		}
+	}
+
+	return resourceSpaceRead(d, meta)
+}
+
+func resourceSpaceDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).SageMakerConn
+
+	name := d.Get("space_name").(string)
+	domainID := d.Get("domain_id").(string)
+
+	input := &sagemaker.DeleteSpaceInput{
+		SpaceName: aws.String(name),
+		DomainId:  aws.String(domainID),
+	}
+
+	if _, err := conn.DeleteSpace(input); err != nil {
+		if !tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+			return fmt.Errorf("deleting SageMaker Space (%s): %w", d.Id(), err)
+		}
+	}
+
+	if _, err := WaitSpaceDeleted(conn, domainID, name); err != nil {
+		if !tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+			return fmt.Errorf("waiting for SageMaker Space (%s) to delete: %w", d.Id(), err)
+		}
+	}
+
+	return nil
+}
+
+func decodeSpaceName(id string) (string, string, error) {
+	userProfileARN, err := arn.Parse(id)
+	if err != nil {
+		return "", "", err
+	}
+
+	userProfileResourceNameName := strings.TrimPrefix(userProfileARN.Resource, "space/")
+	parts := strings.Split(userProfileResourceNameName, "/")
+
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("Unexpected format of ID (%q), expected DOMAIN-ID/SPACE-NAME", userProfileResourceNameName)
+	}
+
+	domainID := parts[0]
+	spaceName := parts[1]
+
+	return domainID, spaceName, nil
+}
+
+func expandSpaceSettings(l []interface{}) *sagemaker.SpaceSettings {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.SpaceSettings{}
+
+	if v, ok := m["jupyter_server_app_settings"].([]interface{}); ok && len(v) > 0 {
+		config.JupyterServerAppSettings = expandDomainJupyterServerAppSettings(v)
+	}
+
+	if v, ok := m["kernel_gateway_app_settings"].([]interface{}); ok && len(v) > 0 {
+		config.KernelGatewayAppSettings = expandDomainKernelGatewayAppSettings(v)
+	}
+
+	return config
+}
+
+func flattenSpaceSettings(config *sagemaker.SpaceSettings) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{}
+
+	if config.JupyterServerAppSettings != nil {
+		m["jupyter_server_app_settings"] = flattenDomainJupyterServerAppSettings(config.JupyterServerAppSettings)
+	}
+
+	if config.KernelGatewayAppSettings != nil {
+		m["kernel_gateway_app_settings"] = flattenDomainKernelGatewayAppSettings(config.KernelGatewayAppSettings)
+	}
+
+	return []map[string]interface{}{m}
+}

--- a/internal/service/sagemaker/space_test.go
+++ b/internal/service/sagemaker/space_test.go
@@ -1,0 +1,481 @@
+package sagemaker_test
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfsagemaker "github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker"
+)
+
+func testAccSpace_basic(t *testing.T) {
+	var domain sagemaker.DescribeSpaceOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_space.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sagemaker.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSpaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpaceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSpaceExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "space_name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_id", "aws_sagemaker_domain.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.#", "0"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "sagemaker", regexp.MustCompile(`space/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "home_efs_file_system_uid"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSpace_tags(t *testing.T) {
+	var domain sagemaker.DescribeSpaceOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_space.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sagemaker.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSpaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpaceConfig_tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSpaceExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccSpaceConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSpaceExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccSpaceConfig_tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSpaceExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSpace_kernelGatewayAppSettings(t *testing.T) {
+	var domain sagemaker.DescribeSpaceOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_space.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sagemaker.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSpaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpaceConfig_kernelGatewayAppSettings(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSpaceExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.0.kernel_gateway_app_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.0.kernel_gateway_app_settings.0.default_resource_spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.0.kernel_gateway_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.micro"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSpace_kernelGatewayAppSettings_lifecycleconfig(t *testing.T) {
+	var domain sagemaker.DescribeSpaceOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_space.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sagemaker.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSpaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpaceConfig_kernelGatewayAppSettingsLifecycle(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSpaceExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.0.kernel_gateway_app_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.0.kernel_gateway_app_settings.0.lifecycle_config_arns.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.0.kernel_gateway_app_settings.0.default_resource_spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.0.kernel_gateway_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.micro"),
+					resource.TestCheckResourceAttrPair(resourceName, "space_settings.0.kernel_gateway_app_settings.0.default_resource_spec.0.lifecycle_config_arn", "aws_sagemaker_studio_lifecycle_config.test", "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSpace_kernelGatewayAppSettings_imageconfig(t *testing.T) {
+	if os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE") == "" {
+		t.Skip("Environment variable SAGEMAKER_IMAGE_VERSION_BASE_IMAGE is not set")
+	}
+
+	var domain sagemaker.DescribeSpaceOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_space.test"
+	baseImage := os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sagemaker.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSpaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpaceConfig_kernelGatewayAppSettingsImage(rName, baseImage),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSpaceExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.0.kernel_gateway_app_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.0.kernel_gateway_app_settings.0.lifecycle_config_arns.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.0.kernel_gateway_app_settings.0.default_resource_spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.0.kernel_gateway_app_settings.0.default_resource_spec.0.instance_type", "ml.t3.micro"),
+					resource.TestCheckResourceAttrPair(resourceName, "space_settings.0.kernel_gateway_app_settings.0.default_resource_spec.0.sagemaker_image_version_arn", "aws_sagemaker_image_version.test", "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSpace_jupyterServerAppSettings(t *testing.T) {
+	var domain sagemaker.DescribeSpaceOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_space.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sagemaker.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSpaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpaceConfig_jupyterServerAppSettings(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSpaceExists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.0.jupyter_server_app_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.0.jupyter_server_app_settings.0.default_resource_spec.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "space_settings.0.jupyter_server_app_settings.0.default_resource_spec.0.instance_type", "system"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSpace_disappears(t *testing.T) {
+	var domain sagemaker.DescribeSpaceOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_space.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sagemaker.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSpaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpaceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSpaceExists(resourceName, &domain),
+					acctest.CheckResourceDisappears(acctest.Provider, tfsagemaker.ResourceSpace(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckSpaceDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).SageMakerConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_sagemaker_space" {
+			continue
+		}
+
+		domainID := rs.Primary.Attributes["domain_id"]
+		spaceName := rs.Primary.Attributes["space_name"]
+
+		space, err := tfsagemaker.FindSpaceByName(conn, domainID, spaceName)
+
+		if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("reading SageMaker Space (%s): %w", rs.Primary.ID, err)
+		}
+
+		spaceArn := aws.StringValue(space.SpaceArn)
+		if spaceArn == rs.Primary.ID {
+			return fmt.Errorf("SageMaker Space %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckSpaceExists(n string, space *sagemaker.DescribeSpaceOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No sagmaker domain ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SageMakerConn
+
+		domainID := rs.Primary.Attributes["domain_id"]
+		spaceName := rs.Primary.Attributes["space_name"]
+
+		resp, err := tfsagemaker.FindSpaceByName(conn, domainID, spaceName)
+		if err != nil {
+			return err
+		}
+
+		*space = *resp
+
+		return nil
+	}
+}
+
+func testAccSpaceConfig_base(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name               = %[1]q
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.test.json
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["sagemaker.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_sagemaker_domain" "test" {
+  domain_name = %[1]q
+  auth_mode   = "IAM"
+  vpc_id      = aws_vpc.test.id
+  subnet_ids  = aws_subnet.test[*].id
+
+  default_user_settings {
+    execution_role = aws_iam_role.test.arn
+  }
+
+  default_space_settings {
+    execution_role = aws_iam_role.test.arn
+  }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
+  }
+}
+`, rName))
+}
+
+func testAccSpaceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccSpaceConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_space" "test" {
+  domain_id  = aws_sagemaker_domain.test.id
+  space_name = %[1]q
+}
+`, rName))
+}
+
+func testAccSpaceConfig_tags1(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(testAccSpaceConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_space" "test" {
+  domain_id  = aws_sagemaker_domain.test.id
+  space_name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1))
+}
+
+func testAccSpaceConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(testAccSpaceConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_space" "test" {
+  domain_id  = aws_sagemaker_domain.test.id
+  space_name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
+}
+
+func testAccSpaceConfig_jupyterServerAppSettings(rName string) string {
+	return acctest.ConfigCompose(testAccSpaceConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_space" "test" {
+  domain_id  = aws_sagemaker_domain.test.id
+  space_name = %[1]q
+
+  space_settings {
+    jupyter_server_app_settings {
+      default_resource_spec {
+        instance_type = "system"
+      }
+    }
+  }
+}
+`, rName))
+}
+
+func testAccSpaceConfig_kernelGatewayAppSettings(rName string) string {
+	return acctest.ConfigCompose(testAccSpaceConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_space" "test" {
+  domain_id  = aws_sagemaker_domain.test.id
+  space_name = %[1]q
+
+  space_settings {
+    kernel_gateway_app_settings {
+      default_resource_spec {
+        instance_type = "ml.t3.micro"
+      }
+    }
+  }
+}
+`, rName))
+}
+
+func testAccSpaceConfig_kernelGatewayAppSettingsLifecycle(rName string) string {
+	return acctest.ConfigCompose(testAccSpaceConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_studio_lifecycle_config" "test" {
+  studio_lifecycle_config_name     = %[1]q
+  studio_lifecycle_config_app_type = "JupyterServer"
+  studio_lifecycle_config_content  = base64encode("echo Hello")
+}
+
+resource "aws_sagemaker_space" "test" {
+  domain_id  = aws_sagemaker_domain.test.id
+  space_name = %[1]q
+
+  space_settings {
+    kernel_gateway_app_settings {
+      default_resource_spec {
+        instance_type        = "ml.t3.micro"
+        lifecycle_config_arn = aws_sagemaker_studio_lifecycle_config.test.arn
+      }
+
+      lifecycle_config_arns = [aws_sagemaker_studio_lifecycle_config.test.arn]
+    }
+  }
+}
+`, rName))
+}
+
+func testAccSpaceConfig_kernelGatewayAppSettingsImage(rName, baseImage string) string {
+	return acctest.ConfigCompose(testAccSpaceConfig_base(rName), fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSageMakerFullAccess"
+}
+
+resource "aws_sagemaker_image" "test" {
+  image_name = %[1]q
+  role_arn   = aws_image_role.test.arn
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+
+resource "aws_sagemaker_image_version" "test" {
+  image_name = aws_sagemaker_image.test.id
+  base_image = %[2]q
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+
+resource "aws_sagemaker_space" "test" {
+  domain_id  = aws_sagemaker_domain.test.id
+  space_name = %[1]q
+
+  space_settings {
+    kernel_gateway_app_settings {
+      default_resource_spec {
+        instance_type               = "ml.t3.micro"
+        sagemaker_image_version_arn = aws_sagemaker_image_version.test.arn
+      }
+    }
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.test]
+}
+`, rName, baseImage))
+}

--- a/internal/service/sagemaker/status.go
+++ b/internal/service/sagemaker/status.go
@@ -16,10 +16,8 @@ const (
 	imageStatusFailed               = "Failed"
 	imageVersionStatusNotFound      = "NotFound"
 	imageVersionStatusFailed        = "Failed"
-	domainStatusNotFound            = "NotFound"
 	userProfileStatusNotFound       = "NotFound"
 	modelPackageGroupStatusNotFound = "NotFound"
-	appStatusNotFound               = "NotFound"
 )
 
 // StatusNotebookInstance fetches the NotebookInstance and its Status
@@ -132,15 +130,7 @@ func StatusDomain(conn *sagemaker.SageMaker, domainID string) resource.StateRefr
 		}
 
 		if err != nil {
-			return nil, sagemaker.DomainStatusFailed, err
-		}
-
-		if output == nil {
-			return nil, domainStatusNotFound, nil
-		}
-
-		if aws.StringValue(output.Status) == sagemaker.DomainStatusFailed {
-			return output, sagemaker.DomainStatusFailed, fmt.Errorf("%s", aws.StringValue(output.FailureReason))
+			return nil, "", err
 		}
 
 		return output, aws.StringValue(output.Status), nil

--- a/internal/service/sagemaker/status.go
+++ b/internal/service/sagemaker/status.go
@@ -125,14 +125,10 @@ func StatusImageVersion(conn *sagemaker.SageMaker, name string) resource.StateRe
 // StatusDomain fetches the Domain and its Status
 func StatusDomain(conn *sagemaker.SageMaker, domainID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		input := &sagemaker.DescribeDomainInput{
-			DomainId: aws.String(domainID),
-		}
+		output, err := FindDomainByName(conn, domainID)
 
-		output, err := conn.DescribeDomain(input)
-
-		if tfawserr.ErrMessageContains(err, "ValidationException", "RecordNotFound") {
-			return nil, sagemaker.UserProfileStatusFailed, nil
+		if tfresource.NotFound(err) {
+			return nil, "", nil
 		}
 
 		if err != nil {
@@ -186,15 +182,10 @@ func StatusFlowDefinition(conn *sagemaker.SageMaker, name string) resource.State
 // StatusUserProfile fetches the UserProfile and its Status
 func StatusUserProfile(conn *sagemaker.SageMaker, domainID, userProfileName string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		input := &sagemaker.DescribeUserProfileInput{
-			DomainId:        aws.String(domainID),
-			UserProfileName: aws.String(userProfileName),
-		}
+		output, err := FindUserProfileByName(conn, domainID, userProfileName)
 
-		output, err := conn.DescribeUserProfile(input)
-
-		if tfawserr.ErrMessageContains(err, "ValidationException", "RecordNotFound") {
-			return nil, userProfileStatusNotFound, nil
+		if tfresource.NotFound(err) {
+			return nil, "", nil
 		}
 
 		if err != nil {
@@ -214,31 +205,16 @@ func StatusUserProfile(conn *sagemaker.SageMaker, domainID, userProfileName stri
 }
 
 // StatusApp fetches the App and its Status
-func StatusApp(conn *sagemaker.SageMaker, domainID, userProfileName, appType, appName string) resource.StateRefreshFunc {
+func StatusApp(conn *sagemaker.SageMaker, domainID, userProfileOrSpaceName, appType, appName string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		input := &sagemaker.DescribeAppInput{
-			DomainId:        aws.String(domainID),
-			UserProfileName: aws.String(userProfileName),
-			AppType:         aws.String(appType),
-			AppName:         aws.String(appName),
-		}
+		output, err := FindAppByName(conn, domainID, userProfileOrSpaceName, appType, appName)
 
-		output, err := conn.DescribeApp(input)
-
-		if tfawserr.ErrMessageContains(err, "ValidationException", "RecordNotFound") {
-			return nil, appStatusNotFound, nil
+		if tfresource.NotFound(err) {
+			return nil, "", nil
 		}
 
 		if err != nil {
-			return nil, sagemaker.AppStatusFailed, err
-		}
-
-		if output == nil {
-			return nil, appStatusNotFound, nil
-		}
-
-		if aws.StringValue(output.Status) == sagemaker.AppStatusFailed {
-			return output, sagemaker.AppStatusFailed, fmt.Errorf("%s", aws.StringValue(output.FailureReason))
+			return nil, "", err
 		}
 
 		return output, aws.StringValue(output.Status), nil
@@ -264,6 +240,22 @@ func StatusProject(conn *sagemaker.SageMaker, name string) resource.StateRefresh
 func StatusWorkforce(conn *sagemaker.SageMaker, name string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindWorkforceByName(conn, name)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}
+
+func StatusSpace(conn *sagemaker.SageMaker, domainId, name string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindSpaceByName(conn, domainId, name)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil

--- a/internal/service/sagemaker/status.go
+++ b/internal/service/sagemaker/status.go
@@ -16,7 +16,6 @@ const (
 	imageStatusFailed               = "Failed"
 	imageVersionStatusNotFound      = "NotFound"
 	imageVersionStatusFailed        = "Failed"
-	userProfileStatusNotFound       = "NotFound"
 	modelPackageGroupStatusNotFound = "NotFound"
 )
 
@@ -179,15 +178,7 @@ func StatusUserProfile(conn *sagemaker.SageMaker, domainID, userProfileName stri
 		}
 
 		if err != nil {
-			return nil, sagemaker.UserProfileStatusFailed, err
-		}
-
-		if output == nil {
-			return nil, userProfileStatusNotFound, nil
-		}
-
-		if aws.StringValue(output.Status) == sagemaker.UserProfileStatusFailed {
-			return output, sagemaker.UserProfileStatusFailed, fmt.Errorf("%s", aws.StringValue(output.FailureReason))
+			return nil, "", err
 		}
 
 		return output, aws.StringValue(output.Status), nil

--- a/internal/service/sagemaker/sweep.go
+++ b/internal/service/sagemaker/sweep.go
@@ -216,6 +216,7 @@ func sweepApps(region string) error {
 			d.Set("app_type", app.AppType)
 			d.Set("domain_id", app.DomainId)
 			d.Set("user_profile_name", app.UserProfileName)
+			d.Set("space_name", app.SpaceName)
 
 			err := r.Delete(d, client)
 			if err != nil {

--- a/internal/service/sagemaker/user_profile.go
+++ b/internal/service/sagemaker/user_profile.go
@@ -101,6 +101,20 @@ func ResourceUserProfile() *schema.Resource {
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"code_repository": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										MaxItems: 10,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"repository_url": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringLenBetween(1, 1024),
+												},
+											},
+										},
+									},
 									"default_resource_spec": {
 										Type:     schema.TypeList,
 										Required: true,

--- a/internal/service/sagemaker/user_profile.go
+++ b/internal/service/sagemaker/user_profile.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
@@ -421,25 +422,25 @@ func resourceUserProfileRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	UserProfile, err := FindUserProfileByName(conn, domainID, userProfileName)
+	userProfile, err := FindUserProfileByName(conn, domainID, userProfileName)
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+		if !d.IsNewResource() && tfresource.NotFound(err) {
 			d.SetId("")
-			log.Printf("[WARN] Unable to find SageMaker User Profile (%s), removing from state", d.Id())
+			log.Printf("[WARN] Unable to find SageMaker User Profile (%s); removing from state", d.Id())
 			return nil
 		}
 		return fmt.Errorf("reading SageMaker User Profile (%s): %w", d.Id(), err)
 	}
 
-	arn := aws.StringValue(UserProfile.UserProfileArn)
-	d.Set("user_profile_name", UserProfile.UserProfileName)
-	d.Set("domain_id", UserProfile.DomainId)
-	d.Set("single_sign_on_user_identifier", UserProfile.SingleSignOnUserIdentifier)
-	d.Set("single_sign_on_user_value", UserProfile.SingleSignOnUserValue)
+	arn := aws.StringValue(userProfile.UserProfileArn)
+	d.Set("user_profile_name", userProfile.UserProfileName)
+	d.Set("domain_id", userProfile.DomainId)
+	d.Set("single_sign_on_user_identifier", userProfile.SingleSignOnUserIdentifier)
+	d.Set("single_sign_on_user_value", userProfile.SingleSignOnUserValue)
 	d.Set("arn", arn)
-	d.Set("home_efs_file_system_uid", UserProfile.HomeEfsFileSystemUid)
+	d.Set("home_efs_file_system_uid", userProfile.HomeEfsFileSystemUid)
 
-	if err := d.Set("user_settings", flattenDomainDefaultUserSettings(UserProfile.UserSettings)); err != nil {
+	if err := d.Set("user_settings", flattenDomainDefaultUserSettings(userProfile.UserSettings)); err != nil {
 		return fmt.Errorf("setting user_settings for SageMaker User Profile (%s): %w", d.Id(), err)
 	}
 

--- a/internal/service/sagemaker/user_profile_test.go
+++ b/internal/service/sagemaker/user_profile_test.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfsagemaker "github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func testAccUserProfile_basic(t *testing.T) {
@@ -331,7 +331,7 @@ func testAccCheckUserProfileDestroy(s *terraform.State) error {
 
 		userProfile, err := tfsagemaker.FindUserProfileByName(conn, domainID, userProfileName)
 
-		if tfawserr.ErrCodeEquals(err, sagemaker.ErrCodeResourceNotFound) {
+		if tfresource.NotFound(err) {
 			continue
 		}
 

--- a/internal/service/sagemaker/wait.go
+++ b/internal/service/sagemaker/wait.go
@@ -34,6 +34,8 @@ const (
 	ProjectDeletedTimeout             = 15 * time.Minute
 	WorkforceActiveTimeout            = 10 * time.Minute
 	WorkforceDeletedTimeout           = 10 * time.Minute
+	SpaceDeletedTimeout               = 10 * time.Minute
+	SpaceInServiceTimeout             = 10 * time.Minute
 )
 
 // WaitNotebookInstanceInService waits for a NotebookInstance to return InService
@@ -359,20 +361,21 @@ func WaitUserProfileDeleted(conn *sagemaker.SageMaker, domainID, userProfileName
 }
 
 // WaitAppInService waits for a App to return InService
-func WaitAppInService(conn *sagemaker.SageMaker, domainID, userProfileName, appType, appName string) (*sagemaker.DescribeAppOutput, error) {
+func WaitAppInService(conn *sagemaker.SageMaker, domainID, userProfileOrSpaceName, appType, appName string) (*sagemaker.DescribeAppOutput, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{
-			appStatusNotFound,
-			sagemaker.AppStatusPending,
-		},
+		Pending: []string{sagemaker.AppStatusPending},
 		Target:  []string{sagemaker.AppStatusInService},
-		Refresh: StatusApp(conn, domainID, userProfileName, appType, appName),
+		Refresh: StatusApp(conn, domainID, userProfileOrSpaceName, appType, appName),
 		Timeout: AppInServiceTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
 
 	if output, ok := outputRaw.(*sagemaker.DescribeAppOutput); ok {
+		if status, reason := aws.StringValue(output.Status), aws.StringValue(output.FailureReason); status == sagemaker.AppStatusFailed && reason != "" {
+			tfresource.SetLastError(err, errors.New(reason))
+		}
+
 		return output, err
 	}
 
@@ -380,21 +383,23 @@ func WaitAppInService(conn *sagemaker.SageMaker, domainID, userProfileName, appT
 }
 
 // WaitAppDeleted waits for a App to return Deleted
-func WaitAppDeleted(conn *sagemaker.SageMaker, domainID, userProfileName, appType, appName string) (*sagemaker.DescribeAppOutput, error) {
+func WaitAppDeleted(conn *sagemaker.SageMaker, domainID, userProfileOrSpaceName, appType, appName string) (*sagemaker.DescribeAppOutput, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
 			sagemaker.AppStatusDeleting,
 		},
-		Target: []string{
-			sagemaker.AppStatusDeleted,
-		},
-		Refresh: StatusApp(conn, domainID, userProfileName, appType, appName),
+		Target:  []string{},
+		Refresh: StatusApp(conn, domainID, userProfileOrSpaceName, appType, appName),
 		Timeout: AppDeletedTimeout,
 	}
 
 	outputRaw, err := stateConf.WaitForState()
 
 	if output, ok := outputRaw.(*sagemaker.DescribeAppOutput); ok {
+		if status, reason := aws.StringValue(output.Status), aws.StringValue(output.FailureReason); status == sagemaker.AppStatusFailed && reason != "" {
+			tfresource.SetLastError(err, errors.New(reason))
+		}
+
 		return output, err
 	}
 
@@ -544,6 +549,48 @@ func WaitWorkforceDeleted(conn *sagemaker.SageMaker, name string) (*sagemaker.Wo
 
 	if output, ok := outputRaw.(*sagemaker.Workforce); ok {
 		if status, reason := aws.StringValue(output.Status), aws.StringValue(output.FailureReason); status == sagemaker.WorkforceStatusFailed && reason != "" {
+			tfresource.SetLastError(err, errors.New(reason))
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func WaitSpaceInService(conn *sagemaker.SageMaker, domainId, name string) (*sagemaker.DescribeSpaceOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{sagemaker.SpaceStatusPending, sagemaker.SpaceStatusUpdating},
+		Target:  []string{sagemaker.SpaceStatusInService},
+		Refresh: StatusSpace(conn, domainId, name),
+		Timeout: SpaceInServiceTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*sagemaker.DescribeSpaceOutput); ok {
+		if status, reason := aws.StringValue(output.Status), aws.StringValue(output.FailureReason); status == sagemaker.SpaceStatusUpdateFailed && reason != "" {
+			tfresource.SetLastError(err, errors.New(reason))
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func WaitSpaceDeleted(conn *sagemaker.SageMaker, domainId, name string) (*sagemaker.DescribeSpaceOutput, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{sagemaker.SpaceStatusDeleting},
+		Target:  []string{},
+		Refresh: StatusSpace(conn, domainId, name),
+		Timeout: SpaceDeletedTimeout,
+	}
+
+	outputRaw, err := stateConf.WaitForState()
+
+	if output, ok := outputRaw.(*sagemaker.DescribeSpaceOutput); ok {
+		if status, reason := aws.StringValue(output.Status), aws.StringValue(output.FailureReason); status == sagemaker.SpaceStatusDeleteFailed && reason != "" {
 			tfresource.SetLastError(err, errors.New(reason))
 		}
 

--- a/website/docs/r/sagemaker_app.html.markdown
+++ b/website/docs/r/sagemaker_app.html.markdown
@@ -28,11 +28,11 @@ resource "aws_sagemaker_app" "example" {
 The following arguments are supported:
 
 * `app_name` - (Required) The name of the app.
-* `app_type` - (Required) The type of app. Valid values are `JupyterServer`, `KernelGateway` and `TensorBoard`.
+* `app_type` - (Required) The type of app. Valid values are `JupyterServer`, `KernelGateway`, `RStudioServerPro`, `RSessionGateway` and `TensorBoard`.
 * `domain_id` - (Required) The domain ID.
-* `user_profile_name` - (Required) The user profile name.
+* `user_profile_name` - (Optional) The user profile name. At least on of `user_profile_name` or `space_name` required.
 * `resource_spec` - (Optional) The instance type and the Amazon Resource Name (ARN) of the SageMaker image created on the instance.See [Resource Spec](#resource-spec) below.
-* `space_name` - (Optional) The name of the space.
+* `space_name` - (Optional) The name of the space. At least on of `user_profile_name` or `space_name` required.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Resource Spec

--- a/website/docs/r/sagemaker_app.html.markdown
+++ b/website/docs/r/sagemaker_app.html.markdown
@@ -32,6 +32,7 @@ The following arguments are supported:
 * `domain_id` - (Required) The domain ID.
 * `user_profile_name` - (Required) The user profile name.
 * `resource_spec` - (Optional) The instance type and the Amazon Resource Name (ARN) of the SageMaker image created on the instance.See [Resource Spec](#resource-spec) below.
+* `space_name` - (Optional) The name of the space.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Resource Spec
@@ -51,7 +52,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-SageMaker Code Apps can be imported using the `id`, e.g.,
+SageMaker Apps can be imported using the `id`, e.g.,
 
 ```
 $ terraform import aws_sagemaker_app.example arn:aws:sagemaker:us-west-2:012345678912:app/domain-id/user-profile-name/app-type/app-name

--- a/website/docs/r/sagemaker_domain.html.markdown
+++ b/website/docs/r/sagemaker_domain.html.markdown
@@ -94,6 +94,7 @@ The following arguments are supported:
 * `auth_mode` - (Required) The mode of authentication that members use to access the domain. Valid values are `IAM` and `SSO`.
 * `vpc_id` - (Required) The ID of the Amazon Virtual Private Cloud (VPC) that Studio uses for communication.
 * `subnet_ids` - (Required) The VPC subnets that Studio uses for communication.
+* `default_space_settings` - (Required) The default space settings. See [Default Space Settings](#default-space-settings) below.
 * `default_user_settings` - (Required) The default user settings. See [Default User Settings](#default-user-settings) below.
 * `domain_settings` - (Optional) The domain settings. See [Domain Settings](#domain-settings) below.
 * `retention_policy` - (Optional) The retention policy for this domain, which specifies whether resources will be retained after the Domain is deleted. By default, all resources are retained. See [Retention Policy](#retention-policy) below.
@@ -101,6 +102,13 @@ The following arguments are supported:
 * `app_network_access_type` - (Optional) Specifies the VPC used for non-EFS traffic. The default value is `PublicInternetOnly`. Valid values are `PublicInternetOnly` and `VpcOnly`.
 * `app_security_group_management` - (Optional) The entity that creates and manages the required security groups for inter-app communication in `VPCOnly` mode. Valid values are `Service` and `Customer`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Default Space Settings
+
+* `execution_role` - (Required) The execution role for the space.
+* `security_groups` - (Optional) The security groups for the Amazon Virtual Private Cloud that the space uses for communication.
+* `jupyter_server_app_settings` - (Optional) The Jupyter server's app settings. See [Jupyter Server App Settings](#jupyter-server-app-settings) below.
+* `kernel_gateway_app_settings` - (Optional) The kernel gateway app settings. See [Kernel Gateway App Settings](#kernel-gateway-app-settings) below.
 
 ### Default User Settings
 
@@ -140,6 +148,7 @@ The following arguments are supported:
 
 #### Jupyter Server App Settings
 
+* `code_repository` - (Optional) A list of Git repositories that SageMaker automatically displays to users for cloning in the JupyterServer application. see [Code Repository](#code-repository) below.
 * `default_resource_spec` - (Optional) The default instance type and the Amazon Resource Name (ARN) of the SageMaker image created on the instance. see [Default Resource Spec](#default-resource-spec) below.
 * `lifecycle_config_arns` - (Optional) The Amazon Resource Name (ARN) of the Lifecycle Configurations.
 
@@ -147,6 +156,10 @@ The following arguments are supported:
 
 * `default_resource_spec` - (Optional) The default instance type and the Amazon Resource Name (ARN) of the SageMaker image created on the instance. see [Default Resource Spec](#default-resource-spec) below.
 * `custom_image` - (Optional) A list of custom SageMaker images that are configured to run as a KernelGateway app. see [Custom Image](#custom-image) below.
+
+##### Code Repository
+
+* `repository_url` - (Optional) The URL of the Git repository.
 
 ##### Default Resource Spec
 
@@ -184,7 +197,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-SageMaker Code Domains can be imported using the `id`, e.g.,
+SageMaker Domains can be imported using the `id`, e.g.,
 
 ```
 $ terraform import aws_sagemaker_domain.test_domain d-8jgsjtilstu8

--- a/website/docs/r/sagemaker_model_package_group.html.markdown
+++ b/website/docs/r/sagemaker_model_package_group.html.markdown
@@ -38,7 +38,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-SageMaker Code Model Package Groups can be imported using the `name`, e.g.,
+SageMaker Model Package Groups can be imported using the `name`, e.g.,
 
 ```
 $ terraform import aws_sagemaker_model_package_group.test_model_package_group my-code-repo

--- a/website/docs/r/sagemaker_model_package_group_policy.html.markdown
+++ b/website/docs/r/sagemaker_model_package_group_policy.html.markdown
@@ -53,7 +53,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-SageMaker Code Model Package Groups can be imported using the `name`, e.g.,
+SageMaker Model Package Groups can be imported using the `name`, e.g.,
 
 ```
 $ terraform import aws_sagemaker_model_package_group_policy.example example

--- a/website/docs/r/sagemaker_space.html.markdown
+++ b/website/docs/r/sagemaker_space.html.markdown
@@ -1,0 +1,82 @@
+---
+subcategory: "SageMaker"
+layout: "aws"
+page_title: "AWS: aws_sagemaker_space"
+description: |-
+  Provides a SageMaker Space resource.
+---
+
+# Resource: aws_sagemaker_space
+
+Provides a SageMaker Space resource.
+
+## Example Usage
+
+### Basic usage
+
+```terraform
+resource "aws_sagemaker_space" "example" {
+  domain_id  = aws_sagemaker_domain.test.id
+  space_name = "example"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `space_name` - (Required) The name of the space.
+* `domain_id` - (Required) The ID of the associated Domain.
+* `space_settings` - (Required) A collection of space settings. See [Space Settings](#space-settings) below.
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Space Settings
+
+* `jupyter_server_app_settings` - (Optional) The Jupyter server's app settings. See [Jupyter Server App Settings](#jupyter-server-app-settings) below.
+* `kernel_gateway_app_settings` - (Optional) The kernel gateway app settings. See [Kernel Gateway App Settings](#kernel-gateway-app-settings) below.
+
+#### Kernel Gateway App Settings
+
+* `default_resource_spec` - (Optional) The default instance type and the Amazon Resource Name (ARN) of the SageMaker image created on the instance. see [Default Resource Spec](#default-resource-spec) below.
+* `custom_image` - (Optional) A list of custom SageMaker images that are configured to run as a KernelGateway app. see [Custom Image](#custom-image) below.
+* `lifecycle_config_arns` - (Optional) The Amazon Resource Name (ARN) of the Lifecycle Configurations.
+
+#### Jupyter Server App Settings
+
+* `code_repository` - (Optional) A list of Git repositories that SageMaker automatically displays to users for cloning in the JupyterServer application. see [Code Repository](#code-repository) below.
+* `default_resource_spec` - (Optional) The default instance type and the Amazon Resource Name (ARN) of the SageMaker image created on the instance. see [Default Resource Spec](#default-resource-spec) below.
+* `lifecycle_config_arns` - (Optional) The Amazon Resource Name (ARN) of the Lifecycle Configurations.
+
+##### Code Repository
+
+* `repository_url` - (Optional) The URL of the Git repository.
+
+##### Default Resource Spec
+
+* `instance_type` - (Optional) The instance type.
+* `lifecycle_config_arn` - (Optional) The Amazon Resource Name (ARN) of the Lifecycle Configuration attached to the Resource.
+* `sagemaker_image_arn` - (Optional) The Amazon Resource Name (ARN) of the SageMaker image created on the instance.
+* `sagemaker_image_version_arn` - (Optional) The ARN of the image version created on the instance.
+
+##### Custom Image
+
+* `app_image_config_name` - (Required) The name of the App Image Config.
+* `image_name` - (Required) The name of the Custom Image.
+* `image_version_number` - (Optional) The version number of the Custom Image.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The space's Amazon Resource Name (ARN).
+* `arn` - The space's Amazon Resource Name (ARN).
+* `home_efs_file_system_uid` - The ID of the space's profile in the Amazon Elastic File System volume.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+
+## Import
+
+SageMaker Spaces can be imported using the `id`, e.g.,
+
+```
+$ terraform import aws_sagemaker_space.test_space arn:aws:sagemaker:us-west-2:123456789012:space/domain-id/space-name
+```

--- a/website/docs/r/sagemaker_studio_lifecycle_config.html.markdown
+++ b/website/docs/r/sagemaker_studio_lifecycle_config.html.markdown
@@ -41,7 +41,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-SageMaker Code Studio Lifecycle Configs can be imported using the `studio_lifecycle_config_name`, e.g.,
+SageMaker Studio Lifecycle Configs can be imported using the `studio_lifecycle_config_name`, e.g.,
 
 ```
 $ terraform import aws_sagemaker_studio_lifecycle_config.example example

--- a/website/docs/r/sagemaker_user_profile.html.markdown
+++ b/website/docs/r/sagemaker_user_profile.html.markdown
@@ -65,6 +65,7 @@ The following arguments are supported:
 
 #### Jupyter Server App Settings
 
+* `code_repository` - (Optional) A list of Git repositories that SageMaker automatically displays to users for cloning in the JupyterServer application. see [Code Repository](#code-repository) below.
 * `default_resource_spec` - (Optional) The default instance type and the Amazon Resource Name (ARN) of the SageMaker image created on the instance. see [Default Resource Spec](#default-resource-spec) below.
 * `lifecycle_config_arns` - (Optional) The Amazon Resource Name (ARN) of the Lifecycle Configurations.
 
@@ -72,6 +73,10 @@ The following arguments are supported:
 
 * `default_resource_spec` - (Optional) The default instance type and the Amazon Resource Name (ARN) of the SageMaker image created on the instance. see [Default Resource Spec](#default-resource-spec) below.
 * `custom_image` - (Optional) A list of custom SageMaker images that are configured to run as a KernelGateway app. see [Custom Image](#custom-image) below.
+
+##### Code Repository
+
+* `repository_url` - (Optional) The URL of the Git repository.
 
 ##### Default Resource Spec
 
@@ -102,7 +107,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-SageMaker Code User Profiles can be imported using the `arn`, e.g.,
+SageMaker User Profiles can be imported using the `arn`, e.g.,
 
 ```
 $ terraform import aws_sagemaker_user_profile.test_user_profile arn:aws:sagemaker:us-west-2:123456789012:user-profile/domain-id/profile-name


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27265
Closes #27990

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccSageMaker_serial/Space

--- PASS: TestAccSageMaker_serial (1666.88s)
    --- PASS: TestAccSageMaker_serial/Space (1666.88s)
        --- PASS: TestAccSageMaker_serial/Space/basic (271.61s)
        --- PASS: TestAccSageMaker_serial/Space/disappears (324.01s)
        --- PASS: TestAccSageMaker_serial/Space/tags (265.95s)
        --- PASS: TestAccSageMaker_serial/Space/kernelGatewayAppSettings (269.04s)
        --- PASS: TestAccSageMaker_serial/Space/kernelGatewayAppSettings_lifecycleConfig (267.09s)
        --- PASS: TestAccSageMaker_serial/Space/jupyterServerAppSettings (269.17s)


--- PASS: TestAccSageMaker_serial (5300.99s)
    --- PASS: TestAccSageMaker_serial/Domain (5300.99s)
        --- PASS: TestAccSageMaker_serial/Domain/sharingSettings (444.31s)
        --- PASS: TestAccSageMaker_serial/Domain/defaultUserSettingsUpdated (305.97s)
        --- PASS: TestAccSageMaker_serial/Domain/tensorboardAppSettingsWithImage (324.92s)
        --- PASS: TestAccSageMaker_serial/Domain/securityGroup (298.91s)
        --- PASS: TestAccSageMaker_serial/Domain/domainSettings (293.67s)
        --- PASS: TestAccSageMaker_serial/Domain/rSessionAppSettings (261.86s)
        --- PASS: TestAccSageMaker_serial/Domain/tags (256.94s)
        --- PASS: TestAccSageMaker_serial/Domain/kernelGatewayAppSettings (264.39s)
        --- PASS: TestAccSageMaker_serial/Domain/kernelGatewayAppSettings_lifecycleConfig (262.01s)
        --- PASS: TestAccSageMaker_serial/Domain/basic (264.71s)
        --- PASS: TestAccSageMaker_serial/Domain/disappears (327.10s)
        --- PASS: TestAccSageMaker_serial/Domain/spaceSettingsKernelGatewayAppSettings (305.11s)
        --- PASS: TestAccSageMaker_serial/Domain/kms (428.08s)
        --- PASS: TestAccSageMaker_serial/Domain/canvas (468.37s)
        --- PASS: TestAccSageMaker_serial/Domain/code (265.32s)
        --- PASS: TestAccSageMaker_serial/Domain/tensorboardAppSettings (264.47s)
        --- PASS: TestAccSageMaker_serial/Domain/jupyterServerAppSettings (264.84s)

--- PASS: TestAccSageMaker_serial (3120.53s)
    --- PASS: TestAccSageMaker_serial/App (3120.52s)
        --- PASS: TestAccSageMaker_serial/App/resourceSpec (410.41s)
        --- PASS: TestAccSageMaker_serial/App/resourceSpecLifecycle (545.64s)
        --- PASS: TestAccSageMaker_serial/App/space (484.87s)
        --- PASS: TestAccSageMaker_serial/App/basic (646.75s)
        --- PASS: TestAccSageMaker_serial/App/disappears (445.85s)
        --- PASS: TestAccSageMaker_serial/App/tags (587.00s)
```


