### PR TITLE
Add Managed Rule Group Config functionality to WAFv2 resource

### DIFF
--- a/.changelog/28594.txt
+++ b/.changelog/28594.txt
@@ -1,0 +1,2 @@
+```release-note:enhancement
+resource/aws_wafv2_web_acl: Add support for ManagedRuleGroupConfig```

--- a/.changelog/28594.txt
+++ b/.changelog/28594.txt
@@ -1,2 +1,3 @@
 ```release-note:enhancement
-resource/aws_wafv2_web_acl: Add support for ManagedRuleGroupConfig```
+resource/aws_wafv2_web_acl: Add support for ManagedRuleGroupConfig
+```

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -985,52 +985,84 @@ func expandManagedRuleGroupStatement(l []interface{}) *wafv2.ManagedRuleGroupSta
 	if v, ok := m["version"]; ok && v != "" {
 		r.Version = aws.String(v.(string))
 	}
-	if s, ok := m["managed_rule_group_config"].([]interface{}); ok && len(s) > 0 && s[0] != nil {
-		r.ManagedRuleGroupConfigs = expandManagedRuleGroupConfigs(s[0].(map[string]interface{}))
+	if v, ok := m["managed_rule_group_config"].([]interface{}); ok && len(v) > 0 {
+		r.ManagedRuleGroupConfigs = expandManagedRuleGroupConfigs(v)
 	}
 
 	return r
 }
 
-func expandManagedRuleGroupConfigs(m map[string]interface{}) []*wafv2.ManagedRuleGroupConfig {
-	c := make([]*wafv2.ManagedRuleGroupConfig, 0)
-
-	if v, ok := m["login_path"]; ok && len(v.(string)) > 0 {
-		c = append(c, &wafv2.ManagedRuleGroupConfig{
-			LoginPath: aws.String(v.(string)),
-		})
+func expandManagedRuleGroupConfigs(tfList []interface{}) []*wafv2.ManagedRuleGroupConfig {
+	if len(tfList) == 0 {
+		return nil
 	}
 
-	if v, ok := m["payload_type"]; ok && len(v.(string)) > 0 {
-		c = append(c, &wafv2.ManagedRuleGroupConfig{
-			PayloadType: aws.String(v.(string)),
-		})
+	var out []*wafv2.ManagedRuleGroupConfig
+	for _, item := range tfList {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		var r wafv2.ManagedRuleGroupConfig
+		if v, ok := m["aws_managed_rules_bot_rule_set"].([]interface{}); ok && len(v) > 0 {
+			r.AWSManagedRulesBotControlRuleSet = expandAWSManagedRulesBotControlRuleSet(v)
+		}
+		if v, ok := m["login_path"].(string); ok && v != "" {
+			r.LoginPath = aws.String(v)
+		}
+		if v, ok := m["payload_type"].(string); ok && v != "" {
+			r.PayloadType = aws.String(v)
+		}
+		if v, ok := m["password_field"].([]interface{}); ok && len(v) > 0 {
+			r.PasswordField = expandPasswordField(v)
+		}
+		if v, ok := m["username_field"].([]interface{}); ok && len(v) > 0 {
+			r.UsernameField = expandUsernameField(v)
+		}
+
+		out = append(out, &r)
 	}
 
-	if v, ok := m["password_field"]; ok && len(v.(string)) > 0 {
-		c = append(c, &wafv2.ManagedRuleGroupConfig{
-			PasswordField: &wafv2.PasswordField{
-				Identifier: aws.String(v.(string)),
-			},
-		})
+	return out
+}
+
+func expandPasswordField(tfList []interface{}) *wafv2.PasswordField {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
 	}
 
-	if v, ok := m["username_field"]; ok && len(v.(string)) > 0 {
-		c = append(c, &wafv2.ManagedRuleGroupConfig{
-			UsernameField: &wafv2.UsernameField{
-				Identifier: aws.String(v.(string)),
-			},
-		})
+	m := tfList[0].(map[string]interface{})
+	out := wafv2.PasswordField{
+		Identifier: aws.String(m["identifier"].(string)),
 	}
 
-	if v, ok := m["inspection_level"]; ok && len(v.(string)) > 0 {
-		c = append(c, &wafv2.ManagedRuleGroupConfig{
-			AWSManagedRulesBotControlRuleSet: &wafv2.AWSManagedRulesBotControlRuleSet{
-				InspectionLevel: aws.String(v.(string)),
-			},
-		})
+	return &out
+}
+
+func expandUsernameField(tfList []interface{}) *wafv2.UsernameField {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
 	}
-	return c
+
+	m := tfList[0].(map[string]interface{})
+	out := wafv2.UsernameField{
+		Identifier: aws.String(m["identifier"].(string)),
+	}
+
+	return &out
+}
+
+func expandAWSManagedRulesBotControlRuleSet(tfList []interface{}) *wafv2.AWSManagedRulesBotControlRuleSet {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	m := tfList[0].(map[string]interface{})
+	out := wafv2.AWSManagedRulesBotControlRuleSet{
+		InspectionLevel: aws.String(m["inspection_level"].(string)),
+	}
+
+	return &out
 }
 
 func expandRateBasedStatement(l []interface{}) *wafv2.RateBasedStatement {

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -2045,7 +2045,6 @@ func flattenManagedRuleGroupConfigs(c []*wafv2.ManagedRuleGroupConfig) []interfa
 		if config.UsernameField != nil {
 			m["username_field"] = flattenUsernameField(config.UsernameField)
 		}
-
 	}
 
 	return []interface{}{m}

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -999,14 +999,12 @@ func expandManagedRuleGroupConfigs(m map[string]interface{}) []*wafv2.ManagedRul
 		c = append(c, &wafv2.ManagedRuleGroupConfig{
 			LoginPath: aws.String(v.(string)),
 		})
-
 	}
 
 	if v, ok := m["payload_type"]; ok && len(v.(string)) > 0 {
 		c = append(c, &wafv2.ManagedRuleGroupConfig{
 			PayloadType: aws.String(v.(string)),
 		})
-
 	}
 
 	if v, ok := m["password_field"]; ok && len(v.(string)) > 0 {
@@ -1015,7 +1013,6 @@ func expandManagedRuleGroupConfigs(m map[string]interface{}) []*wafv2.ManagedRul
 				Identifier: aws.String(v.(string)),
 			},
 		})
-
 	}
 
 	if v, ok := m["username_field"]; ok && len(v.(string)) > 0 {
@@ -1024,7 +1021,6 @@ func expandManagedRuleGroupConfigs(m map[string]interface{}) []*wafv2.ManagedRul
 				Identifier: aws.String(v.(string)),
 			},
 		})
-
 	}
 
 	if v, ok := m["inspection_level"]; ok && len(v.(string)) > 0 {
@@ -1976,6 +1972,7 @@ func flattenManagedRuleGroupStatement(apiObject *wafv2.ManagedRuleGroupStatement
 	if apiObject.Version != nil {
 		tfMap["version"] = aws.StringValue(apiObject.Version)
 	}
+
 	if apiObject.ManagedRuleGroupConfigs != nil {
 		tfMap["managed_rule_group_config"] = []interface{}{flattenManagedRuleGroupConfigs(apiObject.ManagedRuleGroupConfigs)}
 	}
@@ -1990,10 +1987,11 @@ func flattenManagedRuleGroupConfigs(c []*wafv2.ManagedRuleGroupConfig) interface
 		if config.AWSManagedRulesBotControlRuleSet != nil {
 			tfMap["inspection_level"] = aws.StringValue(config.AWSManagedRulesBotControlRuleSet.InspectionLevel)
 		}
+
 		if config.LoginPath != nil {
 			tfMap["login_path"] = aws.StringValue(config.LoginPath)
-
 		}
+
 		if config.PasswordField != nil {
 			tfMap["password_field"] = aws.StringValue(config.PasswordField.Identifier)
 		}
@@ -2001,13 +1999,13 @@ func flattenManagedRuleGroupConfigs(c []*wafv2.ManagedRuleGroupConfig) interface
 		if config.UsernameField != nil {
 			tfMap["username_field"] = aws.StringValue(config.UsernameField.Identifier)
 		}
+
 		if config.PayloadType != nil {
 			tfMap["payload_type"] = aws.StringValue(config.PayloadType)
 		}
 	}
 
 	return tfMap
-
 }
 
 func flattenRateBasedStatement(apiObject *wafv2.RateBasedStatement) interface{} {

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -1003,24 +1003,35 @@ func expandManagedRuleGroupConfigs(tfList []interface{}) []*wafv2.ManagedRuleGro
 		if !ok {
 			continue
 		}
-		var r wafv2.ManagedRuleGroupConfig
+
 		if v, ok := m["aws_managed_rules_bot_rule_set"].([]interface{}); ok && len(v) > 0 {
-			r.AWSManagedRulesBotControlRuleSet = expandAWSManagedRulesBotControlRuleSet(v)
+			out = append(out, &wafv2.ManagedRuleGroupConfig{
+				AWSManagedRulesBotControlRuleSet: expandManagedRulesBotControlRuleSet(v),
+			})
 		}
-		if v, ok := m["login_path"].(string); ok && v != "" {
-			r.LoginPath = aws.String(v)
-		}
-		if v, ok := m["payload_type"].(string); ok && v != "" {
-			r.PayloadType = aws.String(v)
-		}
-		if v, ok := m["password_field"].([]interface{}); ok && len(v) > 0 {
-			r.PasswordField = expandPasswordField(v)
-		}
-		if v, ok := m["username_field"].([]interface{}); ok && len(v) > 0 {
-			r.UsernameField = expandUsernameField(v)
+		if v, ok := m["login_path"]; ok && len(v.(string)) > 0 {
+			out = append(out, &wafv2.ManagedRuleGroupConfig{
+				LoginPath: aws.String(v.(string)),
+			})
 		}
 
-		out = append(out, &r)
+		if v, ok := m["payload_type"]; ok && len(v.(string)) > 0 {
+			out = append(out, &wafv2.ManagedRuleGroupConfig{
+				PayloadType: aws.String(v.(string)),
+			})
+		}
+
+		if v, ok := m["password_field"].([]interface{}); ok && len(v) > 0 {
+			out = append(out, &wafv2.ManagedRuleGroupConfig{
+				PasswordField: expandPasswordField(v),
+			})
+		}
+
+		if v, ok := m["username_field"].([]interface{}); ok && len(v) > 0 {
+			out = append(out, &wafv2.ManagedRuleGroupConfig{
+				UsernameField: expandUsernameField(v),
+			})
+		}
 	}
 
 	return out
@@ -1052,7 +1063,7 @@ func expandUsernameField(tfList []interface{}) *wafv2.UsernameField {
 	return &out
 }
 
-func expandAWSManagedRulesBotControlRuleSet(tfList []interface{}) *wafv2.AWSManagedRulesBotControlRuleSet {
+func expandManagedRulesBotControlRuleSet(tfList []interface{}) *wafv2.AWSManagedRulesBotControlRuleSet {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
@@ -2017,21 +2028,27 @@ func flattenManagedRuleGroupConfigs(c []*wafv2.ManagedRuleGroupConfig) []interfa
 		return nil
 	}
 
-	var out []interface{}
-
+	m := make(map[string]interface{})
 	for _, config := range c {
-		m := map[string]interface{}{
-			"aws_managed_rules_bot_control_rule_set": flattenAWSManagedRulesBotControlRuleSet(config.AWSManagedRulesBotControlRuleSet),
-			"login_path":                             aws.StringValue(config.LoginPath),
-			"payload_type":                           aws.StringValue(config.PayloadType),
-			"password_field":                         flattenPasswordField(config.PasswordField),
-			"username_field":                         flattenUsernameField(config.UsernameField),
+		if config.AWSManagedRulesBotControlRuleSet != nil {
+			m["aws_managed_rules_bot_control_rule_set"] = flattenManagedRulesBotControlRuleSet(config.AWSManagedRulesBotControlRuleSet)
+		}
+		if config.LoginPath != nil {
+			m["login_path"] = aws.StringValue(config.LoginPath)
+		}
+		if config.PayloadType != nil {
+			m["payload_type"] = aws.StringValue(config.PayloadType)
+		}
+		if config.PasswordField != nil {
+			m["password_field"] = flattenPasswordField(config.PasswordField)
+		}
+		if config.UsernameField != nil {
+			m["username_field"] = flattenUsernameField(config.UsernameField)
 		}
 
-		out = append(out, m)
 	}
 
-	return out
+	return []interface{}{m}
 }
 
 func flattenPasswordField(apiObject *wafv2.PasswordField) []interface{} {
@@ -2058,7 +2075,7 @@ func flattenUsernameField(apiObject *wafv2.UsernameField) []interface{} {
 	return []interface{}{m}
 }
 
-func flattenAWSManagedRulesBotControlRuleSet(apiObject *wafv2.AWSManagedRulesBotControlRuleSet) []interface{} {
+func flattenManagedRulesBotControlRuleSet(apiObject *wafv2.AWSManagedRulesBotControlRuleSet) []interface{} {
 	if apiObject == nil {
 		return nil
 	}

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -2006,38 +2006,68 @@ func flattenManagedRuleGroupStatement(apiObject *wafv2.ManagedRuleGroupStatement
 	}
 
 	if apiObject.ManagedRuleGroupConfigs != nil {
-		tfMap["managed_rule_group_config"] = []interface{}{flattenManagedRuleGroupConfigs(apiObject.ManagedRuleGroupConfigs)}
+		tfMap["managed_rule_group_config"] = flattenManagedRuleGroupConfigs(apiObject.ManagedRuleGroupConfigs)
 	}
 
 	return []interface{}{tfMap}
 }
 
-func flattenManagedRuleGroupConfigs(c []*wafv2.ManagedRuleGroupConfig) interface{} {
-	tfMap := map[string]interface{}{}
-
-	for _, config := range c {
-		if config.AWSManagedRulesBotControlRuleSet != nil {
-			tfMap["inspection_level"] = aws.StringValue(config.AWSManagedRulesBotControlRuleSet.InspectionLevel)
-		}
-
-		if config.LoginPath != nil {
-			tfMap["login_path"] = aws.StringValue(config.LoginPath)
-		}
-
-		if config.PasswordField != nil {
-			tfMap["password_field"] = aws.StringValue(config.PasswordField.Identifier)
-		}
-
-		if config.UsernameField != nil {
-			tfMap["username_field"] = aws.StringValue(config.UsernameField.Identifier)
-		}
-
-		if config.PayloadType != nil {
-			tfMap["payload_type"] = aws.StringValue(config.PayloadType)
-		}
+func flattenManagedRuleGroupConfigs(c []*wafv2.ManagedRuleGroupConfig) []interface{} {
+	if len(c) == 0 {
+		return nil
 	}
 
-	return tfMap
+	var out []interface{}
+
+	for _, config := range c {
+		m := map[string]interface{}{
+			"aws_managed_rules_bot_control_rule_set": flattenAWSManagedRulesBotControlRuleSet(config.AWSManagedRulesBotControlRuleSet),
+			"login_path":                             aws.StringValue(config.LoginPath),
+			"payload_type":                           aws.StringValue(config.PayloadType),
+			"password_field":                         flattenPasswordField(config.PasswordField),
+			"username_field":                         flattenUsernameField(config.UsernameField),
+		}
+
+		out = append(out, m)
+	}
+
+	return out
+}
+
+func flattenPasswordField(apiObject *wafv2.PasswordField) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	m := map[string]interface{}{
+		"identifier": aws.StringValue(apiObject.Identifier),
+	}
+
+	return []interface{}{m}
+}
+
+func flattenUsernameField(apiObject *wafv2.UsernameField) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	m := map[string]interface{}{
+		"identifier": aws.StringValue(apiObject.Identifier),
+	}
+
+	return []interface{}{m}
+}
+
+func flattenAWSManagedRulesBotControlRuleSet(apiObject *wafv2.AWSManagedRulesBotControlRuleSet) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	m := map[string]interface{}{
+		"inspection_level": aws.StringValue(apiObject.InspectionLevel),
+	}
+
+	return []interface{}{m}
 }
 
 func flattenRateBasedStatement(apiObject *wafv2.RateBasedStatement) interface{} {

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -985,8 +985,56 @@ func expandManagedRuleGroupStatement(l []interface{}) *wafv2.ManagedRuleGroupSta
 	if v, ok := m["version"]; ok && v != "" {
 		r.Version = aws.String(v.(string))
 	}
+	if s, ok := m["managed_rule_group_config"].([]interface{}); ok && len(s) > 0 && s[0] != nil {
+		r.ManagedRuleGroupConfigs = expandManagedRuleGroupConfigs(s[0].(map[string]interface{}))
+	}
 
 	return r
+}
+
+func expandManagedRuleGroupConfigs(m map[string]interface{}) []*wafv2.ManagedRuleGroupConfig {
+	c := make([]*wafv2.ManagedRuleGroupConfig, 0)
+
+	if v, ok := m["login_path"]; ok && len(v.(string)) > 0 {
+		c = append(c, &wafv2.ManagedRuleGroupConfig{
+			LoginPath: aws.String(v.(string)),
+		})
+
+	}
+
+	if v, ok := m["payload_type"]; ok && len(v.(string)) > 0 {
+		c = append(c, &wafv2.ManagedRuleGroupConfig{
+			PayloadType: aws.String(v.(string)),
+		})
+
+	}
+
+	if v, ok := m["password_field"]; ok && len(v.(string)) > 0 {
+		c = append(c, &wafv2.ManagedRuleGroupConfig{
+			PasswordField: &wafv2.PasswordField{
+				Identifier: aws.String(v.(string)),
+			},
+		})
+
+	}
+
+	if v, ok := m["username_field"]; ok && len(v.(string)) > 0 {
+		c = append(c, &wafv2.ManagedRuleGroupConfig{
+			UsernameField: &wafv2.UsernameField{
+				Identifier: aws.String(v.(string)),
+			},
+		})
+
+	}
+
+	if v, ok := m["inspection_level"]; ok && len(v.(string)) > 0 {
+		c = append(c, &wafv2.ManagedRuleGroupConfig{
+			AWSManagedRulesBotControlRuleSet: &wafv2.AWSManagedRulesBotControlRuleSet{
+				InspectionLevel: aws.String(v.(string)),
+			},
+		})
+	}
+	return c
 }
 
 func expandRateBasedStatement(l []interface{}) *wafv2.RateBasedStatement {
@@ -1928,8 +1976,38 @@ func flattenManagedRuleGroupStatement(apiObject *wafv2.ManagedRuleGroupStatement
 	if apiObject.Version != nil {
 		tfMap["version"] = aws.StringValue(apiObject.Version)
 	}
+	if apiObject.ManagedRuleGroupConfigs != nil {
+		tfMap["managed_rule_group_config"] = []interface{}{flattenManagedRuleGroupConfigs(apiObject.ManagedRuleGroupConfigs)}
+	}
 
 	return []interface{}{tfMap}
+}
+
+func flattenManagedRuleGroupConfigs(c []*wafv2.ManagedRuleGroupConfig) interface{} {
+	tfMap := map[string]interface{}{}
+
+	for _, config := range c {
+		if config.AWSManagedRulesBotControlRuleSet != nil {
+			tfMap["inspection_level"] = aws.StringValue(config.AWSManagedRulesBotControlRuleSet.InspectionLevel)
+		}
+		if config.LoginPath != nil {
+			tfMap["login_path"] = aws.StringValue(config.LoginPath)
+
+		}
+		if config.PasswordField != nil {
+			tfMap["password_field"] = aws.StringValue(config.PasswordField.Identifier)
+		}
+
+		if config.UsernameField != nil {
+			tfMap["username_field"] = aws.StringValue(config.UsernameField.Identifier)
+		}
+		if config.PayloadType != nil {
+			tfMap["payload_type"] = aws.StringValue(config.PayloadType)
+		}
+	}
+
+	return tfMap
+
 }
 
 func flattenRateBasedStatement(apiObject *wafv2.RateBasedStatement) interface{} {

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -841,9 +841,9 @@ func managedRuleGroupStatementSchema(level int) *schema.Schema {
 					Required:     true,
 					ValidateFunc: validation.StringLenBetween(1, 128),
 				},
-				"rule_action_override":      ruleActionOverrideSchema(),
-				"managed_rule_group_config": managedRuleGroupConfigSchema(),
-				"scope_down_statement":      scopeDownStatementSchema(level - 1),
+				"rule_action_override":       ruleActionOverrideSchema(),
+				"managed_rule_group_configs": managedRuleGroupConfigSchema(),
+				"scope_down_statement":       scopeDownStatementSchema(level - 1),
 				"vendor_name": {
 					Type:         schema.TypeString,
 					Required:     true,
@@ -947,7 +947,6 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
-		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"aws_managed_rules_bot_control_rule_set": {

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -967,11 +967,9 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 					),
 				},
 				"payload_type": {
-					Type:     schema.TypeString,
-					Optional: true,
-					ValidateFunc: validation.All(
-						validation.StringMatch(regexp.MustCompile(`(JSON|FORM_ENCODED)`), "valid values are JSON | FORM_ENCODED"),
-					),
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(wafv2.PayloadType_Values(), false),
 				},
 				"username_field": {
 					Type:     schema.TypeString,
@@ -982,11 +980,9 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 					),
 				},
 				"inspection_level": {
-					Type:     schema.TypeString,
-					Optional: true,
-					ValidateFunc: validation.All(
-						validation.StringMatch(regexp.MustCompile(`(COMMON|TARGETED)`), "valid values are COMMON | TARGETED"),
-					),
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(wafv2.InspectionLevel_Values(), false),
 				},
 			},
 		},

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -947,6 +947,7 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
+		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"aws_managed_rules_bot_control_rule_set": {

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -947,9 +947,22 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
-		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
+				"aws_managed_rules_bot_control_rule_set": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"inspection_level": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringInSlice(wafv2.InspectionLevel_Values(), false),
+							},
+						},
+					},
+				},
 				"login_path": {
 					Type:     schema.TypeString,
 					Optional: true,
@@ -959,12 +972,21 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 					),
 				},
 				"password_field": {
-					Type:     schema.TypeString,
+					Type:     schema.TypeList,
 					Optional: true,
-					ValidateFunc: validation.All(
-						validation.StringLenBetween(1, 512),
-						validation.StringMatch(regexp.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
-					),
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"identifier": {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.All(
+									validation.StringLenBetween(1, 512),
+									validation.StringMatch(regexp.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+								),
+							},
+						},
+					},
 				},
 				"payload_type": {
 					Type:         schema.TypeString,
@@ -972,17 +994,21 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 					ValidateFunc: validation.StringInSlice(wafv2.PayloadType_Values(), false),
 				},
 				"username_field": {
-					Type:     schema.TypeString,
+					Type:     schema.TypeList,
 					Optional: true,
-					ValidateFunc: validation.All(
-						validation.StringLenBetween(1, 512),
-						validation.StringMatch(regexp.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
-					),
-				},
-				"inspection_level": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					ValidateFunc: validation.StringInSlice(wafv2.InspectionLevel_Values(), false),
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"identifier": {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.All(
+									validation.StringLenBetween(1, 512),
+									validation.StringMatch(regexp.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+								),
+							},
+						},
+					},
 				},
 			},
 		},

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -841,8 +841,9 @@ func managedRuleGroupStatementSchema(level int) *schema.Schema {
 					Required:     true,
 					ValidateFunc: validation.StringLenBetween(1, 128),
 				},
-				"rule_action_override": ruleActionOverrideSchema(),
-				"scope_down_statement": scopeDownStatementSchema(level - 1),
+				"rule_action_override":      ruleActionOverrideSchema(),
+				"managed_rule_group_config": managedRuleGroupConfigSchema(),
+				"scope_down_statement":      scopeDownStatementSchema(level - 1),
 				"vendor_name": {
 					Type:         schema.TypeString,
 					Required:     true,
@@ -936,6 +937,56 @@ func ruleActionOverrideSchema() *schema.Schema {
 					Type:         schema.TypeString,
 					Required:     true,
 					ValidateFunc: validation.StringLenBetween(1, 128),
+				},
+			},
+		},
+	}
+}
+
+func managedRuleGroupConfigSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"login_path": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 256),
+						validation.StringMatch(regexp.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+					),
+				},
+				"password_field": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 512),
+						validation.StringMatch(regexp.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+					),
+				},
+				"payload_type": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ValidateFunc: validation.All(
+						validation.StringMatch(regexp.MustCompile(`(JSON|FORM_ENCODED)`), "valid values are JSON | FORM_ENCODED"),
+					),
+				},
+				"username_field": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ValidateFunc: validation.All(
+						validation.StringLenBetween(1, 512),
+						validation.StringMatch(regexp.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+					),
+				},
+				"inspection_level": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ValidateFunc: validation.All(
+						validation.StringMatch(regexp.MustCompile(`(COMMON|TARGETED)`), "valid values are COMMON | TARGETED"),
+					),
 				},
 			},
 		},

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -2910,15 +2910,13 @@ resource "aws_wafv2_web_acl" "test" {
         name        = "AWSManagedRulesATPRuleSet"
         vendor_name = "AWS"
 
-		managed_rule_group_config {
-			login_path =  "/login"
-			password_field = "/password"
-			payload_type = "JSON"
-			username_field = "/username"
-		}
-
+        managed_rule_group_config {
+          login_path     = "/login"
+          password_field = "/password"
+          payload_type   = "JSON"
+          username_field = "/username"
+        }
       }
-	  
     }
 
     visibility_config {

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -2964,12 +2964,12 @@ resource "aws_wafv2_web_acl" "test" {
         name        = "AWSManagedRulesATPRuleSet"
         vendor_name = "AWS"
 
-		managed_rule_group_config {
-          login_path     =  "/app-login"
+        managed_rule_group_config {
+          login_path     = "/app-login"
           password_field = "/app-password"
           payload_type   = "JSON"
           username_field = "/app-username"
-		}
+        }
       }
     }
 

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -2965,13 +2965,12 @@ resource "aws_wafv2_web_acl" "test" {
         vendor_name = "AWS"
 
 		managed_rule_group_config {
-			login_path =  "/app-login"
-			password_field = "/app-password"
-			payload_type = "JSON"
-			username_field = "/app-username"
+          login_path     =  "/app-login"
+          password_field = "/app-password"
+          payload_type   = "JSON"
+          username_field = "/app-username"
 		}
       }
-	  
     }
 
     visibility_config {

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -632,15 +632,15 @@ func TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig(t *testing.T) {
 						"override_action.0.count.#": "0",
 						"override_action.0.none.#":  "1",
 						"statement.#":               "1",
-						"statement.0.managed_rule_group_statement.#":                                                         "1",
-						"statement.0.managed_rule_group_statement.0.name":                                                    "AWSManagedRulesATPRuleSet",
-						"statement.0.managed_rule_group_statement.0.vendor_name":                                             "AWS",
-						"statement.0.managed_rule_group_statement.0.excluded_rule.#":                                         "0",
-						"statement.0.managed_rule_group_statement.0.scope_down_statement.#":                                  "0",
-						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.login_path":                  "/login",
-						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.password_field.0.identifier": "/password",
-						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.payload_type":                "JSON",
-						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.username_field.0.identifier": "/username",
+						"statement.0.managed_rule_group_statement.#":                                                          "1",
+						"statement.0.managed_rule_group_statement.0.name":                                                     "AWSManagedRulesATPRuleSet",
+						"statement.0.managed_rule_group_statement.0.vendor_name":                                              "AWS",
+						"statement.0.managed_rule_group_statement.0.excluded_rule.#":                                          "0",
+						"statement.0.managed_rule_group_statement.0.scope_down_statement.#":                                   "0",
+						"statement.0.managed_rule_group_statement.0.managed_rule_group_configs.0.login_path":                  "/login",
+						"statement.0.managed_rule_group_statement.0.managed_rule_group_configs.1.payload_type":                "JSON",
+						"statement.0.managed_rule_group_statement.0.managed_rule_group_configs.2.password_field.0.identifier": "/password",
+						"statement.0.managed_rule_group_statement.0.managed_rule_group_configs.3.username_field.0.identifier": "/username",
 					}),
 				),
 			},
@@ -658,15 +658,15 @@ func TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig(t *testing.T) {
 						"override_action.0.count.#": "0",
 						"override_action.0.none.#":  "1",
 						"statement.#":               "1",
-						"statement.0.managed_rule_group_statement.#":                                                         "1",
-						"statement.0.managed_rule_group_statement.0.name":                                                    "AWSManagedRulesATPRuleSet",
-						"statement.0.managed_rule_group_statement.0.vendor_name":                                             "AWS",
-						"statement.0.managed_rule_group_statement.0.excluded_rule.#":                                         "0",
-						"statement.0.managed_rule_group_statement.0.scope_down_statement.#":                                  "0",
-						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.login_path":                  "/app-login",
-						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.password_field.0.identifier": "/app-password",
-						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.payload_type":                "JSON",
-						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.username_field.0.identifier": "/app-username",
+						"statement.0.managed_rule_group_statement.#":                                                          "1",
+						"statement.0.managed_rule_group_statement.0.name":                                                     "AWSManagedRulesATPRuleSet",
+						"statement.0.managed_rule_group_statement.0.vendor_name":                                              "AWS",
+						"statement.0.managed_rule_group_statement.0.excluded_rule.#":                                          "0",
+						"statement.0.managed_rule_group_statement.0.scope_down_statement.#":                                   "0",
+						"statement.0.managed_rule_group_statement.0.managed_rule_group_configs.0.login_path":                  "/app-login",
+						"statement.0.managed_rule_group_statement.0.managed_rule_group_configs.1.payload_type":                "JSON",
+						"statement.0.managed_rule_group_statement.0.managed_rule_group_configs.2.password_field.0.identifier": "/app-password",
+						"statement.0.managed_rule_group_statement.0.managed_rule_group_configs.3.username_field.0.identifier": "/app-username",
 					}),
 				),
 			},
@@ -2910,14 +2910,18 @@ resource "aws_wafv2_web_acl" "test" {
         name        = "AWSManagedRulesATPRuleSet"
         vendor_name = "AWS"
 
-        managed_rule_group_config {
-          login_path   = "/login"
+        managed_rule_group_configs {
+          login_path = "/login"
+        }
+        managed_rule_group_configs {
           payload_type = "JSON"
-
+        }
+        managed_rule_group_configs {
           password_field {
             identifier = "/password"
           }
-
+        }
+        managed_rule_group_configs {
           username_field {
             identifier = "/username"
           }
@@ -2970,14 +2974,18 @@ resource "aws_wafv2_web_acl" "test" {
         name        = "AWSManagedRulesATPRuleSet"
         vendor_name = "AWS"
 
-        managed_rule_group_config {
-          login_path   = "/app-login"
+        managed_rule_group_configs {
+          login_path = "/app-login"
+        }
+        managed_rule_group_configs {
           payload_type = "JSON"
-
+        }
+        managed_rule_group_configs {
           password_field {
             identifier = "/app-password"
           }
-
+        }
+        managed_rule_group_configs {
           username_field {
             identifier = "/app-username"
           }

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -632,15 +632,15 @@ func TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig(t *testing.T) {
 						"override_action.0.count.#": "0",
 						"override_action.0.none.#":  "1",
 						"statement.#":               "1",
-						"statement.0.managed_rule_group_statement.#":                                            "1",
-						"statement.0.managed_rule_group_statement.0.name":                                       "AWSManagedRulesATPRuleSet",
-						"statement.0.managed_rule_group_statement.0.vendor_name":                                "AWS",
-						"statement.0.managed_rule_group_statement.0.excluded_rule.#":                            "0",
-						"statement.0.managed_rule_group_statement.0.scope_down_statement.#":                     "0",
-						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.login_path":     "/login",
-						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.password_field": "/password",
-						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.payload_type":   "JSON",
-						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.username_field": "/username",
+						"statement.0.managed_rule_group_statement.#":                                                         "1",
+						"statement.0.managed_rule_group_statement.0.name":                                                    "AWSManagedRulesATPRuleSet",
+						"statement.0.managed_rule_group_statement.0.vendor_name":                                             "AWS",
+						"statement.0.managed_rule_group_statement.0.excluded_rule.#":                                         "0",
+						"statement.0.managed_rule_group_statement.0.scope_down_statement.#":                                  "0",
+						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.login_path":                  "/login",
+						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.password_field.0.identifier": "/password",
+						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.payload_type":                "JSON",
+						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.username_field.0.identifier": "/username",
 					}),
 				),
 			},
@@ -658,15 +658,15 @@ func TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig(t *testing.T) {
 						"override_action.0.count.#": "0",
 						"override_action.0.none.#":  "1",
 						"statement.#":               "1",
-						"statement.0.managed_rule_group_statement.#":                                            "1",
-						"statement.0.managed_rule_group_statement.0.name":                                       "AWSManagedRulesATPRuleSet",
-						"statement.0.managed_rule_group_statement.0.vendor_name":                                "AWS",
-						"statement.0.managed_rule_group_statement.0.excluded_rule.#":                            "0",
-						"statement.0.managed_rule_group_statement.0.scope_down_statement.#":                     "0",
-						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.login_path":     "/app-login",
-						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.password_field": "/app-password",
-						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.payload_type":   "JSON",
-						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.username_field": "/app-username",
+						"statement.0.managed_rule_group_statement.#":                                                         "1",
+						"statement.0.managed_rule_group_statement.0.name":                                                    "AWSManagedRulesATPRuleSet",
+						"statement.0.managed_rule_group_statement.0.vendor_name":                                             "AWS",
+						"statement.0.managed_rule_group_statement.0.excluded_rule.#":                                         "0",
+						"statement.0.managed_rule_group_statement.0.scope_down_statement.#":                                  "0",
+						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.login_path":                  "/app-login",
+						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.password_field.0.identifier": "/app-password",
+						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.payload_type":                "JSON",
+						"statement.0.managed_rule_group_statement.0.managed_rule_group_config.0.username_field.0.identifier": "/app-username",
 					}),
 				),
 			},
@@ -2911,10 +2911,16 @@ resource "aws_wafv2_web_acl" "test" {
         vendor_name = "AWS"
 
         managed_rule_group_config {
-          login_path     = "/login"
-          password_field = "/password"
-          payload_type   = "JSON"
-          username_field = "/username"
+          login_path   = "/login"
+          payload_type = "JSON"
+
+          password_field {
+            identifier = "/password"
+          }
+
+          username_field {
+            identifier = "/username"
+          }
         }
       }
     }
@@ -2965,10 +2971,16 @@ resource "aws_wafv2_web_acl" "test" {
         vendor_name = "AWS"
 
         managed_rule_group_config {
-          login_path     = "/app-login"
-          password_field = "/app-password"
-          payload_type   = "JSON"
-          username_field = "/app-username"
+          login_path   = "/app-login"
+          payload_type = "JSON"
+
+          password_field {
+            identifier = "/app-password"
+          }
+
+          username_field {
+            identifier = "/app-username"
+          }
         }
       }
     }

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -605,7 +605,7 @@ The `managed_rule_group_config` block support the following arguments:
 ### Username Field
 
 * `identifier` - (Optional) The name of the username field.
-* 
+
 ### Field to Match
 
 The part of a web request that you want AWS WAF to inspect. Include the single `field_to_match` type that you want to inspect, with additional specifications as needed, according to the type. You specify a single request component in `field_to_match` for each rule statement that requires it. To inspect more than one component of a web request, create a separate rule statement for each component. See the [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-fields.html#waf-rule-statement-request-component) for more details.

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -466,6 +466,7 @@ The `managed_rule_group_statement` block supports the following arguments:
 * `excluded_rule` - (Optional, **Deprecated**) The `rules` whose actions are set to `COUNT` by the web ACL, regardless of the action that is set on the rule. See [Excluded Rule](#excluded-rule) below for details. Use `rule_action_override` instead. (See the [documentation](https://docs.aws.amazon.com/waf/latest/APIReference/API_ManagedRuleGroupStatement.html#WAF-Type-ManagedRuleGroupStatement-ExcludedRules))
 * `name` - (Required) Name of the managed rule group.
 * `rule_action_override` - (Optional) Action settings to use in the place of the rule actions that are configured inside the rule group. You specify one override for each rule whose action you want to change. See [Rule Action Override](#rule-action-override) below for details.
+* `managed_rule_group_config`- (Optional) Additional information that's used by a managed rule group. See [Managed Rule Group Config](#managed-rule-group-config) for more details
 * `scope_down_statement` - Narrows the scope of the statement to matching web requests. This can be any nestable statement, and you can nest statements at any level below this scope-down statement. See [Statement](#statement) above for details.
 * `vendor_name` - (Required) Name of the managed rule group vendor.
 * `version` - (Optional) Version of the managed rule group. You can set `Version_1.0` or `Version_1.1` etc. If you want to use the default version, do not set anything.
@@ -583,6 +584,28 @@ The `rule_action_override` block supports the following arguments:
 * `action_to_use` - (Required) Override action to use, in place of the configured action of the rule in the rule group. See [Action](#action) below for details.
 * `name` - (Required) Name of the rule to override. See the [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html) for a list of names in the appropriate rule group in use.
 
+### Managed Rule Group Config
+
+The `managed_rule_group_config` block support the following arguments:
+
+* `aws_managed_rules_bot_control_rule_set` - (Optional) Additional configuration for using the Bot Control managed rule group. Use this to specify the inspection level that you want to use. See [AWS Managed Rules Bot Control Rule Set](#managed-rules-bot-control-rule-set) for more details
+* `login_path` - (Optional) The path of the login endpoint for your application.
+* `password_field` - (Optional) Details about your login page password field. See [Password Field](#password-field) for more details.
+* `payload_type`- (Optional) The payload type for your login endpoint, either JSON or form encoded.
+* `username_field` - (Optional) Details about your login page username field. See [Username Field](#username-field) for more details.
+
+### Managed Rules Bot Control Rule Set
+
+* `inspection_level` - (Optional) The inspection level to use for the Bot Control rule group.
+
+### Password Field
+
+* `identifier` - (Optional) The name of the password field.
+
+### Username Field
+
+* `identifier` - (Optional) The name of the username field.
+* 
 ### Field to Match
 
 The part of a web request that you want AWS WAF to inspect. Include the single `field_to_match` type that you want to inspect, with additional specifications as needed, according to the type. You specify a single request component in `field_to_match` for each rule statement that requires it. To inspect more than one component of a web request, create a separate rule statement for each component. See the [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-fields.html#waf-rule-statement-request-component) for more details.

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -466,7 +466,7 @@ The `managed_rule_group_statement` block supports the following arguments:
 * `excluded_rule` - (Optional, **Deprecated**) The `rules` whose actions are set to `COUNT` by the web ACL, regardless of the action that is set on the rule. See [Excluded Rule](#excluded-rule) below for details. Use `rule_action_override` instead. (See the [documentation](https://docs.aws.amazon.com/waf/latest/APIReference/API_ManagedRuleGroupStatement.html#WAF-Type-ManagedRuleGroupStatement-ExcludedRules))
 * `name` - (Required) Name of the managed rule group.
 * `rule_action_override` - (Optional) Action settings to use in the place of the rule actions that are configured inside the rule group. You specify one override for each rule whose action you want to change. See [Rule Action Override](#rule-action-override) below for details.
-* `managed_rule_group_configs`- (Optional) Additional information that's used by a managed rule group. Only one rule attribute is allowed in each config. See [Managed Rule Group Config](#managed-rule-group-config) for more details
+* `managed_rule_group_configs`- (Optional) Additional information that's used by a managed rule group. Only one rule attribute is allowed in each config. See [Managed Rule Group Configs](#managed-rule-group-configs) for more details
 * `scope_down_statement` - Narrows the scope of the statement to matching web requests. This can be any nestable statement, and you can nest statements at any level below this scope-down statement. See [Statement](#statement) above for details.
 * `vendor_name` - (Required) Name of the managed rule group vendor.
 * `version` - (Optional) Version of the managed rule group. You can set `Version_1.0` or `Version_1.1` etc. If you want to use the default version, do not set anything.
@@ -584,9 +584,9 @@ The `rule_action_override` block supports the following arguments:
 * `action_to_use` - (Required) Override action to use, in place of the configured action of the rule in the rule group. See [Action](#action) below for details.
 * `name` - (Required) Name of the rule to override. See the [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html) for a list of names in the appropriate rule group in use.
 
-### Managed Rule Group Config
+### Managed Rule Group Configs
 
-The `managed_rule_group_config` block support the following arguments:
+The `managed_rule_group_configs` block support the following arguments:
 
 * `aws_managed_rules_bot_control_rule_set` - (Optional) Additional configuration for using the Bot Control managed rule group. Use this to specify the inspection level that you want to use. See [AWS Managed Rules Bot Control Rule Set](#managed-rules-bot-control-rule-set) for more details
 * `login_path` - (Optional) The path of the login endpoint for your application.

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -466,7 +466,7 @@ The `managed_rule_group_statement` block supports the following arguments:
 * `excluded_rule` - (Optional, **Deprecated**) The `rules` whose actions are set to `COUNT` by the web ACL, regardless of the action that is set on the rule. See [Excluded Rule](#excluded-rule) below for details. Use `rule_action_override` instead. (See the [documentation](https://docs.aws.amazon.com/waf/latest/APIReference/API_ManagedRuleGroupStatement.html#WAF-Type-ManagedRuleGroupStatement-ExcludedRules))
 * `name` - (Required) Name of the managed rule group.
 * `rule_action_override` - (Optional) Action settings to use in the place of the rule actions that are configured inside the rule group. You specify one override for each rule whose action you want to change. See [Rule Action Override](#rule-action-override) below for details.
-* `managed_rule_group_config`- (Optional) Additional information that's used by a managed rule group. See [Managed Rule Group Config](#managed-rule-group-config) for more details
+* `managed_rule_group_configs`- (Optional) Additional information that's used by a managed rule group. Only one rule attribute is allowed in each config. See [Managed Rule Group Config](#managed-rule-group-config) for more details
 * `scope_down_statement` - Narrows the scope of the statement to matching web requests. This can be any nestable statement, and you can nest statements at any level below this scope-down statement. See [Statement](#statement) above for details.
 * `vendor_name` - (Required) Name of the managed rule group vendor.
 * `version` - (Optional) Version of the managed rule group. You can set `Version_1.0` or `Version_1.1` etc. If you want to use the default version, do not set anything.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR implements Managed Rule Group Config support for the WAFv2 Resource to enable the usage of ATP and BotControl WAF rules within terraform. 

Example Configuration: 

```
    statement {
      managed_rule_group_statement {
        name        = "AWSManagedRulesATPRuleSet"
        vendor_name = "AWS"

        managed_rule_group_config {
          login_path     = "/login-test"
          password_field = "/password"
          payload_type   = "JSON"
          username_field = "/username"
        }
      }
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #23290
Closes #26826
Closes #23287

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-bot.html
https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-atp.html
https://docs.aws.amazon.com/waf/latest/APIReference/API_ManagedRuleGroupConfig.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
❯ make testacc PKG=wafv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/wafv2/... -v -count 1 -parallel 20   -timeout 180m
=== RUN   TestAccWAFV2IPSetDataSource_basic
=== PAUSE TestAccWAFV2IPSetDataSource_basic
=== RUN   TestAccWAFV2IPSet_basic
=== PAUSE TestAccWAFV2IPSet_basic
=== RUN   TestAccWAFV2IPSet_disappears
=== PAUSE TestAccWAFV2IPSet_disappears
=== RUN   TestAccWAFV2IPSet_ipv6
=== PAUSE TestAccWAFV2IPSet_ipv6
=== RUN   TestAccWAFV2IPSet_minimal
=== PAUSE TestAccWAFV2IPSet_minimal
=== RUN   TestAccWAFV2IPSet_changeNameForceNew
=== PAUSE TestAccWAFV2IPSet_changeNameForceNew
=== RUN   TestAccWAFV2IPSet_tags
=== PAUSE TestAccWAFV2IPSet_tags
=== RUN   TestAccWAFV2IPSet_large
=== PAUSE TestAccWAFV2IPSet_large
=== RUN   TestAccWAFV2RegexPatternSetDataSource_basic
=== PAUSE TestAccWAFV2RegexPatternSetDataSource_basic
=== RUN   TestAccWAFV2RegexPatternSet_basic
=== PAUSE TestAccWAFV2RegexPatternSet_basic
=== RUN   TestAccWAFV2RegexPatternSet_disappears
=== PAUSE TestAccWAFV2RegexPatternSet_disappears
=== RUN   TestAccWAFV2RegexPatternSet_minimal
=== PAUSE TestAccWAFV2RegexPatternSet_minimal
=== RUN   TestAccWAFV2RegexPatternSet_changeNameForceNew
=== PAUSE TestAccWAFV2RegexPatternSet_changeNameForceNew
=== RUN   TestAccWAFV2RegexPatternSet_tags
=== PAUSE TestAccWAFV2RegexPatternSet_tags
=== RUN   TestAccWAFV2RuleGroupDataSource_basic
=== PAUSE TestAccWAFV2RuleGroupDataSource_basic
=== RUN   TestAccWAFV2RuleGroup_basic
=== PAUSE TestAccWAFV2RuleGroup_basic
=== RUN   TestAccWAFV2RuleGroup_updateRule
=== PAUSE TestAccWAFV2RuleGroup_updateRule
=== RUN   TestAccWAFV2RuleGroup_updateRuleProperties
=== PAUSE TestAccWAFV2RuleGroup_updateRuleProperties
=== RUN   TestAccWAFV2RuleGroup_byteMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_byteMatchStatement
=== RUN   TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch
=== PAUSE TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch
=== RUN   TestAccWAFV2RuleGroup_changeNameForceNew
=== PAUSE TestAccWAFV2RuleGroup_changeNameForceNew
=== RUN   TestAccWAFV2RuleGroup_changeCapacityForceNew
=== PAUSE TestAccWAFV2RuleGroup_changeCapacityForceNew
=== RUN   TestAccWAFV2RuleGroup_changeMetricNameForceNew
=== PAUSE TestAccWAFV2RuleGroup_changeMetricNameForceNew
=== RUN   TestAccWAFV2RuleGroup_disappears
=== PAUSE TestAccWAFV2RuleGroup_disappears
=== RUN   TestAccWAFV2RuleGroup_RuleLabels
=== PAUSE TestAccWAFV2RuleGroup_RuleLabels
=== RUN   TestAccWAFV2RuleGroup_geoMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_geoMatchStatement
=== RUN   TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP
=== PAUSE TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP
=== RUN   TestAccWAFV2RuleGroup_LabelMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_LabelMatchStatement
=== RUN   TestAccWAFV2RuleGroup_ipSetReferenceStatement
=== PAUSE TestAccWAFV2RuleGroup_ipSetReferenceStatement
=== RUN   TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP
=== PAUSE TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP
=== RUN   TestAccWAFV2RuleGroup_logicalRuleStatements
=== PAUSE TestAccWAFV2RuleGroup_logicalRuleStatements
=== RUN   TestAccWAFV2RuleGroup_minimal
=== PAUSE TestAccWAFV2RuleGroup_minimal
=== RUN   TestAccWAFV2RuleGroup_regexMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_regexMatchStatement
=== RUN   TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement
=== PAUSE TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement
=== RUN   TestAccWAFV2RuleGroup_ruleAction
=== PAUSE TestAccWAFV2RuleGroup_ruleAction
=== RUN   TestAccWAFV2RuleGroup_RuleAction_customRequestHandling
=== PAUSE TestAccWAFV2RuleGroup_RuleAction_customRequestHandling
=== RUN   TestAccWAFV2RuleGroup_RuleAction_customResponse
=== PAUSE TestAccWAFV2RuleGroup_RuleAction_customResponse
=== RUN   TestAccWAFV2RuleGroup_sizeConstraintStatement
=== PAUSE TestAccWAFV2RuleGroup_sizeConstraintStatement
=== RUN   TestAccWAFV2RuleGroup_sqliMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_sqliMatchStatement
=== RUN   TestAccWAFV2RuleGroup_tags
=== PAUSE TestAccWAFV2RuleGroup_tags
=== RUN   TestAccWAFV2RuleGroup_xssMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_xssMatchStatement
=== RUN   TestAccWAFV2RuleGroup_rateBasedStatement
=== PAUSE TestAccWAFV2RuleGroup_rateBasedStatement
=== RUN   TestAccWAFV2RuleGroup_RateBased_maxNested
=== PAUSE TestAccWAFV2RuleGroup_RateBased_maxNested
=== RUN   TestAccWAFV2RuleGroup_Operators_maxNested
=== PAUSE TestAccWAFV2RuleGroup_Operators_maxNested
=== RUN   TestAccWAFV2WebACLAssociation_basic
=== PAUSE TestAccWAFV2WebACLAssociation_basic
=== RUN   TestAccWAFV2WebACLAssociation_disappears
=== PAUSE TestAccWAFV2WebACLAssociation_disappears
=== RUN   TestAccWAFV2WebACLDataSource_basic
=== PAUSE TestAccWAFV2WebACLDataSource_basic
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_basic
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_basic
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_updateSingleHeaderRedactedField
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_updateSingleHeaderRedactedField
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_updateMethodRedactedField
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_updateMethodRedactedField
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_updateQueryStringRedactedField
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_updateQueryStringRedactedField
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_updateURIPathRedactedField
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_updateURIPathRedactedField
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_updateMultipleRedactedFields
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_updateMultipleRedactedFields
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_changeResourceARNForceNew
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_changeResourceARNForceNew
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_changeLogDestinationsForceNew
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_changeLogDestinationsForceNew
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_disappears
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_disappears
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_emptyRedactedFields
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_emptyRedactedFields
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_updateEmptyRedactedFields
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_updateEmptyRedactedFields
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_Disappears_webACL
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_Disappears_webACL
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_loggingFilter
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_loggingFilter
=== RUN   TestAccWAFV2WebACL_basic
=== PAUSE TestAccWAFV2WebACL_basic
=== RUN   TestAccWAFV2WebACL_Update_rule
=== PAUSE TestAccWAFV2WebACL_Update_rule
=== RUN   TestAccWAFV2WebACL_Update_ruleProperties
=== PAUSE TestAccWAFV2WebACL_Update_ruleProperties
=== RUN   TestAccWAFV2WebACL_Update_nameForceNew
=== PAUSE TestAccWAFV2WebACL_Update_nameForceNew
=== RUN   TestAccWAFV2WebACL_disappears
=== PAUSE TestAccWAFV2WebACL_disappears
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== RUN   TestAccWAFV2WebACL_minimal
=== PAUSE TestAccWAFV2WebACL_minimal
=== RUN   TestAccWAFV2WebACL_RateBased_basic
=== PAUSE TestAccWAFV2WebACL_RateBased_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_basic
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== RUN   TestAccWAFV2WebACL_GeoMatch_basic
=== PAUSE TestAccWAFV2WebACL_GeoMatch_basic
=== RUN   TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== PAUSE TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== RUN   TestAccWAFV2WebACL_LabelMatchStatement
=== PAUSE TestAccWAFV2WebACL_LabelMatchStatement
=== RUN   TestAccWAFV2WebACL_RuleLabels
=== PAUSE TestAccWAFV2WebACL_RuleLabels
=== RUN   TestAccWAFV2WebACL_IPSetReference_basic
=== PAUSE TestAccWAFV2WebACL_IPSetReference_basic
=== RUN   TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== PAUSE TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== RUN   TestAccWAFV2WebACL_RateBased_forwardedIP
=== PAUSE TestAccWAFV2WebACL_RateBased_forwardedIP
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_basic
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_basic
=== RUN   TestAccWAFV2WebACL_Custom_requestHandling
=== PAUSE TestAccWAFV2WebACL_Custom_requestHandling
=== RUN   TestAccWAFV2WebACL_Custom_response
=== PAUSE TestAccWAFV2WebACL_Custom_response
=== RUN   TestAccWAFV2WebACL_tags
=== PAUSE TestAccWAFV2WebACL_tags
=== RUN   TestAccWAFV2WebACL_RateBased_maxNested
=== PAUSE TestAccWAFV2WebACL_RateBased_maxNested
=== RUN   TestAccWAFV2WebACL_Operators_maxNested
=== PAUSE TestAccWAFV2WebACL_Operators_maxNested
=== CONT  TestAccWAFV2IPSetDataSource_basic
=== CONT  TestAccWAFV2RuleGroup_Operators_maxNested
=== CONT  TestAccWAFV2WebACL_Operators_maxNested
=== CONT  TestAccWAFV2WebACL_RateBased_maxNested
=== CONT  TestAccWAFV2WebACL_tags
=== CONT  TestAccWAFV2WebACL_Custom_response
=== CONT  TestAccWAFV2WebACL_Custom_requestHandling
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_basic
=== CONT  TestAccWAFV2WebACL_RateBased_forwardedIP
=== CONT  TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== CONT  TestAccWAFV2WebACL_IPSetReference_basic
=== CONT  TestAccWAFV2WebACL_RuleLabels
=== CONT  TestAccWAFV2WebACL_LabelMatchStatement
=== CONT  TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_updateEmptyRedactedFields
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_emptyRedactedFields
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_disappears
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_changeLogDestinationsForceNew
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_changeResourceARNForceNew
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_updateMultipleRedactedFields
--- PASS: TestAccWAFV2IPSetDataSource_basic (60.03s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_updateURIPathRedactedField
--- PASS: TestAccWAFV2RuleGroup_Operators_maxNested (162.54s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_updateQueryStringRedactedField
--- PASS: TestAccWAFV2WebACL_Operators_maxNested (184.04s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_updateMethodRedactedField
--- PASS: TestAccWAFV2WebACL_RateBased_maxNested (196.04s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_updateSingleHeaderRedactedField
--- PASS: TestAccWAFV2WebACL_IPSetReference_basic (231.40s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_Disappears_webACL
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_disappears (233.04s)
=== CONT  TestAccWAFV2WebACL_GeoMatch_basic
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_emptyRedactedFields (270.70s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
--- PASS: TestAccWAFV2WebACL_RateBased_forwardedIP (295.91s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_basic
--- PASS: TestAccWAFV2WebACL_RuleLabels (325.06s)
=== CONT  TestAccWAFV2WebACL_RateBased_basic
--- PASS: TestAccWAFV2WebACL_LabelMatchStatement (330.15s)
=== CONT  TestAccWAFV2WebACL_minimal
--- PASS: TestAccWAFV2WebACL_GeoMatch_forwardedIP (331.45s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateEmptyRedactedFields (378.10s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateURIPathRedactedField (331.84s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_basic
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_Disappears_webACL (175.81s)
=== CONT  TestAccWAFV2WebACL_disappears
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_changeLogDestinationsForceNew (456.67s)
=== CONT  TestAccWAFV2WebACL_Update_nameForceNew
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_basic (465.64s)
=== CONT  TestAccWAFV2WebACL_Update_ruleProperties
--- PASS: TestAccWAFV2WebACL_Custom_requestHandling (470.95s)
=== CONT  TestAccWAFV2WebACL_Update_rule
--- PASS: TestAccWAFV2WebACL_tags (473.69s)
=== CONT  TestAccWAFV2WebACL_basic
--- PASS: TestAccWAFV2WebACL_Custom_response (475.44s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_basic
--- PASS: TestAccWAFV2WebACL_minimal (151.10s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_loggingFilter
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateQueryStringRedactedField (329.45s)
=== CONT  TestAccWAFV2WebACLDataSource_basic
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_changeResourceARNForceNew (493.79s)
=== CONT  TestAccWAFV2WebACLAssociation_disappears
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateMultipleRedactedFields (497.38s)
=== CONT  TestAccWAFV2RuleGroup_changeMetricNameForceNew
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateMethodRedactedField (353.59s)
=== CONT  TestAccWAFV2WebACLAssociation_basic
--- PASS: TestAccWAFV2WebACL_GeoMatch_basic (307.68s)
=== CONT  TestAccWAFV2RuleGroup_RateBased_maxNested
--- PASS: TestAccWAFV2WebACL_disappears (140.20s)
=== CONT  TestAccWAFV2RuleGroup_rateBasedStatement
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_jsonBody (315.44s)
=== CONT  TestAccWAFV2RuleGroup_xssMatchStatement
--- PASS: TestAccWAFV2WebACL_IPSetReference_forwardedIP (592.37s)
=== CONT  TestAccWAFV2RuleGroup_logicalRuleStatements
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_basic (310.36s)
=== CONT  TestAccWAFV2RuleGroup_minimal
--- PASS: TestAccWAFV2WebACL_basic (157.78s)
=== CONT  TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion (308.36s)
=== CONT  TestAccWAFV2RuleGroup_tags
--- PASS: TestAccWAFV2WebACL_RateBased_basic (320.19s)
=== CONT  TestAccWAFV2RuleGroup_sqliMatchStatement
--- PASS: TestAccWAFV2WebACLDataSource_basic (165.77s)
=== CONT  TestAccWAFV2RuleGroup_sizeConstraintStatement
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_updateSingleHeaderRedactedField (474.42s)
=== CONT  TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_basic (210.65s)
=== CONT  TestAccWAFV2RuleGroup_ipSetReferenceStatement
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig (310.70s)
=== CONT  TestAccWAFV2RuleGroup_regexMatchStatement
=== CONT  TestAccWAFV2RuleGroup_LabelMatchStatement
--- PASS: TestAccWAFV2RuleGroup_RateBased_maxNested (154.15s)
--- PASS: TestAccWAFV2RuleGroup_minimal (130.27s)
=== CONT  TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP
--- PASS: TestAccWAFV2RuleGroup_changeMetricNameForceNew (245.82s)
=== CONT  TestAccWAFV2RuleGroup_geoMatchStatement
--- PASS: TestAccWAFV2WebACL_Update_nameForceNew (292.72s)
=== CONT  TestAccWAFV2RuleGroup_RuleLabels
--- PASS: TestAccWAFV2WebACLAssociation_basic (245.66s)
=== CONT  TestAccWAFV2RuleGroup_disappears
--- PASS: TestAccWAFV2WebACL_Update_rule (318.62s)
=== CONT  TestAccWAFV2RegexPatternSet_minimal
--- PASS: TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement (170.71s)
=== CONT  TestAccWAFV2RuleGroup_changeCapacityForceNew
--- PASS: TestAccWAFV2RuleGroup_regexMatchStatement (171.84s)
=== CONT  TestAccWAFV2RuleGroup_changeNameForceNew
--- PASS: TestAccWAFV2RuleGroup_ipSetReferenceStatement (175.52s)
=== CONT  TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch
--- PASS: TestAccWAFV2RegexPatternSet_minimal (85.83s)
=== CONT  TestAccWAFV2RuleGroup_byteMatchStatement
--- PASS: TestAccWAFV2RuleGroup_xssMatchStatement (295.78s)
=== CONT  TestAccWAFV2RuleGroup_updateRuleProperties
--- PASS: TestAccWAFV2WebACLAssociation_disappears (412.56s)
=== CONT  TestAccWAFV2RuleGroup_updateRule
=== CONT  TestAccWAFV2RuleGroup_basic
--- PASS: TestAccWAFV2RuleGroup_disappears (140.42s)
--- PASS: TestAccWAFV2RuleGroup_sqliMatchStatement (309.59s)
=== CONT  TestAccWAFV2RuleGroupDataSource_basic
--- PASS: TestAccWAFV2RuleGroup_sizeConstraintStatement (320.10s)
=== CONT  TestAccWAFV2RegexPatternSet_tags
--- PASS: TestAccWAFV2WebACL_Update_ruleProperties (533.09s)
=== CONT  TestAccWAFV2IPSet_tags
--- PASS: TestAccWAFV2RuleGroup_LabelMatchStatement (309.83s)
=== CONT  TestAccWAFV2RegexPatternSet_changeNameForceNew
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_basic (634.62s)
=== CONT  TestAccWAFV2RuleGroup_ruleAction
--- PASS: TestAccWAFV2RuleGroup_tags (412.79s)
=== CONT  TestAccWAFV2RuleGroup_RuleAction_customResponse
--- PASS: TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP (317.86s)
=== CONT  TestAccWAFV2RuleGroup_RuleAction_customRequestHandling
--- PASS: TestAccWAFV2RuleGroup_logicalRuleStatements (464.23s)
=== CONT  TestAccWAFV2RegexPatternSet_disappears
--- PASS: TestAccWAFV2RuleGroup_geoMatchStatement (325.14s)
=== CONT  TestAccWAFV2IPSet_large
--- PASS: TestAccWAFV2RuleGroup_RuleLabels (326.23s)
=== CONT  TestAccWAFV2IPSet_ipv6
--- PASS: TestAccWAFV2RuleGroup_basic (172.78s)
=== CONT  TestAccWAFV2IPSet_minimal
--- PASS: TestAccWAFV2WebACLLoggingConfiguration_loggingFilter (639.78s)
=== CONT  TestAccWAFV2IPSet_changeNameForceNew
--- PASS: TestAccWAFV2RuleGroupDataSource_basic (178.38s)
=== CONT  TestAccWAFV2RegexPatternSetDataSource_basic
--- PASS: TestAccWAFV2RegexPatternSet_disappears (79.04s)
=== CONT  TestAccWAFV2IPSet_disappears
--- PASS: TestAccWAFV2RuleGroup_rateBasedStatement (601.69s)
=== CONT  TestAccWAFV2IPSet_basic
--- PASS: TestAccWAFV2RegexPatternSet_changeNameForceNew (157.00s)
=== CONT  TestAccWAFV2RegexPatternSet_basic
--- PASS: TestAccWAFV2RuleGroup_changeCapacityForceNew (321.09s)
--- PASS: TestAccWAFV2IPSet_large (109.69s)
--- PASS: TestAccWAFV2IPSet_ipv6 (105.22s)
--- PASS: TestAccWAFV2RuleGroup_changeNameForceNew (321.56s)
--- PASS: TestAccWAFV2IPSet_minimal (101.15s)
--- PASS: TestAccWAFV2IPSet_disappears (73.45s)
--- PASS: TestAccWAFV2RegexPatternSet_tags (244.64s)
--- PASS: TestAccWAFV2RegexPatternSetDataSource_basic (93.61s)
--- PASS: TestAccWAFV2RuleGroup_byteMatchStatement (352.95s)
--- PASS: TestAccWAFV2IPSet_tags (239.52s)
--- PASS: TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP (611.93s)
--- PASS: TestAccWAFV2RuleGroup_updateRule (340.91s)
--- PASS: TestAccWAFV2IPSet_changeNameForceNew (132.51s)
--- PASS: TestAccWAFV2IPSet_basic (123.88s)
--- PASS: TestAccWAFV2RegexPatternSet_basic (114.05s)
--- PASS: TestAccWAFV2RuleGroup_updateRuleProperties (407.58s)
--- PASS: TestAccWAFV2RuleGroup_RuleAction_customRequestHandling (236.69s)
--- PASS: TestAccWAFV2RuleGroup_ruleAction (288.07s)
--- PASS: TestAccWAFV2RuleGroup_RuleAction_customResponse (264.81s)
--- PASS: TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch (661.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      1523.486s
```
