### PR TITLE
iot/policy: Improve diffs of policy

### DIFF
--- a/.changelog/28838.txt
+++ b/.changelog/28838.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iot_policy: Improve refresh to avoid unnecessary diffs in `policy`
+```

--- a/internal/service/iot/policy.go
+++ b/internal/service/iot/policy.go
@@ -31,10 +31,11 @@ func ResourcePolicy() *schema.Resource {
 				ForceNew: true,
 			},
 			"policy": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Required:              true,
+				ValidateFunc:          validation.StringIsJSON,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
@@ -56,7 +57,6 @@ func resourcePolicyCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).IoTConn()
 
 	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
-
 	if err != nil {
 		return fmt.Errorf("policy (%s) is invalid JSON: %w", policy, err)
 	}
@@ -97,7 +97,6 @@ func resourcePolicyRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", out.PolicyName)
 
 	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), aws.StringValue(out.PolicyDocument))
-
 	if err != nil {
 		return err
 	}
@@ -112,7 +111,6 @@ func resourcePolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("policy") {
 		policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
-
 		if err != nil {
 			return fmt.Errorf("policy (%s) is invalid JSON: %w", policy, err)
 		}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #23288

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccIoTPolicy_ PKG=iot
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iot/... -v -count 1 -parallel 20 -run='TestAccIoTPolicy_'  -timeout 180m
=== RUN   TestAccIoTPolicy_basic
=== PAUSE TestAccIoTPolicy_basic
=== RUN   TestAccIoTPolicy_disappears
=== PAUSE TestAccIoTPolicy_disappears
=== CONT  TestAccIoTPolicy_basic
=== CONT  TestAccIoTPolicy_disappears
--- PASS: TestAccIoTPolicy_disappears (12.54s)
--- PASS: TestAccIoTPolicy_basic (16.96s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iot	18.694s
```
