### PR TITLE
iam: Provider produced inconsistent final plan

### DIFF
--- a/.changelog/28868.txt
+++ b/.changelog/28868.txt
@@ -1,0 +1,15 @@
+```release-note:bug
+resource/aws_iam_role_policy: Fixed issue that could result in "inconsistent final plan" errors
+```
+
+```release-note:bug
+resource/aws_iam_group_policy: Fixed issue that could result in "inconsistent final plan" errors
+```
+
+```release-note:bug
+resource/aws_iam_role: Fixed issue that could result in "inconsistent final plan" errors
+```
+
+```release-note:bug
+resource/aws_iam_user_policy: Fixed issue that could result in "inconsistent final plan" errors
+```

--- a/internal/service/iam/group_policy_test.go
+++ b/internal/service/iam/group_policy_test.go
@@ -444,6 +444,7 @@ resource "aws_iam_group_policy" "test" {
   name  = %[1]q
   group = aws_iam_group.test.id
 
+  # tflint-ignore: terraform_deprecated_interpolation
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{

--- a/internal/service/iam/group_policy_test.go
+++ b/internal/service/iam/group_policy_test.go
@@ -168,6 +168,34 @@ func TestAccIAMGroupPolicy_generatedName(t *testing.T) {
 	})
 }
 
+// When there are unknowns in the policy (interpolation), TF puts a
+// random GUID (e.g., 14730d5f-efa3-5a5e-94b5-f8bad6f88282) in state
+// at first for the policy which, obviously, behaves differently than
+// a JSON policy. This test checks to make sure nothing goes wrong
+// during that step.
+func TestAccIAMGroupPolicy_unknownsInPolicy(t *testing.T) {
+	var gp iam.GetGroupPolicyOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_group_policy.test"
+	groupName := "aws_iam_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRolePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGroupPolicyConfig_unknowns(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGroupPolicyExists(groupName, resourceName, &gp),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckGroupPolicyDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn()
 
@@ -388,6 +416,53 @@ resource "aws_iam_group_policy" "bar" {
   }
 }
 EOF
+}
+`, rName)
+}
+
+func testAccGroupPolicyConfig_unknowns(rName string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_iam_group" "test" {
+  name = %[1]q
+  path = "/"
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
+}
+
+resource "aws_iam_group_policy" "test" {
+  name  = %[1]q
+  group = aws_iam_group.test.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = ""
+      Effect = "Allow"
+      Action = [
+        "s3:AbortMultipartUpload",
+        "s3:GetBucketLocation",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:PutObject",
+      ]
+      Resource = [
+        "${aws_s3_bucket.test.arn}",
+        "${aws_s3_bucket.test.arn}/*",
+      ]
+    }]
+  })
 }
 `, rName)
 }

--- a/internal/service/iam/group_policy_test.go
+++ b/internal/service/iam/group_policy_test.go
@@ -444,7 +444,6 @@ resource "aws_iam_group_policy" "test" {
   name  = %[1]q
   group = aws_iam_group.test.id
 
-  # tflint-ignore: terraform_deprecated_interpolation
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
@@ -459,7 +458,7 @@ resource "aws_iam_group_policy" "test" {
         "s3:PutObject",
       ]
       Resource = [
-        "${aws_s3_bucket.test.arn}",
+        aws_s3_bucket.test.arn,
         "${aws_s3_bucket.test.arn}/*",
       ]
     }]

--- a/internal/service/iam/role_policy.go
+++ b/internal/service/iam/role_policy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -41,7 +42,7 @@ func ResourceRolePolicy() *schema.Resource {
 				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 				DiffSuppressOnRefresh: true,
 				StateFunc: func(v interface{}) string {
-					json, _ := verify.LegacyPolicyNormalize(v)
+					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
 			},
@@ -73,7 +74,7 @@ func ResourceRolePolicy() *schema.Resource {
 func resourceRolePolicyPut(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).IAMConn()
 
-	policy, err := verify.LegacyPolicyNormalize(d.Get("policy").(string))
+	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
 	if err != nil {
 		return fmt.Errorf("policy (%s) is invalid JSON: %w", policy, err)
 	}
@@ -155,7 +156,7 @@ func resourceRolePolicyRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	policyToSet, err := verify.LegacyPolicyToSet(d.Get("policy").(string), policy)
+	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), policy)
 	if err != nil {
 		return fmt.Errorf("while setting policy (%s), encountered: %w", policyToSet, err)
 	}

--- a/internal/service/iam/role_policy.go
+++ b/internal/service/iam/role_policy.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -42,7 +41,7 @@ func ResourceRolePolicy() *schema.Resource {
 				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 				DiffSuppressOnRefresh: true,
 				StateFunc: func(v interface{}) string {
-					json, _ := structure.NormalizeJsonString(v)
+					json, _ := verify.LegacyPolicyNormalize(v)
 					return json
 				},
 			},
@@ -74,7 +73,7 @@ func ResourceRolePolicy() *schema.Resource {
 func resourceRolePolicyPut(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).IAMConn()
 
-	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
+	policy, err := verify.LegacyPolicyNormalize(d.Get("policy").(string))
 	if err != nil {
 		return fmt.Errorf("policy (%s) is invalid JSON: %w", policy, err)
 	}
@@ -156,7 +155,7 @@ func resourceRolePolicyRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	policyToSet, err := verify.PolicyToSet(d.Get("policy").(string), policy)
+	policyToSet, err := verify.LegacyPolicyToSet(d.Get("policy").(string), policy)
 	if err != nil {
 		return fmt.Errorf("while setting policy (%s), encountered: %w", policyToSet, err)
 	}

--- a/internal/service/iam/role_policy_test.go
+++ b/internal/service/iam/role_policy_test.go
@@ -247,6 +247,34 @@ func TestAccIAMRolePolicy_Policy_invalidResource(t *testing.T) {
 	})
 }
 
+// When there are unknowns in the policy (interpolation), TF puts a
+// random GUID (e.g., 14730d5f-efa3-5a5e-94b5-f8bad6f88282) in state
+// at first for the policy which, obviously, behaves differently than
+// a JSON policy. This test checks to make sure nothing goes wrong
+// during that step.
+func TestAccIAMRolePolicy_unknownsInPolicy(t *testing.T) {
+	var rolePolicy1 iam.GetRolePolicyOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_role_policy.test"
+	roleName := "aws_iam_role.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRolePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRolePolicyConfig_unknowns(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRolePolicyExists(roleName, resourceName, &rolePolicy1),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRolePolicyDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn()
 
@@ -701,6 +729,64 @@ resource "aws_iam_role_policy" "test" {
   }
 }
 EOF
+}
+`, rName)
+}
+
+func testAccRolePolicyConfig_unknowns(rName string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = ""
+      Effect = "Allow"
+      Principal = {
+        Service = "firehose.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
+}
+
+resource "aws_iam_role_policy" "test" {
+  name = %[1]q
+  role = aws_iam_role.test.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = ""
+      Effect = "Allow"
+      Action = [
+        "s3:AbortMultipartUpload",
+        "s3:GetBucketLocation",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:PutObject",
+      ]
+      Resource = [
+        "${aws_s3_bucket.test.arn}",
+        "${aws_s3_bucket.test.arn}/*"
+      ]
+    }]
+  })
 }
 `, rName)
 }

--- a/internal/service/iam/role_policy_test.go
+++ b/internal/service/iam/role_policy_test.go
@@ -768,6 +768,7 @@ resource "aws_iam_role_policy" "test" {
   name = %[1]q
   role = aws_iam_role.test.id
 
+  # tflint-ignore: terraform_deprecated_interpolation
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{

--- a/internal/service/iam/role_policy_test.go
+++ b/internal/service/iam/role_policy_test.go
@@ -783,7 +783,7 @@ resource "aws_iam_role_policy" "test" {
         "s3:PutObject",
       ]
       Resource = [
-        "${aws_s3_bucket.test.arn}",
+        aws_s3_bucket.test.arn,
         "${aws_s3_bucket.test.arn}/*"
       ]
     }]

--- a/internal/verify/json_test.go
+++ b/internal/verify/json_test.go
@@ -654,8 +654,16 @@ func TestLegacyPolicyNormalize(t *testing.T) {
   "Version": "2012-10-17"
 }
 `,
-			Expected: ``,
-			Error:    true,
+			Expected: `{
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+  "Version": "2012-10-17"
+}
+`,
+			Error: true,
 		},
 		{
 			Name: "principal",


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #23288

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS="TestAccIAMRolePolicy_|TestAccIAMGroupPolicy_|TestAccIAMRole_InlinePolicy|TestAccIAMUserPolicy_" PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRolePolicy_|TestAccIAMGroupPolicy_|TestAccIAMRole_InlinePolicy|TestAccIAMUserPolicy_'  -timeout 180m
=== RUN   TestAccIAMGroupPolicy_basic
=== PAUSE TestAccIAMGroupPolicy_basic
=== RUN   TestAccIAMGroupPolicy_disappears
=== PAUSE TestAccIAMGroupPolicy_disappears
=== RUN   TestAccIAMGroupPolicy_namePrefix
=== PAUSE TestAccIAMGroupPolicy_namePrefix
=== RUN   TestAccIAMGroupPolicy_generatedName
=== PAUSE TestAccIAMGroupPolicy_generatedName
=== RUN   TestAccIAMGroupPolicy_unknownsInPolicy
=== PAUSE TestAccIAMGroupPolicy_unknownsInPolicy
=== RUN   TestAccIAMRolePolicy_basic
=== PAUSE TestAccIAMRolePolicy_basic
=== RUN   TestAccIAMRolePolicy_disappears
=== PAUSE TestAccIAMRolePolicy_disappears
=== RUN   TestAccIAMRolePolicy_policyOrder
=== PAUSE TestAccIAMRolePolicy_policyOrder
=== RUN   TestAccIAMRolePolicy_namePrefix
=== PAUSE TestAccIAMRolePolicy_namePrefix
=== RUN   TestAccIAMRolePolicy_generatedName
=== PAUSE TestAccIAMRolePolicy_generatedName
=== RUN   TestAccIAMRolePolicy_invalidJSON
=== PAUSE TestAccIAMRolePolicy_invalidJSON
=== RUN   TestAccIAMRolePolicy_Policy_invalidResource
=== PAUSE TestAccIAMRolePolicy_Policy_invalidResource
=== RUN   TestAccIAMRolePolicy_unknownsInPolicy
=== PAUSE TestAccIAMRolePolicy_unknownsInPolicy
=== RUN   TestAccIAMRole_InlinePolicy_basic
=== PAUSE TestAccIAMRole_InlinePolicy_basic
=== RUN   TestAccIAMRole_InlinePolicy_ignoreOrder
=== PAUSE TestAccIAMRole_InlinePolicy_ignoreOrder
=== RUN   TestAccIAMRole_InlinePolicy_empty
=== PAUSE TestAccIAMRole_InlinePolicy_empty
=== RUN   TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack
=== PAUSE TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack
=== RUN   TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved
=== PAUSE TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved
=== RUN   TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored
=== PAUSE TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored
=== RUN   TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty
=== PAUSE TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty
=== RUN   TestAccIAMUserPolicy_basic
=== PAUSE TestAccIAMUserPolicy_basic
=== RUN   TestAccIAMUserPolicy_disappears
=== PAUSE TestAccIAMUserPolicy_disappears
=== RUN   TestAccIAMUserPolicy_namePrefix
=== PAUSE TestAccIAMUserPolicy_namePrefix
=== RUN   TestAccIAMUserPolicy_generatedName
=== PAUSE TestAccIAMUserPolicy_generatedName
=== RUN   TestAccIAMUserPolicy_multiplePolicies
=== PAUSE TestAccIAMUserPolicy_multiplePolicies
=== RUN   TestAccIAMUserPolicy_policyOrder
=== PAUSE TestAccIAMUserPolicy_policyOrder
=== CONT  TestAccIAMGroupPolicy_basic
=== CONT  TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMRolePolicy_policyOrder
=== CONT  TestAccIAMRolePolicy_invalidJSON
=== CONT  TestAccIAMRolePolicy_disappears
=== CONT  TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored
=== CONT  TestAccIAMUserPolicy_basic
=== CONT  TestAccIAMUserPolicy_policyOrder
=== CONT  TestAccIAMUserPolicy_multiplePolicies
=== CONT  TestAccIAMUserPolicy_generatedName
=== CONT  TestAccIAMUserPolicy_namePrefix
=== CONT  TestAccIAMUserPolicy_disappears
=== CONT  TestAccIAMGroupPolicy_namePrefix
=== CONT  TestAccIAMGroupPolicy_unknownsInPolicy
=== CONT  TestAccIAMGroupPolicy_generatedName
=== CONT  TestAccIAMRolePolicy_unknownsInPolicy
=== CONT  TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved
=== CONT  TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty
=== CONT  TestAccIAMRolePolicy_generatedName
=== CONT  TestAccIAMRolePolicy_namePrefix
--- PASS: TestAccIAMRolePolicy_invalidJSON (6.03s)
=== CONT  TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack
--- PASS: TestAccIAMUserPolicy_disappears (58.81s)
=== CONT  TestAccIAMRole_InlinePolicy_empty
--- PASS: TestAccIAMRolePolicy_disappears (61.64s)
=== CONT  TestAccIAMRole_InlinePolicy_ignoreOrder
--- PASS: TestAccIAMGroupPolicy_unknownsInPolicy (61.86s)
=== CONT  TestAccIAMGroupPolicy_disappears
--- PASS: TestAccIAMRolePolicy_unknownsInPolicy (62.11s)
=== CONT  TestAccIAMRolePolicy_basic
--- PASS: TestAccIAMUserPolicy_policyOrder (84.93s)
=== CONT  TestAccIAMRolePolicy_Policy_invalidResource
--- PASS: TestAccIAMRolePolicy_policyOrder (90.85s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved (109.41s)
--- PASS: TestAccIAMUserPolicy_namePrefix (110.35s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty (110.90s)
--- PASS: TestAccIAMGroupPolicy_namePrefix (115.73s)
--- PASS: TestAccIAMGroupPolicy_generatedName (116.91s)
--- PASS: TestAccIAMUserPolicy_generatedName (116.92s)
--- PASS: TestAccIAMUserPolicy_basic (116.98s)
--- PASS: TestAccIAMRolePolicy_Policy_invalidResource (32.74s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack (111.94s)
--- PASS: TestAccIAMRolePolicy_generatedName (118.01s)
--- PASS: TestAccIAMRolePolicy_namePrefix (118.03s)
--- PASS: TestAccIAMRole_InlinePolicy_empty (59.56s)
--- PASS: TestAccIAMGroupPolicy_disappears (56.68s)
--- PASS: TestAccIAMGroupPolicy_basic (120.58s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored (125.73s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (133.65s)
--- PASS: TestAccIAMRolePolicy_basic (74.14s)
--- PASS: TestAccIAMUserPolicy_multiplePolicies (140.16s)
--- PASS: TestAccIAMRole_InlinePolicy_ignoreOrder (82.83s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	146.416s
```
