### PR TITLE
r/aws_sns_topic_subscription: don't set the FilterPolicyScope attribute in unsupported partitions

### DIFF
--- a/.changelog/28253.txt
+++ b/.changelog/28253.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sns_topic_subscription: Fix unsupported `FilterPolicyScope` attribute error in the aws-cn partition
+```

--- a/internal/service/sns/topic_subscription_test.go
+++ b/internal/service/sns/topic_subscription_test.go
@@ -1205,6 +1205,8 @@ resource "aws_sns_topic_subscription" "test" {
   protocol               = "https"
   endpoint               = replace(aws_api_gateway_deployment.test.invoke_url, "https://", "https://davematthews:granny@")
   endpoint_auto_confirms = true
+
+  confirmation_timeout_in_minutes = 3
 }
 `, rName)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Prevents the `aws_sns_topic_subscription` resource from passing the `FilterPolicyScope` attribute _unless_ it's been set explicitly by the practitioner or read back from the API first. This should fix a change introduced in https://github.com/hashicorp/terraform-provider-aws/pull/28004 that broke subscriptions in AWS China partitions.

I don't have access to the partition where the issue occurs, so this fix is speculative. I ran manual tests to simulate the behaviour of the AWS China partition by unsetting the `FilterPolicyScope` attribute during reads, and checking whether the provider in those cases would attempt to write back the policy scope attribute.

Also increases the confirmation timeout of the `TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint` acceptance test -- at the default value of 1 minute, the test was a bit too flaky.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/28004
Closes https://github.com/hashicorp/terraform-provider-aws/issues/28094

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccSNSTopicSubscription_ PKG=sns
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sns/... -v -count 1 -parallel 20 -run='TestAccSNSTopicSubscription_'  -timeout 180m
=== RUN   TestAccSNSTopicSubscription_basic
=== PAUSE TestAccSNSTopicSubscription_basic
=== RUN   TestAccSNSTopicSubscription_filterPolicy
=== PAUSE TestAccSNSTopicSubscription_filterPolicy
=== RUN   TestAccSNSTopicSubscription_filterPolicyScope
=== PAUSE TestAccSNSTopicSubscription_filterPolicyScope
=== RUN   TestAccSNSTopicSubscription_filterPolicyScope_policyNotSet
=== PAUSE TestAccSNSTopicSubscription_filterPolicyScope_policyNotSet
=== RUN   TestAccSNSTopicSubscription_deliveryPolicy
=== PAUSE TestAccSNSTopicSubscription_deliveryPolicy
=== RUN   TestAccSNSTopicSubscription_redrivePolicy
=== PAUSE TestAccSNSTopicSubscription_redrivePolicy
=== RUN   TestAccSNSTopicSubscription_rawMessageDelivery
=== PAUSE TestAccSNSTopicSubscription_rawMessageDelivery
=== RUN   TestAccSNSTopicSubscription_autoConfirmingEndpoint
=== PAUSE TestAccSNSTopicSubscription_autoConfirmingEndpoint
=== RUN   TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== PAUSE TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== RUN   TestAccSNSTopicSubscription_email
=== PAUSE TestAccSNSTopicSubscription_email
=== RUN   TestAccSNSTopicSubscription_firehose
=== PAUSE TestAccSNSTopicSubscription_firehose
=== RUN   TestAccSNSTopicSubscription_disappears
=== PAUSE TestAccSNSTopicSubscription_disappears
=== RUN   TestAccSNSTopicSubscription_Disappears_topic
=== PAUSE TestAccSNSTopicSubscription_Disappears_topic
=== CONT  TestAccSNSTopicSubscription_basic
=== CONT  TestAccSNSTopicSubscription_deliveryPolicy
=== CONT  TestAccSNSTopicSubscription_filterPolicyScope
=== CONT  TestAccSNSTopicSubscription_filterPolicy
=== CONT  TestAccSNSTopicSubscription_filterPolicyScope_policyNotSet
=== CONT  TestAccSNSTopicSubscription_redrivePolicy
=== CONT  TestAccSNSTopicSubscription_rawMessageDelivery
=== CONT  TestAccSNSTopicSubscription_autoConfirmingEndpoint
=== CONT  TestAccSNSTopicSubscription_Disappears_topic
=== CONT  TestAccSNSTopicSubscription_disappears
=== CONT  TestAccSNSTopicSubscription_firehose
=== CONT  TestAccSNSTopicSubscription_email
=== CONT  TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint
--- PASS: TestAccSNSTopicSubscription_filterPolicyScope_policyNotSet (3.44s)
--- PASS: TestAccSNSTopicSubscription_email (13.04s)
--- PASS: TestAccSNSTopicSubscription_autoConfirmingEndpoint (88.98s)
--- PASS: TestAccSNSTopicSubscription_rawMessageDelivery (91.76s)
--- PASS: TestAccSNSTopicSubscription_filterPolicy (92.09s)
--- PASS: TestAccSNSTopicSubscription_deliveryPolicy (92.34s)
--- PASS: TestAccSNSTopicSubscription_Disappears_topic (96.59s)
--- PASS: TestAccSNSTopicSubscription_basic (98.75s)
--- PASS: TestAccSNSTopicSubscription_disappears (103.20s)
--- PASS: TestAccSNSTopicSubscription_filterPolicyScope (137.91s)
--- PASS: TestAccSNSTopicSubscription_redrivePolicy (141.52s)
--- PASS: TestAccSNSTopicSubscription_firehose (143.22s)
--- PASS: TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint (208.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sns        210.647s
```
