### PR TITLE
Uptick kms key policy propagation timeout to 10m

### DIFF
--- a/.changelog/22339.txt
+++ b/.changelog/22339.txt
@@ -5,3 +5,7 @@ resource/aws_subnet: Add `enable_dns64`, `ipv6_native`, `enable_resource_name_dn
 ```release-note:enhancement
 data-source/aws_subnet: Add `enable_dns64`, `ipv6_native`, `enable_resource_name_dns_aaaa_record_on_launch`, `enable_resource_name_dns_a_record_on_launch` and `private_dns_hostname_type_on_launch` attributes
 ```
+
+```release-note:bug
+resource/aws_kms_key: Increase `policy propagation` eventual consistency timeouts from 5 minutes to 10 minutes
+```

--- a/.changelog/22339.txt
+++ b/.changelog/22339.txt
@@ -5,7 +5,3 @@ resource/aws_subnet: Add `enable_dns64`, `ipv6_native`, `enable_resource_name_dn
 ```release-note:enhancement
 data-source/aws_subnet: Add `enable_dns64`, `ipv6_native`, `enable_resource_name_dns_aaaa_record_on_launch`, `enable_resource_name_dns_a_record_on_launch` and `private_dns_hostname_type_on_launch` attributes
 ```
-
-```release-note:bug
-resource/aws_kms_key: Increase `policy propagation` eventual consistency timeouts from 5 minutes to 10 minutes
-```

--- a/.changelog/28636.txt
+++ b/.changelog/28636.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_kms_key: Increase `policy propagation` eventual consistency timeouts from 5 minutes to 10 minutes
+```

--- a/internal/service/kms/wait.go
+++ b/internal/service/kms/wait.go
@@ -19,7 +19,7 @@ const (
 	KeyDeletedTimeout                = 20 * time.Minute
 	KeyDescriptionPropagationTimeout = 10 * time.Minute
 	KeyMaterialImportedTimeout       = 10 * time.Minute
-	KeyPolicyPropagationTimeout      = 5 * time.Minute
+	KeyPolicyPropagationTimeout      = 10 * time.Minute
 	KeyRotationUpdatedTimeout        = 10 * time.Minute
 	KeyStatePropagationTimeout       = 20 * time.Minute
 	KeyTagsPropagationTimeout        = 10 * time.Minute


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #27422 (issue also deals with incorrect diff on `policy`)

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
