### PR TITLE
glacier/vault: Improve policy diffs

### DIFF
--- a/.changelog/28804.txt
+++ b/.changelog/28804.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_glacier_vault: Improve refresh to avoid unnecessary diffs in `access_policy`
+```
+
+```release-note:bug
+resource/aws_glacier_vault_lock: Improve refresh to avoid unnecessary diffs in `policy`
+```

--- a/internal/service/glacier/vault.go
+++ b/internal/service/glacier/vault.go
@@ -52,10 +52,11 @@ func ResourceVault() *schema.Resource {
 			},
 
 			"access_policy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Optional:              true,
+				ValidateFunc:          validation.StringIsJSON,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json

--- a/internal/service/glacier/vault_lock.go
+++ b/internal/service/glacier/vault_lock.go
@@ -39,11 +39,12 @@ func ResourceVaultLock() *schema.Resource {
 				Default:  false,
 			},
 			"policy": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
-				ValidateFunc:     verify.ValidIAMPolicyJSON,
+				Type:                  schema.TypeString,
+				Required:              true,
+				ForceNew:              true,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
+				ValidateFunc:          verify.ValidIAMPolicyJSON,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #23288 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS="TestAccGlacierVault_|TestAccGlacierVaultLock_" PKG=glacier
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glacier/... -v -count 1 -parallel 20 -run='TestAccGlacierVault_|TestAccGlacierVaultLock_'  -timeout 180m
=== RUN   TestAccGlacierVaultLock_basic
=== PAUSE TestAccGlacierVaultLock_basic
=== RUN   TestAccGlacierVaultLock_completeLock
=== PAUSE TestAccGlacierVaultLock_completeLock
=== RUN   TestAccGlacierVaultLock_ignoreEquivalentPolicy
=== PAUSE TestAccGlacierVaultLock_ignoreEquivalentPolicy
=== RUN   TestAccGlacierVault_basic
=== PAUSE TestAccGlacierVault_basic
=== RUN   TestAccGlacierVault_notification
=== PAUSE TestAccGlacierVault_notification
=== RUN   TestAccGlacierVault_policy
=== PAUSE TestAccGlacierVault_policy
=== RUN   TestAccGlacierVault_tags
=== PAUSE TestAccGlacierVault_tags
=== RUN   TestAccGlacierVault_disappears
=== PAUSE TestAccGlacierVault_disappears
=== RUN   TestAccGlacierVault_ignoreEquivalent
=== PAUSE TestAccGlacierVault_ignoreEquivalent
=== CONT  TestAccGlacierVaultLock_basic
=== CONT  TestAccGlacierVault_policy
=== CONT  TestAccGlacierVault_disappears
=== CONT  TestAccGlacierVault_tags
=== CONT  TestAccGlacierVault_basic
=== CONT  TestAccGlacierVaultLock_ignoreEquivalentPolicy
=== CONT  TestAccGlacierVaultLock_completeLock
=== CONT  TestAccGlacierVault_ignoreEquivalent
=== CONT  TestAccGlacierVault_notification
--- PASS: TestAccGlacierVault_disappears (18.78s)
--- PASS: TestAccGlacierVault_basic (26.39s)
--- PASS: TestAccGlacierVaultLock_basic (28.04s)
--- PASS: TestAccGlacierVaultLock_completeLock (28.12s)
--- PASS: TestAccGlacierVault_ignoreEquivalent (33.13s)
--- PASS: TestAccGlacierVaultLock_ignoreEquivalentPolicy (33.24s)
--- PASS: TestAccGlacierVault_tags (52.38s)
--- PASS: TestAccGlacierVault_policy (53.54s)
--- PASS: TestAccGlacierVault_notification (56.61s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glacier	60.450s
```
