### PR TITLE
Fix #28157 API Gateway v2 sample uses deprecated and now deleted "list" function

### DIFF
--- a/website/docs/r/apigatewayv2_deployment.html.markdown
+++ b/website/docs/r/apigatewayv2_deployment.html.markdown
@@ -40,10 +40,10 @@ resource "aws_apigatewayv2_deployment" "example" {
   description = "Example deployment"
 
   triggers = {
-    redeployment = sha1(join(",", list(
+    redeployment = sha1(join(",", tolist([
       jsonencode(aws_apigatewayv2_integration.example),
       jsonencode(aws_apigatewayv2_route.example),
-    )))
+    ])))
   }
 
   lifecycle {


### PR DESCRIPTION
### Description
Replace `list` by `tolist` in the [API Gateway 2 documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_deployment)

### Relations

Closes #28157