### PR TITLE
r/rum_app_monitor - add `custom_events`

### DIFF
--- a/.changelog/28431.txt
+++ b/.changelog/28431.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/rum_app_monitor: Add `custom_events` argument
+```

--- a/.changelog/28431.txt
+++ b/.changelog/28431.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/rum_app_monitor: Add `custom_events` argument
+resource/aws_rum_app_monitor: Add `custom_events` argument
 ```

--- a/website/docs/r/rum_app_monitor.html.markdown
+++ b/website/docs/r/rum_app_monitor.html.markdown
@@ -27,6 +27,7 @@ The following arguments are supported:
 * `domain` - (Required) The top-level internet domain name for which your application has administrative authority.
 * `app_monitor_configuration` - (Optional) configuration data for the app monitor. See [app_monitor_configuration](#app_monitor_configuration) below.
 * `cw_log_enabled` - (Optional) Data collected by RUM is kept by RUM for 30 days and then deleted. This parameter  specifies whether RUM sends a copy of this telemetry data to Amazon CloudWatch Logs in your account. This enables you to keep the telemetry data for more than 30 days, but it does incur Amazon CloudWatch Logs charges. Default value is `false`.
+* `custom_events` - (Optional) Specifies whether this app monitor allows the web client to define and send custom events. If you omit this parameter, custom events are `DISABLED`. See [custom_events](#custom_events) below.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### app_monitor_configuration
@@ -40,6 +41,10 @@ The following arguments are supported:
 * `included_pages` - (Optional)  If this app monitor is to collect data from only certain pages in your application, this structure lists those pages.
 * `session_sample_rate` - (Optional) Specifies the percentage of user sessions to use for RUM data collection. Choosing a higher percentage gives you more data but also incurs more costs. The number you specify is the percentage of user sessions that will be used. Default value is `0.1`.
 * `telemetries` - (Optional) An array that lists the types of telemetry data that this app monitor is to collect. Valid values are `errors`, `performance`, and `http`.
+
+### custom_events
+
+* `status` - (Optional) Specifies whether this app monitor allows the web client to define and send custom events. The default is for custom events to be `DISABLED`. Valid values are `DISABLED` and `ENABLED`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccRUMAppMonitor_ PKG=rum

--- PASS: TestAccRUMAppMonitor_disappears (20.41s)
--- PASS: TestAccRUMAppMonitor_basic (43.97s)
--- PASS: TestAccRUMAppMonitor_tags (62.20s)
--- PASS: TestAccRUMAppMonitor_customEvents (62.36s)
```
