### PR TITLE
release/2.x: AWS S3 Bucket default encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ NOTES:
 
 * provider: Add OpenBSD to list of OSes which the provider is built on ([#28668](https://github.com/hashicorp/terraform-provider-aws/issues/28668))
 
+ENHANCEMENTS:
+
+* resource/aws_s3_bucket: Mark `server_side_encryption_configuration` as Computed in support of [S3 object encryption by default](https://aws.amazon.com/blogs/aws/amazon-s3-encrypts-new-objects-by-default/) ([#28703](https://github.com/terraform-providers/terraform-provider-aws/issues/28703))
+
 ## 2.70.1 (December 16, 2021)
 
 BUG FIXES:

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -541,6 +541,7 @@ func resourceAwsS3Bucket() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"rule": {

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -287,7 +287,7 @@ resource "aws_s3_bucket" "bucket" {
 }
 ```
 
-### Enable Default Server Side Encryption
+### Enable SSE-KMS Server Side Encryption
 
 ```hcl
 resource "aws_kms_key" "mykey" {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Changes `aws_s3_bucket. server_side_encryption_configuration` to `Computed`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/28701.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28700.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28702.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3Bucket_basic\|TestAccAWSS3Bucket_Security_noConfiguredServerSideEncryptionAfterDefaultEncryptionIsEnabled'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3Bucket_basic\|TestAccAWSS3Bucket_Security_noConfiguredServerSideEncryptionAfterDefaultEncryptionIsEnabled -timeout 120m
=== RUN   TestAccAWSS3Bucket_basic
=== PAUSE TestAccAWSS3Bucket_basic
=== RUN   TestAccAWSS3Bucket_Security_noConfiguredServerSideEncryptionAfterDefaultEncryptionIsEnabled
=== PAUSE TestAccAWSS3Bucket_Security_noConfiguredServerSideEncryptionAfterDefaultEncryptionIsEnabled
=== CONT  TestAccAWSS3Bucket_basic
=== CONT  TestAccAWSS3Bucket_Security_noConfiguredServerSideEncryptionAfterDefaultEncryptionIsEnabled
--- PASS: TestAccAWSS3Bucket_basic (40.36s)
--- PASS: TestAccAWSS3Bucket_Security_noConfiguredServerSideEncryptionAfterDefaultEncryptionIsEnabled (59.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	62.452s
```

##### Without the changes:

```console
% make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3Bucket_basic\|TestAccAWSS3Bucket_Security_noConfiguredServerSideEncryptionAfterDefaultEncryptionIsEnabled'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSS3Bucket_basic\|TestAccAWSS3Bucket_Security_noConfiguredServerSideEncryptionAfterDefaultEncryptionIsEnabled -timeout 120m
=== RUN   TestAccAWSS3Bucket_basic
=== PAUSE TestAccAWSS3Bucket_basic
=== CONT  TestAccAWSS3Bucket_basic
    testing.go:684: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        UPDATE: aws_s3_bucket.bucket
          acceleration_status:                                                                                       "" => ""
          acl:                                                                                                       "private" => "private"
          arn:                                                                                                       "arn:aws:s3:::tf-test-bucket-8155902800538718066" => "arn:aws:s3:::tf-test-bucket-8155902800538718066"
          bucket:                                                                                                    "tf-test-bucket-8155902800538718066" => "tf-test-bucket-8155902800538718066"
          bucket_domain_name:                                                                                        "tf-test-bucket-8155902800538718066.s3.amazonaws.com" => "tf-test-bucket-8155902800538718066.s3.amazonaws.com"
          bucket_regional_domain_name:                                                                               "tf-test-bucket-8155902800538718066.s3.us-west-2.amazonaws.com" => "tf-test-bucket-8155902800538718066.s3.us-west-2.amazonaws.com"
          cors_rule.#:                                                                                               "0" => "0"
          force_destroy:                                                                                             "false" => "false"
          grant.#:                                                                                                   "0" => "0"
          hosted_zone_id:                                                                                            "Z3BJ6K6RIION7M" => "Z3BJ6K6RIION7M"
          id:                                                                                                        "tf-test-bucket-8155902800538718066" => "tf-test-bucket-8155902800538718066"
          lifecycle_rule.#:                                                                                          "0" => "0"
          logging.#:                                                                                                 "0" => "0"
          object_lock_configuration.#:                                                                               "0" => "0"
          region:                                                                                                    "us-west-2" => "us-west-2"
          replication_configuration.#:                                                                               "0" => "0"
          request_payer:                                                                                             "BucketOwner" => "BucketOwner"
          server_side_encryption_configuration.#:                                                                    "1" => "0"
          server_side_encryption_configuration.0.rule.#:                                                             "1" => ""
          server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.#:                   "1" => ""
          server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.kms_master_key_id: "" => ""
          server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.sse_algorithm:     "AES256" => ""
          versioning.#:                                                                                              "1" => "1"
          versioning.0.enabled:                                                                                      "false" => "false"
          versioning.0.mfa_delete:                                                                                   "false" => "false"
          website.#:                                                                                                 "0" => "0"
        
        
        
        STATE:
        
        aws_s3_bucket.bucket:
          ID = tf-test-bucket-8155902800538718066
          provider = provider.aws
          acceleration_status = 
          acl = private
          arn = arn:aws:s3:::tf-test-bucket-8155902800538718066
          bucket = tf-test-bucket-8155902800538718066
          bucket_domain_name = tf-test-bucket-8155902800538718066.s3.amazonaws.com
          bucket_regional_domain_name = tf-test-bucket-8155902800538718066.s3.us-west-2.amazonaws.com
          force_destroy = false
          hosted_zone_id = Z3BJ6K6RIION7M
          region = us-west-2
          request_payer = BucketOwner
          server_side_encryption_configuration.# = 1
          server_side_encryption_configuration.0.rule.# = 1
          server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.# = 1
          server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.kms_master_key_id = 
          server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.sse_algorithm = AES256
          versioning.# = 1
          versioning.0.enabled = false
          versioning.0.mfa_delete = false
--- FAIL: TestAccAWSS3Bucket_basic (22.79s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	27.302s
FAIL
make: *** [testacc] Error 1
```