### PR TITLE
Sweepers: Various RDS fixes

### DIFF
--- a/internal/service/opsworks/sweep.go
+++ b/internal/service/opsworks/sweep.go
@@ -52,6 +52,9 @@ func init() {
 	resource.AddTestSweepers("aws_opsworks_rds_db_instance", &resource.Sweeper{
 		Name: "aws_opsworks_rds_db_instance",
 		F:    sweepRDSDBInstance,
+		Dependencies: []string{
+			"aws_db_instance",
+		},
 	})
 
 	resource.AddTestSweepers("aws_opsworks_user_profile", &resource.Sweeper{

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -1262,12 +1262,13 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			return errs.AppendErrorf(diags, "existing RDS Clusters cannot be migrated between existing RDS Global Clusters")
 		}
 
+		clusterARN := d.Get("arn").(string)
 		input := &rds.RemoveFromGlobalClusterInput{
-			DbClusterIdentifier:     aws.String(d.Get("arn").(string)),
+			DbClusterIdentifier:     aws.String(clusterARN),
 			GlobalClusterIdentifier: aws.String(o),
 		}
 
-		log.Printf("[DEBUG] Removing RDS Cluster from RDS Global Cluster: %s", input)
+		log.Printf("[DEBUG] Removing RDS Cluster (%s) from RDS Global Cluster: %s", clusterARN, o)
 		_, err := conn.RemoveFromGlobalClusterWithContext(ctx, input)
 
 		if err != nil && !tfawserr.ErrCodeEquals(err, rds.ErrCodeGlobalClusterNotFoundFault) && !tfawserr.ErrMessageContains(err, "InvalidParameterValue", "is not found in global cluster") {
@@ -1316,13 +1317,14 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 	// Automatically remove from global cluster to bypass this error on deletion:
 	// InvalidDBClusterStateFault: This cluster is a part of a global cluster, please remove it from globalcluster first
 	if d.Get("global_cluster_identifier").(string) != "" {
+		clusterARN := d.Get("arn").(string)
 		globalClusterID := d.Get("global_cluster_identifier").(string)
 		input := &rds.RemoveFromGlobalClusterInput{
-			DbClusterIdentifier:     aws.String(d.Get("arn").(string)),
+			DbClusterIdentifier:     aws.String(clusterARN),
 			GlobalClusterIdentifier: aws.String(globalClusterID),
 		}
 
-		log.Printf("[DEBUG] Removing RDS Cluster from RDS Global Cluster: %s", input)
+		log.Printf("[DEBUG] Removing RDS Cluster (%s) from RDS Global Cluster: %s", clusterARN, globalClusterID)
 		_, err := conn.RemoveFromGlobalClusterWithContext(ctx, input)
 
 		if err != nil && !tfawserr.ErrCodeEquals(err, rds.ErrCodeGlobalClusterNotFoundFault) && !tfawserr.ErrMessageContains(err, "InvalidParameterValue", "is not found in global cluster") {

--- a/internal/service/rds/cluster_parameter_group.go
+++ b/internal/service/rds/cluster_parameter_group.go
@@ -314,6 +314,8 @@ func resourceClusterParameterGroupDelete(ctx context.Context, d *schema.Resource
 	input := rds_sdkv2.DeleteDBClusterParameterGroupInput{
 		DBClusterParameterGroupName: aws.String(d.Id()),
 	}
+
+	log.Printf("[DEBUG] Deleting RDS Cluster Parameter Group: %s", d.Id())
 	err := resource.Retry(3*time.Minute, func() *resource.RetryError {
 		_, err := conn.DeleteDBClusterParameterGroup(ctx, &input)
 		if errs.IsA[*types.DBParameterGroupNotFoundFault](err) {

--- a/internal/service/rds/cluster_snapshot.go
+++ b/internal/service/rds/cluster_snapshot.go
@@ -244,15 +244,17 @@ func resourcedbClusterSnapshotUpdate(d *schema.ResourceData, meta interface{}) e
 func resourceClusterSnapshotDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).RDSConn
 
-	params := &rds.DeleteDBClusterSnapshotInput{
+	log.Printf("[DEBUG] Deleting RDS DB Cluster Snapshot: %s", d.Id())
+	_, err := conn.DeleteDBClusterSnapshot(&rds.DeleteDBClusterSnapshotInput{
 		DBClusterSnapshotIdentifier: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, rds.ErrCodeDBClusterSnapshotNotFoundFault) {
+		return nil
 	}
-	_, err := conn.DeleteDBClusterSnapshot(params)
+
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, rds.ErrCodeDBClusterSnapshotNotFoundFault) {
-			return nil
-		}
-		return fmt.Errorf("error deleting RDS DB Cluster Snapshot %q: %s", d.Id(), err)
+		return fmt.Errorf("deleting RDS DB Cluster Snapshot (%s): %w", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -306,7 +306,7 @@ func resourceGlobalClusterDelete(d *schema.ResourceData, meta interface{}) error
 		GlobalClusterIdentifier: aws.String(d.Id()),
 	}
 
-	log.Printf("[DEBUG] Deleting RDS Global Cluster (%s): %s", d.Id(), input)
+	log.Printf("[DEBUG] Deleting RDS Global Cluster: %s", d.Id())
 
 	// Allow for eventual consistency
 	// InvalidGlobalClusterStateFault: Global Cluster arn:aws:rds::123456789012:global-cluster:tf-acc-test-5618525093076697001-0 is not empty
@@ -369,7 +369,6 @@ func DescribeGlobalCluster(conn *rds.RDS, globalClusterID string) (*rds.GlobalCl
 		GlobalClusterIdentifier: aws.String(globalClusterID),
 	}
 
-	log.Printf("[DEBUG] Reading RDS Global Cluster (%s): %s", globalClusterID, input)
 	err := conn.DescribeGlobalClustersPages(input, func(page *rds.DescribeGlobalClustersOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
@@ -404,7 +403,6 @@ func DescribeGlobalClusterFromClusterARN(conn *rds.RDS, dbClusterARN string) (*r
 		},
 	}
 
-	log.Printf("[DEBUG] Reading RDS Global Clusters: %s", input)
 	err := conn.DescribeGlobalClustersPages(input, func(page *rds.DescribeGlobalClustersOutput, lastPage bool) bool {
 		if page == nil {
 			return !lastPage
@@ -490,7 +488,6 @@ func WaitForGlobalClusterDeletion(conn *rds.RDS, globalClusterID string, timeout
 		NotFoundChecks: 1,
 	}
 
-	log.Printf("[DEBUG] Waiting for RDS Global Cluster (%s) deletion", globalClusterID)
 	_, err := stateConf.WaitForState()
 
 	if tfresource.NotFound(err) {

--- a/internal/service/rds/instance_automated_backups_replication.go
+++ b/internal/service/rds/instance_automated_backups_replication.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -139,13 +140,17 @@ func resourceInstanceAutomatedBackupsReplicationDelete(d *schema.ResourceData, m
 		return err
 	}
 
-	log.Printf("[DEBUG] Stopping RDS instance automated backups replication: %s", d.Id())
+	log.Printf("[DEBUG] Stopping RDS Instance Automated Backups Replication: %s", d.Id())
 	_, err = conn.StopDBInstanceAutomatedBackupsReplication(&rds.StopDBInstanceAutomatedBackupsReplicationInput{
 		SourceDBInstanceArn: aws.String(d.Get("source_db_instance_arn").(string)),
 	})
 
+	if tfawserr.ErrCodeEquals(err, rds.ErrCodeDBInstanceNotFoundFault) {
+		return nil
+	}
+
 	if err != nil {
-		return fmt.Errorf("stopping RDS instance automated backups replication (%s): %w", d.Id(), err)
+		return fmt.Errorf("stopping RDS Instance Automated Backups Replication (%s): %w", d.Id(), err)
 	}
 
 	// Create a new client to the source region.

--- a/internal/service/rds/option_group.go
+++ b/internal/service/rds/option_group.go
@@ -322,7 +322,7 @@ func resourceOptionGroupDelete(d *schema.ResourceData, meta interface{}) error {
 		OptionGroupName: aws.String(d.Id()),
 	}
 
-	log.Printf("[DEBUG] Delete DB Option Group: %#v", deleteOpts)
+	log.Printf("[DEBUG] Deleting RDS Option Group: %s", d.Id())
 	err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		_, err := conn.DeleteOptionGroup(deleteOpts)
 		if err != nil {

--- a/internal/service/rds/parameter_group.go
+++ b/internal/service/rds/parameter_group.go
@@ -356,6 +356,8 @@ func resourceParameterGroupDelete(ctx context.Context, d *schema.ResourceData, m
 	deleteOpts := rds_sdkv2.DeleteDBParameterGroupInput{
 		DBParameterGroupName: aws.String(d.Id()),
 	}
+
+	log.Printf("[DEBUG] Deleting RDS DB Parameter Group: %s", d.Id())
 	err := resource.Retry(3*time.Minute, func() *resource.RetryError {
 		_, err := conn.DeleteDBParameterGroup(ctx, &deleteOpts)
 		if errs.IsA[*types.DBParameterGroupNotFoundFault](err) {

--- a/internal/service/rds/proxy.go
+++ b/internal/service/rds/proxy.go
@@ -271,17 +271,17 @@ func resourceProxyUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceProxyDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).RDSConn
 
-	log.Printf("[DEBUG] Creating RDS DB Proxy: %s", d.Id())
+	log.Printf("[DEBUG] Deleting RDS DB Proxy: %s", d.Id())
 	_, err := conn.DeleteDBProxy(&rds.DeleteDBProxyInput{
 		DBProxyName: aws.String(d.Id()),
 	})
 
-	if err != nil {
-		return fmt.Errorf("deleting RDS DB Proxy (%s): %w", d.Id(), err)
-	}
-
 	if tfawserr.ErrCodeEquals(err, rds.ErrCodeDBProxyNotFoundFault) {
 		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("deleting RDS DB Proxy (%s): %w", d.Id(), err)
 	}
 
 	if _, err := waitDBProxyDeleted(conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {

--- a/internal/service/rds/snapshot.go
+++ b/internal/service/rds/snapshot.go
@@ -218,16 +218,17 @@ func resourceSnapshotRead(d *schema.ResourceData, meta interface{}) error {
 func resourceSnapshotDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).RDSConn
 
-	params := &rds.DeleteDBSnapshotInput{
+	log.Printf("[DEBUG] Deleting RDS DB Snapshot: %s", d.Id())
+	_, err := conn.DeleteDBSnapshot(&rds.DeleteDBSnapshotInput{
 		DBSnapshotIdentifier: aws.String(d.Id()),
-	}
-	_, err := conn.DeleteDBSnapshot(params)
+	})
+
 	if tfawserr.ErrCodeEquals(err, rds.ErrCodeDBSnapshotNotFoundFault) {
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("Error deleting AWS DB Snapshot %s: %s", d.Id(), err)
+		return fmt.Errorf("deleting RDS DB Snapshot (%s): %w", d.Id(), err)
 	}
 
 	return nil


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Turned into more changes than I initially thought.
The primary issue we were having with RDS sweepers was the dependency inversion on `aws_db_instance` on `aws_db_cluster_snapshot`.
Fixing that I realized that there were other dependency issues.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/26530.

```console
% make sweep SWEEPARGS=-sweep-run=aws_rds_global_cluster                       
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2,us-east-1,us-east-2 -sweep-run=aws_rds_global_cluster -timeout 60m
2022/12/13 14:48:15 [DEBUG] Running Sweepers for region (us-west-2):
2022/12/13 14:48:15 [DEBUG] Running Sweeper (aws_db_instance) in region (us-west-2)
2022/12/13 14:48:15 [INFO] Retrieved credentials from "EnvConfigCredentials"
2022/12/13 14:48:15 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/13 14:48:15 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/13 14:48:16 [DEBUG] Completed Sweeper (aws_db_instance) in region (us-west-2) in 968.631235ms
2022/12/13 14:48:16 [DEBUG] Sweeper (aws_rds_global_cluster) has dependency (aws_rds_cluster), running..
2022/12/13 14:48:16 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
2022/12/13 14:48:16 [DEBUG] Sweeper (aws_db_instance) already ran in region (us-west-2)
2022/12/13 14:48:16 [DEBUG] Running Sweeper (aws_rds_cluster) in region (us-west-2)
2022/12/13 14:48:16 [DEBUG] Completed Sweeper (aws_rds_cluster) in region (us-west-2) in 97.64645ms
2022/12/13 14:48:16 [DEBUG] Running Sweeper (aws_rds_global_cluster) in region (us-west-2)
2022/12/13 14:48:16 [DEBUG] Completed Sweeper (aws_rds_global_cluster) in region (us-west-2) in 107.127044ms
2022/12/13 14:48:16 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
2022/12/13 14:48:16 [DEBUG] Sweeper (aws_db_instance) already ran in region (us-west-2)
2022/12/13 14:48:16 [DEBUG] Sweeper (aws_rds_cluster) already ran in region (us-west-2)
2022/12/13 14:48:16 Completed Sweepers for region (us-west-2) in 1.173716813s
2022/12/13 14:48:16 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_db_instance
	- aws_rds_cluster
	- aws_rds_global_cluster
2022/12/13 14:48:16 [DEBUG] Running Sweepers for region (us-east-1):
2022/12/13 14:48:16 [DEBUG] Sweeper (aws_rds_global_cluster) has dependency (aws_rds_cluster), running..
2022/12/13 14:48:16 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
2022/12/13 14:48:16 [DEBUG] Running Sweeper (aws_db_instance) in region (us-east-1)
2022/12/13 14:48:16 [INFO] Retrieved credentials from "EnvConfigCredentials"
2022/12/13 14:48:16 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/13 14:48:16 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/13 14:48:16 [DEBUG] Completed Sweeper (aws_db_instance) in region (us-east-1) in 323.819009ms
2022/12/13 14:48:16 [DEBUG] Running Sweeper (aws_rds_cluster) in region (us-east-1)
2022/12/13 14:48:16 [DEBUG] Completed Sweeper (aws_rds_cluster) in region (us-east-1) in 31.620554ms
2022/12/13 14:48:16 [DEBUG] Running Sweeper (aws_rds_global_cluster) in region (us-east-1)
2022/12/13 14:48:16 [DEBUG] Completed Sweeper (aws_rds_global_cluster) in region (us-east-1) in 45.49075ms
2022/12/13 14:48:16 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
2022/12/13 14:48:16 [DEBUG] Sweeper (aws_db_instance) already ran in region (us-east-1)
2022/12/13 14:48:16 [DEBUG] Sweeper (aws_rds_cluster) already ran in region (us-east-1)
2022/12/13 14:48:16 [DEBUG] Sweeper (aws_db_instance) already ran in region (us-east-1)
2022/12/13 14:48:16 Completed Sweepers for region (us-east-1) in 401.054317ms
2022/12/13 14:48:16 Sweeper Tests for region (us-east-1) ran successfully:
	- aws_db_instance
	- aws_rds_cluster
	- aws_rds_global_cluster
2022/12/13 14:48:16 [DEBUG] Running Sweepers for region (us-east-2):
2022/12/13 14:48:16 [DEBUG] Sweeper (aws_rds_global_cluster) has dependency (aws_rds_cluster), running..
2022/12/13 14:48:16 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
2022/12/13 14:48:16 [DEBUG] Running Sweeper (aws_db_instance) in region (us-east-2)
2022/12/13 14:48:16 [INFO] Retrieved credentials from "EnvConfigCredentials"
2022/12/13 14:48:16 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/13 14:48:16 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/13 14:48:17 [DEBUG] Completed Sweeper (aws_db_instance) in region (us-east-2) in 366.147524ms
2022/12/13 14:48:17 [DEBUG] Running Sweeper (aws_rds_cluster) in region (us-east-2)
2022/12/13 14:48:17 [DEBUG] Completed Sweeper (aws_rds_cluster) in region (us-east-2) in 69.770861ms
2022/12/13 14:48:17 [DEBUG] Running Sweeper (aws_rds_global_cluster) in region (us-east-2)
2022/12/13 14:48:17 [DEBUG] Completed Sweeper (aws_rds_global_cluster) in region (us-east-2) in 57.149366ms
2022/12/13 14:48:17 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
2022/12/13 14:48:17 [DEBUG] Sweeper (aws_db_instance) already ran in region (us-east-2)
2022/12/13 14:48:17 [DEBUG] Sweeper (aws_rds_cluster) already ran in region (us-east-2)
2022/12/13 14:48:17 [DEBUG] Sweeper (aws_db_instance) already ran in region (us-east-2)
2022/12/13 14:48:17 Completed Sweepers for region (us-east-2) in 493.178636ms
2022/12/13 14:48:17 Sweeper Tests for region (us-east-2) ran successfully:
	- aws_db_instance
	- aws_rds_cluster
	- aws_rds_global_cluster
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	10.764s
```