### PR TITLE
sagemaker/model_package_group_policy: Improve policy diffs

### DIFF
--- a/.changelog/28865.txt
+++ b/.changelog/28865.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sagemaker_model_package_group_policy: Improve refresh to avoid unnecessary diffs in `resource_policy`
+```

--- a/internal/service/sagemaker/model_package_group_policy.go
+++ b/internal/service/sagemaker/model_package_group_policy.go
@@ -32,10 +32,11 @@ func ResourceModelPackageGroupPolicy() *schema.Resource {
 				ForceNew: true,
 			},
 			"resource_policy": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Required:              true,
+				ValidateFunc:          validation.StringIsJSON,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
@@ -49,7 +50,6 @@ func resourceModelPackageGroupPolicyPut(d *schema.ResourceData, meta interface{}
 	conn := meta.(*conns.AWSClient).SageMakerConn()
 
 	policy, err := structure.NormalizeJsonString(d.Get("resource_policy").(string))
-
 	if err != nil {
 		return fmt.Errorf("policy (%s) is invalid JSON: %w", d.Get("resource_policy").(string), err)
 	}
@@ -87,7 +87,6 @@ func resourceModelPackageGroupPolicyRead(d *schema.ResourceData, meta interface{
 	d.Set("model_package_group_name", d.Id())
 
 	policyToSet, err := verify.PolicyToSet(d.Get("resource_policy").(string), aws.StringValue(mpg.ResourcePolicy))
-
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

#23288

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccSageMakerModelPackageGroupPolicy_ PKG=sagemaker 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerModelPackageGroupPolicy_'  -timeout 180m
=== RUN   TestAccSageMakerModelPackageGroupPolicy_basic
=== PAUSE TestAccSageMakerModelPackageGroupPolicy_basic
=== RUN   TestAccSageMakerModelPackageGroupPolicy_disappears
=== PAUSE TestAccSageMakerModelPackageGroupPolicy_disappears
=== RUN   TestAccSageMakerModelPackageGroupPolicy_Disappears_modelPackageGroup
=== PAUSE TestAccSageMakerModelPackageGroupPolicy_Disappears_modelPackageGroup
=== CONT  TestAccSageMakerModelPackageGroupPolicy_basic
=== CONT  TestAccSageMakerModelPackageGroupPolicy_Disappears_modelPackageGroup
=== CONT  TestAccSageMakerModelPackageGroupPolicy_disappears
--- PASS: TestAccSageMakerModelPackageGroupPolicy_Disappears_modelPackageGroup (16.03s)
--- PASS: TestAccSageMakerModelPackageGroupPolicy_disappears (19.52s)
--- PASS: TestAccSageMakerModelPackageGroupPolicy_basic (19.75s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker	21.472s
```
