### PR TITLE
r/sagemaker_endpoint_configurtion - add `shadow_production_variants` and other prod variants args 

### DIFF
--- a/.changelog/28159.txt
+++ b/.changelog/28159.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_sagemaker_endpoint_configurtion: Add `shadow_production_variants`, `production_variants.container_startup_health_check_timeout_in_seconds`, `production_variants.model_data_download_timeout_in_seconds`, and `production_variants.volume_size_in_gb`
+resource/aws_sagemaker_endpoint_configurtion: Add `shadow_production_variants`, `production_variants.container_startup_health_check_timeout_in_seconds`, `production_variants.core_dump_config`, `production_variants.model_data_download_timeout_in_seconds`, and `production_variants.volume_size_in_gb`
 ```

--- a/.changelog/28159.txt
+++ b/.changelog/28159.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_sagemaker_endpoint_configurtion: Add `shadow_production_variants`, `production_variants.container_startup_health_check_timeout_in_seconds`, `production_variants.core_dump_config`, `production_variants.model_data_download_timeout_in_seconds`, and `production_variants.volume_size_in_gb`
+resource/aws_sagemaker_endpoint_configuration: Add `shadow_production_variants`, `production_variants.container_startup_health_check_timeout_in_seconds`, `production_variants.core_dump_config`, `production_variants.model_data_download_timeout_in_seconds`, and `production_variants.volume_size_in_gb` arguments
 ```

--- a/.changelog/28159.txt
+++ b/.changelog/28159.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sagemaker_endpoint_configurtion: Add `shadow_production_variants`, `production_variants.container_startup_health_check_timeout_in_seconds`, `production_variants.model_data_download_timeout_in_seconds`, and `production_variants.volume_size_in_gb`
+```

--- a/internal/service/sagemaker/endpoint_configuration.go
+++ b/internal/service/sagemaker/endpoint_configuration.go
@@ -294,6 +294,7 @@ func ResourceEndpointConfiguration() *schema.Resource {
 						"volume_size_in_gb": {
 							Type:         schema.TypeInt,
 							Optional:     true,
+							Computed:     true,
 							ForceNew:     true,
 							ValidateFunc: validation.IntBetween(1, 512),
 						},

--- a/internal/service/sagemaker/endpoint_configuration.go
+++ b/internal/service/sagemaker/endpoint_configuration.go
@@ -302,7 +302,7 @@ func ResourceEndpointConfiguration() *schema.Resource {
 			},
 			"shadow_production_variants": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				MinItems: 1,
 				MaxItems: 10,
 				Elem: &schema.Resource{

--- a/internal/service/sagemaker/endpoint_configuration.go
+++ b/internal/service/sagemaker/endpoint_configuration.go
@@ -363,7 +363,7 @@ func ResourceEndpointConfiguration() *schema.Resource {
 									},
 									"kms_key_id": {
 										Type:         schema.TypeString,
-										Optional:     true,
+										Required:     true,
 										ForceNew:     true,
 										ValidateFunc: verify.ValidARN,
 									},

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -537,7 +537,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     initial_instance_count = 2
     instance_type          = "ml.t2.medium"
     initial_variant_weight = 1
-  }  
+  }
 }
 `, rName)
 }

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -469,7 +469,7 @@ func testAccCheckEndpointConfigurationExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccEndpointConfigurationConfig_Base(rName string) string {
+func testAccEndpointConfigurationConfig_base(rName string) string {
 	return fmt.Sprintf(`
 data "aws_sagemaker_prebuilt_ecr_image" "test" {
   repository_name = "kmeans"
@@ -504,9 +504,9 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 func testAccEndpointConfigurationConfig_basic(rName string) string {
-	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test" {
-  name = %q
+  name = %[1]q
 
   production_variants {
     variant_name           = "variant-1"
@@ -516,13 +516,13 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     initial_variant_weight = 1
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccEndpointConfigurationConfig_shadowProductionVariants(rName string) string {
-	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test" {
-  name = %q
+  name = %[1]q
 
   production_variants {
     variant_name           = "variant-1"
@@ -540,13 +540,13 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     initial_variant_weight = 1
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccEndpointConfigurationConfig_productionVariantsInitialVariantWeight(rName string) string {
-	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test" {
-  name = %q
+  name = %[1]q
 
   production_variants {
     variant_name           = "variant-1"
@@ -563,13 +563,13 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     initial_variant_weight = 0.5
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccEndpointConfigurationConfig_productionVariantAcceleratorType(rName string) string {
-	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test" {
-  name = %q
+  name = %[1]q
 
   production_variants {
     variant_name           = "variant-1"
@@ -580,11 +580,11 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     initial_variant_weight = 1
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccEndpointConfigurationConfig_kmsKeyID(rName string) string {
-	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test" {
   name        = %[1]q
   kms_key_arn = aws_kms_key.test.arn
@@ -602,11 +602,11 @@ resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 10
 }
-`, rName)
+`, rName))
 }
 
 func testAccEndpointConfigurationConfig_tags1(rName, tagKey1, tagValue1 string) string {
-	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test" {
   name = %[1]q
 
@@ -622,11 +622,11 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     %[2]q = %[3]q
   }
 }
-`, rName, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
 func testAccEndpointConfigurationConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test" {
   name = %[1]q
 
@@ -643,11 +643,11 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     %[4]q = %[5]q
   }
 }
-`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
 func testAccEndpointConfigurationConfig_dataCapture(rName string) string {
-	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
   force_destroy = true
@@ -687,11 +687,11 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     }
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccEndpointConfigurationConfig_asyncKMS(rName string) string {
-	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
   force_destroy = true
@@ -725,11 +725,11 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     }
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccEndpointConfigurationConfig_async(rName string) string {
-	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
   acl           = "private"
@@ -753,11 +753,11 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     }
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccEndpointConfigurationConfig_asyncNotif(rName string) string {
-	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
   force_destroy = true
@@ -800,11 +800,11 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     }
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccEndpointConfigurationConfig_asyncClient(rName string) string {
-	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
   force_destroy = true
@@ -842,13 +842,13 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     }
   }
 }
-`, rName)
+`, rName))
 }
 
 func testAccEndpointConfigurationConfig_serverless(rName string) string {
-	return testAccEndpointConfigurationConfig_Base(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test" {
-  name = %q
+  name = %[1]q
 
   production_variants {
     variant_name = "variant-1"
@@ -860,5 +860,5 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     }
   }
 }
-`, rName)
+`, rName))
 }

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -36,6 +36,7 @@ func TestAccSageMakerEndpointConfiguration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.instance_type", "ml.t2.medium"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.initial_variant_weight", "1"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.serverless_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.core_dump_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "async_inference_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "shadow_production_variants.#", "0"),

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -47,6 +47,7 @@ The following arguments are supported:
 
 * `accelerator_type` - (Optional) The size of the Elastic Inference (EI) instance to use for the production variant.
 * `container_startup_health_check_timeout_in_seconds` - (Optional) The timeout value, in seconds, for your inference container to pass health check by SageMaker Hosting. For more information about health check, see [How Your Container Should Respond to Health Check (Ping) Requests](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-inference-code.html#your-algorithms-inference-algo-ping-requests). Valid values between `60` and `3600`.
+* `core_dump_config` - (Optional) Specifies configuration for a core dump from the model container when the process crashes. Fields are documented below.
 * `initial_instance_count` - (Optional) Initial number of instances used for auto-scaling.
 * `instance_type` - (Optional)  The type of instance to start.
 * `initial_variant_weight` - (Optional) Determines initial traffic distribution among all of the models that you specify in the endpoint configuration. If unspecified, it defaults to `1.0`.
@@ -55,6 +56,11 @@ The following arguments are supported:
 * `serverless_config` - (Optional) Specifies configuration for how an endpoint performs asynchronous inference.
 * `variant_name` - (Optional) The name of the variant. If omitted, Terraform will assign a random, unique name.
 * `volume_size_in_gb` - (Optional) The size, in GB, of the ML storage volume attached to individual inference instance associated with the production variant. Valid values between `1` and `512`.
+
+#### core_dump_config
+
+* `destination_s3_uri` - (Required) The Amazon S3 bucket to send the core dump to.
+* `kms_key_id` - (Required) The Amazon Web Services Key Management Service (Amazon Web Services KMS) key that SageMaker uses to encrypt the core dump data at rest using Amazon S3 server-side encryption.
 
 #### serverless_config
 

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -35,22 +35,26 @@ resource "aws_sagemaker_endpoint_configuration" "ec" {
 
 The following arguments are supported:
 
-* `production_variants` - (Required) Fields are documented below.
+* `production_variants` - (Required) An list of ProductionVariant objects, one for each model that you want to host at this endpoint. Fields are documented below.
 * `kms_key_arn` - (Optional) Amazon Resource Name (ARN) of a AWS Key Management Service key that Amazon SageMaker uses to encrypt data on the storage volume attached to the ML compute instance that hosts the endpoint.
 * `name` - (Optional) The name of the endpoint configuration. If omitted, Terraform will assign a random, unique name.
 * `tags` - (Optional) A mapping of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `data_capture_config` - (Optional) Specifies the parameters to capture input/output of SageMaker models endpoints. Fields are documented below.
 * `async_inference_config` - (Optional) Specifies configuration for how an endpoint performs asynchronous inference.
+* `shadow_production_variants` - (Optional) Array of ProductionVariant objects. There is one for each model that you want to host at this endpoint in shadow mode with production traffic replicated from the model specified on ProductionVariants.If you use this field, you can only specify one variant for ProductionVariants and one variant for ShadowProductionVariants. Fields are documented below.
 
 ### production_variants
 
+* `accelerator_type` - (Optional) The size of the Elastic Inference (EI) instance to use for the production variant.
+* `container_startup_health_check_timeout_in_seconds` - (Optional) The timeout value, in seconds, for your inference container to pass health check by SageMaker Hosting. For more information about health check, see [How Your Container Should Respond to Health Check (Ping) Requests](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-inference-code.html#your-algorithms-inference-algo-ping-requests). Valid values between `60` and `3600`.
 * `initial_instance_count` - (Optional) Initial number of instances used for auto-scaling.
-* `instance_type` (Optional) - The type of instance to start.
-* `accelerator_type` (Optional) - The size of the Elastic Inference (EI) instance to use for the production variant.
-* `initial_variant_weight` (Optional) - Determines initial traffic distribution among all of the models that you specify in the endpoint configuration. If unspecified, it defaults to `1.0`.
+* `instance_type` - (Optional)  The type of instance to start.
+* `initial_variant_weight` - (Optional) Determines initial traffic distribution among all of the models that you specify in the endpoint configuration. If unspecified, it defaults to `1.0`.
+* `model_data_download_timeout_in_seconds` - (Optional) The timeout value, in seconds, to download and extract the model that you want to host from Amazon S3 to the individual inference instance associated with this production variant. Valid values between `60` and `3600`.
 * `model_name` - (Required) The name of the model to use.
-* `variant_name` - (Optional) The name of the variant. If omitted, Terraform will assign a random, unique name.
 * `serverless_config` - (Optional) Specifies configuration for how an endpoint performs asynchronous inference.
+* `variant_name` - (Optional) The name of the variant. If omitted, Terraform will assign a random, unique name.
+* `volume_size_in_gb` - (Optional) The size, in GB, of the ML storage volume attached to individual inference instance associated with the production variant. Valid values between `1` and `512`.
 
 #### serverless_config
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccSageMakerEndpointConfiguration_ PKG=sagemaker
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_serverless (55.74s)
--- PASS: TestAccSageMakerEndpointConfiguration_disappears (56.61s)
--- PASS: TestAccSageMakerEndpointConfiguration_dataCapture (60.05s)
--- PASS: TestAccSageMakerEndpointConfiguration_kmsKeyID (60.09s)
--- PASS: TestAccSageMakerEndpointConfiguration_async_kms (62.37s)
--- PASS: TestAccSageMakerEndpointConfiguration_async (66.44s)
--- PASS: TestAccSageMakerEndpointConfiguration_Async_client (66.63s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_initialVariantWeight (69.12s)
--- PASS: TestAccSageMakerEndpointConfiguration_Async_notif (70.48s)
--- PASS: TestAccSageMakerEndpointConfiguration_basic (72.44s)
--- PASS: TestAccSageMakerEndpointConfiguration_shadowProductionVariants (74.42s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_acceleratorType (75.16s)
--- PASS: TestAccSageMakerEndpointConfiguration_tags (120.77s)
```
