### PR TITLE
Doc: Invalid statement in glue trigger docs

### DIFF
--- a/website/docs/r/glue_trigger.html.markdown
+++ b/website/docs/r/glue_trigger.html.markdown
@@ -109,7 +109,7 @@ The following arguments are supported:
 
 * `actions` – (Required) List of actions initiated by this trigger when it fires. See [Actions](#actions) Below.
 * `description` – (Optional) A description of the new trigger.
-* `enabled` – (Optional) Start the trigger. Defaults to `true`. Required to be `false` when trigger type is `EVENT`.
+* `enabled` – (Optional) Start the trigger. Defaults to `true`.
 * `name` – (Required) The name of the trigger.
 * `predicate` – (Optional) A predicate to specify when the new trigger should fire. Required when trigger type is `CONDITIONAL`. See [Predicate](#predicate) Below.
 * `schedule` – (Optional) A cron expression used to specify the schedule. [Time-Based Schedules for Jobs and Crawlers](https://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html)


### PR DESCRIPTION
### Description
@ewbankkit 
This is to remove an invalid statement added with [a previous PR](https://github.com/hashicorp/terraform-provider-aws/pull/28630) just merged about 9 hours ago. My sincere apologies, I have since realized through subsequent attempts, that this statement is not true. Likewise, I am not able to identify why it had been necessary to resolve a previous error message. Regardless, I cannot say definitely that it is true, therefore I think the statement should be removed.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
