### PR TITLE
Fix Lambda function URL cors settings are not removed

### DIFF
--- a/.changelog/28439.txt
+++ b/.changelog/28439.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_lambda_function_url: Fix Lambda function URL cors settings are not removed
+resource/aws_lambda_function_url: Fix removal of `cors` configuration block
 ```

--- a/.changelog/28439.txt
+++ b/.changelog/28439.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lambda_function_url: Fix Lambda function URL cors settings are not removed
+```

--- a/internal/service/lambda/function_url.go
+++ b/internal/service/lambda/function_url.go
@@ -239,9 +239,10 @@ func resourceFunctionURLUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if d.HasChange("cors") {
-		input.Cors = &lambda.Cors{}
 		if v, ok := d.GetOk("cors"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 			input.Cors = expandCors(v.([]interface{})[0].(map[string]interface{}))
+		} else {
+			input.Cors = &lambda.Cors{}
 		}
 	}
 

--- a/internal/service/lambda/function_url.go
+++ b/internal/service/lambda/function_url.go
@@ -239,6 +239,7 @@ func resourceFunctionURLUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if d.HasChange("cors") {
+		input.Cors = &lambda.Cors{}
 		if v, ok := d.GetOk("cors"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 			input.Cors = expandCors(v.([]interface{})[0].(map[string]interface{}))
 		}

--- a/internal/service/lambda/function_url_test.go
+++ b/internal/service/lambda/function_url_test.go
@@ -116,6 +116,14 @@ func TestAccLambdaFunctionURL_Cors(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cors.0.max_age", "72000"),
 				),
 			},
+			{
+				Config: testAccFunctionURLConfig_basic(funcName, policyName, roleName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckFunctionURLExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "authorization_type", lambda.FunctionUrlAuthTypeNone),
+					resource.TestCheckResourceAttr(resourceName, "cors.#", "0"),
+				),
+			},
 		},
 	})
 }
@@ -271,7 +279,7 @@ func testAccFunctionURLConfig_base(policyName, roleName string) string {
 data "aws_partition" "current" {}
 
 resource "aws_iam_role_policy" "iam_policy_for_lambda" {
-  name = "%s"
+  name = %[1]q
   role = aws_iam_role.iam_for_lambda.id
 
   policy = <<EOF
@@ -322,7 +330,7 @@ EOF
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
-  name = "%s"
+  name = %[2]q
 
   assume_role_policy = <<EOF
 {


### PR DESCRIPTION
### Description
Though removing `cors` block of `aws_lambda_function_url` , actually Terraform does not remove the cors settings.

Reproduction steps:

1. apply

```
resource "aws_lambda_function_url" "example" {
  function_name      = aws_lambda_function.example.function_name
  authorization_type = "NONE"

  cors {
    allow_credentials = false
    allow_origins     = ["*"]
    allow_methods     = ["*"]
    allow_headers     = ["content-type"]
  }
}
```

2. delete the cors settings and apply

```
resource "aws_lambda_function_url" "example" {
  function_name      = aws_lambda_function.example.function_name
  authorization_type = "NONE"
}
```

3. check the AWS management console
cors settings are not removed.
 

### Relations

Relates https://github.com/hashicorp/terraform-provider-aws/issues/24050.

### References
N/A

### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccLambdaFunctionURL PKG=lambda ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 2 -run='TestAccLambdaFunctionURL'  -timeout 180m
=== RUN   TestAccLambdaFunctionURLDataSource_basic
=== PAUSE TestAccLambdaFunctionURLDataSource_basic
=== RUN   TestAccLambdaFunctionURL_basic
=== PAUSE TestAccLambdaFunctionURL_basic
=== RUN   TestAccLambdaFunctionURL_Cors
=== PAUSE TestAccLambdaFunctionURL_Cors
=== RUN   TestAccLambdaFunctionURL_Alias
=== PAUSE TestAccLambdaFunctionURL_Alias
=== RUN   TestAccLambdaFunctionURL_TwoURLs
=== PAUSE TestAccLambdaFunctionURL_TwoURLs
=== CONT  TestAccLambdaFunctionURLDataSource_basic
=== CONT  TestAccLambdaFunctionURL_Alias
--- PASS: TestAccLambdaFunctionURLDataSource_basic (43.57s)
=== CONT  TestAccLambdaFunctionURL_Cors
--- PASS: TestAccLambdaFunctionURL_Alias (52.15s)
=== CONT  TestAccLambdaFunctionURL_TwoURLs
--- PASS: TestAccLambdaFunctionURL_TwoURLs (45.86s)
=== CONT  TestAccLambdaFunctionURL_basic
--- PASS: TestAccLambdaFunctionURL_Cors (60.66s)
--- PASS: TestAccLambdaFunctionURL_basic (44.26s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     144.302s
```