### PR TITLE
r/aws_elasticache_user_group_association: Handle concurrent updates (#28688)

### DIFF
--- a/.changelog/28689.txt
+++ b/.changelog/28689.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_user_group_association: Retry on `InvalidUserGroupState` errors to handle concurrent updates
+```

--- a/internal/service/elasticache/user_group_association_test.go
+++ b/internal/service/elasticache/user_group_association_test.go
@@ -103,6 +103,35 @@ func TestAccElastiCacheUserGroupAssociation_disappears(t *testing.T) {
 	})
 }
 
+func TestAccElastiCacheUserGroupAssociation_multiple(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName1 := "aws_elasticache_user_group_association.test1"
+	resourceName2 := "aws_elasticache_user_group_association.test2"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, elasticache.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserGroupAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserGroupAssociationConfig_preMultiple(rName),
+			},
+			{
+				Config: testAccUserGroupAssociationConfig_multiple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserGroupAssociationExists(resourceName1),
+					testAccCheckUserGroupAssociationExists(resourceName2),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckUserGroupAssociationDestroy(s *terraform.State) error {
 	return testAccCheckUserGroupAssociationDestroyWithProvider(s, acctest.Provider)
 }
@@ -263,6 +292,44 @@ resource "aws_elasticache_user" "test3" {
 }
 
 resource "aws_elasticache_user_group_association" "test" {
+  user_group_id = aws_elasticache_user_group.test.user_group_id
+  user_id       = aws_elasticache_user.test3.user_id
+}
+`, rName))
+}
+
+func testAccUserGroupAssociationConfig_preMultiple(rName string) string {
+	return acctest.ConfigCompose(
+		testAccUserGroupAssociationBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_elasticache_user" "test3" {
+  user_id       = "%[1]s-3"
+  user_name     = "username2"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
+}
+`, rName))
+}
+
+func testAccUserGroupAssociationConfig_multiple(rName string) string {
+	return acctest.ConfigCompose(
+		testAccUserGroupAssociationBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_elasticache_user" "test3" {
+  user_id       = "%[1]s-3"
+  user_name     = "username2"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
+}
+
+resource "aws_elasticache_user_group_association" "test1" {
+  user_group_id = aws_elasticache_user_group.test.user_group_id
+  user_id       = aws_elasticache_user.test2.user_id
+}
+
+resource "aws_elasticache_user_group_association" "test2" {
   user_group_id = aws_elasticache_user_group.test.user_group_id
   user_id       = aws_elasticache_user.test3.user_id
 }


### PR DESCRIPTION
If a group is in status "Modifying", attempts to create or destroy an association fail with an `InvalidUserGroupState` error. Retry the operation until the status changes back to "Active".

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Creating or destroying an `aws_elasticache_user_group_association` sets the user group in status "Modifying". When the group is in this status, no other changes can be made. If two association resources are created or destroyed at the same time (even in the same module), one will fail with an `InvalidUserGroupState` error.

To avoid this, retry create and destroy operations until the `InvalidUserGroupState` error goes away.

### Relations

Closes #28688

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccElastiCacheUserGroupAssociation PKG=elasticache
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheUserGroupAssociation'  -timeout 180m
=== RUN   TestAccElastiCacheUserGroupAssociation_basic
=== PAUSE TestAccElastiCacheUserGroupAssociation_basic
=== RUN   TestAccElastiCacheUserGroupAssociation_update
=== PAUSE TestAccElastiCacheUserGroupAssociation_update
=== RUN   TestAccElastiCacheUserGroupAssociation_disappears
=== PAUSE TestAccElastiCacheUserGroupAssociation_disappears
=== RUN   TestAccElastiCacheUserGroupAssociation_multiple
=== PAUSE TestAccElastiCacheUserGroupAssociation_multiple
=== CONT  TestAccElastiCacheUserGroupAssociation_basic
=== CONT  TestAccElastiCacheUserGroupAssociation_multiple
=== CONT  TestAccElastiCacheUserGroupAssociation_disappears
=== CONT  TestAccElastiCacheUserGroupAssociation_update
--- PASS: TestAccElastiCacheUserGroupAssociation_basic (304.78s)
--- PASS: TestAccElastiCacheUserGroupAssociation_disappears (311.67s)
--- PASS: TestAccElastiCacheUserGroupAssociation_multiple (426.97s)
--- PASS: TestAccElastiCacheUserGroupAssociation_update (436.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        436.419s
```
