### PR TITLE
r/aws_evidently_launch

### DIFF
--- a/.changelog/28752.txt
+++ b/.changelog/28752.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_evidently_launch
+```

--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -53,11 +53,20 @@ func FlattenStringValueList(list []string) []interface{} {
 	return vs
 }
 
-// Expands a map of string to interface to a map of string to *int32
+// Expands a map of string to interface to a map of string to int32
 func ExpandInt32Map(m map[string]interface{}) map[string]int32 {
 	intMap := make(map[string]int32, len(m))
 	for k, v := range m {
 		intMap[k] = int32(v.(int))
+	}
+	return intMap
+}
+
+// Expands a map of string to interface to a map of string to *int64
+func ExpandInt64Map(m map[string]interface{}) map[string]*int64 {
+	intMap := make(map[string]*int64, len(m))
+	for k, v := range m {
+		intMap[k] = aws.Int64(int64(v.(int)))
 	}
 	return intMap
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1532,6 +1532,7 @@ func New(ctx context.Context) (*schema.Provider, error) {
 			"aws_emrserverless_application": emrserverless.ResourceApplication(),
 
 			"aws_evidently_feature": evidently.ResourceFeature(),
+			"aws_evidently_launch":  evidently.ResourceLaunch(),
 			"aws_evidently_project": evidently.ResourceProject(),
 			"aws_evidently_segment": evidently.ResourceSegment(),
 

--- a/internal/service/evidently/find.go
+++ b/internal/service/evidently/find.go
@@ -36,6 +36,32 @@ func FindFeatureWithProjectNameorARN(ctx context.Context, conn *cloudwatcheviden
 	return output.Feature, nil
 }
 
+func FindLaunchWithProjectNameorARN(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, launchName, projectNameOrARN string) (*cloudwatchevidently.Launch, error) {
+	input := &cloudwatchevidently.GetLaunchInput{
+		Launch:  aws.String(launchName),
+		Project: aws.String(projectNameOrARN),
+	}
+
+	output, err := conn.GetLaunchWithContext(ctx, input)
+
+	if tfawserr.ErrCodeEquals(err, cloudwatchevidently.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Launch == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.Launch, nil
+}
+
 func FindProjectByNameOrARN(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string) (*cloudwatchevidently.Project, error) {
 	input := &cloudwatchevidently.GetProjectInput{
 		Project: aws.String(nameOrARN),

--- a/internal/service/evidently/launch.go
+++ b/internal/service/evidently/launch.go
@@ -381,16 +381,16 @@ func resourceLaunchRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.Errorf("setting scheduled_splits_config: %s", err)
 	}
 
-	d.Set("arn", aws.StringValue(launch.Arn))
+	d.Set("arn", launch.Arn)
 	d.Set("created_time", aws.TimeValue(launch.CreatedTime).Format(time.RFC3339))
-	d.Set("description", aws.StringValue(launch.Description))
+	d.Set("description", launch.Description)
 	d.Set("last_updated_time", aws.TimeValue(launch.LastUpdatedTime).Format(time.RFC3339))
-	d.Set("name", aws.StringValue(launch.Name))
-	d.Set("project", aws.StringValue(launch.Project))
-	d.Set("randomization_salt", aws.StringValue(launch.RandomizationSalt))
-	d.Set("status", aws.StringValue(launch.Status))
-	d.Set("status_reason", aws.StringValue(launch.StatusReason))
-	d.Set("type", aws.StringValue(launch.Type))
+	d.Set("name", launch.Name)
+	d.Set("project", launch.Project)
+	d.Set("randomization_salt", launch.RandomizationSalt)
+	d.Set("status", launch.Status)
+	d.Set("status_reason", launch.StatusReason)
+	d.Set("type", launch.Type)
 
 	tags := KeyValueTags(launch.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 

--- a/internal/service/evidently/launch.go
+++ b/internal/service/evidently/launch.go
@@ -24,10 +24,10 @@ import (
 
 func ResourceLaunch() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceLaunchCreate,
-		ReadContext:   resourceLaunchRead,
-		UpdateContext: resourceLaunchUpdate,
-		DeleteContext: resourceLaunchDelete,
+		CreateWithoutTimeout: resourceLaunchCreate,
+		ReadWithoutTimeout:   resourceLaunchRead,
+		UpdateWithoutTimeout: resourceLaunchUpdate,
+		DeleteWithoutTimeout: resourceLaunchDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,

--- a/internal/service/evidently/launch.go
+++ b/internal/service/evidently/launch.go
@@ -1,0 +1,276 @@
+package evidently
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func ResourceLaunch() *schema.Resource {
+	return &schema.Resource{
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(2 * time.Minute),
+			Update: schema.DefaultTimeout(2 * time.Minute),
+			Delete: schema.DefaultTimeout(2 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 160),
+			},
+			"execution": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ended_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"started_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"groups": {
+				Type:     schema.TypeList,
+				Required: true,
+				MinItems: 1,
+				MaxItems: 5,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"description": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(0, 160),
+						},
+						"feature": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.All(
+								validation.StringLenBetween(1, 127),
+								validation.StringMatch(regexp.MustCompile(`^[-a-zA-Z0-9._]*$`), "alphanumeric and can contain hyphens, underscores, and periods"),
+							),
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.All(
+								validation.StringLenBetween(1, 127),
+								validation.StringMatch(regexp.MustCompile(`^[-a-zA-Z0-9._]*$`), "alphanumeric and can contain hyphens, underscores, and periods"),
+							),
+						},
+						"variation": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.All(
+								validation.StringLenBetween(1, 127),
+								validation.StringMatch(regexp.MustCompile(`^[-a-zA-Z0-9._]*$`), "alphanumeric and can contain hyphens, underscores, and periods"),
+							),
+						},
+					},
+				},
+			},
+			"last_updated_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"metric_monitors": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MinItems: 0,
+				MaxItems: 3,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"metric_definition": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"entity_id_key": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringLenBetween(1, 256),
+									},
+									"event_pattern": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ValidateFunc: validation.All(
+											validation.StringLenBetween(0, 1024),
+											validation.StringIsJSON,
+										),
+										DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+										StateFunc: func(v interface{}) string {
+											json, _ := structure.NormalizeJsonString(v)
+											return json
+										},
+									},
+									"name": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringLenBetween(1, 255),
+									},
+									"unit_label": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringLenBetween(1, 256),
+									},
+									"value_key": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringLenBetween(1, 256),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 127),
+					validation.StringMatch(regexp.MustCompile(`^[-a-zA-Z0-9._]*$`), "alphanumeric and can contain hyphens, underscores, and periods"),
+				),
+			},
+			"project": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 2048),
+					validation.StringMatch(regexp.MustCompile(`(^[a-zA-Z0-9._-]*$)|(arn:[^:]*:[^:]*:[^:]*:[^:]*:project/[a-zA-Z0-9._-]*)`), "name or arn of the project"),
+				),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// case 1: User-defined string (old) is a name and is the suffix of API-returned string (new). Check non-empty old in resoure creation scenario
+					// case 2: after setting API-returned string.  User-defined string (new) is suffix of API-returned string (old)
+					return (strings.HasSuffix(new, old) && old != "") || strings.HasSuffix(old, new)
+				},
+			},
+			"randomization_salt": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 127),
+				// Default: set to the launch name if not specified
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return old == d.Get("name").(string) && new == ""
+				},
+			},
+			"scheduled_splits_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"steps": {
+							Type:     schema.TypeList,
+							Required: true,
+							MinItems: 1,
+							MaxItems: 6,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"group_weights": {
+										Type:     schema.TypeMap,
+										Required: true,
+										ValidateDiagFunc: verify.ValidAllDiag(
+											validation.MapKeyLenBetween(1, 127),
+											validation.MapKeyMatch(regexp.MustCompile(`^[-a-zA-Z0-9._]*$`), "alphanumeric and can contain hyphens, underscores, and periods"),
+										),
+										Elem: &schema.Schema{
+											Type:         schema.TypeInt,
+											ValidateFunc: validation.IntBetween(0, 100000),
+										},
+									},
+									"segment_overrides": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MinItems: 0,
+										MaxItems: 6,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"evaluation_order": {
+													Type:     schema.TypeInt,
+													Required: true,
+												},
+												"segment": {
+													Type:     schema.TypeString,
+													Required: true,
+													ValidateFunc: validation.All(
+														validation.StringLenBetween(0, 2048),
+														validation.StringMatch(regexp.MustCompile(`(^[a-zA-Z0-9._-]*$)|(arn:[^:]*:[^:]*:[^:]*:[^:]*:segment/[a-zA-Z0-9._-]*)`), "name or arn of the segment"),
+													),
+													DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+														// case 1: User-defined string (old) is a name and is the suffix of API-returned string (new). Check non-empty old in resoure creation scenario
+														// case 2: after setting API-returned string.  User-defined string (new) is suffix of API-returned string (old)
+														return (strings.HasSuffix(new, old) && old != "") || strings.HasSuffix(old, new)
+													},
+												},
+												"weights": {
+													Type:     schema.TypeMap,
+													Required: true,
+													ValidateDiagFunc: verify.ValidAllDiag(
+														validation.MapKeyLenBetween(1, 127),
+														validation.MapKeyMatch(regexp.MustCompile(`^[-a-zA-Z0-9._]*$`), "alphanumeric and can contain hyphens, underscores, and periods"),
+													),
+													Elem: &schema.Schema{
+														Type:         schema.TypeInt,
+														ValidateFunc: validation.IntBetween(0, 100000),
+													},
+												},
+											},
+										},
+									},
+									"start_time": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: verify.ValidUTCTimestamp,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status_reason": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}

--- a/internal/service/evidently/launch.go
+++ b/internal/service/evidently/launch.go
@@ -1,19 +1,29 @@
 package evidently
 
 import (
+	"context"
+	"fmt"
+	"log"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func ResourceLaunch() *schema.Resource {
 	return &schema.Resource{
+		ReadContext: resourceLaunchRead,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -273,4 +283,265 @@ func ResourceLaunch() *schema.Resource {
 		},
 		CustomizeDiff: verify.SetTagsDiff,
 	}
+}
+
+func resourceLaunchRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).EvidentlyConn()
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	launchName, projectNameOrARN, err := LaunchParseID(d.Id())
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	launch, err := FindLaunchWithProjectNameorARN(ctx, conn, launchName, projectNameOrARN)
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] CloudWatch Evidently Launch (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("reading CloudWatch Evidently Launch (%s) for Project (%s): %s", launchName, projectNameOrARN, err)
+	}
+
+	if err := d.Set("execution", flattenExecution(launch.Execution)); err != nil {
+		return diag.Errorf("setting execution: %s", err)
+	}
+
+	if err := d.Set("groups", flattenGroups(launch.Groups)); err != nil {
+		return diag.Errorf("setting groups: %s", err)
+	}
+
+	if err := d.Set("metric_monitors", flattenMetricMonitors(launch.MetricMonitors)); err != nil {
+		return diag.Errorf("setting metric_monitors: %s", err)
+	}
+
+	if err := d.Set("scheduled_splits_config", flattenScheduledSplitsDefinition(launch.ScheduledSplitsDefinition)); err != nil {
+		return diag.Errorf("setting scheduled_splits_config: %s", err)
+	}
+
+	d.Set("arn", aws.StringValue(launch.Arn))
+	d.Set("created_time", aws.TimeValue(launch.CreatedTime).Format(time.RFC3339))
+	d.Set("description", aws.StringValue(launch.Description))
+	d.Set("last_updated_time", aws.TimeValue(launch.LastUpdatedTime).Format(time.RFC3339))
+	d.Set("name", aws.StringValue(launch.Name))
+	d.Set("project", aws.StringValue(launch.Project))
+	d.Set("randomization_salt", aws.StringValue(launch.RandomizationSalt))
+	d.Set("status", aws.StringValue(launch.Status))
+	d.Set("status_reason", aws.StringValue(launch.StatusReason))
+	d.Set("type", aws.StringValue(launch.Type))
+
+	tags := KeyValueTags(launch.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return diag.Errorf("setting tags: %s", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return diag.Errorf("setting tags_all: %s", err)
+	}
+
+	return nil
+}
+
+func LaunchParseID(id string) (string, string, error) {
+	launchName, projectNameOrARN, _ := strings.Cut(id, ":")
+
+	if launchName == "" || projectNameOrARN == "" {
+		return "", "", fmt.Errorf("unexpected format of ID (%s), expected launchName:projectNameOrARN", id)
+	}
+
+	return launchName, projectNameOrARN, nil
+}
+
+func flattenExecution(apiObjects *cloudwatchevidently.LaunchExecution) []interface{} {
+	if apiObjects == nil {
+		return nil
+	}
+
+	values := map[string]interface{}{}
+
+	if apiObjects.EndedTime != nil {
+		values["ended_time"] = aws.TimeValue(apiObjects.EndedTime).Format(time.RFC3339)
+	}
+
+	if apiObjects.StartedTime != nil {
+		values["started_time"] = aws.TimeValue(apiObjects.StartedTime).Format(time.RFC3339)
+	}
+
+	return []interface{}{values}
+}
+
+func flattenGroups(apiObjects []*cloudwatchevidently.LaunchGroup) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		tfList = append(tfList, flattenGroup(apiObject))
+	}
+
+	return tfList
+}
+
+func flattenGroup(apiObject *cloudwatchevidently.LaunchGroup) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{
+		"name": aws.StringValue(apiObject.Name),
+	}
+
+	for feature, variation := range apiObject.FeatureVariations {
+		tfMap["feature"] = feature
+		tfMap["variation"] = aws.StringValue(variation)
+	}
+
+	if v := apiObject.Description; v != nil {
+		tfMap["description"] = aws.StringValue(v)
+	}
+
+	return tfMap
+}
+
+func flattenMetricMonitors(apiObjects []*cloudwatchevidently.MetricMonitor) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		tfList = append(tfList, flattenMetricMonitor(apiObject))
+	}
+
+	return tfList
+}
+
+func flattenMetricMonitor(apiObject *cloudwatchevidently.MetricMonitor) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{
+		"metric_definition": flattenMetricMonitorDefinition(apiObject.MetricDefinition),
+	}
+
+	return tfMap
+}
+
+func flattenMetricMonitorDefinition(apiObject *cloudwatchevidently.MetricDefinition) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{
+		"entity_id_key": aws.StringValue(apiObject.EntityIdKey),
+		"name":          aws.StringValue(apiObject.Name),
+		"value_key":     aws.StringValue(apiObject.ValueKey),
+	}
+
+	if v := apiObject.EventPattern; v != nil {
+		tfMap["event_pattern"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.UnitLabel; v != nil {
+		tfMap["unit_label"] = aws.StringValue(v)
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenScheduledSplitsDefinition(apiObject *cloudwatchevidently.ScheduledSplitsLaunchDefinition) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{
+		"steps": flattenSteps(apiObject.Steps),
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenSteps(apiObjects []*cloudwatchevidently.ScheduledSplit) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		tfList = append(tfList, flattenStep(apiObject))
+	}
+
+	return tfList
+}
+
+func flattenStep(apiObject *cloudwatchevidently.ScheduledSplit) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{
+		"group_weights": aws.Int64ValueMap(apiObject.GroupWeights),
+		"start_time":    aws.TimeValue(apiObject.StartTime).Format(time.RFC3339),
+	}
+
+	if v := apiObject.SegmentOverrides; v != nil {
+		tfMap["segment_overrides"] = flattenSegmentOverrides(v)
+	}
+
+	return tfMap
+}
+
+func flattenSegmentOverrides(apiObjects []*cloudwatchevidently.SegmentOverride) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		tfList = append(tfList, flattenSegmentOverride(apiObject))
+	}
+
+	return tfList
+}
+
+func flattenSegmentOverride(apiObject *cloudwatchevidently.SegmentOverride) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{
+		"evaluation_order": aws.Int64Value(apiObject.EvaluationOrder),
+		"segment":          aws.StringValue(apiObject.Segment),
+		"weights":          aws.Int64ValueMap(apiObject.Weights),
+	}
+
+	return tfMap
 }

--- a/internal/service/evidently/launch_test.go
+++ b/internal/service/evidently/launch_test.go
@@ -416,6 +416,115 @@ func TestAccEvidentlyLaunch_scheduledSplitsConfig_updateSteps(t *testing.T) {
 	})
 }
 
+func TestAccEvidentlyLaunch_scheduledSplitsConfig_steps_updateSegmentOverrides(t *testing.T) {
+	var launch cloudwatchevidently.Launch
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName4 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName5 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName6 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	startTime := time.Now().AddDate(0, 0, 2).Format("2006-01-02T15:04:05Z")
+	resourceName := "aws_evidently_launch.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(cloudwatchevidently.EndpointsID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLaunchDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLaunchConfig_scheduledSplitsConfigStepsOneSegmentOverrideConfig(rName, rName2, rName3, rName4, rName5, rName6, startTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchExists(resourceName, &launch),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.Variation1", "0"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.0.evaluation_order", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.0.segment", "aws_evidently_segment.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.0.weights.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.0.weights.Variation1", "20000"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.start_time", startTime),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccLaunchConfig_scheduledSplitsConfigStepsTwoSegmentOverridesConfig(rName, rName2, rName3, rName4, rName5, rName6, startTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchExists(resourceName, &launch),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.Variation1", "0"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.0.evaluation_order", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.0.segment", "aws_evidently_segment.test3", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.0.weights.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.0.weights.Variation2", "10000"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.1.evaluation_order", "2"),
+					resource.TestCheckResourceAttrPair(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.1.segment", "aws_evidently_segment.test2", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.1.weights.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.1.weights.Variation1", "40000"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.1.weights.Variation2", "30000"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.start_time", startTime),
+				),
+			},
+			{
+				Config: testAccLaunchConfig_scheduledSplitsConfigStepsThreeSegmentOverridesConfig(rName, rName2, rName3, rName4, rName5, rName6, startTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchExists(resourceName, &launch),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.Variation1", "0"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.0.evaluation_order", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.0.segment", "aws_evidently_segment.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.0.weights.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.0.weights.Variation2", "5000"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.1.evaluation_order", "3"),
+					resource.TestCheckResourceAttrPair(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.1.segment", "aws_evidently_segment.test2", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.1.weights.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.1.weights.Variation1", "60000"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.1.weights.Variation2", "70000"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.2.evaluation_order", "4"),
+					resource.TestCheckResourceAttrPair(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.2.segment", "aws_evidently_segment.test3", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.2.weights.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.2.weights.Variation1", "10000"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.2.weights.Variation2", "90000"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.start_time", startTime),
+				),
+			},
+			{
+				Config: testAccLaunchConfig_scheduledSplitsConfigStepsOneSegmentOverrideConfig(rName, rName2, rName3, rName4, rName5, rName6, startTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchExists(resourceName, &launch),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.Variation1", "0"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.0.evaluation_order", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.0.segment", "aws_evidently_segment.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.0.weights.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.segment_overrides.0.weights.Variation1", "20000"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.start_time", startTime),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEvidentlyLaunch_tags(t *testing.T) {
 	var launch cloudwatchevidently.Launch
 
@@ -1001,6 +1110,180 @@ resource "aws_evidently_launch" "test" {
   }
 }
 `, rName3, startTime, startTime2, startTime3))
+}
+
+func testAccLaunchConfigSegmentOverridesBase(rName, rName2, rName3 string) string {
+	return fmt.Sprintf(`
+resource "aws_evidently_segment" "test" {
+  name    = %[1]q
+  pattern = "{\"Price\":[{\"numeric\":[\">\",10,\"<=\",20]}]}"
+}
+
+resource "aws_evidently_segment" "test2" {
+  name    = %[2]q
+  pattern = "{\"Price\":[{\"numeric\":[\">\",10,\"<=\",20]}]}"
+}
+
+resource "aws_evidently_segment" "test3" {
+  name    = %[3]q
+  pattern = "{\"Price\":[{\"numeric\":[\">\",10,\"<=\",20]}]}"
+}
+`, rName, rName2, rName3)
+}
+
+func testAccLaunchConfig_scheduledSplitsConfigStepsOneSegmentOverrideConfig(rName, rName2, rName3, rName4, rName5, rName6, startTime string) string {
+	return acctest.ConfigCompose(
+		testAccLaunchConfigBase(rName, rName2),
+		testAccLaunchConfigSegmentOverridesBase(rName3, rName4, rName5),
+		fmt.Sprintf(`
+resource "aws_evidently_launch" "test" {
+  name    = %[1]q
+  project = aws_evidently_project.test.name
+
+  groups {
+    feature   = aws_evidently_feature.test.name
+    name      = "Variation1"
+    variation = "Variation1"
+  }
+
+  scheduled_splits_config {
+    steps {
+      group_weights = {
+        "Variation1" = 0
+      }
+
+      segment_overrides {
+        evaluation_order = 1
+        segment          = aws_evidently_segment.test.name
+
+        weights = {
+          "Variation1" = 20000
+        }
+      }
+
+      start_time = %[2]q
+    }
+  }
+}
+`, rName6, startTime))
+}
+
+func testAccLaunchConfig_scheduledSplitsConfigStepsTwoSegmentOverridesConfig(rName, rName2, rName3, rName4, rName5, rName6, startTime string) string {
+	return acctest.ConfigCompose(
+		testAccLaunchConfigBase(rName, rName2),
+		testAccLaunchConfigSegmentOverridesBase(rName3, rName4, rName5),
+		fmt.Sprintf(`
+resource "aws_evidently_launch" "test" {
+  name    = %[1]q
+  project = aws_evidently_project.test.name
+
+  groups {
+    feature   = aws_evidently_feature.test.name
+    name      = "Variation1"
+    variation = "Variation1"
+  }
+
+  groups {
+    feature   = aws_evidently_feature.test.name
+    name      = "Variation2"
+    variation = "Variation2"
+  }
+
+  scheduled_splits_config {
+    steps {
+      group_weights = {
+        "Variation1" = 0
+        "Variation2" = 0
+      }
+
+      segment_overrides {
+        evaluation_order = 1
+        segment          = aws_evidently_segment.test3.name
+
+        weights = {
+          "Variation2" = 10000
+        }
+      }
+
+      segment_overrides {
+        evaluation_order = 2
+        segment          = aws_evidently_segment.test2.name
+
+        weights = {
+          "Variation1" = 40000
+          "Variation2" = 30000
+        }
+      }
+
+      start_time = %[2]q
+    }
+  }
+}
+`, rName6, startTime))
+}
+
+func testAccLaunchConfig_scheduledSplitsConfigStepsThreeSegmentOverridesConfig(rName, rName2, rName3, rName4, rName5, rName6, startTime string) string {
+	return acctest.ConfigCompose(
+		testAccLaunchConfigBase(rName, rName2),
+		testAccLaunchConfigSegmentOverridesBase(rName3, rName4, rName5),
+		fmt.Sprintf(`
+resource "aws_evidently_launch" "test" {
+  name    = %[1]q
+  project = aws_evidently_project.test.name
+
+  groups {
+    feature   = aws_evidently_feature.test.name
+    name      = "Variation1"
+    variation = "Variation1"
+  }
+
+  groups {
+    feature   = aws_evidently_feature.test.name
+    name      = "Variation2"
+    variation = "Variation2"
+  }
+
+  scheduled_splits_config {
+    steps {
+      group_weights = {
+        "Variation1" = 0
+        "Variation2" = 0
+      }
+
+      segment_overrides {
+        evaluation_order = 1
+        segment          = aws_evidently_segment.test.name
+
+        weights = {
+          "Variation2" = 5000
+        }
+      }
+
+      segment_overrides {
+        evaluation_order = 3
+        segment          = aws_evidently_segment.test2.name
+
+        weights = {
+          "Variation1" = 60000
+          "Variation2" = 70000
+        }
+      }
+
+      segment_overrides {
+        evaluation_order = 4
+        segment          = aws_evidently_segment.test3.name
+
+        weights = {
+          "Variation1" = 10000
+          "Variation2" = 90000
+        }
+      }
+
+      start_time = %[2]q
+    }
+  }
+}
+`, rName6, startTime))
 }
 
 func testAccLaunchConfig_tags1(rName, rName2, rName3, startTime, tag, value string) string {

--- a/internal/service/evidently/launch_test.go
+++ b/internal/service/evidently/launch_test.go
@@ -605,7 +605,7 @@ func TestAccEvidentlyLaunch_disappears(t *testing.T) {
 				Config: testAccLaunchConfig_basic(rName, rName2, rName3, startTime),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchExists(ctx, resourceName, &launch),
-					acctest.CheckResourceDisappears(acctest.Provider, tfcloudwatchevidently.ResourceLaunch(), resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfcloudwatchevidently.ResourceLaunch(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/service/evidently/launch_test.go
+++ b/internal/service/evidently/launch_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestAccEvidentlyLaunch_basic(t *testing.T) {
+	ctx := acctest.Context(t)
 	var launch cloudwatchevidently.Launch
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -32,12 +33,12 @@ func TestAccEvidentlyLaunch_basic(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckLaunchDestroy,
+		CheckDestroy:             testAccCheckLaunchDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLaunchConfig_basic(rName, rName2, rName3, startTime),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "evidently", fmt.Sprintf("project/%s/launch/%s", rName, rName3)),
 					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
 					// not returned at create time
@@ -70,6 +71,7 @@ func TestAccEvidentlyLaunch_basic(t *testing.T) {
 }
 
 func TestAccEvidentlyLaunch_updateDescription(t *testing.T) {
+	ctx := acctest.Context(t)
 	var launch cloudwatchevidently.Launch
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -87,12 +89,12 @@ func TestAccEvidentlyLaunch_updateDescription(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckLaunchDestroy,
+		CheckDestroy:             testAccCheckLaunchDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLaunchConfig_description(rName, rName2, rName3, startTime, originalDescription),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "description", originalDescription),
 				),
 			},
@@ -104,7 +106,7 @@ func TestAccEvidentlyLaunch_updateDescription(t *testing.T) {
 			{
 				Config: testAccLaunchConfig_description(rName, rName2, rName3, startTime, updatedDescription),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "description", updatedDescription),
 				),
 			},
@@ -113,6 +115,7 @@ func TestAccEvidentlyLaunch_updateDescription(t *testing.T) {
 }
 
 func TestAccEvidentlyLaunch_updateGroups(t *testing.T) {
+	ctx := acctest.Context(t)
 	var launch cloudwatchevidently.Launch
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -130,12 +133,12 @@ func TestAccEvidentlyLaunch_updateGroups(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckLaunchDestroy,
+		CheckDestroy:             testAccCheckLaunchDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLaunchConfig_basic(rName, rName2, rName3, startTime),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "groups.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "groups.0.feature", "aws_evidently_feature.test", "name"),
 					resource.TestCheckResourceAttr(resourceName, "groups.0.name", "Variation1"),
@@ -150,7 +153,7 @@ func TestAccEvidentlyLaunch_updateGroups(t *testing.T) {
 			{
 				Config: testAccLaunchConfig_twoGroups(rName, rName2, rName3, rName4, rName5, startTime),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "groups.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "groups.0.description", "first-group-add-desc"),
 					resource.TestCheckResourceAttrPair(resourceName, "groups.0.feature", "aws_evidently_feature.test", "name"),
@@ -165,7 +168,7 @@ func TestAccEvidentlyLaunch_updateGroups(t *testing.T) {
 			{
 				Config: testAccLaunchConfig_threeGroups(rName, rName2, rName3, rName4, rName5, startTime),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "groups.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "groups.0.description", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "groups.0.feature", "aws_evidently_feature.test", "name"),
@@ -184,7 +187,7 @@ func TestAccEvidentlyLaunch_updateGroups(t *testing.T) {
 			{
 				Config: testAccLaunchConfig_basic(rName, rName2, rName3, startTime),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "groups.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "groups.0.feature", "aws_evidently_feature.test", "name"),
 					resource.TestCheckResourceAttr(resourceName, "groups.0.name", "Variation1"),
@@ -196,6 +199,7 @@ func TestAccEvidentlyLaunch_updateGroups(t *testing.T) {
 }
 
 func TestAccEvidentlyLaunch_updateMetricMonitors(t *testing.T) {
+	ctx := acctest.Context(t)
 	var launch cloudwatchevidently.Launch
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -211,12 +215,12 @@ func TestAccEvidentlyLaunch_updateMetricMonitors(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckLaunchDestroy,
+		CheckDestroy:             testAccCheckLaunchDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLaunchConfig_oneMetricMonitor(rName, rName2, rName3, startTime),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "metric_monitors.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.0.entity_id_key", "entity_id_key1"),
@@ -234,7 +238,7 @@ func TestAccEvidentlyLaunch_updateMetricMonitors(t *testing.T) {
 			{
 				Config: testAccLaunchConfig_twoMetricMonitors(rName, rName2, rName3, startTime),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "metric_monitors.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.0.entity_id_key", "entity_id_key1a"),
@@ -253,7 +257,7 @@ func TestAccEvidentlyLaunch_updateMetricMonitors(t *testing.T) {
 			{
 				Config: testAccLaunchConfig_threeMetricMonitors(rName, rName2, rName3, startTime),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "metric_monitors.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.0.entity_id_key", "entity_id_key1b"),
@@ -276,7 +280,7 @@ func TestAccEvidentlyLaunch_updateMetricMonitors(t *testing.T) {
 			{
 				Config: testAccLaunchConfig_basic(rName, rName2, rName3, startTime),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "metric_monitors.#", "0"),
 				),
 			},
@@ -285,6 +289,7 @@ func TestAccEvidentlyLaunch_updateMetricMonitors(t *testing.T) {
 }
 
 func TestAccEvidentlyLaunch_updateRandomizationSalt(t *testing.T) {
+	ctx := acctest.Context(t)
 	var launch cloudwatchevidently.Launch
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -302,12 +307,12 @@ func TestAccEvidentlyLaunch_updateRandomizationSalt(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckLaunchDestroy,
+		CheckDestroy:             testAccCheckLaunchDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLaunchConfig_randomizationSalt(rName, rName2, rName3, startTime, originalRandomizationSalt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "randomization_salt", originalRandomizationSalt),
 				),
 			},
@@ -319,7 +324,7 @@ func TestAccEvidentlyLaunch_updateRandomizationSalt(t *testing.T) {
 			{
 				Config: testAccLaunchConfig_randomizationSalt(rName, rName2, rName3, startTime, updatedRandomizationSalt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "randomization_salt", updatedRandomizationSalt),
 				),
 			},
@@ -328,6 +333,7 @@ func TestAccEvidentlyLaunch_updateRandomizationSalt(t *testing.T) {
 }
 
 func TestAccEvidentlyLaunch_scheduledSplitsConfig_updateSteps(t *testing.T) {
+	ctx := acctest.Context(t)
 	var launch cloudwatchevidently.Launch
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -347,12 +353,12 @@ func TestAccEvidentlyLaunch_scheduledSplitsConfig_updateSteps(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckLaunchDestroy,
+		CheckDestroy:             testAccCheckLaunchDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLaunchConfig_basic(rName, rName2, rName3, startTime1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.%", "1"),
@@ -368,7 +374,7 @@ func TestAccEvidentlyLaunch_scheduledSplitsConfig_updateSteps(t *testing.T) {
 			{
 				Config: testAccLaunchConfig_scheduledSplitsConfigTwoStepsConfig(rName, rName2, rName3, startTime2, startTime3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.%", "2"),
@@ -384,7 +390,7 @@ func TestAccEvidentlyLaunch_scheduledSplitsConfig_updateSteps(t *testing.T) {
 			{
 				Config: testAccLaunchConfig_scheduledSplitsConfigThreeStepsConfig(rName, rName2, rName3, startTime3, startTime4, startTime5),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.%", "2"),
@@ -404,7 +410,7 @@ func TestAccEvidentlyLaunch_scheduledSplitsConfig_updateSteps(t *testing.T) {
 			{
 				Config: testAccLaunchConfig_basic(rName, rName2, rName3, startTime1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.%", "1"),
@@ -417,6 +423,7 @@ func TestAccEvidentlyLaunch_scheduledSplitsConfig_updateSteps(t *testing.T) {
 }
 
 func TestAccEvidentlyLaunch_scheduledSplitsConfig_steps_updateSegmentOverrides(t *testing.T) {
+	ctx := acctest.Context(t)
 	var launch cloudwatchevidently.Launch
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -435,12 +442,12 @@ func TestAccEvidentlyLaunch_scheduledSplitsConfig_steps_updateSegmentOverrides(t
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckLaunchDestroy,
+		CheckDestroy:             testAccCheckLaunchDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLaunchConfig_scheduledSplitsConfigStepsOneSegmentOverrideConfig(rName, rName2, rName3, rName4, rName5, rName6, startTime),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.%", "1"),
@@ -461,7 +468,7 @@ func TestAccEvidentlyLaunch_scheduledSplitsConfig_steps_updateSegmentOverrides(t
 			{
 				Config: testAccLaunchConfig_scheduledSplitsConfigStepsTwoSegmentOverridesConfig(rName, rName2, rName3, rName4, rName5, rName6, startTime),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.%", "2"),
@@ -482,7 +489,7 @@ func TestAccEvidentlyLaunch_scheduledSplitsConfig_steps_updateSegmentOverrides(t
 			{
 				Config: testAccLaunchConfig_scheduledSplitsConfigStepsThreeSegmentOverridesConfig(rName, rName2, rName3, rName4, rName5, rName6, startTime),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.%", "2"),
@@ -508,7 +515,7 @@ func TestAccEvidentlyLaunch_scheduledSplitsConfig_steps_updateSegmentOverrides(t
 			{
 				Config: testAccLaunchConfig_scheduledSplitsConfigStepsOneSegmentOverrideConfig(rName, rName2, rName3, rName4, rName5, rName6, startTime),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.%", "1"),
@@ -526,6 +533,7 @@ func TestAccEvidentlyLaunch_scheduledSplitsConfig_steps_updateSegmentOverrides(t
 }
 
 func TestAccEvidentlyLaunch_tags(t *testing.T) {
+	ctx := acctest.Context(t)
 	var launch cloudwatchevidently.Launch
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -541,12 +549,12 @@ func TestAccEvidentlyLaunch_tags(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckLaunchDestroy,
+		CheckDestroy:             testAccCheckLaunchDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLaunchConfig_tags1(rName, rName2, rName3, startTime, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -559,7 +567,7 @@ func TestAccEvidentlyLaunch_tags(t *testing.T) {
 			{
 				Config: testAccLaunchConfig_tags2(rName, rName2, rName3, startTime, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -568,7 +576,7 @@ func TestAccEvidentlyLaunch_tags(t *testing.T) {
 			{
 				Config: testAccLaunchConfig_tags1(rName, rName2, rName3, startTime, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -578,6 +586,7 @@ func TestAccEvidentlyLaunch_tags(t *testing.T) {
 }
 
 func TestAccEvidentlyLaunch_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
 	var launch cloudwatchevidently.Launch
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -590,12 +599,12 @@ func TestAccEvidentlyLaunch_disappears(t *testing.T) {
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckLaunchDestroy,
+		CheckDestroy:             testAccCheckLaunchDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLaunchConfig_basic(rName, rName2, rName3, startTime),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchExists(resourceName, &launch),
+					testAccCheckLaunchExists(ctx, resourceName, &launch),
 					acctest.CheckResourceDisappears(acctest.Provider, tfcloudwatchevidently.ResourceLaunch(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -604,36 +613,38 @@ func TestAccEvidentlyLaunch_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckLaunchDestroy(s *terraform.State) error {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyConn()
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_evidently_launch" {
-			continue
+func testAccCheckLaunchDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyConn()
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_evidently_launch" {
+				continue
+			}
+
+			launchName, projectNameOrARN, err := tfcloudwatchevidently.LaunchParseID(rs.Primary.ID)
+
+			if err != nil {
+				return err
+			}
+
+			_, err = tfcloudwatchevidently.FindLaunchWithProjectNameorARN(ctx, conn, launchName, projectNameOrARN)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("CloudWatch Evidently Launch %s still exists", rs.Primary.ID)
 		}
 
-		launchName, projectNameOrARN, err := tfcloudwatchevidently.LaunchParseID(rs.Primary.ID)
-
-		if err != nil {
-			return err
-		}
-
-		_, err = tfcloudwatchevidently.FindLaunchWithProjectNameorARN(context.Background(), conn, launchName, projectNameOrARN)
-
-		if tfresource.NotFound(err) {
-			continue
-		}
-
-		if err != nil {
-			return err
-		}
-
-		return fmt.Errorf("CloudWatch Evidently Launch %s still exists", rs.Primary.ID)
+		return nil
 	}
-
-	return nil
 }
 
-func testAccCheckLaunchExists(n string, v *cloudwatchevidently.Launch) resource.TestCheckFunc {
+func testAccCheckLaunchExists(ctx context.Context, n string, v *cloudwatchevidently.Launch) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -653,7 +664,7 @@ func testAccCheckLaunchExists(n string, v *cloudwatchevidently.Launch) resource.
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyConn()
 
-		output, err := tfcloudwatchevidently.FindLaunchWithProjectNameorARN(context.Background(), conn, launchName, projectNameOrARN)
+		output, err := tfcloudwatchevidently.FindLaunchWithProjectNameorARN(ctx, conn, launchName, projectNameOrARN)
 
 		if err != nil {
 			return err

--- a/internal/service/evidently/launch_test.go
+++ b/internal/service/evidently/launch_test.go
@@ -1,0 +1,184 @@
+package evidently_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/cloudwatchevidently"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfcloudwatchevidently "github.com/hashicorp/terraform-provider-aws/internal/service/evidently"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func TestAccEvidentlyLaunch_basic(t *testing.T) {
+	var launch cloudwatchevidently.Launch
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	startTime := time.Now().AddDate(0, 0, 2).Format("2006-01-02T15:04:05Z")
+	resourceName := "aws_evidently_launch.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(cloudwatchevidently.EndpointsID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLaunchDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLaunchConfig_basic(rName, rName2, rName3, startTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchExists(resourceName, &launch),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "evidently", fmt.Sprintf("project/%s/launch/%s", rName, rName3)),
+					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
+					// not returned at create time
+					// resource.TestCheckResourceAttr(resourceName, "execution.#", "1"),
+					// resource.TestCheckResourceAttr(resourceName, "execution.0.started_time", startTime),
+					resource.TestCheckResourceAttr(resourceName, "groups.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "groups.0.feature", "aws_evidently_feature.test", "name"),
+					resource.TestCheckResourceAttr(resourceName, "groups.0.name", "Variation1"),
+					resource.TestCheckResourceAttr(resourceName, "groups.0.variation", "Variation1"),
+					acctest.CheckResourceAttrRFC3339(resourceName, "last_updated_time"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName3),
+					resource.TestCheckResourceAttrPair(resourceName, "project", "aws_evidently_project.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "randomization_salt", rName3), // set to name if not specified
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.group_weights.Variation1", "0"),
+					resource.TestCheckResourceAttr(resourceName, "scheduled_splits_config.0.steps.0.start_time", startTime),
+					resource.TestCheckResourceAttr(resourceName, "status", cloudwatchevidently.LaunchStatusCreated),
+					resource.TestCheckResourceAttr(resourceName, "type", cloudwatchevidently.LaunchTypeAwsEvidentlySplits),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckLaunchDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyConn()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_evidently_launch" {
+			continue
+		}
+
+		launchName, projectNameOrARN, err := tfcloudwatchevidently.LaunchParseID(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		_, err = tfcloudwatchevidently.FindLaunchWithProjectNameorARN(context.Background(), conn, launchName, projectNameOrARN)
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("CloudWatch Evidently Launch %s still exists", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckLaunchExists(n string, v *cloudwatchevidently.Launch) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No CloudWatch Evidently Launch ID is set")
+		}
+
+		launchName, projectNameOrARN, err := tfcloudwatchevidently.LaunchParseID(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyConn()
+
+		output, err := tfcloudwatchevidently.FindLaunchWithProjectNameorARN(context.Background(), conn, launchName, projectNameOrARN)
+
+		if err != nil {
+			return err
+		}
+
+		*v = *output
+
+		return nil
+	}
+}
+
+func testAccLaunchConfigBase(rName, rName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_evidently_project" "test" {
+  name = %[1]q
+}
+
+resource "aws_evidently_feature" "test" {
+  name    = %[2]q
+  project = aws_evidently_project.test.name
+
+  variations {
+    name = "Variation1"
+    value {
+      string_value = "test"
+    }
+  }
+
+  variations {
+    name = "Variation1b"
+    value {
+      string_value = "test1b"
+    }
+  }
+}
+`, rName, rName2)
+}
+
+func testAccLaunchConfig_basic(rName, rName2, rName3, startTime string) string {
+	return acctest.ConfigCompose(
+		testAccLaunchConfigBase(rName, rName2),
+		fmt.Sprintf(`
+resource "aws_evidently_launch" "test" {
+  name    = %[1]q
+  project = aws_evidently_project.test.name
+
+  groups {
+    feature   = aws_evidently_feature.test.name
+    name      = "Variation1"
+    variation = "Variation1"
+  }
+
+  scheduled_splits_config {
+    steps {
+      group_weights = {
+        "Variation1" = 0
+      }
+      start_time = %[2]q
+    }
+  }
+}
+`, rName3, startTime))
+}

--- a/internal/service/evidently/launch_test.go
+++ b/internal/service/evidently/launch_test.go
@@ -69,6 +69,33 @@ func TestAccEvidentlyLaunch_basic(t *testing.T) {
 	})
 }
 
+func TestAccEvidentlyLaunch_disappears(t *testing.T) {
+	var launch cloudwatchevidently.Launch
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	startTime := time.Now().AddDate(0, 0, 2).Format("2006-01-02T15:04:05Z")
+	resourceName := "aws_evidently_launch.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLaunchDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLaunchConfig_basic(rName, rName2, rName3, startTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchExists(resourceName, &launch),
+					acctest.CheckResourceDisappears(acctest.Provider, tfcloudwatchevidently.ResourceLaunch(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckLaunchDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).EvidentlyConn()
 	for _, rs := range s.RootModule().Resources {

--- a/internal/service/evidently/launch_test.go
+++ b/internal/service/evidently/launch_test.go
@@ -195,6 +195,95 @@ func TestAccEvidentlyLaunch_updateGroups(t *testing.T) {
 	})
 }
 
+func TestAccEvidentlyLaunch_updateMetricMonitors(t *testing.T) {
+	var launch cloudwatchevidently.Launch
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	startTime := time.Now().AddDate(0, 0, 2).Format("2006-01-02T15:04:05Z")
+	resourceName := "aws_evidently_launch.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(cloudwatchevidently.EndpointsID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, cloudwatchevidently.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLaunchDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLaunchConfig_oneMetricMonitor(rName, rName2, rName3, startTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchExists(resourceName, &launch),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.0.entity_id_key", "entity_id_key1"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.0.event_pattern", "{\"Price\":[{\"numeric\":[\">\",10,\"<=\",20]}]}"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.0.name", "name1"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.0.unit_label", "unit_label1"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.0.value_key", "value_key1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccLaunchConfig_twoMetricMonitors(rName, rName2, rName3, startTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchExists(resourceName, &launch),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.0.entity_id_key", "entity_id_key1a"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.0.event_pattern", "{\"Price\":[{\"numeric\":[\">\",11,\"<=\",22]}]}"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.0.name", "name1a"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.0.unit_label", "unit_label1a"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.0.value_key", "value_key1a"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.1.metric_definition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.1.metric_definition.0.entity_id_key", "entity_id_key2"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.1.metric_definition.0.event_pattern", "{\"Price\":[{\"numeric\":[\">\",9,\"<=\",19]}]}"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.1.metric_definition.0.name", "name2"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.1.metric_definition.0.unit_label", "unit_label2"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.1.metric_definition.0.value_key", "value_key2"),
+				),
+			},
+			{
+				Config: testAccLaunchConfig_threeMetricMonitors(rName, rName2, rName3, startTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchExists(resourceName, &launch),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.0.entity_id_key", "entity_id_key1b"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.0.event_pattern", "{\"Price\":[{\"numeric\":[\">\",15,\"<=\",25]}]}"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.0.name", "name1b"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.0.unit_label", "unit_label1b"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.0.metric_definition.0.value_key", "value_key1b"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.1.metric_definition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.1.metric_definition.0.entity_id_key", "entity_id_key2a"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.1.metric_definition.0.event_pattern", "{\"Price\":[{\"numeric\":[\">\",8,\"<=\",18]}]}"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.1.metric_definition.0.name", "name2a"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.1.metric_definition.0.unit_label", "unit_label2a"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.1.metric_definition.0.value_key", "value_key2a"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.2.metric_definition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.2.metric_definition.0.entity_id_key", "entity_id_key3"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.2.metric_definition.0.name", "name3"),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.2.metric_definition.0.value_key", "value_key3"),
+				),
+			},
+			{
+				Config: testAccLaunchConfig_basic(rName, rName2, rName3, startTime),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchExists(resourceName, &launch),
+					resource.TestCheckResourceAttr(resourceName, "metric_monitors.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEvidentlyLaunch_tags(t *testing.T) {
 	var launch cloudwatchevidently.Launch
 
@@ -527,6 +616,142 @@ resource "aws_evidently_launch" "test" {
   }
 }
 `, rName5, startTime))
+}
+
+func testAccLaunchConfig_oneMetricMonitor(rName, rName2, rName3, startTime string) string {
+	return acctest.ConfigCompose(
+		testAccLaunchConfigBase(rName, rName2),
+		fmt.Sprintf(`
+resource "aws_evidently_launch" "test" {
+  name    = %[1]q
+  project = aws_evidently_project.test.name
+
+  groups {
+    feature   = aws_evidently_feature.test.name
+    name      = "Variation1"
+    variation = "Variation1"
+  }
+
+  metric_monitors {
+    metric_definition {
+      entity_id_key = "entity_id_key1"
+      event_pattern = "{\"Price\":[{\"numeric\":[\">\",10,\"<=\",20]}]}"
+      name          = "name1"
+      unit_label    = "unit_label1"
+      value_key     = "value_key1"
+    }
+  }
+
+  scheduled_splits_config {
+    steps {
+      group_weights = {
+        "Variation1" = 0
+      }
+      start_time = %[2]q
+    }
+  }
+}
+`, rName3, startTime))
+}
+
+func testAccLaunchConfig_twoMetricMonitors(rName, rName2, rName3, startTime string) string {
+	return acctest.ConfigCompose(
+		testAccLaunchConfigBase(rName, rName2),
+		fmt.Sprintf(`
+resource "aws_evidently_launch" "test" {
+  name    = %[1]q
+  project = aws_evidently_project.test.name
+
+  groups {
+    feature   = aws_evidently_feature.test.name
+    name      = "Variation1"
+    variation = "Variation1"
+  }
+
+  metric_monitors {
+    metric_definition {
+      entity_id_key = "entity_id_key1a"
+      event_pattern = "{\"Price\":[{\"numeric\":[\">\",11,\"<=\",22]}]}"
+      name          = "name1a"
+      unit_label    = "unit_label1a"
+      value_key     = "value_key1a"
+    }
+  }
+
+  metric_monitors {
+    metric_definition {
+      entity_id_key = "entity_id_key2"
+      event_pattern = "{\"Price\":[{\"numeric\":[\">\",9,\"<=\",19]}]}"
+      name          = "name2"
+      unit_label    = "unit_label2"
+      value_key     = "value_key2"
+    }
+  }
+
+  scheduled_splits_config {
+    steps {
+      group_weights = {
+        "Variation1" = 0
+      }
+      start_time = %[2]q
+    }
+  }
+}
+`, rName3, startTime))
+}
+
+func testAccLaunchConfig_threeMetricMonitors(rName, rName2, rName3, startTime string) string {
+	return acctest.ConfigCompose(
+		testAccLaunchConfigBase(rName, rName2),
+		fmt.Sprintf(`
+resource "aws_evidently_launch" "test" {
+  name    = %[1]q
+  project = aws_evidently_project.test.name
+
+  groups {
+    feature   = aws_evidently_feature.test.name
+    name      = "Variation1"
+    variation = "Variation1"
+  }
+
+  metric_monitors {
+    metric_definition {
+      entity_id_key = "entity_id_key1b"
+      event_pattern = "{\"Price\":[{\"numeric\":[\">\",15,\"<=\",25]}]}"
+      name          = "name1b"
+      unit_label    = "unit_label1b"
+      value_key     = "value_key1b"
+    }
+  }
+
+  metric_monitors {
+    metric_definition {
+      entity_id_key = "entity_id_key2a"
+      event_pattern = "{\"Price\":[{\"numeric\":[\">\",8,\"<=\",18]}]}"
+      name          = "name2a"
+      unit_label    = "unit_label2a"
+      value_key     = "value_key2a"
+    }
+  }
+
+  metric_monitors {
+    metric_definition {
+      entity_id_key = "entity_id_key3"
+      name          = "name3"
+      value_key     = "value_key3"
+    }
+  }
+
+  scheduled_splits_config {
+    steps {
+      group_weights = {
+        "Variation1" = 0
+      }
+      start_time = %[2]q
+    }
+  }
+}
+`, rName3, startTime))
 }
 
 func testAccLaunchConfig_tags1(rName, rName2, rName3, startTime, tag, value string) string {

--- a/internal/service/evidently/status.go
+++ b/internal/service/evidently/status.go
@@ -31,6 +31,28 @@ func statusFeature(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvid
 	}
 }
 
+func statusLaunch(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		launchName, projectNameOrARN, err := LaunchParseID(id)
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		output, err := FindLaunchWithProjectNameorARN(context.Background(), conn, launchName, projectNameOrARN)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}
+
 func statusProject(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindProjectByNameOrARN(ctx, conn, id)

--- a/internal/service/evidently/status.go
+++ b/internal/service/evidently/status.go
@@ -39,7 +39,7 @@ func statusLaunch(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvide
 			return nil, "", err
 		}
 
-		output, err := FindLaunchWithProjectNameorARN(context.Background(), conn, launchName, projectNameOrARN)
+		output, err := FindLaunchWithProjectNameorARN(ctx, conn, launchName, projectNameOrARN)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil

--- a/internal/service/evidently/wait.go
+++ b/internal/service/evidently/wait.go
@@ -93,6 +93,23 @@ func waitLaunchUpdated(ctx context.Context, conn *cloudwatchevidently.CloudWatch
 	return nil, err
 }
 
+func waitLaunchDeleted(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, id string, timeout time.Duration) (*cloudwatchevidently.Launch, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{cloudwatchevidently.LaunchStatusCreated, cloudwatchevidently.LaunchStatusCompleted, cloudwatchevidently.LaunchStatusRunning, cloudwatchevidently.LaunchStatusCancelled, cloudwatchevidently.LaunchStatusUpdating},
+		Target:  []string{},
+		Refresh: statusLaunch(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(context.Background())
+
+	if output, ok := outputRaw.(*cloudwatchevidently.Launch); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
 func waitProjectCreated(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string, timeout time.Duration) (*cloudwatchevidently.Project, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{},

--- a/internal/service/evidently/wait.go
+++ b/internal/service/evidently/wait.go
@@ -76,6 +76,23 @@ func waitLaunchCreated(ctx context.Context, conn *cloudwatchevidently.CloudWatch
 	return nil, err
 }
 
+func waitLaunchUpdated(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, id string, timeout time.Duration) (*cloudwatchevidently.Launch, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{cloudwatchevidently.LaunchStatusUpdating},
+		Target:  []string{cloudwatchevidently.LaunchStatusCreated, cloudwatchevidently.LaunchStatusRunning},
+		Refresh: statusLaunch(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(context.Background())
+
+	if output, ok := outputRaw.(*cloudwatchevidently.Launch); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
 func waitProjectCreated(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string, timeout time.Duration) (*cloudwatchevidently.Project, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{},

--- a/internal/service/evidently/wait.go
+++ b/internal/service/evidently/wait.go
@@ -59,6 +59,23 @@ func waitFeatureDeleted(ctx context.Context, conn *cloudwatchevidently.CloudWatc
 	return nil, err
 }
 
+func waitLaunchCreated(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, id string, timeout time.Duration) (*cloudwatchevidently.Launch, error) {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{},
+		Target:  []string{cloudwatchevidently.LaunchStatusCreated},
+		Refresh: statusLaunch(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(context.Background())
+
+	if output, ok := outputRaw.(*cloudwatchevidently.Launch); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
 func waitProjectCreated(ctx context.Context, conn *cloudwatchevidently.CloudWatchEvidently, nameOrARN string, timeout time.Duration) (*cloudwatchevidently.Project, error) {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{},

--- a/website/docs/r/evidently_launch.html.markdown
+++ b/website/docs/r/evidently_launch.html.markdown
@@ -342,8 +342,14 @@ The `execution` block supports the following attributes:
 
 ## Import
 
-CloudWatch Evidently Launch can be imported using the launch `name` and `name` or `arn` of the hosting CloudWatch Evidently Project separated by a `:`, e.g.,
+CloudWatch Evidently Launch can be imported using the `name` of the launch and `name` or `arn` of the hosting CloudWatch Evidently Project separated by a `:`, e.g. with the `name` of the launch and `arn` of the project,
 
 ```
-$ terraform import exampleLaunchName:aws_evidently_launch.example arn:aws:evidently:us-east-1:123456789012:project/exampleProjectName
+$ terraform import aws_evidently_launch.example exampleLaunchName:arn:aws:evidently:us-east-1:123456789012:project/exampleProjectName
+```
+
+e.g. with the `name` of the launch and `name` of the project,
+
+```
+$ terraform import aws_evidently_launch.example exampleLaunchName:exampleProjectName
 ```

--- a/website/docs/r/evidently_launch.html.markdown
+++ b/website/docs/r/evidently_launch.html.markdown
@@ -345,5 +345,5 @@ The `execution` block supports the following attributes:
 CloudWatch Evidently Launch can be imported using the launch `name` and `name` or `arn` of the hosting CloudWatch Evidently Project separated by a `:`, e.g.,
 
 ```
-$ terraform import aws_evidently_launch.example arn:aws:evidently:us-east-1:123456789012:project/exampleProjectName/launch/exampleLaunchName
+$ terraform import exampleLaunchName:aws_evidently_launch.example arn:aws:evidently:us-east-1:123456789012:project/exampleProjectName
 ```

--- a/website/docs/r/evidently_launch.html.markdown
+++ b/website/docs/r/evidently_launch.html.markdown
@@ -1,0 +1,349 @@
+---
+subcategory: "CloudWatch Evidently"
+layout: "aws"
+page_title: "AWS: aws_evidently_launch"
+description: |-
+  Provides a CloudWatch Evidently Launch resource.
+---
+
+# Resource: aws_evidently_launch
+
+Provides a CloudWatch Evidently Launch resource.
+
+## Example Usage
+
+### Basic
+
+```terraform
+resource "aws_evidently_launch" "example" {
+  name    = "example"
+  project = aws_evidently_project.example.name
+
+  groups {
+    feature   = aws_evidently_feature.example.name
+    name      = "Variation1"
+    variation = "Variation1"
+  }
+
+  scheduled_splits_config {
+    steps {
+      group_weights = {
+        "Variation1" = 0
+      }
+      start_time = "2024-01-07 01:43:59+00:00"
+    }
+  }
+}
+```
+
+### With description
+
+```terraform
+resource "aws_evidently_launch" "example" {
+  name        = "example"
+  project     = aws_evidently_project.example.name
+  description = "example description"
+
+  groups {
+    feature   = aws_evidently_feature.example.name
+    name      = "Variation1"
+    variation = "Variation1"
+  }
+
+  scheduled_splits_config {
+    steps {
+      group_weights = {
+        "Variation1" = 0
+      }
+      start_time = "2024-01-07 01:43:59+00:00"
+    }
+  }
+}
+```
+
+### With multiple groups
+
+```terraform
+resource "aws_evidently_launch" "example" {
+  name    = "example"
+  project = aws_evidently_project.example.name
+
+  groups {
+    feature     = aws_evidently_feature.example.name
+    name        = "Variation1"
+    variation   = "Variation1"
+    description = "first-group"
+  }
+
+  groups {
+    feature     = aws_evidently_feature.example.name
+    name        = "Variation2"
+    variation   = "Variation2"
+    description = "second-group"
+  }
+
+  scheduled_splits_config {
+    steps {
+      group_weights = {
+        "Variation1" = 0
+        "Variation2" = 0
+      }
+      start_time = "2024-01-07 01:43:59+00:00"
+    }
+  }
+}
+```
+
+### With metric_monitors
+
+```terraform
+resource "aws_evidently_launch" "example" {
+  name    = "example"
+  project = aws_evidently_project.example.name
+
+  groups {
+    feature   = aws_evidently_feature.example.name
+    name      = "Variation1"
+    variation = "Variation1"
+  }
+
+  metric_monitors {
+    metric_definition {
+      entity_id_key = "entity_id_key1"
+      event_pattern = "{\"Price\":[{\"numeric\":[\">\",11,\"<=\",22]}]}"
+      name          = "name1"
+      unit_label    = "unit_label1"
+      value_key     = "value_key1"
+    }
+  }
+
+  metric_monitors {
+    metric_definition {
+      entity_id_key = "entity_id_key2"
+      event_pattern = "{\"Price\":[{\"numeric\":[\">\",9,\"<=\",19]}]}"
+      name          = "name2"
+      unit_label    = "unit_label2"
+      value_key     = "value_key2"
+    }
+  }
+
+  scheduled_splits_config {
+    steps {
+      group_weights = {
+        "Variation1" = 0
+      }
+      start_time = "2024-01-07 01:43:59+00:00"
+    }
+  }
+}
+```
+
+### With randomization_salt
+
+```terraform
+resource "aws_evidently_launch" "example" {
+  name               = "example"
+  project            = aws_evidently_project.example.name
+  randomization_salt = "example randomization salt"
+
+  groups {
+    feature   = aws_evidently_feature.example.name
+    name      = "Variation1"
+    variation = "Variation1"
+  }
+
+  scheduled_splits_config {
+    steps {
+      group_weights = {
+        "Variation1" = 0
+      }
+      start_time = "2024-01-07 01:43:59+00:00"
+    }
+  }
+}
+```
+
+### With multiple steps
+
+```terraform
+resource "aws_evidently_launch" "example" {
+  name    = "example"
+  project = aws_evidently_project.example.name
+
+  groups {
+    feature   = aws_evidently_feature.example.name
+    name      = "Variation1"
+    variation = "Variation1"
+  }
+
+  groups {
+    feature   = aws_evidently_feature.example.name
+    name      = "Variation2"
+    variation = "Variation2"
+  }
+
+  scheduled_splits_config {
+    steps {
+      group_weights = {
+        "Variation1" = 15
+        "Variation2" = 10
+      }
+      start_time = "2024-01-07 01:43:59+00:00"
+    }
+
+    steps {
+      group_weights = {
+        "Variation1" = 20
+        "Variation2" = 25
+      }
+      start_time = "2024-01-08 01:43:59+00:00"
+    }
+  }
+}
+```
+
+### With segment overrides
+
+```terraform
+resource "aws_evidently_launch" "example" {
+  name    = "example"
+  project = aws_evidently_project.example.name
+
+  groups {
+    feature   = aws_evidently_feature.example.name
+    name      = "Variation1"
+    variation = "Variation1"
+  }
+
+  groups {
+    feature   = aws_evidently_feature.example.name
+    name      = "Variation2"
+    variation = "Variation2"
+  }
+
+  scheduled_splits_config {
+    steps {
+      group_weights = {
+        "Variation1" = 0
+        "Variation2" = 0
+      }
+
+      segment_overrides {
+        evaluation_order = 1
+        segment          = aws_evidently_segment.example.name
+
+        weights = {
+          "Variation2" = 10000
+        }
+      }
+
+      segment_overrides {
+        evaluation_order = 2
+        segment          = aws_evidently_segment.example.name
+
+        weights = {
+          "Variation1" = 40000
+          "Variation2" = 30000
+        }
+      }
+
+      start_time = "2024-01-08 01:43:59+00:00"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Optional) Specifies the description of the launch.
+* `groups` - (Required) One or up to five blocks that contain the feature and variations that are to be used for the launch. [Detailed below](#groups).
+* `metric_monitors` - (Optional) One or up to three blocks that define the metrics that will be used to monitor the launch performance. [Detailed below](#metric_monitors).
+* `name` - (Required) The name for the new launch. Minimum length of `1`. Maximum length of `127`.
+* `project` - (Required) The name or ARN of the project that is to contain the new launch.
+* `randomization_salt` - (Optional) When Evidently assigns a particular user session to a launch, it must use a randomization ID to determine which variation the user session is served. This randomization ID is a combination of the entity ID and randomizationSalt. If you omit randomizationSalt, Evidently uses the launch name as the randomizationSalt.
+* `scheduled_splits_config` - (Optional) A block that defines the traffic allocation percentages among the feature variations during each step of the launch. [Detailed below](#scheduled_splits_config).
+* `tags` - (Optional) Tags to apply to the launch. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+### `groups`
+
+The `groups` block supports the following arguments:
+
+* `description` - (Optional) Specifies the description of the launch group.
+* `feature` - (Required) Specifies the name of the feature that the launch is using.
+* `name` - (Required) Specifies the name of the lahnch group.
+* `variation` - (Required) Specifies the feature variation to use for this launch group.
+
+### `metric_monitors`
+
+The `metric_monitors` block supports the following arguments:
+
+* `metric_definition` - (Required) A block that defines the metric. [Detailed below](#metric_definition).
+
+#### `metric_definition`
+
+The `metric_definition` block supports the following arguments:
+
+* `entity_id_key` - (Required) Specifies the entity, such as a user or session, that does an action that causes a metric value to be recorded. An example is `userDetails.userID`.
+* `event_pattern` - (Required) Specifies The EventBridge event pattern that defines how the metric is recorded.
+* `name` - (Required) Specifies the name for the metric.
+* `unit_label` - (Optional) Specifies a label for the units that the metric is measuring.
+* `value_key` - (Required) Specifies the value that is tracked to produce the metric.
+
+### `scheduled_splits_config`
+
+The `scheduled_splits_config` block supports the following arguments:
+
+* `steps` - (Required) One or up to six blocks that define the traffic allocation percentages among the feature variations during each step of the launch. This also defines the start time of each step. [Detailed below](#steps).
+
+#### `steps`
+
+The `steps` block supports the following arguments:
+
+* `group_weights` - (Required) The traffic allocation percentages among the feature variations during one step of a launch. This is a set of key-value pairs. The keys are variation names. The values represent the percentage of traffic to allocate to that variation during this step. For more information, refer to the [AWS documentation for ScheduledSplitConfig groupWeights](https://docs.aws.amazon.com/cloudwatchevidently/latest/APIReference/API_ScheduledSplitConfig.html).
+* `segment_overrides` - (Required) One or up to six blocks that specify different traffic splits for one or more audience segments. A segment is a portion of your audience that share one or more characteristics. Examples could be Chrome browser users, users in Europe, or Firefox browser users in Europe who also fit other criteria that your application collects, such as age. [Detailed below](#segment_overrides).
+* `start_time` - (Required) Specifies the date and time that this step of the launch starts.
+
+##### `segment_overrides`
+
+* `evaluation_order` - (Required) Specifies a number indicating the order to use to evaluate segment overrides, if there are more than one. Segment overrides with lower numbers are evaluated first.
+* `segment` - (Required) The name or ARN of the segment to use.
+* `weights` - (Required) The traffic allocation percentages among the feature variations to assign to this segment. This is a set of key-value pairs. The keys are variation names. The values represent the amount of traffic to allocate to that variation for this segment. This is expressed in thousandths of a percent, so a weight of 50000 represents 50% of traffic.
+
+## Timeouts
+
+[Configuration options](https://www.terraform.io/docs/configuration/blocks/resources/syntax.html#operation-timeouts):
+
+* `create` - (Default `2m`)
+* `delete` - (Default `2m`)
+* `update` - (Default `2m`)
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the launch.
+* `created_time` - The date and time that the launch is created.
+* `execution` - A block that contains information about the start and end times of the launch. [Detailed below](#execution)
+* `id` - The launch `name` and the project `name` or `arn` separated by a colon (`:`).
+* `last_updated_time` - The date and time that the launch was most recently updated.
+* `status` - The current state of the launch. Valid values are `CREATED`, `UPDATING`, `RUNNING`, `COMPLETED`, and `CANCELLED`.
+* `status_reason` - If the launch was stopped, this is the string that was entered by the person who stopped the launch, to explain why it was stopped.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+* `type` - The type of launch.
+
+### `execution`
+
+The `execution` block supports the following attributes:
+
+* `ended_time` - The date and time that the launch ended.
+* `started_time` - The date and time that the launch started.
+
+## Import
+
+CloudWatch Evidently Launch can be imported using the launch `name` and `name` or `arn` of the hosting CloudWatch Evidently Project separated by a `:`, e.g.,
+
+```
+$ terraform import aws_evidently_launch.example arn:aws:evidently:us-east-1:123456789012:project/exampleProjectName/launch/exampleLaunchName
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

`aws_evidently_launch` resource

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #22624

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- [API_CreateLaunch](https://docs.aws.amazon.com/cloudwatchevidently/latest/APIReference/API_CreateLaunch.html)
- [API_GetLaunch](https://docs.aws.amazon.com/cloudwatchevidently/latest/APIReference/API_GetLaunch.html)
- [API_UpdateLaunch](https://docs.aws.amazon.com/cloudwatchevidently/latest/APIReference/API_UpdateLaunch.html)
- [API_DeleteLaunch](https://docs.aws.amazon.com/cloudwatchevidently/latest/APIReference/API_DeleteLaunch.html)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccEvidentlyLaunch' PKG=evidently
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/evidently/... -v -count 1 -parallel 20  -run=TestAccEvidentlyLaunch -timeout 180m
=== RUN   TestAccEvidentlyLaunch_basic
=== PAUSE TestAccEvidentlyLaunch_basic
=== RUN   TestAccEvidentlyLaunch_updateDescription
=== PAUSE TestAccEvidentlyLaunch_updateDescription
=== RUN   TestAccEvidentlyLaunch_updateGroups
=== PAUSE TestAccEvidentlyLaunch_updateGroups
=== RUN   TestAccEvidentlyLaunch_updateMetricMonitors
=== PAUSE TestAccEvidentlyLaunch_updateMetricMonitors
=== RUN   TestAccEvidentlyLaunch_updateRandomizationSalt
=== PAUSE TestAccEvidentlyLaunch_updateRandomizationSalt
=== RUN   TestAccEvidentlyLaunch_scheduledSplitsConfig_updateSteps
=== PAUSE TestAccEvidentlyLaunch_scheduledSplitsConfig_updateSteps
=== RUN   TestAccEvidentlyLaunch_scheduledSplitsConfig_steps_updateSegmentOverrides
=== PAUSE TestAccEvidentlyLaunch_scheduledSplitsConfig_steps_updateSegmentOverrides
=== RUN   TestAccEvidentlyLaunch_tags
=== PAUSE TestAccEvidentlyLaunch_tags
=== RUN   TestAccEvidentlyLaunch_disappears
=== PAUSE TestAccEvidentlyLaunch_disappears
=== CONT  TestAccEvidentlyLaunch_basic
=== CONT  TestAccEvidentlyLaunch_scheduledSplitsConfig_updateSteps
=== CONT  TestAccEvidentlyLaunch_disappears
=== CONT  TestAccEvidentlyLaunch_updateGroups
=== CONT  TestAccEvidentlyLaunch_tags
=== CONT  TestAccEvidentlyLaunch_scheduledSplitsConfig_steps_updateSegmentOverrides
=== CONT  TestAccEvidentlyLaunch_updateRandomizationSalt
=== CONT  TestAccEvidentlyLaunch_updateMetricMonitors
=== CONT  TestAccEvidentlyLaunch_updateDescription
--- PASS: TestAccEvidentlyLaunch_disappears (29.87s)
--- PASS: TestAccEvidentlyLaunch_basic (33.36s)
--- PASS: TestAccEvidentlyLaunch_updateDescription (50.54s)
--- PASS: TestAccEvidentlyLaunch_updateRandomizationSalt (51.83s)
--- PASS: TestAccEvidentlyLaunch_tags (65.68s)
--- PASS: TestAccEvidentlyLaunch_scheduledSplitsConfig_updateSteps (83.80s)
--- PASS: TestAccEvidentlyLaunch_updateMetricMonitors (85.43s)
--- PASS: TestAccEvidentlyLaunch_scheduledSplitsConfig_steps_updateSegmentOverrides (85.67s)
--- PASS: TestAccEvidentlyLaunch_updateGroups (86.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/evidently  86.585s

...
```
