### PR TITLE
r/aws_autoscaling_policy: Update example for predictive scaling

### DIFF
--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -57,23 +57,13 @@ resource "aws_autoscaling_policy" "example" {
           expression = "SUM(SEARCH('{AWS/EC2,AutoScalingGroupName} MetricName=\"CPUUtilization\" my-test-asg', 'Sum', 3600))"
         }
       }
-      customized_scaling_metric_specification {
+      customized_capacity_metric_specification {
         metric_data_queries {
-          id = "scaling"
-          metric_stat {
-            metric {
-              metric_name = "CPUUtilization"
-              namespace   = "AWS/EC2"
-              dimensions {
-                name  = "AutoScalingGroupName"
-                value = "my-test-asg"
-              }
-            }
-            stat = "Average"
-          }
+          id         = "capacity_sum"
+          expression = "SUM(SEARCH('{AWS/AutoScaling,AutoScalingGroupName} MetricName=\"GroupInServiceIntances\" my-test-asg', 'Average', 300))"
         }
       }
-      customized_capacity_metric_specification {
+      customized_scaling_metric_specification {
         metric_data_queries {
           id          = "capacity_sum"
           expression  = "SUM(SEARCH('{AWS/AutoScaling,AutoScalingGroupName} MetricName=\"GroupInServiceIntances\" my-test-asg', 'Average', 300))"
@@ -86,7 +76,7 @@ resource "aws_autoscaling_policy" "example" {
         }
         metric_data_queries {
           id         = "weighted_average"
-          expression = "load_sum / capacity_sum"
+          expression = "load_sum / (capacity_sum * PERIOD(capacity_sum) / 60)"
         }
       }
     }


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The current example is misleading from semantic point of view. Hence, this patch uses [an example in AWS blog "Using EC2 Auto Scaling predictive scaling policies with Blue/Green deployments"](https://aws.amazon.com/blogs/compute/retaining-metrics-across-blue-green-deployment-for-predictive-scaling/) instead.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

N/A

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

A relevant AWS blog: https://aws.amazon.com/blogs/compute/retaining-metrics-across-blue-green-deployment-for-predictive-scaling/


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccAutoScalingPolicy PKG=autoscaling
...
--- PASS: TestAccAutoScalingPolicy_simpleScalingStepAdjustment (34.15s)
--- PASS: TestAccAutoScalingPolicy_predictiveScalingPredefined (37.67s)
--- PASS: TestAccAutoScalingPolicy_predictiveScalingCustom (38.91s)
--- PASS: TestAccAutoScalingPolicy_TargetTrack_predefined (43.27s)
--- PASS: TestAccAutoScalingPolicy_disappears (47.48s)
--- PASS: TestAccAutoScalingPolicy_TargetTrack_custom (51.26s)
--- PASS: TestAccAutoScalingPolicy_predictiveScalingUpdated (51.49s)
--- PASS: TestAccAutoScalingPolicy_predictiveScalingRemoved (58.59s)
--- PASS: TestAccAutoScalingPolicy_zeroValue (59.29s)
--- PASS: TestAccAutoScalingPolicy_basic (67.17s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling	67.299s
```
