### PR TITLE
documentation-issue-28533 in aws_docdb_global_cluster resource

### DIFF
--- a/website/docs/r/docdb_global_cluster.html.markdown
+++ b/website/docs/r/docdb_global_cluster.html.markdown
@@ -47,11 +47,9 @@ resource "aws_docdb_cluster" "primary" {
 resource "aws_docdb_cluster_instance" "primary" {
   provider             = aws.primary
   engine               = aws_docdb_global_cluster.example.engine
-  engine_version       = aws_docdb_global_cluster.example.engine_version
   identifier           = "test-primary-cluster-instance"
   cluster_identifier   = aws_docdb_cluster.primary.id
   instance_class       = "db.r5.large"
-  db_subnet_group_name = "default"
 }
 
 resource "aws_docdb_cluster" "secondary" {
@@ -66,11 +64,9 @@ resource "aws_docdb_cluster" "secondary" {
 resource "aws_docdb_cluster_instance" "secondary" {
   provider             = aws.secondary
   engine               = aws_docdb_global_cluster.example.engine
-  engine_version       = aws_docdb_global_cluster.example.engine_version
   identifier           = "test-secondary-cluster-instance"
   cluster_identifier   = aws_docdb_cluster.secondary.id
   instance_class       = "db.r5.large"
-  db_subnet_group_name = "default"
 
   depends_on = [
     aws_docdb_cluster_instance.primary

--- a/website/docs/r/docdb_global_cluster.html.markdown
+++ b/website/docs/r/docdb_global_cluster.html.markdown
@@ -45,11 +45,11 @@ resource "aws_docdb_cluster" "primary" {
 }
 
 resource "aws_docdb_cluster_instance" "primary" {
-  provider             = aws.primary
-  engine               = aws_docdb_global_cluster.example.engine
-  identifier           = "test-primary-cluster-instance"
-  cluster_identifier   = aws_docdb_cluster.primary.id
-  instance_class       = "db.r5.large"
+  provider           = aws.primary
+  engine             = aws_docdb_global_cluster.example.engine
+  identifier         = "test-primary-cluster-instance"
+  cluster_identifier = aws_docdb_cluster.primary.id
+  instance_class     = "db.r5.large"
 }
 
 resource "aws_docdb_cluster" "secondary" {
@@ -62,11 +62,11 @@ resource "aws_docdb_cluster" "secondary" {
 }
 
 resource "aws_docdb_cluster_instance" "secondary" {
-  provider             = aws.secondary
-  engine               = aws_docdb_global_cluster.example.engine
-  identifier           = "test-secondary-cluster-instance"
-  cluster_identifier   = aws_docdb_cluster.secondary.id
-  instance_class       = "db.r5.large"
+  provider           = aws.secondary
+  engine             = aws_docdb_global_cluster.example.engine
+  identifier         = "test-secondary-cluster-instance"
+  cluster_identifier = aws_docdb_cluster.secondary.id
+  instance_class     = "db.r5.large"
 
   depends_on = [
     aws_docdb_cluster_instance.primary


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
aws_docdb_cluster_instance resource can't have engine_version and db_subnet_group_name

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_global_cluster#new-documentdb-global-cluster

In resource type "aws_docdb_cluster_instance", with resource name "primary" and "secondary", we can't mention below two arguments, as [aws_docdb_cluster_instance ](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster_instance#argument-reference) is not having these arguments

```
  engine_version       = aws_docdb_global_cluster.example.engine_version
  db_subnet_group_name = "default"
```

Removing the above two arguments, in two places.
Otherwise we'll get 
```
Error: Value for unconfigurable attribute

  with aws_docdb_cluster_instance.primary,
  on main.tf line 59, in resource "aws_docdb_cluster_instance" "primary":
  59:   engine_version       = aws_docdb_global_cluster.example.engine_version

Can't configure a value for "engine_version": its value will be decided
automatically based on the result of applying this configuration.
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28533

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Only documentation change
