### PR TITLE
Align aws_ecs_service security_connect_configuration schema with API

### DIFF
--- a/.changelog/28813.txt
+++ b/.changelog/28813.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/aws_ecs_service: Allow multiple `service` blocks within `service_connect_configuration`
+```
+
+```release-note:bug
+resource/aws_ecs_service: Require `service_connect_configuration.log_configuration.log_driver` to be provided
+```
+
+```release-note:bug
+resource/aws_ecs_service: Mark `service_connect_configuration.service.client_alias` as optional and ensure that only 1 such block can be provided
+```

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -336,7 +336,7 @@ func ResourceService() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"log_driver": {
 										Type:         schema.TypeString,
-										Optional:     true,
+										Required:     true,
 										ValidateFunc: validation.StringInSlice(ecs.LogDriver_Values(), false),
 									},
 									"options": {
@@ -371,12 +371,12 @@ func ResourceService() *schema.Resource {
 						"service": {
 							Type:     schema.TypeList,
 							Optional: true,
-							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"client_alias": {
 										Type:     schema.TypeList,
-										Required: true,
+										Optional: true,
+										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"dns_name": {
@@ -386,7 +386,7 @@ func ResourceService() *schema.Resource {
 												"port": {
 													Type:         schema.TypeInt,
 													Required:     true,
-													ValidateFunc: validation.IntBetween(1, 65535),
+													ValidateFunc: validation.IntBetween(0, 65535),
 												},
 											},
 										},
@@ -398,7 +398,7 @@ func ResourceService() *schema.Resource {
 									"ingress_port_override": {
 										Type:         schema.TypeInt,
 										Optional:     true,
-										ValidateFunc: validation.IntBetween(1, 65535),
+										ValidateFunc: validation.IntBetween(0, 65535),
 									},
 									"port_name": {
 										Type:     schema.TypeString,

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -245,7 +245,7 @@ For more information, see [Task Networking](https://docs.aws.amazon.com/AmazonEC
 
 `log_configuration` supports the following:
 
-* `log_driver` - (Optional) The log driver to use for the container.
+* `log_driver` - (Required) The log driver to use for the container.
 * `options` - (Optional) The configuration options to send to the log driver.
 * `secret_option` - (Optional) The secrets to pass to the log configuration. See below.
 
@@ -253,8 +253,8 @@ For more information, see [Task Networking](https://docs.aws.amazon.com/AmazonEC
 
 `secret_option` supports the following:
 
-* `name` - (Optional) The name of the secret.
-* `value_from` - (Optional) The secret to expose to the container. The supported values are either the full ARN of the AWS Secrets Manager secret or the full ARN of the parameter in the SSM Parameter Store.
+* `name` - (Required) The name of the secret.
+* `value_from` - (Required) The secret to expose to the container. The supported values are either the full ARN of the AWS Secrets Manager secret or the full ARN of the parameter in the SSM Parameter Store.
 
 ### service
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Various elements of the aws_ecs_service relating to service_connect_configuration didn't match up with the documented API at https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ServiceConnectConfiguration.html and https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ServiceConnectService.html

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28754

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccECSService_ServiceConnect PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSService_ServiceConnect'  -timeout 180m
=== RUN   TestAccECSService_ServiceConnect_basic
=== PAUSE TestAccECSService_ServiceConnect_basic
=== RUN   TestAccECSService_ServiceConnect_full
=== PAUSE TestAccECSService_ServiceConnect_full
=== RUN   TestAccECSService_ServiceConnect_ingressPortOverride
=== PAUSE TestAccECSService_ServiceConnect_ingressPortOverride
=== RUN   TestAccECSService_ServiceConnect_remove
=== PAUSE TestAccECSService_ServiceConnect_remove
=== CONT  TestAccECSService_ServiceConnect_basic
=== CONT  TestAccECSService_ServiceConnect_ingressPortOverride
=== CONT  TestAccECSService_ServiceConnect_full
=== CONT  TestAccECSService_ServiceConnect_remove
--- PASS: TestAccECSService_ServiceConnect_full (147.65s)
--- PASS: TestAccECSService_ServiceConnect_basic (156.67s)
--- PASS: TestAccECSService_ServiceConnect_ingressPortOverride (157.75s)
--- PASS: TestAccECSService_ServiceConnect_remove (164.91s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	165.015s
```