### PR TITLE
r/aws_networkmanager_core_network

### DIFF
--- a/.changelog/28155.txt
+++ b/.changelog/28155.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_networkmanager_core_network
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1827,6 +1827,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_networkmanager_attachment_accepter":                      networkmanager.ResourceAttachmentAccepter(),
 			"aws_networkmanager_connect_attachment":                       networkmanager.ResourceConnectAttachment(),
 			"aws_networkmanager_connection":                               networkmanager.ResourceConnection(),
+			"aws_networkmanager_core_network":                             networkmanager.ResourceCoreNetwork(),
 			"aws_networkmanager_customer_gateway_association":             networkmanager.ResourceCustomerGatewayAssociation(),
 			"aws_networkmanager_device":                                   networkmanager.ResourceDevice(),
 			"aws_networkmanager_global_network":                           networkmanager.ResourceGlobalNetwork(),

--- a/internal/service/ec2/transitgateway_policy_table_association_test.go
+++ b/internal/service/ec2/transitgateway_policy_table_association_test.go
@@ -19,19 +19,12 @@ func testAccTransitGatewayPolicyTableAssociation_basic(t *testing.T) {
 	resourceName := "aws_ec2_transit_gateway_policy_table_association.test"
 	transitGatewayPolicyTableResourceName := "aws_ec2_transit_gateway_policy_table.test"
 	transitGatewayPeeringResourceName := "aws_networkmanager_transit_gateway_peering.test"
-	testExternalProviders := map[string]resource.ExternalProvider{
-		"awscc": {
-			Source:            "hashicorp/awscc",
-			VersionConstraint: "0.29.0",
-		},
-	}
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckTransitGateway(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		ExternalProviders:        testExternalProviders,
 		CheckDestroy:             testAccCheckTransitGatewayPolicyTableAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -56,19 +49,12 @@ func testAccTransitGatewayPolicyTableAssociation_basic(t *testing.T) {
 func testAccTransitGatewayPolicyTableAssociation_disappears(t *testing.T) {
 	var v ec2.TransitGatewayPolicyTableAssociation
 	resourceName := "aws_ec2_transit_gateway_policy_table_association.test"
-	testExternalProviders := map[string]resource.ExternalProvider{
-		"awscc": {
-			Source:            "hashicorp/awscc",
-			VersionConstraint: "0.29.0",
-		},
-	}
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckTransitGateway(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		ExternalProviders:        testExternalProviders,
 		CheckDestroy:             testAccCheckTransitGatewayPolicyTableAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -168,9 +154,13 @@ resource "aws_networkmanager_global_network" "test" {
   }
 }
 
-resource "awscc_networkmanager_core_network" "test" {
+resource "aws_networkmanager_core_network" "test" {
   global_network_id = aws_networkmanager_global_network.test.id
-  policy_document   = jsonencode(jsondecode(data.aws_networkmanager_core_network_policy_document.test.json))
+  policy_document   = data.aws_networkmanager_core_network_policy_document.test.json
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 data "aws_networkmanager_core_network_policy_document" "test" {
@@ -189,7 +179,7 @@ data "aws_networkmanager_core_network_policy_document" "test" {
 }
 
 resource "aws_networkmanager_transit_gateway_peering" "test" {
-  core_network_id     = awscc_networkmanager_core_network.test.id
+  core_network_id     = aws_networkmanager_core_network.test.id
   transit_gateway_arn = aws_ec2_transit_gateway.test.arn
 
   tags = {

--- a/internal/service/networkmanager/connect_attachment_test.go
+++ b/internal/service/networkmanager/connect_attachment_test.go
@@ -19,19 +19,12 @@ import (
 func TestAccNetworkManagerConnectAttachment_basic(t *testing.T) {
 	var v networkmanager.ConnectAttachment
 	resourceName := "aws_networkmanager_connect_attachment.test"
-	testExternalProviders := map[string]resource.ExternalProvider{
-		"awscc": {
-			Source:            "hashicorp/awscc",
-			VersionConstraint: "0.29.0",
-		},
-	}
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		ExternalProviders:        testExternalProviders,
 		CheckDestroy:             testAccCheckConnectAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -60,19 +53,12 @@ func TestAccNetworkManagerConnectAttachment_basic(t *testing.T) {
 func TestAccNetworkManagerConnectAttachment_basic_NoDependsOn(t *testing.T) {
 	var v networkmanager.ConnectAttachment
 	resourceName := "aws_networkmanager_connect_attachment.test"
-	testExternalProviders := map[string]resource.ExternalProvider{
-		"awscc": {
-			Source:            "hashicorp/awscc",
-			VersionConstraint: "0.29.0",
-		},
-	}
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		ExternalProviders:        testExternalProviders,
 		CheckDestroy:             testAccCheckConnectAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -101,19 +87,12 @@ func TestAccNetworkManagerConnectAttachment_basic_NoDependsOn(t *testing.T) {
 func TestAccNetworkManagerConnectAttachment_disappears(t *testing.T) {
 	var v networkmanager.ConnectAttachment
 	resourceName := "aws_networkmanager_connect_attachment.test"
-	testExternalProviders := map[string]resource.ExternalProvider{
-		"awscc": {
-			Source:            "hashicorp/awscc",
-			VersionConstraint: "0.29.0",
-		},
-	}
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		ExternalProviders:        testExternalProviders,
 		CheckDestroy:             testAccCheckConnectAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -131,19 +110,12 @@ func TestAccNetworkManagerConnectAttachment_disappears(t *testing.T) {
 func TestAccNetworkManagerConnectAttachment_tags(t *testing.T) {
 	var v networkmanager.ConnectAttachment
 	resourceName := "aws_networkmanager_connect_attachment.test"
-	testExternalProviders := map[string]resource.ExternalProvider{
-		"awscc": {
-			Source:            "hashicorp/awscc",
-			VersionConstraint: "0.29.0",
-		},
-	}
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		ExternalProviders:        testExternalProviders,
 		CheckDestroy:             testAccCheckConnectAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -264,9 +236,13 @@ resource "aws_networkmanager_global_network" "test" {
   }
 }
 
-resource "awscc_networkmanager_core_network" "test" {
+resource "aws_networkmanager_core_network" "test" {
   global_network_id = aws_networkmanager_global_network.test.id
-  policy_document   = jsonencode(jsondecode(data.aws_networkmanager_core_network_policy_document.test.json))
+  policy_document   = data.aws_networkmanager_core_network_policy_document.test.json
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 data "aws_networkmanager_core_network_policy_document" "test" {
@@ -312,7 +288,7 @@ func testAccConnectAttachmentConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccConnectAttachmentConfig_base(rName), `
 resource "aws_networkmanager_vpc_attachment" "test" {
   subnet_arns     = aws_subnet.test[*].arn
-  core_network_id = awscc_networkmanager_core_network.test.id
+  core_network_id = aws_networkmanager_core_network.test.id
   vpc_arn         = aws_vpc.test.arn
   tags = {
     segment = "shared"
@@ -325,7 +301,7 @@ resource "aws_networkmanager_attachment_accepter" "test" {
 }
 
 resource "aws_networkmanager_connect_attachment" "test" {
-  core_network_id         = awscc_networkmanager_core_network.test.id
+  core_network_id         = aws_networkmanager_core_network.test.id
   transport_attachment_id = aws_networkmanager_vpc_attachment.test.id
   edge_location           = aws_networkmanager_vpc_attachment.test.edge_location
   options {
@@ -350,7 +326,7 @@ func testAccConnectAttachmentConfig_basic_NoDependsOn(rName string) string {
 	return acctest.ConfigCompose(testAccConnectAttachmentConfig_base(rName), `
 resource "aws_networkmanager_vpc_attachment" "test" {
   subnet_arns     = aws_subnet.test[*].arn
-  core_network_id = awscc_networkmanager_core_network.test.id
+  core_network_id = aws_networkmanager_core_network.test.id
   vpc_arn         = aws_vpc.test.arn
   tags = {
     segment = "shared"
@@ -363,7 +339,7 @@ resource "aws_networkmanager_attachment_accepter" "test" {
 }
 
 resource "aws_networkmanager_connect_attachment" "test" {
-  core_network_id         = awscc_networkmanager_core_network.test.id
+  core_network_id         = aws_networkmanager_core_network.test.id
   transport_attachment_id = aws_networkmanager_vpc_attachment.test.id
   edge_location           = aws_networkmanager_vpc_attachment.test.edge_location
   options {
@@ -385,7 +361,7 @@ func testAccConnectAttachmentConfig_tags1(rName, tagKey1, tagValue1 string) stri
 	return acctest.ConfigCompose(testAccConnectAttachmentConfig_base(rName), fmt.Sprintf(`
 resource "aws_networkmanager_vpc_attachment" "test" {
   subnet_arns     = [aws_subnet.test[0].arn]
-  core_network_id = awscc_networkmanager_core_network.test.id
+  core_network_id = aws_networkmanager_core_network.test.id
   vpc_arn         = aws_vpc.test.arn
   tags = {
     segment = "shared"
@@ -398,7 +374,7 @@ resource "aws_networkmanager_attachment_accepter" "test" {
 }
 
 resource "aws_networkmanager_connect_attachment" "test" {
-  core_network_id         = awscc_networkmanager_core_network.test.id
+  core_network_id         = aws_networkmanager_core_network.test.id
   transport_attachment_id = aws_networkmanager_vpc_attachment.test.id
   edge_location           = aws_networkmanager_vpc_attachment.test.edge_location
   options {
@@ -423,7 +399,7 @@ func testAccConnectAttachmentConfig_tags2(rName, tagKey1, tagValue1, tagKey2, ta
 	return acctest.ConfigCompose(testAccConnectAttachmentConfig_base(rName), fmt.Sprintf(`
 resource "aws_networkmanager_vpc_attachment" "test" {
   subnet_arns     = [aws_subnet.test[0].arn]
-  core_network_id = awscc_networkmanager_core_network.test.id
+  core_network_id = aws_networkmanager_core_network.test.id
   vpc_arn         = aws_vpc.test.arn
   tags = {
     segment = "shared"
@@ -436,7 +412,7 @@ resource "aws_networkmanager_attachment_accepter" "test" {
 }
 
 resource "aws_networkmanager_connect_attachment" "test" {
-  core_network_id         = awscc_networkmanager_core_network.test.id
+  core_network_id         = aws_networkmanager_core_network.test.id
   transport_attachment_id = aws_networkmanager_vpc_attachment.test.id
   edge_location           = aws_networkmanager_vpc_attachment.test.edge_location
   options {

--- a/internal/service/networkmanager/core_network.go
+++ b/internal/service/networkmanager/core_network.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -43,10 +45,80 @@ func ResourceCoreNetwork() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"global_network_id": {
+			"created_at": {
 				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Computed: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 256),
+			},
+			"edges": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"asn": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"edge_location": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"inside_cidr_blocks": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"global_network_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(0, 50),
+			},
+			"policy_document": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 10000000),
+					validation.StringIsJSON,
+				),
+				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
+			},
+			"segments": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"edge_locations": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"shared_segments": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),

--- a/internal/service/networkmanager/core_network.go
+++ b/internal/service/networkmanager/core_network.go
@@ -409,7 +409,7 @@ func waitCoreNetworkCreated(ctx context.Context, conn *networkmanager.NetworkMan
 	return nil, err
 }
 
-func waitCoreNetworkUpdated(ctx context.Context, conn *networkmanager.NetworkManager, id string, timeout time.Duration) (*networkmanager.CoreNetwork, error) {
+func waitCoreNetworkUpdated(ctx context.Context, conn *networkmanager.NetworkManager, id string, timeout time.Duration) (*networkmanager.CoreNetwork, error) { //nolint:unparam
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{networkmanager.CoreNetworkStateUpdating},
 		Target:  []string{networkmanager.CoreNetworkStateAvailable},

--- a/internal/service/networkmanager/core_network_test.go
+++ b/internal/service/networkmanager/core_network_test.go
@@ -189,10 +189,9 @@ func TestAccNetworkManagerCoreNetwork_policyDocument(t *testing.T) {
 						"inside_cidr_blocks.#": "0",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "segments.*", map[string]string{
-						"edge_locations.#": "1",
-						"edge_locations.0": client.Region,
-						// during the test name is not shown as the updatedSegmentValue
-						// "name":              updatedSegmentValue,
+						"edge_locations.#":  "1",
+						"edge_locations.0":  client.Region,
+						"name":              updatedSegmentValue,
 						"shared_segments.#": "0",
 					}),
 				),

--- a/internal/service/networkmanager/core_network_test.go
+++ b/internal/service/networkmanager/core_network_test.go
@@ -45,6 +45,27 @@ func TestAccNetworkManagerCoreNetwork_basic(t *testing.T) {
 	})
 }
 
+func TestAccNetworkManagerCoreNetwork_disappears(t *testing.T) {
+	resourceName := "aws_networkmanager_core_network.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCoreNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoreNetworkConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCoreNetworkExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfnetworkmanager.ResourceCoreNetwork(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckCoreNetworkDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).NetworkManagerConn
 

--- a/internal/service/networkmanager/core_network_test.go
+++ b/internal/service/networkmanager/core_network_test.go
@@ -109,6 +109,40 @@ func TestAccNetworkManagerCoreNetwork_tags(t *testing.T) {
 	})
 }
 
+func TestAccNetworkManagerCoreNetwork_description(t *testing.T) {
+	resourceName := "aws_networkmanager_core_network.test"
+	originalDescription := "description1"
+	updatedDescription := "description2"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCoreNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoreNetworkConfig_description(originalDescription),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCoreNetworkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", originalDescription),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCoreNetworkConfig_description(updatedDescription),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCoreNetworkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", updatedDescription),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCoreNetworkDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).NetworkManagerConn
 
@@ -192,4 +226,17 @@ resource "aws_networkmanager_core_network" "test" {
   }
 }
 `, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccCoreNetworkConfig_description(description string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+resource "aws_networkmanager_global_network" "test" {}
+
+resource "aws_networkmanager_core_network" "test" {
+  global_network_id = aws_networkmanager_global_network.test.id
+  description       = %[1]q
+}
+`, description)
 }

--- a/internal/service/networkmanager/core_network_test.go
+++ b/internal/service/networkmanager/core_network_test.go
@@ -1,0 +1,98 @@
+package networkmanager_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/networkmanager"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfnetworkmanager "github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func TestAccNetworkManagerCoreNetwork_basic(t *testing.T) {
+	resourceName := "aws_networkmanager_core_network.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCoreNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCoreNetworkConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCoreNetworkExists(resourceName),
+					acctest.MatchResourceAttrGlobalARN(resourceName, "arn", "networkmanager", regexp.MustCompile(`core-network/core-network-.+`)),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(`core-network-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "state", networkmanager.CoreNetworkStateAvailable),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckCoreNetworkDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).NetworkManagerConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_networkmanager_core_network" {
+			continue
+		}
+
+		_, err := tfnetworkmanager.FindCoreNetworkByID(context.Background(), conn, rs.Primary.ID)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("Network Manager Core Network %s still exists", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckCoreNetworkExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Network Manager Core Network ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).NetworkManagerConn
+
+		_, err := tfnetworkmanager.FindCoreNetworkByID(context.Background(), conn, rs.Primary.ID)
+
+		return err
+	}
+}
+
+func testAccCoreNetworkConfig_basic() string {
+	return `
+resource "aws_networkmanager_global_network" "test" {}
+
+resource "aws_networkmanager_core_network" "test" {
+  global_network_id = aws_networkmanager_global_network.test.id
+}`
+}

--- a/internal/service/networkmanager/sweep.go
+++ b/internal/service/networkmanager/sweep.go
@@ -29,9 +29,21 @@ func init() {
 		Name: "aws_networkmanager_core_network",
 		F:    sweepCoreNetworks,
 		Dependencies: []string{
+			"aws_networkmanager_connect_attachment",
+			"aws_networkmanager_site_to_site_vpn_attachment",
 			"aws_networkmanager_transit_gateway_peering",
 			"aws_networkmanager_vpc_attachment",
 		},
+	})
+
+	resource.AddTestSweepers("aws_networkmanager_connect_attachment", &resource.Sweeper{
+		Name: "aws_networkmanager_connect_attachment",
+		F:    sweepConnectAttachments,
+	})
+
+	resource.AddTestSweepers("aws_networkmanager_site_to_site_vpn_attachment", &resource.Sweeper{
+		Name: "aws_networkmanager_site_to_site_vpn_attachment",
+		F:    sweepSiteToSiteVPNAttachments,
 	})
 
 	resource.AddTestSweepers("aws_networkmanager_transit_gateway_peering", &resource.Sweeper{
@@ -172,6 +184,96 @@ func sweepCoreNetworks(region string) error {
 
 	if err != nil {
 		return fmt.Errorf("error sweeping Network Manager Core Networks (%s): %w", region, err)
+	}
+
+	return nil
+}
+
+func sweepConnectAttachments(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*conns.AWSClient).NetworkManagerConn
+	input := &networkmanager.ListAttachmentsInput{
+		AttachmentType: aws.String(networkmanager.AttachmentTypeConnect),
+	}
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	err = conn.ListAttachmentsPages(input, func(page *networkmanager.ListAttachmentsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.Attachments {
+			r := ResourceConnectAttachment()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(v.AttachmentId))
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Network Manager Connect Attachment sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error listing Network Manager Connect Attachments (%s): %w", region, err)
+	}
+
+	err = sweep.SweepOrchestrator(sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping Network Manager Connect Attachments (%s): %w", region, err)
+	}
+
+	return nil
+}
+
+func sweepSiteToSiteVPNAttachments(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*conns.AWSClient).NetworkManagerConn
+	input := &networkmanager.ListAttachmentsInput{
+		AttachmentType: aws.String(networkmanager.AttachmentTypeSiteToSiteVpn),
+	}
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	err = conn.ListAttachmentsPages(input, func(page *networkmanager.ListAttachmentsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.Attachments {
+			r := ResourceSiteToSiteVPNAttachment()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(v.AttachmentId))
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Network Manager Site To Site VPN Attachment sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error listing Network Manager Site To Site VPN Attachments (%s): %w", region, err)
+	}
+
+	err = sweep.SweepOrchestrator(sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping Network Manager Site To Site VPN Attachments (%s): %w", region, err)
 	}
 
 	return nil

--- a/internal/service/networkmanager/transit_gateway_peering_test.go
+++ b/internal/service/networkmanager/transit_gateway_peering_test.go
@@ -20,19 +20,12 @@ func TestAccNetworkManagerTransitGatewayPeering_basic(t *testing.T) {
 	var v networkmanager.TransitGatewayPeering
 	resourceName := "aws_networkmanager_transit_gateway_peering.test"
 	tgwResourceName := "aws_ec2_transit_gateway.test"
-	testExternalProviders := map[string]resource.ExternalProvider{
-		"awscc": {
-			Source:            "hashicorp/awscc",
-			VersionConstraint: "0.29.0",
-		},
-	}
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		ExternalProviders:        testExternalProviders,
 		CheckDestroy:             testAccCheckTransitGatewayPeeringDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -62,19 +55,12 @@ func TestAccNetworkManagerTransitGatewayPeering_basic(t *testing.T) {
 func TestAccNetworkManagerTransitGatewayPeering_disappears(t *testing.T) {
 	var v networkmanager.TransitGatewayPeering
 	resourceName := "aws_networkmanager_transit_gateway_peering.test"
-	testExternalProviders := map[string]resource.ExternalProvider{
-		"awscc": {
-			Source:            "hashicorp/awscc",
-			VersionConstraint: "0.29.0",
-		},
-	}
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		ExternalProviders:        testExternalProviders,
 		CheckDestroy:             testAccCheckTransitGatewayPeeringDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -92,19 +78,12 @@ func TestAccNetworkManagerTransitGatewayPeering_disappears(t *testing.T) {
 func TestAccNetworkManagerTransitGatewayPeering_tags(t *testing.T) {
 	var v networkmanager.TransitGatewayPeering
 	resourceName := "aws_networkmanager_transit_gateway_peering.test"
-	testExternalProviders := map[string]resource.ExternalProvider{
-		"awscc": {
-			Source:            "hashicorp/awscc",
-			VersionConstraint: "0.29.0",
-		},
-	}
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		ExternalProviders:        testExternalProviders,
 		CheckDestroy:             testAccCheckTransitGatewayPeeringDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -214,9 +193,13 @@ resource "aws_networkmanager_global_network" "test" {
   }
 }
 
-resource "awscc_networkmanager_core_network" "test" {
+resource "aws_networkmanager_core_network" "test" {
   global_network_id = aws_networkmanager_global_network.test.id
-  policy_document   = jsonencode(jsondecode(data.aws_networkmanager_core_network_policy_document.test.json))
+  policy_document   = data.aws_networkmanager_core_network_policy_document.test.json
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 data "aws_networkmanager_core_network_policy_document" "test" {
@@ -239,7 +222,7 @@ data "aws_networkmanager_core_network_policy_document" "test" {
 func testAccTransitGatewayPeeringConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccTransitGatewayPeeringConfig_base(rName), `
 resource "aws_networkmanager_transit_gateway_peering" "test" {
-  core_network_id     = awscc_networkmanager_core_network.test.id
+  core_network_id     = aws_networkmanager_core_network.test.id
   transit_gateway_arn = aws_ec2_transit_gateway.test.arn
 
   depends_on = [aws_ec2_transit_gateway_policy_table.test]
@@ -250,7 +233,7 @@ resource "aws_networkmanager_transit_gateway_peering" "test" {
 func testAccTransitGatewayPeeringConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccTransitGatewayPeeringConfig_base(rName), fmt.Sprintf(`
 resource "aws_networkmanager_transit_gateway_peering" "test" {
-  core_network_id     = awscc_networkmanager_core_network.test.id
+  core_network_id     = aws_networkmanager_core_network.test.id
   transit_gateway_arn = aws_ec2_transit_gateway.test.arn
 
   tags = {
@@ -265,7 +248,7 @@ resource "aws_networkmanager_transit_gateway_peering" "test" {
 func testAccTransitGatewayPeeringConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccTransitGatewayPeeringConfig_base(rName), fmt.Sprintf(`
 resource "aws_networkmanager_transit_gateway_peering" "test" {
-  core_network_id     = awscc_networkmanager_core_network.test.id
+  core_network_id     = aws_networkmanager_core_network.test.id
   transit_gateway_arn = aws_ec2_transit_gateway.test.arn
 
   tags = {

--- a/internal/service/networkmanager/transit_gateway_route_table_attachment_test.go
+++ b/internal/service/networkmanager/transit_gateway_route_table_attachment_test.go
@@ -19,19 +19,12 @@ import (
 func TestAccNetworkManagerTransitGatewayRouteTableAttachment_basic(t *testing.T) {
 	var v networkmanager.TransitGatewayRouteTableAttachment
 	resourceName := "aws_networkmanager_transit_gateway_route_table_attachment.test"
-	testExternalProviders := map[string]resource.ExternalProvider{
-		"awscc": {
-			Source:            "hashicorp/awscc",
-			VersionConstraint: "0.29.0",
-		},
-	}
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		ExternalProviders:        testExternalProviders,
 		CheckDestroy:             testAccCheckTransitGatewayRouteTableAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -61,19 +54,12 @@ func TestAccNetworkManagerTransitGatewayRouteTableAttachment_basic(t *testing.T)
 func TestAccNetworkManagerTransitGatewayRouteTableAttachment_disappears(t *testing.T) {
 	var v networkmanager.TransitGatewayRouteTableAttachment
 	resourceName := "aws_networkmanager_transit_gateway_route_table_attachment.test"
-	testExternalProviders := map[string]resource.ExternalProvider{
-		"awscc": {
-			Source:            "hashicorp/awscc",
-			VersionConstraint: "0.29.0",
-		},
-	}
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		ExternalProviders:        testExternalProviders,
 		CheckDestroy:             testAccCheckTransitGatewayRouteTableAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -91,19 +77,12 @@ func TestAccNetworkManagerTransitGatewayRouteTableAttachment_disappears(t *testi
 func TestAccNetworkManagerTransitGatewayRouteTableAttachment_tags(t *testing.T) {
 	var v networkmanager.TransitGatewayRouteTableAttachment
 	resourceName := "aws_networkmanager_transit_gateway_route_table_attachment.test"
-	testExternalProviders := map[string]resource.ExternalProvider{
-		"awscc": {
-			Source:            "hashicorp/awscc",
-			VersionConstraint: "0.29.0",
-		},
-	}
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		ExternalProviders:        testExternalProviders,
 		CheckDestroy:             testAccCheckTransitGatewayRouteTableAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -192,7 +171,7 @@ func testAccCheckTransitGatewayRouteTableAttachmentDestroy(s *terraform.State) e
 func testAccTransitGatewayRouteTableAttachmentConfig_base(rName string) string {
 	return acctest.ConfigCompose(testAccTransitGatewayPeeringConfig_base(rName), fmt.Sprintf(`
 resource "aws_networkmanager_transit_gateway_peering" "test" {
-  core_network_id     = awscc_networkmanager_core_network.test.id
+  core_network_id     = aws_networkmanager_core_network.test.id
   transit_gateway_arn = aws_ec2_transit_gateway.test.arn
 
   tags = {

--- a/internal/service/networkmanager/vpc_attachment_test.go
+++ b/internal/service/networkmanager/vpc_attachment_test.go
@@ -19,21 +19,14 @@ import (
 func TestAccNetworkManagerVPCAttachment_basic(t *testing.T) {
 	var v networkmanager.VpcAttachment
 	resourceName := "aws_networkmanager_vpc_attachment.test"
-	coreNetworkResourceName := "awscc_networkmanager_core_network.test"
+	coreNetworkResourceName := "aws_networkmanager_core_network.test"
 	vpcResourceName := "aws_vpc.test"
-	testExternalProviders := map[string]resource.ExternalProvider{
-		"awscc": {
-			Source:            "hashicorp/awscc",
-			VersionConstraint: "0.29.0",
-		},
-	}
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		ExternalProviders:        testExternalProviders,
 		CheckDestroy:             testAccCheckVPCAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -43,7 +36,7 @@ func TestAccNetworkManagerVPCAttachment_basic(t *testing.T) {
 					acctest.MatchResourceAttrGlobalARN(resourceName, "arn", "networkmanager", regexp.MustCompile(`attachment/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "attachment_policy_rule_number", "0"),
 					resource.TestCheckResourceAttr(resourceName, "attachment_type", "VPC"),
-					resource.TestCheckResourceAttrPair(resourceName, "core_network_arn", coreNetworkResourceName, "core_network_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "core_network_arn", coreNetworkResourceName, "arn"),
 					resource.TestCheckResourceAttrSet(resourceName, "core_network_id"),
 					resource.TestCheckResourceAttr(resourceName, "edge_location", acctest.Region()),
 					resource.TestCheckResourceAttr(resourceName, "options.#", "1"),
@@ -69,19 +62,12 @@ func TestAccNetworkManagerVPCAttachment_basic(t *testing.T) {
 func TestAccNetworkManagerVPCAttachment_disappears(t *testing.T) {
 	var v networkmanager.VpcAttachment
 	resourceName := "aws_networkmanager_vpc_attachment.test"
-	testExternalProviders := map[string]resource.ExternalProvider{
-		"awscc": {
-			Source:            "hashicorp/awscc",
-			VersionConstraint: "0.29.0",
-		},
-	}
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		ExternalProviders:        testExternalProviders,
 		CheckDestroy:             testAccCheckVPCAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -99,19 +85,12 @@ func TestAccNetworkManagerVPCAttachment_disappears(t *testing.T) {
 func TestAccNetworkManagerVPCAttachment_tags(t *testing.T) {
 	var v networkmanager.VpcAttachment
 	resourceName := "aws_networkmanager_vpc_attachment.test"
-	testExternalProviders := map[string]resource.ExternalProvider{
-		"awscc": {
-			Source:            "hashicorp/awscc",
-			VersionConstraint: "0.29.0",
-		},
-	}
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		ExternalProviders:        testExternalProviders,
 		CheckDestroy:             testAccCheckVPCAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -151,19 +130,12 @@ func TestAccNetworkManagerVPCAttachment_tags(t *testing.T) {
 func TestAccNetworkManagerVPCAttachment_update(t *testing.T) {
 	var v networkmanager.VpcAttachment
 	resourceName := "aws_networkmanager_vpc_attachment.test"
-	testExternalProviders := map[string]resource.ExternalProvider{
-		"awscc": {
-			Source:            "hashicorp/awscc",
-			VersionConstraint: "0.29.0",
-		},
-	}
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		ExternalProviders:        testExternalProviders,
 		CheckDestroy:             testAccCheckVPCAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -289,9 +261,9 @@ resource "aws_networkmanager_global_network" "test" {
   }
 }
 
-resource "awscc_networkmanager_core_network" "test" {
+resource "aws_networkmanager_core_network" "test" {
   global_network_id = aws_networkmanager_global_network.test.id
-  policy_document   = jsonencode(jsondecode(data.aws_networkmanager_core_network_policy_document.test.json))
+  policy_document   = data.aws_networkmanager_core_network_policy_document.test.json
 }
 
 data "aws_networkmanager_core_network_policy_document" "test" {
@@ -341,7 +313,7 @@ func testAccVPCAttachmentConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccVPCAttachmentConfig_base(rName), `
 resource "aws_networkmanager_vpc_attachment" "test" {
   subnet_arns     = aws_subnet.test[*].arn
-  core_network_id = awscc_networkmanager_core_network.test.id
+  core_network_id = aws_networkmanager_core_network.test.id
   vpc_arn         = aws_vpc.test.arn
 }
 
@@ -356,7 +328,7 @@ func testAccVPCAttachmentConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccVPCAttachmentConfig_base(rName), fmt.Sprintf(`
 resource "aws_networkmanager_vpc_attachment" "test" {
   subnet_arns     = [aws_subnet.test[0].arn]
-  core_network_id = awscc_networkmanager_core_network.test.id
+  core_network_id = aws_networkmanager_core_network.test.id
   vpc_arn         = aws_vpc.test.arn
 
   tags = {
@@ -375,7 +347,7 @@ func testAccVPCAttachmentConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagVal
 	return acctest.ConfigCompose(testAccVPCAttachmentConfig_base(rName), fmt.Sprintf(`
 resource "aws_networkmanager_vpc_attachment" "test" {
   subnet_arns     = [aws_subnet.test[0].arn]
-  core_network_id = awscc_networkmanager_core_network.test.id
+  core_network_id = aws_networkmanager_core_network.test.id
   vpc_arn         = aws_vpc.test.arn
 
   tags = {
@@ -395,7 +367,7 @@ func testAccVPCAttachmentConfig_updates(rName string, nSubnets int, ipv6Support 
 	return acctest.ConfigCompose(testAccVPCAttachmentConfig_base(rName), fmt.Sprintf(`
 resource "aws_networkmanager_vpc_attachment" "test" {
   subnet_arns     = slice(aws_subnet.test[*].arn, 0, %[2]d)
-  core_network_id = awscc_networkmanager_core_network.test.id
+  core_network_id = aws_networkmanager_core_network.test.id
   vpc_arn         = aws_vpc.test.arn
 
   options {

--- a/internal/verify/json.go
+++ b/internal/verify/json.go
@@ -40,17 +40,7 @@ func SuppressEquivalentPolicyDiffs(k, old, new string, d *schema.ResourceData) b
 }
 
 func SuppressEquivalentJSONDiffs(k, old, new string, d *schema.ResourceData) bool {
-	ob := bytes.NewBufferString("")
-	if err := json.Compact(ob, []byte(old)); err != nil {
-		return false
-	}
-
-	nb := bytes.NewBufferString("")
-	if err := json.Compact(nb, []byte(new)); err != nil {
-		return false
-	}
-
-	return JSONBytesEqual(ob.Bytes(), nb.Bytes())
+	return JSONStringsEqual(old, new)
 }
 
 func SuppressEquivalentJSONOrYAMLDiffs(k, old, new string, d *schema.ResourceData) bool {
@@ -81,6 +71,20 @@ func NormalizeJSONOrYAMLString(templateString interface{}) (string, error) {
 
 func looksLikeJSONString(s interface{}) bool {
 	return regexp.MustCompile(`^\s*{`).MatchString(s.(string))
+}
+
+func JSONStringsEqual(s1, s2 string) bool {
+	b1 := bytes.NewBufferString("")
+	if err := json.Compact(b1, []byte(s1)); err != nil {
+		return false
+	}
+
+	b2 := bytes.NewBufferString("")
+	if err := json.Compact(b2, []byte(s2)); err != nil {
+		return false
+	}
+
+	return JSONBytesEqual(b1.Bytes(), b2.Bytes())
 }
 
 func JSONBytesEqual(b1, b2 []byte) bool {

--- a/website/docs/r/networkmanager_core_network.html.markdown
+++ b/website/docs/r/networkmanager_core_network.html.markdown
@@ -59,6 +59,14 @@ The following arguments are supported:
 * `policy_document` - (Optional) Policy document for creating a core network. Note that updating this argument will result in the new policy document version being set as the `LATEST` and `LIVE` policy document. Refer to the [Core network policies documentation](https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-policy-change-sets.html) for more information.
 * `tags` - (Optional) Key-value tags for the Core Network. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `10m`)
+* `delete` - (Default `10m`)
+* `update` - (Default `10m`)
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/website/docs/r/networkmanager_core_network.html.markdown
+++ b/website/docs/r/networkmanager_core_network.html.markdown
@@ -1,0 +1,96 @@
+---
+subcategory: "Network Manager"
+layout: "aws"
+page_title: "AWS: aws_networkmanager_core_network"
+description: |-
+  Provides a core network resource.
+---
+
+# Resource: aws_networkmanager_core_network
+
+Provides a core network resource.
+
+## Example Usage
+
+### Basic
+
+```terraform
+resource "aws_networkmanager_core_network" "example" {
+  global_network_id = aws_networkmanager_global_network.example.id
+}
+```
+
+### With description
+
+```terraform
+resource "aws_networkmanager_core_network" "example" {
+  global_network_id = aws_networkmanager_global_network.example.id
+  description       = "example"
+}
+```
+
+### With policy document
+
+```terraform
+resource "aws_networkmanager_core_network" "example" {
+  global_network_id = aws_networkmanager_global_network.example.id
+  policy_document   = data.aws_networkmanager_core_network_policy_document.example.json
+}
+```
+
+### With tags
+
+```terraform
+resource "aws_networkmanager_core_network" "example" {
+  global_network_id = aws_networkmanager_global_network.example.id
+
+  tags = {
+    "hello" = "world"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Optional) Description of the Core Network.
+* `global_network_id` - (Required) The ID of the global network that a core network will be a part of.
+* `policy_document` - (Optional) Policy document for creating a core network. Note that updating this argument will result in the new policy document version being set as the `LATEST` and `LIVE` policy document. Refer to the [Core network policies documentation](https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-policy-change-sets.html) for more information.
+* `tags` - (Optional) Key-value tags for the Core Network. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Core Network Amazon Resource Name (ARN).
+* `created_at` - Timestamp when a core network was created.
+* `edges` - One or more blocks detailing the edges within a core network. [Detailed below](#edges).
+* `id` - Core Network ID.
+* `segments` - One or more blocks detailing the segments within a core network. [Detailed below](#segments).
+* `state` - Current state of a core network.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+
+### `edges`
+
+The `edges` configuration block supports the following arguments:
+
+* `asn` - ASN of a core network edge.
+* `edge_location` - Region where a core network edge is located.
+* `inside_cidr_blocks` - Inside IP addresses used for core network edges.
+
+### `segments`
+
+The `segments` configuration block supports the following arguments:
+
+* `edge_locations` - Regions where the edges are located.
+* `name` - Name of a core network segment.
+* `shared_segments` - Shared segments of a core network.
+
+## Import
+
+`aws_networkmanager_core_network` can be imported using the core network ID, e.g.
+
+```
+$ terraform import aws_networkmanager_core_network.example core-network-0d47f6t230mz46dy4
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Creates the Network Manager Core Network resource - introduces Create, Read and Update. Note that Delete was already implemented.

Logic of policy versioning

- When the policy is updated, call `PutCoreNetworkPolicy` which creates the new policy labelled as `LATEST`
- Note that the state of the policy goes from `Pending generation` to `Ready to execute`
- Call the `ExecuteCoreNetworkChangeSet` to set the latest policy as the `LIVE` policy. Note that retries are included because we get a Validation exception with message `Incorrect input` if the policy is not in the `Ready to execute` state
- At this time the Core Network goes into the `Updating` state and we wait till it becomes `Available` again

Gotchas

- The data type for `policy_document` In the `Update` (`PutCoreNetworkPolicy` API) differs from that of the `Create` (`CreateCoreNetwork` API).

    - `PutCoreNetworkPolicy`: PolicyDocument aws.JSONValue `type:"jsonvalue" required:"true"` 
    - `CreateCoreNetwork`: PolicyDocument *string `type:"string"`

- There is an attribute that is computed named `segments`. This is populated by the data in `policy_document`. In the test `TestAccNetworkManagerCoreNetwork_policyDocument`, the contents of `segments` is verified at the first test step (when the Core Network is created). However, on Update in the third step, the values do not change in the test. Hence, it is commented out. However, the changes can be seen in the debugger with a `d.Get("segments")`, implying that the third test steps seems to use the previous schema for computed attributes.




### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #25835
or 
Closes #0000
--->

Relates #25835

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- [awscc_networkmanager_core_network (Resource)](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/networkmanager_core_network)
- [CreateCoreNetwork](https://docs.aws.amazon.com/networkmanager/latest/APIReference/API_CreateCoreNetwork.html)
- [ExecuteCoreNetworkChangeSet](https://docs.aws.amazon.com/networkmanager/latest/APIReference/API_ExecuteCoreNetworkChangeSet.html)
- [GetCoreNetwork](https://docs.aws.amazon.com/networkmanager/latest/APIReference/API_GetCoreNetwork.html)
- [PutCoreNetworkPolicy](https://docs.aws.amazon.com/networkmanager/latest/APIReference/API_PutCoreNetworkPolicy.html)
- [UpdateCoreNetwork](https://docs.aws.amazon.com/networkmanager/latest/APIReference/API_UpdateCoreNetwork.html)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccNetworkManagerCoreNetwork' PKG=networkmanager
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkmanager/... -v -count 1 -parallel 20  -run=TestAccNetworkManagerCoreNetwork -timeout 180m
=== RUN   TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== RUN   TestAccNetworkManagerCoreNetwork_basic
=== PAUSE TestAccNetworkManagerCoreNetwork_basic
=== RUN   TestAccNetworkManagerCoreNetwork_disappears
=== PAUSE TestAccNetworkManagerCoreNetwork_disappears
=== RUN   TestAccNetworkManagerCoreNetwork_tags
=== PAUSE TestAccNetworkManagerCoreNetwork_tags
=== RUN   TestAccNetworkManagerCoreNetwork_description
=== PAUSE TestAccNetworkManagerCoreNetwork_description
=== RUN   TestAccNetworkManagerCoreNetwork_policyDocument
=== PAUSE TestAccNetworkManagerCoreNetwork_policyDocument
=== CONT  TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== CONT  TestAccNetworkManagerCoreNetwork_tags
=== CONT  TestAccNetworkManagerCoreNetwork_basic
=== CONT  TestAccNetworkManagerCoreNetwork_description
=== CONT  TestAccNetworkManagerCoreNetwork_disappears
=== CONT  TestAccNetworkManagerCoreNetwork_policyDocument
--- PASS: TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic (14.54s)
--- PASS: TestAccNetworkManagerCoreNetwork_basic (55.88s)
--- PASS: TestAccNetworkManagerCoreNetwork_disappears (63.19s)
--- PASS: TestAccNetworkManagerCoreNetwork_description (85.37s)
--- PASS: TestAccNetworkManagerCoreNetwork_tags (93.06s)
--- PASS: TestAccNetworkManagerCoreNetwork_policyDocument (781.16s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager     781.262s

...
```
