### PR TITLE
Add lambda_function.image_config DiffSuppressFunc

### DIFF
--- a/.changelog/28495.txt
+++ b/.changelog/28495.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lambda_function: Suppress diffs when all `image_config` values are `null`
+```

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -179,6 +179,25 @@ func ResourceFunction() *schema.Resource {
 						},
 					},
 				},
+
+				// Suppress diffs if the image configuration is provided, but values are unset
+				// which is a valid Lambda function configuration. e.g.
+				//   image_config {
+				//     command           = null
+				//     entry_point       = null
+				//	   working_directory = null
+				//   }
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if d.Id() == "" || old == "1" || new == "0" {
+						return false
+					}
+
+					if d.HasChanges("image_config.0.entry_point", "image_config.0.command", "image_config.0.working_directory") {
+						return false
+					}
+
+					return true
+				},
 			},
 			"image_uri": {
 				Type:          schema.TypeString,

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -998,10 +998,19 @@ func TestAccLambdaFunction_imageNullImageConfig(t *testing.T) {
 				ExpectNonEmptyPlan: false,
 				PlanOnly:           true,
 			},
+			{
+				// Make sure that we don't erroneously suppress a valid diff
+				Config:       testAccFunctionConfig_image(rName, imageLatestID),
+				ResourceName: resourceName,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "image_config.0.entry_point.0", "/bootstrap-with-handler"),
+					resource.TestCheckResourceAttr(resourceName, "image_config.0.command.0", "app.lambda_handler"),
+					resource.TestCheckResourceAttr(resourceName, "image_config.0.working_directory", "/var/task"),
+				),
+			},
 		},
 	},
 	)
-
 }
 
 func TestAccLambdaFunction_architectures(t *testing.T) {

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -972,18 +972,6 @@ func TestAccLambdaFunction_imageNullImageConfig(t *testing.T) {
 		t.Skipf("Environment variable %s is not set", key)
 	}
 
-	key = "AWS_LAMBDA_IMAGE_V1_ID"
-	imageV1ID := os.Getenv(key)
-	if imageV1ID == "" {
-		t.Skipf("Environment variable %s is not set", key)
-	}
-
-	key = "AWS_LAMBDA_IMAGE_V2_ID"
-	imageV2ID := os.Getenv(key)
-	if imageV2ID == "" {
-		t.Skipf("Environment variable %s is not set", key)
-	}
-
 	var conf lambda.GetFunctionOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lambda_function.test"
@@ -995,7 +983,7 @@ func TestAccLambdaFunction_imageNullImageConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFunctionConfig_emptyImageConfig(rName, imageLatestID),
+				Config: testAccFunctionConfig_nullImageConfig(rName, imageLatestID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFunctionExists(resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "package_type", lambda.PackageTypeImage),
@@ -1005,7 +993,7 @@ func TestAccLambdaFunction_imageNullImageConfig(t *testing.T) {
 			},
 			{
 				// Test that there are no planned changes when re-planning the same config with an empty `image_config` block
-				Config:             testAccFunctionConfig_emptyImageConfig(rName, imageLatestID),
+				Config:             testAccFunctionConfig_nullImageConfig(rName, imageLatestID),
 				ResourceName:       resourceName,
 				ExpectNonEmptyPlan: false,
 				PlanOnly:           true,
@@ -3344,7 +3332,7 @@ resource "aws_lambda_function" "test" {
 `, rName))
 }
 
-func testAccFunctionConfig_emptyImageConfig(rName, imageID string) string {
+func testAccFunctionConfig_nullImageConfig(rName, imageID string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLambdaBase(rName, rName, rName),
 		fmt.Sprintf(`


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Adds a `DiffSuppressFunc` to the `image_config` attribute of the `aws_lambda_function` resource.

### Relations
Closes #28495 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

```
$ AWS_LAMBDA_IMAGE_LATEST_ID=142421032989.dkr.ecr.us-east-2.amazonaws.com/test:latest AWS_DEFAULT_REGION=us-east-2 make testacc TESTS=^TestAccLambdaFunction_imageNullImageConfig$ PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='^TestAccLambdaFunction_imageNullImageConfig'  -timeout 180m
=== RUN   TestAccLambdaFunction_imageNullImageConfig
=== PAUSE TestAccLambdaFunction_imageNullImageConfig
=== CONT  TestAccLambdaFunction_imageNullImageConfig
--- PASS: TestAccLambdaFunction_imageNullImageConfig (115.04s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     118.137s

...
```
