### PR TITLE
.github/workflows: Use hashicorp/ghaction-terraform-provider-release setup-go-version-file input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,14 +9,6 @@ permissions:
   contents: write
 
 jobs:
-  go-version:
-    runs-on: macos-latest
-    outputs:
-      version: ${{ steps.go-version.outputs.version }}
-    steps:
-      - uses: actions/checkout@v3
-      - id: go-version
-        run: echo "version=$(cat ./.go-version)" >> "$GITHUB_OUTPUT"
   release-notes:
     runs-on: macos-latest
     steps:
@@ -32,7 +24,7 @@ jobs:
           retention-days: 1
   terraform-provider-release:
     name: 'Terraform Provider Release'
-    needs: [go-version, release-notes]
+    needs: [release-notes]
     uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v2
     secrets:
       hc-releases-key-prod: '${{ secrets.HC_RELEASES_KEY_PROD }}'
@@ -47,7 +39,7 @@ jobs:
     with:
       goreleaser-release-args: '--timeout 3h --parallelism 4'
       release-notes: true
-      setup-go-version: '${{ needs.go-version.outputs.version }}'
+      setup-go-version-file: '.go-version'
       # Product Version (e.g. v1.2.3 or github.ref_name)
       product-version: '${{ github.ref_name }}'
   highest-version-tag:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This input is passed through to actions/setup-go's go-version-file input, similar to what is used in other workflows.

### Relations

N/A

### References

Reference: https://github.com/hashicorp/ghaction-terraform-provider-release/releases/tag/v2.2.0
Reference: https://github.com/hashicorp/ghaction-terraform-provider-release/blob/7e53d9adb57f05cb16c227ef0bfd030060fae82e/.github/workflows/hashicorp.yml#L26-L29

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
