### PR TITLE
aws_fsx_openzfs_file_system: support SINGLE_AZ_2 deployment type

### DIFF
--- a/internal/service/fsx/openzfs_file_system.go
+++ b/internal/service/fsx/openzfs_file_system.go
@@ -876,6 +876,9 @@ func resourceOpenZfsFileSystemCustomizeDiff(ctx context.Context, diff *schema.Re
 		valid = resourceOpenZfsFileSystemThroughputSingleAZ1()
 	} else if deploymentType == fsx.OpenZFSDeploymentTypeSingleAz2 {
 		valid = resourceOpenZfsFileSystemThroughputSingleAZ2()
+	} else {
+		// allow validation to pass for unknown/new types
+		valid = []int{throughputCapacity}
 	}
 
 	found := false

--- a/internal/service/fsx/openzfs_file_system_test.go
+++ b/internal/service/fsx/openzfs_file_system_test.go
@@ -691,6 +691,44 @@ func TestAccFSxOpenzfsFileSystem_storageCapacity(t *testing.T) {
 	})
 }
 
+func TestAccFSxOpenzfsFileSystem_deploymentType(t *testing.T) {
+	var filesystem1, filesystem2 fsx.FileSystem
+	resourceName := "aws_fsx_openzfs_file_system.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(fsx.EndpointsID, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, fsx.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOpenzfsFileSystemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenzfsFileSystemConfig_deploymentType(rName, "SINGLE_AZ_1", 64),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOpenzfsFileSystemExists(resourceName, &filesystem1),
+					resource.TestCheckResourceAttr(resourceName, "deployment_type", "SINGLE_AZ_1"),
+					resource.TestCheckResourceAttr(resourceName, "throughput_capacity", "64"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"security_group_ids"},
+			},
+			{
+				Config: testAccOpenzfsFileSystemConfig_deploymentType(rName, "SINGLE_AZ_2", 160),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOpenzfsFileSystemExists(resourceName, &filesystem2),
+					testAccCheckOpenzfsFileSystemRecreated(&filesystem1, &filesystem2),
+					resource.TestCheckResourceAttr(resourceName, "deployment_type", "SINGLE_AZ_2"),
+					resource.TestCheckResourceAttr(resourceName, "throughput_capacity", "160"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckOpenzfsFileSystemExists(resourceName string, fs *fsx.FileSystem) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -1258,4 +1296,19 @@ resource "aws_fsx_openzfs_file_system" "test" {
   }
 }
 `, rName))
+}
+
+func testAccOpenzfsFileSystemConfig_deploymentType(rName, deploymentType string, throughput int) string {
+	return acctest.ConfigCompose(testAccOpenzfsFileSystemBaseConfig(rName), fmt.Sprintf(`
+resource "aws_fsx_openzfs_file_system" "test" {
+  storage_capacity    = 64
+  subnet_ids          = [aws_subnet.test1.id]
+  deployment_type     = %[2]q
+  throughput_capacity = %[3]d
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, deploymentType, throughput))
 }

--- a/website/docs/r/fsx_openzfs_file_system.html.markdown
+++ b/website/docs/r/fsx_openzfs_file_system.html.markdown
@@ -26,10 +26,10 @@ resource "aws_fsx_openzfs_file_system" "test" {
 
 The following arguments are supported:
 
-* `deployment_type` - (Required) - The filesystem deployment type. Only `SINGLE_AZ_1` is supported.
+* `deployment_type` - (Required) - The filesystem deployment type. Only `SINGLE_AZ_1` and `SINGLE_AZ_2` are supported.
 * `storage_capacity` - (Required) The storage capacity (GiB) of the file system. Valid values between `64` and `524288`.
 * `subnet_ids` - (Required) A list of IDs for the subnets that the file system will be accessible from. Exactly 1 subnet need to be provided.
-* `throughput_capacity` - (Required) Throughput (megabytes per second) of the file system in power of 2 increments. Minimum of `64` and maximum of `4096`.
+* `throughput_capacity` - (Required) Throughput (megabytes per second) of the file system. Valid values depend on `deployment_type`. Must be one of `64`, `128`, `256`, `512`, `1024`, `2048`, `4096` for `SINGLE_AZ_1`. Must be one of`160`, `320`, `640`, `1280`, `2560`, `3850`, `5120`, `7680`, `10240` for `SINGLE_AZ_2`. 
 * `automatic_backup_retention_days` - (Optional) The number of days to retain automatic backups. Setting this to 0 disables automatic backups. You can retain automatic backups for a maximum of 90 days.
 * `backup_id` - (Optional) The ID of the source backup to create the filesystem from.
 * `copy_tags_to_backups` - (Optional) A boolean flag indicating whether tags for the file system should be copied to backups. The default value is false.


### PR DESCRIPTION
### Description
- Adds support for `SINGLE_AZ_2` deployment type to `aws_fsx_openzfs_file_system`
- Validates throughput capacity depending on deployment type.

### Relations
Closes #28475

### References
https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/performance.html


### Output from Acceptance Testing
(Running now will update)
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
