### PR TITLE
corrected names_data for ssmincidents

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.0.2
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.15.2
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.33.2
+	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.19.1
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.23.0
 	github.com/aws/smithy-go v1.13.5
 	github.com/beevik/etree v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/aws/aws-sdk-go-v2/service/sesv2 v1.15.2 h1:N9ckaOcC+H8mJ4YcsvVVDD8BAv
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.15.2/go.mod h1:U4u+AYkxs8DSNKkBfCuUs+H06rKtR+jwkW0CijDvVzg=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.33.2 h1:NXq6I98AZ3rrnykgTp93ik4RykmYEInnGDc4I/mYQNk=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.33.2/go.mod h1:bUqD3OXwwp4e+IPXVPfp6g/7OyiSesUjqHwOcwtfZBM=
+github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.19.1 h1:oSJc96s8cVEzxlWCsBUgBm+mK1uvdFTsaLPy/qL+lQc=
+github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.19.1/go.mod h1:5W4cZfis0KG5MCm1g6/R5pZ7rIul94IlvlRjgbKMRIE=
 github.com/aws/aws-sdk-go-v2/service/sso v1.11.4 h1:Uw5wBybFQ1UeA9ts0Y07gbv0ncZnIAyw858tDW0NP2o=
 github.com/aws/aws-sdk-go-v2/service/sso v1.11.4/go.mod h1:cPDwJwsP4Kff9mldCXAmddjJL6JGQqtA3Mzer2zyr88=
 github.com/aws/aws-sdk-go-v2/service/sts v1.16.4 h1:+xtV90n3abQmgzk1pS++FdxZTrPEDgQng6e4/56WR2A=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/scheduler"
 	"github.com/aws/aws-sdk-go-v2/service/sesv2"
 	ssm_sdkv2 "github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/ssmincidents"
 	"github.com/aws/aws-sdk-go-v2/service/transcribe"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/accessanalyzer"
@@ -288,7 +289,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/aws-sdk-go/service/ssmcontacts"
-	"github.com/aws/aws-sdk-go/service/ssmincidents"
 	"github.com/aws/aws-sdk-go/service/sso"
 	"github.com/aws/aws-sdk-go/service/ssoadmin"
 	"github.com/aws/aws-sdk-go/service/ssooidc"
@@ -597,7 +597,7 @@ type AWSClient struct {
 	SQSConn                          *sqs.SQS
 	SSMConn                          *ssm.SSM
 	SSMContactsConn                  *ssmcontacts.SSMContacts
-	SSMIncidentsConn                 *ssmincidents.SSMIncidents
+	SSMIncidentsClient               *ssmincidents.Client
 	SSOConn                          *sso.SSO
 	SSOAdminConn                     *ssoadmin.SSOAdmin
 	SSOOIDCConn                      *ssooidc.SSOOIDC

--- a/internal/conns/config_gen.go
+++ b/internal/conns/config_gen.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/scheduler"
 	"github.com/aws/aws-sdk-go-v2/service/sesv2"
 	ssm_sdkv2 "github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/ssmincidents"
 	"github.com/aws/aws-sdk-go-v2/service/transcribe"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -283,7 +284,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/aws-sdk-go/service/ssmcontacts"
-	"github.com/aws/aws-sdk-go/service/ssmincidents"
 	"github.com/aws/aws-sdk-go/service/sso"
 	"github.com/aws/aws-sdk-go/service/ssoadmin"
 	"github.com/aws/aws-sdk-go/service/ssooidc"
@@ -552,7 +552,6 @@ func (c *Config) sdkv1Conns(client *AWSClient, sess *session.Session) {
 	client.SQSConn = sqs.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SQS])}))
 	client.SSMConn = ssm.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SSM])}))
 	client.SSMContactsConn = ssmcontacts.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SSMContacts])}))
-	client.SSMIncidentsConn = ssmincidents.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SSMIncidents])}))
 	client.SSOConn = sso.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SSO])}))
 	client.SSOAdminConn = ssoadmin.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SSOAdmin])}))
 	client.SSOOIDCConn = ssooidc.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SSOOIDC])}))
@@ -669,6 +668,11 @@ func (c *Config) sdkv2Conns(client *AWSClient, cfg aws_sdkv2.Config) {
 	client.SESV2Client = sesv2.NewFromConfig(cfg, func(o *sesv2.Options) {
 		if endpoint := c.Endpoints[names.SESV2]; endpoint != "" {
 			o.EndpointResolver = sesv2.EndpointResolverFromURL(endpoint)
+		}
+	})
+	client.SSMIncidentsClient = ssmincidents.NewFromConfig(cfg, func(o *ssmincidents.Options) {
+		if endpoint := c.Endpoints[names.SSMIncidents]; endpoint != "" {
+			o.EndpointResolver = ssmincidents.EndpointResolverFromURL(endpoint)
 		}
 	})
 	client.SchedulerClient = scheduler.NewFromConfig(cfg, func(o *scheduler.Options) {

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -327,7 +327,7 @@ sns,sns,sns,sns,,sns,,,SNS,SNS,,1,,,aws_sns_,,sns_,SNS (Simple Notification),Ama
 sqs,sqs,sqs,sqs,,sqs,,,SQS,SQS,,1,,,aws_sqs_,,sqs_,SQS (Simple Queue),Amazon,,,,,
 ssm,ssm,ssm,ssm,,ssm,,,SSM,SSM,,1,2,,aws_ssm_,,ssm_,SSM (Systems Manager),AWS,,,,,
 ssm-contacts,ssmcontacts,ssmcontacts,ssmcontacts,,ssmcontacts,,,SSMContacts,SSMContacts,,1,,,aws_ssmcontacts_,,ssmcontacts_,SSM Incident Manager Contacts,AWS,,,,,
-ssm-incidents,ssmincidents,ssmincidents,ssmincidents,,ssmincidents,,,SSMIncidents,SSMIncidents,,1,,,aws_ssmincidents_,,ssmincidents_,SSM Incident Manager Incidents,AWS,,,,,
+ssm-incidents,ssmincidents,ssmincidents,ssmincidents,,ssmincidents,,,SSMIncidents,SSMIncidents,,,2,,aws_ssmincidents_,,ssmincidents_,SSM Incident Manager Incidents,AWS,,,,,
 sso,sso,sso,sso,,sso,,,SSO,SSO,,1,,,aws_sso_,,sso_,SSO (Single Sign-On),AWS,,,,,
 sso-admin,ssoadmin,ssoadmin,ssoadmin,,ssoadmin,,,SSOAdmin,SSOAdmin,,1,,,aws_ssoadmin_,,ssoadmin_,SSO Admin,AWS,,,,,
 identitystore,identitystore,identitystore,identitystore,,identitystore,,,IdentityStore,IdentityStore,,,2,,aws_identitystore_,,identitystore_,SSO Identity Store,AWS,,,,,


### PR DESCRIPTION
Updated SSMincidents names_data (of which service has not yet been implemented) to correctly specify that it will use the go sdk v2 instead of v1