### PR TITLE
New Resource: `aws_auditmanager_framework`

### DIFF
--- a/.changelog/28257.txt
+++ b/.changelog/28257.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_auditmanager_framework
+```

--- a/internal/service/auditmanager/exports_test.go
+++ b/internal/service/auditmanager/exports_test.go
@@ -1,4 +1,7 @@
 package auditmanager
 
 // Exports for use in tests only.
-var ResourceControl = newResourceControl
+var (
+	ResourceControl   = newResourceControl
+	ResourceFramework = newResourceFramework
+)

--- a/internal/service/auditmanager/framework.go
+++ b/internal/service/auditmanager/framework.go
@@ -1,0 +1,513 @@
+package auditmanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/auditmanager"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/auditmanager/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	sdkv2resource "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func init() {
+	registerFrameworkResourceFactory(newResourceFramework)
+}
+
+func newResourceFramework(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceFramework{}, nil
+}
+
+const (
+	ResNameFramework = "Framework"
+)
+
+type resourceFramework struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceFramework) Metadata(_ context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = "aws_auditmanager_framework"
+}
+
+func (r *resourceFramework) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"arn": framework.ARNAttribute(),
+			"compliance_type": schema.StringAttribute{
+				Optional: true,
+			},
+			"description": schema.StringAttribute{
+				Optional: true,
+			},
+			"framework_type": schema.StringAttribute{
+				Computed: true,
+			},
+			"id": framework.IDAttribute(),
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"tags":     tftags.TagsAttribute(),
+			"tags_all": tftags.TagsAttributeComputedOnly(),
+		},
+		Blocks: map[string]schema.Block{
+			"control_sets": schema.SetNestedBlock{
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"id": framework.IDAttribute(),
+						"name": schema.StringAttribute{
+							Required: true,
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"controls": schema.SetNestedBlock{
+							Validators: []validator.Set{
+								setvalidator.SizeAtLeast(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"id": schema.StringAttribute{
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *resourceFramework) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().AuditManagerClient
+
+	var plan resourceFrameworkData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var cs []frameworkControlSetsData
+	resp.Diagnostics.Append(plan.ControlSets.ElementsAs(ctx, &cs, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	csInput, d := expandFrameworkControlSetsCreate(ctx, cs)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := auditmanager.CreateAssessmentFrameworkInput{
+		Name:        aws.String(plan.Name.ValueString()),
+		ControlSets: csInput,
+	}
+
+	if !plan.ComplianceType.IsNull() {
+		in.ComplianceType = aws.String(plan.ComplianceType.ValueString())
+	}
+	if !plan.Description.IsNull() {
+		in.Description = aws.String(plan.Description.ValueString())
+	}
+
+	defaultTagsConfig := r.Meta().DefaultTagsConfig
+	ignoreTagsConfig := r.Meta().IgnoreTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(plan.Tags))
+	plan.TagsAll = flex.FlattenFrameworkStringValueMap(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
+
+	if len(tags) > 0 {
+		in.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	out, err := conn.CreateAssessmentFramework(ctx, &in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.AuditManager, create.ErrActionCreating, ResNameFramework, plan.Name.String(), nil),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil || out.Framework == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.AuditManager, create.ErrActionCreating, ResNameFramework, plan.Name.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	state := plan
+	resp.Diagnostics.Append(state.refreshFromOutput(ctx, r.Meta(), out.Framework)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}
+
+func (r *resourceFramework) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().AuditManagerClient
+
+	var state resourceFrameworkData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := FindFrameworkByID(ctx, conn, state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		diag.NewWarningDiagnostic(
+			"AWS Resource Not Found During Refresh",
+			fmt.Sprintf("Automatically removing from Terraform State instead of returning the error, which may trigger resource recreation. Original Error: %s", err.Error()),
+		)
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.AuditManager, create.ErrActionReading, ResNameFramework, state.ID.String(), nil),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(state.refreshFromOutput(ctx, r.Meta(), out)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceFramework) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().AuditManagerClient
+
+	var plan, state resourceFrameworkData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.Name.Equal(state.Name) ||
+		!plan.ControlSets.Equal(state.ControlSets) ||
+		!plan.ComplianceType.Equal(state.ComplianceType) ||
+		!plan.Description.Equal(state.Description) {
+		var cs []frameworkControlSetsData
+		resp.Diagnostics.Append(plan.ControlSets.ElementsAs(ctx, &cs, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		csInput, d := expandFrameworkControlSetsUpdate(ctx, cs)
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		in := &auditmanager.UpdateAssessmentFrameworkInput{
+			ControlSets: csInput,
+			FrameworkId: aws.String(plan.ID.ValueString()),
+			Name:        aws.String(plan.Name.ValueString()),
+		}
+
+		if !plan.ComplianceType.IsNull() {
+			in.ComplianceType = aws.String(plan.ComplianceType.ValueString())
+		}
+		if !plan.Description.IsNull() {
+			in.Description = aws.String(plan.Description.ValueString())
+		}
+
+		out, err := conn.UpdateAssessmentFramework(ctx, in)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.AuditManager, create.ErrActionUpdating, ResNameFramework, plan.ID.String(), nil),
+				err.Error(),
+			)
+			return
+		}
+		if out == nil || out.Framework == nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.AuditManager, create.ErrActionUpdating, ResNameFramework, plan.ID.String(), nil),
+				errors.New("empty output").Error(),
+			)
+			return
+		}
+		state.refreshFromOutput(ctx, r.Meta(), out.Framework)
+	}
+
+	if !plan.TagsAll.Equal(state.TagsAll) {
+		if err := UpdateTags(ctx, conn, plan.ARN.ValueString(), state.TagsAll, plan.TagsAll); err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.AuditManager, create.ErrActionUpdating, ResNameControl, plan.ID.String(), nil),
+				err.Error(),
+			)
+			return
+		}
+		state.Tags = plan.Tags
+		state.TagsAll = plan.TagsAll
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceFramework) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().AuditManagerClient
+
+	var state resourceFrameworkData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := conn.DeleteAssessmentFramework(ctx, &auditmanager.DeleteAssessmentFrameworkInput{
+		FrameworkId: aws.String(state.ID.ValueString()),
+	})
+	if err != nil {
+		var nfe *awstypes.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.AuditManager, create.ErrActionDeleting, ResNameFramework, state.ID.String(), nil),
+			err.Error(),
+		)
+	}
+}
+
+func (r *resourceFramework) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *resourceFramework) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if !req.State.Raw.IsNull() && !req.Plan.Raw.IsNull() {
+		var plan resourceFrameworkData
+		resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		var planCs []frameworkControlSetsData
+		resp.Diagnostics.Append(plan.ControlSets.ElementsAs(ctx, &planCs, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		// A net-new control set will be missing id, so force a replacement
+		//
+		// Attribute level plan modifiers are applied before resource modifiers, so ID's
+		// previously in state should never be unknown.
+		for _, item := range planCs {
+			if item.ID.IsUnknown() {
+				resp.RequiresReplace = []path.Path{path.Root("control_sets")}
+			}
+		}
+	}
+
+	r.SetTagsAll(ctx, req, resp)
+}
+
+func FindFrameworkByID(ctx context.Context, conn *auditmanager.Client, id string) (*awstypes.Framework, error) {
+	in := &auditmanager.GetAssessmentFrameworkInput{
+		FrameworkId: aws.String(id),
+	}
+	out, err := conn.GetAssessmentFramework(ctx, in)
+	if err != nil {
+		var nfe *awstypes.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return nil, &sdkv2resource.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil || out.Framework == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out.Framework, nil
+}
+
+var (
+	frameworkControlSetsAttrTypes = map[string]attr.Type{
+		"controls": types.SetType{ElemType: types.ObjectType{AttrTypes: frameworkControlSetsControlsAttrTypes}},
+		"id":       types.StringType,
+		"name":     types.StringType,
+	}
+
+	frameworkControlSetsControlsAttrTypes = map[string]attr.Type{
+		"id": types.StringType,
+	}
+)
+
+type resourceFrameworkData struct {
+	ARN            types.String `tfsdk:"arn"`
+	ComplianceType types.String `tfsdk:"compliance_type"`
+	ControlSets    types.Set    `tfsdk:"control_sets"`
+	Description    types.String `tfsdk:"description"`
+	FrameworkType  types.String `tfsdk:"framework_type"`
+	ID             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	Tags           types.Map    `tfsdk:"tags"`
+	TagsAll        types.Map    `tfsdk:"tags_all"`
+}
+
+type frameworkControlSetsData struct {
+	Controls types.Set    `tfsdk:"controls"`
+	ID       types.String `tfsdk:"id"`
+	Name     types.String `tfsdk:"name"`
+}
+
+type frameworkControlSetsControlsData struct {
+	ID types.String `tfsdk:"id"`
+}
+
+// refreshFromOutput writes state data from an AWS response object
+func (rd *resourceFrameworkData) refreshFromOutput(ctx context.Context, meta *conns.AWSClient, out *awstypes.Framework) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if out == nil {
+		return diags
+	}
+
+	rd.ID = types.StringValue(aws.ToString(out.Id))
+	rd.Name = types.StringValue(aws.ToString(out.Name))
+	cs, d := flattenFrameworkControlSets(ctx, out.ControlSets)
+	diags.Append(d...)
+	rd.ControlSets = cs
+
+	rd.ComplianceType = flex.StringToFramework(ctx, out.ComplianceType)
+	rd.Description = flex.StringToFramework(ctx, out.Description)
+	rd.FrameworkType = flex.StringValueToFramework(ctx, out.Type)
+	rd.ARN = flex.StringToFramework(ctx, out.Arn)
+
+	defaultTagsConfig := meta.DefaultTagsConfig
+	ignoreTagsConfig := meta.IgnoreTagsConfig
+	tags := KeyValueTags(out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+	// AWS APIs often return empty lists of tags when none have been configured.
+	if tags := tags.RemoveDefaultConfig(defaultTagsConfig).Map(); len(tags) == 0 {
+		rd.Tags = tftags.Null
+	} else {
+		rd.Tags = flex.FlattenFrameworkStringValueMap(ctx, tags)
+	}
+	rd.TagsAll = flex.FlattenFrameworkStringValueMap(ctx, tags.Map())
+
+	return diags
+}
+
+func expandFrameworkControlSetsCreate(ctx context.Context, tfList []frameworkControlSetsData) ([]awstypes.CreateAssessmentFrameworkControlSet, diag.Diagnostics) {
+	var ccs []awstypes.CreateAssessmentFrameworkControlSet
+	var diags diag.Diagnostics
+
+	for _, item := range tfList {
+		var controls []frameworkControlSetsControlsData
+		diags.Append(item.Controls.ElementsAs(ctx, &controls, false)...)
+
+		new := awstypes.CreateAssessmentFrameworkControlSet{
+			Name:     aws.String(item.Name.ValueString()),
+			Controls: expandFrameworkControlSetsControls(controls),
+		}
+
+		ccs = append(ccs, new)
+	}
+	return ccs, diags
+}
+
+func expandFrameworkControlSetsUpdate(ctx context.Context, tfList []frameworkControlSetsData) ([]awstypes.UpdateAssessmentFrameworkControlSet, diag.Diagnostics) {
+	var ucs []awstypes.UpdateAssessmentFrameworkControlSet
+	var diags diag.Diagnostics
+
+	for _, item := range tfList {
+		var controls []frameworkControlSetsControlsData
+		diags.Append(item.Controls.ElementsAs(ctx, &controls, false)...)
+
+		new := awstypes.UpdateAssessmentFrameworkControlSet{
+			Controls: expandFrameworkControlSetsControls(controls),
+			Id:       aws.String(item.ID.ValueString()),
+			Name:     aws.String(item.Name.ValueString()),
+		}
+
+		ucs = append(ucs, new)
+	}
+	return ucs, diags
+}
+
+func expandFrameworkControlSetsControls(tfList []frameworkControlSetsControlsData) []awstypes.CreateAssessmentFrameworkControl {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var controlsInput []awstypes.CreateAssessmentFrameworkControl
+	for _, item := range tfList {
+		new := awstypes.CreateAssessmentFrameworkControl{
+			Id: aws.String(item.ID.ValueString()),
+		}
+		controlsInput = append(controlsInput, new)
+	}
+
+	return controlsInput
+}
+
+func flattenFrameworkControlSets(ctx context.Context, apiObject []awstypes.ControlSet) (types.Set, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elemType := types.ObjectType{AttrTypes: frameworkControlSetsAttrTypes}
+
+	elems := []attr.Value{}
+	for _, item := range apiObject {
+		controls, d := flattenFrameworkControlSetsControls(ctx, item.Controls)
+		diags.Append(d...)
+
+		obj := map[string]attr.Value{
+			"controls": controls,
+			"id":       flex.StringToFramework(ctx, item.Id),
+			"name":     flex.StringToFramework(ctx, item.Name),
+		}
+		objVal, d := types.ObjectValue(frameworkControlSetsAttrTypes, obj)
+		diags.Append(d...)
+
+		elems = append(elems, objVal)
+	}
+	setVal, d := types.SetValue(elemType, elems)
+	diags.Append(d...)
+
+	return setVal, diags
+}
+
+func flattenFrameworkControlSetsControls(ctx context.Context, apiObject []awstypes.Control) (types.Set, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elemType := types.ObjectType{AttrTypes: frameworkControlSetsControlsAttrTypes}
+
+	if apiObject == nil {
+		return types.SetValueMust(elemType, []attr.Value{}), diags
+	}
+
+	elems := []attr.Value{}
+	for _, item := range apiObject {
+		obj := map[string]attr.Value{
+			"id": flex.StringToFramework(ctx, item.Id),
+		}
+		objVal, d := types.ObjectValue(frameworkControlSetsControlsAttrTypes, obj)
+		diags.Append(d...)
+
+		elems = append(elems, objVal)
+	}
+	setVal, d := types.SetValue(elemType, elems)
+	diags.Append(d...)
+
+	return setVal, diags
+}

--- a/internal/service/auditmanager/framework_test.go
+++ b/internal/service/auditmanager/framework_test.go
@@ -1,0 +1,313 @@
+package auditmanager_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/auditmanager/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfauditmanager "github.com/hashicorp/terraform-provider-aws/internal/service/auditmanager"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccAuditManagerFramework_basic(t *testing.T) {
+	var framework types.Framework
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_auditmanager_framework.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.AuditManagerEndpointID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AuditManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFrameworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFrameworkConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkExists(resourceName, &framework),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "control_sets.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "control_sets.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "control_sets.0.controls.#", "1"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "auditmanager", regexp.MustCompile(`assessmentFramework/+.`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAuditManagerFramework_disappears(t *testing.T) {
+	var framework types.Framework
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_auditmanager_framework.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.AuditManagerEndpointID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AuditManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFrameworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFrameworkConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkExists(resourceName, &framework),
+					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfauditmanager.ResourceFramework, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAuditManagerFramework_tags(t *testing.T) {
+	var framework types.Framework
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_auditmanager_framework.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.AuditManagerEndpointID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AuditManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFrameworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFrameworkConfig_tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkExists(resourceName, &framework),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccFrameworkConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkExists(resourceName, &framework),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccFrameworkConfig_tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkExists(resourceName, &framework),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAuditManagerFramework_optional(t *testing.T) {
+	var framework types.Framework
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_auditmanager_framework.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.AuditManagerEndpointID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AuditManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFrameworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFrameworkConfig_optional(rName, "text1", "text1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkExists(resourceName, &framework),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "compliance_type", "text1"),
+					resource.TestCheckResourceAttr(resourceName, "description", "text1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccFrameworkConfig_optional(rName, "text2", "text2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkExists(resourceName, &framework),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "compliance_type", "text2"),
+					resource.TestCheckResourceAttr(resourceName, "description", "text2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFrameworkDestroy(s *terraform.State) error {
+	ctx := context.Background()
+	conn := acctest.Provider.Meta().(*conns.AWSClient).AuditManagerClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_auditmanager_framework" {
+			continue
+		}
+
+		_, err := tfauditmanager.FindFrameworkByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			var nfe *types.ResourceNotFoundException
+			if errors.As(err, &nfe) {
+				return nil
+			}
+			return err
+		}
+
+		return create.Error(names.AuditManager, create.ErrActionCheckingDestroyed, tfauditmanager.ResNameFramework, rs.Primary.ID, errors.New("not destroyed"))
+	}
+
+	return nil
+}
+
+func testAccCheckFrameworkExists(name string, framework *types.Framework) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.AuditManager, create.ErrActionCheckingExistence, tfauditmanager.ResNameFramework, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.AuditManager, create.ErrActionCheckingExistence, tfauditmanager.ResNameFramework, name, errors.New("not set"))
+		}
+
+		ctx := context.Background()
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AuditManagerClient
+		resp, err := tfauditmanager.FindFrameworkByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.AuditManager, create.ErrActionCheckingExistence, tfauditmanager.ResNameFramework, rs.Primary.ID, err)
+		}
+
+		*framework = *resp
+
+		return nil
+	}
+}
+
+func testAccFrameworkConfigBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_auditmanager_control" "test" {
+  name = %[1]q
+
+  control_mapping_sources {
+    source_name          = %[1]q
+    source_set_up_option = "Procedural_Controls_Mapping"
+    source_type          = "MANUAL"
+  }
+}
+`, rName)
+}
+
+func testAccFrameworkConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccFrameworkConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_auditmanager_framework" "test" {
+  name = %[1]q
+
+  control_sets {
+    name = %[1]q
+    controls {
+      id = aws_auditmanager_control.test.id
+    }
+  }
+}
+`, rName))
+}
+
+func testAccFrameworkConfig_tags1(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(
+		testAccFrameworkConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_auditmanager_framework" "test" {
+  name = %[1]q
+
+  control_sets {
+    name = %[1]q
+    controls {
+      id = aws_auditmanager_control.test.id
+    }
+  }
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1))
+}
+
+func testAccFrameworkConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(
+		testAccFrameworkConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_auditmanager_framework" "test" {
+  name = %[1]q
+
+  control_sets {
+    name = %[1]q
+    controls {
+      id = aws_auditmanager_control.test.id
+    }
+  }
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
+}
+
+func testAccFrameworkConfig_optional(rName, complianceType, description string) string {
+	return acctest.ConfigCompose(
+		testAccFrameworkConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_auditmanager_framework" "test" {
+  name = %[1]q
+
+  compliance_type = %[2]q
+  description     = %[3]q
+
+  control_sets {
+    name = %[1]q
+    controls {
+      id = aws_auditmanager_control.test.id
+    }
+  }
+}
+`, rName, complianceType, description))
+}

--- a/website/docs/r/auditmanager_framework.html.markdown
+++ b/website/docs/r/auditmanager_framework.html.markdown
@@ -1,0 +1,67 @@
+---
+subcategory: "Audit Manager"
+layout: "aws"
+page_title: "AWS: aws_auditmanager_framework"
+description: |-
+  Terraform resource for managing an AWS Audit Manager Framework.
+---
+
+# Resource: aws_auditmanager_framework
+
+Terraform resource for managing an AWS Audit Manager Framework.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_auditmanager_framework" "test" {
+  name = "example"
+
+  control_sets {
+    name = "example"
+    controls {
+      id = aws_auditmanager_control.test.id
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Name of the framework.
+* `control_sets` - (Required) Control sets that are associated with the framework. See [`control_sets`](#control_sets) below.
+
+The following arguments are optional:
+
+* `compliance_type` - (Optional) Compliance type that the new custom framework supports, such as `CIS` or `HIPAA`.
+* `description` - (Optional) Description of the framework.
+* `tags` - (Optional) A map of tags to assign to the framewor. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### control_sets
+
+* `name` - (Required) Name of the control set.
+* `controls` - (Required) List of controls within the control set. See [`controls`](#controls) below.
+
+### controls
+
+* `id` - (Required) Unique identifier of the control.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Amazon Resource Name (ARN) of the framework.
+* `control_sets[*].id` - Unique identifier for the framework control set.
+* `id` - Unique identifier for the framework.
+* `framework_type` - Framework type, such as a custom framework or a standard framework.
+
+## Import
+
+Audit Manager Framework can be imported using the framework `id`, e.g.,
+
+```
+$ terraform import aws_auditmanager_framework.example abc123-de45
+```


### PR DESCRIPTION
### Description
`aws_auditmanager_framework` will allow practitioners to manage custom assessment frameworks.

### Relations
Relates #17981 


### Output from Acceptance Testing

```console
$ make testacc PKG=auditmanager TESTS=TestAccAuditManagerFramework_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/auditmanager/... -v -count 1 -parallel 20 -run='TestAccAuditManagerFramework_'  -timeout 180m
=== RUN   TestAccAuditManagerFramework_basic
=== PAUSE TestAccAuditManagerFramework_basic
=== RUN   TestAccAuditManagerFramework_disappears
=== PAUSE TestAccAuditManagerFramework_disappears
=== RUN   TestAccAuditManagerFramework_tags
=== PAUSE TestAccAuditManagerFramework_tags
=== RUN   TestAccAuditManagerFramework_optional
=== PAUSE TestAccAuditManagerFramework_optional
=== CONT  TestAccAuditManagerFramework_basic
=== CONT  TestAccAuditManagerFramework_tags
=== CONT  TestAccAuditManagerFramework_optional
=== CONT  TestAccAuditManagerFramework_disappears
--- PASS: TestAccAuditManagerFramework_disappears (24.78s)
--- PASS: TestAccAuditManagerFramework_basic (29.73s)
--- PASS: TestAccAuditManagerFramework_optional (43.80s)
--- PASS: TestAccAuditManagerFramework_tags (52.65s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/auditmanager       56.359s
```