### PR TITLE
Fix typo on AppRunner service docs

### DIFF
--- a/website/docs/r/apprunner_service.html.markdown
+++ b/website/docs/r/apprunner_service.html.markdown
@@ -183,7 +183,7 @@ The `network_configuration` block supports the following arguments:
 
 ### Ingress Configuration
 
-The `encryption_configuration` block supports the following argument:
+The `ingress_configuration` block supports the following argument:
 
 * `is_publicly_accessible` - (Required) Specifies whether your App Runner service is publicly accessible. To make the service publicly accessible set it to True. To make the service privately accessible, from only within an Amazon VPC set it to False.
 

--- a/website/docs/r/apprunner_vpc_connector.html.markdown
+++ b/website/docs/r/apprunner_vpc_connector.html.markdown
@@ -33,7 +33,7 @@ The following arguments supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `vpc_connector_arn` - ARN of VPC connector.
+* `arn` - ARN of VPC connector.
 * `status` - Current state of the VPC connector. If the status of a connector revision is INACTIVE, it was deleted and can't be used. Inactive connector revisions are permanently removed some time after they are deleted.
 * `vpc_connector_revision` - The revision of VPC connector. It's unique among all the active connectors ("Status": "ACTIVE") that share the same Name.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).


### PR DESCRIPTION
### Description
There was a small typo on the Resource > AppRunner Service page, and also the Resource > AppRunner > VPC Connector page.
