### PR TITLE
[WIP] Eventbridge - ECS placement strategy

### DIFF
--- a/internal/service/events/target.go
+++ b/internal/service/events/target.go
@@ -181,6 +181,25 @@ func ResourceTarget() *schema.Resource {
 								},
 							},
 						},
+						"ordered_placement_strategy": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 5,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"field": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringLenBetween(0, 255),
+									},
+									"type": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(eventbridge.PlacementStrategyType_Values(), false),
+									},
+								},
+							},
+						},
 						"platform_version": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -778,6 +797,10 @@ func expandTargetECSParameters(config []interface{}) *eventbridge.EcsParameters 
 			ecsParameters.PlacementConstraints = expandTargetPlacementConstraints(v.List())
 		}
 
+		if v, ok := param["ordered_placement_strategy"]; ok {
+			ecsParameters.PlacementStrategy = expandTargetPlacementStrategies(v.([]interface{}))
+		}
+
 		if v, ok := param["propagate_tags"].(string); ok {
 			ecsParameters.PropagateTags = aws.String(v)
 		}
@@ -971,6 +994,10 @@ func flattenTargetECSParameters(ecsParameters *eventbridge.EcsParameters) []map[
 		config["placement_constraint"] = flattenTargetPlacementConstraints(ecsParameters.PlacementConstraints)
 	}
 
+	if ecsParameters.PlacementStrategy != nil {
+		config["ordered_placement_strategy"] = flattenTargetPlacementStrategies(ecsParameters.PlacementStrategy)
+	}
+
 	if ecsParameters.CapacityProviderStrategy != nil {
 		config["capacity_provider_strategy"] = flattenTargetCapacityProviderStrategy(ecsParameters.CapacityProviderStrategy)
 	}
@@ -1130,6 +1157,36 @@ func expandTargetPlacementConstraints(tfList []interface{}) []*eventbridge.Place
 	return result
 }
 
+func expandTargetPlacementStrategies(tfList []interface{}) []*eventbridge.PlacementStrategy {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var result []*eventbridge.PlacementStrategy
+
+	for _, tfMapRaw := range tfList {
+		if tfMapRaw == nil {
+			continue
+		}
+
+		tfMap := tfMapRaw.(map[string]interface{})
+
+		apiObject := &eventbridge.PlacementStrategy{}
+
+		if v, ok := tfMap["field"].(string); ok && v != "" {
+			apiObject.Field = aws.String(v)
+		}
+
+		if v, ok := tfMap["type"].(string); ok && v != "" {
+			apiObject.Type = aws.String(v)
+		}
+
+		result = append(result, apiObject)
+	}
+
+	return result
+}
+
 func expandTargetCapacityProviderStrategy(tfList []interface{}) []*eventbridge.CapacityProviderStrategyItem {
 	if len(tfList) == 0 {
 		return nil
@@ -1174,6 +1231,23 @@ func flattenTargetPlacementConstraints(pcs []*eventbridge.PlacementConstraint) [
 		c["type"] = aws.StringValue(pc.Type)
 		if pc.Expression != nil {
 			c["expression"] = aws.StringValue(pc.Expression)
+		}
+
+		results = append(results, c)
+	}
+	return results
+}
+
+func flattenTargetPlacementStrategies(pcs []*eventbridge.PlacementStrategy) []map[string]interface{} {
+	if len(pcs) == 0 {
+		return nil
+	}
+	results := make([]map[string]interface{}, 0)
+	for _, pc := range pcs {
+		c := make(map[string]interface{})
+		c["type"] = aws.StringValue(pc.Type)
+		if pc.Field != nil {
+			c["field"] = aws.StringValue(pc.Field)
 		}
 
 		results = append(results, c)

--- a/internal/service/events/target_test.go
+++ b/internal/service/events/target_test.go
@@ -675,6 +675,40 @@ func TestAccEventsTarget_ecsCapacityProvider(t *testing.T) {
 	})
 }
 
+func TestAccEventsTarget_ecsPlacementStrategy(t *testing.T) {
+	var v eventbridge.Target
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cloudwatch_event_target.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, eventbridge.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTargetConfig_ecsPlacementStrategy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTargetExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.task_count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.ordered_placement_strategy.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.ordered_placement_strategy.0.type", "spread"),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.ordered_placement_strategy.0.field", "attribute:ecs.availability-zone"),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.ordered_placement_strategy.1.type", "spread"),
+					resource.TestCheckResourceAttr(resourceName, "ecs_target.0.ordered_placement_strategy.1.field", "instanceId"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccTargetImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccEventsTarget_batch(t *testing.T) {
 	resourceName := "aws_cloudwatch_event_target.test"
 	batchJobDefinitionResourceName := "aws_batch_job_definition.test"
@@ -1763,6 +1797,89 @@ resource "aws_ecs_capacity_provider" "test" {
     }
   }
 }
+`, rName))
+}
+
+func testAccTargetConfig_ecsPlacementStrategy(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinuxHVMEBSAMI(),
+		testAccTargetConfig_ecsBase(rName),
+		fmt.Sprintf(`
+resource "aws_cloudwatch_event_target" "test" {
+  arn       = aws_ecs_cluster.test.id
+  rule      = aws_cloudwatch_event_rule.test.id
+  role_arn  = aws_iam_role.test.arn
+  target_id = %[1]q
+
+  ecs_target {
+    task_definition_arn = aws_ecs_task_definition.task.arn
+    launch_type = "EC2"
+	
+	ordered_placement_strategy {
+	  type = "spread"
+	  field = "attribute:ecs.availability-zone"
+	}
+	   
+	ordered_placement_strategy {
+	  type = "spread"
+	  field = "instanceId"
+	}
+	
+  }
+}
+
+resource "aws_launch_template" "test" {
+  name          = %[1]q
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = "t2.micro"
+}
+
+resource "aws_autoscaling_group" "test" {
+  name                = %[1]q
+  desired_capacity    = 0
+  max_size            = 0
+  min_size            = 0
+  vpc_zone_identifier = [aws_subnet.test[0].id]
+
+  launch_template {
+    id      = aws_launch_template.test.id
+    version = "$Latest"
+  }
+
+  tag {
+    key                 = "AmazonECSManaged"
+    value               = ""
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_ecs_capacity_provider" "test" {
+  name = %[1]q
+  
+  auto_scaling_group_provider {
+    auto_scaling_group_arn         = aws_autoscaling_group.test.arn
+    managed_termination_protection = "DISABLED"
+
+    managed_scaling {
+      maximum_scaling_step_size = 1
+      minimum_scaling_step_size = 1
+      status                    = "ENABLED"
+      target_capacity           = 1
+    }
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "test" {
+  cluster_name = aws_ecs_cluster.test.name
+  capacity_providers = [  %[1]q ]
+
+  default_capacity_provider_strategy {
+	capacity_provider =  %[1]q
+	base              = 1
+	weight            = 100
+  }
+}
+
 `, rName))
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

I've added the `ordered_placement_strategy` stanza to support task placement strategies in an ECS Task target for CloudWatch / EventBridge. 

Todo: 

* [X] Functionality
* [X] Basic acceptance test
* [ ] Documentation updates
* [ ] Add changlog entry

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28259

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

* https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_EcsParameters.html#eventbridge-Type-EcsParameters-PlacementStrategy
* https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccEventsTarget_ecsPlacementStrategy PKG=events
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsTarget_ecsPlacementStrategy'  -timeout 180m
=== RUN   TestAccEventsTarget_ecsPlacementStrategy
=== PAUSE TestAccEventsTarget_ecsPlacementStrategy
=== CONT  TestAccEventsTarget_ecsPlacementStrategy
--- PASS: TestAccEventsTarget_ecsPlacementStrategy (79.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	82.283s
...
```

