### PR TITLE
s3control: Improve policy diffs

### DIFF
--- a/.changelog/28866.txt
+++ b/.changelog/28866.txt
@@ -1,0 +1,19 @@
+```release-note:bug
+resource/aws_s3_access_point: Improve refresh to avoid unnecessary diffs in `policy`
+```
+
+```release-note:bug
+resource/aws_s3control_bucket_policy: Improve refresh to avoid unnecessary diffs in `policy`
+```
+
+```release-note:bug
+resource/aws_s3control_multi_region_access_point_policy: Improve refresh to avoid unnecessary diffs in `details` `policy`
+```
+
+```release-note:bug
+resource/aws_s3control_object_lambda_access_point_policy: Improve refresh to avoid unnecessary diffs in `policy`
+```
+
+```release-note:bug
+resource/aws_s3control_access_point_policy: Improve refresh to avoid unnecessary diffs in `policy`
+```

--- a/internal/service/s3control/access_point.go
+++ b/internal/service/s3control/access_point.go
@@ -88,11 +88,12 @@ func resourceAccessPoint() *schema.Resource {
 				Computed: true,
 			},
 			"policy": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Optional:              true,
+				Computed:              true,
+				ValidateFunc:          validation.StringIsJSON,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
@@ -203,7 +204,6 @@ func resourceAccessPointCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	if v, ok := d.GetOk("policy"); ok && v.(string) != "" && v.(string) != "{}" {
 		policy, err := structure.NormalizeJsonString(v.(string))
-
 		if err != nil {
 			return diag.Errorf("policy (%s) is invalid JSON: %s", v.(string), err)
 		}
@@ -316,7 +316,6 @@ func resourceAccessPointRead(ctx context.Context, d *schema.ResourceData, meta i
 		}
 
 		policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), policy)
-
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -344,7 +343,6 @@ func resourceAccessPointUpdate(ctx context.Context, d *schema.ResourceData, meta
 	if d.HasChange("policy") {
 		if v, ok := d.GetOk("policy"); ok && v.(string) != "" && v.(string) != "{}" {
 			policy, err := structure.NormalizeJsonString(v.(string))
-
 			if err != nil {
 				return diag.Errorf("policy (%s) is invalid JSON: %s", v.(string), err)
 			}

--- a/internal/service/s3control/access_point_policy.go
+++ b/internal/service/s3control/access_point_policy.go
@@ -44,10 +44,11 @@ func resourceAccessPointPolicy() *schema.Resource {
 				Computed: true,
 			},
 			"policy": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Required:              true,
+				ValidateFunc:          validation.StringIsJSON,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
@@ -73,7 +74,6 @@ func resourceAccessPointPolicyCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
-
 	if err != nil {
 		return diag.Errorf("policy (%s) is invalid JSON: %s", d.Get("policy").(string), err)
 	}
@@ -120,7 +120,6 @@ func resourceAccessPointPolicyRead(ctx context.Context, d *schema.ResourceData, 
 
 	if policy != "" {
 		policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), policy)
-
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -143,7 +142,6 @@ func resourceAccessPointPolicyUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
-
 	if err != nil {
 		return diag.Errorf("policy (%s) is invalid JSON: %s", d.Get("policy").(string), err)
 	}

--- a/internal/service/s3control/bucket_policy.go
+++ b/internal/service/s3control/bucket_policy.go
@@ -41,10 +41,11 @@ func resourceBucketPolicy() *schema.Resource {
 				ValidateFunc: verify.ValidARN,
 			},
 			"policy": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+				Type:                  schema.TypeString,
+				Required:              true,
+				ValidateFunc:          validation.StringIsJSON,
+				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+				DiffSuppressOnRefresh: true,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
@@ -60,7 +61,6 @@ func resourceBucketPolicyCreate(ctx context.Context, d *schema.ResourceData, met
 	bucket := d.Get("bucket").(string)
 
 	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
-
 	if err != nil {
 		return diag.Errorf("policy (%s) is invalid JSON: %s", d.Get("policy").(string), err)
 	}
@@ -110,7 +110,6 @@ func resourceBucketPolicyRead(ctx context.Context, d *schema.ResourceData, meta 
 
 	if output.Policy != nil {
 		policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), aws.StringValue(output.Policy))
-
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -127,7 +126,6 @@ func resourceBucketPolicyUpdate(ctx context.Context, d *schema.ResourceData, met
 	conn := meta.(*conns.AWSClient).S3ControlConn()
 
 	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
-
 	if err != nil {
 		return diag.Errorf("policy (%s) is invalid JSON: %s", d.Get("policy").(string), err)
 	}

--- a/internal/service/s3control/multi_region_access_point_policy.go
+++ b/internal/service/s3control/multi_region_access_point_policy.go
@@ -60,10 +60,11 @@ func resourceMultiRegionAccessPointPolicy() *schema.Resource {
 							ValidateFunc: validateS3MultiRegionAccessPointName,
 						},
 						"policy": {
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateFunc:     validation.StringIsJSON,
-							DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
+							Type:                  schema.TypeString,
+							Required:              true,
+							ValidateFunc:          validation.StringIsJSON,
+							DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
+							DiffSuppressOnRefresh: true,
 							StateFunc: func(v interface{}) string {
 								json, _ := structure.NormalizeJsonString(v)
 								return json
@@ -250,7 +251,6 @@ func expandPutMultiRegionAccessPointPolicyInput_(tfMap map[string]interface{}) *
 
 	if v, ok := tfMap["policy"].(string); ok {
 		policy, err := structure.NormalizeJsonString(v)
-
 		if err != nil {
 			policy = v
 		}

--- a/internal/service/s3control/object_lambda_access_point_policy.go
+++ b/internal/service/s3control/object_lambda_access_point_policy.go
@@ -74,7 +74,6 @@ func resourceObjectLambdaAccessPointPolicyCreate(ctx context.Context, d *schema.
 	resourceID := ObjectLambdaAccessPointCreateResourceID(accountID, name)
 
 	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
-
 	if err != nil {
 		return diag.Errorf("policy (%s) is invalid JSON: %s", d.Get("policy").(string), err)
 	}
@@ -123,7 +122,6 @@ func resourceObjectLambdaAccessPointPolicyRead(ctx context.Context, d *schema.Re
 
 	if policy != "" {
 		policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), policy)
-
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -146,7 +144,6 @@ func resourceObjectLambdaAccessPointPolicyUpdate(ctx context.Context, d *schema.
 	}
 
 	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
-
 	if err != nil {
 		return diag.Errorf("policy (%s) is invalid JSON: %s", d.Get("policy").(string), err)
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #23288

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS="TestAccS3ControlAccessPoint_|TestAccS3ControlAccessPointPolicy_|TestAccS3ControlBucketPolicy_|TestAccS3ControlMultiRegionAccessPointPolicy_|TestAccS3ControlObjectLambdaAccessPointPolicy_" PKG=s3control
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3control/... -v -count 1 -parallel 20 -run='TestAccS3ControlAccessPoint_|TestAccS3ControlAccessPointPolicy_|TestAccS3ControlBucketPolicy_|TestAccS3ControlMultiRegionAccessPointPolicy_|TestAccS3ControlObjectLambdaAccessPointPolicy_'  -timeout 180m
=== RUN   TestAccS3ControlAccessPointPolicy_basic
=== PAUSE TestAccS3ControlAccessPointPolicy_basic
=== RUN   TestAccS3ControlAccessPointPolicy_disappears
=== PAUSE TestAccS3ControlAccessPointPolicy_disappears
=== RUN   TestAccS3ControlAccessPointPolicy_disappears_AccessPoint
=== PAUSE TestAccS3ControlAccessPointPolicy_disappears_AccessPoint
=== RUN   TestAccS3ControlAccessPointPolicy_update
=== PAUSE TestAccS3ControlAccessPointPolicy_update
=== RUN   TestAccS3ControlAccessPoint_basic
=== PAUSE TestAccS3ControlAccessPoint_basic
=== RUN   TestAccS3ControlAccessPoint_disappears
=== PAUSE TestAccS3ControlAccessPoint_disappears
=== RUN   TestAccS3ControlAccessPoint_Bucket_arn
=== PAUSE TestAccS3ControlAccessPoint_Bucket_arn
=== RUN   TestAccS3ControlAccessPoint_policy
=== PAUSE TestAccS3ControlAccessPoint_policy
=== RUN   TestAccS3ControlAccessPoint_publicAccessBlock
=== PAUSE TestAccS3ControlAccessPoint_publicAccessBlock
=== RUN   TestAccS3ControlAccessPoint_vpc
=== PAUSE TestAccS3ControlAccessPoint_vpc
=== RUN   TestAccS3ControlBucketPolicy_basic
=== PAUSE TestAccS3ControlBucketPolicy_basic
=== RUN   TestAccS3ControlBucketPolicy_disappears
=== PAUSE TestAccS3ControlBucketPolicy_disappears
=== RUN   TestAccS3ControlBucketPolicy_policy
=== PAUSE TestAccS3ControlBucketPolicy_policy
=== RUN   TestAccS3ControlMultiRegionAccessPointPolicy_basic
=== PAUSE TestAccS3ControlMultiRegionAccessPointPolicy_basic
=== RUN   TestAccS3ControlMultiRegionAccessPointPolicy_disappears_MultiRegionAccessPoint
=== PAUSE TestAccS3ControlMultiRegionAccessPointPolicy_disappears_MultiRegionAccessPoint
=== RUN   TestAccS3ControlMultiRegionAccessPointPolicy_details_policy
=== PAUSE TestAccS3ControlMultiRegionAccessPointPolicy_details_policy
=== RUN   TestAccS3ControlMultiRegionAccessPointPolicy_details_name
=== PAUSE TestAccS3ControlMultiRegionAccessPointPolicy_details_name
=== RUN   TestAccS3ControlObjectLambdaAccessPointPolicy_basic
=== PAUSE TestAccS3ControlObjectLambdaAccessPointPolicy_basic
=== RUN   TestAccS3ControlObjectLambdaAccessPointPolicy_disappears
=== PAUSE TestAccS3ControlObjectLambdaAccessPointPolicy_disappears
=== RUN   TestAccS3ControlObjectLambdaAccessPointPolicy_Disappears_accessPoint
=== PAUSE TestAccS3ControlObjectLambdaAccessPointPolicy_Disappears_accessPoint
=== RUN   TestAccS3ControlObjectLambdaAccessPointPolicy_update
=== PAUSE TestAccS3ControlObjectLambdaAccessPointPolicy_update
=== CONT  TestAccS3ControlAccessPointPolicy_basic
=== CONT  TestAccS3ControlBucketPolicy_disappears
=== CONT  TestAccS3ControlAccessPoint_Bucket_arn
=== CONT  TestAccS3ControlAccessPoint_basic
=== CONT  TestAccS3ControlMultiRegionAccessPointPolicy_details_name
=== CONT  TestAccS3ControlObjectLambdaAccessPointPolicy_Disappears_accessPoint
=== CONT  TestAccS3ControlBucketPolicy_basic
=== CONT  TestAccS3ControlAccessPoint_policy
=== CONT  TestAccS3ControlMultiRegionAccessPointPolicy_disappears_MultiRegionAccessPoint
=== CONT  TestAccS3ControlAccessPoint_disappears
=== CONT  TestAccS3ControlAccessPointPolicy_disappears_AccessPoint
=== CONT  TestAccS3ControlAccessPointPolicy_disappears
=== CONT  TestAccS3ControlObjectLambdaAccessPointPolicy_disappears
=== CONT  TestAccS3ControlAccessPoint_vpc
=== CONT  TestAccS3ControlAccessPoint_publicAccessBlock
=== CONT  TestAccS3ControlObjectLambdaAccessPointPolicy_basic
=== CONT  TestAccS3ControlAccessPointPolicy_update
=== CONT  TestAccS3ControlObjectLambdaAccessPointPolicy_update
=== CONT  TestAccS3ControlMultiRegionAccessPointPolicy_details_policy
=== CONT  TestAccS3ControlMultiRegionAccessPointPolicy_basic
=== CONT  TestAccS3ControlAccessPoint_Bucket_arn
    acctest.go:1368: skipping since no Outposts found
--- SKIP: TestAccS3ControlAccessPoint_Bucket_arn (1.16s)
=== CONT  TestAccS3ControlBucketPolicy_policy
=== CONT  TestAccS3ControlBucketPolicy_disappears
    acctest.go:1368: skipping since no Outposts found
--- SKIP: TestAccS3ControlBucketPolicy_disappears (1.31s)
=== CONT  TestAccS3ControlBucketPolicy_basic
    acctest.go:1368: skipping since no Outposts found
--- SKIP: TestAccS3ControlBucketPolicy_basic (1.31s)
=== CONT  TestAccS3ControlBucketPolicy_policy
    acctest.go:1368: skipping since no Outposts found
--- SKIP: TestAccS3ControlBucketPolicy_policy (0.24s)
--- PASS: TestAccS3ControlAccessPoint_disappears (40.84s)
--- PASS: TestAccS3ControlAccessPointPolicy_disappears_AccessPoint (41.59s)
--- PASS: TestAccS3ControlAccessPointPolicy_disappears (42.32s)
--- PASS: TestAccS3ControlAccessPointPolicy_basic (45.23s)
--- PASS: TestAccS3ControlAccessPoint_basic (47.33s)
--- PASS: TestAccS3ControlAccessPoint_vpc (60.10s)
--- PASS: TestAccS3ControlAccessPoint_publicAccessBlock (61.09s)
--- PASS: TestAccS3ControlAccessPointPolicy_update (64.76s)
--- PASS: TestAccS3ControlObjectLambdaAccessPointPolicy_basic (66.80s)
--- PASS: TestAccS3ControlObjectLambdaAccessPointPolicy_disappears (68.89s)
--- PASS: TestAccS3ControlObjectLambdaAccessPointPolicy_Disappears_accessPoint (73.48s)
--- PASS: TestAccS3ControlAccessPoint_policy (86.20s)
--- PASS: TestAccS3ControlObjectLambdaAccessPointPolicy_update (101.49s)
--- PASS: TestAccS3ControlMultiRegionAccessPointPolicy_disappears_MultiRegionAccessPoint (352.97s)
--- PASS: TestAccS3ControlMultiRegionAccessPointPolicy_basic (361.43s)
--- PASS: TestAccS3ControlMultiRegionAccessPointPolicy_details_policy (408.13s)
--- PASS: TestAccS3ControlMultiRegionAccessPointPolicy_details_name (670.62s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3control	672.613s
```
