### PR TITLE
release/3.x: AWS S3 Bucket default encryption

### DIFF
--- a/.changelog/28702.txt
+++ b/.changelog/28702.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket: Mark `server_side_encryption_configuration` as Computed in support of [S3 object encryption by default](https://aws.amazon.com/blogs/aws/amazon-s3-encrypts-new-objects-by-default/)
+```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -583,6 +583,7 @@ func ResourceBucket() *schema.Resource {
 				Type:       schema.TypeList,
 				MaxItems:   1,
 				Optional:   true,
+				Computed:   true,
 				Deprecated: "Use the aws_s3_bucket_server_side_encryption_configuration resource instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -367,7 +367,7 @@ resource "aws_s3_bucket" "source" {
 }
 ```
 
-### Enable Default Server Side Encryption
+### Enable SSE-KMS Encryption
 
 -> **NOTE:** The parameter `server_side_encryption_configuration` is deprecated.
 Use the resource [`aws_s3_bucket_server_side_encryption_configuration`](s3_bucket_server_side_encryption_configuration.html) instead.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Changes `aws_s3_bucket. server_side_encryption_configuration` to `Computed`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/28701.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28700.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28703.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccS3Bucket_Basic_basic\|TestAccS3Bucket_Security_noConfiguredServerSideEncryptionAfterDefaultEncryptionIsEnabled' PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20  -run=TestAccS3Bucket_Basic_basic\|TestAccS3Bucket_Security_noConfiguredServerSideEncryptionAfterDefaultEncryptionIsEnabled -timeout 180m
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Security_noConfiguredServerSideEncryptionAfterDefaultEncryptionIsEnabled
=== PAUSE TestAccS3Bucket_Security_noConfiguredServerSideEncryptionAfterDefaultEncryptionIsEnabled
=== CONT  TestAccS3Bucket_Basic_basic
=== CONT  TestAccS3Bucket_Security_noConfiguredServerSideEncryptionAfterDefaultEncryptionIsEnabled
--- PASS: TestAccS3Bucket_Basic_basic (30.74s)
--- PASS: TestAccS3Bucket_Security_noConfiguredServerSideEncryptionAfterDefaultEncryptionIsEnabled (49.49s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	53.705s
```

##### Without the changes:

```console
% make testacc TESTARGS='-run=TestAccS3Bucket_Basic_basic\|TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled' PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20  -run=TestAccS3Bucket_Basic_basic\|TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled -timeout 180m
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled
=== PAUSE TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled
=== CONT  TestAccS3Bucket_Basic_basic
=== CONT  TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled
=== CONT  TestAccS3Bucket_Basic_basic
    bucket_test.go:52: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_s3_bucket.bucket will be updated in-place
          ~ resource "aws_s3_bucket" "bucket" {
                id                          = "tf-test-bucket-8439647868545806832"
                # (11 unchanged attributes hidden)
        
              - server_side_encryption_configuration {
                  - rule {
                      - bucket_key_enabled = false -> null
        
                      - apply_server_side_encryption_by_default {
                          - sse_algorithm = "AES256" -> null
                        }
                    }
                }
        
                # (1 unchanged block hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccS3Bucket_Basic_basic (15.56s)
=== CONT  TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled
    bucket_test.go:862: Step 3/3 error: Check failed: 1 error occurred:
        	* Check 2/2 error: aws_s3_bucket.test: Attribute 'server_side_encryption_configuration.#' expected "0", got "1"
        
--- FAIL: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (47.69s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/s3	51.377s
FAIL
make: *** [testacc] Error 1
```
