### PR TITLE
Doc update: Standard way of checking resource disappeared

### DIFF
--- a/docs/running-and-writing-acceptance-tests.md
+++ b/docs/running-and-writing-acceptance-tests.md
@@ -728,7 +728,7 @@ If this test does fail, the fix for this is generally adding error handling imme
 ```go
 output, err := conn.GetThing(input)
 
-if isAWSErr(err, example.ErrCodeResourceNotFound, "") {
+if !d.IsNewResource() && tfresource.NotFound(err) {
   log.Printf("[WARN] Example Thing (%s) not found, removing from state", d.Id())
   d.SetId("")
   return nil


### PR DESCRIPTION
### Description
Was going through document and noticed the example for checking if resource disappeared was not what I was seeing when looking at recent code. Updated with what appears to be the standard.