### PR TITLE
kms: Improve diffs for policies

### DIFF
--- a/.changelog/28853.txt
+++ b/.changelog/28853.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_kms_external_key: Improve refresh to avoid unnecessary diffs in `policy`
+```
+
+```release-note:bug
+resource/aws_kms_key: Improve refresh to avoid unnecessary diffs in `policy`
+```

--- a/internal/service/kms/external_key.go
+++ b/internal/service/kms/external_key.go
@@ -95,6 +95,10 @@ func ResourceExternalKey() *schema.Resource {
 					validation.StringLenBetween(0, 32768),
 					validation.StringIsJSON,
 				),
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),

--- a/internal/service/kms/external_key.go
+++ b/internal/service/kms/external_key.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -85,10 +86,11 @@ func ResourceExternalKey() *schema.Resource {
 				ForceNew: true,
 			},
 			"policy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Optional:              true,
+				Computed:              true,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(0, 32768),
 					validation.StringIsJSON,
@@ -125,7 +127,12 @@ func resourceExternalKeyCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("policy"); ok {
-		input.Policy = aws.String(v.(string))
+		p, err := structure.NormalizeJsonString(v.(string))
+		if err != nil {
+			return fmt.Errorf("policy (%s) is invalid JSON: %w", p, err)
+		}
+
+		input.Policy = aws.String(p)
 	}
 
 	if len(tags) > 0 {
@@ -227,8 +234,7 @@ func resourceExternalKeyRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("key_usage", key.metadata.KeyUsage)
 	d.Set("multi_region", key.metadata.MultiRegion)
 
-	policyToSet, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), key.policy)
-
+	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), key.policy)
 	if err != nil {
 		return fmt.Errorf("while setting policy (%s), encountered: %w", key.policy, err)
 	}

--- a/internal/service/kms/key.go
+++ b/internal/service/kms/key.go
@@ -435,7 +435,6 @@ func updateKeyEnabled(conn *kms.KMS, keyID string, enabled bool) error {
 
 func updateKeyPolicy(conn *kms.KMS, keyID string, policy string, bypassPolicyLockoutSafetyCheck bool) error {
 	policy, err := structure.NormalizeJsonString(policy)
-
 	if err != nil {
 		return fmt.Errorf("policy contains invalid JSON: %w", err)
 	}
@@ -457,14 +456,12 @@ func updateKeyPolicy(conn *kms.KMS, keyID string, policy string, bypassPolicyLoc
 	}
 
 	_, err = tfresource.RetryWhenAWSErrCodeEquals(PropagationTimeout, updateFunc, kms.ErrCodeNotFoundException, kms.ErrCodeMalformedPolicyDocumentException)
-
 	if err != nil {
 		return fmt.Errorf("error updating KMS Key (%s) policy: %w", keyID, err)
 	}
 
 	// Wait for propagation since KMS is eventually consistent.
 	err = WaitKeyPolicyPropagated(conn, keyID, policy)
-
 	if err != nil {
 		return fmt.Errorf("error waiting for KMS Key (%s) policy propagation: %w", keyID, err)
 	}

--- a/internal/service/kms/key.go
+++ b/internal/service/kms/key.go
@@ -92,11 +92,16 @@ func ResourceKey() *schema.Resource {
 				ForceNew: true,
 			},
 			"policy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
-				ValidateFunc:     validation.StringIsJSON,
+				Type:                  schema.TypeString,
+				Optional:              true,
+				Computed:              true,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
+				ValidateFunc:          validation.StringIsJSON,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
@@ -124,6 +129,11 @@ func resourceKeyCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("policy"); ok {
+		p, err := structure.NormalizeJsonString(v.(string))
+		if err != nil {
+			return fmt.Errorf("policy (%s) is invalid JSON: %w", p, err)
+		}
+
 		input.Policy = aws.String(v.(string))
 	}
 
@@ -212,8 +222,7 @@ func resourceKeyRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("key_usage", key.metadata.KeyUsage)
 	d.Set("multi_region", key.metadata.MultiRegion)
 
-	policyToSet, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), key.policy)
-
+	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), key.policy)
 	if err != nil {
 		return fmt.Errorf("while setting policy (%s), encountered: %w", key.policy, err)
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #23288

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% TF_ACC=1 go test ./internal/service/kms/... -v -count 1 -parallel 3 -run='TestAccKMSExternalKey_|TestAccKMSKey_'  -timeout 180m
=== RUN   TestAccKMSExternalKey_basic
=== PAUSE TestAccKMSExternalKey_basic
=== RUN   TestAccKMSExternalKey_disappears
=== PAUSE TestAccKMSExternalKey_disappears
=== RUN   TestAccKMSExternalKey_multiRegion
=== PAUSE TestAccKMSExternalKey_multiRegion
=== RUN   TestAccKMSExternalKey_deletionWindowInDays
=== PAUSE TestAccKMSExternalKey_deletionWindowInDays
=== RUN   TestAccKMSExternalKey_description
=== PAUSE TestAccKMSExternalKey_description
=== RUN   TestAccKMSExternalKey_enabled
=== PAUSE TestAccKMSExternalKey_enabled
=== RUN   TestAccKMSExternalKey_keyMaterialBase64
=== PAUSE TestAccKMSExternalKey_keyMaterialBase64
=== RUN   TestAccKMSExternalKey_policy
=== PAUSE TestAccKMSExternalKey_policy
=== RUN   TestAccKMSExternalKey_policyBypass
=== PAUSE TestAccKMSExternalKey_policyBypass
=== RUN   TestAccKMSExternalKey_tags
=== PAUSE TestAccKMSExternalKey_tags
=== RUN   TestAccKMSExternalKey_validTo
=== PAUSE TestAccKMSExternalKey_validTo
=== RUN   TestAccKMSKey_basic
=== PAUSE TestAccKMSKey_basic
=== RUN   TestAccKMSKey_disappears
=== PAUSE TestAccKMSKey_disappears
=== RUN   TestAccKMSKey_multiRegion
=== PAUSE TestAccKMSKey_multiRegion
=== RUN   TestAccKMSKey_asymmetricKey
=== PAUSE TestAccKMSKey_asymmetricKey
=== RUN   TestAccKMSKey_hmacKey
=== PAUSE TestAccKMSKey_hmacKey
=== RUN   TestAccKMSKey_Policy_basic
=== PAUSE TestAccKMSKey_Policy_basic
=== RUN   TestAccKMSKey_Policy_bypass
=== PAUSE TestAccKMSKey_Policy_bypass
=== RUN   TestAccKMSKey_Policy_bypassUpdate
=== PAUSE TestAccKMSKey_Policy_bypassUpdate
=== RUN   TestAccKMSKey_Policy_iamRole
=== PAUSE TestAccKMSKey_Policy_iamRole
=== RUN   TestAccKMSKey_Policy_iamRoleUpdate
=== PAUSE TestAccKMSKey_Policy_iamRoleUpdate
=== RUN   TestAccKMSKey_Policy_iamRoleOrder
=== PAUSE TestAccKMSKey_Policy_iamRoleOrder
=== RUN   TestAccKMSKey_Policy_iamServiceLinkedRole
=== PAUSE TestAccKMSKey_Policy_iamServiceLinkedRole
=== RUN   TestAccKMSKey_Policy_booleanCondition
=== PAUSE TestAccKMSKey_Policy_booleanCondition
=== RUN   TestAccKMSKey_isEnabled
=== PAUSE TestAccKMSKey_isEnabled
=== RUN   TestAccKMSKey_tags
=== PAUSE TestAccKMSKey_tags
=== CONT  TestAccKMSExternalKey_basic
=== CONT  TestAccKMSKey_multiRegion
=== CONT  TestAccKMSExternalKey_policy
--- PASS: TestAccKMSExternalKey_basic (18.24s)
=== CONT  TestAccKMSKey_disappears
--- PASS: TestAccKMSKey_multiRegion (18.32s)
=== CONT  TestAccKMSKey_basic
--- PASS: TestAccKMSKey_disappears (12.35s)
=== CONT  TestAccKMSExternalKey_validTo
--- PASS: TestAccKMSKey_basic (17.31s)
=== CONT  TestAccKMSExternalKey_tags
--- PASS: TestAccKMSExternalKey_policy (38.08s)
=== CONT  TestAccKMSExternalKey_policyBypass
--- PASS: TestAccKMSExternalKey_policyBypass (21.07s)
=== CONT  TestAccKMSKey_Policy_iamRoleUpdate
--- PASS: TestAccKMSExternalKey_tags (51.81s)
=== CONT  TestAccKMSKey_tags
--- PASS: TestAccKMSKey_Policy_iamRoleUpdate (51.92s)
=== CONT  TestAccKMSKey_isEnabled
--- PASS: TestAccKMSKey_tags (52.86s)
=== CONT  TestAccKMSKey_Policy_booleanCondition
--- PASS: TestAccKMSKey_Policy_booleanCondition (18.94s)
=== CONT  TestAccKMSKey_Policy_iamServiceLinkedRole
--- PASS: TestAccKMSExternalKey_validTo (143.66s)
=== CONT  TestAccKMSKey_Policy_iamRoleOrder
--- PASS: TestAccKMSKey_Policy_iamServiceLinkedRole (63.61s)
=== CONT  TestAccKMSKey_Policy_bypass
--- PASS: TestAccKMSKey_isEnabled (111.93s)
=== CONT  TestAccKMSKey_Policy_iamRole
--- PASS: TestAccKMSKey_Policy_iamRoleOrder (65.39s)
=== CONT  TestAccKMSKey_Policy_bypassUpdate
--- PASS: TestAccKMSKey_Policy_iamRole (42.90s)
=== CONT  TestAccKMSExternalKey_description
--- PASS: TestAccKMSKey_Policy_bypassUpdate (34.62s)
=== CONT  TestAccKMSExternalKey_keyMaterialBase64
--- PASS: TestAccKMSExternalKey_description (40.17s)
=== CONT  TestAccKMSExternalKey_enabled
--- PASS: TestAccKMSKey_Policy_bypass (146.65s)
=== CONT  TestAccKMSKey_hmacKey
--- PASS: TestAccKMSExternalKey_keyMaterialBase64 (103.59s)
=== CONT  TestAccKMSKey_Policy_basic
--- PASS: TestAccKMSKey_hmacKey (13.48s)
=== CONT  TestAccKMSKey_asymmetricKey
--- PASS: TestAccKMSKey_asymmetricKey (13.95s)
=== CONT  TestAccKMSExternalKey_multiRegion
--- PASS: TestAccKMSKey_Policy_basic (35.92s)
=== CONT  TestAccKMSExternalKey_deletionWindowInDays
--- PASS: TestAccKMSExternalKey_multiRegion (20.59s)
=== CONT  TestAccKMSExternalKey_disappears
--- PASS: TestAccKMSExternalKey_disappears (11.72s)
--- PASS: TestAccKMSExternalKey_deletionWindowInDays (27.78s)
--- PASS: TestAccKMSExternalKey_enabled (135.57s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	443.405s
```
