### PR TITLE
Fixed naming bug for argument of aws_appflow_flow resource

### DIFF
--- a/.changelog/28552.txt
+++ b/.changelog/28552.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_appflow_flow: Fix source_connector_properties.0.sapo_data.0.* argument(s) to align with implementation and AWS API behaviour
+```

--- a/.changelog/28552.txt
+++ b/.changelog/28552.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/aws_appflow_flow: Fix source_connector_properties.0.sapo_data.0.* argument(s) to align with implementation and AWS API behaviour
-```

--- a/.changelog/28600.txt
+++ b/.changelog/28600.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_appflow_flow: Fix misspelled `source_connector_properties.0.sapo_data.0.object`, which never worked, to be `object_path`
+```

--- a/internal/service/appflow/flow.go
+++ b/internal/service/appflow/flow.go
@@ -17,6 +17,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+const (
+	AttrObjectPath = "object_path"
 )
 
 func ResourceFlow() *schema.Resource {
@@ -30,17 +35,17 @@ func ResourceFlow() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"arn": {
+			names.AttrARN: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"name": {
+			names.AttrName: {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.All(validation.StringMatch(regexp.MustCompile(`[a-zA-Z0-9][\w!@#.-]+`), "must contain only alphanumeric, exclamation point (!), at sign (@), number sign (#), period (.), and hyphen (-) characters"), validation.StringLenBetween(1, 256)),
 			},
-			"description": {
+			names.AttrDescription: {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringMatch(regexp.MustCompile(`[\w!@#\-.?,\s]*`), "must contain only alphanumeric, underscore (_), exclamation point (!), at sign (@), number sign (#), hyphen (-), period (.), question mark (?), comma (,), and whitespace characters"),
@@ -471,7 +476,7 @@ func ResourceFlow() *schema.Resource {
 														ValidateFunc: validation.All(validation.StringMatch(regexp.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(0, 128)),
 													},
 												},
-												"object_path": {
+												AttrObjectPath: {
 													Type:         schema.TypeString,
 													Required:     true,
 													ValidateFunc: validation.All(validation.StringMatch(regexp.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
@@ -891,7 +896,7 @@ func ResourceFlow() *schema.Resource {
 										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
-												"object_path": {
+												AttrObjectPath: {
 													Type:         schema.TypeString,
 													Required:     true,
 													ValidateFunc: validation.All(validation.StringMatch(regexp.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
@@ -1196,8 +1201,8 @@ func ResourceFlow() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -1208,14 +1213,14 @@ func resourceFlowCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	conn := meta.(*conns.AWSClient).AppFlowConn()
 
 	in := &appflow.CreateFlowInput{
-		FlowName:                  aws.String(d.Get("name").(string)),
+		FlowName:                  aws.String(d.Get(names.AttrName).(string)),
 		DestinationFlowConfigList: expandDestinationFlowConfigs(d.Get("destination_flow_config").(*schema.Set).List()),
 		SourceFlowConfig:          expandSourceFlowConfig(d.Get("source_flow_config").([]interface{})[0].(map[string]interface{})),
 		Tasks:                     expandTasks(d.Get("task").(*schema.Set).List()),
 		TriggerConfig:             expandTriggerConfig(d.Get("trigger_config").([]interface{})[0].(map[string]interface{})),
 	}
 
-	if v, ok := d.GetOk("description"); ok {
+	if v, ok := d.GetOk(names.AttrDescription); ok {
 		in.Description = aws.String(v.(string))
 	}
 
@@ -1224,7 +1229,7 @@ func resourceFlowCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
+	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get(names.AttrTags).(map[string]interface{})))
 	if len(tags) > 0 {
 		in.Tags = Tags(tags.IgnoreAWS())
 	}
@@ -1232,11 +1237,11 @@ func resourceFlowCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	out, err := conn.CreateFlowWithContext(ctx, in)
 
 	if err != nil {
-		return diag.Errorf("creating Appflow Flow (%s): %s", d.Get("name").(string), err)
+		return diag.Errorf("creating Appflow Flow (%s): %s", d.Get(names.AttrName).(string), err)
 	}
 
 	if out == nil || out.FlowArn == nil {
-		return diag.Errorf("creating Appflow Flow (%s): empty output", d.Get("name").(string))
+		return diag.Errorf("creating Appflow Flow (%s): empty output", d.Get(names.AttrName).(string))
 	}
 
 	d.SetId(aws.StringValue(out.FlowArn))
@@ -1269,9 +1274,9 @@ func resourceFlowRead(ctx context.Context, d *schema.ResourceData, meta interfac
 		return diag.Errorf("reading AppFlow Flow (%s): %s", d.Id(), err)
 	}
 
-	d.Set("name", out.FlowName)
-	d.Set("arn", out2.FlowArn)
-	d.Set("description", out2.Description)
+	d.Set(names.AttrName, out.FlowName)
+	d.Set(names.AttrARN, out2.FlowArn)
+	d.Set(names.AttrDescription, out2.Description)
 
 	if err := d.Set("destination_flow_config", flattenDestinationFlowConfigs(out2.DestinationFlowConfigList)); err != nil {
 		return diag.Errorf("error setting destination_flow_config: %s", err)
@@ -1310,11 +1315,11 @@ func resourceFlowRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+	if err := d.Set(names.AttrTags, tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
 		return diag.Errorf("setting tags: %s", err)
 	}
 
-	if err := d.Set("tags_all", tags.Map()); err != nil {
+	if err := d.Set(names.AttrTagsAll, tags.Map()); err != nil {
 		return diag.Errorf("setting tags_all: %s", err)
 	}
 
@@ -1325,15 +1330,15 @@ func resourceFlowUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	conn := meta.(*conns.AWSClient).AppFlowConn()
 
 	in := &appflow.UpdateFlowInput{
-		FlowName:                  aws.String(d.Get("name").(string)),
+		FlowName:                  aws.String(d.Get(names.AttrName).(string)),
 		DestinationFlowConfigList: expandDestinationFlowConfigs(d.Get("destination_flow_config").(*schema.Set).List()),
 		SourceFlowConfig:          expandSourceFlowConfig(d.Get("source_flow_config").([]interface{})[0].(map[string]interface{})),
 		Tasks:                     expandTasks(d.Get("task").(*schema.Set).List()),
 		TriggerConfig:             expandTriggerConfig(d.Get("trigger_config").([]interface{})[0].(map[string]interface{})),
 	}
 
-	if d.HasChange("description") {
-		in.Description = aws.String(d.Get("description").(string))
+	if d.HasChange(names.AttrDescription) {
+		in.Description = aws.String(d.Get(names.AttrDescription).(string))
 	}
 
 	log.Printf("[DEBUG] Updating AppFlow Flow (%s): %#v", d.Id(), in)
@@ -1343,10 +1348,10 @@ func resourceFlowUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.Errorf("updating AppFlow Flow (%s): %s", d.Id(), err)
 	}
 
-	arn := d.Get("arn").(string)
+	arn := d.Get(names.AttrARN).(string)
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
+	if d.HasChange(names.AttrTagsAll) {
+		o, n := d.GetChange(names.AttrTagsAll)
 		if err := UpdateTags(ctx, conn, arn, o, n); err != nil {
 			return diag.Errorf("error updating tags: %s", err)
 		}
@@ -1764,7 +1769,7 @@ func expandSAPODataDestinationProperties(tfMap map[string]interface{}) *appflow.
 		a.IdFieldNames = flex.ExpandStringList(v)
 	}
 
-	if v, ok := tfMap["object_path"].(string); ok && v != "" {
+	if v, ok := tfMap[AttrObjectPath].(string); ok && v != "" {
 		a.ObjectPath = aws.String(v)
 	}
 
@@ -2178,7 +2183,7 @@ func expandSAPODataSourceProperties(tfMap map[string]interface{}) *appflow.SAPOD
 
 	a := &appflow.SAPODataSourceProperties{}
 
-	if v, ok := tfMap["object_path"].(string); ok && v != "" {
+	if v, ok := tfMap[AttrObjectPath].(string); ok && v != "" {
 		a.ObjectPath = aws.String(v)
 	}
 
@@ -2869,7 +2874,7 @@ func flattenSAPODataDestinationProperties(SAPODataDestinationProperties *appflow
 	}
 
 	if v := SAPODataDestinationProperties.ObjectPath; v != nil {
-		m["object_path"] = aws.StringValue(v)
+		m[AttrObjectPath] = aws.StringValue(v)
 	}
 
 	if v := SAPODataDestinationProperties.SuccessResponseHandlingConfig; v != nil {
@@ -3283,7 +3288,7 @@ func flattenSAPODataSourceProperties(sapoDataSourceProperties *appflow.SAPODataS
 	m := map[string]interface{}{}
 
 	if v := sapoDataSourceProperties.ObjectPath; v != nil {
-		m["object_path"] = aws.StringValue(v)
+		m[AttrObjectPath] = aws.StringValue(v)
 	}
 
 	return m

--- a/internal/service/appflow/flow.go
+++ b/internal/service/appflow/flow.go
@@ -891,7 +891,7 @@ func ResourceFlow() *schema.Resource {
 										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
-												"object": {
+												"object_path": {
 													Type:         schema.TypeString,
 													Required:     true,
 													ValidateFunc: validation.All(validation.StringMatch(regexp.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),

--- a/internal/service/appflow/flow_test.go
+++ b/internal/service/appflow/flow_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfappflow "github.com/hashicorp/terraform-provider-aws/internal/service/appflow"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccAppFlowFlow_basic(t *testing.T) {
@@ -36,8 +37,8 @@ func TestAccAppFlowFlow_basic(t *testing.T) {
 				Config: testAccFlowConfig_basic(rSourceName, rDestinationName, rFlowName, scheduleStartTime),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckFlowExists(ctx, resourceName, &flowOutput),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "appflow", regexp.MustCompile(`flow/.+`)),
-					resource.TestCheckResourceAttr(resourceName, "name", rFlowName),
+					acctest.MatchResourceAttrRegionalARN(resourceName, names.AttrARN, "appflow", regexp.MustCompile(`flow/.+`)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rFlowName),
 					resource.TestCheckResourceAttrSet(resourceName, "destination_flow_config.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "destination_flow_config.0.connector_type"),
 					resource.TestCheckResourceAttrSet(resourceName, "destination_flow_config.0.destination_connector_properties.#"),
@@ -93,7 +94,7 @@ func TestAccAppFlowFlow_update(t *testing.T) {
 				Config: testAccFlowConfig_update(rSourceName, rDestinationName, rFlowName, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowExists(ctx, resourceName, &flowOutput),
-					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, description),
 					resource.TestCheckResourceAttr(resourceName, "trigger_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "trigger_config.0.trigger_type", "Scheduled"),
 					resource.TestCheckResourceAttr(resourceName, "trigger_config.0.trigger_properties.#", "1"),

--- a/names/attr_consts.go
+++ b/names/attr_consts.go
@@ -1,11 +1,12 @@
 package names
 
 const (
-	AttrARN       = "arn"
-	AttrEnabled   = "enabled"
-	AttrKMSKeyARN = "kms_key_arn"
-	AttrName      = "name"
-	AttrTags      = "tags"
-	AttrTagsAll   = "tags_all"
-	AttrType      = "type"
+	AttrARN         = "arn"
+	AttrDescription = "description"
+	AttrEnabled     = "enabled"
+	AttrKMSKeyARN   = "kms_key_arn"
+	AttrName        = "name"
+	AttrTags        = "tags"
+	AttrTagsAll     = "tags_all"
+	AttrType        = "type"
 )

--- a/website/docs/r/appflow_flow.html.markdown
+++ b/website/docs/r/appflow_flow.html.markdown
@@ -319,7 +319,7 @@ Amplitude, Datadog, Dynatrace, Google Analytics, Infor Nexus, Marketo, ServiceNo
 
 ##### SAPOData Source Properties
 
-* `object_path` - (Optional) Object path specified in the SAPOData flow source.
+* `object_path` - (Required) Object path specified in the SAPOData flow source.
 
 ##### Veeva Source Properties
 


### PR DESCRIPTION
### Description
Fixed naming bug for argument of "source_connector_properties.0.sao_data" schema of "aws_appflow_flow" resource and adjusted documentation accordingly to match actual argument implementation. This change is required to make creating a new AWS AppFlow flow resource having a SAP OData connector configured as source via Terraform possible.


### Relations

Closes #28552

### References
-


### Output from Acceptance Testing
Checking the available acceptance tests I quickly realized that due to the huge amount of possible argument combinations on the one hand and the necessity for having a huge bunch of third party applications like Salesforce or SAP available no specific tests for that scenario exists. 
However, to test the fix I used my local development environment and checked whether creating a AppFlow flow resource via the updated Terraform Provider code is now possible having SAP configured as a source, and it worked as expected and is not failing with errors complaning an invalid implementation or AWS API invocation anymore.
