### PR TITLE
adding support for NoSuchTagSetError

### DIFF
--- a/.changelog/28530.txt
+++ b/.changelog/28530.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3: Adds graceful return on 'NoSuchTagSetError' response
+```

--- a/.changelog/28530.txt
+++ b/.changelog/28530.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
-resource/aws_s3: Adds graceful return on 'NoSuchTagSetError' response
+resource/aws_s3_bucket: Accept 'NoSuchTagSetError' responses from S3-compatible services
+```
+
+```release-note:enhancement
+resource/aws_s3_object: Accept 'NoSuchTagSetError' responses from S3-compatible services
 ```

--- a/internal/service/s3/tags.go
+++ b/internal/service/s3/tags.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	ErrCodeNoSuchTagSet = "NoSuchTagSet"
+	ErrCodeNoSuchTagSet      = "NoSuchTagSet"
+	ErrCodeNoSuchTagSetError = "NoSuchTagSetError"
 )
 
 // Custom S3 tag service update functions using the same format as generated code.
@@ -33,7 +34,7 @@ func BucketListTags(conn *s3.S3, identifier string) (tftags.KeyValueTags, error)
 	// S3 API Reference (https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html)
 	// lists the special error as NoSuchTagSetError, however the existing logic used NoSuchTagSet
 	// and the AWS Go SDK has neither as a constant.
-	if tfawserr.ErrCodeEquals(err, ErrCodeNoSuchTagSet) {
+	if tfawserr.ErrCodeEquals(err, ErrCodeNoSuchTagSet, ErrCodeNoSuchTagSetError) {
 		return tftags.New(nil), nil
 	}
 
@@ -114,7 +115,7 @@ func ObjectListTags(conn *s3.S3, bucket, key string) (tftags.KeyValueTags, error
 		output, err = conn.GetObjectTagging(input)
 	}
 
-	if tfawserr.ErrCodeEquals(err, ErrCodeNoSuchTagSet) {
+	if tfawserr.ErrCodeEquals(err, ErrCodeNoSuchTagSet, ErrCodeNoSuchTagSetError) {
 		return tftags.New(nil), nil
 	}
 


### PR DESCRIPTION
### Description
Adds support for S3-Compatible services which respond to Tag Requests with "NoSuchTagSetError" instead of "NoSuchTagSet". The current implementation only checks for "NoSuchTagSet" and fails if "NoSuchTagSetError" is received. This should allow both compliant and non-compliant implementations to return gracefully.

### References
The ambiguity was originally described here: https://github.com/hashicorp/terraform-provider-aws/blob/1076f598ee88175e7409c5887edcf87e6cbeab20/internal/service/s3/tags.go#L33

### Output from Acceptance Testing
```
$ make testacc TESTS=TestAccS3Bucket_Tags_ignoreTags PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3Bucket_Tags_ignoreTags'  -timeout 180m
=== RUN   TestAccS3Bucket_Tags_ignoreTags
=== PAUSE TestAccS3Bucket_Tags_ignoreTags
=== CONT  TestAccS3Bucket_Tags_ignoreTags
--- PASS: TestAccS3Bucket_Tags_ignoreTags (47.16s)
PASS
ok    github.com/hashicorp/terraform-provider-aws/internal/service/s3 49.701s

$ make testacc TESTS=TestAccS3Bucket_Tags_withSystemTags PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3Bucket_Tags_withSystemTags'  -timeout 180m
=== RUN   TestAccS3Bucket_Tags_withSystemTags
=== PAUSE TestAccS3Bucket_Tags_withSystemTags
=== CONT  TestAccS3Bucket_Tags_withSystemTags
--- PASS: TestAccS3Bucket_Tags_withSystemTags (119.73s)
PASS
ok    github.com/hashicorp/terraform-provider-aws/internal/service/s3 122.462s

$ make testacc TESTS=TestAccS3BucketObject_ignoreTags PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketObject_ignoreTags'  -timeout 180m
=== RUN   TestAccS3BucketObject_ignoreTags
=== PAUSE TestAccS3BucketObject_ignoreTags
=== CONT  TestAccS3BucketObject_ignoreTags
--- PASS: TestAccS3BucketObject_ignoreTags (47.12s)
PASS
ok    github.com/hashicorp/terraform-provider-aws/internal/service/s3 49.724s

$ make testacc TESTS=TestAccS3Object_ignoreTags PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3Object_ignoreTags'  -timeout 180m
=== RUN   TestAccS3Object_ignoreTags
=== PAUSE TestAccS3Object_ignoreTags
=== CONT  TestAccS3Object_ignoreTags
--- PASS: TestAccS3Object_ignoreTags (45.43s)
PASS
ok    github.com/hashicorp/terraform-provider-aws/internal/service/s3 48.021s
```
