### PR TITLE
r/aws_redshiftdata_statement - add `workgroup_name`

### DIFF
--- a/.changelog/28751.txt
+++ b/.changelog/28751.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_redshiftdata_statement: Add `workgroup_name` argument
+```

--- a/internal/service/redshiftdata/statement_test.go
+++ b/internal/service/redshiftdata/statement_test.go
@@ -124,12 +124,12 @@ resource "aws_redshiftdata_statement" "test" {
 func testAccStatementConfig_workgroup(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshiftserverless_namespace" "test" {
-	namespace_name = %[1]q
+  namespace_name = %[1]q
 }
 
 resource "aws_redshiftserverless_workgroup" "test" {
-	namespace_name = aws_redshiftserverless_namespace.test.namespace_name
-	workgroup_name = %[1]q
+  namespace_name = aws_redshiftserverless_namespace.test.namespace_name
+  workgroup_name = %[1]q
 }
 
 resource "aws_redshiftdata_statement" "test" {

--- a/internal/service/redshiftserverless/workgroup.go
+++ b/internal/service/redshiftserverless/workgroup.go
@@ -116,14 +116,14 @@ func ResourceWorkgroup() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-			"publicly_accessible": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
 			"namespace_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+			},
+			"publicly_accessible": {
+				Type:     schema.TypeBool,
+				Optional: true,
 			},
 			"security_group_ids": {
 				Type:     schema.TypeSet,
@@ -227,14 +227,14 @@ func resourceWorkgroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	arn := aws.StringValue(out.WorkgroupArn)
 	d.Set("arn", arn)
-	d.Set("namespace_name", out.NamespaceName)
-	d.Set("workgroup_name", out.WorkgroupName)
-	d.Set("workgroup_id", out.WorkgroupId)
 	d.Set("base_capacity", out.BaseCapacity)
 	d.Set("enhanced_vpc_routing", out.EnhancedVpcRouting)
+	d.Set("namespace_name", out.NamespaceName)
 	d.Set("publicly_accessible", out.PubliclyAccessible)
 	d.Set("security_group_ids", flex.FlattenStringSet(out.SecurityGroupIds))
 	d.Set("subnet_ids", flex.FlattenStringSet(out.SubnetIds))
+	d.Set("workgroup_id", out.WorkgroupId)
+	d.Set("workgroup_name", out.WorkgroupName)
 	if err := d.Set("config_parameter", flattenConfigParameters(out.ConfigParameters)); err != nil {
 		return fmt.Errorf("setting config_parameter: %w", err)
 	}

--- a/website/docs/r/redshiftdata_statement.html.markdown
+++ b/website/docs/r/redshiftdata_statement.html.markdown
@@ -12,6 +12,8 @@ Executes a Redshift Data Statement.
 
 ## Example Usage
 
+### cluster_identifier
+
 ```terraform
 resource "aws_redshiftdata_statement" "example" {
   cluster_identifier = aws_redshift_cluster.example.cluster_identifier
@@ -21,17 +23,31 @@ resource "aws_redshiftdata_statement" "example" {
 }
 ```
 
+### workgroup_name
+
+```terraform
+resource "aws_redshiftdata_statement" "example" {
+  workgroup_name = aws_redshiftserverless_workgroup.example.workgroup_name
+  database       = "dev"
+  sql            = "CREATE GROUP group_name;"
+}
+```
+
 ## Argument Reference
 
-The following arguments are supported:
+The following arguments are required:
 
-* `cluster_identifier` - (Required) The cluster identifier.
 * `database` - (Required) The name of the database.
+* `sql` - (Required) The SQL statement text to run.
+
+The following arguments are optional:
+
+* `cluster_identifier` - (Optional) The cluster identifier. This parameter is required when connecting to a cluster and authenticating using either Secrets Manager or temporary credentials.
 * `db_user` - (Optional) The database user name.
 * `secret_arn` - (Optional) The name or ARN of the secret that enables access to the database.
-* `sql` - (Required) The SQL statement text to run.
 * `statement_name` - (Optional) The name of the SQL statement. You can name the SQL statement when you create it to identify the query.
 * `with_event` - (Optional) A value that indicates whether to send an event to the Amazon EventBridge event bus after the SQL statement runs.
+* `workgroup_name` - (Optional) The serverless workgroup name. This parameter is required when connecting to a serverless workgroup and authenticating using either Secrets Manager or temporary credentials.
 
 ## Attributes Reference
 

--- a/website/docs/r/redshiftserverless_workgroup.html.markdown
+++ b/website/docs/r/redshiftserverless_workgroup.html.markdown
@@ -21,7 +21,12 @@ resource "aws_redshiftserverless_workgroup" "example" {
 
 ## Argument Reference
 
-The following arguments are supported:
+The following arguments are required:
+
+* `namespace_name` - (Required) The name of the namespace.
+* `workgroup_name` - (Required) The name of the workgroup.
+
+The following arguments are optional:
 
 * `base_capacity` - (Optional) The base data warehouse capacity of the workgroup in Redshift Processing Units (RPUs).
 * `config_parameter` - (Optional) An array of parameters to set for more control over a serverless database. See `Config Parameter` below.
@@ -29,7 +34,6 @@ The following arguments are supported:
 * `publicly_accessible` - (Optional) A value that specifies whether the workgroup can be accessed from a public network.
 * `security_group_ids` - (Optional) An array of security group IDs to associate with the workgroup.
 * `subnet_ids` - (Optional) An array of VPC subnet IDs to associate with the workgroup.
-* `workgroup_name` - (Required) The name of the workgroup.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Config Parameter


### PR DESCRIPTION
### Description
Add support for Redshift serverless by adding `workgroup_name` to `aws_redshiftdata_statement`

### Relations
Closes [#26346](https://github.com/hashicorp/terraform-provider-aws/issues/26346)

### Output from Acceptance Testing
```
make testacc TESTS='TestAccRedshiftDataStatement_workgroup' PKG=redshiftdata
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/redshiftdata/... -v -count 1 -parallel 20 -run='TestAccRedshiftDataStatement_workgroup'  -timeout 180m
=== RUN   TestAccRedshiftDataStatement_workgroup
=== PAUSE TestAccRedshiftDataStatement_workgroup
=== CONT  TestAccRedshiftDataStatement_workgroup
--- PASS: TestAccRedshiftDataStatement_workgroup (533.57s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshiftdata       547.531s
```
