### PR TITLE
Various sweepers: Don't call a resource's `Delete` handler directly

### DIFF
--- a/internal/service/ecs/sweep.go
+++ b/internal/service/ecs/sweep.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
@@ -54,7 +54,6 @@ func sweepCapacityProviders(region string) error {
 	}
 	conn := client.(*conns.AWSClient).ECSConn
 	input := &ecs.DescribeCapacityProvidersInput{}
-	var sweeperErrs *multierror.Error
 	sweepResources := make([]sweep.Sweepable, 0)
 
 	err = describeCapacityProvidersPages(conn, input, func(page *ecs.DescribeCapacityProvidersOutput, lastPage bool) bool {
@@ -62,10 +61,10 @@ func sweepCapacityProviders(region string) error {
 			return !lastPage
 		}
 
-		for _, capacityProvider := range page.CapacityProviders {
-			arn := aws.StringValue(capacityProvider.CapacityProviderArn)
+		for _, v := range page.CapacityProviders {
+			arn := aws.StringValue(v.CapacityProviderArn)
 
-			if name := aws.StringValue(capacityProvider.Name); name == "FARGATE" || name == "FARGATE_SPOT" {
+			if name := aws.StringValue(v.Name); name == "FARGATE" || name == "FARGATE_SPOT" {
 				log.Printf("[INFO] Skipping AWS managed ECS Capacity Provider: %s", arn)
 				continue
 			}
@@ -81,19 +80,21 @@ func sweepCapacityProviders(region string) error {
 	})
 
 	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping ECS Capacity Providers sweep for %s: %s", region, err)
-		return sweeperErrs.ErrorOrNil()
+		log.Printf("[WARN] Skipping ECS Capacity Provider sweep for %s: %s", region, err)
+		return nil
 	}
 
 	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing ECS Capacity Providers for %s: %w", region, err))
+		return fmt.Errorf("error listing ECS Capacity Providers (%s): %w", region, err)
 	}
 
-	if err := sweep.SweepOrchestrator(sweepResources); err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping ECS Capacity Providers for %s: %w", region, err))
+	err = sweep.SweepOrchestrator(sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping ECS Capacity Providers (%s): %w", region, err)
 	}
 
-	return sweeperErrs.ErrorOrNil()
+	return nil
 }
 
 func sweepClusters(region string) error {
@@ -102,33 +103,38 @@ func sweepClusters(region string) error {
 		return fmt.Errorf("error getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).ECSConn
+	input := &ecs.ListClustersInput{}
+	sweepResources := make([]sweep.Sweepable, 0)
 
-	err = conn.ListClustersPages(&ecs.ListClustersInput{}, func(page *ecs.ListClustersOutput, lastPage bool) bool {
+	err = conn.ListClustersPages(input, func(page *ecs.ListClustersOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}
 
-		for _, clusterARNPtr := range page.ClusterArns {
-			clusterARN := aws.StringValue(clusterARNPtr)
-
-			log.Printf("[INFO] Deleting ECS Cluster: %s", clusterARN)
+		for _, v := range page.ClusterArns {
 			r := ResourceCluster()
 			d := r.Data(nil)
-			d.SetId(clusterARN)
-			err = r.Delete(d, client)
-			if err != nil {
-				log.Printf("[ERROR] Error deleting ECS Cluster (%s): %s", clusterARN, err)
-			}
+			d.SetId(aws.StringValue(v))
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
 
 		return !lastPage
 	})
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping ECS Cluster sweep for %s: %s", region, err)
+		return nil
+	}
+
 	if err != nil {
-		if sweep.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping ECS Cluster sweep for %s: %s", region, err)
-			return nil
-		}
-		return fmt.Errorf("error retrieving ECS Clusters: %w", err)
+		return fmt.Errorf("error listing ECS Clusters (%s): %w", region, err)
+	}
+
+	err = sweep.SweepOrchestrator(sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping ECS Clusters (%s): %w", region, err)
 	}
 
 	return nil
@@ -140,28 +146,30 @@ func sweepServices(region string) error {
 		return fmt.Errorf("error getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).ECSConn
-
+	input := &ecs.ListClustersInput{}
 	var sweeperErrs *multierror.Error
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	err = conn.ListClustersPages(&ecs.ListClustersInput{}, func(page *ecs.ListClustersOutput, lastPage bool) bool {
+	err = conn.ListClustersPages(input, func(page *ecs.ListClustersOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}
 
-		for _, clusterARN := range page.ClusterArns {
+		for _, v := range page.ClusterArns {
+			clusterARN := aws.StringValue(v)
 			input := &ecs.ListServicesInput{
-				Cluster: clusterARN,
+				Cluster: aws.String(clusterARN),
 			}
+
 			err := conn.ListServicesPages(input, func(page *ecs.ListServicesOutput, lastPage bool) bool {
 				if page == nil {
 					return !lastPage
 				}
 
-				for _, serviceARN := range page.ServiceArns {
+				for _, v := range page.ServiceArns {
 					r := ResourceService()
 					d := r.Data(nil)
-					d.SetId(aws.StringValue(serviceARN))
+					d.SetId(aws.StringValue(v))
 					d.Set("cluster", clusterARN)
 
 					sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
@@ -169,8 +177,13 @@ func sweepServices(region string) error {
 
 				return !lastPage
 			})
+
+			if sweep.SkipSweepError(err) {
+				continue
+			}
+
 			if err != nil {
-				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("listing ECS Services for Cluster (%s): %w", aws.StringValue(clusterARN), err))
+				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing ECS Services (%s): %w", region, err))
 			}
 		}
 
@@ -179,14 +192,17 @@ func sweepServices(region string) error {
 
 	if sweep.SkipSweepError(err) {
 		log.Printf("[WARN] Skipping ECS Service sweep for %s: %s", region, err)
-		return sweeperErrs.ErrorOrNil()
-	}
-	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("retrieving ECS Services: %w", err))
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
 	}
 
-	if err := sweep.SweepOrchestrator(sweepResources); err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping ECS Services for %s: %w", region, err))
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing ECS Clusters (%s): %w", region, err))
+	}
+
+	err = sweep.SweepOrchestrator(sweepResources)
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping ECS Services (%s): %w", region, err))
 	}
 
 	return sweeperErrs.ErrorOrNil()
@@ -198,37 +214,40 @@ func sweepTaskDefinitions(region string) error {
 		return fmt.Errorf("error getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).ECSConn
-	var sweeperErrs *multierror.Error
+	input := &ecs.ListTaskDefinitionsInput{}
+	sweepResources := make([]sweep.Sweepable, 0)
 
-	err = conn.ListTaskDefinitionsPages(&ecs.ListTaskDefinitionsInput{}, func(page *ecs.ListTaskDefinitionsOutput, lastPage bool) bool {
+	err = conn.ListTaskDefinitionsPages(input, func(page *ecs.ListTaskDefinitionsOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
 		}
 
-		for _, taskDefinitionArn := range page.TaskDefinitionArns {
-			arn := aws.StringValue(taskDefinitionArn)
+		for _, v := range page.TaskDefinitionArns {
+			r := ResourceTaskDefinition()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(v))
+			d.Set("arn", v)
 
-			log.Printf("[INFO] Deleting ECS Task Definition: %s", arn)
-			_, err := conn.DeregisterTaskDefinition(&ecs.DeregisterTaskDefinitionInput{
-				TaskDefinition: aws.String(arn),
-			})
-			if err != nil {
-				sweeperErr := fmt.Errorf("error deleting ECS Task Definition (%s): %w", arn, err)
-				log.Printf("[ERROR] %s", sweeperErr)
-				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
-				continue
-			}
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
 
 		return !lastPage
 	})
+
 	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping ECS Task Definitions sweep for %s: %s", region, err)
-		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
-	}
-	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving ECS Task Definitions: %w", err))
+		log.Printf("[WARN] Skipping ECS Task Definition sweep for %s: %s", region, err)
+		return nil
 	}
 
-	return sweeperErrs.ErrorOrNil()
+	if err != nil {
+		return fmt.Errorf("error listing ECS Task Definitions (%s): %w", region, err)
+	}
+
+	err = sweep.SweepOrchestrator(sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping ECS Task Definitions (%s): %w", region, err)
+	}
+
+	return nil
 }

--- a/internal/service/globalaccelerator/sweep.go
+++ b/internal/service/globalaccelerator/sweep.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/globalaccelerator"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
@@ -19,131 +19,218 @@ func init() {
 	resource.AddTestSweepers("aws_globalaccelerator_accelerator", &resource.Sweeper{
 		Name: "aws_globalaccelerator_accelerator",
 		F:    sweepAccelerators,
+		Dependencies: []string{
+			"aws_globalaccelerator_listener",
+		},
+	})
+
+	resource.AddTestSweepers("aws_globalaccelerator_listener", &resource.Sweeper{
+		Name: "aws_globalaccelerator_listener",
+		F:    sweepListeners,
+		Dependencies: []string{
+			"aws_globalaccelerator_endpoint_group",
+		},
+	})
+
+	resource.AddTestSweepers("aws_globalaccelerator_endpoint_group", &resource.Sweeper{
+		Name: "aws_globalaccelerator_endpoint_group",
+		F:    sweepEndpointGroups,
 	})
 }
 
 func sweepAccelerators(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 	if err != nil {
-		return fmt.Errorf("Error getting client: %s", err)
+		return fmt.Errorf("error getting client: %s", err)
 	}
 	conn := client.(*conns.AWSClient).GlobalAcceleratorConn
-
 	input := &globalaccelerator.ListAcceleratorsInput{}
-	var sweeperErrs *multierror.Error
+	sweepResources := make([]sweep.Sweepable, 0)
 
-	for {
-		output, err := conn.ListAccelerators(input)
-
-		if sweep.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Global Accelerator Accelerator sweep for %s: %s", region, err)
-			return nil
+	err = conn.ListAcceleratorsPages(input, func(page *globalaccelerator.ListAcceleratorsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
 		}
 
-		if err != nil {
-			return fmt.Errorf("Error retrieving Global Accelerator Accelerators: %s", err)
-		}
-
-		for _, accelerator := range output.Accelerators {
-			arn := aws.StringValue(accelerator.AcceleratorArn)
-
-			errs := sweepListeners(client, accelerator.AcceleratorArn)
-			if errs != nil {
-				sweeperErrs = multierror.Append(sweeperErrs, errs)
-			}
-
+		for _, v := range page.Accelerators {
 			r := ResourceAccelerator()
 			d := r.Data(nil)
-			d.SetId(arn)
-			err = r.Delete(d, client)
+			d.SetId(aws.StringValue(v.AcceleratorArn))
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Global Accelerator Accelerator sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error listing Global Accelerator Accelerators (%s): %w", region, err)
+	}
+
+	err = sweep.SweepOrchestrator(sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping Global Accelerator Accelerators (%s): %w", region, err)
+	}
+
+	return nil
+}
+
+func sweepEndpointGroups(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*conns.AWSClient).GlobalAcceleratorConn
+	input := &globalaccelerator.ListAcceleratorsInput{}
+	var sweeperErrs *multierror.Error
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	err = conn.ListAcceleratorsPages(input, func(page *globalaccelerator.ListAcceleratorsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.Accelerators {
+			input := &globalaccelerator.ListListenersInput{
+				AcceleratorArn: v.AcceleratorArn,
+			}
+
+			err := conn.ListListenersPages(input, func(page *globalaccelerator.ListListenersOutput, lastPage bool) bool {
+				if page == nil {
+					return !lastPage
+				}
+
+				for _, v := range page.Listeners {
+					input := &globalaccelerator.ListEndpointGroupsInput{
+						ListenerArn: v.ListenerArn,
+					}
+
+					err := conn.ListEndpointGroupsPages(input, func(page *globalaccelerator.ListEndpointGroupsOutput, lastPage bool) bool {
+						if page == nil {
+							return !lastPage
+						}
+
+						for _, v := range page.EndpointGroups {
+							r := ResourceEndpointGroup()
+							d := r.Data(nil)
+							d.SetId(aws.StringValue(v.EndpointGroupArn))
+
+							sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+						}
+
+						return !lastPage
+					})
+
+					if sweep.SkipSweepError(err) {
+						continue
+					}
+
+					if err != nil {
+						sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Global Accelerator Endpoint Groups (%s): %w", region, err))
+					}
+				}
+
+				return !lastPage
+			})
+
+			if sweep.SkipSweepError(err) {
+				continue
+			}
 
 			if err != nil {
-				sweeperErr := fmt.Errorf("error deleting Global Accelerator Accelerator (%s): %s", arn, err)
-				log.Printf("[ERROR] %s", sweeperErr)
-				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
-				continue
+				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Global Accelerator Listeners (%s): %w", region, err))
 			}
 		}
 
-		if aws.StringValue(output.NextToken) == "" {
-			break
-		}
+		return !lastPage
+	})
 
-		input.NextToken = output.NextToken
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Global Accelerator Endpoint Group sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+	}
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Global Accelerator Accelerators (%s): %w", region, err))
+	}
+
+	err = sweep.SweepOrchestrator(sweepResources)
+
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping Global Accelerator Endpoint Groups (%s): %w", region, err))
 	}
 
 	return sweeperErrs.ErrorOrNil()
 }
 
-func sweepEndpointGroups(client interface{}, listenerArn *string) *multierror.Error {
-	conn := client.(*conns.AWSClient).GlobalAcceleratorConn
-	var sweeperErrs *multierror.Error
-
-	log.Printf("[INFO] deleting Endpoint Groups for Listener %s", *listenerArn)
-	input := &globalaccelerator.ListEndpointGroupsInput{
-		ListenerArn: listenerArn,
-	}
-	output, err := conn.ListEndpointGroups(input)
+func sweepListeners(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
 	if err != nil {
-		sweeperErr := fmt.Errorf("error listing Global Accelerator Endpoint Groups for Listener (%s): %s", *listenerArn, err)
-		log.Printf("[ERROR] %s", sweeperErr)
-		sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+		return fmt.Errorf("error getting client: %s", err)
 	}
-
-	for _, endpoint := range output.EndpointGroups {
-		arn := aws.StringValue(endpoint.EndpointGroupArn)
-
-		r := ResourceEndpointGroup()
-		d := r.Data(nil)
-		d.SetId(arn)
-		err = r.Delete(d, client)
-
-		if err != nil {
-			sweeperErr := fmt.Errorf("error deleting Global Accelerator endpoint group (%s): %s", arn, err)
-			log.Printf("[ERROR] %s", sweeperErr)
-			sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
-			continue
-		}
-	}
-
-	return sweeperErrs
-}
-
-func sweepListeners(client interface{}, acceleratorArn *string) *multierror.Error {
 	conn := client.(*conns.AWSClient).GlobalAcceleratorConn
+	input := &globalaccelerator.ListAcceleratorsInput{}
 	var sweeperErrs *multierror.Error
+	sweepResources := make([]sweep.Sweepable, 0)
 
-	log.Printf("[INFO] deleting Listeners for Accelerator %s", *acceleratorArn)
-	listenersInput := &globalaccelerator.ListListenersInput{
-		AcceleratorArn: acceleratorArn,
+	err = conn.ListAcceleratorsPages(input, func(page *globalaccelerator.ListAcceleratorsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.Accelerators {
+			input := &globalaccelerator.ListListenersInput{
+				AcceleratorArn: v.AcceleratorArn,
+			}
+
+			err := conn.ListListenersPages(input, func(page *globalaccelerator.ListListenersOutput, lastPage bool) bool {
+				if page == nil {
+					return !lastPage
+				}
+
+				for _, v := range page.Listeners {
+					r := ResourceListener()
+					d := r.Data(nil)
+					d.SetId(aws.StringValue(v.ListenerArn))
+
+					sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+				}
+
+				return !lastPage
+			})
+
+			if sweep.SkipSweepError(err) {
+				continue
+			}
+
+			if err != nil {
+				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Global Accelerator Listeners (%s): %w", region, err))
+			}
+		}
+
+		return !lastPage
+	})
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Global Accelerator Listener sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
 	}
-	listenersOutput, err := conn.ListListeners(listenersInput)
+
 	if err != nil {
-		sweeperErr := fmt.Errorf("error listing Global Accelerator Listeners for Accelerator (%s): %s", *acceleratorArn, err)
-		log.Printf("[ERROR] %s", sweeperErr)
-		sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing Global Accelerator Accelerators (%s): %w", region, err))
 	}
 
-	for _, listener := range listenersOutput.Listeners {
-		errs := sweepEndpointGroups(client, listener.ListenerArn)
-		if errs != nil {
-			sweeperErrs = multierror.Append(sweeperErrs, errs)
-		}
+	err = sweep.SweepOrchestrator(sweepResources)
 
-		arn := aws.StringValue(listener.ListenerArn)
-
-		r := ResourceListener()
-		d := r.Data(nil)
-		d.SetId(arn)
-		err = r.Delete(d, client)
-
-		if err != nil {
-			sweeperErr := fmt.Errorf("error deleting Global Accelerator listener (%s): %s", arn, err)
-			log.Printf("[ERROR] %s", sweeperErr)
-			sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
-			continue
-		}
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping Global Accelerator Listeners (%s): %w", region, err))
 	}
 
-	return sweeperErrs
+	return sweeperErrs.ErrorOrNil()
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Causes crashes if the `DeleteWithoutTimeout` handler is implemented instead.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/27282.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28234.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make sweep SWEEPARGS=-sweep-run=aws_vpc_endpoint_service,aws_ec2_carrier_gateway SWEEP=us-east-1,us-east-2
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-east-1,us-east-2 -sweep-run=aws_vpc_endpoint_service,aws_ec2_carrier_gateway -timeout 60m
2022/12/07 09:45:54 [DEBUG] Running Sweepers for region (us-east-1):
2022/12/07 09:45:54 [DEBUG] Sweeper (aws_sagemaker_workforce) has dependency (aws_sagemaker_workteam), running..
2022/12/07 09:45:54 [DEBUG] Running Sweeper (aws_sagemaker_workteam) in region (us-east-1)
2022/12/07 09:45:54 [INFO] Retrieved credentials from "EnvConfigCredentials"
2022/12/07 09:45:54 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/07 09:45:54 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/07 09:45:55 [DEBUG] Completed Sweeper (aws_sagemaker_workteam) in region (us-east-1) in 438.676438ms
2022/12/07 09:45:55 [DEBUG] Running Sweeper (aws_sagemaker_workforce) in region (us-east-1)
2022/12/07 09:45:55 [DEBUG] Completed Sweeper (aws_sagemaker_workforce) in region (us-east-1) in 51.456642ms
2022/12/07 09:45:55 [DEBUG] Sweeper (aws_sagemaker_workteam) already ran in region (us-east-1)
2022/12/07 09:45:55 [DEBUG] Sweeper (aws_vpc_endpoint_service) has dependency (aws_vpc_endpoint), running..
2022/12/07 09:45:55 [DEBUG] Sweeper (aws_vpc_endpoint) has dependency (aws_route_table), running..
2022/12/07 09:45:55 [DEBUG] Running Sweeper (aws_route_table) in region (us-east-1)
2022/12/07 09:45:55 [DEBUG] Completed Sweeper (aws_route_table) in region (us-east-1) in 347.192047ms
2022/12/07 09:45:55 [DEBUG] Sweeper (aws_vpc_endpoint) has dependency (aws_sagemaker_workforce), running..
2022/12/07 09:45:55 [DEBUG] Sweeper (aws_sagemaker_workforce) has dependency (aws_sagemaker_workteam), running..
2022/12/07 09:45:55 [DEBUG] Sweeper (aws_sagemaker_workteam) already ran in region (us-east-1)
2022/12/07 09:45:55 [DEBUG] Sweeper (aws_sagemaker_workforce) already ran in region (us-east-1)
2022/12/07 09:45:55 [DEBUG] Running Sweeper (aws_vpc_endpoint) in region (us-east-1)
2022/12/07 09:45:55 [DEBUG] Completed Sweeper (aws_vpc_endpoint) in region (us-east-1) in 55.681867ms
2022/12/07 09:45:55 [DEBUG] Running Sweeper (aws_vpc_endpoint_service) in region (us-east-1)
2022/12/07 09:45:55 [DEBUG] Completed Sweeper (aws_vpc_endpoint_service) in region (us-east-1) in 70.484915ms
2022/12/07 09:45:55 [DEBUG] Sweeper (aws_vpc_endpoint) has dependency (aws_route_table), running..
2022/12/07 09:45:55 [DEBUG] Sweeper (aws_route_table) already ran in region (us-east-1)
2022/12/07 09:45:55 [DEBUG] Sweeper (aws_vpc_endpoint) has dependency (aws_sagemaker_workforce), running..
2022/12/07 09:45:55 [DEBUG] Sweeper (aws_sagemaker_workforce) has dependency (aws_sagemaker_workteam), running..
2022/12/07 09:45:55 [DEBUG] Sweeper (aws_sagemaker_workteam) already ran in region (us-east-1)
2022/12/07 09:45:55 [DEBUG] Sweeper (aws_sagemaker_workforce) already ran in region (us-east-1)
2022/12/07 09:45:55 [DEBUG] Sweeper (aws_vpc_endpoint) already ran in region (us-east-1)
2022/12/07 09:45:55 [DEBUG] Sweeper (aws_route_table) already ran in region (us-east-1)
2022/12/07 09:45:55 [DEBUG] Running Sweeper (aws_ec2_carrier_gateway) in region (us-east-1)
2022/12/07 09:45:55 [DEBUG] Completed Sweeper (aws_ec2_carrier_gateway) in region (us-east-1) in 80.027403ms
2022/12/07 09:45:55 Completed Sweepers for region (us-east-1) in 1.043951247s
2022/12/07 09:45:55 Sweeper Tests for region (us-east-1) ran successfully:
	- aws_sagemaker_workteam
	- aws_sagemaker_workforce
	- aws_route_table
	- aws_vpc_endpoint
	- aws_vpc_endpoint_service
	- aws_ec2_carrier_gateway
2022/12/07 09:45:55 [DEBUG] Running Sweepers for region (us-east-2):
2022/12/07 09:45:55 [DEBUG] Sweeper (aws_vpc_endpoint) has dependency (aws_route_table), running..
2022/12/07 09:45:55 [DEBUG] Running Sweeper (aws_route_table) in region (us-east-2)
2022/12/07 09:45:55 [INFO] Retrieved credentials from "EnvConfigCredentials"
2022/12/07 09:45:55 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/07 09:45:55 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/07 09:45:56 [DEBUG] Completed Sweeper (aws_route_table) in region (us-east-2) in 478.794912ms
2022/12/07 09:45:56 [DEBUG] Sweeper (aws_vpc_endpoint) has dependency (aws_sagemaker_workforce), running..
2022/12/07 09:45:56 [DEBUG] Sweeper (aws_sagemaker_workforce) has dependency (aws_sagemaker_workteam), running..
2022/12/07 09:45:56 [DEBUG] Running Sweeper (aws_sagemaker_workteam) in region (us-east-2)
2022/12/07 09:45:56 [DEBUG] Completed Sweeper (aws_sagemaker_workteam) in region (us-east-2) in 323.786455ms
2022/12/07 09:45:56 [DEBUG] Running Sweeper (aws_sagemaker_workforce) in region (us-east-2)
2022/12/07 09:45:56 [DEBUG] Completed Sweeper (aws_sagemaker_workforce) in region (us-east-2) in 49.051262ms
2022/12/07 09:45:56 [DEBUG] Running Sweeper (aws_vpc_endpoint) in region (us-east-2)
2022/12/07 09:45:56 [DEBUG] Completed Sweeper (aws_vpc_endpoint) in region (us-east-2) in 53.28297ms
2022/12/07 09:45:56 [DEBUG] Sweeper (aws_route_table) already ran in region (us-east-2)
2022/12/07 09:45:56 [DEBUG] Running Sweeper (aws_ec2_carrier_gateway) in region (us-east-2)
2022/12/07 09:45:56 [WARN] Skipping EC2 Carrier Gateway sweep for us-east-2: UnsupportedOperation: The functionality you requested is not available in this region.
	status code: 400, request id: 6640a444-b236-43f7-87a8-8ab8f92b0be1
2022/12/07 09:45:56 [DEBUG] Completed Sweeper (aws_ec2_carrier_gateway) in region (us-east-2) in 146.490074ms
2022/12/07 09:45:56 [DEBUG] Sweeper (aws_sagemaker_workforce) has dependency (aws_sagemaker_workteam), running..
2022/12/07 09:45:56 [DEBUG] Sweeper (aws_sagemaker_workteam) already ran in region (us-east-2)
2022/12/07 09:45:56 [DEBUG] Sweeper (aws_sagemaker_workforce) already ran in region (us-east-2)
2022/12/07 09:45:56 [DEBUG] Sweeper (aws_sagemaker_workteam) already ran in region (us-east-2)
2022/12/07 09:45:56 [DEBUG] Sweeper (aws_vpc_endpoint_service) has dependency (aws_vpc_endpoint), running..
2022/12/07 09:45:56 [DEBUG] Sweeper (aws_vpc_endpoint) has dependency (aws_route_table), running..
2022/12/07 09:45:56 [DEBUG] Sweeper (aws_route_table) already ran in region (us-east-2)
2022/12/07 09:45:56 [DEBUG] Sweeper (aws_vpc_endpoint) has dependency (aws_sagemaker_workforce), running..
2022/12/07 09:45:56 [DEBUG] Sweeper (aws_sagemaker_workforce) has dependency (aws_sagemaker_workteam), running..
2022/12/07 09:45:56 [DEBUG] Sweeper (aws_sagemaker_workteam) already ran in region (us-east-2)
2022/12/07 09:45:56 [DEBUG] Sweeper (aws_sagemaker_workforce) already ran in region (us-east-2)
2022/12/07 09:45:56 [DEBUG] Sweeper (aws_vpc_endpoint) already ran in region (us-east-2)
2022/12/07 09:45:56 [DEBUG] Running Sweeper (aws_vpc_endpoint_service) in region (us-east-2)
2022/12/07 09:45:56 [DEBUG] Completed Sweeper (aws_vpc_endpoint_service) in region (us-east-2) in 152.995003ms
2022/12/07 09:45:56 Completed Sweepers for region (us-east-2) in 1.206677911s
2022/12/07 09:45:56 Sweeper Tests for region (us-east-2) ran successfully:
	- aws_route_table
	- aws_sagemaker_workteam
	- aws_sagemaker_workforce
	- aws_vpc_endpoint
	- aws_ec2_carrier_gateway
	- aws_vpc_endpoint_service
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	9.495s
% make sweep SWEEPARGS=-sweep-run=aws_ebs_volume,aws_key_pair,aws_launch_template,aws_network_interface SWEEP=us-east-2  
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-east-2 -sweep-run=aws_ebs_volume,aws_key_pair,aws_launch_template,aws_network_interface -timeout 60m
2022/12/07 10:33:20 [DEBUG] Running Sweepers for region (us-east-2):
2022/12/07 10:33:20 [DEBUG] Running Sweeper (aws_eks_addon) in region (us-east-2)
2022/12/07 10:33:20 [INFO] Retrieved credentials from "EnvConfigCredentials"
2022/12/07 10:33:20 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/07 10:33:20 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/07 10:33:20 [DEBUG] Completed Sweeper (aws_eks_addon) in region (us-east-2) in 498.360631ms
2022/12/07 10:33:20 [DEBUG] Sweeper (aws_ec2_transit_gateway_vpc_attachment) has dependency (aws_ec2_transit_gateway_connect), running..
2022/12/07 10:33:20 [DEBUG] Sweeper (aws_ec2_transit_gateway_connect) has dependency (aws_ec2_transit_gateway_connect_peer), running..
2022/12/07 10:33:20 [DEBUG] Running Sweeper (aws_ec2_transit_gateway_connect_peer) in region (us-east-2)
2022/12/07 10:33:21 [DEBUG] Completed Sweeper (aws_ec2_transit_gateway_connect_peer) in region (us-east-2) in 195.185473ms
2022/12/07 10:33:21 [DEBUG] Running Sweeper (aws_ec2_transit_gateway_connect) in region (us-east-2)
2022/12/07 10:33:21 [DEBUG] Completed Sweeper (aws_ec2_transit_gateway_connect) in region (us-east-2) in 59.4353ms
2022/12/07 10:33:21 [DEBUG] Sweeper (aws_ec2_transit_gateway_vpc_attachment) has dependency (aws_ec2_transit_gateway_multicast_domain), running..
2022/12/07 10:33:21 [DEBUG] Running Sweeper (aws_ec2_transit_gateway_multicast_domain) in region (us-east-2)
2022/12/07 10:33:21 [DEBUG] Completed Sweeper (aws_ec2_transit_gateway_multicast_domain) in region (us-east-2) in 118.473595ms
2022/12/07 10:33:21 [DEBUG] Running Sweeper (aws_ec2_transit_gateway_vpc_attachment) in region (us-east-2)
2022/12/07 10:33:21 [DEBUG] Completed Sweeper (aws_ec2_transit_gateway_vpc_attachment) in region (us-east-2) in 64.30291ms
2022/12/07 10:33:21 [DEBUG] Running Sweeper (aws_autoscaling_group) in region (us-east-2)
2022/12/07 10:33:21 [DEBUG] Completed Sweeper (aws_autoscaling_group) in region (us-east-2) in 268.801465ms
2022/12/07 10:33:21 [DEBUG] Sweeper (aws_launch_template) has dependency (aws_autoscaling_group), running..
2022/12/07 10:33:21 [DEBUG] Sweeper (aws_autoscaling_group) already ran in region (us-east-2)
2022/12/07 10:33:21 [DEBUG] Sweeper (aws_launch_template) has dependency (aws_batch_compute_environment), running..
2022/12/07 10:33:21 [DEBUG] Sweeper (aws_batch_compute_environment) has dependency (aws_batch_job_queue), running..
2022/12/07 10:33:21 [DEBUG] Running Sweeper (aws_batch_job_queue) in region (us-east-2)
2022/12/07 10:33:21 [DEBUG] Completed Sweeper (aws_batch_job_queue) in region (us-east-2) in 198.826913ms
2022/12/07 10:33:21 [DEBUG] Running Sweeper (aws_batch_compute_environment) in region (us-east-2)
2022/12/07 10:33:22 [DEBUG] Completed Sweeper (aws_batch_compute_environment) in region (us-east-2) in 111.243603ms
2022/12/07 10:33:22 [DEBUG] Running Sweeper (aws_launch_template) in region (us-east-2)
2022/12/07 10:33:22 [DEBUG] Completed Sweeper (aws_launch_template) in region (us-east-2) in 55.230015ms
2022/12/07 10:33:22 [DEBUG] Sweeper (aws_instance) has dependency (aws_autoscaling_group), running..
2022/12/07 10:33:22 [DEBUG] Sweeper (aws_autoscaling_group) already ran in region (us-east-2)
2022/12/07 10:33:22 [DEBUG] Sweeper (aws_instance) has dependency (aws_spot_fleet_request), running..
2022/12/07 10:33:22 [DEBUG] Running Sweeper (aws_spot_fleet_request) in region (us-east-2)
2022/12/07 10:33:22 [DEBUG] No Spot Fleet Requests to sweep
2022/12/07 10:33:22 [DEBUG] Completed Sweeper (aws_spot_fleet_request) in region (us-east-2) in 73.111586ms
2022/12/07 10:33:22 [DEBUG] Sweeper (aws_instance) has dependency (aws_spot_instance_request), running..
2022/12/07 10:33:22 [DEBUG] Running Sweeper (aws_spot_instance_request) in region (us-east-2)
2022/12/07 10:33:22 [DEBUG] No Spot Instance Requests to sweep
2022/12/07 10:33:22 [DEBUG] Completed Sweeper (aws_spot_instance_request) in region (us-east-2) in 144.343399ms
2022/12/07 10:33:22 [DEBUG] Running Sweeper (aws_instance) in region (us-east-2)
2022/12/07 10:33:22 [DEBUG] Completed Sweeper (aws_instance) in region (us-east-2) in 137.299528ms
2022/12/07 10:33:22 [DEBUG] Running Sweeper (aws_transfer_server) in region (us-east-2)
2022/12/07 10:33:22 [DEBUG] Completed Sweeper (aws_transfer_server) in region (us-east-2) in 175.683899ms
2022/12/07 10:33:22 [DEBUG] Sweeper (aws_ec2_transit_gateway_multicast_domain) already ran in region (us-east-2)
2022/12/07 10:33:22 [DEBUG] Running Sweeper (aws_db_proxy) in region (us-east-2)
2022/12/07 10:33:22 [DEBUG] Completed Sweeper (aws_db_proxy) in region (us-east-2) in 217.130269ms
2022/12/07 10:33:22 [DEBUG] Sweeper (aws_vpc_endpoint_service) has dependency (aws_vpc_endpoint), running..
2022/12/07 10:33:22 [DEBUG] Sweeper (aws_vpc_endpoint) has dependency (aws_route_table), running..
2022/12/07 10:33:22 [DEBUG] Running Sweeper (aws_route_table) in region (us-east-2)
2022/12/07 10:33:22 [DEBUG] Completed Sweeper (aws_route_table) in region (us-east-2) in 77.405109ms
2022/12/07 10:33:22 [DEBUG] Sweeper (aws_vpc_endpoint) has dependency (aws_sagemaker_workforce), running..
2022/12/07 10:33:22 [DEBUG] Sweeper (aws_sagemaker_workforce) has dependency (aws_sagemaker_workteam), running..
2022/12/07 10:33:22 [DEBUG] Running Sweeper (aws_sagemaker_workteam) in region (us-east-2)
2022/12/07 10:33:23 [DEBUG] Completed Sweeper (aws_sagemaker_workteam) in region (us-east-2) in 227.809363ms
2022/12/07 10:33:23 [DEBUG] Running Sweeper (aws_sagemaker_workforce) in region (us-east-2)
2022/12/07 10:33:23 [DEBUG] Completed Sweeper (aws_sagemaker_workforce) in region (us-east-2) in 68.011597ms
2022/12/07 10:33:23 [DEBUG] Running Sweeper (aws_vpc_endpoint) in region (us-east-2)
2022/12/07 10:33:23 [DEBUG] Completed Sweeper (aws_vpc_endpoint) in region (us-east-2) in 71.169312ms
2022/12/07 10:33:23 [DEBUG] Running Sweeper (aws_vpc_endpoint_service) in region (us-east-2)
2022/12/07 10:33:23 [DEBUG] Completed Sweeper (aws_vpc_endpoint_service) in region (us-east-2) in 151.803148ms
2022/12/07 10:33:23 [DEBUG] Running Sweeper (aws_appstream_directory_config) in region (us-east-2)
2022/12/07 10:33:23 [DEBUG] Completed Sweeper (aws_appstream_directory_config) in region (us-east-2) in 571.396967ms
2022/12/07 10:33:23 [DEBUG] Running Sweeper (aws_elastic_beanstalk_environment) in region (us-east-2)
2022/12/07 10:33:24 [DEBUG] No aws beanstalk environments to sweep
2022/12/07 10:33:24 [DEBUG] Completed Sweeper (aws_elastic_beanstalk_environment) in region (us-east-2) in 630.431056ms
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_key_pair) has dependency (aws_elastic_beanstalk_environment), running..
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_elastic_beanstalk_environment) already ran in region (us-east-2)
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_key_pair) has dependency (aws_instance), running..
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_instance) has dependency (aws_autoscaling_group), running..
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_autoscaling_group) already ran in region (us-east-2)
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_instance) has dependency (aws_spot_fleet_request), running..
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_spot_fleet_request) already ran in region (us-east-2)
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_instance) has dependency (aws_spot_instance_request), running..
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_spot_instance_request) already ran in region (us-east-2)
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_instance) already ran in region (us-east-2)
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_key_pair) has dependency (aws_spot_fleet_request), running..
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_spot_fleet_request) already ran in region (us-east-2)
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_key_pair) has dependency (aws_spot_instance_request), running..
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_spot_instance_request) already ran in region (us-east-2)
2022/12/07 10:33:24 [DEBUG] Running Sweeper (aws_key_pair) in region (us-east-2)
2022/12/07 10:33:24 [DEBUG] Completed Sweeper (aws_key_pair) in region (us-east-2) in 51.702224ms
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_vpc_endpoint) has dependency (aws_route_table), running..
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_route_table) already ran in region (us-east-2)
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_vpc_endpoint) has dependency (aws_sagemaker_workforce), running..
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_sagemaker_workforce) has dependency (aws_sagemaker_workteam), running..
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_sagemaker_workteam) already ran in region (us-east-2)
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_sagemaker_workforce) already ran in region (us-east-2)
2022/12/07 10:33:24 [DEBUG] Sweeper (aws_vpc_endpoint) already ran in region (us-east-2)
2022/12/07 10:33:24 [DEBUG] Running Sweeper (aws_connect_instance) in region (us-east-2)
2022/12/07 10:33:26 [WARN] Skipping Connect Instances sweep for us-east-2: 1 error occurred:
	* error listing Connect Instances: RequestError: send request failed
caused by: Get "https://connect.us-east-2.amazonaws.com/instance?maxResults=10": dial tcp: lookup connect.us-east-2.amazonaws.com: no such host

2022/12/07 10:33:26 [DEBUG] Completed Sweeper (aws_connect_instance) in region (us-east-2) in 1.458824669s
2022/12/07 10:33:26 [DEBUG] Sweeper (aws_ec2_transit_gateway_connect) has dependency (aws_ec2_transit_gateway_connect_peer), running..
2022/12/07 10:33:26 [DEBUG] Sweeper (aws_ec2_transit_gateway_connect_peer) already ran in region (us-east-2)
2022/12/07 10:33:26 [DEBUG] Sweeper (aws_ec2_transit_gateway_connect) already ran in region (us-east-2)
2022/12/07 10:33:26 [DEBUG] Running Sweeper (aws_lb_listener) in region (us-east-2)
2022/12/07 10:33:26 [DEBUG] No LBs to sweep
2022/12/07 10:33:26 [DEBUG] Completed Sweeper (aws_lb_listener) in region (us-east-2) in 531.036812ms
2022/12/07 10:33:26 [DEBUG] Running Sweeper (aws_opsworks_rds_db_instance) in region (us-east-2)
2022/12/07 10:33:26 [DEBUG] Completed Sweeper (aws_opsworks_rds_db_instance) in region (us-east-2) in 265.590507ms
2022/12/07 10:33:26 [DEBUG] Running Sweeper (aws_fsx_ontap_volume) in region (us-east-2)
2022/12/07 10:33:27 [DEBUG] Completed Sweeper (aws_fsx_ontap_volume) in region (us-east-2) in 1.030160882s
2022/12/07 10:33:27 [DEBUG] Sweeper (aws_network_interface) has dependency (aws_db_proxy), running..
2022/12/07 10:33:27 [DEBUG] Sweeper (aws_db_proxy) already ran in region (us-east-2)
2022/12/07 10:33:27 [DEBUG] Sweeper (aws_network_interface) has dependency (aws_directory_service_directory), running..
2022/12/07 10:33:27 [DEBUG] Sweeper (aws_directory_service_directory) has dependency (aws_appstream_directory_config), running..
2022/12/07 10:33:27 [DEBUG] Sweeper (aws_appstream_directory_config) already ran in region (us-east-2)
2022/12/07 10:33:27 [DEBUG] Sweeper (aws_directory_service_directory) has dependency (aws_connect_instance), running..
2022/12/07 10:33:27 [DEBUG] Sweeper (aws_connect_instance) already ran in region (us-east-2)
2022/12/07 10:33:27 [DEBUG] Sweeper (aws_directory_service_directory) has dependency (aws_db_instance), running..
2022/12/07 10:33:27 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_opsworks_rds_db_instance), running..
2022/12/07 10:33:27 [DEBUG] Sweeper (aws_opsworks_rds_db_instance) already ran in region (us-east-2)
2022/12/07 10:33:27 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_db_cluster_snapshot), running..
2022/12/07 10:33:27 [DEBUG] Running Sweeper (aws_db_cluster_snapshot) in region (us-east-2)
2022/12/07 10:33:27 [DEBUG] Completed Sweeper (aws_db_cluster_snapshot) in region (us-east-2) in 47.327223ms
2022/12/07 10:33:27 [DEBUG] Running Sweeper (aws_db_instance) in region (us-east-2)
2022/12/07 10:33:28 [DEBUG] Completed Sweeper (aws_db_instance) in region (us-east-2) in 34.786302ms
2022/12/07 10:33:28 [DEBUG] Sweeper (aws_directory_service_directory) has dependency (aws_ec2_client_vpn_endpoint), running..
2022/12/07 10:33:28 [DEBUG] Sweeper (aws_ec2_client_vpn_endpoint) has dependency (aws_ec2_client_vpn_network_association), running..
2022/12/07 10:33:28 [DEBUG] Running Sweeper (aws_ec2_client_vpn_network_association) in region (us-east-2)
2022/12/07 10:33:28 [DEBUG] Completed Sweeper (aws_ec2_client_vpn_network_association) in region (us-east-2) in 88.777996ms
2022/12/07 10:33:28 [DEBUG] Running Sweeper (aws_ec2_client_vpn_endpoint) in region (us-east-2)
2022/12/07 10:33:28 [DEBUG] Completed Sweeper (aws_ec2_client_vpn_endpoint) in region (us-east-2) in 87.080995ms
2022/12/07 10:33:28 [DEBUG] Sweeper (aws_directory_service_directory) has dependency (aws_fsx_ontap_storage_virtual_machine), running..
2022/12/07 10:33:28 [DEBUG] Sweeper (aws_fsx_ontap_storage_virtual_machine) has dependency (aws_fsx_ontap_volume), running..
2022/12/07 10:33:28 [DEBUG] Sweeper (aws_fsx_ontap_volume) already ran in region (us-east-2)
2022/12/07 10:33:28 [DEBUG] Running Sweeper (aws_fsx_ontap_storage_virtual_machine) in region (us-east-2)
2022/12/07 10:33:28 [DEBUG] Completed Sweeper (aws_fsx_ontap_storage_virtual_machine) in region (us-east-2) in 229.381294ms
2022/12/07 10:33:28 [DEBUG] Sweeper (aws_directory_service_directory) has dependency (aws_fsx_windows_file_system), running..
2022/12/07 10:33:28 [DEBUG] Running Sweeper (aws_fsx_windows_file_system) in region (us-east-2)
2022/12/07 10:33:28 [DEBUG] Completed Sweeper (aws_fsx_windows_file_system) in region (us-east-2) in 228.820979ms
2022/12/07 10:33:28 [DEBUG] Sweeper (aws_directory_service_directory) has dependency (aws_transfer_server), running..
2022/12/07 10:33:28 [DEBUG] Sweeper (aws_transfer_server) already ran in region (us-east-2)
2022/12/07 10:33:28 [DEBUG] Sweeper (aws_directory_service_directory) has dependency (aws_workspaces_directory), running..
2022/12/07 10:33:28 [DEBUG] Sweeper (aws_workspaces_directory) has dependency (aws_workspaces_workspace), running..
2022/12/07 10:33:28 [DEBUG] Running Sweeper (aws_workspaces_workspace) in region (us-east-2)
2022/12/07 10:33:30 [WARN] Skipping workspaces sweep for us-east-2: RequestError: send request failed
caused by: Post "https://workspaces.us-east-2.amazonaws.com/": dial tcp: lookup workspaces.us-east-2.amazonaws.com: no such host
2022/12/07 10:33:30 [DEBUG] Completed Sweeper (aws_workspaces_workspace) in region (us-east-2) in 1.55365333s
2022/12/07 10:33:30 [DEBUG] Sweeper (aws_workspaces_directory) has dependency (aws_workspaces_ip_group), running..
2022/12/07 10:33:30 [DEBUG] Running Sweeper (aws_workspaces_ip_group) in region (us-east-2)
2022/12/07 10:33:31 [WARN] Skipping WorkSpaces Ip Group sweep for us-east-2: RequestError: send request failed
caused by: Post "https://workspaces.us-east-2.amazonaws.com/": dial tcp: lookup workspaces.us-east-2.amazonaws.com: no such host
2022/12/07 10:33:31 [DEBUG] Completed Sweeper (aws_workspaces_ip_group) in region (us-east-2) in 1.516270841s
2022/12/07 10:33:31 [DEBUG] Running Sweeper (aws_workspaces_directory) in region (us-east-2)
2022/12/07 10:33:32 [WARN] Skipping WorkSpaces Directory sweep for us-east-2: RequestError: send request failed
caused by: Post "https://workspaces.us-east-2.amazonaws.com/": dial tcp: lookup workspaces.us-east-2.amazonaws.com: no such host
2022/12/07 10:33:32 [DEBUG] Completed Sweeper (aws_workspaces_directory) in region (us-east-2) in 1.230155909s
2022/12/07 10:33:32 [DEBUG] Sweeper (aws_directory_service_directory) has dependency (aws_directory_service_region), running..
2022/12/07 10:33:32 [DEBUG] Running Sweeper (aws_directory_service_region) in region (us-east-2)
2022/12/07 10:33:33 [DEBUG] Completed Sweeper (aws_directory_service_region) in region (us-east-2) in 520.468835ms
2022/12/07 10:33:33 [DEBUG] Running Sweeper (aws_directory_service_directory) in region (us-east-2)
2022/12/07 10:33:33 [DEBUG] Completed Sweeper (aws_directory_service_directory) in region (us-east-2) in 38.06168ms
2022/12/07 10:33:33 [DEBUG] Sweeper (aws_network_interface) has dependency (aws_ec2_client_vpn_endpoint), running..
2022/12/07 10:33:33 [DEBUG] Sweeper (aws_ec2_client_vpn_endpoint) has dependency (aws_ec2_client_vpn_network_association), running..
2022/12/07 10:33:33 [DEBUG] Sweeper (aws_ec2_client_vpn_network_association) already ran in region (us-east-2)
2022/12/07 10:33:33 [DEBUG] Sweeper (aws_ec2_client_vpn_endpoint) already ran in region (us-east-2)
2022/12/07 10:33:33 [DEBUG] Sweeper (aws_network_interface) has dependency (aws_ec2_transit_gateway_vpc_attachment), running..
2022/12/07 10:33:33 [DEBUG] Sweeper (aws_ec2_transit_gateway_vpc_attachment) has dependency (aws_ec2_transit_gateway_connect), running..
2022/12/07 10:33:33 [DEBUG] Sweeper (aws_ec2_transit_gateway_connect) has dependency (aws_ec2_transit_gateway_connect_peer), running..
2022/12/07 10:33:33 [DEBUG] Sweeper (aws_ec2_transit_gateway_connect_peer) already ran in region (us-east-2)
2022/12/07 10:33:33 [DEBUG] Sweeper (aws_ec2_transit_gateway_connect) already ran in region (us-east-2)
2022/12/07 10:33:33 [DEBUG] Sweeper (aws_ec2_transit_gateway_vpc_attachment) has dependency (aws_ec2_transit_gateway_multicast_domain), running..
2022/12/07 10:33:33 [DEBUG] Sweeper (aws_ec2_transit_gateway_multicast_domain) already ran in region (us-east-2)
2022/12/07 10:33:33 [DEBUG] Sweeper (aws_ec2_transit_gateway_vpc_attachment) already ran in region (us-east-2)
2022/12/07 10:33:33 [DEBUG] Sweeper (aws_network_interface) has dependency (aws_eks_cluster), running..
2022/12/07 10:33:33 [DEBUG] Sweeper (aws_eks_cluster) has dependency (aws_eks_addon), running..
2022/12/07 10:33:33 [DEBUG] Sweeper (aws_eks_addon) already ran in region (us-east-2)
2022/12/07 10:33:33 [DEBUG] Sweeper (aws_eks_cluster) has dependency (aws_eks_fargate_profile), running..
2022/12/07 10:33:33 [DEBUG] Running Sweeper (aws_eks_fargate_profile) in region (us-east-2)
2022/12/07 10:33:33 [DEBUG] Completed Sweeper (aws_eks_fargate_profile) in region (us-east-2) in 61.748125ms
2022/12/07 10:33:33 [DEBUG] Sweeper (aws_eks_cluster) has dependency (aws_eks_node_group), running..
2022/12/07 10:33:33 [DEBUG] Running Sweeper (aws_eks_node_group) in region (us-east-2)
2022/12/07 10:33:33 [DEBUG] Completed Sweeper (aws_eks_node_group) in region (us-east-2) in 62.257777ms
2022/12/07 10:33:33 [DEBUG] Sweeper (aws_eks_cluster) has dependency (aws_emrcontainers_virtual_cluster), running..
2022/12/07 10:33:33 [DEBUG] Running Sweeper (aws_emrcontainers_virtual_cluster) in region (us-east-2)
2022/12/07 10:33:34 [DEBUG] Completed Sweeper (aws_emrcontainers_virtual_cluster) in region (us-east-2) in 701.574505ms
2022/12/07 10:33:34 [DEBUG] Running Sweeper (aws_eks_cluster) in region (us-east-2)
2022/12/07 10:33:34 [DEBUG] Completed Sweeper (aws_eks_cluster) in region (us-east-2) in 67.239051ms
2022/12/07 10:33:34 [DEBUG] Sweeper (aws_network_interface) has dependency (aws_elb), running..
2022/12/07 10:33:34 [DEBUG] Running Sweeper (aws_elb) in region (us-east-2)
2022/12/07 10:33:34 [INFO] No ELBs found for sweeping
2022/12/07 10:33:34 [DEBUG] Completed Sweeper (aws_elb) in region (us-east-2) in 55.305136ms
2022/12/07 10:33:34 [DEBUG] Sweeper (aws_network_interface) has dependency (aws_instance), running..
2022/12/07 10:33:34 [DEBUG] Sweeper (aws_instance) has dependency (aws_autoscaling_group), running..
2022/12/07 10:33:34 [DEBUG] Sweeper (aws_autoscaling_group) already ran in region (us-east-2)
2022/12/07 10:33:34 [DEBUG] Sweeper (aws_instance) has dependency (aws_spot_fleet_request), running..
2022/12/07 10:33:34 [DEBUG] Sweeper (aws_spot_fleet_request) already ran in region (us-east-2)
2022/12/07 10:33:34 [DEBUG] Sweeper (aws_instance) has dependency (aws_spot_instance_request), running..
2022/12/07 10:33:34 [DEBUG] Sweeper (aws_spot_instance_request) already ran in region (us-east-2)
2022/12/07 10:33:34 [DEBUG] Sweeper (aws_instance) already ran in region (us-east-2)
2022/12/07 10:33:34 [DEBUG] Sweeper (aws_network_interface) has dependency (aws_lb), running..
2022/12/07 10:33:34 [DEBUG] Sweeper (aws_lb) has dependency (aws_api_gateway_vpc_link), running..
2022/12/07 10:33:34 [DEBUG] Running Sweeper (aws_api_gateway_vpc_link) in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] Completed Sweeper (aws_api_gateway_vpc_link) in region (us-east-2) in 548.010123ms
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_lb) has dependency (aws_vpc_endpoint_service), running..
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_vpc_endpoint_service) has dependency (aws_vpc_endpoint), running..
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_vpc_endpoint) has dependency (aws_route_table), running..
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_route_table) already ran in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_vpc_endpoint) has dependency (aws_sagemaker_workforce), running..
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_sagemaker_workforce) has dependency (aws_sagemaker_workteam), running..
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_sagemaker_workteam) already ran in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_sagemaker_workforce) already ran in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_vpc_endpoint) already ran in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_vpc_endpoint_service) already ran in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_lb) has dependency (aws_lb_listener), running..
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_lb_listener) already ran in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] Running Sweeper (aws_lb) in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] No LBs to sweep
2022/12/07 10:33:35 [DEBUG] Completed Sweeper (aws_lb) in region (us-east-2) in 57.554718ms
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_network_interface) has dependency (aws_nat_gateway), running..
2022/12/07 10:33:35 [DEBUG] Running Sweeper (aws_nat_gateway) in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] Completed Sweeper (aws_nat_gateway) in region (us-east-2) in 59.864459ms
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_network_interface) has dependency (aws_rds_cluster), running..
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_opsworks_rds_db_instance), running..
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_opsworks_rds_db_instance) already ran in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_db_cluster_snapshot), running..
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_db_cluster_snapshot) already ran in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_db_instance) already ran in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_cluster_snapshot), running..
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_db_cluster_snapshot) already ran in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] Running Sweeper (aws_rds_cluster) in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] Completed Sweeper (aws_rds_cluster) in region (us-east-2) in 41.011569ms
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_network_interface) has dependency (aws_rds_global_cluster), running..
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_rds_global_cluster) has dependency (aws_rds_cluster), running..
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_opsworks_rds_db_instance), running..
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_opsworks_rds_db_instance) already ran in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_db_cluster_snapshot), running..
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_db_cluster_snapshot) already ran in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_db_instance) already ran in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_cluster_snapshot), running..
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_db_cluster_snapshot) already ran in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] Sweeper (aws_rds_cluster) already ran in region (us-east-2)
2022/12/07 10:33:35 [DEBUG] Running Sweeper (aws_rds_global_cluster) in region (us-east-2)
2022/12/07 10:33:35 [INFO] Deleting RDS Global Cluster: tf-acc-test-1879441249946083452
2022/12/07 10:33:35 [ERROR] Failed to delete RDS Global Cluster (tf-acc-test-1879441249946083452): InvalidGlobalClusterStateFault: Global Cluster arn:aws:rds::187416307283:global-cluster:tf-acc-test-1879441249946083452 is not empty
	status code: 400, request id: e8c4036f-91f8-4126-8367-79fe0f840171
2022/12/07 10:33:35 [INFO] Deleting RDS Global Cluster: tf-acc-test-2818091595393174215
2022/12/07 10:33:36 [ERROR] Failed to delete RDS Global Cluster (tf-acc-test-2818091595393174215): InvalidGlobalClusterStateFault: Global Cluster arn:aws:rds::187416307283:global-cluster:tf-acc-test-2818091595393174215 is not empty
	status code: 400, request id: 6ed9e11e-59ef-4070-bd81-41af60801495
2022/12/07 10:33:36 [INFO] Deleting RDS Global Cluster: tf-acc-test-3889019509333212225
2022/12/07 10:33:36 [ERROR] Failed to delete RDS Global Cluster (tf-acc-test-3889019509333212225): InvalidGlobalClusterStateFault: Global Cluster arn:aws:rds::187416307283:global-cluster:tf-acc-test-3889019509333212225 is not empty
	status code: 400, request id: e32b67e7-d2f9-4c3a-8145-1c1708bad99a
2022/12/07 10:33:36 [INFO] Deleting RDS Global Cluster: tf-acc-test-5206781776592171390
2022/12/07 10:33:36 [ERROR] Failed to delete RDS Global Cluster (tf-acc-test-5206781776592171390): InvalidGlobalClusterStateFault: Global Cluster arn:aws:rds::187416307283:global-cluster:tf-acc-test-5206781776592171390 is not empty
	status code: 400, request id: 893a7ecc-ed2e-4e1f-9734-bb895e44b636
2022/12/07 10:33:36 [INFO] Deleting RDS Global Cluster: tf-acc-test-5313890248224861518
2022/12/07 10:33:37 [ERROR] Failed to delete RDS Global Cluster (tf-acc-test-5313890248224861518): InvalidGlobalClusterStateFault: Global Cluster arn:aws:rds::187416307283:global-cluster:tf-acc-test-5313890248224861518 is not empty
	status code: 400, request id: 33526214-1b31-4791-b58d-ab2281084267
2022/12/07 10:33:37 [INFO] Deleting RDS Global Cluster: tf-acc-test-5675574290613652085
2022/12/07 10:33:37 [ERROR] Failed to delete RDS Global Cluster (tf-acc-test-5675574290613652085): InvalidGlobalClusterStateFault: Global Cluster arn:aws:rds::187416307283:global-cluster:tf-acc-test-5675574290613652085 is not empty
	status code: 400, request id: 591f9201-0eeb-4f16-bc51-b7c7b8c14be6
2022/12/07 10:33:37 [INFO] Deleting RDS Global Cluster: tf-acc-test-7919375150444781084
2022/12/07 10:33:37 [ERROR] Failed to delete RDS Global Cluster (tf-acc-test-7919375150444781084): InvalidGlobalClusterStateFault: Global Cluster arn:aws:rds::187416307283:global-cluster:tf-acc-test-7919375150444781084 is not empty
	status code: 400, request id: 12f265ee-e399-483d-870e-47dd92b5b695
2022/12/07 10:33:37 [DEBUG] Completed Sweeper (aws_rds_global_cluster) in region (us-east-2) in 2.638778179s
2022/12/07 10:33:37 [DEBUG] Running Sweeper (aws_network_interface) in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Completed Sweeper (aws_network_interface) in region (us-east-2) in 71.365811ms
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_workspaces_directory) has dependency (aws_workspaces_workspace), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_workspaces_workspace) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_workspaces_directory) has dependency (aws_workspaces_ip_group), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_workspaces_ip_group) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_workspaces_directory) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_workspaces_workspace) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_ec2_client_vpn_network_association) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_ec2_client_vpn_endpoint) has dependency (aws_ec2_client_vpn_network_association), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_ec2_client_vpn_network_association) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_ec2_client_vpn_endpoint) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_opsworks_rds_db_instance), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_opsworks_rds_db_instance) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_db_cluster_snapshot), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_cluster_snapshot) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_instance) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_sagemaker_workforce) has dependency (aws_sagemaker_workteam), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_sagemaker_workteam) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_sagemaker_workforce) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_lb) has dependency (aws_api_gateway_vpc_link), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_api_gateway_vpc_link) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_lb) has dependency (aws_vpc_endpoint_service), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_vpc_endpoint_service) has dependency (aws_vpc_endpoint), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_vpc_endpoint) has dependency (aws_route_table), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_route_table) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_vpc_endpoint) has dependency (aws_sagemaker_workforce), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_sagemaker_workforce) has dependency (aws_sagemaker_workteam), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_sagemaker_workteam) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_sagemaker_workforce) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_vpc_endpoint) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_vpc_endpoint_service) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_lb) has dependency (aws_lb_listener), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_lb_listener) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_lb) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_emrcontainers_virtual_cluster) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_directory_service_region) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_sagemaker_workteam) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_opsworks_rds_db_instance), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_opsworks_rds_db_instance) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_db_cluster_snapshot), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_cluster_snapshot) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_instance) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_cluster_snapshot), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_cluster_snapshot) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_rds_cluster) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_spot_instance_request) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_eks_cluster) has dependency (aws_eks_addon), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_eks_addon) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_eks_cluster) has dependency (aws_eks_fargate_profile), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_eks_fargate_profile) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_eks_cluster) has dependency (aws_eks_node_group), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_eks_node_group) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_eks_cluster) has dependency (aws_emrcontainers_virtual_cluster), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_emrcontainers_virtual_cluster) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_eks_cluster) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_workspaces_ip_group) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_nat_gateway) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_fsx_ontap_storage_virtual_machine) has dependency (aws_fsx_ontap_volume), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_fsx_ontap_volume) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_fsx_ontap_storage_virtual_machine) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_fsx_windows_file_system) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_spot_fleet_request) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_ebs_volume) has dependency (aws_instance), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_instance) has dependency (aws_autoscaling_group), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_autoscaling_group) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_instance) has dependency (aws_spot_fleet_request), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_spot_fleet_request) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_instance) has dependency (aws_spot_instance_request), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_spot_instance_request) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_instance) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Running Sweeper (aws_ebs_volume) in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Completed Sweeper (aws_ebs_volume) in region (us-east-2) in 71.710034ms
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_eks_fargate_profile) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_rds_global_cluster) has dependency (aws_rds_cluster), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_opsworks_rds_db_instance), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_opsworks_rds_db_instance) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_db_cluster_snapshot), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_cluster_snapshot) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_instance) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_cluster_snapshot), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_cluster_snapshot) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_rds_cluster) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_rds_global_cluster) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_directory_service_directory) has dependency (aws_appstream_directory_config), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_appstream_directory_config) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_directory_service_directory) has dependency (aws_connect_instance), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_connect_instance) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_directory_service_directory) has dependency (aws_db_instance), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_opsworks_rds_db_instance), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_opsworks_rds_db_instance) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_db_cluster_snapshot), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_cluster_snapshot) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_instance) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_directory_service_directory) has dependency (aws_ec2_client_vpn_endpoint), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_ec2_client_vpn_endpoint) has dependency (aws_ec2_client_vpn_network_association), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_ec2_client_vpn_network_association) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_ec2_client_vpn_endpoint) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_directory_service_directory) has dependency (aws_fsx_ontap_storage_virtual_machine), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_fsx_ontap_storage_virtual_machine) has dependency (aws_fsx_ontap_volume), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_fsx_ontap_volume) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_fsx_ontap_storage_virtual_machine) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_directory_service_directory) has dependency (aws_fsx_windows_file_system), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_fsx_windows_file_system) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_directory_service_directory) has dependency (aws_transfer_server), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_transfer_server) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_directory_service_directory) has dependency (aws_workspaces_directory), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_workspaces_directory) has dependency (aws_workspaces_workspace), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_workspaces_workspace) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_workspaces_directory) has dependency (aws_workspaces_ip_group), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_workspaces_ip_group) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_workspaces_directory) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_directory_service_directory) has dependency (aws_directory_service_region), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_directory_service_region) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_directory_service_directory) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_batch_compute_environment) has dependency (aws_batch_job_queue), running..
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_batch_job_queue) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_batch_compute_environment) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_elb) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_ec2_transit_gateway_connect_peer) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_db_cluster_snapshot) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_batch_job_queue) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_api_gateway_vpc_link) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_route_table) already ran in region (us-east-2)
2022/12/07 10:33:37 [DEBUG] Sweeper (aws_eks_node_group) already ran in region (us-east-2)
2022/12/07 10:33:37 Completed Sweepers for region (us-east-2) in 17.467837582s
2022/12/07 10:33:37 Sweeper Tests for region (us-east-2) ran successfully:
	- aws_ebs_volume
	- aws_eks_addon
	- aws_ec2_transit_gateway_multicast_domain
	- aws_fsx_ontap_volume
	- aws_batch_compute_environment
	- aws_spot_instance_request
	- aws_instance
	- aws_appstream_directory_config
	- aws_elastic_beanstalk_environment
	- aws_ec2_client_vpn_endpoint
	- aws_workspaces_workspace
	- aws_elb
	- aws_api_gateway_vpc_link
	- aws_ec2_transit_gateway_connect
	- aws_ec2_transit_gateway_vpc_attachment
	- aws_directory_service_region
	- aws_directory_service_directory
	- aws_autoscaling_group
	- aws_db_proxy
	- aws_vpc_endpoint_service
	- aws_key_pair
	- aws_eks_cluster
	- aws_lb
	- aws_rds_cluster
	- aws_network_interface
	- aws_launch_template
	- aws_sagemaker_workforce
	- aws_opsworks_rds_db_instance
	- aws_workspaces_directory
	- aws_emrcontainers_virtual_cluster
	- aws_nat_gateway
	- aws_rds_global_cluster
	- aws_spot_fleet_request
	- aws_sagemaker_workteam
	- aws_connect_instance
	- aws_lb_listener
	- aws_db_cluster_snapshot
	- aws_ec2_client_vpn_network_association
	- aws_fsx_windows_file_system
	- aws_eks_fargate_profile
	- aws_eks_node_group
	- aws_ec2_transit_gateway_connect_peer
	- aws_batch_job_queue
	- aws_transfer_server
	- aws_route_table
	- aws_vpc_endpoint
	- aws_db_instance
	- aws_fsx_ontap_storage_virtual_machine
	- aws_workspaces_ip_group
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	21.878s
% make sweep SWEEPARGS=-sweep-run=aws_ecs_task_definition,aws_ecs_task_definition SWEEP=us-east-1,us-east-2
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-east-1,us-east-2 -sweep-run=aws_ecs_task_definition,aws_ecs_task_definition -timeout 60m
2022/12/07 10:48:32 [DEBUG] Running Sweepers for region (us-east-1):
2022/12/07 10:48:32 [DEBUG] Sweeper (aws_ecs_task_definition) has dependency (aws_ecs_service), running..
2022/12/07 10:48:32 [DEBUG] Running Sweeper (aws_ecs_service) in region (us-east-1)
2022/12/07 10:48:32 [INFO] Retrieved credentials from "EnvConfigCredentials"
2022/12/07 10:48:32 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/07 10:48:32 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/07 10:48:33 [DEBUG] Completed Sweeper (aws_ecs_service) in region (us-east-1) in 588.198277ms
2022/12/07 10:48:33 [DEBUG] Running Sweeper (aws_ecs_task_definition) in region (us-east-1)
2022/12/07 10:48:33 [DEBUG] Completed Sweeper (aws_ecs_task_definition) in region (us-east-1) in 106.268589ms
2022/12/07 10:48:33 [DEBUG] Sweeper (aws_ecs_service) already ran in region (us-east-1)
2022/12/07 10:48:33 Completed Sweepers for region (us-east-1) in 694.66027ms
2022/12/07 10:48:33 Sweeper Tests for region (us-east-1) ran successfully:
	- aws_ecs_service
	- aws_ecs_task_definition
2022/12/07 10:48:33 [DEBUG] Running Sweepers for region (us-east-2):
2022/12/07 10:48:33 [DEBUG] Sweeper (aws_ecs_task_definition) has dependency (aws_ecs_service), running..
2022/12/07 10:48:33 [DEBUG] Running Sweeper (aws_ecs_service) in region (us-east-2)
2022/12/07 10:48:33 [INFO] Retrieved credentials from "EnvConfigCredentials"
2022/12/07 10:48:33 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/07 10:48:33 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/07 10:48:33 [DEBUG] Completed Sweeper (aws_ecs_service) in region (us-east-2) in 406.227371ms
2022/12/07 10:48:33 [DEBUG] Running Sweeper (aws_ecs_task_definition) in region (us-east-2)
2022/12/07 10:48:33 [DEBUG] Completed Sweeper (aws_ecs_task_definition) in region (us-east-2) in 33.400444ms
2022/12/07 10:48:33 [DEBUG] Sweeper (aws_ecs_service) already ran in region (us-east-2)
2022/12/07 10:48:33 Completed Sweepers for region (us-east-2) in 439.679315ms
2022/12/07 10:48:33 Sweeper Tests for region (us-east-2) ran successfully:
	- aws_ecs_service
	- aws_ecs_task_definition
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	5.664s
% make sweep SWEEPARGS=-sweep-run=aws_globalaccelerator_accelerator SWEEP=us-east-1,us-east-2
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-east-1,us-east-2 -sweep-run=aws_globalaccelerator_accelerator -timeout 60m
2022/12/07 11:20:29 [DEBUG] Running Sweepers for region (us-east-1):
2022/12/07 11:20:29 [DEBUG] Sweeper (aws_globalaccelerator_accelerator) has dependency (aws_globalaccelerator_listener), running..
2022/12/07 11:20:29 [DEBUG] Sweeper (aws_globalaccelerator_listener) has dependency (aws_globalaccelerator_endpoint_group), running..
2022/12/07 11:20:29 [DEBUG] Running Sweeper (aws_globalaccelerator_endpoint_group) in region (us-east-1)
2022/12/07 11:20:29 [INFO] Retrieved credentials from "EnvConfigCredentials"
2022/12/07 11:20:29 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/07 11:20:29 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/07 11:20:30 [DEBUG] Completed Sweeper (aws_globalaccelerator_endpoint_group) in region (us-east-1) in 685.532797ms
2022/12/07 11:20:30 [DEBUG] Running Sweeper (aws_globalaccelerator_listener) in region (us-east-1)
2022/12/07 11:20:30 [DEBUG] Completed Sweeper (aws_globalaccelerator_listener) in region (us-east-1) in 122.775551ms
2022/12/07 11:20:30 [DEBUG] Running Sweeper (aws_globalaccelerator_accelerator) in region (us-east-1)
2022/12/07 11:20:30 [DEBUG] Completed Sweeper (aws_globalaccelerator_accelerator) in region (us-east-1) in 146.841419ms
2022/12/07 11:20:30 [DEBUG] Sweeper (aws_globalaccelerator_listener) has dependency (aws_globalaccelerator_endpoint_group), running..
2022/12/07 11:20:30 [DEBUG] Sweeper (aws_globalaccelerator_endpoint_group) already ran in region (us-east-1)
2022/12/07 11:20:30 [DEBUG] Sweeper (aws_globalaccelerator_listener) already ran in region (us-east-1)
2022/12/07 11:20:30 [DEBUG] Sweeper (aws_globalaccelerator_endpoint_group) already ran in region (us-east-1)
2022/12/07 11:20:30 Completed Sweepers for region (us-east-1) in 955.406749ms
2022/12/07 11:20:30 Sweeper Tests for region (us-east-1) ran successfully:
	- aws_globalaccelerator_endpoint_group
	- aws_globalaccelerator_listener
	- aws_globalaccelerator_accelerator
2022/12/07 11:20:30 [DEBUG] Running Sweepers for region (us-east-2):
2022/12/07 11:20:30 [DEBUG] Sweeper (aws_globalaccelerator_accelerator) has dependency (aws_globalaccelerator_listener), running..
2022/12/07 11:20:30 [DEBUG] Sweeper (aws_globalaccelerator_listener) has dependency (aws_globalaccelerator_endpoint_group), running..
2022/12/07 11:20:30 [DEBUG] Running Sweeper (aws_globalaccelerator_endpoint_group) in region (us-east-2)
2022/12/07 11:20:30 [INFO] Retrieved credentials from "EnvConfigCredentials"
2022/12/07 11:20:30 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/07 11:20:30 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/07 11:20:31 [DEBUG] Completed Sweeper (aws_globalaccelerator_endpoint_group) in region (us-east-2) in 599.191734ms
2022/12/07 11:20:31 [DEBUG] Running Sweeper (aws_globalaccelerator_listener) in region (us-east-2)
2022/12/07 11:20:31 [DEBUG] Completed Sweeper (aws_globalaccelerator_listener) in region (us-east-2) in 128.813625ms
2022/12/07 11:20:31 [DEBUG] Running Sweeper (aws_globalaccelerator_accelerator) in region (us-east-2)
2022/12/07 11:20:31 [DEBUG] Completed Sweeper (aws_globalaccelerator_accelerator) in region (us-east-2) in 136.757814ms
2022/12/07 11:20:31 [DEBUG] Sweeper (aws_globalaccelerator_listener) has dependency (aws_globalaccelerator_endpoint_group), running..
2022/12/07 11:20:31 [DEBUG] Sweeper (aws_globalaccelerator_endpoint_group) already ran in region (us-east-2)
2022/12/07 11:20:31 [DEBUG] Sweeper (aws_globalaccelerator_listener) already ran in region (us-east-2)
2022/12/07 11:20:31 [DEBUG] Sweeper (aws_globalaccelerator_endpoint_group) already ran in region (us-east-2)
2022/12/07 11:20:31 Completed Sweepers for region (us-east-2) in 864.883469ms
2022/12/07 11:20:31 Sweeper Tests for region (us-east-2) ran successfully:
	- aws_globalaccelerator_listener
	- aws_globalaccelerator_accelerator
	- aws_globalaccelerator_endpoint_group
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	6.565s
```
