### PR TITLE
d/aws_lambda_functions: new data resource

### DIFF
--- a/.changelog/28254.txt
+++ b/.changelog/28254.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_lambda_functions
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ FEATURES:
 * **New Resource:** `aws_resourceexplorer2_index` ([#28144](https://github.com/hashicorp/terraform-provider-aws/issues/28144))
 * **New Resource:** `aws_vpc_network_performance_metric_subscription` ([#28150](https://github.com/hashicorp/terraform-provider-aws/issues/28150))
 
+ENHANCEMENTS:
+
+* resource/aws_glue_crawler: Add `catalog_target.dlq_event_queue_arn`, `catalog_target.event_queue_arn`, `catalog_target.connection_name`, `lake_formation_configuration`, and `jdbc_target.enable_additional_metadata` arguments ([#28156](https://github.com/hashicorp/terraform-provider-aws/issues/28156))
+* resource/aws_glue_crawler: Make `delta_target.connection_name` optional ([#28156](https://github.com/hashicorp/terraform-provider-aws/issues/28156))
+
 BUG FIXES:
 
 * resource/aws_dms_s3_endpoint: Fix disparate handling of endpoint attributes in different regions ([#28220](https://github.com/hashicorp/terraform-provider-aws/issues/28220))

--- a/internal/service/lambda/functions_data_source.go
+++ b/internal/service/lambda/functions_data_source.go
@@ -3,6 +3,7 @@ package lambda
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -21,12 +22,12 @@ func DataSourceFunctions() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"function_arns": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"function_names": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
@@ -39,7 +40,7 @@ func dataSourceFunctionsRead(ctx context.Context, d *schema.ResourceData, meta i
 
 	input := &lambda.ListFunctionsInput{}
 
-	var functionArns []string
+	var functionARNs []string
 	var functionNames []string
 
 	err := conn.ListFunctionsPagesWithContext(ctx, input, func(page *lambda.ListFunctionsOutput, lastPage bool) bool {
@@ -52,8 +53,8 @@ func dataSourceFunctionsRead(ctx context.Context, d *schema.ResourceData, meta i
 				continue
 			}
 
-			functionArns = append(functionArns, *function.FunctionArn)
-			functionNames = append(functionNames, *function.FunctionName)
+			functionARNs = append(functionARNs, aws.StringValue(function.FunctionArn))
+			functionNames = append(functionNames, aws.StringValue(function.FunctionName))
 		}
 
 		return !lastPage
@@ -64,7 +65,7 @@ func dataSourceFunctionsRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)
-	d.Set("function_arns", functionArns)
+	d.Set("function_arns", functionARNs)
 	d.Set("function_names", functionNames)
 
 	return nil

--- a/internal/service/lambda/functions_data_source_test.go
+++ b/internal/service/lambda/functions_data_source_test.go
@@ -1,16 +1,16 @@
 package lambda_test
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/lambda"
-
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
 func TestAccLambdaFunctionsDataSource_basic(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_lambda_functions.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -19,18 +19,20 @@ func TestAccLambdaFunctionsDataSource_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLambdaFunctionsDataSourceConfig_basic(),
+				Config: testAccFunctionsDataSourceConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestMatchResourceAttr(dataSourceName, "function_names.#", regexp.MustCompile("[^0].*$")),
-					resource.TestMatchResourceAttr(dataSourceName, "function_arns.#", regexp.MustCompile("[^0].*$")),
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "function_arns.#", "0"),
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "function_names.#", "0"),
 				),
 			},
 		},
 	})
 }
 
-func testAccLambdaFunctionsDataSourceConfig_basic() string {
-	return `
-data "aws_lambda_functions" "test" {}
-`
+func testAccFunctionsDataSourceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccFunctionConfig_basic(rName, rName, rName, rName), `
+data "aws_lambda_functions" "test" {
+  depends_on = [aws_lambda_function.test]
+}
+`)
 }

--- a/website/docs/d/lambda_functions.html.markdown
+++ b/website/docs/d/lambda_functions.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Lambda"
 layout: "aws"
 page_title: "AWS: aws_lambda_functions"
 description: |-
-  Provides a Lambda Functions data source.
+  Terraform data resource to get a list of Lambda Functions.
 ---
 
-# aws_lambda_function
+# aws_lambda_functions
 
-Terraform data resource to get a list of Lambda Functions for a provider.
+Terraform data resource to get a list of Lambda Functions.
 
 ## Example Usage
 


### PR DESCRIPTION
### Description
This PR introduces the `aws_lambda_functions` plural data source.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #24522
Closes #17701

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
The Go AWS SDK does not support filters, for maintainability custom filters were not implemented in the provider.

https://docs.aws.amazon.com/sdk-for-go/api/service/lambda/#ListFunctionsInput

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccLambdaFunctionsDataSource_basic' PKG=lambda ACCTEST_PARALLELISM=2   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 2  -run=TestAccLambdaFunctionsDataSource_basic -timeout 180m
=== RUN   TestAccLambdaFunctionsDataSource_basic
=== PAUSE TestAccLambdaFunctionsDataSource_basic
=== CONT  TestAccLambdaFunctionsDataSource_basic
--- PASS: TestAccLambdaFunctionsDataSource_basic (28.99s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     41.899s
```
