### PR TITLE
dms/repl_subnet_grp: Fix inconsistent result after apply

### DIFF
--- a/.changelog/28748.txt
+++ b/.changelog/28748.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dms_replication_subnet_group: Fix error ("Provider produced inconsistent result") when an error is encountered during creation
+```

--- a/internal/service/dms/replication_subnet_group.go
+++ b/internal/service/dms/replication_subnet_group.go
@@ -133,7 +133,7 @@ func resourceReplicationSubnetGroupRead(d *schema.ResourceData, meta interface{}
 		},
 	})
 	if err != nil {
-		return err
+		return create.Error(names.DMS, create.ErrActionReading, ResNameReplicationSubnetGroup, d.Id(), err)
 	}
 	if len(response.ReplicationSubnetGroups) == 0 {
 		d.SetId("")
@@ -153,24 +153,24 @@ func resourceReplicationSubnetGroupRead(d *schema.ResourceData, meta interface{}
 
 	err = resourceReplicationSubnetGroupSetState(d, response.ReplicationSubnetGroups[0])
 	if err != nil {
-		return err
+		return create.Error(names.DMS, create.ErrActionReading, ResNameReplicationSubnetGroup, d.Id(), err)
 	}
 
 	tags, err := ListTags(conn, arn)
 
 	if err != nil {
-		return fmt.Errorf("error listing tags for DMS Replication Subnet Group (%s): %s", arn, err)
+		return create.Error(names.DMS, create.ErrActionReading, ResNameReplicationSubnetGroup, d.Id(), err)
 	}
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
+		return create.SettingError(names.DMS, ResNameReplicationSubnetGroup, d.Id(), "tags", err)
 	}
 
 	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return fmt.Errorf("error setting tags_all: %w", err)
+		return create.SettingError(names.DMS, ResNameReplicationSubnetGroup, d.Id(), "tags_all", err)
 	}
 
 	return nil
@@ -195,7 +195,7 @@ func resourceReplicationSubnetGroupUpdate(d *schema.ResourceData, meta interface
 		o, n := d.GetChange("tags_all")
 
 		if err := UpdateTags(conn, arn, o, n); err != nil {
-			return fmt.Errorf("error updating DMS Replication Subnet Group (%s) tags: %s", arn, err)
+			return create.Error(names.DMS, create.ErrActionUpdating, ResNameReplicationSubnetGroup, d.Id(), err)
 		}
 	}
 
@@ -203,7 +203,7 @@ func resourceReplicationSubnetGroupUpdate(d *schema.ResourceData, meta interface
 
 	_, err := conn.ModifyReplicationSubnetGroup(request)
 	if err != nil {
-		return err
+		return create.Error(names.DMS, create.ErrActionUpdating, ResNameReplicationSubnetGroup, d.Id(), err)
 	}
 
 	return resourceReplicationSubnetGroupRead(d, meta)
@@ -219,7 +219,7 @@ func resourceReplicationSubnetGroupDelete(d *schema.ResourceData, meta interface
 	log.Printf("[DEBUG] DMS delete replication subnet group: %#v", request)
 
 	_, err := conn.DeleteReplicationSubnetGroup(request)
-	return err
+	return create.Error(names.DMS, create.ErrActionDeleting, ResNameReplicationSubnetGroup, d.Id(), err)
 }
 
 func resourceReplicationSubnetGroupSetState(d *schema.ResourceData, group *dms.ReplicationSubnetGroup) error {

--- a/internal/service/dms/replication_subnet_group.go
+++ b/internal/service/dms/replication_subnet_group.go
@@ -132,9 +132,17 @@ func resourceReplicationSubnetGroupRead(d *schema.ResourceData, meta interface{}
 			},
 		},
 	})
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		create.LogNotFoundRemoveState(names.DMS, create.ErrActionReading, ResNameReplicationSubnetGroup, d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return create.Error(names.DMS, create.ErrActionReading, ResNameReplicationSubnetGroup, d.Id(), err)
 	}
+
 	if len(response.ReplicationSubnetGroups) == 0 {
 		d.SetId("")
 		return nil
@@ -219,7 +227,12 @@ func resourceReplicationSubnetGroupDelete(d *schema.ResourceData, meta interface
 	log.Printf("[DEBUG] DMS delete replication subnet group: %#v", request)
 
 	_, err := conn.DeleteReplicationSubnetGroup(request)
-	return create.Error(names.DMS, create.ErrActionDeleting, ResNameReplicationSubnetGroup, d.Id(), err)
+
+	if err != nil {
+		return create.Error(names.DMS, create.ErrActionDeleting, ResNameReplicationSubnetGroup, d.Id(), err)
+	}
+
+	return nil
 }
 
 func resourceReplicationSubnetGroupSetState(d *schema.ResourceData, group *dms.ReplicationSubnetGroup) error {

--- a/website/docs/r/dms_replication_subnet_group.html.markdown
+++ b/website/docs/r/dms_replication_subnet_group.html.markdown
@@ -10,21 +10,71 @@ description: |-
 
 Provides a DMS (Data Migration Service) replication subnet group resource. DMS replication subnet groups can be created, updated, deleted, and imported.
 
+~> **Note:** AWS requires a special IAM role called `dms-vpc-role` when using this resource. See the example below to create it as part of your configuration.
+
 ## Example Usage
+
+### Basic
 
 ```terraform
 # Create a new replication subnet group
-resource "aws_dms_replication_subnet_group" "test" {
-  replication_subnet_group_description = "Test replication subnet group"
-  replication_subnet_group_id          = "test-dms-replication-subnet-group-tf"
+resource "aws_dms_replication_subnet_group" "example" {
+  replication_subnet_group_description = "Example replication subnet group"
+  replication_subnet_group_id          = "example-dms-replication-subnet-group-tf"
 
   subnet_ids = [
     "subnet-12345678",
+    "subnet-12345679",
   ]
 
   tags = {
-    Name = "test"
+    Name = "example"
   }
+}
+```
+
+### Creating special IAM role
+
+If your account does not already include the `dms-vpc-role` IAM role, you will need to create it to allow DMS to manage subnets in the VPC.
+
+```terraform
+resource "aws_iam_role" "dms-vpc-role" {
+  name        = "dms-vpc-role"
+  description = "Allows DMS to manage VPC"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "dms.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "example" {
+  role       = aws_iam_role.dms-vpc-role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonDMSVPCManagementRole"
+}
+
+resource "aws_dms_replication_subnet_group" "example" {
+  replication_subnet_group_description = "Example"
+  replication_subnet_group_id          = "example-id"
+
+  subnet_ids = [
+    "subnet-12345678",
+    "subnet-12345679",
+  ]
+
+  tags = {
+    Name = "example-id"
+  }
+
+  # explicit depends_on is needed since this resource doesn't reference the role or policy attachment
+  depends_on = [aws_iam_role_policy_attachment.example]
 }
 ```
 
@@ -32,14 +82,10 @@ resource "aws_dms_replication_subnet_group" "test" {
 
 The following arguments are supported:
 
-* `replication_subnet_group_description` - (Required) The description for the subnet group.
-* `replication_subnet_group_id` - (Required) The name for the replication subnet group. This value is stored as a lowercase string.
-
-    - Must contain no more than 255 alphanumeric characters, periods, spaces, underscores, or hyphens.
-    - Must not be "default".
-
-* `subnet_ids` - (Required) A list of the EC2 subnet IDs for the subnet group.
-* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `replication_subnet_group_description` - (Required) Description for the subnet group.
+* `replication_subnet_group_id` - (Required) Name for the replication subnet group. This value is stored as a lowercase string. It must contain no more than 255 alphanumeric characters, periods, spaces, underscores, or hyphens and cannot be `default`.
+* `subnet_ids` - (Required) List of at least 2 EC2 subnet IDs for the subnet group. The subnets must cover at least 2 availability zones.
+* `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference
 
@@ -47,6 +93,14 @@ In addition to all arguments above, the following attributes are exported:
 
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `vpc_id` - The ID of the VPC the subnet group is in.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `create` - (Default `15m`)
+- `update` - (Default `15m`)
+- `delete` - (Default `15m`)
 
 ## Import
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This resolves 3 different problems with `aws_dms_replication_subnet_group`:

1. Inconsistent result error: This happens because of a code bug. If there's a non-timeout error during creation, instead of returning the error, it ignores it. On the `read`, when there is no resource found, there's no check for it being not found. 
2. Documenting the need to use subnets that cover 2 AZs and, thus, requiring at least 2 subnet IDs.
3. Documenting having the IAM role `dms-vpc-role` in place.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27420

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
% make testacc TESTS=TestAccDMSReplicationSubnetGroup_ PKG=dms
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dms/... -v -count 1 -parallel 20 -run='TestAccDMSReplicationSubnetGroup_'  -timeout 180m
=== RUN   TestAccDMSReplicationSubnetGroup_basic
=== PAUSE TestAccDMSReplicationSubnetGroup_basic
=== CONT  TestAccDMSReplicationSubnetGroup_basic
--- PASS: TestAccDMSReplicationSubnetGroup_basic (42.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dms	44.646s
```
