### PR TITLE
aws_apprunner_service observability_configuration_arn optional

### DIFF
--- a/.changelog/28620.txt
+++ b/.changelog/28620.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_apprunner_service: `observability_configuration_arn` is optional
+```

--- a/internal/service/apprunner/service.go
+++ b/internal/service/apprunner/service.go
@@ -205,7 +205,7 @@ func ResourceService() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"observability_configuration_arn": {
 							Type:         schema.TypeString,
-							Required:     true,
+							Optional:     true,
 							ValidateFunc: verify.ValidARN,
 						},
 						"observability_enabled": {
@@ -790,7 +790,7 @@ func expandServiceObservabilityConfiguration(l []interface{}) *apprunner.Service
 
 	result := &apprunner.ServiceObservabilityConfiguration{}
 
-	if v, ok := tfMap["observability_configuration_arn"].(string); ok {
+	if v, ok := tfMap["observability_configuration_arn"].(string); ok && len(v) > 0 {
 		result.ObservabilityConfigurationArn = aws.String(v)
 	}
 

--- a/website/docs/r/apprunner_service.html.markdown
+++ b/website/docs/r/apprunner_service.html.markdown
@@ -198,8 +198,8 @@ The `egress_configuration` block supports the following argument:
 
 The `observability_configuration` block supports the following arguments:
 
-* `observability_configuration_arn` - (Required) ARN of the observability configuration that is associated with the service.
 * `observability_enabled` - (Required) When `true`, an observability configuration resource is associated with the service.
+* `observability_configuration_arn` - (Optional) ARN of the observability configuration that is associated with the service. Specified only when `observability_enabled` is `true`.
 
 ### Code Repository
 


### PR DESCRIPTION
### Description
Make `observability_configuration_arn` optional

### Relations
Closes [#27733](https://github.com/hashicorp/terraform-provider-aws/issues/27733)

### References
https://docs.aws.amazon.com/apprunner/latest/api/API_ServiceObservabilityConfiguration.html


### Output from Acceptance Testing
```
make testacc TESTS='TestAccAppRunnerService_ImageRepository_observabilityConfiguration' PKG=apprunner
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apprunner/... -v -count 1 -parallel 20 -run='TestAccAppRunnerService_ImageRepository_observabilityConfiguration'  -timeout 180m
=== RUN   TestAccAppRunnerService_ImageRepository_observabilityConfiguration
=== PAUSE TestAccAppRunnerService_ImageRepository_observabilityConfiguration
=== CONT  TestAccAppRunnerService_ImageRepository_observabilityConfiguration
--- PASS: TestAccAppRunnerService_ImageRepository_observabilityConfiguration (546.44s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apprunner  560.685s
```
