### PR TITLE
New Resource `aws_auditmanager_assessment_report`

### DIFF
--- a/.changelog/28663.txt
+++ b/.changelog/28663.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_auditmanager_assessment_report
+```

--- a/internal/service/auditmanager/assessment_report.go
+++ b/internal/service/auditmanager/assessment_report.go
@@ -1,0 +1,261 @@
+package auditmanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/auditmanager"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/auditmanager/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	sdkv2resource "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+const reportCompletionTimeout = 5 * time.Minute
+
+func init() {
+	_sp.registerFrameworkResourceFactory(newResourceAssessmentReport)
+}
+
+func newResourceAssessmentReport(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceAssessmentReport{}, nil
+}
+
+const (
+	ResNameAssessmentReport = "AssessmentReport"
+)
+
+type resourceAssessmentReport struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceAssessmentReport) Metadata(_ context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = "aws_auditmanager_assessment_report"
+}
+
+func (r *resourceAssessmentReport) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"assessment_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"author": schema.StringAttribute{
+				Computed: true,
+			},
+			"description": schema.StringAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"id": framework.IDAttribute(),
+			"name": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"status": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+	}
+}
+
+func (r *resourceAssessmentReport) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().AuditManagerClient()
+
+	var plan resourceAssessmentReportData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := auditmanager.CreateAssessmentReportInput{
+		AssessmentId: aws.String(plan.AssessmentID.ValueString()),
+		Name:         aws.String(plan.Name.ValueString()),
+	}
+	if !plan.Description.IsNull() {
+		in.Description = aws.String(plan.Description.ValueString())
+	}
+
+	out, err := conn.CreateAssessmentReport(ctx, &in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.AuditManager, create.ErrActionCreating, ResNameAssessmentReport, plan.Name.String(), nil),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil || out.AssessmentReport == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.AuditManager, create.ErrActionCreating, ResNameAssessmentReport, plan.Name.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	state := plan
+	state.refreshFromOutput(ctx, out.AssessmentReport)
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}
+
+func (r *resourceAssessmentReport) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().AuditManagerClient()
+
+	var state resourceAssessmentReportData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := FindAssessmentReportByID(ctx, conn, state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.Diagnostics.AddWarning(
+			"AWS Resource Not Found During Refresh",
+			fmt.Sprintf("Automatically removing from Terraform State instead of returning the error, which may trigger resource recreation. Original Error: %s", err.Error()),
+		)
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.AuditManager, create.ErrActionReading, ResNameAssessmentReport, state.ID.String(), nil),
+			err.Error(),
+		)
+		return
+	}
+
+	state.refreshFromOutputMetadata(ctx, out)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// There is no update API, so this method is a no-op
+func (r *resourceAssessmentReport) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+}
+
+func (r *resourceAssessmentReport) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().AuditManagerClient()
+
+	var state resourceAssessmentReportData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Retry on ValidationException (report status is not completed or failed)
+	//
+	// Example:
+	//   ValidationException: The assessment report is currently being generated and can’t be
+	//   deleted. You can only delete assessment reports that are completed or failed
+	err := tfresource.RetryContext(ctx, reportCompletionTimeout, func() *sdkv2resource.RetryError {
+		_, err := conn.DeleteAssessmentReport(ctx, &auditmanager.DeleteAssessmentReportInput{
+			AssessmentId:       aws.String(state.AssessmentID.ValueString()),
+			AssessmentReportId: aws.String(state.ID.ValueString()),
+		})
+		if err != nil {
+			var ve *awstypes.ValidationException
+			if errors.As(err, &ve) {
+				return sdkv2resource.RetryableError(err)
+			}
+			return sdkv2resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		var nfe *awstypes.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.AuditManager, create.ErrActionDeleting, ResNameAssessmentReport, state.ID.String(), nil),
+			err.Error(),
+		)
+	}
+}
+
+func (r *resourceAssessmentReport) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func FindAssessmentReportByID(ctx context.Context, conn *auditmanager.Client, id string) (*awstypes.AssessmentReportMetadata, error) {
+	// There is no GetAssessmentReport API, so make use of the ListAssessmentReports API
+	// and return when an ID match is found
+	in := &auditmanager.ListAssessmentReportsInput{}
+	pages := auditmanager.NewListAssessmentReportsPaginator(conn, in)
+
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, report := range page.AssessmentReports {
+			if id == aws.ToString(report.Id) {
+				return &report, nil
+			}
+		}
+	}
+
+	return nil, &sdkv2resource.NotFoundError{
+		LastRequest: in,
+	}
+}
+
+type resourceAssessmentReportData struct {
+	AssessmentID types.String `tfsdk:"assessment_id"`
+	Author       types.String `tfsdk:"author"`
+	Description  types.String `tfsdk:"description"`
+	ID           types.String `tfsdk:"id"`
+	Name         types.String `tfsdk:"name"`
+	Status       types.String `tfsdk:"status"`
+}
+
+// refreshFromOutput writes state data from an AWS response object
+//
+// This variant of the refresh method is for use with the create operation
+// response type (AssesmentReport).
+func (rd *resourceAssessmentReportData) refreshFromOutput(ctx context.Context, out *awstypes.AssessmentReport) {
+	if out == nil {
+		return
+	}
+
+	rd.AssessmentID = flex.StringToFramework(ctx, out.AssessmentId)
+	rd.Author = flex.StringToFramework(ctx, out.Author)
+	rd.Description = flex.StringToFramework(ctx, out.Description)
+	rd.ID = flex.StringToFramework(ctx, out.Id)
+	rd.Name = flex.StringToFramework(ctx, out.Name)
+	rd.Status = flex.StringValueToFramework(ctx, out.Status)
+}
+
+// refreshFromOutputMetadata writes state data from an AWS response object
+//
+// This variant of the refresh method is for use with the list operation
+// response type (AssesmentReportMetadata).
+func (rd *resourceAssessmentReportData) refreshFromOutputMetadata(ctx context.Context, out *awstypes.AssessmentReportMetadata) {
+	if out == nil {
+		return
+	}
+
+	rd.AssessmentID = flex.StringToFramework(ctx, out.AssessmentId)
+	rd.Author = flex.StringToFramework(ctx, out.Author)
+	rd.Description = flex.StringToFramework(ctx, out.Description)
+	rd.ID = flex.StringToFramework(ctx, out.Id)
+	rd.Name = flex.StringToFramework(ctx, out.Name)
+	rd.Status = flex.StringValueToFramework(ctx, out.Status)
+}

--- a/internal/service/auditmanager/assessment_report_test.go
+++ b/internal/service/auditmanager/assessment_report_test.go
@@ -1,0 +1,277 @@
+package auditmanager_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/auditmanager/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfauditmanager "github.com/hashicorp/terraform-provider-aws/internal/service/auditmanager"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccAuditManagerAssessmentReport_basic(t *testing.T) {
+	var assessmentReport types.AssessmentReportMetadata
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_auditmanager_assessment_report.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.AuditManagerEndpointID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AuditManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAssessmentReportDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAssessmentReportConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAssessmentReportExists(resourceName, &assessmentReport),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "assessment_id", "aws_auditmanager_assessment.test", "id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"status"},
+			},
+		},
+	})
+}
+
+func TestAccAuditManagerAssessmentReport_disappears(t *testing.T) {
+	var assessmentReport types.AssessmentReportMetadata
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_auditmanager_assessment_report.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.AuditManagerEndpointID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AuditManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAssessmentReportDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAssessmentReportConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAssessmentReportExists(resourceName, &assessmentReport),
+					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfauditmanager.ResourceAssessmentReport, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAuditManagerAssessmentReport_optional(t *testing.T) {
+	var assessmentReport types.AssessmentReportMetadata
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_auditmanager_assessment_report.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.AuditManagerEndpointID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AuditManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAssessmentReportDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAssessmentReportConfig_optional(rName, "text"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAssessmentReportExists(resourceName, &assessmentReport),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "assessment_id", "aws_auditmanager_assessment.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "description", "text"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"status"},
+			},
+			{
+				Config: testAccAssessmentReportConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAssessmentReportExists(resourceName, &assessmentReport),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "assessment_id", "aws_auditmanager_assessment.test", "id"),
+				),
+			},
+			{
+				Config: testAccAssessmentReportConfig_optional(rName, "text-updated"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAssessmentReportExists(resourceName, &assessmentReport),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "assessment_id", "aws_auditmanager_assessment.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "description", "text-updated"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAssessmentReportDestroy(s *terraform.State) error {
+	ctx := context.Background()
+	conn := acctest.Provider.Meta().(*conns.AWSClient).AuditManagerClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_auditmanager_assessment_report" {
+			continue
+		}
+
+		_, err := tfauditmanager.FindAssessmentReportByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			var nfe *resource.NotFoundError
+			if errors.As(err, &nfe) {
+				return nil
+			}
+			return err
+		}
+
+		return create.Error(names.AuditManager, create.ErrActionCheckingDestroyed, tfauditmanager.ResNameAssessmentReport, rs.Primary.ID, errors.New("not destroyed"))
+	}
+
+	return nil
+}
+
+func testAccCheckAssessmentReportExists(name string, assessmentReport *types.AssessmentReportMetadata) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.AuditManager, create.ErrActionCheckingExistence, tfauditmanager.ResNameAssessmentReport, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.AuditManager, create.ErrActionCheckingExistence, tfauditmanager.ResNameAssessmentReport, name, errors.New("not set"))
+		}
+
+		ctx := context.Background()
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AuditManagerClient()
+		resp, err := tfauditmanager.FindAssessmentReportByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.AuditManager, create.ErrActionCheckingExistence, tfauditmanager.ResNameAssessmentReport, rs.Primary.ID, err)
+		}
+
+		*assessmentReport = *resp
+
+		return nil
+	}
+}
+
+func testAccAssessmentReportConfigBase(rName string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_auditmanager_control" "test" {
+  name = %[1]q
+
+  control_mapping_sources {
+    source_name          = %[1]q
+    source_set_up_option = "Procedural_Controls_Mapping"
+    source_type          = "MANUAL"
+  }
+}
+
+resource "aws_auditmanager_framework" "test" {
+  name = %[1]q
+
+  control_sets {
+    name = %[1]q
+    controls {
+      id = aws_auditmanager_control.test.id
+    }
+  }
+}
+
+resource "aws_auditmanager_assessment" "test" {
+  name = %[1]q
+
+  assessment_reports_destination {
+    destination      = "s3://${aws_s3_bucket.test.id}"
+    destination_type = "S3"
+  }
+
+  framework_id = aws_auditmanager_framework.test.id
+
+  roles {
+    role_arn  = aws_iam_role.test.arn
+    role_type = "PROCESS_OWNER"
+  }
+
+  scope {
+    aws_accounts {
+      id = data.aws_caller_identity.current.account_id
+    }
+    aws_services {
+      service_name = "S3"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAssessmentReportConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccAssessmentReportConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_auditmanager_assessment_report" "test" {
+  name          = %[1]q
+  assessment_id = aws_auditmanager_assessment.test.id
+}
+`, rName))
+}
+
+func testAccAssessmentReportConfig_optional(rName, description string) string {
+	return acctest.ConfigCompose(
+		testAccAssessmentReportConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_auditmanager_assessment_report" "test" {
+  name          = %[1]q
+  assessment_id = aws_auditmanager_assessment.test.id
+
+  description = %[2]q
+}
+`, rName, description))
+}

--- a/internal/service/auditmanager/exports_test.go
+++ b/internal/service/auditmanager/exports_test.go
@@ -4,6 +4,7 @@ package auditmanager
 var (
 	ResourceAccountRegistration = newResourceAccountRegistration
 	ResourceAssessment          = newResourceAssessment
+	ResourceAssessmentReport    = newResourceAssessmentReport
 	ResourceControl             = newResourceControl
 	ResourceFramework           = newResourceFramework
 )

--- a/website/docs/r/auditmanager_assessment_report.html.markdown
+++ b/website/docs/r/auditmanager_assessment_report.html.markdown
@@ -1,0 +1,49 @@
+---
+subcategory: "Audit Manager"
+layout: "aws"
+page_title: "AWS: aws_auditmanager_assessment_report"
+description: |-
+  Terraform resource for managing an AWS Audit Manager Assessment Report.
+---
+
+# Resource: aws_auditmanager_assessment_report
+
+Terraform resource for managing an AWS Audit Manager Assessment Report.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_auditmanager_assessment_report" "test" {
+  name          = "example"
+  assessment_id = aws_auditmanager_assessment.test.id
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Name of the assessment report.
+* `assessment_id` - (Required) Unique identifier of the assessment to create the report from.
+
+The following arguments are optional:
+
+* `description` - (Optional) Description of the assessment report.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `author` - Name of the user who created the assessment report.
+* `id` - Unique identifier for the assessment report.
+* `status` - Current status of the specified assessment report. Valid values are `COMPLETE`, `IN_PROGRESS`, and `FAILED`.
+
+## Import
+
+Audit Manager Assessment Reports can be imported using the assessment report `id`, e.g.,
+
+```
+$ terraform import aws_auditmanager_assessment_report.example abc123-de45
+```


### PR DESCRIPTION
### Description
`aws_auditmanager_assessment_report` will allow practitioners to manage assessment reports.

### Relations
Relates #17981

### Output from Acceptance Testing

```console
$ make testacc PKG=auditmanager TESTS=TestAccAuditManagerAssessmentReport_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/auditmanager/... -v -count 1 -parallel 20 -run='TestAccAuditManagerAssessmentReport_'  -timeout 180m
=== RUN   TestAccAuditManagerAssessmentReport_basic
=== PAUSE TestAccAuditManagerAssessmentReport_basic
=== RUN   TestAccAuditManagerAssessmentReport_disappears
=== PAUSE TestAccAuditManagerAssessmentReport_disappears
=== RUN   TestAccAuditManagerAssessmentReport_optional
=== PAUSE TestAccAuditManagerAssessmentReport_optional
=== CONT  TestAccAuditManagerAssessmentReport_basic
=== CONT  TestAccAuditManagerAssessmentReport_optional
=== CONT  TestAccAuditManagerAssessmentReport_disappears
--- PASS: TestAccAuditManagerAssessmentReport_basic (28.96s)
--- PASS: TestAccAuditManagerAssessmentReport_disappears (35.30s)
--- PASS: TestAccAuditManagerAssessmentReport_optional (55.09s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/auditmanager       58.133s
```