### PR TITLE
Fix aws_ecrpublic_authorization_token region to us-east-1

### DIFF
--- a/.changelog/28281.txt
+++ b/.changelog/28281.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data/aws_ecrpublic_authorization_token: ecr-public get-authorization-token [only support us-east-1 region](https://docs.aws.amazon.com/AmazonECR/latest/public/public-registries.html#get-login-password)
+```

--- a/internal/service/ecrpublic/authorization_token_data_source.go
+++ b/internal/service/ecrpublic/authorization_token_data_source.go
@@ -40,7 +40,8 @@ func DataSourceAuthorizationToken() *schema.Resource {
 }
 
 func dataSourceAuthorizationTokenRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*conns.AWSClient).ECRPublicConn()
+	conn := ecrpublic.New(meta.(*conns.AWSClient).Session, aws.NewConfig().WithRegion("us-east-1"))
+
 	params := &ecrpublic.GetAuthorizationTokenInput{}
 
 	out, err := conn.GetAuthorizationToken(params)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
aws ecrpublic get-authorization-token [only support us-east-1 region](https://docs.aws.amazon.com/AmazonECR/latest/public/public-registries.html#get-login-password).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #28281
or 
Closes #0000
--->

Closes #28281

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
