### PR TITLE
Fixed bug in validation regex of aws_appflow_connector_profile resource

### DIFF
--- a/.changelog/28550.txt
+++ b/.changelog/28550.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_appflow_connector_profile: Fix bug in connector_profile_config.0.connector_profile_properties.0.sapo_data.0.logon_language validation regex
+```

--- a/internal/service/appflow/connector_profile.go
+++ b/internal/service/appflow/connector_profile.go
@@ -1176,7 +1176,7 @@ func ResourceConnectorProfile() *schema.Resource {
 													Optional: true,
 													ValidateFunc: validation.All(
 														validation.StringLenBetween(0, 2),
-														validation.StringMatch(regexp.MustCompile(` ^[a-zA-Z0-9_]*$`), "must contain only alphanumeric characters and the underscore (_) character"),
+														validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_]*$`), "must contain only alphanumeric characters and the underscore (_) character"),
 													),
 												},
 												"oauth_properties": {


### PR DESCRIPTION
### Description
Fixed bug in validation regex of "aws_appflow_connector_profile" resource causing any given value for the "connector_profile_config.0.connector_profile_properties.0.sapo_data.0.logon_language" field to be denied


### Relations
Closes #28550


### References
-


### Output from Acceptance Testing
Checking the available acceptance tests I quickly realized that due to the huge amount of possible argument combinations on the one hand and the necessity for having a huge bunch of third party applications like Salesforce or SAP available no specific tests for that scenario exists.
However, to test the fix I used my local development environment and checked whether setting an AppFlow Connector's SAP logon language via the updated Terraform Provider code is now possible when using a valid value (e.g. EN), and it worked as expected and is not failing with validation errors during planning anymore.
