### PR TITLE
codebuild/repository_permissions_policy: Improve policy diffs

### DIFF
--- a/.changelog/28796.txt
+++ b/.changelog/28796.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_codebuild_resource_policy: Improve refresh to avoid unnecessary diffs in `policy`
+```

--- a/internal/service/codebuild/resource_policy.go
+++ b/internal/service/codebuild/resource_policy.go
@@ -28,10 +28,15 @@ func ResourceResourcePolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"policy": {
-				Type:             schema.TypeString,
-				Required:         true,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
-				ValidateFunc:     validation.StringIsJSON,
+				Type:                  schema.TypeString,
+				Required:              true,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
+				ValidateFunc:          validation.StringIsJSON,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 			"resource_arn": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #23288 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
% make testacc TESTS=TestAccCodeBuildResourcePolicy_ PKG=codebuild 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/codebuild/... -v -count 1 -parallel 20 -run='TestAccCodeBuildResourcePolicy_'  -timeout 180m
=== RUN   TestAccCodeBuildResourcePolicy_basic
=== PAUSE TestAccCodeBuildResourcePolicy_basic
=== RUN   TestAccCodeBuildResourcePolicy_disappears
=== PAUSE TestAccCodeBuildResourcePolicy_disappears
=== RUN   TestAccCodeBuildResourcePolicy_disappears_resource
=== PAUSE TestAccCodeBuildResourcePolicy_disappears_resource
=== CONT  TestAccCodeBuildResourcePolicy_basic
=== CONT  TestAccCodeBuildResourcePolicy_disappears_resource
=== CONT  TestAccCodeBuildResourcePolicy_disappears
--- PASS: TestAccCodeBuildResourcePolicy_disappears_resource (15.42s)
--- PASS: TestAccCodeBuildResourcePolicy_disappears (16.56s)
--- PASS: TestAccCodeBuildResourcePolicy_basic (18.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codebuild	20.148s
```
