### PR TITLE
Bugfix: `aws_lightsail_disk_attachment` crash on failure

### DIFF
--- a/.changelog/28593.txt
+++ b/.changelog/28593.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lightsail_disk_attachment: Resolves a panic when an attachment fails and attempts to display the error returned by AWS.
+```

--- a/internal/service/lightsail/disk_attachment.go
+++ b/internal/service/lightsail/disk_attachment.go
@@ -57,18 +57,18 @@ func resourceDiskAttachmentCreate(ctx context.Context, d *schema.ResourceData, m
 	out, err := conn.AttachDiskWithContext(ctx, &in)
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, lightsail.OperationTypeAttachDisk, ResDiskAttachment, d.Get("name").(string), err)
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeAttachDisk, ResDiskAttachment, d.Get("disk_name").(string), err)
 	}
 
 	if len(out.Operations) == 0 {
-		return create.DiagError(names.Lightsail, lightsail.OperationTypeAttachDisk, ResDiskAttachment, d.Get("name").(string), errors.New("No operations found for Attach Disk request"))
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeAttachDisk, ResDiskAttachment, d.Get("disk_name").(string), errors.New("No operations found for Attach Disk request"))
 	}
 
 	op := out.Operations[0]
 
 	err = waitOperation(conn, op.Id)
 	if err != nil {
-		return create.DiagError(names.Lightsail, lightsail.OperationTypeAttachDisk, ResDiskAttachment, d.Get("name").(string), errors.New("Error waiting for Attach Disk request operation"))
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeAttachDisk, ResDiskAttachment, d.Get("disk_name").(string), errors.New("Error waiting for Attach Disk request operation"))
 	}
 
 	// Generate an ID
@@ -144,18 +144,18 @@ func resourceDiskAttachmentDelete(ctx context.Context, d *schema.ResourceData, m
 	})
 
 	if err != nil {
-		return create.DiagError(names.Lightsail, lightsail.OperationTypeDetachDisk, ResDiskAttachment, d.Get("name").(string), err)
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeDetachDisk, ResDiskAttachment, d.Get("disk_name").(string), err)
 	}
 
 	if len(out.Operations) == 0 {
-		return create.DiagError(names.Lightsail, lightsail.OperationTypeDetachDisk, ResDiskAttachment, d.Get("name").(string), errors.New("No operations found for Detach Disk request"))
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeDetachDisk, ResDiskAttachment, d.Get("disk_name").(string), errors.New("No operations found for Detach Disk request"))
 	}
 
 	op := out.Operations[0]
 
 	err = waitOperation(conn, op.Id)
 	if err != nil {
-		return create.DiagError(names.Lightsail, lightsail.OperationTypeDetachDisk, ResDiskAttachment, d.Get("name").(string), errors.New("Error waiting for Detach Disk request operation"))
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeDetachDisk, ResDiskAttachment, d.Get("disk_name").(string), errors.New("Error waiting for Detach Disk request operation"))
 	}
 
 	iStateOut, err = waitInstanceStateWithContext(ctx, conn, &iName)

--- a/internal/service/lightsail/disk_attachment_test.go
+++ b/internal/service/lightsail/disk_attachment_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/lightsail"
@@ -24,6 +25,7 @@ func TestAccLightsailDiskAttachment_basic(t *testing.T) {
 	dName := sdkacctest.RandomWithPrefix("tf-acc-test")
 	liName := sdkacctest.RandomWithPrefix("tf-acc-test")
 	diskPath := "/dev/xvdf"
+	diskPathBad := "/jenkins-home"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -43,6 +45,10 @@ func TestAccLightsailDiskAttachment_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "disk_path", diskPath),
 					resource.TestCheckResourceAttr(resourceName, "instance_name", liName),
 				),
+			},
+			{
+				Config:      testAccDiskAttachmentConfig_basic(dName, liName, diskPathBad),
+				ExpectError: regexp.MustCompile(`The disk path is invalid. You must specify a valid disk path.`),
 			},
 		},
 	})
@@ -149,7 +155,7 @@ resource "aws_lightsail_disk" "test" {
 resource "aws_lightsail_instance" "test" {
   name              = %[2]q
   availability_zone = data.aws_availability_zones.available.names[0]
-  blueprint_id      = "amazon_linux"
+  blueprint_id      = "amazon_linux_2"
   bundle_id         = "nano_1_0"
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR resolves a crash that occurs when terraform fails to attach a disk to an instance. The crash was taking place because the logs originally referenced an attribute that does not exist. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28024

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
➜ terraform-provider-aws (b-aws_lightsail_disk_attachemnt_crash) ✗ make testacc TESTARGS='-run=TestAccLightsailDiskAttachment' PKG=lightsail
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lightsail/... -v -count 1 -parallel 20  -run=TestAccLightsailDiskAttachment -timeout 180m
=== RUN   TestAccLightsailDiskAttachment_basic
=== PAUSE TestAccLightsailDiskAttachment_basic
=== RUN   TestAccLightsailDiskAttachment_disappears
=== PAUSE TestAccLightsailDiskAttachment_disappears
=== CONT  TestAccLightsailDiskAttachment_basic
=== CONT  TestAccLightsailDiskAttachment_disappears

--- PASS: TestAccLightsailDiskAttachment_disappears (168.07s)
--- PASS: TestAccLightsailDiskAttachment_basic (194.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  196.259s

...
```
