### PR TITLE
Fix retry when updating `aws_lambda_event_source_mapping`

### DIFF
--- a/internal/service/lambda/event_source_mapping.go
+++ b/internal/service/lambda/event_source_mapping.go
@@ -639,6 +639,18 @@ func resourceEventSourceMappingUpdate(d *schema.ResourceData, meta interface{}) 
 			return resource.RetryableError(err)
 		}
 
+		if tfawserr.ErrMessageContains(err, lambda.ErrCodeInvalidParameterValueException, "cannot be assumed by Lambda") {
+			return resource.RetryableError(err)
+		}
+
+		if tfawserr.ErrMessageContains(err, lambda.ErrCodeInvalidParameterValueException, "execution role does not have permissions") {
+			return resource.RetryableError(err)
+		}
+
+		if tfawserr.ErrMessageContains(err, lambda.ErrCodeInvalidParameterValueException, "ensure the role can perform") {
+			return resource.RetryableError(err)
+		}
+
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}

--- a/internal/service/lambda/event_source_mapping_test.go
+++ b/internal/service/lambda/event_source_mapping_test.go
@@ -1857,10 +1857,48 @@ resource "aws_lambda_event_source_mapping" "test" {
 
 func testAccEventSourceMappingConfig_sqsUpdateFunctionName(rName string) string {
 	return acctest.ConfigCompose(testAccEventSourceMappingConfig_sqsBase(rName), fmt.Sprintf(`
+resource "aws_iam_role" "test_update" {
+	name = "%[1]s-update"
+
+	assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [{
+		"Action": "sts:AssumeRole",
+		"Principal": {
+			"Service": "lambda.amazonaws.com"
+		},
+		"Effect": "Allow"
+	}]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test_update" {
+	role = aws_iam_role.test_update.name
+
+	policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Action": [
+				"sqs:*"
+			],
+			"Resource": "*"
+		}
+	]
+}
+EOF
+
+	depends_on = [aws_lambda_function.test_update]
+}
+
 resource "aws_lambda_function" "test_update" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%[1]s-update"
-  role          = aws_iam_role.test.arn
+  role          = aws_iam_role.test_update.arn
   handler       = "exports.example"
   runtime       = "nodejs16.x"
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

This PR takes the retry logic when creating an `aws_lambda_event_source_mapping` resource and adds it to when updating the resource.

### Relations

Closes #22973

### Output from Acceptance Testing

I updated an existing test

![Screenshot 2022-12-26 at 23 04 34](https://user-images.githubusercontent.com/60179183/209690145-30d0e0b4-c692-4e24-9bb1-e01b9bb81cd0.jpg)
