### PR TITLE
Rollup `aws_sdk-go-v2` dependency updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.15.3
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.33.3
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.19.2
-	github.com/aws/aws-sdk-go-v2/service/transcribe v1.23.1
+	github.com/aws/aws-sdk-go-v2/service/transcribe v1.24.0
 	github.com/aws/smithy-go v1.13.5
 	github.com/beevik/etree v1.1.0
 	github.com/google/go-cmp v0.5.9

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rds v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.0.4
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.0.14
-	github.com/aws/aws-sdk-go-v2/service/route53domains v1.12.21
+	github.com/aws/aws-sdk-go-v2/service/route53domains v1.13.0
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.28.2
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.0.3
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.15.3

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.18.2
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.77.0
 	github.com/aws/aws-sdk-go-v2/service/fis v1.13.5
-	github.com/aws/aws-sdk-go-v2/service/identitystore v1.15.9
+	github.com/aws/aws-sdk-go-v2/service/identitystore v1.15.10
 	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.9.2
 	github.com/aws/aws-sdk-go-v2/service/ivschat v1.2.1
 	github.com/aws/aws-sdk-go-v2/service/kendra v1.36.2

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.9.2
 	github.com/aws/aws-sdk-go-v2/service/ivschat v1.2.1
 	github.com/aws/aws-sdk-go-v2/service/kendra v1.36.2
-	github.com/aws/aws-sdk-go-v2/service/medialive v1.26.1
+	github.com/aws/aws-sdk-go-v2/service/medialive v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.0.3
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.0.2
 	github.com/aws/aws-sdk-go-v2/service/rds v1.35.1

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.15.10
 	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.10.0
 	github.com/aws/aws-sdk-go-v2/service/ivschat v1.2.1
-	github.com/aws/aws-sdk-go-v2/service/kendra v1.36.2
+	github.com/aws/aws-sdk-go-v2/service/kendra v1.36.3
 	github.com/aws/aws-sdk-go-v2/service/medialive v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.0.3
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.0.2

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.10.21
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.17.3
 	github.com/aws/aws-sdk-go-v2/service/comprehend v1.20.2
-	github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.18.2
+	github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.19.0
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.77.0
 	github.com/aws/aws-sdk-go-v2/service/fis v1.13.5
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.15.10

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.77.0
 	github.com/aws/aws-sdk-go-v2/service/fis v1.13.5
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.15.10
-	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.9.2
+	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.10.0
 	github.com/aws/aws-sdk-go-v2/service/ivschat v1.2.1
 	github.com/aws/aws-sdk-go-v2/service/kendra v1.36.2
 	github.com/aws/aws-sdk-go-v2/service/medialive v1.27.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7
 	github.com/aws/aws-sdk-go v1.44.171
 	github.com/aws/aws-sdk-go-v2 v1.17.3
-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.20
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.21
 	github.com/aws/aws-sdk-go-v2/service/auditmanager v1.21.2
 	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.10.21
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.17.3

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.0.3
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.0.2
 	github.com/aws/aws-sdk-go-v2/service/rds v1.35.1
-	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.0.4
+	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.1.0
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.0.14
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.13.0
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.28.2

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.28.2
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.0.3
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.15.3
-	github.com/aws/aws-sdk-go-v2/service/ssm v1.33.3
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.33.4
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.19.2
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.24.0
 	github.com/aws/smithy-go v1.13.5

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/medialive v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.0.3
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.0.2
-	github.com/aws/aws-sdk-go-v2/service/rds v1.35.1
+	github.com/aws/aws-sdk-go-v2/service/rds v1.38.0
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.1.0
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.0.14
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/aws/aws-sdk-go-v2/service/iam v1.18.25 h1:Np+wTW2nuSBGyEu0WFsiu0LO05r
 github.com/aws/aws-sdk-go-v2/service/iam v1.18.25/go.mod h1:OyAuvpFeSVNppcSsp1hFOVQcaTRc1LE24YIR7pMbbAA=
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.15.10 h1:Dz0+Uux9AsYVrMOLf4MxfrAglld4NkvGuhPBx10W7tA=
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.15.10/go.mod h1:mN2AeMZcyQWmPJhkrMU2fFUh2ZrUlLZER+V+YKplyMQ=
-github.com/aws/aws-sdk-go-v2/service/inspector2 v1.9.2 h1:dRZvAVPbhVxhSmSXD7YYAwaGALZAEYxDYr48Q05dI6M=
-github.com/aws/aws-sdk-go-v2/service/inspector2 v1.9.2/go.mod h1:/QsVqJ/J9mmPWc0RD68wd49ZROMlVT6FEOGfZx7Bbhc=
+github.com/aws/aws-sdk-go-v2/service/inspector2 v1.10.0 h1:F7M3ahO584qQU6yqD+gfPF2LrBeaytbYmLDks0hBtTw=
+github.com/aws/aws-sdk-go-v2/service/inspector2 v1.10.0/go.mod h1:/QsVqJ/J9mmPWc0RD68wd49ZROMlVT6FEOGfZx7Bbhc=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.4/go.mod h1:uKkN7qmSIsNJVyMtxNQoCEYMvFEXbOg9fwCJPdfp2u8=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.21 h1:5C6XgTViSb0bunmU57b3CT+MhxULqHH2721FVA+/kDM=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.21/go.mod h1:lRToEJsn+DRA9lW4O9L9+/3hjTkUzlzyzHqn8MTds5k=

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,8 @@ github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.0.4 h1:UAz34oien0Br75Y
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.0.4/go.mod h1:lUeyleY1tUUKDjP6TwzgNp4sXV9EVtfdNMeJX/1eh94=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.0.14 h1:cuIB2zJRoE20Dr7szWa/M9R4169c8cir7go1/lDCGJ0=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.0.14/go.mod h1:wY8k3cLxTBWLurkQaQtU3Etj5h/490WOB7oF6445rYA=
-github.com/aws/aws-sdk-go-v2/service/route53domains v1.12.21 h1:6tzCaDiUwpqPHOEP5Uumnz8M6XcRClAcE9rJtsQhnEk=
-github.com/aws/aws-sdk-go-v2/service/route53domains v1.12.21/go.mod h1:TTvu6PV1OnaZWl5QWRgpP1iH79bEESwPnCNya1sDqyM=
+github.com/aws/aws-sdk-go-v2/service/route53domains v1.13.0 h1:0isIvtqn8syj503AEQSdu56dMtuEeu0h5LJ7sgpR8CY=
+github.com/aws/aws-sdk-go-v2/service/route53domains v1.13.0/go.mod h1:TTvu6PV1OnaZWl5QWRgpP1iH79bEESwPnCNya1sDqyM=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.28.2 h1:HILTJewyveEWszPKAN3C3gALrs2x13tCIN3BZZrUgkE=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.28.2/go.mod h1:4DfdtJVYJj82pZdBoOwyA87ocrDYfQgAgbW6e17Xr2U=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.0.3 h1:y06COYMS5OWfEv31VWaOCgTXsfWEZydwqqGvTkvl9nc=

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/aws/aws-sdk-go-v2/service/sso v1.11.27/go.mod h1:wo/B7uUm/7zw/dWhBJ4F
 github.com/aws/aws-sdk-go-v2/service/sts v1.16.4/go.mod h1:lfSYenAXtavyX2A1LsViglqlG9eEFYxNryTZS5rn3QE=
 github.com/aws/aws-sdk-go-v2/service/sts v1.17.7 h1:9Mtq1KM6nD8/+HStvWcvYnixJ5N85DX+P+OY3kI3W2k=
 github.com/aws/aws-sdk-go-v2/service/sts v1.17.7/go.mod h1:+lGbb3+1ugwKrNTWcf2RT05Xmp543B06zDFTwiTLp7I=
-github.com/aws/aws-sdk-go-v2/service/transcribe v1.23.1 h1:60k44xRkZ7SCleDQbe0fUHB4y+/IKJ5mI2ZjFxUkBak=
-github.com/aws/aws-sdk-go-v2/service/transcribe v1.23.1/go.mod h1:oeI59utlQft5YCg385wnce1SXs3MBsN+4QRYNcNQ/q8=
+github.com/aws/aws-sdk-go-v2/service/transcribe v1.24.0 h1:TwdloCK4UtAndX6HLC/iFzuLeerhoziB3Z94L3oeH4U=
+github.com/aws/aws-sdk-go-v2/service/transcribe v1.24.0/go.mod h1:oeI59utlQft5YCg385wnce1SXs3MBsN+4QRYNcNQ/q8=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
 github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/aws/aws-sdk-go-v2/service/pipes v1.0.2 h1:z5OG4u/64wiUf8MvBS/xNLb3rOm
 github.com/aws/aws-sdk-go-v2/service/pipes v1.0.2/go.mod h1:IoNBKgOeaqkD/L5DEXSLvc1yG8vV1RSMrbiaGYYpNgg=
 github.com/aws/aws-sdk-go-v2/service/rds v1.35.1 h1:FntkAuYRMN5Mi7fxtxZm4508i4SLCCmp7lfPeUpZ16w=
 github.com/aws/aws-sdk-go-v2/service/rds v1.35.1/go.mod h1:Ume9NHqT871hUdxIRojWtWsPFyCswQmSjHHhyGot7v0=
-github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.0.4 h1:UAz34oien0Br75YoP25YAkJMblblOPwCn2oySsmORiI=
-github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.0.4/go.mod h1:lUeyleY1tUUKDjP6TwzgNp4sXV9EVtfdNMeJX/1eh94=
+github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.1.0 h1:fn6A843nyHRVCiAP1+VYPsP/UlSkGUVd3KhiWZXP/v0=
+github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.1.0/go.mod h1:lUeyleY1tUUKDjP6TwzgNp4sXV9EVtfdNMeJX/1eh94=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.0.14 h1:cuIB2zJRoE20Dr7szWa/M9R4169c8cir7go1/lDCGJ0=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.0.14/go.mod h1:wY8k3cLxTBWLurkQaQtU3Etj5h/490WOB7oF6445rYA=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.13.0 h1:0isIvtqn8syj503AEQSdu56dMtuEeu0h5LJ7sgpR8CY=

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/aws/aws-sdk-go-v2/service/ivschat v1.2.1 h1:plIanbFBmYTdw1P4N2sE/nF9y
 github.com/aws/aws-sdk-go-v2/service/ivschat v1.2.1/go.mod h1:MN1kUXX3qtMXpbOawWI+C7zQIl12EeClXLeFhWz09Kk=
 github.com/aws/aws-sdk-go-v2/service/kendra v1.36.2 h1:CmqOjrRfsQtDQJVX7LbLnqwR5JWGjlrjHkiSRk+V8yo=
 github.com/aws/aws-sdk-go-v2/service/kendra v1.36.2/go.mod h1:NfvbpeRCrHffyqCK9k0YYWNXztAIFWlKoWNAa6kLAWE=
-github.com/aws/aws-sdk-go-v2/service/medialive v1.26.1 h1:CXDUf+WN2y97vk379jaMlGan0q61b2IiLcnDFo48Q2s=
-github.com/aws/aws-sdk-go-v2/service/medialive v1.26.1/go.mod h1:1AOSYkP6RMSPzywGpYi26D4d2X74mHQzyC2TPYRNzvQ=
+github.com/aws/aws-sdk-go-v2/service/medialive v1.27.0 h1:VlP7aGkfqqi0FKyzClsIi4HbEMKVOEeufWZxwpUTkks=
+github.com/aws/aws-sdk-go-v2/service/medialive v1.27.0/go.mod h1:1AOSYkP6RMSPzywGpYi26D4d2X74mHQzyC2TPYRNzvQ=
 github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.0.3 h1:lSSSC0nmT8+nQQrGxE90me3vJAkIFlfVli2U8LGsrAE=
 github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.0.3/go.mod h1:rO7YPEn0bTBM/4SvjspJSZz/EgOawgUnNqZlvN4dXNw=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.0.2 h1:z5OG4u/64wiUf8MvBS/xNLb3rOmLSjJFjyFTq/JS/f4=

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.0.3 h1:lSSSC0nmT8+n
 github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.0.3/go.mod h1:rO7YPEn0bTBM/4SvjspJSZz/EgOawgUnNqZlvN4dXNw=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.0.2 h1:z5OG4u/64wiUf8MvBS/xNLb3rOmLSjJFjyFTq/JS/f4=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.0.2/go.mod h1:IoNBKgOeaqkD/L5DEXSLvc1yG8vV1RSMrbiaGYYpNgg=
-github.com/aws/aws-sdk-go-v2/service/rds v1.35.1 h1:FntkAuYRMN5Mi7fxtxZm4508i4SLCCmp7lfPeUpZ16w=
-github.com/aws/aws-sdk-go-v2/service/rds v1.35.1/go.mod h1:Ume9NHqT871hUdxIRojWtWsPFyCswQmSjHHhyGot7v0=
+github.com/aws/aws-sdk-go-v2/service/rds v1.38.0 h1:4LyiHO7LPBNQmP8QbK4pa/9wgjpaI16Z4PGZVNJhKTA=
+github.com/aws/aws-sdk-go-v2/service/rds v1.38.0/go.mod h1:Ume9NHqT871hUdxIRojWtWsPFyCswQmSjHHhyGot7v0=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.1.0 h1:fn6A843nyHRVCiAP1+VYPsP/UlSkGUVd3KhiWZXP/v0=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.1.0/go.mod h1:lUeyleY1tUUKDjP6TwzgNp4sXV9EVtfdNMeJX/1eh94=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.0.14 h1:cuIB2zJRoE20Dr7szWa/M9R4169c8cir7go1/lDCGJ0=

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.21 h1:vY5siRXvW5TrO
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.21/go.mod h1:WZvNXT1XuH8dnJM0HvOlvk+RNn7NbAPvA/ACO0QarSc=
 github.com/aws/aws-sdk-go-v2/service/ivschat v1.2.1 h1:plIanbFBmYTdw1P4N2sE/nF9yAD3rn4SIM7EU5e2wC0=
 github.com/aws/aws-sdk-go-v2/service/ivschat v1.2.1/go.mod h1:MN1kUXX3qtMXpbOawWI+C7zQIl12EeClXLeFhWz09Kk=
-github.com/aws/aws-sdk-go-v2/service/kendra v1.36.2 h1:CmqOjrRfsQtDQJVX7LbLnqwR5JWGjlrjHkiSRk+V8yo=
-github.com/aws/aws-sdk-go-v2/service/kendra v1.36.2/go.mod h1:NfvbpeRCrHffyqCK9k0YYWNXztAIFWlKoWNAa6kLAWE=
+github.com/aws/aws-sdk-go-v2/service/kendra v1.36.3 h1:+lgBiTtTfB/m9n8HkXHVBWS28JdX+G/eu07X4encZuM=
+github.com/aws/aws-sdk-go-v2/service/kendra v1.36.3/go.mod h1:NfvbpeRCrHffyqCK9k0YYWNXztAIFWlKoWNAa6kLAWE=
 github.com/aws/aws-sdk-go-v2/service/medialive v1.27.0 h1:VlP7aGkfqqi0FKyzClsIi4HbEMKVOEeufWZxwpUTkks=
 github.com/aws/aws-sdk-go-v2/service/medialive v1.27.0/go.mod h1:1AOSYkP6RMSPzywGpYi26D4d2X74mHQzyC2TPYRNzvQ=
 github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.0.3 h1:lSSSC0nmT8+nQQrGxE90me3vJAkIFlfVli2U8LGsrAE=

--- a/go.sum
+++ b/go.sum
@@ -30,7 +30,6 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/aws/aws-sdk-go v1.44.171 h1:maREiPAmibvuONMOEZIkCH2OTosLRnDelceTtH3SYfo=
 github.com/aws/aws-sdk-go v1.44.171/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v1.16.3/go.mod h1:ytwTPBG6fXTZLxxeeCCWj2/EMYp/xDUgX+OET6TLNNU=
-github.com/aws/aws-sdk-go-v2 v1.17.2/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2 v1.17.3 h1:shN7NlnVzvDUgPQ+1rLMSxY8OWRNDRYtiqe0p/PgrhY=
 github.com/aws/aws-sdk-go-v2 v1.17.3/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2/config v1.15.4 h1:P4mesY1hYUxru4f9SU0XxNKXmzfxsD0FtMIPRBjkH7Q=
@@ -38,8 +37,8 @@ github.com/aws/aws-sdk-go-v2/config v1.15.4/go.mod h1:ZijHHh0xd/A+ZY53az0qzC5tT4
 github.com/aws/aws-sdk-go-v2/credentials v1.12.0 h1:4R/NqlcRFSkR0wxOhgHi+agGpbEr5qMCjn7VqUIJY+E=
 github.com/aws/aws-sdk-go-v2/credentials v1.12.0/go.mod h1:9YWk7VW+eyKsoIL6/CljkTrNVWBSK9pkqOPUuijid4A=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.4/go.mod h1:u/s5/Z+ohUQOPXl00m2yJVyioWDECsbpXTQlaqSlufc=
-github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.20 h1:tpNOglTZ8kg9T38NpcGBxudqfUAwUzyUnLQ4XSd0CHE=
-github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.20/go.mod h1:d9xFpWd3qYwdIXM0fvu7deD08vvdRXyc/ueV+0SqaWE=
+github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.21 h1:j9wi1kQ8b+e0FBVHxCqCGo4kxDU175hoDHcWAi0sauU=
+github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.21/go.mod h1:ugwW57Z5Z48bpvUyZuaPy4Kv+vEfJWnIrky7RmkBvJg=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.10/go.mod h1:F+EZtuIwjlv35kRJPyBGcsA4f7bnSoz15zOQ2lJq1Z4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.27 h1:I3cakv2Uy1vNmmhRQmFptYDxOvBnwCdNwyw63N0RaRU=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.27/go.mod h1:a1/UpzeyBBerajpnP5nGZa9mGzsBn5cOKxm6NWQsvoI=

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.17.3 h1:GKDlULxx6rUH67l/C
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.17.3/go.mod h1:xHK1ta0bQEa5jL6rahKRJvsibjzDO7NTIs5itzsF4w8=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.20.2 h1:WlQpwFNADYOfgHrYf53XmpWuClAh3pN8q6TLs2mWXiw=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.20.2/go.mod h1:7Bx+sSNDcv8fkOzom5lCUpGEQ6s9m8KTy2F5DLb2rP0=
-github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.18.2 h1:jFxCKvlglvo1YRVIuy7g+SQj6N9kBh7H2EQe4VirCdg=
-github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.18.2/go.mod h1:GVIZsOKHO1IqycUD2Ps9Ut3dVq7ZZ8cI6NAmH68QTmY=
+github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.19.0 h1:OZrCHyOvjBxeID+kv/WWZoBpNP5ejz0AB2YkzLx69X4=
+github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.19.0/go.mod h1:GVIZsOKHO1IqycUD2Ps9Ut3dVq7ZZ8cI6NAmH68QTmY=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.77.0 h1:m6HYlpZlTWb9vHuuRHpWRieqPHWlS0mvQ90OJNrG/Nk=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.77.0/go.mod h1:mV0E7631M1eXdB+tlGFIw6JxfsC7Pz7+7Aw15oLVhZw=
 github.com/aws/aws-sdk-go-v2/service/fis v1.13.5 h1:FLv7hwflYyovRz+fbvsuk6GwzGPFzbtmszI5rVWsxqA=

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/aws/aws-sdk-go-v2/service/fis v1.13.5 h1:FLv7hwflYyovRz+fbvsuk6GwzGPF
 github.com/aws/aws-sdk-go-v2/service/fis v1.13.5/go.mod h1:GB4gMrhbD4CES5oNwCFV2hUd7mxN5wEmAQ28Uteoa6g=
 github.com/aws/aws-sdk-go-v2/service/iam v1.18.25 h1:Np+wTW2nuSBGyEu0WFsiu0LO05rxLFMh3hYVAjOzyVw=
 github.com/aws/aws-sdk-go-v2/service/iam v1.18.25/go.mod h1:OyAuvpFeSVNppcSsp1hFOVQcaTRc1LE24YIR7pMbbAA=
-github.com/aws/aws-sdk-go-v2/service/identitystore v1.15.9 h1:d93DFhdoRG59asXPsHRK4eJMrTFZkCSjF5VoVHqry0w=
-github.com/aws/aws-sdk-go-v2/service/identitystore v1.15.9/go.mod h1:mN2AeMZcyQWmPJhkrMU2fFUh2ZrUlLZER+V+YKplyMQ=
+github.com/aws/aws-sdk-go-v2/service/identitystore v1.15.10 h1:Dz0+Uux9AsYVrMOLf4MxfrAglld4NkvGuhPBx10W7tA=
+github.com/aws/aws-sdk-go-v2/service/identitystore v1.15.10/go.mod h1:mN2AeMZcyQWmPJhkrMU2fFUh2ZrUlLZER+V+YKplyMQ=
 github.com/aws/aws-sdk-go-v2/service/inspector2 v1.9.2 h1:dRZvAVPbhVxhSmSXD7YYAwaGALZAEYxDYr48Q05dI6M=
 github.com/aws/aws-sdk-go-v2/service/inspector2 v1.9.2/go.mod h1:/QsVqJ/J9mmPWc0RD68wd49ZROMlVT6FEOGfZx7Bbhc=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.4/go.mod h1:uKkN7qmSIsNJVyMtxNQoCEYMvFEXbOg9fwCJPdfp2u8=

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/aws/aws-sdk-go-v2/service/scheduler v1.0.3 h1:y06COYMS5OWfEv31VWaOCgT
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.0.3/go.mod h1:ZnD5i/e5nCIh1w3ivCfifQ5r4PLh3aOCElnOrZz+WnQ=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.15.3 h1:JK8OY6BvODGFdv1B01s3kTjdJWoCQQUIItcEJCZEbwo=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.15.3/go.mod h1:Q+I4FY+sxSWRVgbNXULzRnK+REDSF8oXzY5Eya/Y33c=
-github.com/aws/aws-sdk-go-v2/service/ssm v1.33.3 h1:dU0tej1HVbqbpe8Mbe+8EeOBnjVNcTaPj/7HvY6zefA=
-github.com/aws/aws-sdk-go-v2/service/ssm v1.33.3/go.mod h1:Hf7wSogKP1XCJ9GgW8erZDL6IZ1NLwLN7bYdV/Gn/LI=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.33.4 h1:s8o8aN6cOaYQ6oJ4D7DMV98iyNhkiY1PDFSk5uSbqF8=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.33.4/go.mod h1:Hf7wSogKP1XCJ9GgW8erZDL6IZ1NLwLN7bYdV/Gn/LI=
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.19.2 h1:2D1raEtASdpWBsf+/P9GLpQPh6F1fipnoP9FgwF1jC0=
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.19.2/go.mod h1:Vgq/TeO40RAkIErPwhosQyOwaD4syp5+sUm6uePFO7U=
 github.com/aws/aws-sdk-go-v2/service/sso v1.11.4/go.mod h1:cPDwJwsP4Kff9mldCXAmddjJL6JGQqtA3Mzer2zyr88=


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Consolidates all the `aws_sdk-go-v2` _dependabot_ updates for the last few of weeks.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/28503.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28625.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28502.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28415.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28504.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28506.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28525.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28527.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28544.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28566.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28606.