### PR TITLE
Add Ability to Lookup AMP Workspace by Alias

### DIFF
--- a/.changelog/28568.txt
+++ b/.changelog/28568.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+datasource/aws_prometheus_workspace: Add ability to query by workspace alias
+```

--- a/website/docs/d/prometheus_workspace.html.markdown
+++ b/website/docs/d/prometheus_workspace.html.markdown
@@ -12,7 +12,15 @@ Provides an Amazon Managed Prometheus workspace data source.
 
 ## Example Usage
 
-### Basic configuration
+### By Workspace Alias
+
+```terraform
+data "aws_prometheus_workspace" "example" {
+  alias = "example"
+}
+```
+
+### By Workspace ID
 
 ```terraform
 data "aws_prometheus_workspace" "example" {
@@ -20,11 +28,11 @@ data "aws_prometheus_workspace" "example" {
 }
 ```
 
+
 ## Argument Reference
 
-The following arguments are required:
-
-* `workspace_id` - (Required) Prometheus workspace ID.
+* `alias` - (Optional) Prometheus workspace alias. Conflicts with `workspace_id`.
+* `workspace_id` - (Optional) Prometheus workspace ID. Conflicts with `alias`.
 
 ## Attributes Reference
 
@@ -33,6 +41,5 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - ARN of the Prometheus workspace.
 * `created_date` - Creation date of the Prometheus workspace.
 * `prometheus_endpoint` - Endpoint of the Prometheus workspace.
-* `alias` - Prometheus workspace alias.
 * `status` - Status of the Prometheus workspace.
 * `tags` - Tags assigned to the resource.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds the ability to lookup an AMP workspace by workspace alias. Previously the provider allowed lookups by `workspace_id`, this change requires that only one of `workspace_id` or `alias` is specified.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #26400

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccAMPWorkspaceDataSource_' PKG=amp ACCTEST_PARALLELISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/amp/... -v -count 1 -parallel 1  -run=TestAccAMPWorkspaceDataSource_ -timeout 180m
=== RUN   TestAccAMPWorkspaceDataSource_workspace_id
--- PASS: TestAccAMPWorkspaceDataSource_workspace_id (18.06s)
=== RUN   TestAccAMPWorkspaceDataSource_alias
--- PASS: TestAccAMPWorkspaceDataSource_alias (16.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/amp	37.454s
```
