### PR TITLE
Fix bug in aws_apprunner_vpc_connector not handling default_tags

### DIFF
--- a/.changelog/28736.txt
+++ b/.changelog/28736.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_apprunner_vpc_connector: Fix default_tags not handled correctly
+resource/aws_apprunner_vpc_connector: Fix `default_tags` not handled correctly
 ```

--- a/.changelog/28736.txt
+++ b/.changelog/28736.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_apprunner_vpc_connector: Fix default_tags not handled correctly
+```

--- a/internal/service/apprunner/vpc_connector.go
+++ b/internal/service/apprunner/vpc_connector.go
@@ -137,7 +137,7 @@ func resourceVPCConnectorRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("setting tags: %s", err)
 	}
 
-	if err := d.Set("tags_all", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+	if err := d.Set("tags_all", tags.Map()); err != nil {
 		return diag.Errorf("setting tags_all: %s", err)
 	}
 

--- a/internal/service/apprunner/vpc_connector.go
+++ b/internal/service/apprunner/vpc_connector.go
@@ -51,7 +51,7 @@ func ResourceVPCConnector() *schema.Resource {
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"tags":     tftags.TagsSchemaComputed(),
+			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 			"vpc_connector_name": {
 				Type:         schema.TypeString,

--- a/internal/service/apprunner/vpc_connector_test.go
+++ b/internal/service/apprunner/vpc_connector_test.go
@@ -112,6 +112,50 @@ func TestAccAppRunnerVPCConnector_tags(t *testing.T) {
 	})
 }
 
+func TestAccAppRunnerVPCConnector_defaultTags(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_apprunner_vpc_connector.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckVPCConnector(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, apprunner.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckVPCConnectorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ConfigCompose(
+					acctest.ConfigDefaultTags_Tags1("providerkey1", "providervalue1"),
+					testAccVPCConnectorConfig_basic(rName),
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCConnectorExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.providerkey1", "providervalue1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: acctest.ConfigCompose(
+					acctest.ConfigDefaultTags_Tags2("providerkey1", "providervalue1", "providerkey2", "providervalue2"),
+					testAccVPCConnectorConfig_basic(rName),
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCConnectorExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.providerkey1", "providervalue1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.providerkey2", "providervalue2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckVPCConnectorDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_apprunner_vpc_connector" {


### PR DESCRIPTION
### Description
Fixes the bug where `default_tags` from the provider is not handled correctly by `aws_apprunner_vpc_connector`

### Relations

Closes #28634 


### Output from Acceptance Testing

```
❯ make testacc PKG=apprunner TESTS=TestAccAppRunnerVPCConnector
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apprunner/... -v -count 1 -parallel 20 -run='TestAccAppRunnerVPCConnector'  -timeout 180m
=== RUN   TestAccAppRunnerVPCConnector_basic
=== PAUSE TestAccAppRunnerVPCConnector_basic
=== RUN   TestAccAppRunnerVPCConnector_disappears
=== PAUSE TestAccAppRunnerVPCConnector_disappears
=== RUN   TestAccAppRunnerVPCConnector_tags
=== PAUSE TestAccAppRunnerVPCConnector_tags
=== RUN   TestAccAppRunnerVPCConnector_defaultTags
=== PAUSE TestAccAppRunnerVPCConnector_defaultTags
=== CONT  TestAccAppRunnerVPCConnector_basic
=== CONT  TestAccAppRunnerVPCConnector_tags
=== CONT  TestAccAppRunnerVPCConnector_defaultTags
=== CONT  TestAccAppRunnerVPCConnector_disappears
--- PASS: TestAccAppRunnerVPCConnector_disappears (78.07s)
--- PASS: TestAccAppRunnerVPCConnector_basic (90.53s)
--- PASS: TestAccAppRunnerVPCConnector_defaultTags (99.82s)
--- PASS: TestAccAppRunnerVPCConnector_tags (155.93s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apprunner	183.850s
```
