### PR TITLE
r/aws_fsx_ontap_storage_virtual_machine: Undeprecate `subtype`

### DIFF
--- a/.changelog/28085.txt
+++ b/.changelog/28085.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_fsx_ontap_storage_virtual_machine: The `subtype` attribute will always have the value `"DEFAULT"`
+```

--- a/.changelog/28085.txt
+++ b/.changelog/28085.txt
@@ -1,3 +1,0 @@
-```release-note:note
-resource/aws_fsx_ontap_storage_virtual_machine: The `subtype` attribute will always have the value `"DEFAULT"`
-```

--- a/.changelog/28567.txt
+++ b/.changelog/28567.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_fsx_ontap_storage_virtual_machine: The `subtype` attribute is no longer deprecated
+```

--- a/internal/service/fsx/ontap_storage_virtual_machine.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine.go
@@ -293,9 +293,7 @@ func resourceOntapStorageVirtualMachineRead(d *schema.ResourceData, meta interfa
 	//RootVolumeSecurityStyle and SVMAdminPassword are write only properties so they don't get returned from the describe API so we just store the original setting to state
 	d.Set("root_volume_security_style", d.Get("root_volume_security_style").(string))
 	d.Set("svm_admin_password", d.Get("svm_admin_password").(string))
-	// Subtype removed in AWS SDK for Go v1.44.147.
-	// d.Set("subtype", storageVirtualMachine.Subtype)
-	d.Set("subtype", nil)
+	d.Set("subtype", storageVirtualMachine.Subtype)
 	d.Set("uuid", storageVirtualMachine.UUID)
 
 	if err := d.Set("active_directory_configuration", flattenOntapSvmActiveDirectoryConfiguration(d, storageVirtualMachine.ActiveDirectoryConfiguration)); err != nil {

--- a/internal/service/fsx/ontap_storage_virtual_machine.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine.go
@@ -295,7 +295,7 @@ func resourceOntapStorageVirtualMachineRead(d *schema.ResourceData, meta interfa
 	d.Set("svm_admin_password", d.Get("svm_admin_password").(string))
 	// Subtype removed in AWS SDK for Go v1.44.147.
 	// d.Set("subtype", storageVirtualMachine.Subtype)
-	d.Set("subtype", "DEFAULT")
+	d.Set("subtype", nil)
 	d.Set("uuid", storageVirtualMachine.UUID)
 
 	if err := d.Set("active_directory_configuration", flattenOntapSvmActiveDirectoryConfiguration(d, storageVirtualMachine.ActiveDirectoryConfiguration)); err != nil {

--- a/internal/service/fsx/ontap_storage_virtual_machine.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine.go
@@ -208,9 +208,8 @@ func ResourceOntapStorageVirtualMachine() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(fsx.StorageVirtualMachineRootVolumeSecurityStyle_Values(), false),
 			},
 			"subtype": {
-				Type:       schema.TypeString,
-				Computed:   true,
-				Deprecated: `this trait has been removed from the API`,
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"svm_admin_password": {
 				Type:         schema.TypeString,

--- a/internal/service/fsx/ontap_storage_virtual_machine_test.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine_test.go
@@ -44,7 +44,6 @@ func TestAccFSxOntapStorageVirtualMachine_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					// Subtype removed in AWS SDK for Go v1.44.147.
 					//resource.TestCheckResourceAttr(resourceName, "subtype", fsx.StorageVirtualMachineSubtypeDefault),
-					resource.TestCheckResourceAttr(resourceName, "subtype", "DEFAULT"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "uuid"),
 				),

--- a/internal/service/fsx/ontap_storage_virtual_machine_test.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine_test.go
@@ -42,8 +42,7 @@ func TestAccFSxOntapStorageVirtualMachine_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "endpoints.0.nfs.0.dns_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "file_system_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					// Subtype removed in AWS SDK for Go v1.44.147.
-					//resource.TestCheckResourceAttr(resourceName, "subtype", fsx.StorageVirtualMachineSubtypeDefault),
+					resource.TestCheckResourceAttr(resourceName, "subtype", fsx.StorageVirtualMachineSubtypeDefault),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "uuid"),
 				),

--- a/website/docs/r/fsx_ontap_storage_virtual_machine.html.markdown
+++ b/website/docs/r/fsx_ontap_storage_virtual_machine.html.markdown
@@ -78,7 +78,7 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - Amazon Resource Name of the storage virtual machine.
 * `endpoints` - The endpoints that are used to access data or to manage the storage virtual machine using the NetApp ONTAP CLI, REST API, or NetApp SnapMirror. See [Endpoints](#endpoints) below.
 * `id` - Identifier of the storage virtual machine, e.g., `svm-12345678`
-* `subtype` (**Deprecated**) - Describes the SVM's subtype, e.g. `DEFAULT`
+* `subtype` - Describes the SVM's subtype, e.g. `DEFAULT`
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `uuid` - The SVM's UUID (universally unique identifier).
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Ibid.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/28565.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccFSxOntapStorageVirtualMachine_basic' PKG=fsx
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/fsx/... -v -count 1 -parallel 20  -run=TestAccFSxOntapStorageVirtualMachine_basic -timeout 180m
=== RUN   TestAccFSxOntapStorageVirtualMachine_basic
=== PAUSE TestAccFSxOntapStorageVirtualMachine_basic
=== CONT  TestAccFSxOntapStorageVirtualMachine_basic
--- PASS: TestAccFSxOntapStorageVirtualMachine_basic (2617.64s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/fsx	2622.732s
```
