### PR TITLE
r/aws_db_instance: Fix error modifying `allocated_storage` when `storage_type` is `"gp3"`

### DIFF
--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -5146,6 +5146,14 @@ func testAccInstanceConfig_orderableClassMySQLGP3() string {
 	return testAccInstanceConfig_orderableClass("mysql", "general-public-license", "gp3", mySQLPreferredInstanceClasses)
 }
 
+func testAccInstanceConfig_orderableClassPostgres() string {
+	return testAccInstanceConfig_orderableClass("postgres", "postgresql-license", "standard", postgresPreferredInstanceClasses)
+}
+
+func testAccInstanceConfig_orderableClassPostgresGP3() string {
+	return testAccInstanceConfig_orderableClass("postgres", "postgresql-license", "gp3", postgresPreferredInstanceClasses)
+}
+
 func testAccInstanceConfig_orderableClassMariadb() string {
 	return testAccInstanceConfig_orderableClass("mariadb", "general-public-license", "standard", mariaDBPreferredInstanceClasses)
 }
@@ -6765,28 +6773,18 @@ resource "aws_db_instance" "test" {
 }
 
 func testAccInstanceConfig_EnabledCloudWatchLogsExports_postgreSQL(rName string) string {
-	return fmt.Sprintf(`
-data "aws_rds_engine_version" "default" {
-  engine = "postgres"
-}
-
-data "aws_rds_orderable_db_instance" "test" {
-  engine                     = data.aws_rds_engine_version.default.engine
-  engine_version             = data.aws_rds_engine_version.default.version
-  preferred_instance_classes = [%[1]s]
-}
-
+	return acctest.ConfigCompose(testAccInstanceConfig_orderableClassPostgres(), fmt.Sprintf(`
 resource "aws_db_instance" "test" {
   allocated_storage               = 10
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
   engine                          = data.aws_rds_engine_version.default.engine
-  identifier                      = %[2]q
+  identifier                      = %[1]q
   instance_class                  = data.aws_rds_orderable_db_instance.test.instance_class
   password                        = "avoid-plaintext-passwords"
   username                        = "tfacctest"
   skip_final_snapshot             = true
 }
-`, postgresPreferredInstanceClasses, rName)
+`, rName))
 }
 
 func testAccInstanceConfig_maxAllocatedStorage(rName string, maxAllocatedStorage int) string {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Prevents errors like

```
 Error: updating RDS DB Instance (tf-acc-test-5977403606277891875): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: 6086d274-e75b-445c-afc5-8f6b14bbba02, api error InvalidParameterCombination: You can't specify IOPS or storage throughput for engine mysql and a storage size less than 400.
```

modifying `allocated_storage` when `storage_type` is `"gp3"` and `allocated_storage` is below a per-engine threshold.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28160.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccRDSInstance_storageTypePostgres' PKG=rds ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 3  -run=TestAccRDSInstance_storageTypePostgres -timeout 180m
=== RUN   TestAccRDSInstance_storageTypePostgres
=== PAUSE TestAccRDSInstance_storageTypePostgres
=== CONT  TestAccRDSInstance_storageTypePostgres
--- PASS: TestAccRDSInstance_storageTypePostgres (796.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	801.356s
% make testacc TESTARGS='-run=TestAccRDSInstance_gp3SQLServer' PKG=rds ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 3  -run=TestAccRDSInstance_gp3SQLServer -timeout 180m
=== RUN   TestAccRDSInstance_gp3SQLServer
=== PAUSE TestAccRDSInstance_gp3SQLServer
=== CONT  TestAccRDSInstance_gp3SQLServer
--- PASS: TestAccRDSInstance_gp3SQLServer (1061.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	1066.408s

% make testacc TESTARGS='-run=TestAccRDSInstance_storageThroughput' PKG=rds ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 3  -run=TestAccRDSInstance_storageThroughput -timeout 180m
=== RUN   TestAccRDSInstance_storageThroughput
=== PAUSE TestAccRDSInstance_storageThroughput
=== CONT  TestAccRDSInstance_storageThroughput
--- PASS: TestAccRDSInstance_storageThroughput (783.71s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	788.368s
% make testacc TESTARGS='-run=TestAccRDSInstance_gp3' PKG=rds ACCTEST_PARALLELISM=3     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 3  -run=TestAccRDSInstance_gp3 -timeout 180m
=== RUN   TestAccRDSInstance_gp3MySQL
=== PAUSE TestAccRDSInstance_gp3MySQL
=== RUN   TestAccRDSInstance_gp3Postgres
=== PAUSE TestAccRDSInstance_gp3Postgres
=== CONT  TestAccRDSInstance_gp3MySQL
=== CONT  TestAccRDSInstance_gp3Postgres
--- PASS: TestAccRDSInstance_gp3Postgres (693.72s)
--- PASS: TestAccRDSInstance_gp3MySQL (860.05s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	865.392s
% make testacc TESTARGS='-run=TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops\|TestAccRDSInstance_basic\|TestAccRDSInstance_ReplicateSourceDB_iops\|TestAccRDSInstance_SnapshotIdentifier_io1Storage' PKG=rds ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 3  -run=TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops\|TestAccRDSInstance_basic\|TestAccRDSInstance_ReplicateSourceDB_iops\|TestAccRDSInstance_SnapshotIdentifier_io1Storage -timeout 180m
=== RUN   TestAccRDSInstance_basic
=== PAUSE TestAccRDSInstance_basic
=== RUN   TestAccRDSInstance_ReplicateSourceDB_iops
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_iops
=== RUN   TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops
=== RUN   TestAccRDSInstance_SnapshotIdentifier_io1Storage
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_io1Storage
=== CONT  TestAccRDSInstance_basic
=== CONT  TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops
=== CONT  TestAccRDSInstance_ReplicateSourceDB_iops
--- PASS: TestAccRDSInstance_basic (367.23s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_io1Storage
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops (1467.13s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iops (1548.51s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_io1Storage (1418.08s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	1790.471s
```
