### PR TITLE
Skip configured budgets

### DIFF
--- a/internal/service/budgets/sweep.go
+++ b/internal/service/budgets/sweep.go
@@ -6,6 +6,7 @@ package budgets
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/budgets"
@@ -94,7 +95,7 @@ func sweepBudgets(region string) error { // nosemgrep:ci.budgets-in-func-name
 
 		for _, v := range page.Budgets {
 			// skip budgets we have configured to track our spend
-			if !strings.HasPrefix(v.BudgetName, "tf-acc") {
+			if !strings.HasPrefix(*v.BudgetName, "tf-acc") {
 				continue
 			}
 

--- a/internal/service/budgets/sweep.go
+++ b/internal/service/budgets/sweep.go
@@ -93,6 +93,11 @@ func sweepBudgets(region string) error { // nosemgrep:ci.budgets-in-func-name
 		}
 
 		for _, v := range page.Budgets {
+
+			if !strings.HasPrefix(v.BudgetName, "tf-acc") {
+				continue
+			}
+
 			r := ResourceBudget()
 			d := r.Data(nil)
 			d.SetId(BudgetCreateResourceID(accountID, aws.StringValue(v.BudgetName)))

--- a/internal/service/budgets/sweep.go
+++ b/internal/service/budgets/sweep.go
@@ -93,7 +93,7 @@ func sweepBudgets(region string) error { // nosemgrep:ci.budgets-in-func-name
 		}
 
 		for _, v := range page.Budgets {
-
+			// skip budgets we have configured to track our spend
 			if !strings.HasPrefix(v.BudgetName, "tf-acc") {
 				continue
 			}

--- a/internal/service/budgets/sweep.go
+++ b/internal/service/budgets/sweep.go
@@ -95,13 +95,14 @@ func sweepBudgets(region string) error { // nosemgrep:ci.budgets-in-func-name
 
 		for _, v := range page.Budgets {
 			// skip budgets we have configured to track our spend
-			if !strings.HasPrefix(*v.BudgetName, "tf-acc") {
+			budgetName := aws.StringValue(v.BudgetName)
+			if !strings.HasPrefix(budgetName, "tf-acc") {
 				continue
 			}
 
 			r := ResourceBudget()
 			d := r.Data(nil)
-			d.SetId(BudgetCreateResourceID(accountID, aws.StringValue(v.BudgetName)))
+			d.SetId(BudgetCreateResourceID(accountID, budgetName))
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Configure `aws_budgets_budget` to skip any tests not named with the standard naming prefix.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make sweep SWEEPARGS=-sweep-run=aws_budgets_budget        
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2,us-east-1,us-east-2 -sweep-run=aws_budgets_budget -timeout 60m
2023/01/05 10:43:24 [DEBUG] Running Sweepers for region (us-west-2):
2023/01/05 10:43:24 [DEBUG] Running Sweeper (aws_budgets_budget_action) in region (us-west-2)
2023/01/05 10:43:24 [INFO] Retrieved credentials from "SharedConfigCredentials: /Users/jdoe/.aws/credentials"
2023/01/05 10:43:24 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2023/01/05 10:43:24 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2023/01/05 10:43:25 [DEBUG] Completed Sweeper (aws_budgets_budget_action) in region (us-west-2) in 803.466748ms
2023/01/05 10:43:25 [DEBUG] Sweeper (aws_budgets_budget) has dependency (aws_budgets_budget_action), running..
2023/01/05 10:43:25 [DEBUG] Sweeper (aws_budgets_budget_action) already ran in region (us-west-2)
2023/01/05 10:43:25 [DEBUG] Running Sweeper (aws_budgets_budget) in region (us-west-2)
2023/01/05 10:43:25 [DEBUG] Completed Sweeper (aws_budgets_budget) in region (us-west-2) in 137.59995ms
2023/01/05 10:43:25 Completed Sweepers for region (us-west-2) in 941.20342ms
2023/01/05 10:43:25 Sweeper Tests for region (us-west-2) ran successfully:
        - aws_budgets_budget_action
        - aws_budgets_budget
2023/01/05 10:43:25 [DEBUG] Running Sweepers for region (us-east-1):
2023/01/05 10:43:25 [DEBUG] Running Sweeper (aws_budgets_budget_action) in region (us-east-1)
2023/01/05 10:43:25 [INFO] Retrieved credentials from "SharedConfigCredentials: /Users/jdoe/.aws/credentials"
2023/01/05 10:43:25 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2023/01/05 10:43:26 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2023/01/05 10:43:26 [DEBUG] Completed Sweeper (aws_budgets_budget_action) in region (us-east-1) in 826.93883ms
2023/01/05 10:43:26 [DEBUG] Sweeper (aws_budgets_budget) has dependency (aws_budgets_budget_action), running..
2023/01/05 10:43:26 [DEBUG] Sweeper (aws_budgets_budget_action) already ran in region (us-east-1)
2023/01/05 10:43:26 [DEBUG] Running Sweeper (aws_budgets_budget) in region (us-east-1)
2023/01/05 10:43:26 [DEBUG] Completed Sweeper (aws_budgets_budget) in region (us-east-1) in 156.212171ms
2023/01/05 10:43:26 Completed Sweepers for region (us-east-1) in 983.188474ms
2023/01/05 10:43:26 Sweeper Tests for region (us-east-1) ran successfully:
        - aws_budgets_budget_action
        - aws_budgets_budget
2023/01/05 10:43:26 [DEBUG] Running Sweepers for region (us-east-2):
2023/01/05 10:43:26 [DEBUG] Sweeper (aws_budgets_budget) has dependency (aws_budgets_budget_action), running..
2023/01/05 10:43:26 [DEBUG] Running Sweeper (aws_budgets_budget_action) in region (us-east-2)
2023/01/05 10:43:26 [INFO] Retrieved credentials from "SharedConfigCredentials: /Users/jdoe/.aws/credentials"
2023/01/05 10:43:26 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2023/01/05 10:43:27 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2023/01/05 10:43:27 [DEBUG] Completed Sweeper (aws_budgets_budget_action) in region (us-east-2) in 922.578564ms
2023/01/05 10:43:27 [DEBUG] Running Sweeper (aws_budgets_budget) in region (us-east-2)
2023/01/05 10:43:27 [DEBUG] Completed Sweeper (aws_budgets_budget) in region (us-east-2) in 142.136536ms
2023/01/05 10:43:27 [DEBUG] Sweeper (aws_budgets_budget_action) already ran in region (us-east-2)
2023/01/05 10:43:27 Completed Sweepers for region (us-east-2) in 1.064756764s
2023/01/05 10:43:27 Sweeper Tests for region (us-east-2) ran successfully:
        - aws_budgets_budget_action
        - aws_budgets_budget
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      7.102s

...
```
