### PR TITLE
resource/aws_service_discovery_service: Add type argument

### DIFF
--- a/.changelog/28778.txt
+++ b/.changelog/28778.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_service_discovery_service: Add `type` argument
+```

--- a/internal/service/servicediscovery/service.go
+++ b/internal/service/servicediscovery/service.go
@@ -132,6 +132,12 @@ func ResourceService() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 		},
@@ -169,6 +175,10 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	if v, ok := d.GetOk("namespace_id"); ok {
 		input.NamespaceId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("type"); ok {
+		input.Type = aws.String(v.(string))
 	}
 
 	if len(tags) > 0 {
@@ -230,6 +240,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 	d.Set("name", service.Name)
 	d.Set("namespace_id", service.NamespaceId)
+	d.Set("type", service.Type)
 
 	tags, err := ListTagsWithContext(ctx, conn, arn)
 

--- a/internal/service/servicediscovery/service_test.go
+++ b/internal/service/servicediscovery/service_test.go
@@ -144,6 +144,36 @@ func TestAccServiceDiscoveryService_public(t *testing.T) {
 	})
 }
 
+func TestAccServiceDiscoveryService_private_http(t *testing.T) {
+	rName := fmt.Sprintf("%s-%s", acctest.ResourcePrefix, sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha))
+	resourceName := "aws_service_discovery_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(servicediscovery.EndpointsID, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, servicediscovery.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceConfig_private_http(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(resourceName),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "servicediscovery", regexp.MustCompile(`service/.+`)),
+					resource.TestCheckResourceAttrSet(resourceName, "namespace_id"),
+					resource.TestCheckResourceAttr(resourceName, "type", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
 func TestAccServiceDiscoveryService_http(t *testing.T) {
 	rName := fmt.Sprintf("%s-%s", acctest.ResourcePrefix, sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha))
 	resourceName := "aws_service_discovery_service.test"
@@ -358,6 +388,31 @@ resource "aws_service_discovery_service" "test" {
   }
 }
 `, rName, th)
+}
+
+func testAccServiceConfig_private_http(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_service_discovery_private_dns_namespace" "test" {
+  name = "%[1]s.test"
+  vpc  = aws_vpc.test.id
+}
+
+resource "aws_service_discovery_service" "test" {
+  name = %[1]q
+
+  namespace_id = aws_service_discovery_private_dns_namespace.test.id
+
+  type = "HTTP"
+}
+`, rName)
 }
 
 func testAccServiceConfig_public(rName string, th int, path string) string {

--- a/internal/service/servicediscovery/service_test.go
+++ b/internal/service/servicediscovery/service_test.go
@@ -46,6 +46,7 @@ func TestAccServiceDiscoveryService_private(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check_custom_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check_custom_config.0.failure_threshold", "5"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "type", "DNS_HTTP"),
 				),
 			},
 			{
@@ -71,6 +72,7 @@ func TestAccServiceDiscoveryService_private(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check_custom_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "health_check_custom_config.0.failure_threshold", "5"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "type", "DNS_HTTP"),
 				),
 			},
 		},
@@ -145,7 +147,7 @@ func TestAccServiceDiscoveryService_public(t *testing.T) {
 }
 
 func TestAccServiceDiscoveryService_private_http(t *testing.T) {
-	rName := fmt.Sprintf("%s-%s", acctest.ResourcePrefix, sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_service_discovery_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -175,7 +177,7 @@ func TestAccServiceDiscoveryService_private_http(t *testing.T) {
 }
 
 func TestAccServiceDiscoveryService_http(t *testing.T) {
-	rName := fmt.Sprintf("%s-%s", acctest.ResourcePrefix, sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_service_discovery_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -204,7 +206,7 @@ func TestAccServiceDiscoveryService_http(t *testing.T) {
 }
 
 func TestAccServiceDiscoveryService_disappears(t *testing.T) {
-	rName := fmt.Sprintf("%s-%s", acctest.ResourcePrefix, sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_service_discovery_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -226,7 +228,7 @@ func TestAccServiceDiscoveryService_disappears(t *testing.T) {
 }
 
 func TestAccServiceDiscoveryService_tags(t *testing.T) {
-	rName := fmt.Sprintf("%s-%s", acctest.ResourcePrefix, sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha))
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_service_discovery_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/website/docs/r/service_discovery_service.html.markdown
+++ b/website/docs/r/service_discovery_service.html.markdown
@@ -82,6 +82,7 @@ The following arguments are supported:
 * `force_destroy` - (Optional, Default:false ) A boolean that indicates all instances should be deleted from the service so that the service can be destroyed without error. These instances are not recoverable.
 * `health_check_custom_config` - (Optional, ForceNew) A complex type that contains settings for ECS managed health checks.
 * `namespace_id` - (Optional) The ID of the namespace that you want to use to create the service.
+* `type` - (Optional) If present, specifies that the service instances are only discoverable using the `DiscoverInstances` API operation. No DNS records is registered for the service instances. The only valid value is `HTTP`.
 * `tags` - (Optional) A map of tags to assign to the service. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### dns_config


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds `type` argument to `resource/aws_service_discovery_service`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes [#18401](https://github.com/hashicorp/terraform-provider-aws/issues/18401)

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccServiceDiscoveryService_private PKG=servicediscovery
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicediscovery/... -v -count 1 -parallel 20 -run='TestAccServiceDiscoveryService_private'  -timeout 180m
=== RUN   TestAccServiceDiscoveryService_private
=== PAUSE TestAccServiceDiscoveryService_private
=== RUN   TestAccServiceDiscoveryService_private_http
=== PAUSE TestAccServiceDiscoveryService_private_http
=== CONT  TestAccServiceDiscoveryService_private
=== CONT  TestAccServiceDiscoveryService_private_http
--- PASS: TestAccServiceDiscoveryService_private_http (108.28s)
--- PASS: TestAccServiceDiscoveryService_private (121.71s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicediscovery	123.822s
```
