### PR TITLE
Update example in `aws_appstream_image_builder` docs

### DIFF
--- a/website/docs/r/appstream_image_builder.html.markdown
+++ b/website/docs/r/appstream_image_builder.html.markdown
@@ -18,7 +18,7 @@ resource "aws_appstream_image_builder" "test_fleet" {
   description                    = "Description of a ImageBuilder"
   display_name                   = "Display name of a ImageBuilder"
   enable_default_internet_access = false
-  image_name                     = "AppStream-WinServer2012R2-07-19-2021"
+  image_name                     = "AppStream-WinServer2019-10-05-2022"
   instance_type                  = "stream.standard.large"
 
   vpc_config {


### PR DESCRIPTION
### Description

This PR updates the `aws_appstream_image_builder` example in the documentation, as the `image_name` previous used is deprecated.

### Relations

Closes #28601

### References

- [AWS image name doc](https://docs.aws.amazon.com/appstream2/latest/developerguide/base-image-version-history.html)

### Output from Acceptance Testing

n/a, docs
