### PR TITLE
d/cognito_risk_configuration.html.markdown fix notify_email_type text_body

### DIFF
--- a/website/docs/r/cognito_risk_configuration.html.markdown
+++ b/website/docs/r/cognito_risk_configuration.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `html_body` - (Required) The email HTML body.
 * `subject` - (Required) The email subject.
-* `test_body` - (Required) The email text body.
+* `text_body` - (Required) The email text body.
 
 #### actions
 


### PR DESCRIPTION
### Description

This PR correct the cognito_risk_configuration.html.markdown documentation where notify_email_type contains test_body instead of text_body.


### Relations

Closes #28250

### References

https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/set-risk-configuration.html

Shows that the emails contain:

Subject -> (string) The email subject.
HtmlBody -> (string) The email HTML body.
TextBody -> (string) The email text body.
