### PR TITLE
Update resource references to aws_macsec_key_association

### DIFF
--- a/website/docs/r/dx_macsec_key_association.html.markdown
+++ b/website/docs/r/dx_macsec_key_association.html.markdown
@@ -15,7 +15,7 @@ Creating this resource will also create a resource of type [`aws_secretsmanager_
 ~> **Note:** All arguments including `ckn` and `cak` will be stored in the raw state as plain-text.
 [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 
-~> **Note:** The `secret_arn` argument can only be used to reference a previously created MACSec key. You cannot associate a Secrets Manager secret created outside of the `aws_dx_macsec_key` resource.
+~> **Note:** The `secret_arn` argument can only be used to reference a previously created MACSec key. You cannot associate a Secrets Manager secret created outside of the `aws_dx_macsec_key_association` resource.
 
 ## Example Usage
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Updates the documentation for resource `aws_dx_macsec_key_association` to correct references to nonexistent resource type `aws_dx_macsec_key`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28587 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

Original PR with correct resources: https://github.com/hashicorp/terraform-provider-aws/pull/26274

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
