### PR TITLE
s3/bucket policy: Improve diffs with policies

### DIFF
--- a/.changelog/28855.txt
+++ b/.changelog/28855.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_s3_bucket: Improve refresh to avoid unnecessary diffs in `policy`
+```
+
+```release-note:bug
+resource/aws_s3_bucket_policy: Improve refresh to avoid unnecessary diffs in `policy`
+```

--- a/internal/service/s3/bucket_policy.go
+++ b/internal/service/s3/bucket_policy.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -13,8 +14,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func ResourceBucketPolicy() *schema.Resource {
@@ -35,10 +38,15 @@ func ResourceBucketPolicy() *schema.Resource {
 			},
 
 			"policy": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Required:              true,
+				ValidateFunc:          validation.StringIsJSON,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
+				StateFunc: func(v interface{}) string {
+					json, _ := structure.NormalizeJsonString(v)
+					return json
+				},
 			},
 		},
 	}
@@ -50,7 +58,6 @@ func resourceBucketPolicyPut(d *schema.ResourceData, meta interface{}) error {
 	bucket := d.Get("bucket").(string)
 
 	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
-
 	if err != nil {
 		return fmt.Errorf("policy (%s) is an invalid JSON: %w", policy, err)
 	}
@@ -98,21 +105,17 @@ func resourceBucketPolicyRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	v := ""
-	if err == nil && pol.Policy != nil {
-		v = aws.StringValue(pol.Policy)
+	if err != nil {
+		create.Error(names.S3, create.ErrActionReading, "Bucket Policy", d.Id(), err)
 	}
 
-	policyToSet, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), v)
+	if pol.Policy == nil {
+		create.Error(names.S3, create.ErrActionReading, "Bucket Policy", d.Id(), errors.New("empty policy returned"))
+	}
 
+	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), aws.StringValue(pol.Policy))
 	if err != nil {
 		return fmt.Errorf("while setting policy (%s), encountered: %w", policyToSet, err)
-	}
-
-	policyToSet, err = structure.NormalizeJsonString(policyToSet)
-
-	if err != nil {
-		return fmt.Errorf("policy (%s) is an invalid JSON: %w", policyToSet, err)
 	}
 
 	if err := d.Set("policy", policyToSet); err != nil {

--- a/internal/service/s3/bucket_policy.go
+++ b/internal/service/s3/bucket_policy.go
@@ -106,11 +106,11 @@ func resourceBucketPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		create.Error(names.S3, create.ErrActionReading, "Bucket Policy", d.Id(), err)
+		return create.Error(names.S3, create.ErrActionReading, "Bucket Policy", d.Id(), err)
 	}
 
 	if pol.Policy == nil {
-		create.Error(names.S3, create.ErrActionReading, "Bucket Policy", d.Id(), errors.New("empty policy returned"))
+		return create.Error(names.S3, create.ErrActionReading, "Bucket Policy", d.Id(), errors.New("empty policy returned"))
 	}
 
 	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), aws.StringValue(pol.Policy))

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -409,7 +409,7 @@ func TestAccS3Bucket_Duplicate_UsEast1AltAccount(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccBucketConfig_duplicateAltAccount(endpoints.UsEast1RegionID, bucketName),
-				ExpectError: regexp.MustCompile(s3.ErrCodeBucketAlreadyExists),
+				ExpectError: regexp.MustCompile(s3.ErrCodeBucketAlreadyOwnedByYou),
 			},
 		},
 	})


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #23288 
Closes #18878
Closes #22030
Closes #24338

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Errors unrelated to these changes.

```console
% TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 3 -run='TestAccS3BucketPolicy_|TestAccS3Bucket_'  -timeout 180m
TF_ACC=1 go test ./internal/service/kms/... -v -count 1 -parallel 3 -run='TestAccKMSExternalKey_|TestAccKMSKey_'  -timeout 180m=== RUN   TestAccS3BucketPolicy_basic
=== PAUSE TestAccS3BucketPolicy_basic
=== RUN   TestAccS3BucketPolicy_disappears
=== PAUSE TestAccS3BucketPolicy_disappears
=== RUN   TestAccS3BucketPolicy_disappears_bucket
=== PAUSE TestAccS3BucketPolicy_disappears_bucket
=== RUN   TestAccS3BucketPolicy_policyUpdate
=== PAUSE TestAccS3BucketPolicy_policyUpdate
=== RUN   TestAccS3BucketPolicy_IAMRoleOrder_policyDoc
=== PAUSE TestAccS3BucketPolicy_IAMRoleOrder_policyDoc
=== RUN   TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal
=== PAUSE TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal
=== RUN   TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode
=== PAUSE TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode
=== RUN   TestAccS3BucketPolicy_migrate_noChange
=== PAUSE TestAccS3BucketPolicy_migrate_noChange
=== RUN   TestAccS3BucketPolicy_migrate_withChange
=== PAUSE TestAccS3BucketPolicy_migrate_withChange
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Basic_emptyString
=== PAUSE TestAccS3Bucket_Basic_emptyString
=== RUN   TestAccS3Bucket_Basic_generatedName
=== PAUSE TestAccS3Bucket_Basic_generatedName
=== RUN   TestAccS3Bucket_Basic_namePrefix
=== PAUSE TestAccS3Bucket_Basic_namePrefix
=== RUN   TestAccS3Bucket_Basic_forceDestroy
=== PAUSE TestAccS3Bucket_Basic_forceDestroy
=== RUN   TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
=== PAUSE TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
=== RUN   TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
=== PAUSE TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
=== RUN   TestAccS3Bucket_Basic_acceleration
=== PAUSE TestAccS3Bucket_Basic_acceleration
=== RUN   TestAccS3Bucket_Basic_keyEnabled
=== PAUSE TestAccS3Bucket_Basic_keyEnabled
=== RUN   TestAccS3Bucket_Basic_requestPayer
=== PAUSE TestAccS3Bucket_Basic_requestPayer
=== RUN   TestAccS3Bucket_disappears
=== PAUSE TestAccS3Bucket_disappears
=== RUN   TestAccS3Bucket_Duplicate_basic
=== PAUSE TestAccS3Bucket_Duplicate_basic
=== RUN   TestAccS3Bucket_Duplicate_UsEast1
=== PAUSE TestAccS3Bucket_Duplicate_UsEast1
=== RUN   TestAccS3Bucket_Duplicate_UsEast1AltAccount
=== PAUSE TestAccS3Bucket_Duplicate_UsEast1AltAccount
=== RUN   TestAccS3Bucket_Tags_basic
=== PAUSE TestAccS3Bucket_Tags_basic
=== RUN   TestAccS3Bucket_Tags_withNoSystemTags
=== PAUSE TestAccS3Bucket_Tags_withNoSystemTags
=== RUN   TestAccS3Bucket_Tags_withSystemTags
=== PAUSE TestAccS3Bucket_Tags_withSystemTags
=== RUN   TestAccS3Bucket_Tags_ignoreTags
=== PAUSE TestAccS3Bucket_Tags_ignoreTags
=== RUN   TestAccS3Bucket_Manage_lifecycleBasic
=== PAUSE TestAccS3Bucket_Manage_lifecycleBasic
=== RUN   TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly
=== PAUSE TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly
=== RUN   TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock
=== PAUSE TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock
=== RUN   TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration
=== PAUSE TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration
=== RUN   TestAccS3Bucket_Manage_lifecycleRemove
=== PAUSE TestAccS3Bucket_Manage_lifecycleRemove
=== RUN   TestAccS3Bucket_Manage_objectLock
=== PAUSE TestAccS3Bucket_Manage_objectLock
=== RUN   TestAccS3Bucket_Manage_objectLock_deprecatedEnabled
=== PAUSE TestAccS3Bucket_Manage_objectLock_deprecatedEnabled
=== RUN   TestAccS3Bucket_Manage_objectLock_migrate
=== PAUSE TestAccS3Bucket_Manage_objectLock_migrate
=== RUN   TestAccS3Bucket_Manage_objectLockWithVersioning
=== PAUSE TestAccS3Bucket_Manage_objectLockWithVersioning
=== RUN   TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled
=== PAUSE TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled
=== RUN   TestAccS3Bucket_Manage_versioning
=== PAUSE TestAccS3Bucket_Manage_versioning
=== RUN   TestAccS3Bucket_Manage_versioningDisabled
=== PAUSE TestAccS3Bucket_Manage_versioningDisabled
=== RUN   TestAccS3Bucket_Manage_MFADeleteDisabled
=== PAUSE TestAccS3Bucket_Manage_MFADeleteDisabled
=== RUN   TestAccS3Bucket_Manage_versioningAndMFADeleteDisabled
=== PAUSE TestAccS3Bucket_Manage_versioningAndMFADeleteDisabled
=== RUN   TestAccS3Bucket_Replication_basic
=== PAUSE TestAccS3Bucket_Replication_basic
=== RUN   TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter
=== PAUSE TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter
=== RUN   TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter
=== PAUSE TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter
=== RUN   TestAccS3Bucket_Replication_twoDestination
=== PAUSE TestAccS3Bucket_Replication_twoDestination
=== RUN   TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation
=== PAUSE TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation
=== RUN   TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation
=== PAUSE TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation
=== RUN   TestAccS3Bucket_Replication_withoutStorageClass
=== PAUSE TestAccS3Bucket_Replication_withoutStorageClass
=== RUN   TestAccS3Bucket_Replication_expectVersioningValidationError
=== PAUSE TestAccS3Bucket_Replication_expectVersioningValidationError
=== RUN   TestAccS3Bucket_Replication_withoutPrefix
=== PAUSE TestAccS3Bucket_Replication_withoutPrefix
=== RUN   TestAccS3Bucket_Replication_schemaV2
=== PAUSE TestAccS3Bucket_Replication_schemaV2
=== RUN   TestAccS3Bucket_Replication_schemaV2SameRegion
=== PAUSE TestAccS3Bucket_Replication_schemaV2SameRegion
=== RUN   TestAccS3Bucket_Replication_RTC_valid
=== PAUSE TestAccS3Bucket_Replication_RTC_valid
=== RUN   TestAccS3Bucket_Security_updateACL
=== PAUSE TestAccS3Bucket_Security_updateACL
=== RUN   TestAccS3Bucket_Security_updateGrant
=== PAUSE TestAccS3Bucket_Security_updateGrant
=== RUN   TestAccS3Bucket_Security_aclToGrant
=== PAUSE TestAccS3Bucket_Security_aclToGrant
=== RUN   TestAccS3Bucket_Security_grantToACL
=== PAUSE TestAccS3Bucket_Security_grantToACL
=== RUN   TestAccS3Bucket_Security_corsUpdate
=== PAUSE TestAccS3Bucket_Security_corsUpdate
=== RUN   TestAccS3Bucket_Security_corsDelete
=== PAUSE TestAccS3Bucket_Security_corsDelete
=== RUN   TestAccS3Bucket_Security_corsEmptyOrigin
=== PAUSE TestAccS3Bucket_Security_corsEmptyOrigin
=== RUN   TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin
=== PAUSE TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin
=== RUN   TestAccS3Bucket_Security_logging
=== PAUSE TestAccS3Bucket_Security_logging
=== RUN   TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical
=== PAUSE TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical
=== RUN   TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed
=== PAUSE TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed
=== RUN   TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled
=== PAUSE TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled
=== RUN   TestAccS3Bucket_Security_policy
=== PAUSE TestAccS3Bucket_Security_policy
=== RUN   TestAccS3Bucket_Web_simple
=== PAUSE TestAccS3Bucket_Web_simple
=== RUN   TestAccS3Bucket_Web_redirect
=== PAUSE TestAccS3Bucket_Web_redirect
=== RUN   TestAccS3Bucket_Web_routingRules
=== PAUSE TestAccS3Bucket_Web_routingRules
=== CONT  TestAccS3BucketPolicy_basic
=== CONT  TestAccS3Bucket_Manage_objectLockWithVersioning
=== CONT  TestAccS3Bucket_Replication_RTC_valid
    bucket_test.go:1687: Step 1/4 error: Error running pre-apply refresh: exit status 1
        
        Error: Invalid data source
        
          on terraform_plugin_test.tf line 6, in data "aws_partition" "current":
           6: data "aws_partition" "current" {}
        
        The provider hashicorp/aws does not support data source "aws_partition".
=== CONT  TestAccS3Bucket_Web_routingRules
--- FAIL: TestAccS3Bucket_Replication_RTC_valid (2.17s)
--- PASS: TestAccS3BucketPolicy_basic (28.88s)
=== CONT  TestAccS3Bucket_Web_redirect
--- PASS: TestAccS3Bucket_Manage_objectLockWithVersioning (30.83s)
=== CONT  TestAccS3Bucket_Web_simple
--- PASS: TestAccS3Bucket_Web_routingRules (46.33s)
=== CONT  TestAccS3Bucket_Security_policy
--- PASS: TestAccS3Bucket_Web_redirect (68.11s)
=== CONT  TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled
--- PASS: TestAccS3Bucket_Web_simple (67.82s)
=== CONT  TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed
--- PASS: TestAccS3Bucket_Security_policy (58.18s)
=== CONT  TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (23.11s)
=== CONT  TestAccS3Bucket_Security_logging
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (27.84s)
=== CONT  TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (38.24s)
=== CONT  TestAccS3Bucket_Security_corsEmptyOrigin
--- PASS: TestAccS3Bucket_Security_logging (33.87s)
=== CONT  TestAccS3Bucket_Security_corsDelete
--- PASS: TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin (23.63s)
=== CONT  TestAccS3Bucket_Security_corsUpdate
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (28.10s)
=== CONT  TestAccS3Bucket_Security_grantToACL
--- PASS: TestAccS3Bucket_Security_corsDelete (25.29s)
=== CONT  TestAccS3Bucket_Security_aclToGrant
--- PASS: TestAccS3Bucket_Security_corsUpdate (43.15s)
=== CONT  TestAccS3Bucket_Security_updateGrant
--- PASS: TestAccS3Bucket_Security_grantToACL (38.34s)
=== CONT  TestAccS3Bucket_Security_updateACL
--- PASS: TestAccS3Bucket_Security_aclToGrant (37.90s)
=== CONT  TestAccS3Bucket_Replication_twoDestination
    bucket_test.go:1321: Step 1/2 error: Error running pre-apply refresh: exit status 1
        
        Error: Invalid data source
        
          on terraform_plugin_test.tf line 6, in data "aws_partition" "current":
           6: data "aws_partition" "current" {}
        
        The provider hashicorp/aws does not support data source "aws_partition".
=== CONT  TestAccS3Bucket_Replication_schemaV2SameRegion
--- FAIL: TestAccS3Bucket_Replication_twoDestination (1.25s)
--- PASS: TestAccS3Bucket_Security_updateACL (39.80s)
=== CONT  TestAccS3Bucket_Replication_schemaV2
    bucket_test.go:1572: Step 1/6 error: Error running pre-apply refresh: exit status 1
        
        Error: Invalid data source
        
          on terraform_plugin_test.tf line 6, in data "aws_partition" "current":
           6: data "aws_partition" "current" {}
        
        The provider hashicorp/aws does not support data source "aws_partition".
=== CONT  TestAccS3Bucket_Replication_withoutPrefix
--- FAIL: TestAccS3Bucket_Replication_schemaV2 (1.26s)
=== CONT  TestAccS3Bucket_Replication_withoutPrefix
    bucket_test.go:1535: Step 1/2 error: Error running pre-apply refresh: exit status 1
        
        Error: Invalid data source
        
          on terraform_plugin_test.tf line 6, in data "aws_partition" "current":
           6: data "aws_partition" "current" {}
        
        The provider hashicorp/aws does not support data source "aws_partition".
--- FAIL: TestAccS3Bucket_Replication_withoutPrefix (1.27s)
=== CONT  TestAccS3Bucket_Replication_expectVersioningValidationError
    bucket_test.go:1508: Step 1/1, expected an error with pattern, no match on: Error running pre-apply refresh: exit status 1
        
        Error: Invalid data source
        
          on terraform_plugin_test.tf line 6, in data "aws_partition" "current":
           6: data "aws_partition" "current" {}
        
        The provider hashicorp/aws does not support data source "aws_partition".
--- FAIL: TestAccS3Bucket_Replication_expectVersioningValidationError (1.20s)
=== CONT  TestAccS3Bucket_Replication_withoutStorageClass
    bucket_test.go:1475: Step 1/2 error: Error running pre-apply refresh: exit status 1
        
        Error: Invalid data source
        
          on terraform_plugin_test.tf line 6, in data "aws_partition" "current":
           6: data "aws_partition" "current" {}
        
        The provider hashicorp/aws does not support data source "aws_partition".
--- FAIL: TestAccS3Bucket_Replication_withoutStorageClass (1.35s)
=== CONT  TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation
    bucket_test.go:1427: Step 1/3 error: Error running pre-apply refresh: exit status 1
        
        Error: Invalid data source
        
          on terraform_plugin_test.tf line 6, in data "aws_partition" "current":
           6: data "aws_partition" "current" {}
        
        The provider hashicorp/aws does not support data source "aws_partition".
        
        Error: Invalid data source
        
          on terraform_plugin_test.tf line 37, in data "aws_caller_identity" "current":
          37: data "aws_caller_identity" "current" {}
        
        The provider hashicorp/aws does not support data source
        "aws_caller_identity".
--- FAIL: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (1.29s)
=== CONT  TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation
    bucket_test.go:1379: Step 1/3 error: Error running pre-apply refresh: exit status 1
        
        Error: Invalid data source
        
          on terraform_plugin_test.tf line 6, in data "aws_partition" "current":
           6: data "aws_partition" "current" {}
        
        The provider hashicorp/aws does not support data source "aws_partition".
        
        Error: Invalid data source
        
          on terraform_plugin_test.tf line 37, in data "aws_caller_identity" "current":
          37: data "aws_caller_identity" "current" {}
        
        The provider hashicorp/aws does not support data source
        "aws_caller_identity".
--- FAIL: TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation (1.29s)
=== CONT  TestAccS3Bucket_Manage_versioningAndMFADeleteDisabled
--- PASS: TestAccS3Bucket_Replication_schemaV2SameRegion (31.07s)
=== CONT  TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter
    bucket_test.go:1250: Step 1/2 error: Error running pre-apply refresh: exit status 1
        
        Error: Invalid data source
        
          on terraform_plugin_test.tf line 6, in data "aws_partition" "current":
           6: data "aws_partition" "current" {}
        
        The provider hashicorp/aws does not support data source "aws_partition".
--- FAIL: TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter (1.33s)
=== CONT  TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter
    bucket_test.go:1183: Step 1/2 error: Error running pre-apply refresh: exit status 1
        
        Error: Invalid data source
        
          on terraform_plugin_test.tf line 6, in data "aws_partition" "current":
           6: data "aws_partition" "current" {}
        
        The provider hashicorp/aws does not support data source "aws_partition".
--- FAIL: TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter (6.02s)
=== CONT  TestAccS3Bucket_Replication_basic
    bucket_test.go:1132: Step 1/3 error: Error running pre-apply refresh: exit status 1
        
        Error: Invalid data source
        
          on terraform_plugin_test.tf line 6, in data "aws_partition" "current":
           6: data "aws_partition" "current" {}
        
        The provider hashicorp/aws does not support data source "aws_partition".
--- FAIL: TestAccS3Bucket_Replication_basic (1.35s)
=== CONT  TestAccS3Bucket_Basic_requestPayer
--- PASS: TestAccS3Bucket_Security_updateGrant (66.35s)
=== CONT  TestAccS3Bucket_Manage_objectLock_migrate
--- PASS: TestAccS3Bucket_Manage_versioningAndMFADeleteDisabled (25.92s)
=== CONT  TestAccS3Bucket_Manage_objectLock_deprecatedEnabled
--- PASS: TestAccS3Bucket_Manage_objectLock_migrate (31.91s)
=== CONT  TestAccS3Bucket_Manage_objectLock
--- PASS: TestAccS3Bucket_Manage_objectLock_deprecatedEnabled (28.08s)
=== CONT  TestAccS3Bucket_Manage_lifecycleRemove
--- PASS: TestAccS3Bucket_Basic_requestPayer (45.97s)
=== CONT  TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (32.05s)
=== CONT  TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock
--- PASS: TestAccS3Bucket_Manage_objectLock (44.73s)
=== CONT  TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly
--- PASS: TestAccS3Bucket_Manage_lifecycleRemove (43.35s)
=== CONT  TestAccS3Bucket_Manage_lifecycleBasic
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (23.86s)
=== CONT  TestAccS3Bucket_Tags_ignoreTags
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (43.61s)
=== CONT  TestAccS3Bucket_Tags_withSystemTags
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (45.77s)
=== CONT  TestAccS3Bucket_Tags_withNoSystemTags
--- PASS: TestAccS3Bucket_Tags_ignoreTags (42.08s)
=== CONT  TestAccS3Bucket_Tags_basic
--- PASS: TestAccS3Bucket_Tags_basic (26.69s)
--- PASS: TestAccS3Bucket_Duplicate_UsEast1AltAccount (17.22s)
=== CONT  TestAccS3Bucket_Duplicate_UsEast1
--- PASS: TestAccS3Bucket_Duplicate_UsEast1 (11.73s)
=== CONT  TestAccS3Bucket_Duplicate_basic
--- PASS: TestAccS3Bucket_Duplicate_basic (11.84s)
=== CONT  TestAccS3Bucket_disappears
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (82.28s)
=== CONT  TestAccS3Bucket_Basic_basic
--- PASS: TestAccS3Bucket_disappears (16.02s)
=== CONT  TestAccS3Bucket_Basic_keyEnabled
--- PASS: TestAccS3Bucket_Basic_basic (24.15s)
=== CONT  TestAccS3Bucket_Basic_acceleration
--- PASS: TestAccS3Bucket_Basic_keyEnabled (25.95s)
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
--- PASS: TestAccS3Bucket_Tags_withSystemTags (135.80s)
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (26.62s)
=== CONT  TestAccS3Bucket_Basic_forceDestroy
--- PASS: TestAccS3Bucket_Basic_acceleration (46.81s)
=== CONT  TestAccS3Bucket_Basic_namePrefix
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (25.66s)
=== CONT  TestAccS3Bucket_Basic_generatedName
--- PASS: TestAccS3Bucket_Basic_forceDestroy (20.63s)
=== CONT  TestAccS3Bucket_Basic_emptyString
--- PASS: TestAccS3Bucket_Basic_namePrefix (23.45s)
=== CONT  TestAccS3Bucket_Manage_versioningDisabled
--- PASS: TestAccS3Bucket_Basic_generatedName (24.19s)
=== CONT  TestAccS3Bucket_Manage_MFADeleteDisabled
--- PASS: TestAccS3Bucket_Basic_emptyString (23.58s)
=== CONT  TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal
--- PASS: TestAccS3Bucket_Manage_versioningDisabled (23.76s)
=== CONT  TestAccS3BucketPolicy_migrate_withChange
--- PASS: TestAccS3Bucket_Manage_MFADeleteDisabled (23.76s)
=== CONT  TestAccS3BucketPolicy_migrate_noChange
--- PASS: TestAccS3BucketPolicy_migrate_withChange (35.86s)
=== CONT  TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal (65.27s)
=== CONT  TestAccS3Bucket_Manage_versioning
--- PASS: TestAccS3BucketPolicy_migrate_noChange (91.20s)
=== CONT  TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled
--- PASS: TestAccS3Bucket_Manage_versioning (44.99s)
=== CONT  TestAccS3BucketPolicy_policyUpdate
--- PASS: TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled (29.10s)
=== CONT  TestAccS3BucketPolicy_IAMRoleOrder_policyDoc
--- PASS: TestAccS3BucketPolicy_policyUpdate (43.51s)
=== CONT  TestAccS3BucketPolicy_disappears_bucket
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode (117.69s)
=== CONT  TestAccS3BucketPolicy_disappears
--- PASS: TestAccS3BucketPolicy_disappears_bucket (16.80s)
--- PASS: TestAccS3BucketPolicy_disappears (21.18s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDoc (62.91s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/s3	785.096s
```
