### PR TITLE
(docs): Inform about potential traffic blocking

### DIFF
--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -21,6 +21,8 @@ a conflict of rule settings and will overwrite rules.
 
 ~> **NOTE:** Due to [AWS Lambda improved VPC networking changes that began deploying in September 2019](https://aws.amazon.com/blogs/compute/announcing-improved-vpc-networking-for-aws-lambda-functions/), security groups associated with Lambda Functions can take up to 45 minutes to successfully delete. Terraform AWS Provider version 2.31.0 and later automatically handles this increased timeout, however prior versions require setting the [customizable deletion timeout](#timeouts) to 45 minutes (`delete = "45m"`). AWS and HashiCorp are working together to reduce the amount of time required for resource deletion and updates can be tracked in this [GitHub issue](https://github.com/hashicorp/terraform-provider-aws/issues/10329).
 
+~> **NOTE:** The `cidr_blocks` and `ipv6_cidr_blocks` parameters is an optional parameter in the ingress and egress block. If nothing is spesified, the traffic will be blocked as described in the note later in this page redarding Egress rules.
+
 ## Example Usage
 
 ### Basic Usage

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -21,7 +21,7 @@ a conflict of rule settings and will overwrite rules.
 
 ~> **NOTE:** Due to [AWS Lambda improved VPC networking changes that began deploying in September 2019](https://aws.amazon.com/blogs/compute/announcing-improved-vpc-networking-for-aws-lambda-functions/), security groups associated with Lambda Functions can take up to 45 minutes to successfully delete. Terraform AWS Provider version 2.31.0 and later automatically handles this increased timeout, however prior versions require setting the [customizable deletion timeout](#timeouts) to 45 minutes (`delete = "45m"`). AWS and HashiCorp are working together to reduce the amount of time required for resource deletion and updates can be tracked in this [GitHub issue](https://github.com/hashicorp/terraform-provider-aws/issues/10329).
 
-~> **NOTE:** The `cidr_blocks` and `ipv6_cidr_blocks` parameters is an optional parameter in the ingress and egress block. If nothing is spesified, the traffic will be blocked as described in the note later in this page redarding Egress rules.
+~> **NOTE:** The `cidr_blocks` and `ipv6_cidr_blocks` parameters are optional in the `ingress` and `egress` blocks. If nothing is specified, traffic will be blocked as described in _NOTE on Egress rules_ later.
 
 ## Example Usage
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
As mentioned in issue #27820 traffic can be blocked on a resource if you create a security group without any of the available `cidr_block` parameters. It's intentional to have these optional so that you're not forced to have all of them present if you only need one or the other. A note should be present informing the user about that not providing any of them could lead to your traffic being blocked. 


### Relations
Closes #27820 
