### PR TITLE
ecr/policies: Improve diff handling

### DIFF
--- a/.changelog/28799.txt
+++ b/.changelog/28799.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/aws_ecr_repository_policy: Improve refresh to avoid unnecessary diffs in `policy`
+```
+
+```release-note:bug
+resource/aws_ecr_registry_policy: Improve refresh to avoid unnecessary diffs in `policy`
+```
+
+```release-note:bug
+resource/aws_ecrpublic_repository_policy: Improve refresh to avoid unnecessary diffs in `policy`
+```

--- a/internal/service/ecr/registry_policy.go
+++ b/internal/service/ecr/registry_policy.go
@@ -26,10 +26,15 @@ func ResourceRegistryPolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"policy": {
-				Type:             schema.TypeString,
-				Required:         true,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
-				ValidateFunc:     validation.StringIsJSON,
+				Type:                  schema.TypeString,
+				Required:              true,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
+				ValidateFunc:          validation.StringIsJSON,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 			"registry_id": {
 				Type:     schema.TypeString,

--- a/internal/service/ecr/repository_policy.go
+++ b/internal/service/ecr/repository_policy.go
@@ -33,10 +33,15 @@ func ResourceRepositoryPolicy() *schema.Resource {
 				ForceNew: true,
 			},
 			"policy": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Required:              true,
+				ValidateFunc:          validation.StringIsJSON,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 			"registry_id": {
 				Type:     schema.TypeString,

--- a/internal/service/ecrpublic/repository_policy.go
+++ b/internal/service/ecrpublic/repository_policy.go
@@ -29,10 +29,15 @@ func ResourceRepositoryPolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"policy": {
-				Type:             schema.TypeString,
-				Required:         true,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
-				ValidateFunc:     validation.StringIsJSON,
+				Type:                  schema.TypeString,
+				Required:              true,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
+				ValidateFunc:          validation.StringIsJSON,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 			"registry_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #23288 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS="TestAccECRRepositoryPolicy_|TestAccECRRegistryPolicy_serial" PKG=ecr
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRRepositoryPolicy_|TestAccECRRegistryPolicy_serial'  -timeout 180m
=== RUN   TestAccECRRegistryPolicy_serial
=== RUN   TestAccECRRegistryPolicy_serial/basic
=== RUN   TestAccECRRegistryPolicy_serial/disappears
--- PASS: TestAccECRRegistryPolicy_serial (40.78s)
    --- PASS: TestAccECRRegistryPolicy_serial/basic (27.52s)
    --- PASS: TestAccECRRegistryPolicy_serial/disappears (13.26s)
=== RUN   TestAccECRRepositoryPolicy_basic
=== PAUSE TestAccECRRepositoryPolicy_basic
=== RUN   TestAccECRRepositoryPolicy_IAM_basic
=== PAUSE TestAccECRRepositoryPolicy_IAM_basic
=== RUN   TestAccECRRepositoryPolicy_IAM_principalOrder
=== PAUSE TestAccECRRepositoryPolicy_IAM_principalOrder
=== RUN   TestAccECRRepositoryPolicy_disappears
=== PAUSE TestAccECRRepositoryPolicy_disappears
=== RUN   TestAccECRRepositoryPolicy_Disappears_repository
=== PAUSE TestAccECRRepositoryPolicy_Disappears_repository
=== CONT  TestAccECRRepositoryPolicy_basic
=== CONT  TestAccECRRepositoryPolicy_disappears
=== CONT  TestAccECRRepositoryPolicy_Disappears_repository
=== CONT  TestAccECRRepositoryPolicy_IAM_principalOrder
=== CONT  TestAccECRRepositoryPolicy_IAM_basic
--- PASS: TestAccECRRepositoryPolicy_Disappears_repository (13.66s)
--- PASS: TestAccECRRepositoryPolicy_disappears (15.87s)
--- PASS: TestAccECRRepositoryPolicy_basic (29.05s)
--- PASS: TestAccECRRepositoryPolicy_IAM_basic (34.50s)
--- PASS: TestAccECRRepositoryPolicy_IAM_principalOrder (49.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecr	94.588s
% make testacc TESTS=TestAccECRPublicRepositoryPolicy_ PKG=ecrpublic
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecrpublic/... -v -count 1 -parallel 20 -run='TestAccECRPublicRepositoryPolicy_'  -timeout 180m
=== RUN   TestAccECRPublicRepositoryPolicy_basic
=== PAUSE TestAccECRPublicRepositoryPolicy_basic
=== RUN   TestAccECRPublicRepositoryPolicy_disappears
=== PAUSE TestAccECRPublicRepositoryPolicy_disappears
=== RUN   TestAccECRPublicRepositoryPolicy_Disappears_repository
=== PAUSE TestAccECRPublicRepositoryPolicy_Disappears_repository
=== RUN   TestAccECRPublicRepositoryPolicy_iam
=== PAUSE TestAccECRPublicRepositoryPolicy_iam
=== CONT  TestAccECRPublicRepositoryPolicy_basic
=== CONT  TestAccECRPublicRepositoryPolicy_Disappears_repository
=== CONT  TestAccECRPublicRepositoryPolicy_disappears
=== CONT  TestAccECRPublicRepositoryPolicy_iam
--- PASS: TestAccECRPublicRepositoryPolicy_Disappears_repository (11.39s)
--- PASS: TestAccECRPublicRepositoryPolicy_disappears (12.77s)
--- PASS: TestAccECRPublicRepositoryPolicy_basic (22.30s)
--- PASS: TestAccECRPublicRepositoryPolicy_iam (39.07s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecrpublic	40.717s
```
