### PR TITLE
secretsmanager: Improve diffs with policies

### DIFF
--- a/.changelog/28863.txt
+++ b/.changelog/28863.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_secretsmanager_secret: Improve refresh to avoid unnecessary diffs in `policy`
+```
+
+```release-note:bug
+resource/aws_secretsmanager_secret_policy: Improve refresh to avoid unnecessary diffs in `policy`
+```

--- a/internal/service/secretsmanager/secret.go
+++ b/internal/service/secretsmanager/secret.go
@@ -66,11 +66,12 @@ func ResourceSecret() *schema.Resource {
 				ValidateFunc:  validSecretNamePrefix,
 			},
 			"policy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Optional:              true,
+				Computed:              true,
+				ValidateFunc:          validation.StringIsJSON,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
@@ -203,7 +204,6 @@ func resourceSecretCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("policy"); ok && v.(string) != "" && v.(string) != "{}" {
 		policy, err := structure.NormalizeJsonString(v.(string))
-
 		if err != nil {
 			return fmt.Errorf("policy (%s) is invalid JSON: %w", v.(string), err)
 		}
@@ -299,7 +299,6 @@ func resourceSecretRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("reading Secrets Manager Secret (%s) policy: %w", d.Id(), err)
 	} else if v := output.ResourcePolicy; v != nil {
 		policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), aws.StringValue(v))
-
 		if err != nil {
 			return err
 		}
@@ -378,7 +377,6 @@ func resourceSecretUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("policy") {
 		if v, ok := d.GetOk("policy"); ok && v.(string) != "" && v.(string) != "{}" {
 			policy, err := structure.NormalizeJsonString(v.(string))
-
 			if err != nil {
 				return fmt.Errorf("policy contains an invalid JSON: %w", err)
 			}

--- a/internal/service/secretsmanager/secret_policy.go
+++ b/internal/service/secretsmanager/secret_policy.go
@@ -34,10 +34,11 @@ func ResourceSecretPolicy() *schema.Resource {
 				ValidateFunc: verify.ValidARN,
 			},
 			"policy": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Required:              true,
+				ValidateFunc:          validation.StringIsJSON,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
@@ -55,7 +56,6 @@ func resourceSecretPolicyCreate(d *schema.ResourceData, meta interface{}) error 
 	conn := meta.(*conns.AWSClient).SecretsManagerConn()
 
 	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
-
 	if err != nil {
 		return fmt.Errorf("policy (%s) is invalid JSON: %w", d.Get("policy").(string), err)
 	}
@@ -125,7 +125,6 @@ func resourceSecretPolicyRead(d *schema.ResourceData, meta interface{}) error {
 
 	if output.ResourcePolicy != nil {
 		policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), aws.StringValue(output.ResourcePolicy))
-
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #23288

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS="TestAccSecretsManagerSecret_|TestAccSecretsManagerSecretPolicy_" PKG=secretsmanager
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/secretsmanager/... -v -count 1 -parallel 20 -run='TestAccSecretsManagerSecret_|TestAccSecretsManagerSecretPolicy_'  -timeout 180m
=== RUN   TestAccSecretsManagerSecretPolicy_basic
=== PAUSE TestAccSecretsManagerSecretPolicy_basic
=== RUN   TestAccSecretsManagerSecretPolicy_blockPublicPolicy
=== PAUSE TestAccSecretsManagerSecretPolicy_blockPublicPolicy
=== RUN   TestAccSecretsManagerSecretPolicy_disappears
=== PAUSE TestAccSecretsManagerSecretPolicy_disappears
=== RUN   TestAccSecretsManagerSecret_basic
=== PAUSE TestAccSecretsManagerSecret_basic
=== RUN   TestAccSecretsManagerSecret_withNamePrefix
=== PAUSE TestAccSecretsManagerSecret_withNamePrefix
=== RUN   TestAccSecretsManagerSecret_description
=== PAUSE TestAccSecretsManagerSecret_description
=== RUN   TestAccSecretsManagerSecret_basicReplica
=== PAUSE TestAccSecretsManagerSecret_basicReplica
=== RUN   TestAccSecretsManagerSecret_overwriteReplica
=== PAUSE TestAccSecretsManagerSecret_overwriteReplica
=== RUN   TestAccSecretsManagerSecret_kmsKeyID
=== PAUSE TestAccSecretsManagerSecret_kmsKeyID
=== RUN   TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate
=== PAUSE TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate
=== RUN   TestAccSecretsManagerSecret_rotationLambdaARN
=== PAUSE TestAccSecretsManagerSecret_rotationLambdaARN
=== RUN   TestAccSecretsManagerSecret_rotationRules
=== PAUSE TestAccSecretsManagerSecret_rotationRules
=== RUN   TestAccSecretsManagerSecret_tags
=== PAUSE TestAccSecretsManagerSecret_tags
=== RUN   TestAccSecretsManagerSecret_policy
=== PAUSE TestAccSecretsManagerSecret_policy
=== CONT  TestAccSecretsManagerSecretPolicy_basic
=== CONT  TestAccSecretsManagerSecret_overwriteReplica
=== CONT  TestAccSecretsManagerSecret_withNamePrefix
=== CONT  TestAccSecretsManagerSecretPolicy_disappears
=== CONT  TestAccSecretsManagerSecret_basic
=== CONT  TestAccSecretsManagerSecret_basicReplica
=== CONT  TestAccSecretsManagerSecretPolicy_blockPublicPolicy
=== CONT  TestAccSecretsManagerSecret_rotationRules
=== CONT  TestAccSecretsManagerSecret_policy
=== CONT  TestAccSecretsManagerSecret_tags
=== CONT  TestAccSecretsManagerSecret_rotationLambdaARN
=== CONT  TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate
=== CONT  TestAccSecretsManagerSecret_kmsKeyID
=== CONT  TestAccSecretsManagerSecret_description
--- PASS: TestAccSecretsManagerSecret_basic (36.39s)
--- PASS: TestAccSecretsManagerSecret_withNamePrefix (37.46s)
--- PASS: TestAccSecretsManagerSecret_basicReplica (45.09s)
--- PASS: TestAccSecretsManagerSecretPolicy_disappears (45.50s)
--- PASS: TestAccSecretsManagerSecret_description (59.35s)
--- PASS: TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate (60.72s)
--- PASS: TestAccSecretsManagerSecret_kmsKeyID (63.12s)
--- PASS: TestAccSecretsManagerSecretPolicy_basic (68.46s)
--- PASS: TestAccSecretsManagerSecret_rotationLambdaARN (79.76s)
--- PASS: TestAccSecretsManagerSecret_policy (82.79s)
--- PASS: TestAccSecretsManagerSecret_rotationRules (84.32s)
--- PASS: TestAccSecretsManagerSecretPolicy_blockPublicPolicy (85.32s)
--- PASS: TestAccSecretsManagerSecret_tags (88.81s)
--- PASS: TestAccSecretsManagerSecret_overwriteReplica (113.71s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	115.725s
```
