### PR TITLE
Enable encryption configuration for AWS NetworkFirewall resources

### DIFF
--- a/internal/service/networkfirewall/firewall.go
+++ b/internal/service/networkfirewall/firewall.go
@@ -50,6 +50,7 @@ func ResourceFirewall() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"encryption_configuration": encryptionConfigurationSchema(),
 			"firewall_policy_arn": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -151,6 +152,10 @@ func resourceFirewallCreate(ctx context.Context, d *schema.ResourceData, meta in
 		input.Description = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("encryption_configuration"); ok {
+		input.EncryptionConfiguration = expandEncryptionConfiguration(v.([]interface{}))
+	}
+
 	if v, ok := d.GetOk("firewall_policy_change_protection"); ok {
 		input.FirewallPolicyChangeProtection = aws.Bool(v.(bool))
 	}
@@ -208,6 +213,7 @@ func resourceFirewallRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("arn", firewall.FirewallArn)
 	d.Set("delete_protection", firewall.DeleteProtection)
 	d.Set("description", firewall.Description)
+	d.Set("encryption_configuration", flattenEncryptionConfiguration(firewall.EncryptionConfiguration))
 	d.Set("name", firewall.FirewallName)
 	d.Set("firewall_policy_arn", firewall.FirewallPolicyArn)
 	d.Set("firewall_policy_change_protection", firewall.FirewallPolicyChangeProtection)
@@ -251,6 +257,22 @@ func resourceFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 		if resp == nil {
 			return diag.FromErr(fmt.Errorf("error updating NetworkFirewall Firewall (%s) description: empty update_token", arn))
+		}
+		updateToken = resp.UpdateToken
+	}
+
+	if d.HasChange("encryption_configuration") {
+		input := &networkfirewall.UpdateFirewallEncryptionConfigurationInput{
+			EncryptionConfiguration: expandEncryptionConfiguration(d.Get("encryption_configuration").([]interface{})),
+			FirewallArn:             aws.String(arn),
+			UpdateToken:             updateToken,
+		}
+		resp, err := conn.UpdateFirewallEncryptionConfigurationWithContext(ctx, input)
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("error updating NetworkFirewall Firewall (%s) encryption configuration: %w", d.Id(), err))
+		}
+		if resp == nil {
+			return diag.FromErr(fmt.Errorf("error updating NetworkFirewall Firewall (%s) encryption configuration: empty update_token", arn))
 		}
 		updateToken = resp.UpdateToken
 	}

--- a/internal/service/networkfirewall/firewall_test.go
+++ b/internal/service/networkfirewall/firewall_test.go
@@ -142,6 +142,48 @@ func TestAccNetworkFirewallFirewall_deleteProtection(t *testing.T) {
 	})
 }
 
+func TestAccNetworkFirewallFirewall_encryptionConfiguration(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_networkfirewall_firewall.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, networkfirewall.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFirewallDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirewallConfig_encryptionConfiguration(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFirewallExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.type", "CUSTOMER_KMS"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccFirewallConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFirewallExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "0"),
+				),
+			},
+			{
+				Config: testAccFirewallConfig_encryptionConfiguration(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFirewallExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.type", "CUSTOMER_KMS"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNetworkFirewallFirewall_SubnetMappings_updateSubnet(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_networkfirewall_firewall.test"
@@ -553,6 +595,29 @@ resource "aws_networkfirewall_firewall" "test" {
 
   subnet_mapping {
     subnet_id = aws_subnet.example.id
+  }
+}
+`, rName))
+}
+
+func testAccFirewallConfig_encryptionConfiguration(rName string) string {
+	return acctest.ConfigCompose(
+		testAccFirewallDependenciesConfig(rName),
+		fmt.Sprintf(`
+resource "aws_kms_key" "test" {}
+
+resource "aws_networkfirewall_firewall" "test" {
+  name                = %[1]q
+  firewall_policy_arn = aws_networkfirewall_firewall_policy.test.arn
+  vpc_id              = aws_vpc.test.id
+
+  encryption_configuration {
+    key_id = aws_kms_key.test.arn
+    type   = "CUSTOMER_KMS"
+  }
+
+  subnet_mapping {
+    subnet_id = aws_subnet.test.id
   }
 }
 `, rName))

--- a/internal/service/networkfirewall/rule_group_test.go
+++ b/internal/service/networkfirewall/rule_group_test.go
@@ -824,6 +824,49 @@ func TestAccNetworkFirewallRuleGroup_tags(t *testing.T) {
 	})
 }
 
+func TestAccNetworkFirewallRuleGroup_encryptionConfiguration(t *testing.T) {
+	var ruleGroup networkfirewall.DescribeRuleGroupOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_networkfirewall_rule_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, networkfirewall.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRuleGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuleGroupConfig_encryptionConfiguration(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuleGroupExists(resourceName, &ruleGroup),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.type", "CUSTOMER_KMS"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRuleGroupConfig_encryptionConfigurationDisabled(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuleGroupExists(resourceName, &ruleGroup),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "0"),
+				),
+			},
+			{
+				Config: testAccRuleGroupConfig_encryptionConfiguration(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuleGroupExists(resourceName, &ruleGroup),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.type", "CUSTOMER_KMS"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNetworkFirewallRuleGroup_disappears(t *testing.T) {
 	var ruleGroup networkfirewall.DescribeRuleGroupOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1372,6 +1415,57 @@ resource "aws_networkfirewall_rule_group" "test" {
   tags = {
     Name        = %[1]q
     Description = "updated"
+  }
+}
+`, rName)
+}
+
+func testAccRuleGroupConfig_encryptionConfiguration(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {}
+
+resource "aws_networkfirewall_rule_group" "test" {
+  capacity = 100
+  name     = %q
+  type     = "STATEFUL"
+  rule_group {
+    rules_source {
+      rules_source_list {
+        generated_rules_type = "ALLOWLIST"
+        target_types         = ["HTTP_HOST"]
+        targets              = ["test.example.com"]
+      }
+    }
+  }
+  encryption_configuration {
+    key_id = aws_kms_key.test.arn
+    type   = "CUSTOMER_KMS"
+  }
+}
+`, rName)
+}
+
+// The KMS key resource must stay in state while removing encryption configuration. If not
+// (ie. using the _basic config), the KMS key is deleted before the rule group is updated,
+// leaving the group in a "misconfigured" state. This causes update to fail with:
+//
+// InvalidRequestException: rule group has KMS key misconfigured
+func testAccRuleGroupConfig_encryptionConfigurationDisabled(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {}
+
+resource "aws_networkfirewall_rule_group" "test" {
+  capacity = 100
+  name     = %q
+  type     = "STATEFUL"
+  rule_group {
+    rules_source {
+      rules_source_list {
+        generated_rules_type = "ALLOWLIST"
+        target_types         = ["HTTP_HOST"]
+        targets              = ["test.example.com"]
+      }
+    }
   }
 }
 `, rName)


### PR DESCRIPTION
### Description
Adds an `encryption_configuration` attribute to the `aws_networkfirewall_firewall`, `aws_networkfirewall_firewall_policy`, and `aws_networkfirewall_rule_group` resources.


### Relations
Closes #27285 

### References
* https://docs.aws.amazon.com/network-firewall/latest/developerguide/kms-encryption-at-rest.html
* https://docs.aws.amazon.com/network-firewall/latest/APIReference/API_CreateFirewall.html
* https://docs.aws.amazon.com/network-firewall/latest/APIReference/API_CreateFirewallPolicy.html
* https://docs.aws.amazon.com/network-firewall/latest/APIReference/API_CreateRuleGroup.html

### Output from Acceptance Testing

```console
$ make testacc PKG=networkfirewall TESTS=TestAccNetworkFirewallFirewall_encryptionConfiguration
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkfirewall/... -v -count 1 -parallel 20 -run='TestAccNetworkFirewallFirewall_encryptionConfiguration'  -timeout 180m
=== RUN   TestAccNetworkFirewallFirewall_encryptionConfiguration
=== PAUSE TestAccNetworkFirewallFirewall_encryptionConfiguration
=== CONT  TestAccNetworkFirewallFirewall_encryptionConfiguration
--- PASS: TestAccNetworkFirewallFirewall_encryptionConfiguration (1083.77s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall    1086.750s
```

```console
$ make testacc PKG=networkfirewall TESTS=TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkfirewall/... -v -count 1 -parallel 20 -run='TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration'  -timeout 180m
=== RUN   TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration
=== PAUSE TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration
=== CONT  TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration
--- PASS: TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration (161.07s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall    164.081s
```

```console
$ make testacc PKG=networkfirewall TESTS=TestAccNetworkFirewallRuleGroup_encryptionConfiguration
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkfirewall/... -v -count 1 -parallel 20 -run='TestAccNetworkFirewallRuleGroup_encryptionConfiguration'  -timeout 180m
=== RUN   TestAccNetworkFirewallRuleGroup_encryptionConfiguration
=== PAUSE TestAccNetworkFirewallRuleGroup_encryptionConfiguration
=== CONT  TestAccNetworkFirewallRuleGroup_encryptionConfiguration
--- PASS: TestAccNetworkFirewallRuleGroup_encryptionConfiguration (163.58s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall    166.973s
```