### PR TITLE
Correct aws_ec2_local_gateway_route_tables usage doc

### DIFF
--- a/website/docs/d/ec2_local_gateway_route_tables.html.markdown
+++ b/website/docs/d/ec2_local_gateway_route_tables.html.markdown
@@ -15,10 +15,10 @@ Provides information for multiple EC2 Local Gateway Route Tables, such as their 
 The following shows outputing all Local Gateway Route Table Ids.
 
 ```terraform
-data "aws_ec2_local_gateway_route_table" "foo" {}
+data "aws_ec2_local_gateway_route_tables" "foo" {}
 
 output "foo" {
-  value = data.aws_ec2_local_gateway_route_table.foo.ids
+  value = data.aws_ec2_local_gateway_route_tables.foo.ids
 }
 ```
 


### PR DESCRIPTION
### Description
Update doc for `aws_ec2_local_gateway_route_tables` to use proper plural version of the data source. It's currently referring to the singular `aws_ec2_local_gateway_route_table` version that doesn't support `ids` and expects a single route table.
