### PR TITLE
iam: Improve policy diff handling

### DIFF
--- a/.changelog/28836.txt
+++ b/.changelog/28836.txt
@@ -1,0 +1,19 @@
+```release-note:bug
+resource/aws_iam_group_policy: Improve refresh to avoid unnecessary diffs in `policy`
+```
+
+```release-note:bug
+resource/aws_iam_policy: Improve refresh to avoid unnecessary diffs in `policy`, `tags`
+```
+
+```release-note:bug
+resource/aws_iam_role: Improve refresh to avoid unnecessary diffs in `inline_policy.*.policy`, `tags`
+```
+
+```release-note:bug
+resource/aws_iam_role_policy: Improve refresh to avoid unnecessary diffs in `policy`
+```
+
+```release-note:bug
+resource/aws_iam_user_policy: Improve refresh to avoid unnecessary diffs in `policy`
+```

--- a/internal/service/iam/group_policy_test.go
+++ b/internal/service/iam/group_policy_test.go
@@ -339,12 +339,12 @@ resource "aws_iam_group_policy" "test" {
 
   policy = <<EOF
 {
-  "Version": "2012-10-17",
   "Statement": {
     "Effect": "Allow",
     "Action": %[2]q,
     "Resource": "*"
-  }
+  },
+  "Version": "2012-10-17"
 }
 EOF
 }

--- a/internal/service/iam/policy_test.go
+++ b/internal/service/iam/policy_test.go
@@ -239,7 +239,7 @@ func TestAccIAMPolicy_policy(t *testing.T) {
 	})
 }
 
-// https://github.com/hashicorp/terraform-provider-aws/issues/23288#issuecomment-1175361016
+// https://github.com/hashicorp/terraform-provider-aws/issues/28833
 func TestAccIAMPolicy_diffs(t *testing.T) {
 	var out iam.GetPolicyOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/iam/policy_test.go
+++ b/internal/service/iam/policy_test.go
@@ -239,6 +239,94 @@ func TestAccIAMPolicy_policy(t *testing.T) {
 	})
 }
 
+// https://github.com/hashicorp/terraform-provider-aws/issues/23288#issuecomment-1175361016
+func TestAccIAMPolicy_diffs(t *testing.T) {
+	var out iam.GetPolicyOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyConfig_diffs(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyExists(resourceName, &out),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPolicyConfig_diffs(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyExists(resourceName, &out),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				Config:   testAccPolicyConfig_diffs(rName, ""),
+				PlanOnly: true,
+			},
+			{
+				Config:   testAccPolicyConfig_diffs(rName, ""),
+				PlanOnly: true,
+			},
+			{
+				Config:   testAccPolicyConfig_diffs(rName, ""),
+				PlanOnly: true,
+			},
+			{
+				Config:   testAccPolicyConfig_diffs(rName, ""),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccPolicyConfig_diffs(rName, "tags = {}"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyExists(resourceName, &out),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				Config: testAccPolicyConfig_diffs(rName, "tags = {}"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyExists(resourceName, &out),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				Config:   testAccPolicyConfig_diffs(rName, "tags = {}"),
+				PlanOnly: true,
+			},
+			{
+				Config:   testAccPolicyConfig_diffs(rName, "tags = {}"),
+				PlanOnly: true,
+			},
+			{
+				Config:   testAccPolicyConfig_diffs(rName, "tags = {}"),
+				PlanOnly: true,
+			},
+			{
+				Config:   testAccPolicyConfig_diffs(rName, "tags = {}"),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccPolicyConfig_diffs(rName, "tags = {}"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyExists(resourceName, &out),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckPolicyExists(resource string, res *iam.GetPolicyOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resource]
@@ -447,4 +535,74 @@ EOF
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccPolicyConfig_diffs(rName string, tags string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_policy" "test" {
+  name = %[1]q
+
+  policy = jsonencode({
+    Id = %[1]q
+    Version = "2012-10-17"
+    Statement = [{
+      Sid = "60c9d11f"
+      Effect = "Allow"
+      Action = [
+        "kms:Describe*",
+        "kms:Get*",
+        "kms:List*",
+        "kms:CreateKey",
+        "kms:DescribeKey",
+        "kms:ScheduleKeyDeletion",
+        "kms:TagResource",
+        "kms:UntagResource",
+        "s3:ListMultipartUploadParts",
+        "s3:ListBucketVersions",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListBucket",
+        "s3:GetReplicationConfiguration",
+        "s3:GetObjectVersionTorrent",
+        "s3:GetObjectVersionTagging",
+        "s3:GetObjectVersionForReplication",
+        "s3:GetObjectVersionAcl",
+        "s3:GetObjectVersion",
+        "s3:GetObjectTorrent",
+        "s3:GetObjectTagging",
+        "s3:GetObjectRetention",
+        "s3:GetObjectLegalHold",
+        "s3:GetObjectAcl",
+        "s3:GetObject",
+        "s3:GetMetricsConfiguration",
+        "s3:GetLifecycleConfiguration",
+        "s3:GetJobTagging",
+        "s3:GetInventoryConfiguration",
+        "s3:GetEncryptionConfiguration",
+        "s3:GetBucketWebsite",
+        "s3:GetBucketVersioning",
+        "s3:GetBucketTagging",
+        "s3:GetBucketRequestPayment",
+        "s3:GetBucketPublicAccessBlock",
+        "s3:GetBucketPolicyStatus",
+        "s3:GetBucketPolicy",
+        "s3:GetBucketOwnershipControls",
+        "s3:GetBucketObjectLockConfiguration",
+        "s3:GetBucketNotification",
+        "s3:GetBucketLogging",
+        "s3:GetBucketLocation",
+        "s3:GetBucketCORS",
+        "s3:GetBucketAcl",
+        "s3:GetAnalyticsConfiguration",
+        "s3:GetAccessPointPolicyStatus",
+        "s3:GetAccessPointPolicy",
+        "s3:GetAccelerateConfiguration",
+        "s3:DescribeJob",
+      ]
+      Resource = "*"
+    }]
+  })
+
+  %[2]s
+}
+`, rName, tags)
 }

--- a/internal/service/iam/policy_test.go
+++ b/internal/service/iam/policy_test.go
@@ -543,10 +543,10 @@ resource "aws_iam_policy" "test" {
   name = %[1]q
 
   policy = jsonencode({
-    Id = %[1]q
+    Id      = %[1]q
     Version = "2012-10-17"
     Statement = [{
-      Sid = "60c9d11f"
+      Sid    = "60c9d11f"
       Effect = "Allow"
       Action = [
         "kms:Describe*",

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -36,9 +36,11 @@ func ResourceRole() *schema.Resource {
 		Read:   resourceRoleRead,
 		Update: resourceRoleUpdate,
 		Delete: resourceRoleDelete,
+
 		Importer: &schema.ResourceImporter{
 			State: resourceRoleImport,
 		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
@@ -93,6 +95,10 @@ func ResourceRole() *schema.Resource {
 							ValidateFunc:          verify.ValidIAMPolicyJSON,
 							DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 							DiffSuppressOnRefresh: true,
+							StateFunc: func(v interface{}) string {
+								json, _ := verify.LegacyPolicyNormalize(v)
+								return json
+							},
 						},
 					},
 				},
@@ -170,7 +176,6 @@ func resourceRoleCreate(d *schema.ResourceData, meta interface{}) error {
 	tags := defaultTagsConfig.MergeTags(tftags.New(d.Get("tags").(map[string]interface{})))
 
 	assumeRolePolicy, err := structure.NormalizeJsonString(d.Get("assume_role_policy").(string))
-
 	if err != nil {
 		return fmt.Errorf("assume_role_policy (%s) is invalid JSON: %w", assumeRolePolicy, err)
 	}
@@ -287,13 +292,11 @@ func resourceRoleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("unique_id", role.RoleId)
 
 	assumeRolePolicy, err := url.QueryUnescape(aws.StringValue(role.AssumeRolePolicyDocument))
-
 	if err != nil {
 		return err
 	}
 
 	policyToSet, err := verify.PolicyToSet(d.Get("assume_role_policy").(string), assumeRolePolicy)
-
 	if err != nil {
 		return err
 	}
@@ -341,7 +344,6 @@ func resourceRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("assume_role_policy") {
 		assumeRolePolicy, err := structure.NormalizeJsonString(d.Get("assume_role_policy").(string))
-
 		if err != nil {
 			return fmt.Errorf("assume_role_policy (%s) is invalid JSON: %w", assumeRolePolicy, err)
 		}
@@ -857,23 +859,19 @@ func readRoleInlinePolicies(roleName string, meta interface{}) ([]*iam.PutRolePo
 			return nil, err
 		}
 
+		p, err := structure.NormalizeJsonString(policy)
+		if err != nil {
+			return nil, fmt.Errorf("policy (%s) is invalid JSON: %w", p, err)
+		}
+
 		apiObject := &iam.PutRolePolicyInput{
 			RoleName:       aws.String(roleName),
-			PolicyDocument: aws.String(policy),
+			PolicyDocument: aws.String(p),
 			PolicyName:     policyName,
 		}
 
 		apiObjects = append(apiObjects, apiObject)
 	}
-
-	/*
-		if len(apiObjects) == 0 {
-			apiObjects = append(apiObjects, &iam.PutRolePolicyInput{
-				PolicyDocument: aws.String(""),
-				PolicyName:     aws.String(""),
-			})
-		}
-	*/
 
 	return apiObjects, nil
 }

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -859,7 +859,7 @@ func readRoleInlinePolicies(roleName string, meta interface{}) ([]*iam.PutRolePo
 			return nil, err
 		}
 
-		p, err := structure.NormalizeJsonString(policy)
+		p, err := verify.LegacyPolicyNormalize(policy)
 		if err != nil {
 			return nil, fmt.Errorf("policy (%s) is invalid JSON: %w", p, err)
 		}

--- a/internal/service/iam/role_test.go
+++ b/internal/service/iam/role_test.go
@@ -1307,7 +1307,7 @@ resource "aws_iam_role" "test" {
   path = "/"
 
   assume_role_policy = jsonencode({
-    Id = %[1]q
+    Id      = %[1]q
     Version = "2012-10-17"
     Statement = [{
       Action = "sts:AssumeRole"

--- a/internal/service/iam/role_test.go
+++ b/internal/service/iam/role_test.go
@@ -175,6 +175,189 @@ func TestAccIAMRole_testNameChange(t *testing.T) {
 	})
 }
 
+// https://github.com/hashicorp/terraform-provider-aws/issues/23288
+// https://github.com/hashicorp/terraform-provider-aws/issues/28833
+func TestAccIAMRole_diffs(t *testing.T) {
+	var conf iam.Role
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_role.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoleConfig_diffs(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleExists(resourceName, &conf),
+				),
+			},
+			{
+				Config:   testAccRoleConfig_diffs(rName, ""),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccRoleConfig_diffs(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleExists(resourceName, &conf),
+				),
+			},
+			{
+				Config:   testAccRoleConfig_diffs(rName, ""),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccRoleConfig_diffs(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleExists(resourceName, &conf),
+				),
+			},
+			{
+				Config:   testAccRoleConfig_diffs(rName, ""),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccRoleConfig_diffs(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleExists(resourceName, &conf),
+				),
+			},
+			{
+				Config:   testAccRoleConfig_diffs(rName, ""),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccRoleConfig_diffs(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleExists(resourceName, &conf),
+				),
+			},
+			{
+				Config:   testAccRoleConfig_diffs(rName, ""),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccRoleConfig_diffs(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleExists(resourceName, &conf),
+				),
+			},
+			{
+				Config:   testAccRoleConfig_diffs(rName, ""),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccRoleConfig_diffs(rName, "tags = {}"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleExists(resourceName, &conf),
+				),
+			},
+			{
+				Config:   testAccRoleConfig_diffs(rName, "tags = {}"),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccRoleConfig_diffs(rName, "tags = {}"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleExists(resourceName, &conf),
+				),
+			},
+			{
+				Config:   testAccRoleConfig_diffs(rName, "tags = {}"),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccRoleConfig_diffs(rName, "tags = {}"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleExists(resourceName, &conf),
+				),
+			},
+			{
+				Config:   testAccRoleConfig_diffs(rName, "tags = {}"),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccRoleConfig_diffs(rName, "tags = {}"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleExists(resourceName, &conf),
+				),
+			},
+			{
+				Config:   testAccRoleConfig_diffs(rName, "tags = {}"),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccRoleConfig_diffs(rName, "tags = {}"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleExists(resourceName, &conf),
+				),
+			},
+			{
+				Config:   testAccRoleConfig_diffs(rName, "tags = {}"),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccRoleConfig_diffs(rName, "tags = {}"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleExists(resourceName, &conf),
+				),
+			},
+			{
+				Config:   testAccRoleConfig_diffs(rName, "tags = {}"),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// https://github.com/hashicorp/terraform-provider-aws/issues/28835
+func TestAccIAMRole_diffsCondition(t *testing.T) {
+	var conf iam.Role
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_role.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoleConfig_diffsCondition(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleExists(resourceName, &conf),
+				),
+			},
+			{
+				Config:   testAccRoleConfig_diffsCondition(rName),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccRoleConfig_diffsCondition(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleExists(resourceName, &conf),
+				),
+			},
+			{
+				Config:   testAccRoleConfig_diffsCondition(rName),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccRoleConfig_diffsCondition(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleExists(resourceName, &conf),
+				),
+			},
+			{
+				Config:   testAccRoleConfig_diffsCondition(rName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccIAMRole_badJSON(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -441,16 +624,16 @@ func TestAccIAMRole_InlinePolicy_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"inline_policy.0.policy"},
 			},
 		},
 	})
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/19444
-// This test currently fails but should not. A new PR will fix it.
 func TestAccIAMRole_InlinePolicy_ignoreOrder(t *testing.T) {
 	var role iam.Role
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1081,6 +1264,103 @@ resource "aws_iam_role" "test" {
       Action = "sts:AssumeRole",
       Principal = {
         Service = "ec2.${data.aws_partition.current.dns_suffix}",
+      }
+      Effect = "Allow"
+      Sid    = ""
+    }]
+  })
+}
+`, rName)
+}
+
+func testAccRoleConfig_diffs(rName, tags string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_user" "user1" {
+  name = "%[1]s-baa204a2"
+  path = "/"
+}
+
+resource "aws_iam_user" "user2" {
+  name = "%[1]s-fee06121"
+  path = "/"
+}
+
+resource "aws_iam_user" "user3" {
+  name = "%[1]s-2f0d132b"
+  path = "/"
+}
+
+resource "aws_iam_user" "user4" {
+  name = "%[1]s-d1eaee06"
+  path = "/"
+}
+
+resource "aws_iam_user" "user5" {
+  name = "%[1]s-d4a38c26"
+  path = "/"
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  path = "/"
+
+  assume_role_policy = jsonencode({
+    Id = %[1]q
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Principal = {
+        AWS = [
+          aws_iam_user.user1.arn,
+          aws_iam_user.user2.arn,
+          aws_iam_user.user3.arn,
+          aws_iam_user.user4.arn,
+          aws_iam_user.user5.arn,
+        ]
+      }
+      Effect = "Allow"
+      Sid    = ""
+    }]
+  })
+
+  %[2]s
+}
+`, rName, tags)
+}
+
+func testAccRoleConfig_diffsCondition(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_user" "user1" {
+  name = "%[1]s-cde2c453"
+  path = "/"
+}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  path = "/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRoleWithSAML"
+      Condition = {
+        IpAddress = {
+          "aws:SourceIp" = [
+            "0.0.0.0/0",
+          ]
+        }
+        StringEquals = {
+          "SAML:aud" = "https://signin.aws.amazon.com/saml"
+        }
+      }
+      Principal = {
+        AWS = [
+          aws_iam_user.user1.arn,
+        ]
       }
       Effect = "Allow"
       Sid    = ""

--- a/internal/service/iam/user_policy_test.go
+++ b/internal/service/iam/user_policy_test.go
@@ -19,8 +19,8 @@ import (
 
 func TestAccIAMUserPolicy_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policy1 := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"*","Resource":"*"}}`
-	policy2 := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"iam:*","Resource":"*"}}`
+	policy1 := `{"Version":"2012-10-17","Statement":{"Action":"*","Effect":"Allow","Resource":"*"}}`
+	policy2 := `{"Version":"2012-10-17","Statement":{"Action":"iam:*","Effect":"Allow","Resource":"*"}}`
 	policyResourceName := "aws_iam_user_policy.test"
 	userResourceName := "aws_iam_user.test"
 
@@ -87,8 +87,8 @@ func TestAccIAMUserPolicy_disappears(t *testing.T) {
 
 func TestAccIAMUserPolicy_namePrefix(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policy1 := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"*","Resource":"*"}}`
-	policy2 := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"iam:*","Resource":"*"}}`
+	policy1 := `{"Version":"2012-10-17","Statement":{"Action":"*","Effect":"Allow","Resource":"*"}}`
+	policy2 := `{"Version":"2012-10-17","Statement":{"Action":"iam:*","Effect":"Allow","Resource":"*"}}`
 	policyResourceName := "aws_iam_user_policy.test"
 	userResourceName := "aws_iam_user.test"
 
@@ -128,8 +128,8 @@ func TestAccIAMUserPolicy_namePrefix(t *testing.T) {
 
 func TestAccIAMUserPolicy_generatedName(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policy1 := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"*","Resource":"*"}}`
-	policy2 := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"iam:*","Resource":"*"}}`
+	policy1 := `{"Version":"2012-10-17","Statement":{"Action":"*","Effect":"Allow","Resource":"*"}}`
+	policy2 := `{"Version":"2012-10-17","Statement":{"Action":"iam:*","Effect":"Allow","Resource":"*"}}`
 	policyResourceName := "aws_iam_user_policy.test"
 	userResourceName := "aws_iam_user.test"
 
@@ -167,8 +167,8 @@ func TestAccIAMUserPolicy_generatedName(t *testing.T) {
 
 func TestAccIAMUserPolicy_multiplePolicies(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	policy1 := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"*","Resource":"*"}}`
-	policy2 := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"iam:*","Resource":"*"}}`
+	policy1 := `{"Version":"2012-10-17","Statement":{"Action":"*","Effect":"Allow","Resource":"*"}}`
+	policy2 := `{"Version":"2012-10-17","Statement":{"Action":"iam:*","Effect":"Allow","Resource":"*"}}`
 	policyResourceName1 := "aws_iam_user_policy.test"
 	policyResourceName2 := "aws_iam_user_policy.test2"
 	userResourceName := "aws_iam_user.test"

--- a/internal/verify/json.go
+++ b/internal/verify/json.go
@@ -133,15 +133,52 @@ func SecondJSONUnlessEquivalent(old, new string) (string, error) {
 // Otherwise, it returns the new policy. Either policy is normalized.
 func PolicyToSet(exist, new string) (string, error) {
 	policyToSet, err := SecondJSONUnlessEquivalent(exist, new)
-
 	if err != nil {
 		return "", fmt.Errorf("while checking equivalency of existing policy (%s) and new policy (%s), encountered: %w", exist, new, err)
 	}
 
 	policyToSet, err = structure.NormalizeJsonString(policyToSet)
-
 	if err != nil {
 		return "", fmt.Errorf("policy (%s) is invalid JSON: %w", policyToSet, err)
+	}
+
+	return policyToSet, nil
+}
+
+// LegacyPolicyNormalize returns a "normalized" JSON policy document except
+// the Version element is first in the JSON as required by AWS in many places.
+// Version not being first is one reason for this error:
+// MalformedPolicyDocument: The policy failed legacy parsing
+func LegacyPolicyNormalize(policy interface{}) (string, error) {
+	np, err := structure.NormalizeJsonString(policy)
+	if err != nil {
+		return "", fmt.Errorf("legacy policy (%s) is invalid JSON: %w", policy, err)
+	}
+
+	//fmt.Printf("first norm: %s\n", np)
+
+	m := regexp.MustCompile(`(?s)^(\{\n?)(.*?)(,\s*)?(  )?("Version":\s*"2012-10-17")(,)?(\n)?(.*?)(\})`)
+
+	n := m.ReplaceAllString(np, `$1$4$5$3$2$6$7$8$9`)
+	_, err = structure.NormalizeJsonString(n)
+	if err != nil {
+		return "", fmt.Errorf("LegacyPolicyNormalize created a policy (%s) that is invalid JSON: %w", n, err)
+	}
+
+	return n, nil
+}
+
+// PolicyToSet returns the existing policy if the new policy is equivalent.
+// Otherwise, it returns the new policy. Either policy is normalized.
+func LegacyPolicyToSet(exist, new string) (string, error) {
+	policyToSet, err := SecondJSONUnlessEquivalent(exist, new)
+	if err != nil {
+		return "", fmt.Errorf("while checking equivalency of existing policy (%s) and new policy (%s), encountered: %w", exist, new, err)
+	}
+
+	policyToSet, err = LegacyPolicyNormalize(policyToSet)
+	if err != nil {
+		return "", fmt.Errorf("legacy policy (%s) is invalid JSON: %w", policyToSet, err)
 	}
 
 	return policyToSet, nil

--- a/internal/verify/json.go
+++ b/internal/verify/json.go
@@ -168,8 +168,8 @@ func LegacyPolicyNormalize(policy interface{}) (string, error) {
 	return n, nil
 }
 
-// PolicyToSet returns the existing policy if the new policy is equivalent.
-// Otherwise, it returns the new policy. Either policy is normalized.
+// LegacyPolicyToSet returns the existing policy if the new policy is equivalent.
+// Otherwise, it returns the new policy. Either policy is legacy normalized.
 func LegacyPolicyToSet(exist, new string) (string, error) {
 	policyToSet, err := SecondJSONUnlessEquivalent(exist, new)
 	if err != nil {

--- a/internal/verify/json_test.go
+++ b/internal/verify/json_test.go
@@ -613,3 +613,178 @@ Outputs:
 		}
 	}
 }
+
+func TestLegacyPolicyNormalize(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		Name     string
+		Input    string
+		Expected string
+		Error    bool
+	}{
+		{
+			Name:     "basic",
+			Input:    `{"Statement":{"Action":"*","Effect":"Allow","Resource":"*"},"Version":"2012-10-17"}`,
+			Expected: `{"Version":"2012-10-17","Statement":{"Action":"*","Effect":"Allow","Resource":"*"}}`,
+			Error:    false,
+		},
+		{
+			Name: "normalWhitespace",
+			Input: `{
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  },
+  "Version": "2012-10-17"
+}
+`,
+			Expected: `{"Version":"2012-10-17","Statement":{"Action":"*","Effect":"Allow","Resource":"*"}}`,
+			Error:    false,
+		},
+		{
+			Name: "badJSON",
+			Input: `{
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+  "Version": "2012-10-17"
+}
+`,
+			Expected: ``,
+			Error:    true,
+		},
+		{
+			Name: "principal",
+			Input: `{
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "s3.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""    }
+  ],
+  "Version": "2012-10-17"
+}
+`,
+			Expected: `{"Version":"2012-10-17","Statement":[{"Action":"sts:AssumeRole","Effect":"Allow","Principal":{"Service":"s3.amazonaws.com"},"Sid":""}]}`,
+			Error:    false,
+		},
+		{
+			Name: "id",
+			Input: `{
+  "Id": "Kygo",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "s3.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""    }
+  ],
+  "Version": "2012-10-17"
+}
+`,
+			Expected: `{"Version":"2012-10-17","Id":"Kygo","Statement":[{"Action":"sts:AssumeRole","Effect":"Allow","Principal":{"Service":"s3.amazonaws.com"},"Sid":""}]}`,
+			Error:    false,
+		},
+		{
+			Name: "newOrder",
+			Input: `{
+  "Id": "Kygo",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "s3.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""    }
+  ]
+}
+`,
+			Expected: `{"Version":"2012-10-17","Id":"Kygo","Statement":[{"Action":"sts:AssumeRole","Effect":"Allow","Principal":{"Service":"s3.amazonaws.com"},"Sid":""}]}`,
+			Error:    false,
+		},
+		{
+			Name: "complex1",
+			Input: `{
+"Id": "kms-tf-1",
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "Enable IAM User Permissions",
+    "Effect": "Allow",
+    "Principal": {
+      "AWS": [
+        "arn:aws:iam::012345678901:role/felixjaehn",
+        "arn:aws:iam::012345678901:role/garethemery",
+        "arn:aws:iam::012345678901:role/kidnap",
+        "arn:aws:iam::012345678901:role/paulvandyk",
+        "arn:aws:iam::012345678901:role/tinlicker"
+      ]
+    },
+    "Action": [
+      "kms:Describe*",
+      "kms:Get*",
+      "kms:List*",
+      "kms:CreateKey",
+      "kms:DescribeKey",
+      "kms:ScheduleKeyDeletion",
+      "kms:TagResource",
+      "kms:UntagResource"
+    ],
+    "Resource": "*"
+  }
+]
+}`,
+			Expected: `{"Version":"2012-10-17","Id":"kms-tf-1","Statement":[{"Action":["kms:Describe*","kms:Get*","kms:List*","kms:CreateKey","kms:DescribeKey","kms:ScheduleKeyDeletion","kms:TagResource","kms:UntagResource"],"Effect":"Allow","Principal":{"AWS":["arn:aws:iam::012345678901:role/felixjaehn","arn:aws:iam::012345678901:role/garethemery","arn:aws:iam::012345678901:role/kidnap","arn:aws:iam::012345678901:role/paulvandyk","arn:aws:iam::012345678901:role/tinlicker"]},"Resource":"*","Sid":"Enable IAM User Permissions"}]}`,
+			Error:    false,
+		},
+		{
+			Name: "complex2",
+			Input: `{
+"Id": "kms-tf-1",
+"ZedsDead": "StillWorse",
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "Enable IAM User Permissions"
+  }
+]
+}`,
+			Expected: `{"Version":"2012-10-17","Id":"kms-tf-1","Statement":[{"Sid":"Enable IAM User Permissions"}],"ZedsDead":"StillWorse"}`,
+			Error:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			p, err := LegacyPolicyNormalize(tc.Input)
+
+			if tc.Error {
+				if err == nil {
+					t.Errorf("expected an error")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %s", err)
+				}
+			}
+
+			if p != tc.Expected {
+				t.Errorf("expected %s, got: %s", tc.Expected, p)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Based on new changes and improvements, I haven't been able to reproduce the problems noted in #28833 and #28835. I've added acceptance tests specifically to test the examples given that are now passing.

In #23288, I am not able to reproduce the issues noted there. For anything that I'm not addressing, I created new issues.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28833
Closes #28835
Closes #23288

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccIAMGroupPolicy_ PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMGroupPolicy_'  -timeout 180m
=== RUN   TestAccIAMGroupPolicy_basic
=== PAUSE TestAccIAMGroupPolicy_basic
=== RUN   TestAccIAMGroupPolicy_disappears
=== PAUSE TestAccIAMGroupPolicy_disappears
=== RUN   TestAccIAMGroupPolicy_namePrefix
=== PAUSE TestAccIAMGroupPolicy_namePrefix
=== RUN   TestAccIAMGroupPolicy_generatedName
=== PAUSE TestAccIAMGroupPolicy_generatedName
=== CONT  TestAccIAMGroupPolicy_basic
=== CONT  TestAccIAMGroupPolicy_namePrefix
=== CONT  TestAccIAMGroupPolicy_disappears
=== CONT  TestAccIAMGroupPolicy_generatedName
--- PASS: TestAccIAMGroupPolicy_disappears (16.15s)
--- PASS: TestAccIAMGroupPolicy_namePrefix (28.89s)
--- PASS: TestAccIAMGroupPolicy_generatedName (29.17s)
--- PASS: TestAccIAMGroupPolicy_basic (31.57s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	33.825s
% make testacc TESTS=TestAccIAMPolicy_ PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMPolicy_'  -timeout 180m
=== RUN   TestAccIAMPolicy_basic
=== PAUSE TestAccIAMPolicy_basic
=== RUN   TestAccIAMPolicy_description
=== PAUSE TestAccIAMPolicy_description
=== RUN   TestAccIAMPolicy_tags
=== PAUSE TestAccIAMPolicy_tags
=== RUN   TestAccIAMPolicy_disappears
=== PAUSE TestAccIAMPolicy_disappears
=== RUN   TestAccIAMPolicy_namePrefix
=== PAUSE TestAccIAMPolicy_namePrefix
=== RUN   TestAccIAMPolicy_path
=== PAUSE TestAccIAMPolicy_path
=== RUN   TestAccIAMPolicy_policy
=== PAUSE TestAccIAMPolicy_policy
=== RUN   TestAccIAMPolicy_diffs
=== PAUSE TestAccIAMPolicy_diffs
=== CONT  TestAccIAMPolicy_basic
=== CONT  TestAccIAMPolicy_namePrefix
=== CONT  TestAccIAMPolicy_tags
=== CONT  TestAccIAMPolicy_description
=== CONT  TestAccIAMPolicy_policy
=== CONT  TestAccIAMPolicy_path
=== CONT  TestAccIAMPolicy_diffs
=== CONT  TestAccIAMPolicy_disappears
--- PASS: TestAccIAMPolicy_disappears (18.55s)
--- PASS: TestAccIAMPolicy_path (24.76s)
--- PASS: TestAccIAMPolicy_description (24.80s)
--- PASS: TestAccIAMPolicy_namePrefix (24.81s)
--- PASS: TestAccIAMPolicy_basic (24.96s)
--- PASS: TestAccIAMPolicy_policy (36.49s)
--- PASS: TestAccIAMPolicy_tags (46.92s)
--- PASS: TestAccIAMPolicy_diffs (121.01s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	122.663s
% make testacc TESTS=TestAccIAMRole_ PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRole_'  -timeout 180m
=== RUN   TestAccIAMRole_basic
=== PAUSE TestAccIAMRole_basic
=== RUN   TestAccIAMRole_description
=== PAUSE TestAccIAMRole_description
=== RUN   TestAccIAMRole_nameGenerated
=== PAUSE TestAccIAMRole_nameGenerated
=== RUN   TestAccIAMRole_namePrefix
=== PAUSE TestAccIAMRole_namePrefix
=== RUN   TestAccIAMRole_testNameChange
=== PAUSE TestAccIAMRole_testNameChange
=== RUN   TestAccIAMRole_diffs
=== PAUSE TestAccIAMRole_diffs
=== RUN   TestAccIAMRole_diffsCondition
=== PAUSE TestAccIAMRole_diffsCondition
=== RUN   TestAccIAMRole_badJSON
=== PAUSE TestAccIAMRole_badJSON
=== RUN   TestAccIAMRole_disappears
=== PAUSE TestAccIAMRole_disappears
=== RUN   TestAccIAMRole_policiesForceDetach
=== PAUSE TestAccIAMRole_policiesForceDetach
=== RUN   TestAccIAMRole_maxSessionDuration
=== PAUSE TestAccIAMRole_maxSessionDuration
=== RUN   TestAccIAMRole_permissionsBoundary
=== PAUSE TestAccIAMRole_permissionsBoundary
=== RUN   TestAccIAMRole_tags
=== PAUSE TestAccIAMRole_tags
=== RUN   TestAccIAMRole_InlinePolicy_basic
=== PAUSE TestAccIAMRole_InlinePolicy_basic
=== RUN   TestAccIAMRole_InlinePolicy_ignoreOrder
=== PAUSE TestAccIAMRole_InlinePolicy_ignoreOrder
=== RUN   TestAccIAMRole_InlinePolicy_empty
=== PAUSE TestAccIAMRole_InlinePolicy_empty
=== RUN   TestAccIAMRole_ManagedPolicy_basic
=== PAUSE TestAccIAMRole_ManagedPolicy_basic
=== RUN   TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack
=== PAUSE TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack
=== RUN   TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack
=== PAUSE TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack
=== RUN   TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved
=== PAUSE TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved
=== RUN   TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved
=== PAUSE TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved
=== RUN   TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored
=== PAUSE TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored
=== RUN   TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored
=== PAUSE TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored
=== RUN   TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty
=== PAUSE TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty
=== RUN   TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty
=== PAUSE TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty
=== CONT  TestAccIAMRole_basic
=== CONT  TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMRole_diffsCondition
=== CONT  TestAccIAMRole_nameGenerated
=== CONT  TestAccIAMRole_badJSON
=== CONT  TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved
=== CONT  TestAccIAMRole_testNameChange
=== CONT  TestAccIAMRole_tags
=== CONT  TestAccIAMRole_permissionsBoundary
=== CONT  TestAccIAMRole_maxSessionDuration
=== CONT  TestAccIAMRole_policiesForceDetach
=== CONT  TestAccIAMRole_disappears
=== CONT  TestAccIAMRole_diffs
=== CONT  TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty
=== CONT  TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty
=== CONT  TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored
=== CONT  TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored
=== CONT  TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved
=== CONT  TestAccIAMRole_ManagedPolicy_basic
=== CONT  TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack
--- PASS: TestAccIAMRole_badJSON (7.54s)
=== CONT  TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack
--- PASS: TestAccIAMRole_disappears (53.62s)
=== CONT  TestAccIAMRole_namePrefix
--- PASS: TestAccIAMRole_basic (68.87s)
=== CONT  TestAccIAMRole_description
--- PASS: TestAccIAMRole_nameGenerated (69.54s)
=== CONT  TestAccIAMRole_InlinePolicy_empty
--- PASS: TestAccIAMRole_policiesForceDetach (73.13s)
=== CONT  TestAccIAMRole_InlinePolicy_ignoreOrder
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored (98.94s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack (104.64s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty (105.84s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved (107.01s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack (99.67s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved (107.68s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty (107.68s)
--- PASS: TestAccIAMRole_testNameChange (111.80s)
--- PASS: TestAccIAMRole_tags (113.49s)
--- PASS: TestAccIAMRole_namePrefix (63.61s)
--- PASS: TestAccIAMRole_InlinePolicy_empty (50.05s)
--- PASS: TestAccIAMRole_maxSessionDuration (120.66s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored (127.05s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (130.77s)
--- PASS: TestAccIAMRole_ManagedPolicy_basic (134.92s)
--- PASS: TestAccIAMRole_InlinePolicy_ignoreOrder (80.23s)
--- PASS: TestAccIAMRole_description (87.08s)
--- PASS: TestAccIAMRole_diffsCondition (162.12s)
--- PASS: TestAccIAMRole_permissionsBoundary (163.85s)
--- PASS: TestAccIAMRole_diffs (330.42s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	335.228s
% make testacc TESTS=TestAccIAMRolePolicy_ PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRolePolicy_'  -timeout 180m
=== RUN   TestAccIAMRolePolicy_basic
=== PAUSE TestAccIAMRolePolicy_basic
=== RUN   TestAccIAMRolePolicy_disappears
=== PAUSE TestAccIAMRolePolicy_disappears
=== RUN   TestAccIAMRolePolicy_policyOrder
=== PAUSE TestAccIAMRolePolicy_policyOrder
=== RUN   TestAccIAMRolePolicy_namePrefix
=== PAUSE TestAccIAMRolePolicy_namePrefix
=== RUN   TestAccIAMRolePolicy_generatedName
=== PAUSE TestAccIAMRolePolicy_generatedName
=== RUN   TestAccIAMRolePolicy_invalidJSON
=== PAUSE TestAccIAMRolePolicy_invalidJSON
=== RUN   TestAccIAMRolePolicy_Policy_invalidResource
=== PAUSE TestAccIAMRolePolicy_Policy_invalidResource
=== CONT  TestAccIAMRolePolicy_basic
=== CONT  TestAccIAMRolePolicy_generatedName
=== CONT  TestAccIAMRolePolicy_policyOrder
=== CONT  TestAccIAMRolePolicy_namePrefix
=== CONT  TestAccIAMRolePolicy_disappears
=== CONT  TestAccIAMRolePolicy_Policy_invalidResource
=== CONT  TestAccIAMRolePolicy_invalidJSON
--- PASS: TestAccIAMRolePolicy_invalidJSON (2.36s)
--- PASS: TestAccIAMRolePolicy_Policy_invalidResource (11.21s)
--- PASS: TestAccIAMRolePolicy_disappears (18.62s)
--- PASS: TestAccIAMRolePolicy_policyOrder (25.90s)
--- PASS: TestAccIAMRolePolicy_namePrefix (32.77s)
--- PASS: TestAccIAMRolePolicy_generatedName (33.92s)
--- PASS: TestAccIAMRolePolicy_basic (33.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	35.724s
% make testacc TESTS=TestAccIAMUserPolicy_ PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMUserPolicy_'  -timeout 180m
=== RUN   TestAccIAMUserPolicy_basic
=== PAUSE TestAccIAMUserPolicy_basic
=== RUN   TestAccIAMUserPolicy_disappears
=== PAUSE TestAccIAMUserPolicy_disappears
=== RUN   TestAccIAMUserPolicy_namePrefix
=== PAUSE TestAccIAMUserPolicy_namePrefix
=== RUN   TestAccIAMUserPolicy_generatedName
=== PAUSE TestAccIAMUserPolicy_generatedName
=== RUN   TestAccIAMUserPolicy_multiplePolicies
=== PAUSE TestAccIAMUserPolicy_multiplePolicies
=== RUN   TestAccIAMUserPolicy_policyOrder
=== PAUSE TestAccIAMUserPolicy_policyOrder
=== CONT  TestAccIAMUserPolicy_basic
=== CONT  TestAccIAMUserPolicy_generatedName
=== CONT  TestAccIAMUserPolicy_multiplePolicies
=== CONT  TestAccIAMUserPolicy_policyOrder
=== CONT  TestAccIAMUserPolicy_disappears
=== CONT  TestAccIAMUserPolicy_namePrefix
--- PASS: TestAccIAMUserPolicy_disappears (18.03s)
--- PASS: TestAccIAMUserPolicy_policyOrder (25.42s)
--- PASS: TestAccIAMUserPolicy_generatedName (32.56s)
--- PASS: TestAccIAMUserPolicy_namePrefix (32.57s)
--- PASS: TestAccIAMUserPolicy_basic (32.85s)
--- PASS: TestAccIAMUserPolicy_multiplePolicies (52.76s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	54.524s
```
