### PR TITLE
mq/configuration: Improve diff handling of data

### DIFF
--- a/.changelog/28837.txt
+++ b/.changelog/28837.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_mq_configuration: Improve refresh to avoid unnecessary diffs in `data`
+```

--- a/internal/service/mq/configuration.go
+++ b/internal/service/mq/configuration.go
@@ -61,9 +61,10 @@ func ResourceConfiguration() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(mq.AuthenticationStrategy_Values(), true),
 			},
 			"data": {
-				Type:             schema.TypeString,
-				Required:         true,
-				DiffSuppressFunc: suppressXMLEquivalentConfig,
+				Type:                  schema.TypeString,
+				Required:              true,
+				DiffSuppressFunc:      suppressXMLEquivalentConfig,
+				DiffSuppressOnRefresh: true,
 			},
 			"description": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #21619
Relates #23288

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccMQConfiguration_ PKG=mq
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/mq/... -v -count 1 -parallel 20 -run='TestAccMQConfiguration_'  -timeout 180m
=== RUN   TestAccMQConfiguration_basic
=== PAUSE TestAccMQConfiguration_basic
=== RUN   TestAccMQConfiguration_withData
=== PAUSE TestAccMQConfiguration_withData
=== RUN   TestAccMQConfiguration_withLdapData
=== PAUSE TestAccMQConfiguration_withLdapData
=== RUN   TestAccMQConfiguration_tags
=== PAUSE TestAccMQConfiguration_tags
=== CONT  TestAccMQConfiguration_basic
=== CONT  TestAccMQConfiguration_withLdapData
=== CONT  TestAccMQConfiguration_withData
=== CONT  TestAccMQConfiguration_tags
--- PASS: TestAccMQConfiguration_withLdapData (21.46s)
--- PASS: TestAccMQConfiguration_withData (23.54s)
--- PASS: TestAccMQConfiguration_basic (35.80s)
--- PASS: TestAccMQConfiguration_tags (46.19s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mq	47.941s
```
