### PR TITLE
codebuild_webhook example should use BASE_REF

### DIFF
--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -31,7 +31,7 @@ resource "aws_codebuild_webhook" "example" {
     }
 
     filter {
-      type    = "HEAD_REF"
+      type    = "BASE_REF"
       pattern = "master"
     }
   }


### PR DESCRIPTION
The codebuild_webhook example should use BASE_REF instead of HEAD_REF. BASE_REF would refer to a branch like `master` or `main`, whereas `HEAD_REF` would refer to a feature branch. Since most people are probably using Codebuild to run CI tests on their pull requests, and their pull requests are meant to merge into master, changing this to BASE_REF provides a more easily pasteable example.