### PR TITLE
td/aws_networkmanager_core_network-increase-default-timeout

### DIFF
--- a/.changelog/28363.txt
+++ b/.changelog/28363.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_networkmanager_core_network: Increase Create, Update, and Delete timeouts to 30 minutes
+```

--- a/.changelog/28363.txt
+++ b/.changelog/28363.txt
@@ -1,3 +1,3 @@
-```release-note:bug
+```release-note:enhancement
 resource/aws_networkmanager_core_network: Increase Create, Update, and Delete timeouts to 30 minutes
 ```

--- a/internal/service/networkmanager/core_network.go
+++ b/internal/service/networkmanager/core_network.go
@@ -45,9 +45,9 @@ func ResourceCoreNetwork() *schema.Resource {
 		),
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(10 * time.Minute),
-			Update: schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(10 * time.Minute),
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/website/docs/r/networkmanager_core_network.html.markdown
+++ b/website/docs/r/networkmanager_core_network.html.markdown
@@ -63,9 +63,9 @@ The following arguments are supported:
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-* `create` - (Default `10m`)
-* `delete` - (Default `10m`)
-* `update` - (Default `10m`)
+* `create` - (Default `30m`)
+* `delete` - (Default `30m`)
+* `update` - (Default `30m`)
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Increase default timeout for core network to 30 minutes as it takes longer to create depending on the complexity of the Policy Document.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #28155

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
