### PR TITLE
vpc/endpoint: Improve diff handling of policy

### DIFF
--- a/.changelog/28798.txt
+++ b/.changelog/28798.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_vpc_endpoint: Improve refresh to avoid unnecessary diffs in `policy`
+```
+
+```release-note:bug
+resource/aws_vpc_endpoint_policy: Improve refresh to avoid unnecessary diffs in `policy`
+```

--- a/internal/service/ec2/vpc_endpoint.go
+++ b/internal/service/ec2/vpc_endpoint.go
@@ -99,11 +99,12 @@ func ResourceVPCEndpoint() *schema.Resource {
 				Computed: true,
 			},
 			"policy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Optional:              true,
+				Computed:              true,
+				ValidateFunc:          validation.StringIsJSON,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json

--- a/internal/service/ec2/vpc_endpoint_policy.go
+++ b/internal/service/ec2/vpc_endpoint_policy.go
@@ -27,11 +27,12 @@ func ResourceVPCEndpointPolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"policy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Optional:              true,
+				Computed:              true,
+				ValidateFunc:          validation.StringIsJSON,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #23288

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS="TestAccVPCEndpoint_|TestAccVPCEndpointPolicy_" PKG=vpc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCEndpoint_|TestAccVPCEndpointPolicy_'  -timeout 180m
=== RUN   TestAccVPCEndpointPolicy_basic
=== PAUSE TestAccVPCEndpointPolicy_basic
=== RUN   TestAccVPCEndpointPolicy_disappears
=== PAUSE TestAccVPCEndpointPolicy_disappears
=== RUN   TestAccVPCEndpointPolicy_disappears_endpoint
=== PAUSE TestAccVPCEndpointPolicy_disappears_endpoint
=== RUN   TestAccVPCEndpoint_gatewayBasic
=== PAUSE TestAccVPCEndpoint_gatewayBasic
=== RUN   TestAccVPCEndpoint_interfaceBasic
=== PAUSE TestAccVPCEndpoint_interfaceBasic
=== RUN   TestAccVPCEndpoint_disappears
=== PAUSE TestAccVPCEndpoint_disappears
=== RUN   TestAccVPCEndpoint_tags
=== PAUSE TestAccVPCEndpoint_tags
=== RUN   TestAccVPCEndpoint_gatewayWithRouteTableAndPolicy
=== PAUSE TestAccVPCEndpoint_gatewayWithRouteTableAndPolicy
=== RUN   TestAccVPCEndpoint_gatewayPolicy
=== PAUSE TestAccVPCEndpoint_gatewayPolicy
=== RUN   TestAccVPCEndpoint_ignoreEquivalent
=== PAUSE TestAccVPCEndpoint_ignoreEquivalent
=== RUN   TestAccVPCEndpoint_ipAddressType
=== PAUSE TestAccVPCEndpoint_ipAddressType
=== RUN   TestAccVPCEndpoint_interfaceWithSubnetAndSecurityGroup
=== PAUSE TestAccVPCEndpoint_interfaceWithSubnetAndSecurityGroup
=== RUN   TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnCreate
=== PAUSE TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnCreate
=== RUN   TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnUpdate
=== PAUSE TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnUpdate
=== RUN   TestAccVPCEndpoint_VPCEndpointType_gatewayLoadBalancer
=== PAUSE TestAccVPCEndpoint_VPCEndpointType_gatewayLoadBalancer
=== CONT  TestAccVPCEndpointPolicy_basic
=== CONT  TestAccVPCEndpoint_gatewayPolicy
=== CONT  TestAccVPCEndpoint_interfaceBasic
=== CONT  TestAccVPCEndpoint_interfaceWithSubnetAndSecurityGroup
=== CONT  TestAccVPCEndpoint_ignoreEquivalent
=== CONT  TestAccVPCEndpointPolicy_disappears_endpoint
=== CONT  TestAccVPCEndpointPolicy_disappears
=== CONT  TestAccVPCEndpoint_ipAddressType
=== CONT  TestAccVPCEndpoint_tags
=== CONT  TestAccVPCEndpoint_VPCEndpointType_gatewayLoadBalancer
=== CONT  TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnUpdate
=== CONT  TestAccVPCEndpoint_gatewayBasic
=== CONT  TestAccVPCEndpoint_disappears
=== CONT  TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnCreate
=== CONT  TestAccVPCEndpoint_gatewayWithRouteTableAndPolicy
--- PASS: TestAccVPCEndpoint_disappears (44.79s)
--- PASS: TestAccVPCEndpoint_gatewayBasic (48.93s)
--- PASS: TestAccVPCEndpointPolicy_disappears_endpoint (65.55s)
--- PASS: TestAccVPCEndpointPolicy_disappears (66.93s)
--- PASS: TestAccVPCEndpoint_gatewayWithRouteTableAndPolicy (72.58s)
--- PASS: TestAccVPCEndpoint_ignoreEquivalent (73.46s)
--- PASS: TestAccVPCEndpoint_gatewayPolicy (77.37s)
--- PASS: TestAccVPCEndpoint_tags (82.99s)
--- PASS: TestAccVPCEndpointPolicy_basic (87.84s)
--- PASS: TestAccVPCEndpoint_interfaceBasic (117.79s)
--- PASS: TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnUpdate (339.57s)
--- PASS: TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnCreate (349.07s)
--- PASS: TestAccVPCEndpoint_VPCEndpointType_gatewayLoadBalancer (354.24s)
--- PASS: TestAccVPCEndpoint_ipAddressType (374.15s)
--- PASS: TestAccVPCEndpoint_interfaceWithSubnetAndSecurityGroup (441.60s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	443.374s
```
