### PR TITLE
[WIP] - Allow `suppressed_reasons` to be an empty list in order to overwrite the default suppressed reasons

### DIFF
--- a/internal/service/sesv2/configuration_set.go
+++ b/internal/service/sesv2/configuration_set.go
@@ -107,7 +107,6 @@ func ResourceConfigurationSet() *schema.Resource {
 						"suppressed_reasons": {
 							Type:     schema.TypeList,
 							Optional: true,
-							MinItems: 1,
 							Elem: &schema.Schema{
 								Type:             schema.TypeString,
 								ValidateDiagFunc: enum.Validate[types.SuppressionListReason](),

--- a/internal/service/sesv2/configuration_set.go
+++ b/internal/service/sesv2/configuration_set.go
@@ -572,8 +572,12 @@ func expandSuppressionOptions(tfMap map[string]interface{}) *types.SuppressionOp
 
 	a := &types.SuppressionOptions{}
 
-	if v, ok := tfMap["suppressed_reasons"].([]interface{}); ok && len(v) > 0 {
-		a.SuppressedReasons = expandSuppressedReasons(v)
+	if v, ok := tfMap["suppressed_reasons"].([]interface{}); ok {
+		if len(v) > 0 {
+			a.SuppressedReasons = expandSuppressedReasons(v)
+		} else {
+			a.SuppressedReasons = make([]types.SuppressionListReason, 0)
+		}
 	}
 
 	return a

--- a/internal/service/sesv2/configuration_set_test.go
+++ b/internal/service/sesv2/configuration_set_test.go
@@ -209,6 +209,33 @@ func TestAccSESV2ConfigurationSet_suppressedReasons(t *testing.T) {
 	})
 }
 
+func TestAccSESV2ConfigurationSet_suppressedReasonsEmpty(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sesv2_configuration_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfigurationSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigurationSetConfig_suppressedReasonsEmpty(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationSetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "suppression_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "suppression_options.0.suppressed_reasons.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccSESV2ConfigurationSet_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sesv2_configuration_set.test"
@@ -354,6 +381,18 @@ resource "aws_sesv2_configuration_set" "test" {
   }
 }
 `, rName, suppressedReason)
+}
+
+func testAccConfigurationSetConfig_suppressedReasonsEmpty(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_sesv2_configuration_set" "test" {
+  configuration_set_name = %[1]q
+
+  suppression_options {
+    suppressed_reasons = []
+  }
+}
+`, rName)
 }
 
 func testAccConfigurationSetConfig_tags1(rName, tagKey1, tagValue1 string) string {


### PR DESCRIPTION
Closes #28669

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
