### PR TITLE
`flex` framework flattener/expander updates

### DIFF
--- a/internal/flex/framework.go
+++ b/internal/flex/framework.go
@@ -10,6 +10,34 @@ import (
 
 // Terraform Plugin Framework variants of standard flatteners and expanders.
 
+func ExpandFrameworkStringList(ctx context.Context, list types.List) []*string {
+	if list.IsNull() || list.IsUnknown() {
+		return nil
+	}
+
+	var vl []*string
+
+	if list.ElementsAs(ctx, &vl, false).HasError() {
+		return nil
+	}
+
+	return vl
+}
+
+func ExpandFrameworkStringValueList(ctx context.Context, list types.List) []string {
+	if list.IsNull() || list.IsUnknown() {
+		return nil
+	}
+
+	var vl []string
+
+	if list.ElementsAs(ctx, &vl, false).HasError() {
+		return nil
+	}
+
+	return vl
+}
+
 func ExpandFrameworkStringSet(ctx context.Context, set types.Set) []*string {
 	if set.IsNull() || set.IsUnknown() {
 		return nil

--- a/internal/flex/framework.go
+++ b/internal/flex/framework.go
@@ -80,6 +80,24 @@ func ExpandFrameworkStringValueMap(ctx context.Context, set types.Map) map[strin
 	return m
 }
 
+// FlattenFrameworkStringList converts a slice of string pointers to a framework List value.
+//
+// A nil slice is converted to a null List.
+// An empty slice is converted to a null List.
+func FlattenFrameworkStringList(_ context.Context, vs []*string) types.List {
+	if len(vs) == 0 {
+		return types.ListNull(types.StringType)
+	}
+
+	elems := make([]attr.Value, len(vs))
+
+	for i, v := range vs {
+		elems[i] = types.StringValue(aws.ToString(v))
+	}
+
+	return types.ListValueMust(types.StringType, elems)
+}
+
 // FlattenFrameworkStringListLegacy is the Plugin Framework variant of FlattenStringList.
 // A nil slice is converted to an empty (non-null) List.
 func FlattenFrameworkStringListLegacy(_ context.Context, vs []*string) types.List {
@@ -87,6 +105,24 @@ func FlattenFrameworkStringListLegacy(_ context.Context, vs []*string) types.Lis
 
 	for i, v := range vs {
 		elems[i] = types.StringValue(aws.ToString(v))
+	}
+
+	return types.ListValueMust(types.StringType, elems)
+}
+
+// FlattenFrameworkStringValueList converts a slice of string values to a framework List value.
+//
+// A nil slice is converted to a null List.
+// An empty slice is converted to a null List.
+func FlattenFrameworkStringValueList(_ context.Context, vs []string) types.List {
+	if len(vs) == 0 {
+		return types.ListNull(types.StringType)
+	}
+
+	elems := make([]attr.Value, len(vs))
+
+	for i, v := range vs {
+		elems[i] = types.StringValue(v)
 	}
 
 	return types.ListValueMust(types.StringType, elems)
@@ -102,6 +138,24 @@ func FlattenFrameworkStringValueListLegacy(_ context.Context, vs []string) types
 	}
 
 	return types.ListValueMust(types.StringType, elems)
+}
+
+// FlattenFrameworkStringValueSet converts a slice of string values to a framework Set value.
+//
+// A nil slice is converted to a null Set.
+// An empty slice is converted to a null Set.
+func FlattenFrameworkStringValueSet(_ context.Context, vs []string) types.Set {
+	if len(vs) == 0 {
+		return types.SetNull(types.StringType)
+	}
+
+	elems := make([]attr.Value, len(vs))
+
+	for i, v := range vs {
+		elems[i] = types.StringValue(v)
+	}
+
+	return types.SetValueMust(types.StringType, elems)
 }
 
 // FlattenFrameworkStringValueSetLegacy is the Plugin Framework variant of FlattenStringValueSet.

--- a/internal/flex/framework.go
+++ b/internal/flex/framework.go
@@ -80,9 +80,9 @@ func ExpandFrameworkStringValueMap(ctx context.Context, set types.Map) map[strin
 	return m
 }
 
-// FlattenFrameworkStringList is the Plugin Framework variant of FlattenStringList.
-// In particular, a nil slice is converted to an empty (non-null) List.
-func FlattenFrameworkStringList(_ context.Context, vs []*string) types.List {
+// FlattenFrameworkStringListLegacy is the Plugin Framework variant of FlattenStringList.
+// A nil slice is converted to an empty (non-null) List.
+func FlattenFrameworkStringListLegacy(_ context.Context, vs []*string) types.List {
 	elems := make([]attr.Value, len(vs))
 
 	for i, v := range vs {
@@ -92,9 +92,9 @@ func FlattenFrameworkStringList(_ context.Context, vs []*string) types.List {
 	return types.ListValueMust(types.StringType, elems)
 }
 
-// FlattenFrameworkStringValueList is the Plugin Framework variant of FlattenStringValueList.
-// In particular, a nil slice is converted to an empty (non-null) List.
-func FlattenFrameworkStringValueList(_ context.Context, vs []string) types.List {
+// FlattenFrameworkStringValueListLegacy is the Plugin Framework variant of FlattenStringValueList.
+// A nil slice is converted to an empty (non-null) List.
+func FlattenFrameworkStringValueListLegacy(_ context.Context, vs []string) types.List {
 	elems := make([]attr.Value, len(vs))
 
 	for i, v := range vs {
@@ -104,9 +104,9 @@ func FlattenFrameworkStringValueList(_ context.Context, vs []string) types.List 
 	return types.ListValueMust(types.StringType, elems)
 }
 
-// FlattenFrameworkStringValueSet is the Plugin Framework variant of FlattenStringValueSet.
-// In particular, a nil slice is converted to an empty (non-null) Set.
-func FlattenFrameworkStringValueSet(_ context.Context, vs []string) types.Set {
+// FlattenFrameworkStringValueSetLegacy is the Plugin Framework variant of FlattenStringValueSet.
+// A nil slice is converted to an empty (non-null) Set.
+func FlattenFrameworkStringValueSetLegacy(_ context.Context, vs []string) types.Set {
 	elems := make([]attr.Value, len(vs))
 
 	for i, v := range vs {
@@ -116,9 +116,9 @@ func FlattenFrameworkStringValueSet(_ context.Context, vs []string) types.Set {
 	return types.SetValueMust(types.StringType, elems)
 }
 
-// FlattenFrameworkStringValueMap has no Plugin SDK equivalent as schema.ResourceData.Set can be passed string value maps directly.
-// In particular, a nil map is converted to an empty (non-null) Map.
-func FlattenFrameworkStringValueMap(_ context.Context, m map[string]string) types.Map {
+// FlattenFrameworkStringValueMapLegacy has no Plugin SDK equivalent as schema.ResourceData.Set can be passed string value maps directly.
+// A nil map is converted to an empty (non-null) Map.
+func FlattenFrameworkStringValueMapLegacy(_ context.Context, m map[string]string) types.Map {
 	elems := make(map[string]attr.Value, len(m))
 
 	for k, v := range m {

--- a/internal/flex/framework_test.go
+++ b/internal/flex/framework_test.go
@@ -19,6 +19,14 @@ func TestExpandFrameworkStringSet(t *testing.T) {
 		expected []*string
 	}
 	tests := map[string]testCase{
+		"null": {
+			input:    types.SetNull(types.StringType),
+			expected: nil,
+		},
+		"unknown": {
+			input:    types.SetUnknown(types.StringType),
+			expected: nil,
+		},
 		"two elements": {
 			input: types.SetValueMust(types.StringType, []attr.Value{
 				types.StringValue("GET"),
@@ -60,6 +68,14 @@ func TestExpandFrameworkStringValueSet(t *testing.T) {
 		expected []string
 	}
 	tests := map[string]testCase{
+		"null": {
+			input:    types.SetNull(types.StringType),
+			expected: nil,
+		},
+		"unknown": {
+			input:    types.SetUnknown(types.StringType),
+			expected: nil,
+		},
 		"two elements": {
 			input: types.SetValueMust(types.StringType, []attr.Value{
 				types.StringValue("GET"),

--- a/internal/flex/framework_test.go
+++ b/internal/flex/framework_test.go
@@ -259,6 +259,45 @@ func TestExpandFrameworkStringValueMap(t *testing.T) {
 	}
 }
 
+func TestFlattenFrameworkStringList(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    []*string
+		expected types.List
+	}
+	tests := map[string]testCase{
+		"two elements": {
+			input: []*string{aws.String("GET"), aws.String("HEAD")},
+			expected: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
+		},
+		"zero elements": {
+			input:    []*string{},
+			expected: types.ListNull(types.StringType),
+		},
+		"nil array": {
+			input:    nil,
+			expected: types.ListNull(types.StringType),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := FlattenFrameworkStringList(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
 func TestFlattenFrameworkStringListLegacy(t *testing.T) {
 	t.Parallel()
 
@@ -298,6 +337,45 @@ func TestFlattenFrameworkStringListLegacy(t *testing.T) {
 	}
 }
 
+func TestFlattenFrameworkStringValueList(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    []string
+		expected types.List
+	}
+	tests := map[string]testCase{
+		"two elements": {
+			input: []string{"GET", "HEAD"},
+			expected: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
+		},
+		"zero elements": {
+			input:    []string{},
+			expected: types.ListNull(types.StringType),
+		},
+		"nil array": {
+			input:    nil,
+			expected: types.ListNull(types.StringType),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := FlattenFrameworkStringValueList(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
 func TestFlattenFrameworkStringValueListLegacy(t *testing.T) {
 	t.Parallel()
 
@@ -329,6 +407,45 @@ func TestFlattenFrameworkStringValueListLegacy(t *testing.T) {
 			t.Parallel()
 
 			got := FlattenFrameworkStringValueListLegacy(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestFlattenFrameworkStringValueSet(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    []string
+		expected types.Set
+	}
+	tests := map[string]testCase{
+		"two elements": {
+			input: []string{"GET", "HEAD"},
+			expected: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
+		},
+		"zero elements": {
+			input:    []string{},
+			expected: types.SetNull(types.StringType),
+		},
+		"nil array": {
+			input:    nil,
+			expected: types.SetNull(types.StringType),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := FlattenFrameworkStringValueSet(context.Background(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)

--- a/internal/flex/framework_test.go
+++ b/internal/flex/framework_test.go
@@ -11,6 +11,104 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+func TestExpandFrameworkStringList(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    types.List
+		expected []*string
+	}
+	tests := map[string]testCase{
+		"null": {
+			input:    types.ListNull(types.StringType),
+			expected: nil,
+		},
+		"unknown": {
+			input:    types.ListUnknown(types.StringType),
+			expected: nil,
+		},
+		"two elements": {
+			input: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
+			expected: []*string{aws.String("GET"), aws.String("HEAD")},
+		},
+		"zero elements": {
+			input:    types.ListValueMust(types.StringType, []attr.Value{}),
+			expected: []*string{},
+		},
+		"invalid element type": {
+			input: types.ListValueMust(types.Int64Type, []attr.Value{
+				types.Int64Value(42),
+			}),
+			expected: nil,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ExpandFrameworkStringList(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestExpandFrameworkStringValueList(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    types.List
+		expected []string
+	}
+	tests := map[string]testCase{
+		"null": {
+			input:    types.ListNull(types.StringType),
+			expected: nil,
+		},
+		"unknown": {
+			input:    types.ListUnknown(types.StringType),
+			expected: nil,
+		},
+		"two elements": {
+			input: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("GET"),
+				types.StringValue("HEAD"),
+			}),
+			expected: []string{"GET", "HEAD"},
+		},
+		"zero elements": {
+			input:    types.ListValueMust(types.StringType, []attr.Value{}),
+			expected: []string{},
+		},
+		"invalid element type": {
+			input: types.ListValueMust(types.Int64Type, []attr.Value{
+				types.Int64Value(42),
+			}),
+			expected: nil,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ExpandFrameworkStringValueList(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
 func TestExpandFrameworkStringSet(t *testing.T) {
 	t.Parallel()
 

--- a/internal/flex/framework_test.go
+++ b/internal/flex/framework_test.go
@@ -117,6 +117,14 @@ func TestExpandFrameworkStringValueMap(t *testing.T) {
 		expected map[string]string
 	}
 	tests := map[string]testCase{
+		"null": {
+			input:    types.MapNull(types.StringType),
+			expected: nil,
+		},
+		"unknown": {
+			input:    types.MapUnknown(types.StringType),
+			expected: nil,
+		},
 		"two elements": {
 			input: types.MapValueMust(types.StringType, map[string]attr.Value{
 				"one": types.StringValue("GET"),

--- a/internal/flex/framework_test.go
+++ b/internal/flex/framework_test.go
@@ -259,7 +259,7 @@ func TestExpandFrameworkStringValueMap(t *testing.T) {
 	}
 }
 
-func TestFlattenFrameworkStringList(t *testing.T) {
+func TestFlattenFrameworkStringListLegacy(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
@@ -289,7 +289,7 @@ func TestFlattenFrameworkStringList(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := FlattenFrameworkStringList(context.Background(), test.input)
+			got := FlattenFrameworkStringListLegacy(context.Background(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
@@ -298,7 +298,7 @@ func TestFlattenFrameworkStringList(t *testing.T) {
 	}
 }
 
-func TestFlattenFrameworkStringValueList(t *testing.T) {
+func TestFlattenFrameworkStringValueListLegacy(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
@@ -328,7 +328,7 @@ func TestFlattenFrameworkStringValueList(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := FlattenFrameworkStringValueList(context.Background(), test.input)
+			got := FlattenFrameworkStringValueListLegacy(context.Background(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
@@ -337,7 +337,7 @@ func TestFlattenFrameworkStringValueList(t *testing.T) {
 	}
 }
 
-func TestFlattenFrameworkStringValueSet(t *testing.T) {
+func TestFlattenFrameworkStringValueSetLegacy(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
@@ -367,7 +367,7 @@ func TestFlattenFrameworkStringValueSet(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := FlattenFrameworkStringValueSet(context.Background(), test.input)
+			got := FlattenFrameworkStringValueSetLegacy(context.Background(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
@@ -376,7 +376,7 @@ func TestFlattenFrameworkStringValueSet(t *testing.T) {
 	}
 }
 
-func TestFlattenFrameworkStringValueMap(t *testing.T) {
+func TestFlattenFrameworkStringValueMapLegacy(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
@@ -409,7 +409,7 @@ func TestFlattenFrameworkStringValueMap(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := FlattenFrameworkStringValueMap(context.Background(), test.input)
+			got := FlattenFrameworkStringValueMapLegacy(context.Background(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)

--- a/internal/framework/base.go
+++ b/internal/framework/base.go
@@ -75,7 +75,7 @@ func (r *ResourceWithConfigure) SetTagsAll(ctx context.Context, request resource
 
 		allTags := defaultTagsConfig.MergeTags(resourceTags).IgnoreConfig(ignoreTagsConfig)
 
-		response.Diagnostics.Append(response.Plan.SetAttribute(ctx, path.Root("tags_all"), flex.FlattenFrameworkStringValueMap(ctx, allTags.Map()))...)
+		response.Diagnostics.Append(response.Plan.SetAttribute(ctx, path.Root("tags_all"), flex.FlattenFrameworkStringValueMapLegacy(ctx, allTags.Map()))...)
 	} else {
 		response.Diagnostics.Append(response.Plan.SetAttribute(ctx, path.Root("tags_all"), tftags.Unknown)...)
 	}

--- a/internal/service/auditmanager/assessment.go
+++ b/internal/service/auditmanager/assessment.go
@@ -201,7 +201,7 @@ func (r *resourceAssessment) Create(ctx context.Context, req resource.CreateRequ
 	defaultTagsConfig := r.Meta().DefaultTagsConfig
 	ignoreTagsConfig := r.Meta().IgnoreTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(plan.Tags))
-	plan.TagsAll = flex.FlattenFrameworkStringValueMap(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
+	plan.TagsAll = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
 
 	if len(tags) > 0 {
 		in.Tags = Tags(tags.IgnoreAWS())
@@ -513,9 +513,9 @@ func (rd *resourceAssessmentData) refreshFromOutput(ctx context.Context, meta *c
 	if tags := tags.RemoveDefaultConfig(defaultTagsConfig).Map(); len(tags) == 0 {
 		rd.Tags = tftags.Null
 	} else {
-		rd.Tags = flex.FlattenFrameworkStringValueMap(ctx, tags)
+		rd.Tags = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags)
 	}
-	rd.TagsAll = flex.FlattenFrameworkStringValueMap(ctx, tags.Map())
+	rd.TagsAll = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags.Map())
 
 	return diags
 }

--- a/internal/service/auditmanager/control.go
+++ b/internal/service/auditmanager/control.go
@@ -164,7 +164,7 @@ func (r *resourceControl) Create(ctx context.Context, req resource.CreateRequest
 	defaultTagsConfig := r.Meta().DefaultTagsConfig
 	ignoreTagsConfig := r.Meta().IgnoreTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(plan.Tags))
-	plan.TagsAll = flex.FlattenFrameworkStringValueMap(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
+	plan.TagsAll = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
 
 	if len(tags) > 0 {
 		in.Tags = Tags(tags.IgnoreAWS())
@@ -456,9 +456,9 @@ func (rd *resourceControlData) refreshFromOutput(ctx context.Context, meta *conn
 	if tags := tags.RemoveDefaultConfig(defaultTagsConfig).Map(); len(tags) == 0 {
 		rd.Tags = tftags.Null
 	} else {
-		rd.Tags = flex.FlattenFrameworkStringValueMap(ctx, tags)
+		rd.Tags = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags)
 	}
-	rd.TagsAll = flex.FlattenFrameworkStringValueMap(ctx, tags.Map())
+	rd.TagsAll = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags.Map())
 
 	return diags
 }

--- a/internal/service/auditmanager/framework.go
+++ b/internal/service/auditmanager/framework.go
@@ -134,7 +134,7 @@ func (r *resourceFramework) Create(ctx context.Context, req resource.CreateReque
 	defaultTagsConfig := r.Meta().DefaultTagsConfig
 	ignoreTagsConfig := r.Meta().IgnoreTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(plan.Tags))
-	plan.TagsAll = flex.FlattenFrameworkStringValueMap(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
+	plan.TagsAll = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
 
 	if len(tags) > 0 {
 		in.Tags = Tags(tags.IgnoreAWS())
@@ -403,9 +403,9 @@ func (rd *resourceFrameworkData) refreshFromOutput(ctx context.Context, meta *co
 	if tags := tags.RemoveDefaultConfig(defaultTagsConfig).Map(); len(tags) == 0 {
 		rd.Tags = tftags.Null
 	} else {
-		rd.Tags = flex.FlattenFrameworkStringValueMap(ctx, tags)
+		rd.Tags = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags)
 	}
-	rd.TagsAll = flex.FlattenFrameworkStringValueMap(ctx, tags.Map())
+	rd.TagsAll = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags.Map())
 
 	return diags
 }

--- a/internal/service/ec2/vpc_security_group_ingress_rule.go
+++ b/internal/service/ec2/vpc_security_group_ingress_rule.go
@@ -327,7 +327,7 @@ func (r *resourceSecurityGroupRule) create(ctx context.Context, request resource
 	// Set values for unknowns.
 	data.ARN = r.arn(ctx, securityGroupRuleID)
 	data.SecurityGroupRuleID = types.StringValue(securityGroupRuleID)
-	data.TagsAll = flex.FlattenFrameworkStringValueMap(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
+	data.TagsAll = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
@@ -413,9 +413,9 @@ func (r *resourceSecurityGroupRule) read(ctx context.Context, request resource.R
 	if tags := tags.RemoveDefaultConfig(defaultTagsConfig).Map(); len(tags) == 0 {
 		data.Tags = tftags.Null
 	} else {
-		data.Tags = flex.FlattenFrameworkStringValueMap(ctx, tags)
+		data.Tags = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags)
 	}
-	data.TagsAll = flex.FlattenFrameworkStringValueMap(ctx, tags.Map())
+	data.TagsAll = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags.Map())
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }

--- a/internal/service/globalaccelerator/accelerator_data_source.go
+++ b/internal/service/globalaccelerator/accelerator_data_source.go
@@ -179,7 +179,7 @@ func (d *dataSourceAccelerator) Read(ctx context.Context, request datasource.Rea
 		return
 	}
 
-	data.Tags = flex.FlattenFrameworkStringValueMap(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
+	data.Tags = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
@@ -195,7 +195,7 @@ func (d *dataSourceAccelerator) flattenIPSetFramework(ctx context.Context, apiOb
 	}
 
 	attributes := map[string]attr.Value{
-		"ip_addresses": flex.FlattenFrameworkStringList(ctx, apiObject.IpAddresses),
+		"ip_addresses": flex.FlattenFrameworkStringListLegacy(ctx, apiObject.IpAddresses),
 		"ip_family":    flex.StringToFrameworkLegacy(ctx, apiObject.IpFamily),
 	}
 

--- a/internal/service/meta/default_tags_data_source.go
+++ b/internal/service/meta/default_tags_data_source.go
@@ -64,7 +64,7 @@ func (d *dataSourceDefaultTags) Read(ctx context.Context, request datasource.Rea
 	tags := defaultTagsConfig.GetTags()
 
 	data.ID = types.StringValue(d.Meta().Partition)
-	data.Tags = flex.FlattenFrameworkStringValueMap(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
+	data.Tags = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }

--- a/internal/service/meta/ip_ranges_data_source.go
+++ b/internal/service/meta/ip_ranges_data_source.go
@@ -154,8 +154,8 @@ func (d *dataSourceIPRanges) Read(ctx context.Context, request datasource.ReadRe
 
 	data.CreateDate = types.StringValue(ipRanges.CreateDate)
 	data.ID = types.StringValue(ipRanges.SyncToken)
-	data.IPv4CIDRBlocks = flex.FlattenFrameworkStringValueList(ctx, ipv4Prefixes)
-	data.IPv6CIDRBlocks = flex.FlattenFrameworkStringValueList(ctx, ipv6Prefixes)
+	data.IPv4CIDRBlocks = flex.FlattenFrameworkStringValueListLegacy(ctx, ipv4Prefixes)
+	data.IPv6CIDRBlocks = flex.FlattenFrameworkStringValueListLegacy(ctx, ipv6Prefixes)
 	data.SyncToken = types.Int64Value(int64(syncToken))
 	data.URL = types.StringValue(url)
 

--- a/internal/service/meta/regions_data_source.go
+++ b/internal/service/meta/regions_data_source.go
@@ -89,7 +89,7 @@ func (d *dataSourceRegions) Read(ctx context.Context, request datasource.ReadReq
 	}
 
 	data.ID = types.StringValue(d.Meta().Partition)
-	data.Names = flex.FlattenFrameworkStringValueSet(ctx, names)
+	data.Names = flex.FlattenFrameworkStringValueSetLegacy(ctx, names)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }

--- a/internal/service/resourceexplorer2/index.go
+++ b/internal/service/resourceexplorer2/index.go
@@ -141,7 +141,7 @@ func (r *resourceIndex) Create(ctx context.Context, request resource.CreateReque
 
 	// Set values for unknowns.
 	data.ARN = types.StringValue(arn)
-	data.TagsAll = flex.FlattenFrameworkStringValueMap(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
+	data.TagsAll = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map())
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
@@ -182,9 +182,9 @@ func (r *resourceIndex) Read(ctx context.Context, request resource.ReadRequest, 
 	if tags := tags.RemoveDefaultConfig(defaultTagsConfig).Map(); len(tags) == 0 {
 		data.Tags = tftags.Null
 	} else {
-		data.Tags = flex.FlattenFrameworkStringValueMap(ctx, tags)
+		data.Tags = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags)
 	}
-	data.TagsAll = flex.FlattenFrameworkStringValueMap(ctx, tags.Map())
+	data.TagsAll = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags.Map())
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }


### PR DESCRIPTION
### Description
Several updates and additions to the `flex` package's framework specific helper functions, including:

- Add flatten functions for string list/set/map objects that return null values for nil and empty inputs
- Rename flatten functions for string list/set/map objects that return empty values for nil inputs with the `Legacy` suffix adopted by the value conversion helpers
- Add string list expander functions
- Extend various test cases

The non-legacy flatteners will allow omitted list/set attributes to be set as null for net-new resources, while the legacy versions preserve the empty list/set/map return behavior where needed (tags, refactored resources/data sources, etc.). 

### Output from Acceptance Testing

```console
$ go test -count=1 ./internal/flex/...
ok      github.com/hashicorp/terraform-provider-aws/internal/flex       0.257s
```
