### PR TITLE
r/aws_ami: Use paginated `DescribeImages` API

### DIFF
--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -34,7 +34,7 @@ func init() {
 
 	resource.AddTestSweepers("aws_ec2_carrier_gateway", &resource.Sweeper{
 		Name: "aws_ec2_carrier_gateway",
-		F:    sweepCarrierGateway,
+		F:    sweepCarrierGateways,
 	})
 
 	resource.AddTestSweepers("aws_ec2_client_vpn_endpoint", &resource.Sweeper{
@@ -52,7 +52,7 @@ func init() {
 
 	resource.AddTestSweepers("aws_ec2_fleet", &resource.Sweeper{
 		Name: "aws_ec2_fleet",
-		F:    sweepFleet,
+		F:    sweepFleets,
 	})
 
 	resource.AddTestSweepers("aws_ebs_volume", &resource.Sweeper{
@@ -415,7 +415,7 @@ func sweepCapacityReservations(region string) error {
 	return nil
 }
 
-func sweepCarrierGateway(region string) error {
+func sweepCarrierGateways(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
@@ -568,7 +568,7 @@ func sweepClientVPNNetworkAssociations(region string) error {
 	return sweeperErrs.ErrorOrNil()
 }
 
-func sweepFleet(region string) error {
+func sweepFleets(region string) error {
 	client, err := sweep.SharedRegionalSweepClient(region)
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
@@ -2424,7 +2424,21 @@ func sweepAMIs(region string) error {
 	conn := client.(*conns.AWSClient).EC2Conn
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	output, err := conn.DescribeImages(input)
+	err = conn.DescribeImagesPages(input, func(page *ec2.DescribeImagesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.Images {
+			r := ResourceAMI()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(v.ImageId))
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
 
 	if sweep.SkipSweepError(err) {
 		log.Printf("[WARN] Skipping AMI sweep for %s: %s", region, err)
@@ -2433,14 +2447,6 @@ func sweepAMIs(region string) error {
 
 	if err != nil {
 		return fmt.Errorf("error listing AMIs (%s): %w", region, err)
-	}
-
-	for _, v := range output.Images {
-		r := ResourceAMI()
-		d := r.Data(nil)
-		d.SetId(aws.StringValue(v.ImageId))
-
-		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 	}
 
 	err = sweep.SweepOrchestrator(sweepResources)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Use the paginated EC2 [`DescribeImages`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html) API.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/28515.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make sweep SWEEPARGS=-sweep-run=aws_ami SWEEP=us-west-1
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-1 -sweep-run=aws_ami -timeout 60m
2022/12/21 09:05:53 [DEBUG] Running Sweepers for region (us-west-1):
2022/12/21 09:05:53 [DEBUG] Running Sweeper (aws_ami) in region (us-west-1)
2022/12/21 09:05:53 [INFO] Retrieved credentials from "EnvConfigCredentials"
2022/12/21 09:05:53 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/21 09:05:53 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2022/12/21 09:05:54 [DEBUG] Completed Sweeper (aws_ami) in region (us-west-1) in 972.178692ms
2022/12/21 09:05:54 Completed Sweepers for region (us-west-1) in 972.423294ms
2022/12/21 09:05:54 Sweeper Tests for region (us-west-1) ran successfully:
	- aws_ami
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	5.733s
% make testacc TESTARGS='-run=TestAccEC2AMI_basic\|TestAccEC2AMI_disappears' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccEC2AMI_basic\|TestAccEC2AMI_disappears -timeout 180m
=== RUN   TestAccEC2AMI_basic
=== PAUSE TestAccEC2AMI_basic
=== RUN   TestAccEC2AMI_disappears
=== PAUSE TestAccEC2AMI_disappears
=== CONT  TestAccEC2AMI_basic
=== CONT  TestAccEC2AMI_disappears
--- PASS: TestAccEC2AMI_disappears (66.49s)
--- PASS: TestAccEC2AMI_basic (69.19s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	74.584s
```
