### PR TITLE
Release: Restore provider version in HTTP User-Agent strings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,7 +36,7 @@ builds:
       - goarch: arm64
         goos: openbsd
     ldflags:
-      - -s -w -X version.ProviderVersion={{.Version}}
+      - -s -w -X 'github.com/hashicorp/terraform-provider-aws/version.ProviderVersion={{ .Version }}'
     mod_timestamp: '{{ .CommitTimestamp }}'
 checksum:
   algorithm: sha256


### PR DESCRIPTION
Due to a change in the release process or Go tooling, the released version of the provider was incorrectly sending `dev` as the provider version in HTTP User-Agent strings. Restore the actual version.

Previously, setting

```
-ldflags ... -X version.ProviderVersion={{ .Version }}
```

worked. We now need to specify the full path of the variable if it is not in the `main` package, i.e.

```
-ldflags ... -X 'github.com/hashicorp/terraform-provider-aws/version.ProviderVersion={{ .Version }}'
```

## Testing

Using [development override](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers):

```hcl
provider_installation {

  dev_overrides {
    "hashicorp/aws" = "<provider-code-directory>/dist/terraform-provider-aws_darwin_amd64_v1"
  }

  direct {}
}
```

### Previously

```console
$ goreleaser build --single-target --debug --rm-dist --skip-validate
$ TF_LOG=DEBUG terraform plan
...
User-Agent: APN/1.0 HashiCorp/1.0 Terraform/1.2.9 (+https://www.terraform.io) terraform-provider-aws/dev (+https://registry.terraform.io/providers/hashicorp/aws) aws-sdk-go/1.44.153 (go1.19.3; darwin; amd64)
```

### Now

```console
$ goreleaser build --single-target --debug --rm-dist --skip-validate
$ TF_LOG=DEBUG terraform plan
...
User-Agent: APN/1.0 HashiCorp/1.0 Terraform/1.2.9 (+https://www.terraform.io) terraform-provider-aws/4.45.0 (+https://registry.terraform.io/providers/hashicorp/aws) aws-sdk-go/1.44.153 (go1.19.3; darwin; amd64)
```