### PR TITLE
appstream_image_builder: Fix iam role eventual consistency and domain_join bugs  28128 26677

### DIFF
--- a/.changelog/28195.txt
+++ b/.changelog/28195.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_appstream_image_builder: fix IAM eventual consistency error for optional role
+```
+
+```release-note:bug
+resource/aws_appstream_image_builder: fix domain_join data mismatch error
+```

--- a/internal/service/appstream/image_builder.go
+++ b/internal/service/appstream/image_builder.go
@@ -291,11 +291,11 @@ func resourceImageBuilderRead(ctx context.Context, d *schema.ResourceData, meta 
 	if err = d.Set("access_endpoint", flattenAccessEndpoints(imageBuilder.AccessEndpoints)); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `%s` for AppStream ImageBuilder (%s): %w", "access_endpoints", d.Id(), err))
 	}
-	if err = d.Set("domain_join_info", flattenDomainInfo(imageBuilder.DomainJoinInfo)); err != nil {
+	if err = d.Set("domain_join_info", []interface{}{flattenDomainInfo(imageBuilder.DomainJoinInfo)}); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `%s` for AppStream ImageBuilder (%s): %w", "domain_join_info", d.Id(), err))
 	}
 
-	if err = d.Set("vpc_config", flattenVPCConfig(imageBuilder.VpcConfig)); err != nil {
+	if err = d.Set("vpc_config", []interface{}{flattenVPCConfig(imageBuilder.VpcConfig)}); err != nil {
 		return diag.FromErr(fmt.Errorf("error setting `%s` for AppStream ImageBuilder (%s): %w", "vpc_config", d.Id(), err))
 	}
 

--- a/internal/service/appstream/image_builder_test.go
+++ b/internal/service/appstream/image_builder_test.go
@@ -47,7 +47,7 @@ func TestAccAppStreamImageBuilder_basic(t *testing.T) {
 
 func TestAccAppStreamImageBuilder_withIAMRole(t *testing.T) {
 	resourceName := "aws_appstream_image_builder.test"
-	instanceType := "stream.standard.small"
+	instanceType := "stream.standard.medium"
 	imageName := "AppStream-WinServer2019-07-12-2022"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -150,7 +150,7 @@ func TestAccAppStreamImageBuilder_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV5ProviderFactories: acctest.ProoV5ProviderFactories,
 		CheckDestroy:             testAccCheckImageBuilderDestroy,
 		ErrorCheck:               acctest.ErrorCheck(t, appstream.EndpointsID),
 		Steps: []resource.TestStep{

--- a/internal/service/appstream/image_builder_test.go
+++ b/internal/service/appstream/image_builder_test.go
@@ -193,7 +193,7 @@ func TestAccAppStreamImageBuilder_imageARN(t *testing.T) {
 	resourceName := "aws_appstream_image_builder.test"
 	// imageName selected from the available AWS Managed AppStream 2.0 Base Images
 	// Reference: https://docs.aws.amazon.com/appstream2/latest/developerguide/base-image-version-history.html
-	imageName := "AppStream-WinServer2012R2-07-19-2021"
+	imageName := "AppStream-WinServer2019-07-12-2022"
 	instanceType := "stream.standard.small"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -271,7 +271,7 @@ func testAccCheckImageBuilderDestroy(s *terraform.State) error {
 func testAccImageBuilderConfig_basic(instanceType, name string) string {
 	return fmt.Sprintf(`
 resource "aws_appstream_image_builder" "test" {
-  image_name    = "AppStream-WinServer2012R2-07-19-2021"
+  image_name    = "AppStream-WinServer2019-07-12-2022"
   instance_type = %[1]q
   name          = %[2]q
 }
@@ -293,7 +293,7 @@ resource "aws_subnet" "test" {
 }
 
 resource "aws_appstream_image_builder" "test" {
-  image_name                     = "AppStream-WinServer2012R2-07-19-2021"
+  image_name                     = "AppStream-WinServer2019-07-12-2022"
   name                           = %[1]q
   description                    = %[2]q
   enable_default_internet_access = false
@@ -308,7 +308,7 @@ resource "aws_appstream_image_builder" "test" {
 func testAccImageBuilderConfig_tags1(instanceType, name, key, value string) string {
 	return fmt.Sprintf(`
 resource "aws_appstream_image_builder" "test" {
-  image_name    = "AppStream-WinServer2012R2-07-19-2021"
+  image_name    = "AppStream-WinServer2019-07-12-2022"
   instance_type = %[1]q
   name          = %[2]q
 
@@ -322,7 +322,7 @@ resource "aws_appstream_image_builder" "test" {
 func testAccImageBuilderConfig_tags2(instanceType, name, key1, value1, key2, value2 string) string {
 	return fmt.Sprintf(`
 resource "aws_appstream_image_builder" "test" {
-  image_name    = "AppStream-WinServer2012R2-07-19-2021"
+  image_name    = "AppStream-WinServer2019-07-12-2022"
   instance_type = %[1]q
   name          = %[2]q
 

--- a/internal/service/appstream/image_builder_test.go
+++ b/internal/service/appstream/image_builder_test.go
@@ -45,7 +45,7 @@ func TestAccAppStreamImageBuilder_basic(t *testing.T) {
 	})
 }
 
-func TestAccAppstreamImageBuilder_withIAMRole(t *testing.T) {
+func TestAccAppStreamImageBuilder_withIAMRole(t *testing.T) {
 	resourceName := "aws_appstream_image_builder.test"
 	instanceType := "stream.standard.small"
 	imageName := "AppStream-WinServer2019-07-12-2022"

--- a/internal/service/appstream/image_builder_test.go
+++ b/internal/service/appstream/image_builder_test.go
@@ -150,7 +150,7 @@ func TestAccAppStreamImageBuilder_tags(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProoV5ProviderFactories,
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckImageBuilderDestroy,
 		ErrorCheck:               acctest.ErrorCheck(t, appstream.EndpointsID),
 		Steps: []resource.TestStep{

--- a/internal/service/appstream/wait.go
+++ b/internal/service/appstream/wait.go
@@ -25,7 +25,9 @@ const (
 	imageBuilderStateTimeout = 60 * time.Minute
 	// userOperationTimeout Maximum amount of time to wait for User operation eventual consistency
 	userOperationTimeout = 4 * time.Minute
-	userAvailable        = "AVAILABLE"
+	// iamPropagationTimeout Maximum amount of time to wait for an iam resource eventual consistency
+	iamPropagationTimeout = 2 * time.Minute
+	userAvailable         = "AVAILABLE"
 )
 
 // waitStackStateDeleted waits for a deleted stack


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This PR fixes issues #28128 and #26677 affecting the ability for appstream image builders to be deployed. There were IAM eventual consistency errors and data type mismatch errors preventing appstream from successfully deploying when an optional iam role was attached.

Also added a new acceptance test for a minimal image builder configuration that uses an iam role.

### Relations

Closes #28128.
Closes #26677.

### References

Uses the same method that #26060 does for fixing IAM eventual consistency error, via adding retry logic. Added a wait constant for IAM resources specifically to prevent terraform from waiting up to 60 minutes on a potential iam failure.

Uses the same method that #26454 does for fixing appstream_fleet domain_join bugs. It certainly seems like flattenDomainInfo and flattenVpcInfo should be returning lists instead of maps, as all the code that uses them expects lists anyways.


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccAppStreamImageBuilder PKG=appstream
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appstream/... -v -count 1 -parallel 20 -run='TestAccAppStreamImageBuilder'  -timeout 180m
=== RUN   TestAccAppStreamImageBuilder_basic
=== PAUSE TestAccAppStreamImageBuilder_basic
=== RUN   TestAccAppStreamImageBuilder_withIAMRole
=== PAUSE TestAccAppStreamImageBuilder_withIAMRole
=== RUN   TestAccAppStreamImageBuilder_disappears
=== PAUSE TestAccAppStreamImageBuilder_disappears
=== RUN   TestAccAppStreamImageBuilder_complete
=== PAUSE TestAccAppStreamImageBuilder_complete
=== RUN   TestAccAppStreamImageBuilder_tags
=== PAUSE TestAccAppStreamImageBuilder_tags
=== RUN   TestAccAppStreamImageBuilder_imageARN
=== PAUSE TestAccAppStreamImageBuilder_imageARN
=== CONT  TestAccAppStreamImageBuilder_basic
=== CONT  TestAccAppStreamImageBuilder_complete
=== CONT  TestAccAppStreamImageBuilder_disappears
=== CONT  TestAccAppStreamImageBuilder_imageARN
=== CONT  TestAccAppStreamImageBuilder_tags
=== CONT  TestAccAppStreamImageBuilder_withIAMRole
--- PASS: TestAccAppStreamImageBuilder_disappears (655.79s)
--- PASS: TestAccAppStreamImageBuilder_withIAMRole (657.89s)
--- PASS: TestAccAppStreamImageBuilder_basic (682.57s)
--- PASS: TestAccAppStreamImageBuilder_tags (783.61s)
--- PASS: TestAccAppStreamImageBuilder_imageARN (784.72s)
--- PASS: TestAccAppStreamImageBuilder_complete (1384.84s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appstream  1384.922s
```
