### PR TITLE
issue 26920 support colon in LakeFormation lf-tag key

### DIFF
--- a/.changelog/_xxxx.txt
+++ b/.changelog/_xxxx.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lakeformation_lf_tag: Fix support for keys with colons in the name
+```

--- a/internal/service/lakeformation/lf_tag.go
+++ b/internal/service/lakeformation/lf_tag.go
@@ -172,7 +172,7 @@ func resourceLFTagDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func ReadLFTagID(id string) (catalogID string, tagKey string, err error) {
-	idParts := strings.Split(id, ":")
+	idParts := strings.SplitN(id, ":", 2)
 	if len(idParts) != 2 {
 		return "", "", fmt.Errorf("unexpected format of ID (%q), expected CATALOG-ID:TAG-KEY", id)
 	}

--- a/internal/service/lakeformation/lf_tag_test.go
+++ b/internal/service/lakeformation/lf_tag_test.go
@@ -103,6 +103,14 @@ func testAccLFTag_values(t *testing.T) {
 					acctest.CheckResourceAttrAccountID(resourceName, "catalog_id"),
 				),
 			},
+			{
+				Config:  testAccLFTagConfig_values(rName+":Colon", []string{"value1", "value2"}),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLFTagExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "key", rName+":Colon"),
+				),
+			},
 		},
 	})
 }

--- a/internal/service/lakeformation/permissions_test.go
+++ b/internal/service/lakeformation/permissions_test.go
@@ -1332,7 +1332,6 @@ resource "aws_lakeformation_permissions" "test" {
 }
 
 func testAccPermissionsConfig_lfTag(rName string, key string) string {
-
 	if len(key) == 0 {
 		key = rName
 	}
@@ -1395,7 +1394,6 @@ resource "aws_lakeformation_permissions" "test" {
 }
 
 func testAccPermissionsConfig_lfTagPolicy(rName string, keyName string) string {
-
 	if len(keyName) == 0 {
 		keyName = rName
 	}


### PR DESCRIPTION

### Description
Adds support for LF-TAGS to use colons in the key names. It's fairly common to use sub categories like Sales:LoB or Department:LoB to further focus the tag to a domain.  AWS supports using colons in tags, as well as other characters, however colons was the only character impacted due to how Terraform processed tf files.


### Relations

Closes #26920


### Output from Acceptance Testing


```
make testacc TESTS=testAccLFTag_basic PKG=lakeformation

make testacc PKG=lakeformation
...
```
Integration tests were run for all of Lake Formation functions
```
=== RUN   TestAccLakeFormation_serial
=== RUN   TestAccLakeFormation_serial/DataLakeSettings
=== RUN   TestAccLakeFormation_serial/DataLakeSettings/basic
=== RUN   TestAccLakeFormation_serial/DataLakeSettings/dataSource
=== RUN   TestAccLakeFormation_serial/DataLakeSettings/disappears
=== RUN   TestAccLakeFormation_serial/DataLakeSettings/withoutCatalogId
=== RUN   TestAccLakeFormation_serial/PermissionsBasic
=== RUN   TestAccLakeFormation_serial/PermissionsBasic/dataLocation
=== RUN   TestAccLakeFormation_serial/PermissionsBasic/disappears
=== RUN   TestAccLakeFormation_serial/PermissionsBasic/lfTag
=== RUN   TestAccLakeFormation_serial/PermissionsBasic/lfTagPolicy
=== RUN   TestAccLakeFormation_serial/PermissionsBasic/basic
=== RUN   TestAccLakeFormation_serial/PermissionsBasic/database
=== RUN   TestAccLakeFormation_serial/PermissionsBasic/databaseIAMAllowed
=== RUN   TestAccLakeFormation_serial/PermissionsBasic/databaseMultiple
=== RUN   TestAccLakeFormation_serial/PermissionsDataSource
=== RUN   TestAccLakeFormation_serial/PermissionsDataSource/database
=== RUN   TestAccLakeFormation_serial/PermissionsDataSource/dataLocation
=== RUN   TestAccLakeFormation_serial/PermissionsDataSource/lfTag
=== RUN   TestAccLakeFormation_serial/PermissionsDataSource/lfTagPolicy
=== RUN   TestAccLakeFormation_serial/PermissionsDataSource/table
=== RUN   TestAccLakeFormation_serial/PermissionsDataSource/tableWithColumns
=== RUN   TestAccLakeFormation_serial/PermissionsDataSource/basic
=== RUN   TestAccLakeFormation_serial/PermissionsTable
=== RUN   TestAccLakeFormation_serial/PermissionsTable/wildcardNoSelect
=== RUN   TestAccLakeFormation_serial/PermissionsTable/wildcardSelectPlus
=== RUN   TestAccLakeFormation_serial/PermissionsTable/implicit
=== RUN   TestAccLakeFormation_serial/PermissionsTable/selectPlus
=== RUN   TestAccLakeFormation_serial/PermissionsTable/multipleRoles
=== RUN   TestAccLakeFormation_serial/PermissionsTable/selectOnly
=== RUN   TestAccLakeFormation_serial/PermissionsTable/wildcardSelectOnly
=== RUN   TestAccLakeFormation_serial/PermissionsTable/basic
=== RUN   TestAccLakeFormation_serial/PermissionsTable/iamAllowed
=== RUN   TestAccLakeFormation_serial/PermissionsTableWithColumns
=== RUN   TestAccLakeFormation_serial/PermissionsTableWithColumns/basic
=== RUN   TestAccLakeFormation_serial/PermissionsTableWithColumns/implicit
=== RUN   TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardExcludedColumns
=== RUN   TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardSelectOnly
=== RUN   TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardSelectPlus
=== RUN   TestAccLakeFormation_serial/LFTags
=== RUN   TestAccLakeFormation_serial/LFTags/values
=== RUN   TestAccLakeFormation_serial/LFTags/basic
=== RUN   TestAccLakeFormation_serial/LFTags/disappears
=== RUN   TestAccLakeFormation_serial/ResourceLFTags
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/basic
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/database
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/databaseMultiple
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/table
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/tableWithColumns
--- PASS: TestAccLakeFormation_serial (1685.53s)
    --- PASS: TestAccLakeFormation_serial/DataLakeSettings (80.64s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettings/basic (21.60s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettings/dataSource (20.76s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettings/disappears (19.59s)
        --- PASS: TestAccLakeFormation_serial/DataLakeSettings/withoutCatalogId (18.68s)
    --- PASS: TestAccLakeFormation_serial/PermissionsBasic (418.27s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/dataLocation (35.84s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/disappears (91.57s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/lfTag (49.08s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/lfTagPolicy (70.66s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/basic (38.58s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/database (40.90s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/databaseIAMAllowed (51.91s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/databaseMultiple (39.72s)
    --- PASS: TestAccLakeFormation_serial/PermissionsDataSource (318.90s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/database (43.23s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/dataLocation (38.17s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/lfTag (55.32s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/lfTagPolicy (67.88s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/table (38.04s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/tableWithColumns (35.50s)
        --- PASS: TestAccLakeFormation_serial/PermissionsDataSource/basic (40.76s)
    --- PASS: TestAccLakeFormation_serial/PermissionsTable (320.35s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/wildcardNoSelect (31.58s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/wildcardSelectPlus (33.03s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/implicit (33.70s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/selectPlus (33.13s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/multipleRoles (33.98s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/selectOnly (33.56s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/wildcardSelectOnly (33.82s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/basic (33.69s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTable/iamAllowed (53.87s)
    --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns (229.00s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/basic (86.69s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/implicit (40.46s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardExcludedColumns (34.63s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardSelectOnly (34.03s)
        --- PASS: TestAccLakeFormation_serial/PermissionsTableWithColumns/wildcardSelectPlus (33.18s)
    --- PASS: TestAccLakeFormation_serial/LFTags (107.88s)
        --- PASS: TestAccLakeFormation_serial/LFTags/values (62.73s)
        --- PASS: TestAccLakeFormation_serial/LFTags/basic (25.47s)
        --- PASS: TestAccLakeFormation_serial/LFTags/disappears (19.68s)
    --- PASS: TestAccLakeFormation_serial/ResourceLFTags (210.49s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/basic (23.65s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/database (42.86s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/databaseMultiple (56.61s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/table (44.01s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/tableWithColumns (43.35s)
```

