### PR TITLE
Amp create logging configuration bug 27472

### DIFF
--- a/.changelog/27472.txt
+++ b/.changelog/27472.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/amp: Fix issue where amp workspace fails to create logging configuration during workspace update.
+```

--- a/internal/service/amp/workspace.go
+++ b/internal/service/amp/workspace.go
@@ -69,7 +69,7 @@ func ResourceWorkspace() *schema.Resource {
 }
 
 func resourceWorkspaceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).AMPConn
+	conn := meta.(*conns.AWSClient).AMPConn()
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
@@ -117,7 +117,7 @@ func resourceWorkspaceCreate(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func resourceWorkspaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).AMPConn
+	conn := meta.(*conns.AWSClient).AMPConn()
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -170,7 +170,7 @@ func resourceWorkspaceRead(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func resourceWorkspaceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).AMPConn
+	conn := meta.(*conns.AWSClient).AMPConn()
 
 	if d.HasChange("alias") {
 		input := &prometheusservice.UpdateWorkspaceAliasInput{
@@ -257,7 +257,7 @@ func resourceWorkspaceUpdate(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func resourceWorkspaceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).AMPConn
+	conn := meta.(*conns.AWSClient).AMPConn()
 
 	log.Printf("[INFO] Deleting Prometheus Workspace: %s", d.Id())
 	_, err := conn.DeleteWorkspaceWithContext(ctx, &prometheusservice.DeleteWorkspaceInput{

--- a/internal/service/amp/workspace_test.go
+++ b/internal/service/amp/workspace_test.go
@@ -46,6 +46,42 @@ func TestAccAMPWorkspace_basic(t *testing.T) {
 	})
 }
 
+func TestAccAMPWorkspace_addLoggingConfig(t *testing.T) {
+	var v prometheusservice.WorkspaceDescription
+	resourceName := "aws_prometheus_workspace.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(prometheusservice.EndpointsID, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, prometheusservice.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkspaceConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkspaceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "alias", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "prometheus_endpoint"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				Config: testAccWorkspaceConfig_loggingConfiguration(resourceName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWorkspaceExists(resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "alias", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "prometheus_endpoint"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAMPWorkspace_disappears(t *testing.T) {
 	var v prometheusservice.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
@@ -218,7 +254,7 @@ func testAccCheckWorkspaceExists(n string, v *prometheusservice.WorkspaceDescrip
 			return fmt.Errorf("No Prometheus Workspace ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AMPConn()
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AMPConn
 
 		output, err := tfamp.FindWorkspaceByID(context.Background(), conn, rs.Primary.ID)
 
@@ -233,7 +269,7 @@ func testAccCheckWorkspaceExists(n string, v *prometheusservice.WorkspaceDescrip
 }
 
 func testAccCheckWorkspaceDestroy(s *terraform.State) error {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).AMPConn()
+	conn := acctest.Provider.Meta().(*conns.AWSClient).AMPConn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_prometheus_workspace" {

--- a/internal/service/amp/workspace_test.go
+++ b/internal/service/amp/workspace_test.go
@@ -254,7 +254,7 @@ func testAccCheckWorkspaceExists(n string, v *prometheusservice.WorkspaceDescrip
 			return fmt.Errorf("No Prometheus Workspace ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AMPConn
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AMPConn()
 
 		output, err := tfamp.FindWorkspaceByID(context.Background(), conn, rs.Primary.ID)
 
@@ -269,7 +269,7 @@ func testAccCheckWorkspaceExists(n string, v *prometheusservice.WorkspaceDescrip
 }
 
 func testAccCheckWorkspaceDestroy(s *terraform.State) error {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).AMPConn
+	conn := acctest.Provider.Meta().(*conns.AWSClient).AMPConn()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_prometheus_workspace" {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27472

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
AWS_PROFILE=default make  testacc TESTS=TestAccAMPWorkspace_addLoggingConfig PKG=amp                                          
==> Checking that code complies with gofmt requirements...                                                                                                                                                 
TF_ACC=1 go test ./internal/service/amp/... -v -count 1 -parallel 20 -run='TestAccAMPWorkspace_addLoggingConfig'  -timeout 180m                                                                            
=== RUN   TestAccAMPWorkspace_addLoggingConfig                                                                                                                                                             
=== PAUSE TestAccAMPWorkspace_addLoggingConfig
=== CONT  TestAccAMPWorkspace_addLoggingConfig
--- PASS: TestAccAMPWorkspace_addLoggingConfig (68.40s)
PASS
ok      [github.com/hashicorp/terraform-provider-aws/internal/service/amp](https://urldefense.com/v3/__http://github.com/hashicorp/terraform-provider-aws/internal/service/amp__;!!IqRYp603ny2KL2MbNA!0U_Pf7ucinjSNlQlSD5c4IvyTQe4BSXi5Fz8tVJPFlP1ouxjL_7mNnQW2D9mJ-XPoeG078pSebL0ji26nxAyF5jVP-79KvJhj-4Z$)        68.524s

...
```
