### PR TITLE
ses: Improve diffs for policies

### DIFF
--- a/.changelog/28861.txt
+++ b/.changelog/28861.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ses_identity_policy: Improve refresh to avoid unnecessary diffs in `policy`
+```

--- a/internal/service/ses/identity_policy.go
+++ b/internal/service/ses/identity_policy.go
@@ -41,10 +41,11 @@ func ResourceIdentityPolicy() *schema.Resource {
 				),
 			},
 			"policy": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Required:              true,
+				ValidateFunc:          validation.StringIsJSON,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
@@ -61,7 +62,6 @@ func resourceIdentityPolicyCreate(d *schema.ResourceData, meta interface{}) erro
 	policyName := d.Get("name").(string)
 
 	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
-
 	if err != nil {
 		return fmt.Errorf("policy (%s) is invalid JSON: %w", d.Get("policy").(string), err)
 	}
@@ -91,7 +91,6 @@ func resourceIdentityPolicyUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
-
 	if err != nil {
 		return fmt.Errorf("policy (%s) is invalid JSON: %w", d.Get("policy").(string), err)
 	}
@@ -150,7 +149,6 @@ func resourceIdentityPolicyRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("name", policyName)
 
 	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), aws.StringValue(policy))
-
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #23288

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccSESIdentityPolicy_ PKG=ses
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ses/... -v -count 1 -parallel 20 -run='TestAccSESIdentityPolicy_'  -timeout 180m
=== RUN   TestAccSESIdentityPolicy_basic
=== PAUSE TestAccSESIdentityPolicy_basic
=== RUN   TestAccSESIdentityPolicy_Identity_email
=== PAUSE TestAccSESIdentityPolicy_Identity_email
=== RUN   TestAccSESIdentityPolicy_policy
=== PAUSE TestAccSESIdentityPolicy_policy
=== RUN   TestAccSESIdentityPolicy_ignoreEquivalent
=== PAUSE TestAccSESIdentityPolicy_ignoreEquivalent
=== CONT  TestAccSESIdentityPolicy_basic
=== CONT  TestAccSESIdentityPolicy_ignoreEquivalent
=== CONT  TestAccSESIdentityPolicy_Identity_email
=== CONT  TestAccSESIdentityPolicy_policy
--- PASS: TestAccSESIdentityPolicy_Identity_email (20.30s)
--- PASS: TestAccSESIdentityPolicy_basic (20.36s)
--- PASS: TestAccSESIdentityPolicy_ignoreEquivalent (25.21s)
--- PASS: TestAccSESIdentityPolicy_policy (31.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ses	33.858s
```
