### PR TITLE
DOC: Removing extra R from db_instance docs

### DIFF
--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -104,7 +104,7 @@ Defaults to true.
   or will use [RDS Blue/Green deployments][blue-green].
 * `backup_window` - (Optional) The daily time range (in UTC) during which automated backups are created if they are enabled.
   Example: "09:46-10:16". Must not overlap with `maintenance_window`.
-* `blue_green_update` - (Optional) Enables low-downtime updates using R[RDS Blue/Green deployments][blue-green].
+* `blue_green_update` - (Optional) Enables low-downtime updates using [RDS Blue/Green deployments][blue-green].
   See [blue_green_update](#blue_green_update) below
 * `ca_cert_identifier` - (Optional) The identifier of the CA certificate for the DB instance.
 * `character_set_name` - (Optional) The character set name to use for DB


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Removing an additional R from documentation from the `blue_green_update` argument for `db_instance` resource. Believe this is a typo which should read 'RDS Blue/Green deployments' and not '**R**RDS Blue/Green deployments'


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->


Introduced via #28046 



