### PR TITLE
apigateway/rest_api: Improve diff handling for policies

### DIFF
--- a/.changelog/28789.txt
+++ b/.changelog/28789.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_api_gateway_rest_api: Improve refresh to avoid unnecessary diffs in `policy`
 ```
+
+```release-note:bug
+resource/aws_api_gateway_rest_api_policy: Improve refresh to avoid unnecessary diffs in `policy`
+```

--- a/.changelog/28789.txt
+++ b/.changelog/28789.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_api_gateway_rest_api: Improve refresh to avoid unnecessary diffs in `policy`
+```

--- a/internal/service/apigateway/rest_api.go
+++ b/internal/service/apigateway/rest_api.go
@@ -117,11 +117,12 @@ func ResourceRestAPI() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"policy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Optional:              true,
+				Computed:              true,
+				ValidateFunc:          validation.StringIsJSON,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json

--- a/internal/service/apigateway/rest_api_policy.go
+++ b/internal/service/apigateway/rest_api_policy.go
@@ -33,10 +33,11 @@ func ResourceRestAPIPolicy() *schema.Resource {
 			},
 
 			"policy": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Required:              true,
+				ValidateFunc:          validation.StringIsJSON,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #23288 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccAPIGatewayRestAPIPolicy_ PKG=apigateway
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayRestAPIPolicy_'  -timeout 180m
=== RUN   TestAccAPIGatewayRestAPIPolicy_basic
=== PAUSE TestAccAPIGatewayRestAPIPolicy_basic
=== RUN   TestAccAPIGatewayRestAPIPolicy_disappears
=== PAUSE TestAccAPIGatewayRestAPIPolicy_disappears
=== RUN   TestAccAPIGatewayRestAPIPolicy_Disappears_restAPI
=== PAUSE TestAccAPIGatewayRestAPIPolicy_Disappears_restAPI
=== CONT  TestAccAPIGatewayRestAPIPolicy_basic
=== CONT  TestAccAPIGatewayRestAPIPolicy_Disappears_restAPI
=== CONT  TestAccAPIGatewayRestAPIPolicy_disappears
--- PASS: TestAccAPIGatewayRestAPIPolicy_Disappears_restAPI (14.36s)
--- PASS: TestAccAPIGatewayRestAPIPolicy_basic (41.81s)
--- PASS: TestAccAPIGatewayRestAPIPolicy_disappears (97.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigateway	100.111s
% make testacc TESTS=TestAccAPIGatewayRestAPI_ PKG=apigateway
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayRestAPI_'  -timeout 180m
=== RUN   TestAccAPIGatewayRestAPI_basic
=== PAUSE TestAccAPIGatewayRestAPI_basic
=== RUN   TestAccAPIGatewayRestAPI_tags
=== PAUSE TestAccAPIGatewayRestAPI_tags
=== RUN   TestAccAPIGatewayRestAPI_disappears
=== PAUSE TestAccAPIGatewayRestAPI_disappears
=== RUN   TestAccAPIGatewayRestAPI_endpoint
=== PAUSE TestAccAPIGatewayRestAPI_endpoint
=== RUN   TestAccAPIGatewayRestAPI_Endpoint_private
=== PAUSE TestAccAPIGatewayRestAPI_Endpoint_private
=== RUN   TestAccAPIGatewayRestAPI_apiKeySource
=== PAUSE TestAccAPIGatewayRestAPI_apiKeySource
=== RUN   TestAccAPIGatewayRestAPI_APIKeySource_overrideBody
=== PAUSE TestAccAPIGatewayRestAPI_APIKeySource_overrideBody
=== RUN   TestAccAPIGatewayRestAPI_APIKeySource_setByBody
=== PAUSE TestAccAPIGatewayRestAPI_APIKeySource_setByBody
=== RUN   TestAccAPIGatewayRestAPI_binaryMediaTypes
=== PAUSE TestAccAPIGatewayRestAPI_binaryMediaTypes
=== RUN   TestAccAPIGatewayRestAPI_BinaryMediaTypes_overrideBody
=== PAUSE TestAccAPIGatewayRestAPI_BinaryMediaTypes_overrideBody
=== RUN   TestAccAPIGatewayRestAPI_BinaryMediaTypes_setByBody
=== PAUSE TestAccAPIGatewayRestAPI_BinaryMediaTypes_setByBody
=== RUN   TestAccAPIGatewayRestAPI_body
=== PAUSE TestAccAPIGatewayRestAPI_body
=== RUN   TestAccAPIGatewayRestAPI_description
=== PAUSE TestAccAPIGatewayRestAPI_description
=== RUN   TestAccAPIGatewayRestAPI_Description_overrideBody
=== PAUSE TestAccAPIGatewayRestAPI_Description_overrideBody
=== RUN   TestAccAPIGatewayRestAPI_Description_setByBody
=== PAUSE TestAccAPIGatewayRestAPI_Description_setByBody
=== RUN   TestAccAPIGatewayRestAPI_disableExecuteAPIEndpoint
=== PAUSE TestAccAPIGatewayRestAPI_disableExecuteAPIEndpoint
=== RUN   TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_overrideBody
=== PAUSE TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_overrideBody
=== RUN   TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_setByBody
=== PAUSE TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_setByBody
=== RUN   TestAccAPIGatewayRestAPI_Endpoint_vpcEndpointIDs
=== PAUSE TestAccAPIGatewayRestAPI_Endpoint_vpcEndpointIDs
=== RUN   TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideBody
=== PAUSE TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideBody
=== RUN   TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_mergeBody
=== PAUSE TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_mergeBody
=== RUN   TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideToMergeBody
=== PAUSE TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideToMergeBody
=== RUN   TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_setByBody
=== PAUSE TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_setByBody
=== RUN   TestAccAPIGatewayRestAPI_minimumCompressionSize
=== PAUSE TestAccAPIGatewayRestAPI_minimumCompressionSize
=== RUN   TestAccAPIGatewayRestAPI_MinimumCompressionSize_overrideBody
=== PAUSE TestAccAPIGatewayRestAPI_MinimumCompressionSize_overrideBody
=== RUN   TestAccAPIGatewayRestAPI_MinimumCompressionSize_setByBody
=== PAUSE TestAccAPIGatewayRestAPI_MinimumCompressionSize_setByBody
=== RUN   TestAccAPIGatewayRestAPI_Name_overrideBody
=== PAUSE TestAccAPIGatewayRestAPI_Name_overrideBody
=== RUN   TestAccAPIGatewayRestAPI_parameters
=== PAUSE TestAccAPIGatewayRestAPI_parameters
=== RUN   TestAccAPIGatewayRestAPI_Policy_basic
=== PAUSE TestAccAPIGatewayRestAPI_Policy_basic
=== RUN   TestAccAPIGatewayRestAPI_Policy_order
=== PAUSE TestAccAPIGatewayRestAPI_Policy_order
=== RUN   TestAccAPIGatewayRestAPI_Policy_overrideBody
=== PAUSE TestAccAPIGatewayRestAPI_Policy_overrideBody
=== RUN   TestAccAPIGatewayRestAPI_Policy_setByBody
=== PAUSE TestAccAPIGatewayRestAPI_Policy_setByBody
=== CONT  TestAccAPIGatewayRestAPI_basic
=== CONT  TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_setByBody
=== CONT  TestAccAPIGatewayRestAPI_BinaryMediaTypes_overrideBody
=== CONT  TestAccAPIGatewayRestAPI_Policy_overrideBody
=== CONT  TestAccAPIGatewayRestAPI_apiKeySource
=== CONT  TestAccAPIGatewayRestAPI_endpoint
=== CONT  TestAccAPIGatewayRestAPI_Endpoint_private
=== CONT  TestAccAPIGatewayRestAPI_Description_setByBody
=== CONT  TestAccAPIGatewayRestAPI_body
=== CONT  TestAccAPIGatewayRestAPI_MinimumCompressionSize_setByBody
=== CONT  TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideToMergeBody
=== CONT  TestAccAPIGatewayRestAPI_MinimumCompressionSize_overrideBody
=== CONT  TestAccAPIGatewayRestAPI_minimumCompressionSize
=== CONT  TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_setByBody
=== CONT  TestAccAPIGatewayRestAPI_tags
=== CONT  TestAccAPIGatewayRestAPI_Description_overrideBody
=== CONT  TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_overrideBody
=== CONT  TestAccAPIGatewayRestAPI_disableExecuteAPIEndpoint
=== CONT  TestAccAPIGatewayRestAPI_disappears
=== CONT  TestAccAPIGatewayRestAPI_Policy_setByBody
--- PASS: TestAccAPIGatewayRestAPI_Description_setByBody (49.36s)
=== CONT  TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideBody
--- PASS: TestAccAPIGatewayRestAPI_Endpoint_private (87.49s)
=== CONT  TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_mergeBody
--- PASS: TestAccAPIGatewayRestAPI_body (97.34s)
=== CONT  TestAccAPIGatewayRestAPI_APIKeySource_setByBody
--- PASS: TestAccAPIGatewayRestAPI_Description_overrideBody (111.97s)
=== CONT  TestAccAPIGatewayRestAPI_binaryMediaTypes
--- PASS: TestAccAPIGatewayRestAPI_minimumCompressionSize (146.03s)
=== CONT  TestAccAPIGatewayRestAPI_Policy_basic
--- PASS: TestAccAPIGatewayRestAPI_basic (200.47s)
=== CONT  TestAccAPIGatewayRestAPI_Endpoint_vpcEndpointIDs
--- PASS: TestAccAPIGatewayRestAPI_MinimumCompressionSize_setByBody (252.83s)
=== CONT  TestAccAPIGatewayRestAPI_parameters
--- PASS: TestAccAPIGatewayRestAPI_MinimumCompressionSize_overrideBody (281.87s)
=== CONT  TestAccAPIGatewayRestAPI_Name_overrideBody
--- PASS: TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_mergeBody (198.55s)
=== CONT  TestAccAPIGatewayRestAPI_Policy_order
--- PASS: TestAccAPIGatewayRestAPI_disableExecuteAPIEndpoint (291.08s)
=== CONT  TestAccAPIGatewayRestAPI_APIKeySource_overrideBody
--- PASS: TestAccAPIGatewayRestAPI_Name_overrideBody (49.68s)
=== CONT  TestAccAPIGatewayRestAPI_BinaryMediaTypes_setByBody
--- PASS: TestAccAPIGatewayRestAPI_BinaryMediaTypes_setByBody (22.03s)
=== CONT  TestAccAPIGatewayRestAPI_description
--- PASS: TestAccAPIGatewayRestAPI_APIKeySource_overrideBody (62.86s)
--- PASS: TestAccAPIGatewayRestAPI_description (36.61s)
--- PASS: TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_overrideBody (441.55s)
--- PASS: TestAccAPIGatewayRestAPI_binaryMediaTypes (361.91s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_overrideBody (510.88s)
--- PASS: TestAccAPIGatewayRestAPI_Endpoint_vpcEndpointIDs (338.60s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_basic (443.98s)
--- PASS: TestAccAPIGatewayRestAPI_parameters (370.58s)
--- PASS: TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_setByBody (653.05s)
--- PASS: TestAccAPIGatewayRestAPI_tags (654.13s)
--- PASS: TestAccAPIGatewayRestAPI_disappears (698.83s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_setByBody (746.50s)
--- PASS: TestAccAPIGatewayRestAPI_BinaryMediaTypes_overrideBody (785.89s)
--- PASS: TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideToMergeBody (791.21s)
--- PASS: TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_setByBody (837.71s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_order (600.00s)
--- PASS: TestAccAPIGatewayRestAPI_APIKeySource_setByBody (813.07s)
--- PASS: TestAccAPIGatewayRestAPI_endpoint (1012.46s)
--- PASS: TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideBody (1093.83s)
--- PASS: TestAccAPIGatewayRestAPI_apiKeySource (1162.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigateway	1165.316s
```
