### PR TITLE
r/glue_crawler - add args to targets 

### DIFF
--- a/.changelog/28156.txt
+++ b/.changelog/28156.txt
@@ -1,5 +1,5 @@
 ```release-note:enhancement
-resource/aws_glue_crawler: Add `catalog_target.dlq_event_queue_arn`, `catalog_target.event_queue_arn`, `catalog_target.connection_name`, and `jdbc_target.enable_additional_metadata` arguments
+resource/aws_glue_crawler: Add `catalog_target.dlq_event_queue_arn`, `catalog_target.event_queue_arn`, `catalog_target.connection_name`, `lake_formation_configuration`, and `jdbc_target.enable_additional_metadata` arguments
 ```
 
 ```release-note:enhancement

--- a/.changelog/28156.txt
+++ b/.changelog/28156.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_glue_crawler: Add `catalog_target.dlq_event_queue_arn`, `catalog_target.event_queue_arn`, `catalog_target.connection_name`, and `jdbc_target.enable_additional_metadata` arguments
+```
+
+```release-note:enhancement
+resource/aws_glue_crawler: Make `delta_target.connection_name` optional
+```

--- a/internal/service/glue/crawler_test.go
+++ b/internal/service/glue/crawler_test.go
@@ -800,7 +800,7 @@ func TestAccGlueCrawler_S3Target_dlqeventqueue(t *testing.T) {
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "s3_target.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "s3_target.0.event_queue_arn", "aws_sqs_queue.test", "arn"),
-					resource.TestCheckResourceAttrPair(resourceName, "s3_target.0.dlq_event_queue_arn", "aws_sqs_queue.test_dql", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "s3_target.0.dlq_event_queue_arn", "aws_sqs_queue.test_dlq", "arn"),
 					resource.TestCheckResourceAttr(resourceName, "recrawl_policy.0.recrawl_behavior", "CRAWL_EVENT_MODE"),
 				),
 			},

--- a/internal/service/glue/crawler_test.go
+++ b/internal/service/glue/crawler_test.go
@@ -770,7 +770,7 @@ func TestAccGlueCrawler_CatalogTarget_dlqeventqueue(t *testing.T) {
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "catalog_target.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "catalog_target.0.event_queue_arn", "aws_sqs_queue.test", "arn"),
-					resource.TestCheckResourceAttrPair(resourceName, "catalog_target.0.dlq_event_queue_arn", "aws_sqs_queue.test_dql", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "catalog_target.0.dlq_event_queue_arn", "aws_sqs_queue.test_dlq", "arn"),
 				),
 			},
 			{
@@ -2375,7 +2375,7 @@ resource "aws_lakeformation_permissions" "test" {
 }
 
 resource "aws_glue_crawler" "test" {
-  depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole, aws_iam_role_policy.test]
+  depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole, aws_iam_role_policy.test_sqs]
 
   database_name = aws_glue_catalog_database.test.name
   name          = %[1]q

--- a/internal/service/glue/crawler_test.go
+++ b/internal/service/glue/crawler_test.go
@@ -1642,7 +1642,7 @@ func testAccCrawlerConfig_base(rName string) string {
 data "aws_partition" "current" {}
 
 resource "aws_iam_role" "test" {
-  name               = %q
+  name               = %[1]q
   assume_role_policy = data.aws_iam_policy_document.assume.json
 }
 
@@ -1689,13 +1689,13 @@ EOF
 }
 
 func testAccCrawlerConfig_classifiersSingle(rName string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
-  name = %q
+  name = %[1]q
 }
 
 resource "aws_glue_classifier" "test1" {
-  name = %q
+  name = %[2]q
 
   grok_classifier {
     classification = "example"
@@ -1704,7 +1704,7 @@ resource "aws_glue_classifier" "test1" {
 }
 
 resource "aws_glue_classifier" "test2" {
-  name = %q
+  name = %[3]q
 
   grok_classifier {
     classification = "example"
@@ -1716,7 +1716,7 @@ resource "aws_glue_crawler" "test" {
   depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]
 
   classifiers   = [aws_glue_classifier.test1.id]
-  name          = %q
+  name          = %[4]q
   database_name = aws_glue_catalog_database.test.name
   role          = aws_iam_role.test.name
 
@@ -1724,17 +1724,17 @@ resource "aws_glue_crawler" "test" {
     path = "s3://bucket-name"
   }
 }
-`, rName, rName+"1", rName+"2", rName)
+`, rName, rName+"1", rName+"2", rName))
 }
 
 func testAccCrawlerConfig_classifiersMultiple(rName string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
-  name = %q
+  name = %[1]q
 }
 
 resource "aws_glue_classifier" "test1" {
-  name = %q
+  name = %[2]q
 
   grok_classifier {
     classification = "example"
@@ -1743,7 +1743,7 @@ resource "aws_glue_classifier" "test1" {
 }
 
 resource "aws_glue_classifier" "test2" {
-  name = %q
+  name = %[3]q
 
   grok_classifier {
     classification = "example"
@@ -1755,7 +1755,7 @@ resource "aws_glue_crawler" "test" {
   depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]
 
   classifiers   = [aws_glue_classifier.test1.id, aws_glue_classifier.test2.id]
-  name          = %q
+  name          = %[4]q
   database_name = aws_glue_catalog_database.test.name
   role          = aws_iam_role.test.name
 
@@ -1763,53 +1763,53 @@ resource "aws_glue_crawler" "test" {
     path = "s3://bucket-name"
   }
 }
-`, rName, rName+"1", rName+"2", rName)
+`, rName, rName+"1", rName+"2", rName))
 }
 
 func testAccCrawlerConfig_configuration(rName, configuration string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
-  name = %q
+  name = %[1]q
 }
 
 resource "aws_glue_crawler" "test" {
   depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]
 
-  configuration = %s
+  configuration = %[2]s
   database_name = aws_glue_catalog_database.test.name
-  name          = %q
+  name          = %[3]q
   role          = aws_iam_role.test.name
 
   s3_target {
     path = "s3://bucket-name"
   }
 }
-`, rName, strconv.Quote(configuration), rName)
+`, rName, strconv.Quote(configuration), rName))
 }
 
 func testAccCrawlerConfig_description(rName, description string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
-  name = %q
+  name = %[1]q
 }
 
 resource "aws_glue_crawler" "test" {
   depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]
 
   database_name = aws_glue_catalog_database.test.name
-  description   = %q
-  name          = %q
+  description   = %[2]q
+  name          = %[3]q
   role          = aws_iam_role.test.name
 
   s3_target {
     path = "s3://bucket-name"
   }
 }
-`, rName, description, rName)
+`, rName, description, rName))
 }
 
 func testAccCrawlerConfig_dynamoDBTarget(rName, path string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -1825,11 +1825,11 @@ resource "aws_glue_crawler" "test" {
     path = %[2]q
   }
 }
-`, rName, path)
+`, rName, path))
 }
 
 func testAccCrawlerConfig_dynamoDBTargetScanAll(rName, path string, scanAll bool) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -1846,11 +1846,11 @@ resource "aws_glue_crawler" "test" {
     scan_all = %[3]t
   }
 }
-`, rName, path, scanAll)
+`, rName, path, scanAll))
 }
 
 func testAccCrawlerConfig_dynamoDBTargetScanRate(rName, path string, scanRate float64) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -1867,11 +1867,11 @@ resource "aws_glue_crawler" "test" {
     scan_rate = %[3]g
   }
 }
-`, rName, path, scanRate)
+`, rName, path, scanRate))
 }
 
 func testAccCrawlerConfig_jdbcTarget(rName, jdbcConnectionUrl, path string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -1898,11 +1898,11 @@ resource "aws_glue_crawler" "test" {
     path            = %[3]q
   }
 }
-`, rName, jdbcConnectionUrl, path)
+`, rName, jdbcConnectionUrl, path))
 }
 
 func testAccCrawlerConfig_jdbcTargetExclusions1(rName, jdbcConnectionUrl, exclusion1 string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -1930,11 +1930,11 @@ resource "aws_glue_crawler" "test" {
     path            = "database-name/table1"
   }
 }
-`, rName, jdbcConnectionUrl, exclusion1)
+`, rName, jdbcConnectionUrl, exclusion1))
 }
 
 func testAccCrawlerConfig_jdbcTargetExclusions2(rName, jdbcConnectionUrl, exclusion1, exclusion2 string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -1962,11 +1962,11 @@ resource "aws_glue_crawler" "test" {
     path            = "database-name/table1"
   }
 }
-`, rName, jdbcConnectionUrl, exclusion1, exclusion2)
+`, rName, jdbcConnectionUrl, exclusion1, exclusion2))
 }
 
 func testAccCrawlerConfig_jdbcTargetMultiple(rName, jdbcConnectionUrl, path1, path2 string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -1998,11 +1998,11 @@ resource "aws_glue_crawler" "test" {
     path            = %[4]q
   }
 }
-`, rName, jdbcConnectionUrl, path1, path2)
+`, rName, jdbcConnectionUrl, path1, path2))
 }
 
 func testAccCrawlerConfig_roleARNNoPath(rName string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2018,7 +2018,7 @@ resource "aws_glue_crawler" "test" {
     path = "s3://bucket-name"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccCrawlerConfig_roleARNPath(rName string) string {
@@ -2118,7 +2118,7 @@ resource "aws_glue_crawler" "test" {
 }
 
 func testAccCrawlerConfig_s3Target(rName, path string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2134,11 +2134,11 @@ resource "aws_glue_crawler" "test" {
     path = %[2]q
   }
 }
-`, rName, path)
+`, rName, path))
 }
 
 func testAccCrawlerConfig_s3TargetExclusions1(rName, exclusion1 string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2155,30 +2155,13 @@ resource "aws_glue_crawler" "test" {
     path       = "s3://bucket1"
   }
 }
-`, rName, exclusion1)
+`, rName, exclusion1))
 }
 
 func testAccCrawlerConfig_s3TargetConnectionName(rName string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-glue-connection-base"
-  }
-}
-
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
 resource "aws_security_group" "test" {
-  name   = "%[1]s"
+  name   = %[1]q
   vpc_id = aws_vpc.test.id
 
   ingress {
@@ -2187,17 +2170,9 @@ resource "aws_security_group" "test" {
     self      = true
     to_port   = 65535
   }
-}
-
-resource "aws_subnet" "test" {
-  count = 2
-
-  availability_zone = data.aws_availability_zones.available.names[count.index]
-  cidr_block        = "10.0.${count.index}.0/24"
-  vpc_id            = aws_vpc.test.id
 
   tags = {
-    Name = "terraform-testacc-glue-connection-base"
+    Name = %[1]q
   }
 }
 
@@ -2233,11 +2208,11 @@ resource "aws_glue_crawler" "test" {
     path            = "s3://bucket1"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccCrawlerConfig_s3TargetExclusions2(rName, exclusion1, exclusion2 string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2254,11 +2229,11 @@ resource "aws_glue_crawler" "test" {
     path       = "s3://bucket1"
   }
 }
-`, rName, exclusion1, exclusion2)
+`, rName, exclusion1, exclusion2))
 }
 
 func testAccCrawlerConfig_s3TargetEventQueue(rName string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2322,11 +2297,11 @@ resource "aws_glue_crawler" "test" {
     recrawl_behavior = "CRAWL_EVENT_MODE"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccCrawlerConfig_catalogTargetDlqEventQueue(rName string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_sqs_queue" "test" {
   name = %[1]q
 
@@ -2424,11 +2399,11 @@ resource "aws_glue_crawler" "test" {
 }
 EOF
 }
-`, rName)
+`, rName))
 }
 
 func testAccCrawlerConfig_s3TargetDlqEventQueue(rName string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2500,11 +2475,11 @@ resource "aws_glue_crawler" "test" {
     recrawl_behavior = "CRAWL_EVENT_MODE"
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccCrawlerConfig_s3TargetMultiple(rName, path1, path2 string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2524,11 +2499,11 @@ resource "aws_glue_crawler" "test" {
     path = %[3]q
   }
 }
-`, rName, path1, path2)
+`, rName, path1, path2))
 }
 
 func testAccCrawlerConfig_catalogTarget(rName string, tableCount int) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2587,11 +2562,11 @@ resource "aws_glue_crawler" "test" {
 }
 EOF
 }
-`, rName, tableCount)
+`, rName, tableCount))
 }
 
 func testAccCrawlerConfig_catalogTargetMultiple(rName string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   count = 2
   name  = "%[1]s_database_${count.index}"
@@ -2655,11 +2630,11 @@ resource "aws_glue_crawler" "test" {
 }
 EOF
 }
-`, rName)
+`, rName))
 }
 
 func testAccCrawlerConfig_schedule(rName, schedule string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2676,11 +2651,11 @@ resource "aws_glue_crawler" "test" {
     path = "s3://bucket-name"
   }
 }
-`, rName, schedule)
+`, rName, schedule))
 }
 
 func testAccCrawlerConfig_schemaChangePolicy(rName, deleteBehavior, updateBehavior string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2701,11 +2676,11 @@ resource "aws_glue_crawler" "test" {
     update_behavior = %[3]q
   }
 }
-`, rName, deleteBehavior, updateBehavior)
+`, rName, deleteBehavior, updateBehavior))
 }
 
 func testAccCrawlerConfig_tablePrefix(rName, tablePrefix string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2722,11 +2697,11 @@ resource "aws_glue_crawler" "test" {
     path = "s3://bucket-name"
   }
 }
-`, rName, tablePrefix)
+`, rName, tablePrefix))
 }
 
 func testAccCrawlerConfig_tags1(rName, tagKey1, tagValue1 string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2747,11 +2722,11 @@ resource "aws_glue_crawler" "test" {
     %[2]q = %[3]q
   }
 }
-`, rName, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
 func testAccCrawlerConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2773,11 +2748,11 @@ resource "aws_glue_crawler" "test" {
     %[4]q = %[5]q
   }
 }
-`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
 func testAccCrawlerConfig_securityConfiguration(rName, securityConfiguration string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2812,11 +2787,11 @@ resource "aws_glue_crawler" "test" {
     path = "s3://bucket-name"
   }
 }
-`, rName, securityConfiguration)
+`, rName, securityConfiguration))
 }
 
 func testAccCrawlerConfig_mongoDBTarget(rName, connectionUrl, path string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2844,11 +2819,11 @@ resource "aws_glue_crawler" "test" {
     path            = %[3]q
   }
 }
-`, rName, connectionUrl, path)
+`, rName, connectionUrl, path))
 }
 
 func testAccCrawlerConfig_mongoDBTargetScanAll(rName, connectionUrl string, scan bool) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2877,11 +2852,11 @@ resource "aws_glue_crawler" "test" {
     scan_all        = %[3]t
   }
 }
-`, rName, connectionUrl, scan)
+`, rName, connectionUrl, scan))
 }
 
 func testAccCrawlerConfig_mongoDBMultiple(rName, connectionUrl, path1, path2 string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2914,11 +2889,11 @@ resource "aws_glue_crawler" "test" {
     path            = %[4]q
   }
 }
-`, rName, connectionUrl, path1, path2)
+`, rName, connectionUrl, path1, path2))
 }
 
 func testAccCrawlerConfig_deltaTarget(rName, connectionUrl, tableName string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2947,11 +2922,11 @@ resource "aws_glue_crawler" "test" {
     write_manifest  = false
   }
 }
-`, rName, connectionUrl, tableName)
+`, rName, connectionUrl, tableName))
 }
 
 func testAccCrawlerConfig_lakeformation(rName string, use bool) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2971,11 +2946,11 @@ resource "aws_glue_crawler" "test" {
     path = "s3://bucket-name"
   }
 }
-`, rName, use)
+`, rName, use))
 }
 
 func testAccCrawlerConfig_lineage(rName, lineageConfig string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -2995,11 +2970,11 @@ resource "aws_glue_crawler" "test" {
     path = "s3://bucket-name"
   }
 }
-`, rName, lineageConfig)
+`, rName, lineageConfig))
 }
 
 func testAccCrawlerConfig_recrawlPolicy(rName, policy string) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -3024,11 +2999,11 @@ resource "aws_glue_crawler" "test" {
     path = "s3://bucket-name"
   }
 }
-`, rName, policy)
+`, rName, policy))
 }
 
 func testAccCrawlerConfig_s3TargetSampleSize(rName string, size int) string {
-	return testAccCrawlerConfig_base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
 }
@@ -3045,5 +3020,5 @@ resource "aws_glue_crawler" "test" {
     path        = "s3://bucket1"
   }
 }
-`, rName, size)
+`, rName, size))
 }

--- a/internal/service/glue/find.go
+++ b/internal/service/glue/find.go
@@ -261,3 +261,27 @@ func FindClassifierByName(conn *glue.Glue, name string) (*glue.Classifier, error
 
 	return output.Classifier, nil
 }
+
+func FindCrawlerByName(conn *glue.Glue, name string) (*glue.Crawler, error) {
+	input := &glue.GetCrawlerInput{
+		Name: aws.String(name),
+	}
+
+	output, err := conn.GetCrawler(input)
+	if tfawserr.ErrCodeEquals(err, glue.ErrCodeEntityNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Crawler == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.Crawler, nil
+}

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -144,6 +144,7 @@ The following arguments are supported:
 * `mongodb_target` (Optional) List nested MongoDB target arguments. See [MongoDB Target](#mongodb-target) below.
 * `schedule` (Optional) A cron expression used to specify the schedule. For more information, see [Time-Based Schedules for Jobs and Crawlers](https://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html). For example, to run something every day at 12:15 UTC, you would specify: `cron(15 12 * * ? *)`.
 * `schema_change_policy` (Optional) Policy for the crawler's update and deletion behavior. See [Schema Change Policy](#schema-change-policy) below.
+* `lake_formation_configuration` (Optional) Specifies Lake Formation configuration settings for the crawler. See [Lake Formation Configuration](#lake-formation-configuration) below.
 * `lineage_configuration` (Optional) Specifies data lineage configuration settings for the crawler. See [Lineage Configuration](#lineage-configuration) below.
 * `recrawl_policy` (Optional)  A policy that specifies whether to crawl the entire dataset again, or to crawl only folders that were added since the last crawler run.. See [Recrawl Policy](#recrawl-policy) below.
 * `security_configuration` (Optional) The name of Security Configuration to be used by the crawler
@@ -200,6 +201,11 @@ The following arguments are supported:
 
 * `delete_behavior` - (Optional) The deletion behavior when the crawler finds a deleted object. Valid values: `LOG`, `DELETE_FROM_DATABASE`, or `DEPRECATE_IN_DATABASE`. Defaults to `DEPRECATE_IN_DATABASE`.
 * `update_behavior` - (Optional) The update behavior when the crawler finds a changed schema. Valid values: `LOG` or `UPDATE_IN_DATABASE`. Defaults to `UPDATE_IN_DATABASE`.
+
+### Lake Formation Configuration
+
+* `account_id` - (Optional) Required for cross account crawls. For same account crawls as the target data, this can ommited.
+* `use_lake_formation_credentials` - (Optional) Specifies whether to use Lake Formation credentials for the crawler instead of the IAM role credentials.
 
 ### Lineage Configuration
 

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -204,7 +204,7 @@ The following arguments are supported:
 
 ### Lake Formation Configuration
 
-* `account_id` - (Optional) Required for cross account crawls. For same account crawls as the target data, this can ommited.
+* `account_id` - (Optional) Required for cross account crawls. For same account crawls as the target data, this can omitted.
 * `use_lake_formation_credentials` - (Optional) Specifies whether to use Lake Formation credentials for the crawler instead of the IAM role credentials.
 
 ### Lineage Configuration

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -128,7 +128,7 @@ resource "aws_glue_crawler" "events_crawler" {
 
 ## Argument Reference
 
-~> **NOTE:** Must specify at least one of `dynamodb_target`, `jdbc_target`, `s3_target` or `catalog_target`.
+~> **NOTE:** Must specify at least one of `dynamodb_target`, `jdbc_target`, `s3_target`, `mongodb_target` or `catalog_target`.
 
 The following arguments are supported:
 
@@ -161,6 +161,7 @@ The following arguments are supported:
 * `connection_name` - (Required) The name of the connection to use to connect to the JDBC target.
 * `path` - (Required) The path of the JDBC target.
 * `exclusions` - (Optional) A list of glob patterns used to exclude from the crawl.
+* `enable_additional_metadata` - (Optional) Specify a value of `RAWTYPES` or `COMMENTS` to enable additional metadata intable responses. `RAWTYPES` provides the native-level datatype. `COMMENTS` provides comments associated with a column or table in the database.
 
 ### S3 Target
 
@@ -173,8 +174,11 @@ The following arguments are supported:
 
 ### Catalog Target
 
+* `connection_name` - (Optional) The name of the connection for an Amazon S3-backed Data Catalog table to be a target of the crawl when using a Catalog connection type paired with a `NETWORK` Connection type.
 * `database_name` - (Required) The name of the Glue database to be synchronized.
 * `tables` - (Required) A list of catalog tables to be synchronized.
+* `event_queue_arn` - (Optional)  A valid Amazon SQS ARN.
+* `dlq_event_queue_arn` - (Optional)  A valid Amazon SQS ARN.
 
 ~> **Note:** `deletion_behavior` of catalog target doesn't support `DEPRECATE_IN_DATABASE`.
 
@@ -188,7 +192,7 @@ The following arguments are supported:
 
 ### Delta Target
 
-* `connection_name` - (Required) The name of the connection to use to connect to the Delta table target.
+* `connection_name` - (Optional) The name of the connection to use to connect to the Delta table target.
 * `delta_tables` - (Required) A list of the Amazon S3 paths to the Delta tables.
 * `write_manifest` - (Required) Specifies whether to write the manifest files to the Delta table path.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27331
Closes #27745

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccGlueCrawler_ PKG=glue
--- PASS: TestAccGlueCrawler_RoleName_path (58.00s)
--- PASS: TestAccGlueCrawler_disappears (67.33s)
--- PASS: TestAccGlueCrawler_S3Target_connectionName (86.44s)
--- PASS: TestAccGlueCrawler_S3Target_exclusions (107.86s)
--- PASS: TestAccGlueCrawler_deltaTarget (109.96s)
--- PASS: TestAccGlueCrawler_jdbcTarget (110.31s)
--- PASS: TestAccGlueCrawler_S3Target_eventqueue (116.07s)
--- PASS: TestAccGlueCrawler_S3Target_dlqeventqueue (117.16s)
--- PASS: TestAccGlueCrawler_description (117.37s)
--- PASS: TestAccGlueCrawler_S3Target_sampleSize (117.91s)
--- PASS: TestAccGlueCrawler_mongoDBTarget (118.56s)
--- PASS: TestAccGlueCrawler_dynamoDBTarget (119.01s)
--- PASS: TestAccGlueCrawler_catalogTarget (138.38s)
--- PASS: TestAccGlueCrawler_Configuration (141.25s)
--- PASS: TestAccGlueCrawler_S3Target_multiple (143.01s)
--- PASS: TestAccGlueCrawler_MongoDBTargetScan_all (146.30s)
--- PASS: TestAccGlueCrawler_JDBCTarget_multiple (146.69s)
--- PASS: TestAccGlueCrawler_MongoDBTarget_multiple (147.18s)
--- PASS: TestAccGlueCrawler_classifiers (147.93s)
--- PASS: TestAccGlueCrawler_schedule (149.84s)
--- PASS: TestAccGlueCrawler_JDBCTarget_exclusions (100.37s)
--- PASS: TestAccGlueCrawler_RoleARN_path (49.24s)
--- PASS: TestAccGlueCrawler_RoleARN_noPath (52.79s)
--- PASS: TestAccGlueCrawler_DynamoDBTarget_scanRate (123.51s)
--- PASS: TestAccGlueCrawler_security (79.49s)
--- PASS: TestAccGlueCrawler_s3Target (80.35s)
--- PASS: TestAccGlueCrawler_DynamoDBTarget_scanAll (111.94s)
--- PASS: TestAccGlueCrawler_tablePrefix (79.37s)
--- PASS: TestAccGlueCrawler_removeTablePrefix (76.53s)
--- PASS: TestAccGlueCrawler_tags (107.23s)
--- PASS: TestAccGlueCrawler_reCrawlPolicy (107.32s)
--- PASS: TestAccGlueCrawler_lineage (107.10s)
--- PASS: TestAccGlueCrawler_schemaChangePolicy (77.36s)
--- PASS: TestAccGlueCrawler_CatalogTarget_multiple (145.12s)
--- PASS: TestAccGlueCrawler_CatalogTarget_dlqeventqueue (72.94s)
--- PASS: TestAccGlueCrawler_lakeformation (66.58s)
```
