### PR TITLE
release/2.x: Correct release incantation for Terraform CLI 0.11 & 0.12 support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,8 +10,8 @@ before:
     - 'go mod download'
 builds:
   -
-    # Binary naming only required for Terraform CLI 0.12
-    binary: '{{ .ProjectName }}_{{ .Version }}'
+    # _x4 suffix required for Terraform CLI < 0.12
+    binary: '{{ .ProjectName }}_{{ .Version }}_x4'
     env:
       - CGO_ENABLED=0
     flags:
@@ -45,13 +45,11 @@ checksum:
 publishers:
   - checksum: true
     # Terraform CLI 0.10 - 0.11 perform discovery via HTTP headers on releases.hashicorp.com
-    # For providers which have existed since those CLI versions, exclude
-    # discovery by setting the protocol version headers to 5.
     env:
       - HC_RELEASES_HOST={{ .Env.HC_RELEASES_HOST }}
       - HC_RELEASES_KEY={{ .Env.HC_RELEASES_KEY }}
     cmd: |
-      hc-releases upload -product {{ .ProjectName }} -version {{ .Version }} -file={{ .ArtifactPath }}={{ .ArtifactName }} -header=x-terraform-protocol-version=5 -header=x-terraform-protocol-versions=5.0
+      hc-releases upload -product {{ .ProjectName }} -version {{ .Version }} -file={{ .ArtifactPath }}={{ .ArtifactName }} -header=x-terraform-protocol-version=4 -header=x-terraform-protocol-versions=4.0,5.0
     name: upload
     signature: true
 release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 2.70.3 (Unreleased)
+
+BUG FIXES:
+
+* provider: Fix Terraform v0.12 `failed to find installed plugin version 2.70.2` error ([#28739](https://github.com/hashicorp/terraform-provider-aws/issues/28739))
+
 ## 2.70.2 (January 05, 2023)
 
 NOTES:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Corrects the built binary filename (adds `_x4` suffix) and HTTP headers to allow TF CLI versions 0.11 and 0.12 to install the **v2._x_** provider.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/28706.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28698.
