### PR TITLE
events/bus_policy: Improve diffs

### DIFF
--- a/.changelog/28802.txt
+++ b/.changelog/28802.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_event_bus_policy: Improve refresh to avoid unnecessary diffs in `policy`
+```

--- a/internal/service/events/bus_policy.go
+++ b/internal/service/events/bus_policy.go
@@ -38,10 +38,11 @@ func ResourceBusPolicy() *schema.Resource {
 				Default:      DefaultEventBusName,
 			},
 			"policy": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Required:              true,
+				ValidateFunc:          validation.StringIsJSON,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates: #23288 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccEventsBusPolicy_ PKG=events
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsBusPolicy_'  -timeout 180m
=== RUN   TestAccEventsBusPolicy_basic
=== PAUSE TestAccEventsBusPolicy_basic
=== RUN   TestAccEventsBusPolicy_ignoreEquivalent
=== PAUSE TestAccEventsBusPolicy_ignoreEquivalent
=== RUN   TestAccEventsBusPolicy_disappears
=== PAUSE TestAccEventsBusPolicy_disappears
=== CONT  TestAccEventsBusPolicy_basic
=== CONT  TestAccEventsBusPolicy_disappears
=== CONT  TestAccEventsBusPolicy_ignoreEquivalent
--- PASS: TestAccEventsBusPolicy_ignoreEquivalent (43.97s)
--- PASS: TestAccEventsBusPolicy_basic (57.68s)
--- PASS: TestAccEventsBusPolicy_disappears (149.38s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	153.329s
```
