### PR TITLE
Update valid values for `resource_types` on `aws_inspector2_enabler`

### DIFF
--- a/website/docs/r/inspector2_enabler.html.markdown
+++ b/website/docs/r/inspector2_enabler.html.markdown
@@ -39,7 +39,7 @@ resource "aws_inspector2_enabler" "test" {
 The following arguments are required:
 
 * `account_ids` - (Required) Set of account IDs.
-* `resource_types` - (Required) Type of resources to scan. Valid values are `EC2` and `ECR`. If you only use one type, Terraform will ignore the status of the other type.
+* `resource_types` - (Required) Type of resources to scan. Valid values are `EC2`, `ECR`, and `LAMBDA`. If you only use one type, Terraform will ignore the status of the other type.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Description

The value values for `aws_inspector2_enabler.resource_types` has [been updated to include `LAMBDA`](https://docs.aws.amazon.com/inspector/v2/APIReference/API_Enable.html#inspector2-Enable-request-resourceTypes), which will be available as of the next release of the provider. This PR updates the documentation to match this.

### Relations

Closes #28329

### References

- [Schema `ValidateFunc` reference](https://github.com/hashicorp/terraform-provider-aws/blob/e9ea507012986603aec663169da2e8d694990112/internal/service/inspector2/enabler.go#L57)
- [Go SDK reference](https://github.com/aws/aws-sdk-go-v2/blob/93c3f1871b862d743e0bd2e2e7180246df3a9212/service/inspector2/types/enums.go#L916-L920)

### Output from Acceptance Testing

N/a, docs