### PR TITLE
BUGFIX: `aws_appconfig_extenstion_association`, Resolve crash when logging errror

### DIFF
--- a/internal/service/appconfig/extension_association.go
+++ b/internal/service/appconfig/extension_association.go
@@ -73,11 +73,11 @@ func resourceExtensionAssociationCreate(ctx context.Context, d *schema.ResourceD
 	out, err := conn.CreateExtensionAssociationWithContext(ctx, &in)
 
 	if err != nil {
-		return create.DiagError(names.AppConfig, create.ErrActionCreating, ResExtensionAssociation, d.Get("name").(string), err)
+		return create.DiagError(names.AppConfig, create.ErrActionCreating, ResExtensionAssociation, d.Get("extension_arn").(string), err)
 	}
 
 	if out == nil {
-		return create.DiagError(names.AppConfig, create.ErrActionCreating, ResExtensionAssociation, d.Get("name").(string), errors.New("No Extension Association returned with create request."))
+		return create.DiagError(names.AppConfig, create.ErrActionCreating, ResExtensionAssociation, d.Get("extension_arn").(string), errors.New("No Extension Association returned with create request."))
 	}
 
 	d.SetId(aws.StringValue(out.Id))
@@ -126,11 +126,11 @@ func resourceExtensionAssociationUpdate(ctx context.Context, d *schema.ResourceD
 		out, err := conn.UpdateExtensionAssociationWithContext(ctx, in)
 
 		if err != nil {
-			return create.DiagError(names.AppConfig, create.ErrActionWaitingForUpdate, ResExtensionAssociation, d.Get("name").(string), err)
+			return create.DiagError(names.AppConfig, create.ErrActionWaitingForUpdate, ResExtensionAssociation, d.Id(), err)
 		}
 
 		if out == nil {
-			return create.DiagError(names.AppConfig, create.ErrActionWaitingForUpdate, ResExtensionAssociation, d.Get("name").(string), errors.New("No ExtensionAssociation returned with update request."))
+			return create.DiagError(names.AppConfig, create.ErrActionWaitingForUpdate, ResExtensionAssociation, d.Id(), errors.New("No ExtensionAssociation returned with update request."))
 		}
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This resolves an a crash when the AWS API returns an error. The "name" attribute is not an attribute of an "association".

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
➜ terraform-provider-aws (b-aws_appconfig_extension_association_crash) ✗ make testacc TESTARGS='-run=TestAccAppConfigExtensionAssociation' PKG=appconfig
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appconfig/... -v -count 1 -parallel 20  -run=TestAccAppConfigExtensionAssociation -timeout 180m
=== RUN   TestAccAppConfigExtensionAssociation_basic
=== PAUSE TestAccAppConfigExtensionAssociation_basic
=== RUN   TestAccAppConfigExtensionAssociation_Parameters
=== PAUSE TestAccAppConfigExtensionAssociation_Parameters
=== RUN   TestAccAppConfigExtensionAssociation_disappears
=== PAUSE TestAccAppConfigExtensionAssociation_disappears
=== CONT  TestAccAppConfigExtensionAssociation_basic
=== CONT  TestAccAppConfigExtensionAssociation_disappears
=== CONT  TestAccAppConfigExtensionAssociation_Parameters
--- PASS: TestAccAppConfigExtensionAssociation_disappears (29.64s)
--- PASS: TestAccAppConfigExtensionAssociation_basic (36.35s)
--- PASS: TestAccAppConfigExtensionAssociation_Parameters (91.01s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appconfig  93.309s

...
```
