### PR TITLE
release/2.x: Correct `x-terraform-protocol-versions` HTTP header value

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,7 @@ publishers:
       - HC_RELEASES_HOST={{ .Env.HC_RELEASES_HOST }}
       - HC_RELEASES_KEY={{ .Env.HC_RELEASES_KEY }}
     cmd: |
-      hc-releases upload -product {{ .ProjectName }} -version {{ .Version }} -file={{ .ArtifactPath }}={{ .ArtifactName }} -header=x-terraform-protocol-version=4 -header=x-terraform-protocol-versions=4.0,5.0
+      hc-releases upload -product {{ .ProjectName }} -version {{ .Version }} -file={{ .ArtifactPath }}={{ .ArtifactName }} -header=x-terraform-protocol-version=4 -header="x-terraform-protocol-versions=4.0, 5.0"
     name: upload
     signature: true
 release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 2.70.4 (Unreleased)
+
+BUG FIXES:
+
+* provider: Fix Terraform v0.12 `incompatible provider version` error with provider v2.70.3 ([#28743](https://github.com/hashicorp/terraform-provider-aws/issues/28743))
+
 ## 2.70.3 (January 06, 2023)
 
 BUG FIXES:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Add a missing space character for the `x-terraform-protocol-versions` HTTP header value separator.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28743.