### PR TITLE
r/ce_anomaly_subscripton - add `threshold_expression` and deprecate `threshold`

### DIFF
--- a/.changelog/28573.txt
+++ b/.changelog/28573.txt
@@ -3,5 +3,5 @@ resource/aws_ce_anomaly_subscripton: Add `threshold_expression` argument
 ```
 
 ```release-note:enhancement
-resource/aws_ce_anomaly_subscripton: Depreacate `threshold` argument in favour of `threshold_expression`
+resource/aws_ce_anomaly_subscripton: Depracated `threshold` argument in favour of `threshold_expression`
 ```

--- a/.changelog/28573.txt
+++ b/.changelog/28573.txt
@@ -1,7 +1,7 @@
 ```release-note:enhancement
-resource/aws_ce_anomaly_subscripton: Add `threshold_expression` argument
+resource/aws_ce_anomaly_subscription: Add `threshold_expression` argument
 ```
 
 ```release-note:enhancement
-resource/aws_ce_anomaly_subscripton: Depracated `threshold` argument in favour of `threshold_expression`
+resource/aws_ce_anomaly_subscription: Depracated `threshold` argument in favour of `threshold_expression`
 ```

--- a/.changelog/28573.txt
+++ b/.changelog/28573.txt
@@ -2,6 +2,6 @@
 resource/aws_ce_anomaly_subscription: Add `threshold_expression` argument
 ```
 
-```release-note:enhancement
+```release-note:note
 resource/aws_ce_anomaly_subscription: Deprecate `threshold` argument in favour of `threshold_expression`
 ```

--- a/.changelog/28573.txt
+++ b/.changelog/28573.txt
@@ -3,5 +3,5 @@ resource/aws_ce_anomaly_subscription: Add `threshold_expression` argument
 ```
 
 ```release-note:enhancement
-resource/aws_ce_anomaly_subscription: Depracated `threshold` argument in favour of `threshold_expression`
+resource/aws_ce_anomaly_subscription: Deprecate `threshold` argument in favour of `threshold_expression`
 ```

--- a/.changelog/28573.txt
+++ b/.changelog/28573.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_ce_anomaly_subscripton: Add `threshold_expression` argument
+```
+
+```release-note:enhancement
+resource/aws_ce_anomaly_subscripton: Depreacate `threshold` argument in favour of `threshold_expression`
+```

--- a/internal/service/ce/anomaly_subscription.go
+++ b/internal/service/ce/anomaly_subscription.go
@@ -79,6 +79,7 @@ func ResourceAnomalySubscription() *schema.Resource {
 			"threshold": {
 				Type:         schema.TypeFloat,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.FloatAtLeast(0.0),
 				Deprecated:   "use threshold_expression instead",
 			},

--- a/internal/service/ce/anomaly_subscription.go
+++ b/internal/service/ce/anomaly_subscription.go
@@ -32,7 +32,7 @@ func ResourceAnomalySubscription() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`[\\S\\s]*`), "Must be a valid AWS Account ID matching expression: [\\S\\s]*"),
+				ValidateFunc: verify.ValidAccountID,
 			},
 			"arn": {
 				Type:     schema.TypeString,
@@ -48,8 +48,16 @@ func ResourceAnomalySubscription() *schema.Resource {
 				Required: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.StringMatch(regexp.MustCompile(`arn:aws[-a-z0-9]*:[a-z0-9]+:[-a-z0-9]*:[0-9]{12}:[-a-zA-Z0-9/:_]+`), "Must be a valid anomaly monitor ARN"),
+					ValidateFunc: verify.ValidARN,
 				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 1024),
+					validation.StringMatch(regexp.MustCompile(`[\\S\\s]*`), "Must be a valid Anomaly Subscription Name matching expression: [\\S\\s]*")),
 			},
 			"subscriber": {
 				Type:     schema.TypeSet,
@@ -63,23 +71,23 @@ func ResourceAnomalySubscription() *schema.Resource {
 						"type": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{costexplorer.SubscriberTypeEmail, costexplorer.SubscriberTypeSns}, false),
+							ValidateFunc: validation.StringInSlice(costexplorer.SubscriberType_Values(), false),
 						},
 					},
 				},
 			},
 			"threshold": {
 				Type:         schema.TypeFloat,
-				Required:     true,
+				Optional:     true,
 				ValidateFunc: validation.FloatAtLeast(0.0),
+				Deprecated:   "use threshold_expression instead",
 			},
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 1024),
-					validation.StringMatch(regexp.MustCompile(`[\\S\\s]*`), "Must be a valid Anomaly Subscription Name matching expression: [\\S\\s]*")),
+			"threshold_expression": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Computed: true,
+				Optional: true,
+				Elem:     schemaCostCategoryRule(),
 			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
@@ -100,12 +108,19 @@ func resourceAnomalySubscriptionCreate(ctx context.Context, d *schema.ResourceDa
 			Frequency:        aws.String(d.Get("frequency").(string)),
 			MonitorArnList:   aws.StringSlice(expandAnomalySubscriptionMonitorARNList(d.Get("monitor_arn_list").([]interface{}))),
 			Subscribers:      expandAnomalySubscriptionSubscribers(d.Get("subscriber").(*schema.Set).List()),
-			Threshold:        aws.Float64(d.Get("threshold").(float64)),
 		},
 	}
 
 	if v, ok := d.GetOk("account_id"); ok {
 		input.AnomalySubscription.AccountId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("threshold"); ok {
+		input.AnomalySubscription.Threshold = aws.Float64(v.(float64))
+	}
+
+	if v, ok := d.GetOk("threshold_expression"); ok {
+		input.AnomalySubscription.ThresholdExpression = expandCostExpression(v.([]interface{})[0].(map[string]interface{}))
 	}
 
 	if len(tags) > 0 {
@@ -152,6 +167,10 @@ func resourceAnomalySubscriptionRead(ctx context.Context, d *schema.ResourceData
 	d.Set("threshold", subscription.Threshold)
 	d.Set("name", subscription.SubscriptionName)
 
+	if err = d.Set("threshold_expression", []interface{}{flattenCostCategoryRuleExpression(subscription.ThresholdExpression)}); err != nil {
+		return create.DiagError(names.CE, "setting threshold_expression", ResNameAnomalySubscription, d.Id(), err)
+	}
+
 	tags, err := ListTags(conn, aws.StringValue(subscription.SubscriptionArn))
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
@@ -173,30 +192,37 @@ func resourceAnomalySubscriptionRead(ctx context.Context, d *schema.ResourceData
 
 func resourceAnomalySubscriptionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).CEConn()
-	requestUpdate := false
 
-	input := &costexplorer.UpdateAnomalySubscriptionInput{
-		SubscriptionArn: aws.String(d.Id()),
-	}
+	if d.HasChangesExcept("tags", "tags_All") {
+		input := &costexplorer.UpdateAnomalySubscriptionInput{
+			SubscriptionArn: aws.String(d.Id()),
+		}
 
-	if d.HasChange("frequency") {
-		input.Frequency = aws.String(d.Get("frequency").(string))
-		requestUpdate = true
-	}
+		if d.HasChange("frequency") {
+			input.Frequency = aws.String(d.Get("frequency").(string))
+		}
 
-	if d.HasChange("monitor_arn_list") {
-		input.MonitorArnList = aws.StringSlice(expandAnomalySubscriptionMonitorARNList(d.Get("monitor_arn_list").([]interface{})))
-		requestUpdate = true
-	}
+		if d.HasChange("monitor_arn_list") {
+			input.MonitorArnList = aws.StringSlice(expandAnomalySubscriptionMonitorARNList(d.Get("monitor_arn_list").([]interface{})))
+		}
 
-	if d.HasChange("subscriber") {
-		input.Subscribers = expandAnomalySubscriptionSubscribers(d.Get("subscriber").(*schema.Set).List())
-		requestUpdate = true
-	}
+		if d.HasChange("subscriber") {
+			input.Subscribers = expandAnomalySubscriptionSubscribers(d.Get("subscriber").(*schema.Set).List())
+		}
 
-	if d.HasChange("threshold") {
-		input.Threshold = aws.Float64(d.Get("threshold").(float64))
-		requestUpdate = true
+		if d.HasChange("threshold") {
+			input.Threshold = aws.Float64(d.Get("threshold").(float64))
+		}
+
+		if d.HasChange("threshold_expression") {
+			input.ThresholdExpression = expandCostExpression(d.Get("threshold_expression").([]interface{})[0].(map[string]interface{}))
+		}
+
+		_, err := conn.UpdateAnomalySubscriptionWithContext(ctx, input)
+
+		if err != nil {
+			return create.DiagError(names.CE, create.ErrActionUpdating, ResNameAnomalySubscription, d.Id(), err)
+		}
 	}
 
 	if d.HasChange("tags") {
@@ -211,14 +237,6 @@ func resourceAnomalySubscriptionUpdate(ctx context.Context, d *schema.ResourceDa
 		o, n := d.GetChange("tags_all")
 
 		if err := UpdateTags(conn, d.Id(), o, n); err != nil {
-			return create.DiagError(names.CE, create.ErrActionUpdating, ResNameAnomalySubscription, d.Id(), err)
-		}
-	}
-
-	if requestUpdate {
-		_, err := conn.UpdateAnomalySubscriptionWithContext(ctx, input)
-
-		if err != nil {
 			return create.DiagError(names.CE, create.ErrActionUpdating, ResNameAnomalySubscription, d.Id(), err)
 		}
 	}

--- a/internal/service/ce/anomaly_subscription_test.go
+++ b/internal/service/ce/anomaly_subscription_test.go
@@ -38,7 +38,7 @@ func TestAccCEAnomalySubscription_basic(t *testing.T) {
 					testAccCheckAnomalySubscriptionExists(resourceName, &subscription),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					acctest.MatchResourceAttrGlobalARN(resourceName, "arn", "ce", regexp.MustCompile(`anomalysubscription/.+`)),
-					resource.TestCheckResourceAttrSet(resourceName, "account_id"),
+					acctest.CheckResourceAttrAccountID(resourceName, "account_id"),
 					resource.TestCheckResourceAttr(resourceName, "frequency", "DAILY"),
 					resource.TestCheckResourceAttrSet(resourceName, "monitor_arn_list.#"),
 					resource.TestCheckResourceAttr(resourceName, "subscriber.0.type", "EMAIL"),

--- a/internal/service/ce/anomaly_subscription_test.go
+++ b/internal/service/ce/anomaly_subscription_test.go
@@ -451,11 +451,11 @@ resource "aws_ce_anomaly_subscription" "test" {
   }
 
   threshold_expression {
-	dimension {
-	  key           = "ANOMALY_TOTAL_IMPACT_ABSOLUTE"
-	  values        = ["100.0"]
-	  match_options = ["GREATER_THAN_OR_EQUAL"]
-	}
+    dimension {
+      key           = "ANOMALY_TOTAL_IMPACT_ABSOLUTE"
+      values        = ["100.0"]
+      match_options = ["GREATER_THAN_OR_EQUAL"]
+    }
   }
 }
 `, rName, address))

--- a/website/docs/r/ce_anomaly_subscription.html.markdown
+++ b/website/docs/r/ce_anomaly_subscription.html.markdown
@@ -139,15 +139,43 @@ resource "aws_ce_anomaly_subscription" "realtime_subscription" {
 
 The following arguments are required:
 
-* `name` - (Required) The name for the subscription.
+* `account_id` - (Optional) The unique identifier for the AWS account in which the anomaly subscription ought to be created.
 * `frequency` - (Required) The frequency that anomaly reports are sent. Valid Values: `DAILY` | `IMMEDIATE` | `WEEKLY`.
 * `monitor_arn_list` - (Required) A list of cost anomaly monitors.
+* `name` - (Required) The name for the subscription.
 * `subscriber` - (Required) A subscriber configuration. Multiple subscribers can be defined.
     * `type` - (Required) The type of subscription. Valid Values: `SNS` | `EMAIL`.
     * `address` - (Required) The address of the subscriber. If type is `SNS`, this will be the arn of the sns topic. If type is `EMAIL`, this will be the destination email address.
-* `threshold` - (Required) The dollar value that triggers a notification if the threshold is exceeded.
-* `account_id` - (Optional) The unique identifier for the AWS account in which the anomaly subscription ought to be created.
+* `threshold` - (Optional) The dollar value that triggers a notification if the threshold is exceeded.
+* `threshold_expression` - (Optional) An Expression object used to specify the anomalies that you want to generate alerts for. See [Threshold Expression](#threshold-expression).
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### Threshold Expression
+
+* `and` - (Optional) Return results that match both [Dimension](#dimension) objects.
+* `cost_category` - (Optional) Configuration block for the filter that's based on  values. See [Cost Category](#cost-category) below.
+* `dimension` - (Optional) Configuration block for the specific [Dimension](#dimension) to use for.
+* `not` - (Optional) Return results that match both [Dimension](#dimension) object.
+* `or` - (Optional) Return results that match both [Dimension](#dimension) object.
+* `tags` - (Optional) Configuration block for the specific Tag to use for. See [Tags](#tags) below.
+
+### Cost Category
+
+* `key` - (Optional) Unique name of the Cost Category.
+* `match_options` - (Optional) Match options that you can use to filter your results. MatchOptions is only applicable for actions related to cost category. The default values for MatchOptions is `EQUALS` and `CASE_SENSITIVE`. Valid values are: `EQUALS`,  `ABSENT`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS`, `CASE_SENSITIVE`, `CASE_INSENSITIVE`.
+* `values` - (Optional) Specific value of the Cost Category.
+
+### Dimension
+
+* `key` - (Optional) Unique name of the Cost Category.
+* `match_options` - (Optional) Match options that you can use to filter your results. MatchOptions is only applicable for actions related to cost category. The default values for MatchOptions is `EQUALS` and `CASE_SENSITIVE`. Valid values are: `EQUALS`,  `ABSENT`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS`, `CASE_SENSITIVE`, `CASE_INSENSITIVE`.
+* `values` - (Optional) Specific value of the Cost Category.
+
+### Tags
+
+* `key` - (Optional) Key for the tag.
+* `match_options` - (Optional) Match options that you can use to filter your results. MatchOptions is only applicable for actions related to cost category. The default values for MatchOptions is `EQUALS` and `CASE_SENSITIVE`. Valid values are: `EQUALS`,  `ABSENT`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS`, `CASE_SENSITIVE`, `CASE_INSENSITIVE`.
+* `values` - (Optional) Specific value of the Cost Category.
 
 ## Attributes Reference
 

--- a/website/docs/r/ce_anomaly_subscription.html.markdown
+++ b/website/docs/r/ce_anomaly_subscription.html.markdown
@@ -146,7 +146,7 @@ The following arguments are required:
 * `subscriber` - (Required) A subscriber configuration. Multiple subscribers can be defined.
     * `type` - (Required) The type of subscription. Valid Values: `SNS` | `EMAIL`.
     * `address` - (Required) The address of the subscriber. If type is `SNS`, this will be the arn of the sns topic. If type is `EMAIL`, this will be the destination email address.
-* `threshold` - (Optional) The dollar value that triggers a notification if the threshold is exceeded.
+* `threshold` - (Optional) The dollar value that triggers a notification if the threshold is exceeded. Depracated, use `threshold_expression` instead.
 * `threshold_expression` - (Optional) An Expression object used to specify the anomalies that you want to generate alerts for. See [Threshold Expression](#threshold-expression).
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28571

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccCEAnomalySubscription_ PKG=ce

--- PASS: TestAccCEAnomalySubscription_disappears (26.03s)
--- PASS: TestAccCEAnomalySubscription_basic (29.81s)
--- PASS: TestAccCEAnomalySubscription_thresholdExpression (30.07s)
--- PASS: TestAccCEAnomalySubscription_Frequency (46.56s)
--- PASS: TestAccCEAnomalySubscription_Threshold (48.53s)
--- PASS: TestAccCEAnomalySubscription_MonitorARNList (49.49s)
--- PASS: TestAccCEAnomalySubscription_Tags (64.24s)
--- PASS: TestAccCEAnomalySubscription_Subscriber (92.84s)
```
