### PR TITLE
Tests: Simplify provider initialization

### DIFF
--- a/docs/running-and-writing-acceptance-tests.md
+++ b/docs/running-and-writing-acceptance-tests.md
@@ -1063,32 +1063,24 @@ When encountering these types of components, the acceptance testing can be setup
 
 To convert to serialized (one test at a time) acceptance testing:
 
-- Convert all existing capital `T` test functions with the limited component to begin with a lowercase `t`, e.g., `TestAccSageMakerDomain_basic` becomes `testAccSageMakerDomain_basic`. This will prevent the test framework from executing these tests directly as the prefix `Test` is required.
+- Convert all existing capital `T` test functions with the limited component to begin with a lowercase `t`, e.g., `TestAccSageMakerDomain_basic` becomes `testDomain_basic`. This will prevent the test framework from executing these tests directly as the prefix `Test` is required.
     - In each of these test functions, convert `resource.ParallelTest` to `resource.Test`
 - Create a capital `T` `TestAcc{Service}{Thing}_serial` test function that then references all the lowercase `t` test functions. If multiple test files are referenced, this new test be created in a new shared file such as `internal/service/{SERVICE}/{SERVICE}_test.go`. The contents of this test can be setup like the following:
 
 ```go
 func TestAccExampleThing_serial(t *testing.T) {
+  t.Parallel()
+
 	testCases := map[string]map[string]func(t *testing.T){
 		"Thing": {
-			"basic":        testAccExampleThing_basic,
-			"disappears":   testAccExampleThing_disappears,
+			"basic":        testAccThing_basic,
+			"disappears":   testAccThing_disappears,
 			// ... potentially other resource tests ...
 		},
 		// ... potentially other top level resource test groups ...
 	}
 
-	for group, m := range testCases {
-		m := m
-		t.Run(group, func(t *testing.T) {
-			for name, tc := range m {
-				tc := tc
-				t.Run(name, func(t *testing.T) {
-					tc(t)
-				})
-			}
-		})
-	}
+	acctest.RunSerialTests2Levels(t, testCases, 0)
 }
 ```
 

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -124,8 +124,7 @@ func protoV5ProviderFactoriesInit(providerNames ...string) map[string]func() (tf
 	return factories
 }
 
-func factoriesInit(t *testing.T, providers *[]*schema.Provider, providerNames []string) map[string]func() (*schema.Provider, error) {
-	ctx := context.Background()
+func factoriesInit(ctx context.Context, t *testing.T, providers *[]*schema.Provider, providerNames []string) map[string]func() (*schema.Provider, error) {
 	var factories = make(map[string]func() (*schema.Provider, error), len(providerNames))
 
 	for _, name := range providerNames {
@@ -153,7 +152,7 @@ func factoriesInit(t *testing.T, providers *[]*schema.Provider, providerNames []
 //
 // For cross-account testing: Typically paired with PreCheckAlternateAccount and ConfigAlternateAccountProvider.
 func FactoriesAlternate(t *testing.T, providers *[]*schema.Provider) map[string]func() (*schema.Provider, error) {
-	return factoriesInit(t, providers, []string{
+	return factoriesInit(context.Background(), t, providers, []string{
 		ProviderName,
 		ProviderNameAlternate,
 	})

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/envvar"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/provider"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	tforganizations "github.com/hashicorp/terraform-provider-aws/internal/service/organizations"
@@ -76,6 +77,7 @@ func Skip(t *testing.T, message string) {
 // Use other ProviderFactories functions, such as FactoriesAlternate,
 // for tests requiring special provider configurations.
 var (
+	// TODO Convert to function taking testing.T.
 	ProtoV5ProviderFactories map[string]func() (tfprotov5.ProviderServer, error) = protoV5ProviderFactoriesInit(context.Background(), ProviderName)
 )
 
@@ -94,15 +96,6 @@ var Provider *schema.Provider
 // not prevent reconfiguration that may happen should the address of
 // Provider be errantly reused in ProviderFactories.
 var testAccProviderConfigure sync.Once
-
-func init() {
-	var err error
-	Provider, err = provider.New(context.Background())
-
-	if err != nil {
-		panic(err)
-	}
-}
 
 func protoV5ProviderFactoriesInit(ctx context.Context, providerNames ...string) map[string]func() (tfprotov5.ProviderServer, error) {
 	factories := make(map[string]func() (tfprotov5.ProviderServer, error), len(providerNames))
@@ -202,6 +195,8 @@ func PreCheck(t *testing.T) {
 	// Since we are outside the scope of the Terraform configuration we must
 	// call Configure() to properly initialize the provider configuration.
 	testAccProviderConfigure.Do(func() {
+		ctx := context.Background()
+
 		envvar.FailIfAllEmpty(t, []string{envvar.Profile, envvar.AccessKeyId, envvar.ContainerCredentialsFullURI}, "credentials for running acceptance testing")
 
 		if os.Getenv(envvar.AccessKeyId) != "" {
@@ -218,10 +213,19 @@ func PreCheck(t *testing.T) {
 		region := Region()
 		os.Setenv(envvar.DefaultRegion, region)
 
-		err := Provider.Configure(context.Background(), terraform.NewResourceConfigRaw(nil))
+		p, err := provider.New(ctx)
+
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		err = sdkdiag.DiagnosticsError(p.Configure(ctx, terraform.NewResourceConfigRaw(nil)))
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		Provider = p
 	})
 }
 

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/envvar"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/provider"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	tforganizations "github.com/hashicorp/terraform-provider-aws/internal/service/organizations"
@@ -218,7 +219,8 @@ func PreCheck(t *testing.T) {
 		region := Region()
 		os.Setenv(envvar.DefaultRegion, region)
 
-		err := Provider.Configure(context.Background(), terraform.NewResourceConfigRaw(nil))
+		err := sdkdiag.DiagnosticsError(Provider.Configure(context.Background(), terraform.NewResourceConfigRaw(nil)))
+
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/acctest/provider_test.go
+++ b/internal/acctest/provider_test.go
@@ -36,53 +36,6 @@ func TestProvider(t *testing.T) {
 	}
 }
 
-func TestReverseDNS(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "empty",
-			input:    "",
-			expected: "",
-		},
-		{
-			name:     "amazonaws.com",
-			input:    "amazonaws.com",
-			expected: "com.amazonaws",
-		},
-		{
-			name:     "amazonaws.com.cn",
-			input:    "amazonaws.com.cn",
-			expected: "cn.com.amazonaws",
-		},
-		{
-			name:     "sc2s.sgov.gov",
-			input:    "sc2s.sgov.gov",
-			expected: "gov.sgov.sc2s",
-		},
-		{
-			name:     "c2s.ic.gov",
-			input:    "c2s.ic.gov",
-			expected: "gov.ic.c2s",
-		},
-	}
-
-	for _, testCase := range testCases {
-		testCase := testCase
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			if got, want := conns.ReverseDNS(testCase.input), testCase.expected; got != want {
-				t.Errorf("got: %s, expected: %s", got, want)
-			}
-		})
-	}
-}
-
 func TestAccProvider_DefaultTags_emptyBlock(t *testing.T) {
 	var provider *schema.Provider
 

--- a/internal/acctest/provider_test.go
+++ b/internal/acctest/provider_test.go
@@ -20,22 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestProvider(t *testing.T) {
-	t.Parallel()
-
-	p, err := provider.New(context.Background())
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = p.InternalValidate()
-
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestAccProvider_DefaultTags_emptyBlock(t *testing.T) {
 	var provider *schema.Provider
 

--- a/internal/conns/conns_test.go
+++ b/internal/conns/conns_test.go
@@ -1,0 +1,52 @@
+package conns
+
+import (
+	"testing"
+)
+
+func TestReverseDNS(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "amazonaws.com",
+			input:    "amazonaws.com",
+			expected: "com.amazonaws",
+		},
+		{
+			name:     "amazonaws.com.cn",
+			input:    "amazonaws.com.cn",
+			expected: "cn.com.amazonaws",
+		},
+		{
+			name:     "sc2s.sgov.gov",
+			input:    "sc2s.sgov.gov",
+			expected: "gov.sgov.sc2s",
+		},
+		{
+			name:     "c2s.ic.gov",
+			input:    "c2s.ic.gov",
+			expected: "gov.ic.c2s",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got, want := ReverseDNS(testCase.input), testCase.expected; got != want {
+				t.Errorf("got: %s, expected: %s", got, want)
+			}
+		})
+	}
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,12 +1,29 @@
 package provider
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
+
+func TestProvider(t *testing.T) {
+	t.Parallel()
+
+	p, err := New(context.Background())
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = p.InternalValidate()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestExpandEndpoints(t *testing.T) { //nolint:paralleltest
 	oldEnv := stashEnv()

--- a/internal/service/ec2/ec2_ami_data_source.go
+++ b/internal/service/ec2/ec2_ami_data_source.go
@@ -223,51 +223,51 @@ func DataSourceAMI() *schema.Resource {
 	}
 }
 
-// dataSourceAwsAmiDescriptionRead performs the AMI lookup.
 func dataSourceAMIRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).EC2Conn()
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	params := &ec2.DescribeImagesInput{
+	input := &ec2.DescribeImagesInput{
 		IncludeDeprecated: aws.Bool(d.Get("include_deprecated").(bool)),
 	}
 
-	if v, ok := d.GetOk("owners"); ok && len(v.([]interface{})) > 0 {
-		params.Owners = flex.ExpandStringList(v.([]interface{}))
-	}
-
 	if v, ok := d.GetOk("executable_users"); ok {
-		params.ExecutableUsers = flex.ExpandStringList(v.([]interface{}))
+		input.ExecutableUsers = flex.ExpandStringList(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("filter"); ok {
-		params.Filters = BuildFiltersDataSource(v.(*schema.Set))
+		input.Filters = BuildFiltersDataSource(v.(*schema.Set))
 	}
 
-	log.Printf("[DEBUG] Reading AMI: %s", params)
-	resp, err := conn.DescribeImages(params)
+	if v, ok := d.GetOk("owners"); ok && len(v.([]interface{})) > 0 {
+		input.Owners = flex.ExpandStringList(v.([]interface{}))
+	}
+
+	images, err := FindImages(conn, input)
+
 	if err != nil {
-		return err
+		return fmt.Errorf("reading EC2 AMIs: %w", err)
 	}
 
 	var filteredImages []*ec2.Image
-	if nameRegex, ok := d.GetOk("name_regex"); ok {
-		r := regexp.MustCompile(nameRegex.(string))
-		for _, image := range resp.Images {
+	if v, ok := d.GetOk("name_regex"); ok {
+		r := regexp.MustCompile(v.(string))
+		for _, image := range images {
+			name := aws.StringValue(image.Name)
+
 			// Check for a very rare case where the response would include no
 			// image name. No name means nothing to attempt a match against,
 			// therefore we are skipping such image.
-			if image.Name == nil || aws.StringValue(image.Name) == "" {
-				log.Printf("[WARN] Unable to find AMI name to match against "+
-					"for image ID %q owned by %q, nothing to do.",
-					aws.StringValue(image.ImageId), aws.StringValue(image.OwnerId))
+			if name == "" {
 				continue
 			}
-			if r.MatchString(aws.StringValue(image.Name)) {
+
+			if r.MatchString(name) {
 				filteredImages = append(filteredImages, image)
 			}
 		}
 	} else {
-		filteredImages = resp.Images[:]
+		filteredImages = images[:]
 	}
 
 	if len(filteredImages) < 1 {
@@ -286,16 +286,20 @@ func dataSourceAMIRead(d *schema.ResourceData, meta interface{}) error {
 		})
 	}
 
-	return amiDescriptionAttributes(d, filteredImages[0], meta)
-}
+	image := filteredImages[0]
 
-// populate the numerous fields that the image description returns.
-func amiDescriptionAttributes(d *schema.ResourceData, image *ec2.Image, meta interface{}) error {
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-
-	// Simple attributes first
 	d.SetId(aws.StringValue(image.ImageId))
 	d.Set("architecture", image.Architecture)
+	imageArn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Region:    meta.(*conns.AWSClient).Region,
+		Service:   ec2.ServiceName,
+		Resource:  fmt.Sprintf("image/%s", d.Id()),
+	}.String()
+	d.Set("arn", imageArn)
+	if err := d.Set("block_device_mappings", flattenAMIBlockDeviceMappings(image.BlockDeviceMappings)); err != nil {
+		return fmt.Errorf("setting block_device_mappings: %w", err)
+	}
 	d.Set("boot_mode", image.BootMode)
 	d.Set("creation_date", image.CreationDate)
 	d.Set("deprecation_time", image.DeprecationTime)
@@ -312,6 +316,9 @@ func amiDescriptionAttributes(d *schema.ResourceData, image *ec2.Image, meta int
 	d.Set("owner_id", image.OwnerId)
 	d.Set("platform", image.Platform)
 	d.Set("platform_details", image.PlatformDetails)
+	if err := d.Set("product_codes", flattenAMIProductCodes(image.ProductCodes)); err != nil {
+		return fmt.Errorf("setting product_codes: %w", err)
+	}
 	d.Set("public", image.Public)
 	d.Set("ramdisk_id", image.RamdiskId)
 	d.Set("root_device_name", image.RootDeviceName)
@@ -319,38 +326,21 @@ func amiDescriptionAttributes(d *schema.ResourceData, image *ec2.Image, meta int
 	d.Set("root_snapshot_id", amiRootSnapshotId(image))
 	d.Set("sriov_net_support", image.SriovNetSupport)
 	d.Set("state", image.State)
+	if err := d.Set("state_reason", flattenAMIStateReason(image.StateReason)); err != nil {
+		return fmt.Errorf("setting state_reason: %w", err)
+	}
 	d.Set("tpm_support", image.TpmSupport)
 	d.Set("usage_operation", image.UsageOperation)
 	d.Set("virtualization_type", image.VirtualizationType)
 
-	// Complex types get their own functions
-	if err := d.Set("block_device_mappings", amiBlockDeviceMappings(image.BlockDeviceMappings)); err != nil {
-		return err
-	}
-	if err := d.Set("product_codes", amiProductCodes(image.ProductCodes)); err != nil {
-		return err
-	}
-	if err := d.Set("state_reason", amiStateReason(image.StateReason)); err != nil {
-		return err
-	}
 	if err := d.Set("tags", KeyValueTags(image.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
+		return fmt.Errorf("setting tags: %w", err)
 	}
-
-	imageArn := arn.ARN{
-		Partition: meta.(*conns.AWSClient).Partition,
-		Region:    meta.(*conns.AWSClient).Region,
-		Resource:  fmt.Sprintf("image/%s", d.Id()),
-		Service:   ec2.ServiceName,
-	}.String()
-
-	d.Set("arn", imageArn)
 
 	return nil
 }
 
-// Returns a set of block device mappings.
-func amiBlockDeviceMappings(m []*ec2.BlockDeviceMapping) *schema.Set {
+func flattenAMIBlockDeviceMappings(m []*ec2.BlockDeviceMapping) *schema.Set {
 	s := &schema.Set{
 		F: amiBlockDeviceMappingHash,
 	}
@@ -380,8 +370,7 @@ func amiBlockDeviceMappings(m []*ec2.BlockDeviceMapping) *schema.Set {
 	return s
 }
 
-// Returns a set of product codes.
-func amiProductCodes(m []*ec2.ProductCode) *schema.Set {
+func flattenAMIProductCodes(m []*ec2.ProductCode) *schema.Set {
 	s := &schema.Set{
 		F: amiProductCodesHash,
 	}
@@ -395,7 +384,6 @@ func amiProductCodes(m []*ec2.ProductCode) *schema.Set {
 	return s
 }
 
-// Returns the root snapshot ID for an image, if it has one
 func amiRootSnapshotId(image *ec2.Image) string {
 	if image.RootDeviceName == nil {
 		return ""
@@ -412,8 +400,7 @@ func amiRootSnapshotId(image *ec2.Image) string {
 	return ""
 }
 
-// Returns the state reason.
-func amiStateReason(m *ec2.StateReason) map[string]interface{} {
+func flattenAMIStateReason(m *ec2.StateReason) map[string]interface{} {
 	s := make(map[string]interface{})
 	if m != nil {
 		s["code"] = aws.StringValue(m.Code)
@@ -425,8 +412,6 @@ func amiStateReason(m *ec2.StateReason) map[string]interface{} {
 	return s
 }
 
-// Generates a hash for the set hash function used by the block_device_mappings
-// attribute.
 func amiBlockDeviceMappingHash(v interface{}) int {
 	var buf bytes.Buffer
 	// All keys added in alphabetical order.
@@ -454,8 +439,6 @@ func amiBlockDeviceMappingHash(v interface{}) int {
 	return create.StringHashcode(buf.String())
 }
 
-// Generates a hash for the set hash function used by the product_codes
-// attribute.
 func amiProductCodesHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})

--- a/internal/service/ec2/ec2_ami_data_source_test.go
+++ b/internal/service/ec2/ec2_ami_data_source_test.go
@@ -1,19 +1,18 @@
 package ec2_test
 
 import (
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
 func TestAccEC2AMIDataSource_natInstance(t *testing.T) {
-	resourceName := "data.aws_ami.nat_ami"
+	datasourceName := "data.aws_ami.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -22,7 +21,6 @@ func TestAccEC2AMIDataSource_natInstance(t *testing.T) {
 			{
 				Config: testAccAMIDataSourceConfig_basic,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAMIIDDataSource(resourceName),
 					// Check attributes. Some attributes are tough to test - any not contained here should not be considered
 					// stable and should not be used in interpolation. Exception to block_device_mappings which should both
 					// show up consistently and break if certain references are not available. However modification of the
@@ -30,35 +28,35 @@ func TestAccEC2AMIDataSource_natInstance(t *testing.T) {
 					// deep inspection is not included, simply the count is checked.
 					// Tags and product codes may need more testing, but I'm having a hard time finding images with
 					// these attributes set.
-					resource.TestCheckResourceAttr(resourceName, "architecture", "x86_64"),
-					acctest.MatchResourceAttrRegionalARNNoAccount(resourceName, "arn", "ec2", regexp.MustCompile(`image/ami-.+`)),
-					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.#", "1"),
-					resource.TestMatchResourceAttr(resourceName, "creation_date", regexp.MustCompile("^20[0-9]{2}-")),
-					resource.TestMatchResourceAttr(resourceName, "deprecation_time", regexp.MustCompile("^20[0-9]{2}-")),
-					resource.TestMatchResourceAttr(resourceName, "description", regexp.MustCompile("^Amazon Linux AMI")),
-					resource.TestCheckResourceAttr(resourceName, "ena_support", "true"),
-					resource.TestCheckResourceAttr(resourceName, "hypervisor", "xen"),
-					resource.TestMatchResourceAttr(resourceName, "image_id", regexp.MustCompile("^ami-")),
-					resource.TestMatchResourceAttr(resourceName, "image_location", regexp.MustCompile("^amazon/")),
-					resource.TestCheckResourceAttr(resourceName, "image_owner_alias", "amazon"),
-					resource.TestCheckResourceAttr(resourceName, "image_type", "machine"),
-					resource.TestCheckResourceAttr(resourceName, "imds_support", ""),
-					resource.TestCheckResourceAttr(resourceName, "most_recent", "true"),
-					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile("^amzn-ami-vpc-nat")),
-					acctest.MatchResourceAttrAccountID(resourceName, "owner_id"),
-					resource.TestCheckResourceAttr(resourceName, "platform_details", "Linux/UNIX"),
-					resource.TestCheckResourceAttr(resourceName, "product_codes.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "public", "true"),
-					resource.TestCheckResourceAttr(resourceName, "root_device_name", "/dev/xvda"),
-					resource.TestCheckResourceAttr(resourceName, "root_device_type", "ebs"),
-					resource.TestMatchResourceAttr(resourceName, "root_snapshot_id", regexp.MustCompile("^snap-")),
-					resource.TestCheckResourceAttr(resourceName, "sriov_net_support", "simple"),
-					resource.TestCheckResourceAttr(resourceName, "state", "available"),
-					resource.TestCheckResourceAttr(resourceName, "state_reason.code", "UNSET"),
-					resource.TestCheckResourceAttr(resourceName, "state_reason.message", "UNSET"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "usage_operation", "RunInstances"),
-					resource.TestCheckResourceAttr(resourceName, "virtualization_type", "hvm"),
+					resource.TestCheckResourceAttr(datasourceName, "architecture", "x86_64"),
+					acctest.MatchResourceAttrRegionalARNNoAccount(datasourceName, "arn", "ec2", regexp.MustCompile(`image/ami-.+`)),
+					resource.TestCheckResourceAttr(datasourceName, "block_device_mappings.#", "1"),
+					resource.TestMatchResourceAttr(datasourceName, "creation_date", regexp.MustCompile("^20[0-9]{2}-")),
+					resource.TestMatchResourceAttr(datasourceName, "deprecation_time", regexp.MustCompile("^20[0-9]{2}-")),
+					resource.TestMatchResourceAttr(datasourceName, "description", regexp.MustCompile("^Amazon Linux AMI")),
+					resource.TestCheckResourceAttr(datasourceName, "ena_support", "true"),
+					resource.TestCheckResourceAttr(datasourceName, "hypervisor", "xen"),
+					resource.TestMatchResourceAttr(datasourceName, "image_id", regexp.MustCompile("^ami-")),
+					resource.TestMatchResourceAttr(datasourceName, "image_location", regexp.MustCompile("^amazon/")),
+					resource.TestCheckResourceAttr(datasourceName, "image_owner_alias", "amazon"),
+					resource.TestCheckResourceAttr(datasourceName, "image_type", "machine"),
+					resource.TestCheckResourceAttr(datasourceName, "imds_support", ""),
+					resource.TestCheckResourceAttr(datasourceName, "most_recent", "true"),
+					resource.TestMatchResourceAttr(datasourceName, "name", regexp.MustCompile("^amzn-ami-vpc-nat")),
+					acctest.MatchResourceAttrAccountID(datasourceName, "owner_id"),
+					resource.TestCheckResourceAttr(datasourceName, "platform_details", "Linux/UNIX"),
+					resource.TestCheckResourceAttr(datasourceName, "product_codes.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "public", "true"),
+					resource.TestCheckResourceAttr(datasourceName, "root_device_name", "/dev/xvda"),
+					resource.TestCheckResourceAttr(datasourceName, "root_device_type", "ebs"),
+					resource.TestMatchResourceAttr(datasourceName, "root_snapshot_id", regexp.MustCompile("^snap-")),
+					resource.TestCheckResourceAttr(datasourceName, "sriov_net_support", "simple"),
+					resource.TestCheckResourceAttr(datasourceName, "state", "available"),
+					resource.TestCheckResourceAttr(datasourceName, "state_reason.code", "UNSET"),
+					resource.TestCheckResourceAttr(datasourceName, "state_reason.message", "UNSET"),
+					resource.TestCheckResourceAttr(datasourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "usage_operation", "RunInstances"),
+					resource.TestCheckResourceAttr(datasourceName, "virtualization_type", "hvm"),
 				),
 			},
 		},
@@ -66,7 +64,8 @@ func TestAccEC2AMIDataSource_natInstance(t *testing.T) {
 }
 
 func TestAccEC2AMIDataSource_windowsInstance(t *testing.T) {
-	resourceName := "data.aws_ami.windows_ami"
+	datasourceName := "data.aws_ami.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -75,36 +74,35 @@ func TestAccEC2AMIDataSource_windowsInstance(t *testing.T) {
 			{
 				Config: testAccAMIDataSourceConfig_windows,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAMIIDDataSource(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "architecture", "x86_64"),
-					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.#", "27"),
-					resource.TestMatchResourceAttr(resourceName, "creation_date", regexp.MustCompile("^20[0-9]{2}-")),
-					resource.TestMatchResourceAttr(resourceName, "deprecation_time", regexp.MustCompile("^20[0-9]{2}-")),
-					resource.TestMatchResourceAttr(resourceName, "description", regexp.MustCompile("^Microsoft Windows Server")),
-					resource.TestCheckResourceAttr(resourceName, "ena_support", "true"),
-					resource.TestCheckResourceAttr(resourceName, "hypervisor", "xen"),
-					resource.TestMatchResourceAttr(resourceName, "image_id", regexp.MustCompile("^ami-")),
-					resource.TestMatchResourceAttr(resourceName, "image_location", regexp.MustCompile("^amazon/")),
-					resource.TestCheckResourceAttr(resourceName, "image_owner_alias", "amazon"),
-					resource.TestCheckResourceAttr(resourceName, "image_type", "machine"),
-					resource.TestCheckResourceAttr(resourceName, "most_recent", "true"),
-					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile("^Windows_Server-2012-R2")),
-					acctest.MatchResourceAttrAccountID(resourceName, "owner_id"),
-					resource.TestCheckResourceAttr(resourceName, "platform", "windows"),
-					resource.TestMatchResourceAttr(resourceName, "platform_details", regexp.MustCompile(`Windows`)),
-					resource.TestCheckResourceAttr(resourceName, "product_codes.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "public", "true"),
-					resource.TestCheckResourceAttr(resourceName, "root_device_name", "/dev/sda1"),
-					resource.TestCheckResourceAttr(resourceName, "root_device_type", "ebs"),
-					resource.TestMatchResourceAttr(resourceName, "root_snapshot_id", regexp.MustCompile("^snap-")),
-					resource.TestCheckResourceAttr(resourceName, "sriov_net_support", "simple"),
-					resource.TestCheckResourceAttr(resourceName, "state", "available"),
-					resource.TestCheckResourceAttr(resourceName, "state_reason.code", "UNSET"),
-					resource.TestCheckResourceAttr(resourceName, "state_reason.message", "UNSET"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "tpm_support", ""),
-					resource.TestMatchResourceAttr(resourceName, "usage_operation", regexp.MustCompile(`^RunInstances`)),
-					resource.TestCheckResourceAttr(resourceName, "virtualization_type", "hvm"),
+					resource.TestCheckResourceAttr(datasourceName, "architecture", "x86_64"),
+					resource.TestCheckResourceAttr(datasourceName, "block_device_mappings.#", "27"),
+					resource.TestMatchResourceAttr(datasourceName, "creation_date", regexp.MustCompile("^20[0-9]{2}-")),
+					resource.TestMatchResourceAttr(datasourceName, "deprecation_time", regexp.MustCompile("^20[0-9]{2}-")),
+					resource.TestMatchResourceAttr(datasourceName, "description", regexp.MustCompile("^Microsoft Windows Server")),
+					resource.TestCheckResourceAttr(datasourceName, "ena_support", "true"),
+					resource.TestCheckResourceAttr(datasourceName, "hypervisor", "xen"),
+					resource.TestMatchResourceAttr(datasourceName, "image_id", regexp.MustCompile("^ami-")),
+					resource.TestMatchResourceAttr(datasourceName, "image_location", regexp.MustCompile("^amazon/")),
+					resource.TestCheckResourceAttr(datasourceName, "image_owner_alias", "amazon"),
+					resource.TestCheckResourceAttr(datasourceName, "image_type", "machine"),
+					resource.TestCheckResourceAttr(datasourceName, "most_recent", "true"),
+					resource.TestMatchResourceAttr(datasourceName, "name", regexp.MustCompile("^Windows_Server-2012-R2")),
+					acctest.MatchResourceAttrAccountID(datasourceName, "owner_id"),
+					resource.TestCheckResourceAttr(datasourceName, "platform", "windows"),
+					resource.TestMatchResourceAttr(datasourceName, "platform_details", regexp.MustCompile(`Windows`)),
+					resource.TestCheckResourceAttr(datasourceName, "product_codes.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "public", "true"),
+					resource.TestCheckResourceAttr(datasourceName, "root_device_name", "/dev/sda1"),
+					resource.TestCheckResourceAttr(datasourceName, "root_device_type", "ebs"),
+					resource.TestMatchResourceAttr(datasourceName, "root_snapshot_id", regexp.MustCompile("^snap-")),
+					resource.TestCheckResourceAttr(datasourceName, "sriov_net_support", "simple"),
+					resource.TestCheckResourceAttr(datasourceName, "state", "available"),
+					resource.TestCheckResourceAttr(datasourceName, "state_reason.code", "UNSET"),
+					resource.TestCheckResourceAttr(datasourceName, "state_reason.message", "UNSET"),
+					resource.TestCheckResourceAttr(datasourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "tpm_support", ""),
+					resource.TestMatchResourceAttr(datasourceName, "usage_operation", regexp.MustCompile(`^RunInstances`)),
+					resource.TestCheckResourceAttr(datasourceName, "virtualization_type", "hvm"),
 				),
 			},
 		},
@@ -112,7 +110,8 @@ func TestAccEC2AMIDataSource_windowsInstance(t *testing.T) {
 }
 
 func TestAccEC2AMIDataSource_instanceStore(t *testing.T) {
-	resourceName := "data.aws_ami.amzn-ami-minimal-hvm-instance-store"
+	datasourceName := "data.aws_ami.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -121,32 +120,31 @@ func TestAccEC2AMIDataSource_instanceStore(t *testing.T) {
 			{
 				Config: testAccAMIDataSourceConfig_latestAmazonLinuxHVMInstanceStore(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAMIIDDataSource(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "architecture", "x86_64"),
-					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.#", "0"),
-					resource.TestMatchResourceAttr(resourceName, "creation_date", regexp.MustCompile("^20[0-9]{2}-")),
-					resource.TestMatchResourceAttr(resourceName, "deprecation_time", regexp.MustCompile("^20[0-9]{2}-")),
-					resource.TestCheckResourceAttr(resourceName, "ena_support", "true"),
-					resource.TestCheckResourceAttr(resourceName, "hypervisor", "xen"),
-					resource.TestMatchResourceAttr(resourceName, "image_id", regexp.MustCompile("^ami-")),
-					resource.TestMatchResourceAttr(resourceName, "image_location", regexp.MustCompile("amzn-ami-minimal-hvm")),
-					resource.TestCheckResourceAttr(resourceName, "image_type", "machine"),
-					resource.TestCheckResourceAttr(resourceName, "most_recent", "true"),
-					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile("amzn-ami-minimal-hvm")),
-					acctest.MatchResourceAttrAccountID(resourceName, "owner_id"),
-					resource.TestCheckResourceAttr(resourceName, "platform_details", "Linux/UNIX"),
-					resource.TestCheckResourceAttr(resourceName, "product_codes.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "public", "true"),
-					resource.TestCheckResourceAttr(resourceName, "root_device_type", "instance-store"),
-					resource.TestCheckResourceAttr(resourceName, "root_snapshot_id", ""),
-					resource.TestCheckResourceAttr(resourceName, "sriov_net_support", "simple"),
-					resource.TestCheckResourceAttr(resourceName, "state", "available"),
-					resource.TestCheckResourceAttr(resourceName, "state_reason.code", "UNSET"),
-					resource.TestCheckResourceAttr(resourceName, "state_reason.message", "UNSET"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "tpm_support", ""),
-					resource.TestCheckResourceAttr(resourceName, "usage_operation", "RunInstances"),
-					resource.TestCheckResourceAttr(resourceName, "virtualization_type", "hvm"),
+					resource.TestCheckResourceAttr(datasourceName, "architecture", "x86_64"),
+					resource.TestCheckResourceAttr(datasourceName, "block_device_mappings.#", "0"),
+					resource.TestMatchResourceAttr(datasourceName, "creation_date", regexp.MustCompile("^20[0-9]{2}-")),
+					resource.TestMatchResourceAttr(datasourceName, "deprecation_time", regexp.MustCompile("^20[0-9]{2}-")),
+					resource.TestCheckResourceAttr(datasourceName, "ena_support", "true"),
+					resource.TestCheckResourceAttr(datasourceName, "hypervisor", "xen"),
+					resource.TestMatchResourceAttr(datasourceName, "image_id", regexp.MustCompile("^ami-")),
+					resource.TestMatchResourceAttr(datasourceName, "image_location", regexp.MustCompile("amzn-ami-minimal-hvm")),
+					resource.TestCheckResourceAttr(datasourceName, "image_type", "machine"),
+					resource.TestCheckResourceAttr(datasourceName, "most_recent", "true"),
+					resource.TestMatchResourceAttr(datasourceName, "name", regexp.MustCompile("amzn-ami-minimal-hvm")),
+					acctest.MatchResourceAttrAccountID(datasourceName, "owner_id"),
+					resource.TestCheckResourceAttr(datasourceName, "platform_details", "Linux/UNIX"),
+					resource.TestCheckResourceAttr(datasourceName, "product_codes.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "public", "true"),
+					resource.TestCheckResourceAttr(datasourceName, "root_device_type", "instance-store"),
+					resource.TestCheckResourceAttr(datasourceName, "root_snapshot_id", ""),
+					resource.TestCheckResourceAttr(datasourceName, "sriov_net_support", "simple"),
+					resource.TestCheckResourceAttr(datasourceName, "state", "available"),
+					resource.TestCheckResourceAttr(datasourceName, "state_reason.code", "UNSET"),
+					resource.TestCheckResourceAttr(datasourceName, "state_reason.message", "UNSET"),
+					resource.TestCheckResourceAttr(datasourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "tpm_support", ""),
+					resource.TestCheckResourceAttr(datasourceName, "usage_operation", "RunInstances"),
+					resource.TestCheckResourceAttr(datasourceName, "virtualization_type", "hvm"),
 				),
 			},
 		},
@@ -154,6 +152,8 @@ func TestAccEC2AMIDataSource_instanceStore(t *testing.T) {
 }
 
 func TestAccEC2AMIDataSource_localNameFilter(t *testing.T) {
+	datasourceName := "data.aws_ami.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
@@ -162,8 +162,7 @@ func TestAccEC2AMIDataSource_localNameFilter(t *testing.T) {
 			{
 				Config: testAccAMIDataSourceConfig_nameRegex,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAMIIDDataSource("data.aws_ami.name_regex_filtered_ami"),
-					resource.TestMatchResourceAttr("data.aws_ami.name_regex_filtered_ami", "image_id", regexp.MustCompile("^ami-")),
+					resource.TestMatchResourceAttr(datasourceName, "image_id", regexp.MustCompile("^ami-")),
 				),
 			},
 		},
@@ -183,7 +182,6 @@ func TestAccEC2AMIDataSource_gp3BlockDevice(t *testing.T) {
 			{
 				Config: testAccAMIDataSourceConfig_gp3BlockDevice(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAMIIDDataSource(datasourceName),
 					resource.TestCheckResourceAttrPair(datasourceName, "architecture", resourceName, "architecture"),
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(datasourceName, "block_device_mappings.#", resourceName, "ebs_block_device.#"),
@@ -202,26 +200,12 @@ func TestAccEC2AMIDataSource_gp3BlockDevice(t *testing.T) {
 	})
 }
 
-func testAccCheckAMIIDDataSource(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Can't find AMI data source: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("AMI data source ID not set")
-		}
-		return nil
-	}
-}
-
 // testAccAMIDataSourceConfig_latestAmazonLinuxHVMInstanceStore returns the configuration for a data source that
 // describes the latest Amazon Linux AMI using HVM virtualization and an instance store root device.
 // The data source is named 'amzn-ami-minimal-hvm-instance-store'.
 func testAccAMIDataSourceConfig_latestAmazonLinuxHVMInstanceStore() string {
 	return `
-data "aws_ami" "amzn-ami-minimal-hvm-instance-store" {
+data "aws_ami" "test" {
   most_recent = true
 
   filter {
@@ -242,7 +226,7 @@ data "aws_ami" "amzn-ami-minimal-hvm-instance-store" {
 // for testing this after that may be Ubuntu's AMI's, or Amazon's regular
 // Amazon Linux AMIs.
 const testAccAMIDataSourceConfig_basic = `
-data "aws_ami" "nat_ami" {
+data "aws_ami" "test" {
   most_recent = true
   owners      = ["amazon"]
 
@@ -270,7 +254,7 @@ data "aws_ami" "nat_ami" {
 
 // Windows image test.
 const testAccAMIDataSourceConfig_windows = `
-data "aws_ami" "windows_ami" {
+data "aws_ami" "test" {
   most_recent = true
   owners      = ["amazon"]
 
@@ -298,7 +282,7 @@ data "aws_ami" "windows_ami" {
 
 // Testing name_regex parameter
 const testAccAMIDataSourceConfig_nameRegex = `
-data "aws_ami" "name_regex_filtered_ami" {
+data "aws_ami" "test" {
   most_recent = true
   owners      = ["amazon"]
 

--- a/internal/service/ec2/ec2_ami_ids_data_source_test.go
+++ b/internal/service/ec2/ec2_ami_ids_data_source_test.go
@@ -6,20 +6,21 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
 func TestAccEC2AMIIDsDataSource_basic(t *testing.T) {
+	datasourceName := "data.aws_ami_ids.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAMIIdsDataSourceConfig_basic,
+				Config: testAccAMIIDsDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAMIIDDataSource("data.aws_ami_ids.ubuntu"),
+					acctest.CheckResourceAttrGreaterThanValue(datasourceName, "ids.#", "0"),
 				),
 			},
 		},
@@ -27,57 +28,35 @@ func TestAccEC2AMIIDsDataSource_basic(t *testing.T) {
 }
 
 func TestAccEC2AMIIDsDataSource_sorted(t *testing.T) {
+	datasourceName := "data.aws_ami_ids.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAMIIdsDataSourceConfig_sorted(false),
+				Config: testAccAMIIDsDataSourceConfig_sorted(false),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_ami_ids.test", "ids.#", "2"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_ami_ids.test", "ids.0",
-						"data.aws_ami.amzn_linux_2018_03", "id"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_ami_ids.test", "ids.1",
-						"data.aws_ami.amzn_linux_2016_09_0", "id"),
+					resource.TestCheckResourceAttr(datasourceName, "ids.#", "2"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ids.0", "data.aws_ami.test2", "id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ids.1", "data.aws_ami.test1", "id"),
 				),
 			},
-			// Make sure when sort_ascending is set, they're sorted in the inverse order
-			// it uses the same config / dataset as above so no need to verify the other
-			// bits
 			{
-				Config: testAccAMIIdsDataSourceConfig_sorted(true),
+				Config: testAccAMIIDsDataSourceConfig_sorted(true),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(
-						"data.aws_ami_ids.test", "ids.0",
-						"data.aws_ami.amzn_linux_2016_09_0", "id"),
-					resource.TestCheckResourceAttrPair(
-						"data.aws_ami_ids.test", "ids.1",
-						"data.aws_ami.amzn_linux_2018_03", "id"),
+					resource.TestCheckResourceAttr(datasourceName, "ids.#", "2"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ids.0", "data.aws_ami.test1", "id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ids.1", "data.aws_ami.test2", "id"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckAMIIDDataSource(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Can't find AMI data source: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("AMI data source ID not set")
-		}
-		return nil
-	}
-}
-
-const testAccAMIIdsDataSourceConfig_basic = `
-data "aws_ami_ids" "ubuntu" {
+const testAccAMIIDsDataSourceConfig_basic = `
+data "aws_ami_ids" "test" {
   owners = ["099720109477"]
 
   filter {
@@ -87,23 +66,23 @@ data "aws_ami_ids" "ubuntu" {
 }
 `
 
-func testAccAMIIdsDataSourceConfig_sorted(sort_ascending bool) string {
+func testAccAMIIDsDataSourceConfig_sorted(sortAscending bool) string {
 	return fmt.Sprintf(`
-data "aws_ami" "amzn_linux_2016_09_0" {
+data "aws_ami" "test1" {
   owners = ["amazon"]
 
   filter {
     name   = "name"
-    values = ["amzn-ami-hvm-2016.09.0.20161028-x86_64-gp2"]
+    values = ["amzn-ami-hvm-2018.03.0.20221018.0-x86_64-gp2"]
   }
 }
 
-data "aws_ami" "amzn_linux_2018_03" {
+data "aws_ami" "test2" {
   owners = ["amazon"]
 
   filter {
     name   = "name"
-    values = ["amzn-ami-hvm-2018.03.0.20180811-x86_64-gp2"]
+    values = ["amzn-ami-hvm-2018.03.0.20221209.1-x86_64-gp2"]
   }
 }
 
@@ -112,10 +91,10 @@ data "aws_ami_ids" "test" {
 
   filter {
     name   = "name"
-    values = ["amzn-ami-hvm-2018.03.0.20180811-x86_64-gp2", "amzn-ami-hvm-2016.09.0.20161028-x86_64-gp2"]
+    values = [data.aws_ami.test1.name, data.aws_ami.test2.name]
   }
 
-  sort_ascending = "%t"
+  sort_ascending = %[1]t
 }
-`, sort_ascending)
+`, sortAscending)
 }

--- a/internal/service/ec2/ec2_ami_ids_data_source_test.go
+++ b/internal/service/ec2/ec2_ami_ids_data_source_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
@@ -59,6 +60,20 @@ func TestAccEC2AMIIDsDataSource_sorted(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckAMIIDDataSource(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find AMI data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("AMI data source ID not set")
+		}
+		return nil
+	}
 }
 
 const testAccAMIIdsDataSourceConfig_basic = `


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Simplifies provider initialization for acceptance tests.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/28809.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccEC2AMIDataSource_' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccEC2AMIDataSource_ -timeout 180m
=== RUN   TestAccEC2AMIDataSource_natInstance
=== PAUSE TestAccEC2AMIDataSource_natInstance
=== RUN   TestAccEC2AMIDataSource_windowsInstance
=== PAUSE TestAccEC2AMIDataSource_windowsInstance
=== RUN   TestAccEC2AMIDataSource_instanceStore
=== PAUSE TestAccEC2AMIDataSource_instanceStore
=== RUN   TestAccEC2AMIDataSource_localNameFilter
=== PAUSE TestAccEC2AMIDataSource_localNameFilter
=== RUN   TestAccEC2AMIDataSource_gp3BlockDevice
=== PAUSE TestAccEC2AMIDataSource_gp3BlockDevice
=== CONT  TestAccEC2AMIDataSource_natInstance
=== CONT  TestAccEC2AMIDataSource_localNameFilter
=== CONT  TestAccEC2AMIDataSource_instanceStore
--- PASS: TestAccEC2AMIDataSource_natInstance (22.05s)
=== CONT  TestAccEC2AMIDataSource_windowsInstance
--- PASS: TestAccEC2AMIDataSource_localNameFilter (22.63s)
=== CONT  TestAccEC2AMIDataSource_gp3BlockDevice
--- PASS: TestAccEC2AMIDataSource_instanceStore (29.43s)
--- PASS: TestAccEC2AMIDataSource_windowsInstance (22.11s)
--- PASS: TestAccEC2AMIDataSource_gp3BlockDevice (63.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	91.789s
% make testacc TESTARGS='-run=TestAccEC2AMIIDsDataSource_' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccEC2AMIIDsDataSource_ -timeout 180m
=== RUN   TestAccEC2AMIIDsDataSource_basic
=== PAUSE TestAccEC2AMIIDsDataSource_basic
=== RUN   TestAccEC2AMIIDsDataSource_sorted
=== PAUSE TestAccEC2AMIIDsDataSource_sorted
=== CONT  TestAccEC2AMIIDsDataSource_basic
=== CONT  TestAccEC2AMIIDsDataSource_sorted
--- PASS: TestAccEC2AMIIDsDataSource_basic (16.13s)
--- PASS: TestAccEC2AMIIDsDataSource_sorted (60.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	67.111s
```
