### PR TITLE
Fix unnecessary replacements, user settings update panic for `aws_appstream_stack`

### DIFF
--- a/.changelog/28766.txt
+++ b/.changelog/28766.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_appstream_stack: Fix panic on user_settings update
+```
+
+```release-note:bug
+resource/aws_appstream_stack: Prevent unnecessary replacements on update
+```

--- a/internal/service/appstream/stack.go
+++ b/internal/service/appstream/stack.go
@@ -25,10 +25,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-var (
-	flagDiffUserSettings = false
-)
-
 func ResourceStack() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceStackCreate,
@@ -707,6 +703,7 @@ func flattenUserSettings(apiObjects []*appstream.UserSetting) []map[string]inter
 }
 
 func suppressAppsStreamStackUserSettings(k, old, new string, d *schema.ResourceData) bool {
+	flagDiffUserSettings := false
 	count := len(d.Get("user_settings").(*schema.Set).List())
 	defaultCount := len(appstream.Action_Values())
 

--- a/internal/service/appstream/stack.go
+++ b/internal/service/appstream/stack.go
@@ -402,7 +402,7 @@ func resourceStackUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if d.HasChange("user_settings") {
-		input.UserSettings = expandUserSettings(d.Get("user_settings").([]interface{}))
+		input.UserSettings = expandUserSettings(d.Get("user_settings").(*schema.Set).List())
 	}
 
 	resp, err := conn.UpdateStack(input)

--- a/internal/service/appstream/stack.go
+++ b/internal/service/appstream/stack.go
@@ -91,15 +91,11 @@ func ResourceStack() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(0, 256),
 			},
 			"display_name": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(0, 100),
 			},
 			"embed_host_domains": {
@@ -184,7 +180,7 @@ func ResourceStack() *schema.Resource {
 				},
 				Set: userSettingsHash,
 			},
-			"tags":     tftags.TagsSchemaForceNew(),
+			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 		},
 

--- a/internal/service/appstream/stack_test.go
+++ b/internal/service/appstream/stack_test.go
@@ -110,7 +110,7 @@ func TestAccAppStreamStack_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "feedback_url", ""),
 					resource.TestCheckResourceAttr(resourceName, "redirect_url", ""),
 					resource.TestCheckResourceAttr(resourceName, "storage_connectors.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "7"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
 				),
@@ -380,19 +380,28 @@ resource "aws_appstream_stack" "test" {
     action     = "CLIPBOARD_COPY_FROM_LOCAL_DEVICE"
     permission = "ENABLED"
   }
-
   user_settings {
     action     = "CLIPBOARD_COPY_TO_LOCAL_DEVICE"
     permission = "ENABLED"
   }
-
+  user_settings {
+    action     = "DOMAIN_PASSWORD_SIGNIN"
+    permission = "ENABLED"
+  }
+  user_settings {
+    action     = "DOMAIN_SMART_CARD_SIGNIN"
+    permission = "DISABLED"
+  }
+  user_settings {
+    action     = "FILE_DOWNLOAD"
+    permission = "ENABLED"
+  }
   user_settings {
     action     = "FILE_UPLOAD"
     permission = "ENABLED"
   }
-
   user_settings {
-    action     = "FILE_DOWNLOAD"
+    action     = "PRINTING_TO_LOCAL_DEVICE"
     permission = "ENABLED"
   }
 
@@ -451,29 +460,28 @@ resource "aws_appstream_stack" "test" {
     action     = "CLIPBOARD_COPY_FROM_LOCAL_DEVICE"
     permission = "ENABLED"
   }
-
   user_settings {
     action     = "CLIPBOARD_COPY_TO_LOCAL_DEVICE"
     permission = "ENABLED"
   }
-
   user_settings {
-    action     = "FILE_UPLOAD"
+    action     = "DOMAIN_PASSWORD_SIGNIN"
+    permission = "ENABLED"
+  }
+  user_settings {
+    action     = "DOMAIN_SMART_CARD_SIGNIN"
     permission = "DISABLED"
   }
-
   user_settings {
     action     = "FILE_DOWNLOAD"
     permission = "ENABLED"
   }
-
   user_settings {
-    action     = "PRINTING_TO_LOCAL_DEVICE"
+    action     = "FILE_UPLOAD"
     permission = "ENABLED"
   }
-
   user_settings {
-    action     = "DOMAIN_PASSWORD_SIGNIN"
+    action     = "PRINTING_TO_LOCAL_DEVICE"
     permission = "ENABLED"
   }
 

--- a/website/docs/r/appstream_stack.html.markdown
+++ b/website/docs/r/appstream_stack.html.markdown
@@ -33,11 +33,23 @@ resource "aws_appstream_stack" "example" {
     permission = "ENABLED"
   }
   user_settings {
+    action     = "DOMAIN_PASSWORD_SIGNIN"
+    permission = "ENABLED"
+  }
+  user_settings {
+    action     = "DOMAIN_SMART_CARD_SIGNIN"
+    permission = "DISABLED"
+  }
+  user_settings {
+    action     = "FILE_DOWNLOAD"
+    permission = "ENABLED"
+  }
+  user_settings {
     action     = "FILE_UPLOAD"
     permission = "ENABLED"
   }
   user_settings {
-    action     = "FILE_DOWNLOAD"
+    action     = "PRINTING_TO_LOCAL_DEVICE"
     permission = "ENABLED"
   }
 
@@ -71,7 +83,7 @@ The following arguments are optional:
 * `redirect_url` - (Optional) URL that users are redirected to after their streaming session ends.
 * `storage_connectors` - (Optional) Configuration block for the storage connectors to enable.
   See [`storage_connectors`](#storage_connectors) below.
-* `user_settings` - (Optional) Configuration block for the actions that are enabled or disabled for users during their streaming sessions. By default, these actions are enabled.
+* `user_settings` - (Optional) Configuration block for the actions that are enabled or disabled for users during their streaming sessions. If not provided, these settings are configured automatically by AWS. If provided, the terraform configuration should include a block for each configurable action.
   See [`user_settings`](#user_settings) below.
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
### Description
Fixes a pair of bugs in the `aws_appstream_stack` resource:

- Prevent unnecessary replacements for changes to attributes that can be updated in-place.
- Fix panic when `user_settings` are updated.

Also
- Updates the `user_settings` attribute documentation to indicate that all settings must be explicitly provided when not using the AWS defaults.
- Updates the `user_settings` configuration in acceptance tests.

---
Planned `description` update after code changes:

```
Terraform will perform the following actions:

  # aws_appstream_stack.test will be updated in-place
  ~ resource "aws_appstream_stack" "test" {
      ~ description        = "text" -> "text2"
        id                 = "jb-test"
        name               = "jb-test"
        tags               = {}
        # (4 unchanged attributes hidden)

        # (8 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```


### Relations
Closes #28764
Closes #25784
Closes #23338
Closes #22652

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

```console
$ make testacc PKG=appstream TESTS=TestAccAppStreamStack_ ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appstream/... -v -count 1 -parallel 2 -run='TestAccAppStreamStack_'  -timeout 180m
=== RUN   TestAccAppStreamStack_basic
=== PAUSE TestAccAppStreamStack_basic
=== RUN   TestAccAppStreamStack_disappears
=== PAUSE TestAccAppStreamStack_disappears
=== RUN   TestAccAppStreamStack_complete
=== PAUSE TestAccAppStreamStack_complete
=== RUN   TestAccAppStreamStack_applicationSettings_basic
=== PAUSE TestAccAppStreamStack_applicationSettings_basic
=== RUN   TestAccAppStreamStack_applicationSettings_removeFromEnabled
=== PAUSE TestAccAppStreamStack_applicationSettings_removeFromEnabled
=== RUN   TestAccAppStreamStack_applicationSettings_removeFromDisabled
=== PAUSE TestAccAppStreamStack_applicationSettings_removeFromDisabled
=== RUN   TestAccAppStreamStack_withTags
=== PAUSE TestAccAppStreamStack_withTags
=== CONT  TestAccAppStreamStack_basic
=== CONT  TestAccAppStreamStack_applicationSettings_removeFromEnabled
--- PASS: TestAccAppStreamStack_basic (15.36s)
=== CONT  TestAccAppStreamStack_withTags
--- PASS: TestAccAppStreamStack_applicationSettings_removeFromEnabled (22.68s)
=== CONT  TestAccAppStreamStack_applicationSettings_removeFromDisabled
--- PASS: TestAccAppStreamStack_withTags (23.50s)
=== CONT  TestAccAppStreamStack_complete
--- PASS: TestAccAppStreamStack_applicationSettings_removeFromDisabled (17.11s)
=== CONT  TestAccAppStreamStack_applicationSettings_basic
--- PASS: TestAccAppStreamStack_complete (24.86s)
=== CONT  TestAccAppStreamStack_disappears
--- PASS: TestAccAppStreamStack_disappears (9.00s)
--- PASS: TestAccAppStreamStack_applicationSettings_basic (36.09s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appstream  78.893s
```
