### PR TITLE
Fix issue hashicorp#28157 

### DIFF
--- a/website/docs/r/apigatewayv2_deployment.html.markdown
+++ b/website/docs/r/apigatewayv2_deployment.html.markdown
@@ -40,7 +40,7 @@ resource "aws_apigatewayv2_deployment" "example" {
   description = "Example deployment"
 
   triggers = {
-    redeployment = sha1(join(",", list(
+    redeployment = sha1(join(",", tolist(
       jsonencode(aws_apigatewayv2_integration.example),
       jsonencode(aws_apigatewayv2_route.example),
     )))


### PR DESCRIPTION

### Description

"The user used the deprecated function "list" and changed it to "tolist" as listed in the issue"


### References
issue hashicorp#28157


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
