### PR TITLE
r/aws_kinesis_firehose_delivery_stream: update test with defaults

### DIFF
--- a/internal/service/firehose/delivery_stream_test.go
+++ b/internal/service/firehose/delivery_stream_test.go
@@ -2424,6 +2424,14 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
           parameter_name  = "LambdaArn"
           parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
         }
+        parameters {
+          parameter_name  = "BufferSizeInMBs"
+          parameter_value = "1"
+        }
+        parameters {
+          parameter_name  = "BufferIntervalInSeconds"
+          parameter_value = "70"
+        }
       }
     }
 
@@ -2897,6 +2905,14 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
           parameter_name  = "LambdaArn"
           parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
         }
+        parameters {
+          parameter_name  = "BufferSizeInMBs"
+          parameter_value = "1"
+        }
+        parameters {
+          parameter_name  = "BufferIntervalInSeconds"
+          parameter_value = "70"
+        }
       }
     }
   }
@@ -2935,6 +2951,14 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
         parameters {
           parameter_name  = "LambdaArn"
           parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
+        }
+        parameters {
+          parameter_name  = "BufferSizeInMBs"
+          parameter_value = "1"
+        }
+        parameters {
+          parameter_name  = "BufferIntervalInSeconds"
+          parameter_value = "70"
         }
       }
 
@@ -2975,6 +2999,14 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
         parameters {
           parameter_name  = "LambdaArn"
           parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
+        }
+        parameters {
+          parameter_name  = "BufferSizeInMBs"
+          parameter_value = "1"
+        }
+        parameters {
+          parameter_name  = "BufferIntervalInSeconds"
+          parameter_value = "70"
         }
       }
     }
@@ -3130,6 +3162,14 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
         parameters {
           parameter_name  = "LambdaArn"
           parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
+        }
+        parameters {
+          parameter_name  = "BufferSizeInMBs"
+          parameter_value = "1"
+        }
+        parameters {
+          parameter_name  = "BufferIntervalInSeconds"
+          parameter_value = "70"
         }
       }
     }
@@ -3687,6 +3727,14 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
           parameter_name  = "LambdaArn"
           parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
         }
+        parameters {
+          parameter_name  = "BufferSizeInMBs"
+          parameter_value = "1"
+        }
+        parameters {
+          parameter_name  = "BufferIntervalInSeconds"
+          parameter_value = "70"
+        }
       }
     }
   }
@@ -3730,6 +3778,14 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
         parameters {
           parameter_name  = "LambdaArn"
           parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
+        }
+        parameters {
+          parameter_name  = "BufferSizeInMBs"
+          parameter_value = "1"
+        }
+        parameters {
+          parameter_name  = "BufferIntervalInSeconds"
+          parameter_value = "70"
         }
       }
     }
@@ -3793,6 +3849,14 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
         parameters {
           parameter_name  = "LambdaArn"
           parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
+        }
+        parameters {
+          parameter_name  = "BufferSizeInMBs"
+          parameter_value = "1"
+        }
+        parameters {
+          parameter_name  = "BufferIntervalInSeconds"
+          parameter_value = "70"
         }
       }
     }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.


--->

Closes #28519

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccFirehoseDeliveryStream_' PKG=firehose

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/firehose/... -v -count 1 -parallel 20  -run=TestAccFirehoseDeliveryStream_ -timeout 180m
--- PASS: TestAccFirehoseDeliveryStream_s3KinesisStreamSource (68.20s)
--- PASS: TestAccFirehoseDeliveryStream_disappears (359.09s)
--- PASS: TestAccFirehoseDeliveryStream_missingProcessing (373.29s)
--- PASS: TestAccFirehoseDeliveryStream_basic (375.51s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionOpenXJSONSerDe_empty (381.63s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionDeserializer_update (325.75s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionParquetSerDe_empty (399.02s)
--- PASS: TestAccFirehoseDeliveryStream_s3basic (404.78s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversion_enabled (439.39s)
--- PASS: TestAccFirehoseDeliveryStream_Splunk_ErrorOutputPrefix (445.64s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionHiveJSONSerDe_empty (491.75s)
--- PASS: TestAccFirehoseDeliveryStream_s3basicWithSSE (498.87s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3_kinesisStreamSource (69.50s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionSerializer_update (531.66s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3_externalUpdate (532.16s)
--- PASS: TestAccFirehoseDeliveryStream_s3Updates (532.44s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionOrcSerDe_empty (533.27s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3_errorOutputPrefix (540.08s)
--- PASS: TestAccFirehoseDeliveryStream_s3basicWithSSEAndKeyARN (628.52s)
--- PASS: TestAccFirehoseDeliveryStream_extendedS3Updates (337.46s)
--- PASS: TestAccFirehoseDeliveryStream_s3basicWithTags (354.38s)
--- PASS: TestAccFirehoseDeliveryStream_splunkUpdates (345.28s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3Processing_empty (277.97s)
--- PASS: TestAccFirehoseDeliveryStream_extendedS3KMSKeyARN (324.93s)
--- PASS: TestAccFirehoseDeliveryStream_extendedS3DynamicPartitioning (340.60s)
--- PASS: TestAccFirehoseDeliveryStream_extendedS3basic (267.41s)
--- PASS: TestAccFirehoseDeliveryStream_s3WithCloudWatchLogging (265.97s)
--- PASS: TestAccFirehoseDeliveryStream_HTTPEndpoint_retryDuration (271.20s)
--- PASS: TestAccFirehoseDeliveryStream_HTTPEndpoint_ErrorOutputPrefix (266.41s)
--- PASS: TestAccFirehoseDeliveryStream_s3basicWithPrefixes (276.01s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3_S3BackupConfiguration_ErrorOutputPrefix (318.75s)
--- PASS: TestAccFirehoseDeliveryStream_s3basicWithSSEAndKeyType (388.04s)
--- PASS: TestAccFirehoseDeliveryStream_httpEndpoint (269.83s)
--- PASS: TestAccFirehoseDeliveryStream_tagUpdates (534.48s)
--- PASS: TestAccFirehoseDeliveryStream_redshiftUpdates (569.76s)
--- PASS: TestAccFirehoseDeliveryStream_Elasticsearch_ErrorOutputPrefix (1743.55s)
--- PASS: TestAccFirehoseDeliveryStream_elasticSearchEndpointUpdates (1772.30s)
--- PASS: TestAccFirehoseDeliveryStream_elasticSearchUpdates (1683.74s)
--- PASS: TestAccFirehoseDeliveryStream_elasticSearchWithVPCUpdates (2747.62s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/firehose	2750.610s
...
```
