### PR TITLE
fix(resource_ssm_document): handle dynamic field refresh when content is updated

### DIFF
--- a/internal/service/ssm/document.go
+++ b/internal/service/ssm/document.go
@@ -3,6 +3,7 @@ package ssm
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"log"
 	"regexp"
 	"strings"
@@ -192,7 +193,24 @@ func ResourceDocument() *schema.Resource {
 			},
 		},
 
-		CustomizeDiff: verify.SetTagsDiff,
+		CustomizeDiff: customdiff.Sequence(
+			customdiff.ComputedIf("default_version", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+				return diff.HasChange("content")
+			}),
+			customdiff.ComputedIf("document_version", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+				return diff.HasChange("content")
+			}),
+			customdiff.ComputedIf("hash", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+				return diff.HasChange("content")
+			}),
+			customdiff.ComputedIf("latest_version", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+				return diff.HasChange("content")
+			}),
+			customdiff.ComputedIf("parameter", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+				return diff.HasChange("content")
+			}),
+			verify.SetTagsDiff,
+		),
 	}
 }
 

--- a/internal/service/ssm/document_test.go
+++ b/internal/service/ssm/document_test.go
@@ -163,8 +163,14 @@ func TestAccSSMDocument_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDocumentExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "schema_version", "2.0"),
+					resource.TestCheckResourceAttr(resourceName, "document_version", "1"),
 					resource.TestCheckResourceAttr(resourceName, "latest_version", "1"),
 					resource.TestCheckResourceAttr(resourceName, "default_version", "1"),
+					resource.TestCheckOutput("default_version", "1"),
+					resource.TestCheckOutput("document_version", "1"),
+					resource.TestCheckOutput("hash", "1a200df3fefa0e7f8814829781d6295e616474945a239a956561876b4c820cde"),
+					resource.TestCheckOutput("latest_version", "1"),
+					resource.TestCheckOutput("parameter_len", "0"),
 				),
 			},
 			{
@@ -175,9 +181,15 @@ func TestAccSSMDocument_update(t *testing.T) {
 			{
 				Config: testAccDocumentConfig_20Updated(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDocumentExists(ctx, resourceName),
+					testAccCheckDocumentExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "document_version", "2"),
 					resource.TestCheckResourceAttr(resourceName, "latest_version", "2"),
 					resource.TestCheckResourceAttr(resourceName, "default_version", "2"),
+					resource.TestCheckOutput("default_version", "2"),
+					resource.TestCheckOutput("document_version", "2"),
+					resource.TestCheckOutput("hash", "214c51d87f98ae07b868a63cd866955578c1ef41c3ab8c36f80039dfd9565f53"),
+					resource.TestCheckOutput("latest_version", "2"),
+					resource.TestCheckOutput("parameter_len", "1"),
 				),
 			},
 		},
@@ -805,6 +817,22 @@ resource "aws_ssm_document" "test" {
 DOC
 
 }
+
+output "default_version" {
+  value = aws_ssm_document.test.default_version
+}
+output "document_version" {
+  value = aws_ssm_document.test.document_version
+}
+output "hash" {
+  value = aws_ssm_document.test.hash
+}
+output "latest_version" {
+  value = aws_ssm_document.test.latest_version
+}
+output "parameter_len" {
+  value = length(aws_ssm_document.test.parameter)
+}
 `, rName)
 }
 
@@ -818,14 +846,20 @@ resource "aws_ssm_document" "test" {
 {
   "schemaVersion": "2.0",
   "description": "Sample version 2.0 document v2",
-  "parameters": {},
+  "parameters": {
+    "processOptions": {
+      "type": "String",
+      "default": "-Verbose",
+      "description": "(Optional) Get-Process command options."
+    }
+  },
   "mainSteps": [
     {
       "action": "aws:runPowerShellScript",
       "name": "runPowerShellScript",
       "inputs": {
         "runCommand": [
-          "Get-Process -Verbose"
+          "Get-Process {{processOptions}}"
         ]
       }
     }
@@ -833,6 +867,22 @@ resource "aws_ssm_document" "test" {
 }
 DOC
 
+}
+
+output "default_version" {
+  value = aws_ssm_document.test.default_version
+}
+output "document_version" {
+  value = aws_ssm_document.test.document_version
+}
+output "hash" {
+  value = aws_ssm_document.test.hash
+}
+output "latest_version" {
+  value = aws_ssm_document.test.latest_version
+}
+output "parameter_len" {
+  value = length(aws_ssm_document.test.parameter)
 }
 `, rName)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Declare computed field for `*_version`, `hash`, `parameter` when `content` is updated


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #26363

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```bash
➜ make testacc TESTS=TestAccSSMDocument_update PKG=ssm                                                                                                                        15:24:22 

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMDocument_update'  -timeout 180m
=== RUN   TestAccSSMDocument_update
=== PAUSE TestAccSSMDocument_update
=== CONT  TestAccSSMDocument_update
--- PASS: TestAccSSMDocument_update (62.85s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        65.890s

```
