### PR TITLE
Add `auditmanager` sweepers

### DIFF
--- a/internal/service/auditmanager/sweep.go
+++ b/internal/service/auditmanager/sweep.go
@@ -1,0 +1,129 @@
+//go:build sweep
+// +build sweep
+
+package auditmanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/auditmanager"
+	"github.com/aws/aws-sdk-go-v2/service/auditmanager/types"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_auditmanager_control", &resource.Sweeper{
+		Name: "aws_auditmanager_control",
+		F:    sweepControls,
+	})
+	resource.AddTestSweepers("aws_auditmanager_framework", &resource.Sweeper{
+		Name: "aws_auditmanager_framework",
+		F:    sweepFrameworks,
+	})
+}
+
+// isCompleteSetupError checks whether the returned error message indicates
+// AuditManager isn't yet enabled in the current region.
+//
+// For example:
+// AccessDeniedException: Please complete AWS Audit Manager setup from home page to enable this action in this account.
+func isCompleteSetupError(err error) bool {
+	var ade *types.AccessDeniedException
+	if errors.As(err, &ade) {
+		return true
+	}
+	return false
+}
+
+func sweepControls(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		fmt.Errorf("error getting client: %s", err)
+	}
+
+	ctx := context.Background()
+	conn := client.(*conns.AWSClient).AuditManagerClient
+	sweepResources := make([]sweep.Sweepable, 0)
+	in := &auditmanager.ListControlsInput{ControlType: types.ControlTypeCustom}
+	var errs *multierror.Error
+
+	pages := auditmanager.NewListControlsPaginator(conn, in)
+
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if sweep.SkipSweepError(err) || isCompleteSetupError(err) {
+			log.Printf("[WARN] Skipping AuditManager Controls sweep for %s: %s", region, err)
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("error retrieving AuditManager Controls: %w", err)
+		}
+
+		for _, control := range page.ControlMetadataList {
+			id := aws.ToString(control.Id)
+
+			log.Printf("[INFO] Deleting AuditManager Control: %s", id)
+			sweepResources = append(sweepResources, sweep.NewSweepFrameworkResource(newResourceControl, id, client))
+		}
+	}
+
+	if err := sweep.SweepOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping AuditManager Controls for %s: %w", region, err))
+	}
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping AuditManager Controls sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func sweepFrameworks(region string) error {
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		fmt.Errorf("error getting client: %s", err)
+	}
+
+	ctx := context.Background()
+	conn := client.(*conns.AWSClient).AuditManagerClient
+	sweepResources := make([]sweep.Sweepable, 0)
+	in := &auditmanager.ListAssessmentFrameworksInput{FrameworkType: types.FrameworkTypeCustom}
+	var errs *multierror.Error
+
+	pages := auditmanager.NewListAssessmentFrameworksPaginator(conn, in)
+
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if sweep.SkipSweepError(err) || isCompleteSetupError(err) {
+			log.Printf("[WARN] Skipping AuditManager Frameworks sweep for %s: %s", region, err)
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("error retrieving AuditManager Frameworks: %w", err)
+		}
+
+		for _, framework := range page.FrameworkMetadataList {
+			id := aws.ToString(framework.Id)
+
+			log.Printf("[INFO] Deleting AuditManager Framework: %s", id)
+			sweepResources = append(sweepResources, sweep.NewSweepFrameworkResource(newResourceFramework, id, client))
+		}
+	}
+
+	if err := sweep.SweepOrchestrator(sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error sweeping AuditManager Frameworks for %s: %w", region, err))
+	}
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping AuditManager Frameworks sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/appstream"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/appsync"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/athena"
+	_ "github.com/hashicorp/terraform-provider-aws/internal/service/auditmanager"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/autoscalingplans"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/backup"


### PR DESCRIPTION
### Description
Adding sweepers for the `auditmanager` service. Currently this includes the `control` and `framework` resources.

### Relations
Relates #17981 

### Output from Acceptance Testing
```
$ SWEEPARGS=-sweep-run=aws_auditmanager_ make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2,us-east-1,us-east-2 -sweep-run=aws_auditmanager_ -timeout 60m
<snip>
2022/12/09 10:31:49 [DEBUG] Completed Sweeper (aws_auditmanager_framework) in region (us-east-2) in 122.288625ms
2022/12/09 10:31:49 Completed Sweepers for region (us-east-2) in 474.862791ms
2022/12/09 10:31:49 Sweeper Tests for region (us-east-2) ran successfully:
        - aws_auditmanager_control
        - aws_auditmanager_framework
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      4.628s
```
