### PR TITLE
cloudsearch/domain_service_access_policy: Improve diff handling of policy

### DIFF
--- a/.changelog/28792.txt
+++ b/.changelog/28792.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudsearch_domain_service_access_policy: Improve refresh to avoid unnecessary diffs in `access_policy`
+```

--- a/internal/service/cloudsearch/domain_service_access_policy.go
+++ b/internal/service/cloudsearch/domain_service_access_policy.go
@@ -34,10 +34,11 @@ func ResourceDomainServiceAccessPolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"access_policy": {
-				Type:             schema.TypeString,
-				Required:         true,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
-				ValidateFunc:     validation.StringIsJSON,
+				Type:                  schema.TypeString,
+				Required:              true,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
+				ValidateFunc:          validation.StringIsJSON,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #23288 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccCloudSearchDomainServiceAccessPolicy_ PKG=cloudsearch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudsearch/... -v -count 1 -parallel 20 -run='TestAccCloudSearchDomainServiceAccessPolicy_'  -timeout 180m
=== RUN   TestAccCloudSearchDomainServiceAccessPolicy_basic
=== PAUSE TestAccCloudSearchDomainServiceAccessPolicy_basic
=== RUN   TestAccCloudSearchDomainServiceAccessPolicy_update
=== PAUSE TestAccCloudSearchDomainServiceAccessPolicy_update
=== CONT  TestAccCloudSearchDomainServiceAccessPolicy_basic
=== CONT  TestAccCloudSearchDomainServiceAccessPolicy_update
--- PASS: TestAccCloudSearchDomainServiceAccessPolicy_basic (2192.16s)
--- PASS: TestAccCloudSearchDomainServiceAccessPolicy_update (2292.48s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudsearch	2297.117s
```
