### PR TITLE
include a doc url in aws_subnet_ids deprecation message

### DIFF
--- a/internal/service/ec2/vpc_subnet_ids_data_source.go
+++ b/internal/service/ec2/vpc_subnet_ids_data_source.go
@@ -36,7 +36,7 @@ func DataSourceSubnetIDs() *schema.Resource {
 		},
 		DeprecationMessage: `The aws_subnet_ids data source has been deprecated and will be removed in a future version. ` +
 			`Use the aws_subnets data source instead: ` +
-            `https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets`,
+			`https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets`,
 	}
 }
 

--- a/internal/service/ec2/vpc_subnet_ids_data_source.go
+++ b/internal/service/ec2/vpc_subnet_ids_data_source.go
@@ -35,7 +35,8 @@ func DataSourceSubnetIDs() *schema.Resource {
 			},
 		},
 		DeprecationMessage: `The aws_subnet_ids data source has been deprecated and will be removed in a future version. ` +
-			`Use the aws_subnets data source instead.`,
+			`Use the aws_subnets data source instead: ` +
+            `https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets`,
 	}
 }
 


### PR DESCRIPTION
### Description
Having a URL will be helpful for people just getting started with terraform. In my case, without a URL, I got mislead by a google search and ended up in the wrong place:

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet

I'm sorry--this change is untested on my side. I'm very new to terraform and I don't have a development environment for it. The change is pretty trivial, though.

### Relations
Closes #28645