### PR TITLE
Correct `aws_codebuild_project` documentation

### DIFF
--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -269,11 +269,11 @@ The following arguments are optional:
 ### build_batch_config
 
 * `combine_artifacts` - (Optional) Specifies if the build artifacts for the batch build should be combined into a single artifact location.
-* `restrictions` - (Optional) Specifies the restrictions for the batch build.
+* `restrictions` - (Optional) Configuration block specifying the restrictions for the batch build. Detailed below.
 * `service_role` - (Required) Specifies the service role ARN for the batch build project.
 * `timeout_in_mins` - (Optional) Specifies the maximum amount of time, in minutes, that the batch build must be completed in.
 
-#### restrictions
+#### build_batch_config: restrictions
 
 * `compute_types_allowed` - (Optional) An array of strings that specify the compute types that are allowed for the batch build. See [Build environment compute types](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html) in the AWS CodeBuild User Guide for these values.
 * `maximum_builds_allowed` - (Optional) Specifies the maximum number of builds allowed.
@@ -307,6 +307,16 @@ Credentials for access to a private Docker registry.
 
 * `credential` - (Required) ARN or name of credentials created using AWS Secrets Manager.
 * `credential_provider` - (Required) Service that created the credentials to access a private Docker registry. Valid value: `SECRETS_MANAGER` (AWS Secrets Manager).
+
+### file_system_locations
+
+See [ProjectFileSystemLocation](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_ProjectFileSystemLocation.html) for more details of the fields.
+
+* `identifier` - (Optional) The name used to access a file system created by Amazon EFS. CodeBuild creates an environment variable by appending the identifier in all capital letters to CODEBUILD\_. For example, if you specify my-efs for identifier, a new environment variable is create named CODEBUILD_MY-EFS.
+* `location` - (Optional) A string that specifies the location of the file system created by Amazon EFS. Its format is `efs-dns-name:/directory-path`.
+* `mount_options` - (Optional) The mount options for a file system created by AWS EFS.
+* `mount_point` - (Optional) The location in the container where you mount the file system.
+* `type` - (Optional) The type of the file system. The one supported type is `EFS`.
 
 ### logs_config
 
@@ -348,7 +358,7 @@ Credentials for access to a private Docker registry.
 * `insecure_ssl` - (Optional) Ignore SSL warnings when connecting to source control.
 * `location` - (Optional) Location of the source code from git or s3.
 * `report_build_status` - (Optional) Whether to report the status of a build's start and finish to your source provider. This option is only valid when your source provider is `GITHUB`, `BITBUCKET`, or `GITHUB_ENTERPRISE`.
-* `build_status_config` - (Optional) Contains information that defines how the build project reports the build status to the source provider. This option is only used when the source provider is `GITHUB`, `GITHUB_ENTERPRISE`, or `BITBUCKET`.
+* `build_status_config` - (Optional) Configuration block that contains information that defines how the build project reports the build status to the source provider. This option is only used when the source provider is `GITHUB`, `GITHUB_ENTERPRISE`, or `BITBUCKET`. `build_status_config` blocks are documented below.
 * `source_identifier` - (Required) An identifier for this project source. The identifier can only contain alphanumeric characters and underscores, and must be less than 128 characters in length.
 * `type` - (Required) Type of repository that contains the source code to be built. Valid values: `CODECOMMIT`, `CODEPIPELINE`, `GITHUB`, `GITHUB_ENTERPRISE`, `BITBUCKET` or `S3`.
 
@@ -382,17 +392,8 @@ This block is only valid when the `type` is `CODECOMMIT`, `GITHUB` or `GITHUB_EN
 * `insecure_ssl` - (Optional) Ignore SSL warnings when connecting to source control.
 * `location` - (Optional) Location of the source code from git or s3.
 * `report_build_status` - (Optional) Whether to report the status of a build's start and finish to your source provider. This option is only valid when the `type` is `BITBUCKET` or `GITHUB`.
+* `build_status_config` - (Optional) Configuration block that contains information that defines how the build project reports the build status to the source provider. This option is only used when the source provider is `GITHUB`, `GITHUB_ENTERPRISE`, or `BITBUCKET`. `build_status_config` blocks are documented below.
 * `type` - (Required) Type of repository that contains the source code to be built. Valid values: `CODECOMMIT`, `CODEPIPELINE`, `GITHUB`, `GITHUB_ENTERPRISE`, `BITBUCKET`, `S3`, `NO_SOURCE`.
-
-`file_system_locations` supports the following:
-
-See [ProjectFileSystemLocation](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_ProjectFileSystemLocation.html) for more details of the fields.
-
-* `identifier` - (Optional) The name used to access a file system created by Amazon EFS. CodeBuild creates an environment variable by appending the identifier in all capital letters to CODEBUILD\_. For example, if you specify my-efs for identifier, a new environment variable is create named CODEBUILD_MY-EFS.
-* `location` - (Optional) A string that specifies the location of the file system created by Amazon EFS. Its format is `efs-dns-name:/directory-path`.
-* `mount_options` - (Optional) The mount options for a file system created by AWS EFS.
-* `mount_point` - (Optional) The location in the container where you mount the file system.
-* `type` - (Optional) The type of the file system. The one supported type is `EFS`.
 
 #### source: auth
 
@@ -404,6 +405,11 @@ See [ProjectFileSystemLocation](https://docs.aws.amazon.com/codebuild/latest/API
 This block is only valid when the `type` is `CODECOMMIT`, `GITHUB` or `GITHUB_ENTERPRISE`.
 
 * `fetch_submodules` - (Required) Whether to fetch Git submodules for the AWS CodeBuild build project.
+
+#### source: build_status_config
+
+* `context` - (Optional) Specifies the context of the build status CodeBuild sends to the source provider. The usage of this parameter depends on the source provider.
+* `target_url` - (Optional) Specifies the target url of the build status CodeBuild sends to the source provider. The usage of this parameter depends on the source provider.
 
 ### vpc_config
 


### PR DESCRIPTION
### Description

The documentation for `aws_codebuild_project` had a few issues, including:

- A few misnamed headers
- `file_system_location` header being out of alpha order, and in the middle of the `source` headers.
- Missing `source.build_status_config` documentation

### Relations

Closes #28324

### References

- [Resource schema](https://github.com/hashicorp/terraform-provider-aws/blob/bfcd55c7cde9b2190aa0a18e6110c967e1ad5458/internal/service/codebuild/project.go#L624-L640)

### Output from Acceptance Testing

N/a, docs