### PR TITLE
codeartifact: Improve diff handling of policies

### DIFF
--- a/.changelog/28794.txt
+++ b/.changelog/28794.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_codeartifact_repository_permissions_policy: Improve refresh to avoid unnecessary diffs in `policy_document`
+```
+
+```release-note:bug
+resource/aws_codeartifact_domain_permissions_policy: Improve refresh to avoid unnecessary diffs in `policy_document`
+```

--- a/internal/service/codeartifact/domain_permissions_policy.go
+++ b/internal/service/codeartifact/domain_permissions_policy.go
@@ -39,10 +39,11 @@ func ResourceDomainPermissionsPolicy() *schema.Resource {
 				ForceNew: true,
 			},
 			"policy_document": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Required:              true,
+				ValidateFunc:          validation.StringIsJSON,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json

--- a/internal/service/codeartifact/repository_permissions_policy.go
+++ b/internal/service/codeartifact/repository_permissions_policy.go
@@ -44,10 +44,11 @@ func ResourceRepositoryPermissionsPolicy() *schema.Resource {
 				ForceNew: true,
 			},
 			"policy_document": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Required:              true,
+				ValidateFunc:          validation.StringIsJSON,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #23288 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS="TestAccCodeArtifact_serial/RepositoryPermis" PKG=codeartifact 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/codeartifact/... -v -count 1 -parallel 20 -run='TestAccCodeArtifact_serial/RepositoryPermis'  -timeout 180m
=== RUN   TestAccCodeArtifact_serial
=== RUN   TestAccCodeArtifact_serial/RepositoryPermissionsPolicy
=== RUN   TestAccCodeArtifact_serial/RepositoryPermissionsPolicy/disappears
=== RUN   TestAccCodeArtifact_serial/RepositoryPermissionsPolicy/owner
=== RUN   TestAccCodeArtifact_serial/RepositoryPermissionsPolicy/disappearsDomain
=== RUN   TestAccCodeArtifact_serial/RepositoryPermissionsPolicy/ignoreEquivalent
=== RUN   TestAccCodeArtifact_serial/RepositoryPermissionsPolicy/basic
--- PASS: TestAccCodeArtifact_serial (112.27s)
    --- PASS: TestAccCodeArtifact_serial/RepositoryPermissionsPolicy (112.27s)
        --- PASS: TestAccCodeArtifact_serial/RepositoryPermissionsPolicy/disappears (18.39s)
        --- PASS: TestAccCodeArtifact_serial/RepositoryPermissionsPolicy/owner (19.56s)
        --- PASS: TestAccCodeArtifact_serial/RepositoryPermissionsPolicy/disappearsDomain (17.07s)
        --- PASS: TestAccCodeArtifact_serial/RepositoryPermissionsPolicy/ignoreEquivalent (25.52s)
        --- PASS: TestAccCodeArtifact_serial/RepositoryPermissionsPolicy/basic (31.72s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codeartifact	113.803s
% make testacc TESTS="TestAccCodeArtifact_serial/DomainPermis" PKG=codeartifact
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/codeartifact/... -v -count 1 -parallel 20 -run='TestAccCodeArtifact_serial/DomainPermis'  -timeout 180m
=== RUN   TestAccCodeArtifact_serial
=== RUN   TestAccCodeArtifact_serial/DomainPermissionsPolicy
=== RUN   TestAccCodeArtifact_serial/DomainPermissionsPolicy/disappears
=== RUN   TestAccCodeArtifact_serial/DomainPermissionsPolicy/owner
=== RUN   TestAccCodeArtifact_serial/DomainPermissionsPolicy/disappearsDomain
=== RUN   TestAccCodeArtifact_serial/DomainPermissionsPolicy/ignoreEquivalent
=== RUN   TestAccCodeArtifact_serial/DomainPermissionsPolicy/basic
--- PASS: TestAccCodeArtifact_serial (104.04s)
    --- PASS: TestAccCodeArtifact_serial/DomainPermissionsPolicy (104.04s)
        --- PASS: TestAccCodeArtifact_serial/DomainPermissionsPolicy/disappears (16.47s)
        --- PASS: TestAccCodeArtifact_serial/DomainPermissionsPolicy/owner (17.98s)
        --- PASS: TestAccCodeArtifact_serial/DomainPermissionsPolicy/disappearsDomain (15.54s)
        --- PASS: TestAccCodeArtifact_serial/DomainPermissionsPolicy/ignoreEquivalent (23.88s)
        --- PASS: TestAccCodeArtifact_serial/DomainPermissionsPolicy/basic (30.17s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codeartifact	105.540s
```
