### PR TITLE
add aws_ssoadmin_permissions_boundary_attachment resource

### DIFF
--- a/.changelog/28241.txt
+++ b/.changelog/28241.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_ssoadmin_permissions_boundary_attachment
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2166,6 +2166,7 @@ func New(_ context.Context) (*schema.Provider, error) {
 			"aws_ssoadmin_managed_policy_attachment":          ssoadmin.ResourceManagedPolicyAttachment(),
 			"aws_ssoadmin_permission_set":                     ssoadmin.ResourcePermissionSet(),
 			"aws_ssoadmin_permission_set_inline_policy":       ssoadmin.ResourcePermissionSetInlinePolicy(),
+			"aws_ssoadmin_permissions_boundary_attachment":    ssoadmin.ResourcePermissionsBoundaryAttachment(),
 
 			"aws_storagegateway_cache":                   storagegateway.ResourceCache(),
 			"aws_storagegateway_cached_iscsi_volume":     storagegateway.ResourceCachediSCSIVolume(),

--- a/internal/service/ssoadmin/find.go
+++ b/internal/service/ssoadmin/find.go
@@ -117,3 +117,27 @@ func FindCustomerManagedPolicy(conn *ssoadmin.SSOAdmin, policyName, policyPath, 
 
 	return attachedPolicy, nil
 }
+
+// FindPermissionsBoundary returns the permissions boundary attached to a permission set within a specified SSO instance.
+// Returns an error if no permissions boundary is found.
+func FindPermissionsBoundary(conn *ssoadmin.SSOAdmin, permissionSetArn, instanceArn string) (*ssoadmin.PermissionsBoundary, error) {
+	input := &ssoadmin.GetPermissionsBoundaryForPermissionSetInput{
+		PermissionSetArn: aws.String(permissionSetArn),
+		InstanceArn:      aws.String(instanceArn),
+	}
+
+	output, err := conn.GetPermissionsBoundaryForPermissionSet(input)
+
+	if tfawserr.ErrCodeEquals(err, ssoadmin.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return output.PermissionsBoundary, nil
+}

--- a/internal/service/ssoadmin/permissions_boundary_attachment.go
+++ b/internal/service/ssoadmin/permissions_boundary_attachment.go
@@ -31,6 +31,18 @@ func ResourcePermissionsBoundaryAttachment() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"instance_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"permission_set_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
 			"permissions_boundary": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -70,18 +82,6 @@ func ResourcePermissionsBoundaryAttachment() *schema.Resource {
 						},
 					},
 				},
-			},
-			"instance_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"permission_set_arn": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
 			},
 		},
 	}

--- a/internal/service/ssoadmin/permissions_boundary_attachment.go
+++ b/internal/service/ssoadmin/permissions_boundary_attachment.go
@@ -1,0 +1,239 @@
+package ssoadmin
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ssoadmin"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+const (
+	permissionsBoundaryAttachmentTimeout = 5 * time.Minute
+)
+
+func ResourcePermissionsBoundaryAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePermissionsBoundaryAttachmentCreate,
+		Read:   resourcePermissionsBoundaryAttachmentRead,
+		Delete: resourcePermissionsBoundaryAttachmentDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"permissions_boundary": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"customer_managed_policy_reference": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringLenBetween(0, 128),
+									},
+									"path": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Default:      "/",
+										ForceNew:     true,
+										ValidateFunc: validation.StringLenBetween(0, 512),
+									},
+								},
+							},
+						},
+						"managed_policy_arn": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "",
+							ForceNew:     true,
+							ValidateFunc: validation.StringLenBetween(0, 2048),
+						},
+					},
+				},
+			},
+			"instance_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"permission_set_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+		},
+	}
+}
+
+func resourcePermissionsBoundaryAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).SSOAdminConn
+
+	tfMap := d.Get("permissions_boundary").([]interface{})[0].(map[string]interface{})
+	instanceARN := d.Get("instance_arn").(string)
+	permissionSetARN := d.Get("permission_set_arn").(string)
+	id := PermissionsBoundaryAttachmentCreateResourceID(permissionSetARN, instanceARN)
+	input := &ssoadmin.PutPermissionsBoundaryToPermissionSetInput{
+		PermissionsBoundary: expandPermissionsBoundary(tfMap),
+		InstanceArn:         aws.String(instanceARN),
+		PermissionSetArn:    aws.String(permissionSetARN),
+	}
+
+	log.Printf("[INFO] Attaching permissions boundary to permission set: %s", input)
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(permissionsBoundaryAttachmentTimeout, func() (interface{}, error) {
+		return conn.PutPermissionsBoundaryToPermissionSet(input)
+	}, ssoadmin.ErrCodeConflictException, ssoadmin.ErrCodeThrottlingException)
+
+	if err != nil {
+		return fmt.Errorf("creating SSO Permissions Boundary Attachment (%s): %w", id, err)
+	}
+
+	d.SetId(id)
+
+	// After the policy has been attached to the permission set, provision in all accounts that use this permission set.
+	if err := provisionPermissionSet(conn, permissionSetARN, instanceARN); err != nil {
+		return err
+	}
+
+	return resourcePermissionsBoundaryAttachmentRead(d, meta)
+}
+
+func resourcePermissionsBoundaryAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).SSOAdminConn
+
+	permissionSetARN, instanceARN, err := PermissionsBoundaryAttachmentParseResourceID(d.Id())
+
+	if err != nil {
+		return err
+	}
+
+	policy, err := FindPermissionsBoundary(conn, permissionSetARN, instanceARN)
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] SSO Permissions Boundary Attachment (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("reading SSO Permissions Boundary Attachment (%s): %w", d.Id(), err)
+	}
+
+	if err := d.Set("permissions_boundary", []interface{}{flattenPermissionsBoundary(policy)}); err != nil {
+		return fmt.Errorf("setting permissions_boundary: %w", err)
+	}
+	d.Set("instance_arn", instanceARN)
+	d.Set("permission_set_arn", permissionSetARN)
+
+	return nil
+}
+
+func resourcePermissionsBoundaryAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*conns.AWSClient).SSOAdminConn
+
+	permissionSetARN, instanceARN, err := PermissionsBoundaryAttachmentParseResourceID(d.Id())
+
+	if err != nil {
+		return err
+	}
+
+	input := &ssoadmin.DeletePermissionsBoundaryFromPermissionSetInput{
+		InstanceArn:      aws.String(instanceARN),
+		PermissionSetArn: aws.String(permissionSetARN),
+	}
+
+	log.Printf("[INFO] Detaching permissions boundary from permission set: %s", input)
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(permissionsBoundaryAttachmentTimeout, func() (interface{}, error) {
+		return conn.DeletePermissionsBoundaryFromPermissionSet(input)
+	}, ssoadmin.ErrCodeConflictException, ssoadmin.ErrCodeThrottlingException)
+
+	if tfawserr.ErrCodeEquals(err, ssoadmin.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("deleting SSO Permissions Boundary Attachment (%s): %w", d.Id(), err)
+	}
+
+	// After the policy has been detached from the permission set, provision in all accounts that use this permission set.
+	if err := provisionPermissionSet(conn, permissionSetARN, instanceARN); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+const permissionsBoundaryAttachmentIDSeparator = ","
+
+func PermissionsBoundaryAttachmentCreateResourceID(permissionSetARN, instanceARN string) string {
+	parts := []string{permissionSetARN, instanceARN}
+	id := strings.Join(parts, permissionsBoundaryAttachmentIDSeparator)
+
+	return id
+}
+
+func PermissionsBoundaryAttachmentParseResourceID(id string) (string, string, error) {
+	parts := strings.Split(id, permissionsBoundaryAttachmentIDSeparator)
+
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+		return parts[0], parts[1], nil
+	}
+
+	return "", "", fmt.Errorf("unexpected format for ID (%[1]s), expected PERMISSION_SET_ARN%[2]sINSTANCE_ARN", id, permissionsBoundaryAttachmentIDSeparator)
+}
+
+func expandPermissionsBoundary(tfMap map[string]interface{}) *ssoadmin.PermissionsBoundary {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &ssoadmin.PermissionsBoundary{}
+
+	if v, ok := tfMap["customer_managed_policy_reference"].([]interface{}); ok && len(v) > 0 {
+		if cmpr, ok := v[0].(map[string]interface{}); ok {
+			apiObject.CustomerManagedPolicyReference = expandCustomerManagedPolicyReference(cmpr)
+		}
+	}
+	if v, ok := tfMap["managed_policy_arn"].(string); ok && v != "" {
+		apiObject.ManagedPolicyArn = aws.String(v)
+	}
+
+	return apiObject
+}
+
+func flattenPermissionsBoundary(apiObject *ssoadmin.PermissionsBoundary) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.ManagedPolicyArn; v != nil {
+		tfMap["managed_policy_arn"] = aws.StringValue(v)
+	} else if v := apiObject.CustomerManagedPolicyReference; v != nil {
+		tfMap["customer_managed_policy_reference"] = []map[string]interface{}{flattenCustomerManagedPolicyReference(v)}
+	}
+
+	return tfMap
+}

--- a/internal/service/ssoadmin/permissions_boundary_attachment_test.go
+++ b/internal/service/ssoadmin/permissions_boundary_attachment_test.go
@@ -289,12 +289,14 @@ resource "aws_ssoadmin_permissions_boundary_attachment" "test" {
 
 func testAccPermissionsBoundaryAttachmentConfig_managedPolicyAndCustomerManagedPolicyRefBothDefined(rName, rNamePolicy1, rNamePolicy2 string) string {
 	return acctest.ConfigCompose(testAccPermissionsBoundaryAttachmentConfig_base(rName, rNamePolicy1, rNamePolicy2), `
+data "aws_partition" "partition" {}
+
 resource "aws_ssoadmin_permissions_boundary_attachment" "test" {
   instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.test.arn
 
   permissions_boundary {
-    managed_policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+    managed_policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/ReadOnlyAccess"
     customer_managed_policy_reference {
       name = aws_iam_policy.test1.name
       path = "/"

--- a/internal/service/ssoadmin/permissions_boundary_attachment_test.go
+++ b/internal/service/ssoadmin/permissions_boundary_attachment_test.go
@@ -1,0 +1,305 @@
+package ssoadmin_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ssoadmin"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfssoadmin "github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func TestAccSSOAdminPermissionsBoundaryAttachment_basic(t *testing.T) {
+	resourceName := "aws_ssoadmin_permissions_boundary_attachment.test"
+	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPermissionsBoundaryAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPermissionsBoundaryAttachmentConfig_basic(rName, rNamePolicy1, rNamePolicy2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPermissionsBoundaryAttachmentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "permissions_boundary.0.customer_managed_policy_reference.0.name", rNamePolicy1),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_arn", permissionSetResourceName, "instance_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "permission_set_arn", permissionSetResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSSOAdminPermissionsBoundaryAttachment_forceNew(t *testing.T) {
+	resourceName := "aws_ssoadmin_permissions_boundary_attachment.test"
+	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPermissionsBoundaryAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPermissionsBoundaryAttachmentConfig_basic(rName, rNamePolicy1, rNamePolicy2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPermissionsBoundaryAttachmentExists(resourceName),
+				),
+			},
+			{
+				Config: testAccPermissionsBoundaryAttachmentConfig_forceNew(rName, rNamePolicy1, rNamePolicy2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPermissionsBoundaryAttachmentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "permissions_boundary.0.customer_managed_policy_reference.0.name", rNamePolicy2),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_arn", permissionSetResourceName, "instance_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "permission_set_arn", permissionSetResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSSOAdminPermissionsBoundaryAttachment_disappears(t *testing.T) {
+	resourceName := "aws_ssoadmin_permissions_boundary_attachment.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPermissionsBoundaryAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPermissionsBoundaryAttachmentConfig_basic(rName, rNamePolicy1, rNamePolicy2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPermissionsBoundaryAttachmentExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfssoadmin.ResourcePermissionsBoundaryAttachment(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccSSOAdminPermissionsBoundaryAttachment_Disappears_permissionSet(t *testing.T) {
+	resourceName := "aws_ssoadmin_permissions_boundary_attachment.test"
+	permissionSetResourceName := "aws_ssoadmin_permission_set.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPermissionsBoundaryAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPermissionsBoundaryAttachmentConfig_basic(rName, rNamePolicy1, rNamePolicy2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPermissionsBoundaryAttachmentExists(resourceName),
+					acctest.CheckResourceDisappears(acctest.Provider, tfssoadmin.ResourcePermissionSet(), permissionSetResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccSSOAdminPermissionsBoundaryAttachment_managedPolicyAndCustomerManagedPolicyRefBothDefined(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNamePolicy2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckInstances(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ssoadmin.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPermissionsBoundaryAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccPermissionsBoundaryAttachmentConfig_managedPolicyAndCustomerManagedPolicyRefBothDefined(rName, rNamePolicy1, rNamePolicy2),
+				ExpectError: regexp.MustCompile(".*ValidationException: Only ManagedPolicyArn or CustomerManagedPolicyReference should be given.*"),
+			},
+		},
+	})
+}
+
+func testAccCheckPermissionsBoundaryAttachmentDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).SSOAdminConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ssoadmin_permissions_boundary_attachment" {
+			continue
+		}
+
+		permissionSetARN, instanceARN, err := tfssoadmin.PermissionsBoundaryAttachmentParseResourceID(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		_, err = tfssoadmin.FindPermissionsBoundary(conn, permissionSetARN, instanceARN)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("SSO Permissions Boundary Attachment %s still exists", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckPermissionsBoundaryAttachmentExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No SSO Permissions Boundary Attachment ID is set")
+		}
+
+		permissionSetARN, instanceARN, err := tfssoadmin.PermissionsBoundaryAttachmentParseResourceID(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).SSOAdminConn
+
+		_, err = tfssoadmin.FindPermissionsBoundary(conn, permissionSetARN, instanceARN)
+
+		return err
+	}
+}
+
+func testAccPermissionsBoundaryAttachmentConfig_base(rName, rNamePolicy1, rNamePolicy2 string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_ssoadmin_instances" "test" {}
+
+resource "aws_ssoadmin_permission_set" "test" {
+  name         = %[1]q
+  instance_arn = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+}
+
+resource "aws_iam_policy" "test1" {
+  name        = %[2]q
+  path        = "/"
+  description = "My test policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ec2:Describe*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "test2" {
+  name        = %[3]q
+  path        = "/"
+  description = "My test policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ec2:Describe*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+`, rName, rNamePolicy1, rNamePolicy2)
+}
+
+func testAccPermissionsBoundaryAttachmentConfig_basic(rName, rNamePolicy1, rNamePolicy2 string) string {
+	return acctest.ConfigCompose(testAccPermissionsBoundaryAttachmentConfig_base(rName, rNamePolicy1, rNamePolicy2), `
+resource "aws_ssoadmin_permissions_boundary_attachment" "test" {
+  instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.test.arn
+
+  permissions_boundary {
+    customer_managed_policy_reference {
+      name = aws_iam_policy.test1.name
+      path = "/"
+    }
+  }
+}
+`)
+}
+
+func testAccPermissionsBoundaryAttachmentConfig_forceNew(rName, rNamePolicy1, rNamePolicy2 string) string {
+	return acctest.ConfigCompose(testAccPermissionsBoundaryAttachmentConfig_base(rName, rNamePolicy1, rNamePolicy2), `
+resource "aws_ssoadmin_permissions_boundary_attachment" "test" {
+  instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.test.arn
+
+  permissions_boundary {
+    customer_managed_policy_reference {
+      name = aws_iam_policy.test2.name
+      path = "/"
+    }
+  }
+}
+`)
+}
+
+func testAccPermissionsBoundaryAttachmentConfig_managedPolicyAndCustomerManagedPolicyRefBothDefined(rName, rNamePolicy1, rNamePolicy2 string) string {
+	return acctest.ConfigCompose(testAccPermissionsBoundaryAttachmentConfig_base(rName, rNamePolicy1, rNamePolicy2), `
+resource "aws_ssoadmin_permissions_boundary_attachment" "test" {
+  instance_arn       = aws_ssoadmin_permission_set.test.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.test.arn
+
+  permissions_boundary {
+    managed_policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+    customer_managed_policy_reference {
+      name = aws_iam_policy.test1.name
+      path = "/"
+    }
+  }
+}
+`)
+}

--- a/website/docs/r/ssoadmin_permissions_boundary_attachment.html.markdown
+++ b/website/docs/r/ssoadmin_permissions_boundary_attachment.html.markdown
@@ -3,12 +3,12 @@ subcategory: "SSO Admin"
 layout: "aws"
 page_title: "AWS: aws_ssoadmin_permissions_boundary_attachment"
 description: |-
-  Attaches a permissions boundary policy to a Single Sign-On (SSO) Permission Set resource
+  Attaches a permissions boundary policy to a Single Sign-On (SSO) Permission Set resource.
 ---
 
 # Resource: aws_ssoadmin_permissions_boundary_attachment
 
-Attaches a permissions boundary policy to a Single Sign-On (SSO) Permission Set resource
+Attaches a permissions boundary policy to a Single Sign-On (SSO) Permission Set resource.
 
 ~> **NOTE:** A permission set can have at most one permissions boundary attached; using more than one `aws_ssoadmin_permissions_boundary_attachment` references the same permission set will show a permanent difference.
 
@@ -51,7 +51,6 @@ resource "aws_ssoadmin_permissions_boundary_attachment" "example" {
     }
   }
 }
-
 ```
 
 ### Attaching an AWS-managed policy
@@ -72,16 +71,21 @@ The following arguments are required:
 
 * `instance_arn` - (Required, Forces new resource) The Amazon Resource Name (ARN) of the SSO Instance under which the operation will be executed.
 * `permission_set_arn` - (Required, Forces new resource) The Amazon Resource Name (ARN) of the Permission Set.
-* `permissions_boundary` - (Required, Forces new resource) The permissions boundary policy
+* `permissions_boundary` - (Required, Forces new resource) The permissions boundary policy. See below.
 
-### permissions_boundary Configuration Block
+### Permissions Boundary
 
-The `permissions_boundary` config block describes the permissions boundary policy to attach. You can reference either an AWS-managed policy, or a customer-managed policy.
+The `permissions_boundary` config block describes the permissions boundary policy to attach. You can reference either an AWS-managed policy, or a customer managed policy, but only one may be set.
 
-Only one of `managed_policy_arn` and `customer_managed_policy_reference` may be set on a given `permissions_boundary` resource.
+* `managed_policy_arn` - (Optional) AWS-managed IAM policy ARN to use as the permissions boundary.
+* `customer_managed_policy_reference` - (Optional) Specifies the name and path of a customer managed policy. See below.
 
-* `managed_policy_arn` - (Optional) the ARN of an AWS-managed IAM policy to use as the permissions boundary
-* `customer_managed_policy_reference` - (Optional) a reference to a customer-managed IAM policy to use as the permissions boundary.  Same as the [`customer_managed_policy_reference`](ssoadmin_customer_managed_policy_attachment.html#customer-managed-policy-reference) argument of the [`aws_ssoadmin_customer_managed_policy_attachment`](ssoadmin_customer_managed_policy_attachment.html) resource.  You must have an IAM policy that matches the name and path in each AWS account where you want to deploy your specified permission set.
+### Customer Managed Policy Reference
+
+The `customer_managed_policy_reference` config block describes a customer managed IAM policy. You must have an IAM policy that matches the name and path in each AWS account where you want to deploy your specified permission set.
+
+* `name` - (Required, Forces new resource) Name of the customer managed IAM Policy to be attached.
+* `path` - (Optional, Forces new resource) The path to the IAM policy to be attached. The default is `/`. See [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-friendly-names) for more information.
 
 ## Attributes Reference
 

--- a/website/docs/r/ssoadmin_permissions_boundary_attachment.html.markdown
+++ b/website/docs/r/ssoadmin_permissions_boundary_attachment.html.markdown
@@ -72,7 +72,7 @@ The following arguments are required:
 
 * `instance_arn` - (Required, Forces new resource) The Amazon Resource Name (ARN) of the SSO Instance under which the operation will be executed.
 * `permission_set_arn` - (Required, Forces new resource) The Amazon Resource Name (ARN) of the Permission Set.
-* `permissions_boundary` - (Required, Forces new resource) The permissions boundary policy 
+* `permissions_boundary` - (Required, Forces new resource) The permissions boundary policy
 
 ### permissions_boundary Configuration Block
 
@@ -81,7 +81,7 @@ The `permissions_boundary` config block describes the permissions boundary polic
 Only one of `managed_policy_arn` and `customer_managed_policy_reference` may be set on a given `permissions_boundary` resource.
 
 * `managed_policy_arn` - (Optional) the ARN of an AWS-managed IAM policy to use as the permissions boundary
-* `customer_managed_policy_reference` - (Optional) a reference to a customer-managed IAM policy to use as the permissions boundary.  Same as the [`customer_managed_policy_reference`](aws_ssoadmin_customer_managed_policy_attachment.html#customer-managed-policy-reference) argument of the [`aws_ssoadmin_customer_managed_policy_attachment`](aws_ssoadmin_customer_managed_policy_attachment.html) resource.  You must have an IAM policy that matches the name and path in each AWS account where you want to deploy your specified permission set.
+* `customer_managed_policy_reference` - (Optional) a reference to a customer-managed IAM policy to use as the permissions boundary.  Same as the [`customer_managed_policy_reference`](ssoadmin_customer_managed_policy_attachment.html#customer-managed-policy-reference) argument of the [`aws_ssoadmin_customer_managed_policy_attachment`](ssoadmin_customer_managed_policy_attachment.html) resource.  You must have an IAM policy that matches the name and path in each AWS account where you want to deploy your specified permission set.
 
 ## Attributes Reference
 
@@ -94,5 +94,5 @@ In addition to all arguments above, the following attributes are exported:
 SSO Admin Permissions Boundary Attachments can be imported using the `permission_set_arn` and `instance_arn`, separated by a comma (`,`) e.g.,
 
 ```
-$ terraform import aws_ssoadmin_customer_managed_policy_attachment.example arn:aws:sso:::permissionSet/ssoins-2938j0x8920sbj72/ps-80383020jr9302rk,arn:aws:sso:::instance/ssoins-2938j0x8920sbj72
+$ terraform import aws_ssoadmin_permissions_boundary_attachment.example arn:aws:sso:::permissionSet/ssoins-2938j0x8920sbj72/ps-80383020jr9302rk,arn:aws:sso:::instance/ssoins-2938j0x8920sbj72
 ```

--- a/website/docs/r/ssoadmin_permissions_boundary_attachment.html.markdown
+++ b/website/docs/r/ssoadmin_permissions_boundary_attachment.html.markdown
@@ -1,0 +1,98 @@
+---
+subcategory: "SSO Admin"
+layout: "aws"
+page_title: "AWS: aws_ssoadmin_permissions_boundary_attachment"
+description: |-
+  Attaches a permissions boundary policy to a Single Sign-On (SSO) Permission Set resource
+---
+
+# Resource: aws_ssoadmin_permissions_boundary_attachment
+
+Attaches a permissions boundary policy to a Single Sign-On (SSO) Permission Set resource
+
+~> **NOTE:** A permission set can have at most one permissions boundary attached; using more than one `aws_ssoadmin_permissions_boundary_attachment` references the same permission set will show a permanent difference.
+
+## Example Usage
+
+### Attaching a customer-managed policy
+
+```terraform
+data "aws_ssoadmin_instances" "example" {}
+
+resource "aws_ssoadmin_permission_set" "example" {
+  name         = "Example"
+  instance_arn = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+}
+
+resource "aws_iam_policy" "example" {
+  name        = "TestPolicy"
+  description = "My test policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ec2:Describe*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_ssoadmin_permissions_boundary_attachment" "example" {
+  instance_arn       = aws_ssoadmin_permission_set.example.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.example.arn
+  permissions_boundary {
+    customer_managed_policy_reference {
+      name = aws_iam_policy.example.name
+      path = "/"
+    }
+  }
+}
+
+```
+
+### Attaching an AWS-managed policy
+
+```terraform
+resource "aws_ssoadmin_permissions_boundary_attachment" "example" {
+  instance_arn       = aws_ssoadmin_permission_set.example.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.example.arn
+  permissions_boundary {
+    managed_policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `instance_arn` - (Required, Forces new resource) The Amazon Resource Name (ARN) of the SSO Instance under which the operation will be executed.
+* `permission_set_arn` - (Required, Forces new resource) The Amazon Resource Name (ARN) of the Permission Set.
+* `permissions_boundary` - (Required, Forces new resource) The permissions boundary policy 
+
+### permissions_boundary Configuration Block
+
+The `permissions_boundary` config block describes the permissions boundary policy to attach. You can reference either an AWS-managed policy, or a customer-managed policy.
+
+Only one of `managed_policy_arn` and `customer_managed_policy_reference` may be set on a given `permissions_boundary` resource.
+
+* `managed_policy_arn` - (Optional) the ARN of an AWS-managed IAM policy to use as the permissions boundary
+* `customer_managed_policy_reference` - (Optional) a reference to a customer-managed IAM policy to use as the permissions boundary.  Same as the [`customer_managed_policy_reference`](aws_ssoadmin_customer_managed_policy_attachment.html#customer-managed-policy-reference) argument of the [`aws_ssoadmin_customer_managed_policy_attachment`](aws_ssoadmin_customer_managed_policy_attachment.html) resource.  You must have an IAM policy that matches the name and path in each AWS account where you want to deploy your specified permission set.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Permission Set Amazon Resource Name (ARN) and SSO Instance ARN, separated by a comma (`,`).
+
+## Import
+
+SSO Admin Permissions Boundary Attachments can be imported using the `permission_set_arn` and `instance_arn`, separated by a comma (`,`) e.g.,
+
+```
+$ terraform import aws_ssoadmin_customer_managed_policy_attachment.example arn:aws:sso:::permissionSet/ssoins-2938j0x8920sbj72/ps-80383020jr9302rk,arn:aws:sso:::instance/ssoins-2938j0x8920sbj72
+```


### PR DESCRIPTION
### Description

Adds a `aws_ssoadmin_permissions_boundary_attachment` resource to enable attaching a permissions boundary to a permission set.  Example usage:

```hcl
resource "aws_ssoadmin_permissions_boundary_attachment" "example" {
  instance_arn       = aws_ssoadmin_permission_set.example.instance_arn
  permission_set_arn = aws_ssoadmin_permission_set.example.arn
  permissions_boundary {
    customer_managed_policy_reference {
      name = aws_iam_policy.example.name
      path = "/"
    }
  }
}
```

This is my first contribution, so if I've failed to follow any important conventions in the code, documentation, or this PR itself, please let me know!

### Relations

Closes #25893

### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccSSOAdminPermissionsBoundaryAttachment_ PKG=ssoadmin 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.19 test ./internal/service/ssoadmin/... -v -count 1 -parallel 20 -run='TestAccSSOAdminPermissionsBoundaryAttachment_'  -timeout 180m
=== RUN   TestAccSSOAdminPermissionsBoundaryAttachment_basic
=== PAUSE TestAccSSOAdminPermissionsBoundaryAttachment_basic
=== RUN   TestAccSSOAdminPermissionsBoundaryAttachment_forceNew
=== PAUSE TestAccSSOAdminPermissionsBoundaryAttachment_forceNew
=== RUN   TestAccSSOAdminPermissionsBoundaryAttachment_disappears
--- PASS: TestAccSSOAdminPermissionsBoundaryAttachment_disappears (39.21s)
=== RUN   TestAccSSOAdminPermissionsBoundaryAttachment_Disappears_permissionSet
--- PASS: TestAccSSOAdminPermissionsBoundaryAttachment_Disappears_permissionSet (32.64s)
=== RUN   TestAccSSOAdminPermissionsBoundaryAttachment_managedPolicyAndCustomerManagedPolicyRefBothDefined
=== PAUSE TestAccSSOAdminPermissionsBoundaryAttachment_managedPolicyAndCustomerManagedPolicyRefBothDefined
=== CONT  TestAccSSOAdminPermissionsBoundaryAttachment_basic
=== CONT  TestAccSSOAdminPermissionsBoundaryAttachment_managedPolicyAndCustomerManagedPolicyRefBothDefined
=== CONT  TestAccSSOAdminPermissionsBoundaryAttachment_forceNew
--- PASS: TestAccSSOAdminPermissionsBoundaryAttachment_managedPolicyAndCustomerManagedPolicyRefBothDefined (16.58s)
--- PASS: TestAccSSOAdminPermissionsBoundaryAttachment_basic (45.94s)
--- PASS: TestAccSSOAdminPermissionsBoundaryAttachment_forceNew (77.32s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin	151.866s
```
