### PR TITLE
tests: Benchmark provider construction

### DIFF
--- a/internal/provider/factory_test.go
+++ b/internal/provider/factory_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/provider"
 )
 
-// go test -bench=BenchmarkProtoV5ProviderServerFactory -benchtime 2x -v ./internal/provider
+// go test -bench=BenchmarkProtoV5ProviderServerFactory -benchtime 1x -benchmem -run=B -v ./internal/provider
 func BenchmarkProtoV5ProviderServerFactory(b *testing.B) {
 	_, p, err := provider.ProtoV5ProviderServerFactory(context.Background())
 

--- a/internal/provider/factory_test.go
+++ b/internal/provider/factory_test.go
@@ -1,0 +1,21 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/provider"
+)
+
+// go test -bench=BenchmarkProtoV5ProviderServerFactory -benchtime 2x -v ./internal/provider
+func BenchmarkProtoV5ProviderServerFactory(b *testing.B) {
+	_, p, err := provider.ProtoV5ProviderServerFactory(context.Background())
+
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	if b.N == 1 {
+		b.Logf("%d resources, %d data sources", len(p.ResourcesMap), len(p.DataSourcesMap))
+	}
+}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds a test to benchmark provider construction.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/26626.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28202.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test -bench=BenchmarkProtoV5ProviderServerFactory -benchtime 1x -benchmem -run=B -v ./internal/provider
goos: darwin
goarch: amd64
pkg: github.com/hashicorp/terraform-provider-aws/internal/provider
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkProtoV5ProviderServerFactory
    factory_test.go:19: 1124 resources, 425 data sources
BenchmarkProtoV5ProviderServerFactory-8   	       1	 139206149 ns/op	78189992 B/op	 1076525 allocs/op
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider	4.721s
```
