### PR TITLE
fix(aws_lambda_permission): source_account creates invalid IAM condition key

### DIFF
--- a/internal/service/lambda/permission.go
+++ b/internal/service/lambda/permission.go
@@ -216,7 +216,7 @@ func resourcePermissionRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if stringEquals, ok := statement.Condition["StringEquals"]; ok {
-		d.Set("source_account", stringEquals["AWS:SourceAccount"])
+		d.Set("source_account", stringEquals["aws:SourceAccount"])
 		d.Set("event_source_token", stringEquals["lambda:EventSourceToken"])
 		d.Set("principal_org_id", stringEquals["aws:PrincipalOrgID"])
 		d.Set("function_url_auth_type", stringEquals["lambda:FunctionUrlAuthType"])

--- a/internal/service/lambda/permission_test.go
+++ b/internal/service/lambda/permission_test.go
@@ -47,8 +47,8 @@ func TestPermissionUnmarshalling(t *testing.T) {
 
 	expectedSourceAccount := "319201112229"
 	strEquals := stmt.Condition["StringEquals"]
-	if strEquals["AWS:SourceAccount"] != expectedSourceAccount {
-		t.Fatalf("Expected Source Account to match (%q != %q)", strEquals["AWS:SourceAccount"], expectedSourceAccount)
+	if strEquals["aws:SourceAccount"] != expectedSourceAccount {
+		t.Fatalf("Expected Source Account to match (%q != %q)", strEquals["aws:SourceAccount"], expectedSourceAccount)
 	}
 
 	expectedEventSourceToken := "test-event-source-token"
@@ -981,7 +981,7 @@ var testPolicy = []byte(`{
     {
       "Condition": {
         "StringEquals": {
-          "AWS:SourceAccount": "319201112229",
+          "aws:SourceAccount": "319201112229",
           "lambda:EventSourceToken": "test-event-source-token"
         },
         "ArnLike": {

--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -198,7 +198,7 @@ resource "aws_lambda_permission" "url" {
   # Adds the following condition keys
   # "Condition": {
   #      "StringEquals": {
-  #        "AWS:SourceAccount": "444455556666",
+  #        "aws:SourceAccount": "444455556666",
   #        "lambda:FunctionUrlAuthType": "AWS_IAM"
   #      }
   #    }


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Closes #28296 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make testacc TESTS=TestPermission PKG=lambda                                         bjorn@Bjorns-MacBook-Pro
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestPermission'  -timeout 180m
=== RUN   TestPermissionUnmarshalling
--- PASS: TestPermissionUnmarshalling (0.00s)
=== RUN   TestPermissionOrgUnmarshalling
--- PASS: TestPermissionOrgUnmarshalling (0.00s)
=== RUN   TestPermissionGetQualifierFromAliasOrVersionARN_alias
--- PASS: TestPermissionGetQualifierFromAliasOrVersionARN_alias (0.00s)
=== RUN   TestPermissionGetQualifierFromAliasOrVersionARN_govcloud
--- PASS: TestPermissionGetQualifierFromAliasOrVersionARN_govcloud (0.00s)
=== RUN   TestPermissionGetQualifierFromAliasOrVersionARN_version
--- PASS: TestPermissionGetQualifierFromAliasOrVersionARN_version (0.00s)
=== RUN   TestPermissionGetQualifierFromAliasOrVersionARN_invalid
--- PASS: TestPermissionGetQualifierFromAliasOrVersionARN_invalid (0.00s)
=== RUN   TestPermissionGetFunctionNameFromARN_invalid
--- PASS: TestPermissionGetFunctionNameFromARN_invalid (0.00s)
=== RUN   TestPermissionGetFunctionNameFromARN_valid
--- PASS: TestPermissionGetFunctionNameFromARN_valid (0.00s)
=== RUN   TestPermissionGetFunctionNameFromGovCloudARN
--- PASS: TestPermissionGetFunctionNameFromGovCloudARN (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     1.988s

...
```

NOTE: I will still perform some manual testing with the provider to verify the issue is resolved.