### PR TITLE
`aws_opensearch_domain`: Omit IOPS/Throughput when not supported

### DIFF
--- a/.changelog/28862.txt
+++ b/.changelog/28862.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_opensearch_domain: Omit `throughput` and `iops` for unsupported volume types 
+```

--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -1318,3 +1318,31 @@ func ParseEngineVersion(engineVersion string) (string, string, error) {
 
 	return parts[0], parts[1], nil
 }
+
+// EBSVolumeTypePermitsIopsInput returns true if the volume type supports the Iops input
+//
+// This check prevents a ValidationException when updating EBS volume types from a value
+// that supports IOPS (ex. gp3) to one that doesn't (ex. gp2).
+func EBSVolumeTypePermitsIopsInput(volumeType string) bool {
+	permittedTypes := []string{opensearchservice.VolumeTypeGp3, opensearchservice.VolumeTypeIo1}
+	for _, t := range permittedTypes {
+		if volumeType == t {
+			return true
+		}
+	}
+	return false
+}
+
+// EBSVolumeTypePermitsIopsInput returns true if the volume type supports the Throughput input
+//
+// This check prevents a ValidationException when updating EBS volume types from a value
+// that supports Throughput (ex. gp3) to one that doesn't (ex. gp2).
+func EBSVolumeTypePermitsThroughputInput(volumeType string) bool {
+	permittedTypes := []string{opensearchservice.VolumeTypeGp3}
+	for _, t := range permittedTypes {
+		if volumeType == t {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -1549,7 +1549,7 @@ func TestAccOpenSearchDomain_VolumeType_update(t *testing.T) {
 // support the throughput and iops input values (ex. gp2)
 //
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/27467
-func TestAccOpenSearchDomain_VolumeType_GP3ToGP2(t *testing.T) {
+func TestAccOpenSearchDomain_VolumeType_gp3ToGP2(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -2348,7 +2348,7 @@ resource "aws_opensearch_domain" "test" {
 
   ebs_options {
     ebs_enabled = true
-    volume_size = %d
+    volume_size = %[2]d
     volume_type = "gp3"
   }
 
@@ -2366,7 +2366,7 @@ resource "aws_opensearch_domain" "test" {
 
   ebs_options {
     ebs_enabled = true
-    volume_size = %d
+    volume_size = %[2]d
     volume_type = "gp2"
   }
 

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -20,6 +20,58 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
+func TestEBSVolumeTypePermitsIopsInput(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		volumeType string
+		want       bool
+	}{
+		{"empty", "", false},
+		{"gp2", opensearchservice.VolumeTypeGp2, false},
+		{"gp3", opensearchservice.VolumeTypeGp3, true},
+		{"io1", opensearchservice.VolumeTypeIo1, true},
+		{"standard", opensearchservice.VolumeTypeStandard, false},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tfopensearch.EBSVolumeTypePermitsIopsInput(testCase.volumeType); got != testCase.want {
+				t.Errorf("EBSVolumeTypePermitsIopsInput() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestEBSVolumeTypePermitsThroughputInput(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		volumeType string
+		want       bool
+	}{
+		{"empty", "", false},
+		{"gp2", opensearchservice.VolumeTypeGp2, false},
+		{"gp3", opensearchservice.VolumeTypeGp3, true},
+		{"io1", opensearchservice.VolumeTypeIo1, false},
+		{"standard", opensearchservice.VolumeTypeStandard, false},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tfopensearch.EBSVolumeTypePermitsThroughputInput(testCase.volumeType); got != testCase.want {
+				t.Errorf("EBSVolumeTypePermitsThroughputInput() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
 func TestParseEngineVersion(t *testing.T) {
 	t.Parallel()
 
@@ -1493,6 +1545,54 @@ func TestAccOpenSearchDomain_VolumeType_update(t *testing.T) {
 		}})
 }
 
+// Verifies that EBS volume_type can be changed from gp3 to a type which does not
+// support the throughput and iops input values (ex. gp2)
+//
+// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/27467
+func TestAccOpenSearchDomain_VolumeType_GP3ToGP2(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var input opensearchservice.DomainStatus
+	rName := testAccRandomDomainName()
+	resourceName := "aws_opensearch_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIAMServiceLinkedRole(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, opensearchservice.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_clusterEBSVolumeGP3DefaultIopsThroughput(rName, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(resourceName, &input),
+					resource.TestCheckResourceAttr(resourceName, "ebs_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_options.0.ebs_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_options.0.volume_size", "10"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_options.0.volume_type", "gp3"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     rName,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDomainConfig_clusterEBSVolumeGP2(rName, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(resourceName, &input),
+					resource.TestCheckResourceAttr(resourceName, "ebs_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_options.0.ebs_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_options.0.volume_size", "10"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_options.0.volume_type", "gp2"),
+				),
+			},
+		}})
+}
+
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/13867
 func TestAccOpenSearchDomain_VolumeType_missing(t *testing.T) {
 	if testing.Short() {
@@ -2239,6 +2339,42 @@ resource "aws_opensearch_domain" "test" {
   }
 }
 `, rName, volumeSize, volumeThroughput, volumeIops)
+}
+
+func testAccDomainConfig_clusterEBSVolumeGP3DefaultIopsThroughput(rName string, volumeSize int) string {
+	return fmt.Sprintf(`
+resource "aws_opensearch_domain" "test" {
+  domain_name = %[1]q
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = %d
+    volume_type = "gp3"
+  }
+
+  cluster_config {
+    instance_type = "t3.small.search"
+  }
+}
+`, rName, volumeSize)
+}
+
+func testAccDomainConfig_clusterEBSVolumeGP2(rName string, volumeSize int) string {
+	return fmt.Sprintf(`
+resource "aws_opensearch_domain" "test" {
+  domain_name = %[1]q
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = %d
+    volume_type = "gp2"
+  }
+
+  cluster_config {
+    instance_type = "t3.small.search"
+  }
+}
+`, rName, volumeSize)
 }
 
 func testAccDomainConfig_clusterUpdateVersion(rName, version string) string {

--- a/internal/service/opensearch/flex.go
+++ b/internal/service/opensearch/flex.go
@@ -76,17 +76,20 @@ func expandEBSOptions(m map[string]interface{}) *opensearchservice.EBSOptions {
 		options.EBSEnabled = aws.Bool(ebsEnabled.(bool))
 
 		if ebsEnabled.(bool) {
-			if v, ok := m["iops"]; ok && v.(int) > 0 {
-				options.Iops = aws.Int64(int64(v.(int)))
-			}
-			if v, ok := m["throughput"]; ok && v.(int) > 0 {
-				options.Throughput = aws.Int64(int64(v.(int)))
-			}
 			if v, ok := m["volume_size"]; ok && v.(int) > 0 {
 				options.VolumeSize = aws.Int64(int64(v.(int)))
 			}
+			var volumeType string
 			if v, ok := m["volume_type"]; ok && v.(string) != "" {
-				options.VolumeType = aws.String(v.(string))
+				volumeType = v.(string)
+				options.VolumeType = aws.String(volumeType)
+			}
+
+			if v, ok := m["iops"]; ok && v.(int) > 0 && EBSVolumeTypePermitsIopsInput(volumeType) {
+				options.Iops = aws.Int64(int64(v.(int)))
+			}
+			if v, ok := m["throughput"]; ok && v.(int) > 0 && EBSVolumeTypePermitsThroughputInput(volumeType) {
+				options.Throughput = aws.Int64(int64(v.(int)))
 			}
 		}
 	}


### PR DESCRIPTION
### Description
This fix prevents the `Throughput` and `Iops` EBS options from being included in the input struct when the specified volume type does not support them. 

Specifically, this can happen when a configuration uses a `gp3` volume type without specifying `iops` or `throughput`, then the volume type changes to a type that doesn't support these arguments. On the first apply, the default values set by AWS are written to state. On the subsequent apply these should be omitted from the UpdateDomain request input to avoid a `ValidationException`.

### Relations
Closes #27467

### References
https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/opensearch@v1.12.0/types#EBSOptions


### Output from Acceptance Testing

```console
$ make testacc PKG=opensearch TESTS=TestAccOpenSearchDomain_VolumeType
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchDomain_VolumeType'  -timeout 180m
=== RUN   TestAccOpenSearchDomain_VolumeType_update
=== PAUSE TestAccOpenSearchDomain_VolumeType_update
=== RUN   TestAccOpenSearchDomain_VolumeType_GP3ToGP2
=== PAUSE TestAccOpenSearchDomain_VolumeType_GP3ToGP2
=== RUN   TestAccOpenSearchDomain_VolumeType_missing
=== PAUSE TestAccOpenSearchDomain_VolumeType_missing
=== CONT  TestAccOpenSearchDomain_VolumeType_update
=== CONT  TestAccOpenSearchDomain_VolumeType_missing
=== CONT  TestAccOpenSearchDomain_VolumeType_GP3ToGP2
--- PASS: TestAccOpenSearchDomain_VolumeType_missing (1195.95s)
--- PASS: TestAccOpenSearchDomain_VolumeType_GP3ToGP2 (3440.65s)
--- PASS: TestAccOpenSearchDomain_VolumeType_update (4052.78s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 4055.888s
```

```console
$ go test -v ./internal/service/opensearch/... -run ^TestEBS
=== RUN   TestEBSVolumeTypePermitsIopsInput
=== PAUSE TestEBSVolumeTypePermitsIopsInput
=== RUN   TestEBSVolumeTypePermitsThroughputInput
=== PAUSE TestEBSVolumeTypePermitsThroughputInput
=== CONT  TestEBSVolumeTypePermitsIopsInput
=== RUN   TestEBSVolumeTypePermitsIopsInput/empty
=== PAUSE TestEBSVolumeTypePermitsIopsInput/empty
=== RUN   TestEBSVolumeTypePermitsIopsInput/gp2
=== PAUSE TestEBSVolumeTypePermitsIopsInput/gp2
=== RUN   TestEBSVolumeTypePermitsIopsInput/gp3
=== PAUSE TestEBSVolumeTypePermitsIopsInput/gp3
=== RUN   TestEBSVolumeTypePermitsIopsInput/io1
=== PAUSE TestEBSVolumeTypePermitsIopsInput/io1
=== CONT  TestEBSVolumeTypePermitsThroughputInput
=== RUN   TestEBSVolumeTypePermitsIopsInput/standard
=== PAUSE TestEBSVolumeTypePermitsIopsInput/standard
=== RUN   TestEBSVolumeTypePermitsThroughputInput/empty
=== CONT  TestEBSVolumeTypePermitsIopsInput/empty
=== PAUSE TestEBSVolumeTypePermitsThroughputInput/empty
=== CONT  TestEBSVolumeTypePermitsIopsInput/gp3
=== CONT  TestEBSVolumeTypePermitsIopsInput/gp2
=== CONT  TestEBSVolumeTypePermitsIopsInput/io1
=== CONT  TestEBSVolumeTypePermitsIopsInput/standard
--- PASS: TestEBSVolumeTypePermitsIopsInput (0.00s)
    --- PASS: TestEBSVolumeTypePermitsIopsInput/empty (0.00s)
    --- PASS: TestEBSVolumeTypePermitsIopsInput/gp3 (0.00s)
    --- PASS: TestEBSVolumeTypePermitsIopsInput/gp2 (0.00s)
    --- PASS: TestEBSVolumeTypePermitsIopsInput/io1 (0.00s)
    --- PASS: TestEBSVolumeTypePermitsIopsInput/standard (0.00s)
=== RUN   TestEBSVolumeTypePermitsThroughputInput/gp2
=== PAUSE TestEBSVolumeTypePermitsThroughputInput/gp2
=== RUN   TestEBSVolumeTypePermitsThroughputInput/gp3
=== PAUSE TestEBSVolumeTypePermitsThroughputInput/gp3
=== RUN   TestEBSVolumeTypePermitsThroughputInput/io1
=== PAUSE TestEBSVolumeTypePermitsThroughputInput/io1
=== RUN   TestEBSVolumeTypePermitsThroughputInput/standard
=== PAUSE TestEBSVolumeTypePermitsThroughputInput/standard
=== CONT  TestEBSVolumeTypePermitsThroughputInput/empty
=== CONT  TestEBSVolumeTypePermitsThroughputInput/standard
=== CONT  TestEBSVolumeTypePermitsThroughputInput/io1
=== CONT  TestEBSVolumeTypePermitsThroughputInput/gp2
=== CONT  TestEBSVolumeTypePermitsThroughputInput/gp3
--- PASS: TestEBSVolumeTypePermitsThroughputInput (0.00s)
    --- PASS: TestEBSVolumeTypePermitsThroughputInput/empty (0.00s)
    --- PASS: TestEBSVolumeTypePermitsThroughputInput/standard (0.00s)
    --- PASS: TestEBSVolumeTypePermitsThroughputInput/io1 (0.00s)
    --- PASS: TestEBSVolumeTypePermitsThroughputInput/gp2 (0.00s)
    --- PASS: TestEBSVolumeTypePermitsThroughputInput/gp3 (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 2.908s
```

---

Output of the new acceptance test prior to the expander changes that confirms the behavior:

```console
$ make testacc PKG=opensearch TESTS=TestAccOpenSearchDomain_VolumeType_gp3ToStandard
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchDomain_VolumeType_gp3ToStandard'  -timeout 180m
=== RUN   TestAccOpenSearchDomain_VolumeType_gp3ToStandard
=== PAUSE TestAccOpenSearchDomain_VolumeType_gp3ToStandard
=== CONT  TestAccOpenSearchDomain_VolumeType_gp3ToStandard
    domain_test.go:1509: Step 3/3 error: Error running apply: exit status 1

        Error: ValidationException: Throughput is only valid when volume type is GP3.

          with aws_opensearch_domain.test,
          on terraform_plugin_test.tf line 2, in resource "aws_opensearch_domain" "test":
           2: resource "aws_opensearch_domain" "test" {

--- FAIL: TestAccOpenSearchDomain_VolumeType_gp3ToStandard (1387.59s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 1390.825s
FAIL
make: *** [testacc] Error 1
```