### PR TITLE
[elasticache] [bug:28011] Fixes downgrade paths detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## 5.8.0 (Unreleased)
+## 5.9.0 (Unreleased)
+## 5.8.0 (July 13, 2023)
 
 ENHANCEMENTS:
 

--- a/internal/service/elasticache/engine_version_test.go
+++ b/internal/service/elasticache/engine_version_test.go
@@ -342,6 +342,17 @@ func TestCustomizeDiffEngineVersionIsDowngrade(t *testing.T) {
 			new:      "6.0",
 			expected: false,
 		},
+		"upgrade major 3.0": {
+			old:      "2.8.12",
+			new:      "3.0.5",
+			expected: false,
+		},
+
+		"upgrade minor 6.x": {
+			old:      "6.x",
+			new:      "6.2",
+			expected: false,
+		},
 
 		"downgrade minor versions": {
 			old:      "1.3.5",


### PR DESCRIPTION
### Description

Fixes recreation of `aws_elasticache_replication_group` when changing `engine_version` to upgraded versions.

There are at least some situations fixed by this PR:
- Migration of `2.8.x` to any version
- Migration of `6.x` ( 6.0.x in the real version ) to `6.0` or `6.2`.
- Whatever version that is `X.[6-9]` to any major version that is less than the previous minor version

### Relations

Closes #28011

### Output from Unit Testing

```
$ go test -v ./internal/service/elasticache/... -timeout=1m -run TestCustomizeDiffEngineVersionIsDowngrade
=== RUN   TestCustomizeDiffEngineVersionIsDowngrade
=== PAUSE TestCustomizeDiffEngineVersionIsDowngrade
=== CONT  TestCustomizeDiffEngineVersionIsDowngrade
=== RUN   TestCustomizeDiffEngineVersionIsDowngrade/upgrade_major_3.0
=== PAUSE TestCustomizeDiffEngineVersionIsDowngrade/upgrade_major_3.0
=== RUN   TestCustomizeDiffEngineVersionIsDowngrade/upgrade_minor_6.x
=== PAUSE TestCustomizeDiffEngineVersionIsDowngrade/upgrade_minor_6.x
=== RUN   TestCustomizeDiffEngineVersionIsDowngrade/no_change
=== PAUSE TestCustomizeDiffEngineVersionIsDowngrade/no_change
=== RUN   TestCustomizeDiffEngineVersionIsDowngrade/upgrade_minor_versions
=== PAUSE TestCustomizeDiffEngineVersionIsDowngrade/upgrade_minor_versions
=== RUN   TestCustomizeDiffEngineVersionIsDowngrade/upgrade_major_6.digit
=== PAUSE TestCustomizeDiffEngineVersionIsDowngrade/upgrade_major_6.digit
=== RUN   TestCustomizeDiffEngineVersionIsDowngrade/downgrade_minor_versions
=== PAUSE TestCustomizeDiffEngineVersionIsDowngrade/downgrade_minor_versions
=== RUN   TestCustomizeDiffEngineVersionIsDowngrade/downgrade_major_versions
=== PAUSE TestCustomizeDiffEngineVersionIsDowngrade/downgrade_major_versions
=== RUN   TestCustomizeDiffEngineVersionIsDowngrade/downgrade_major_6.digit
=== PAUSE TestCustomizeDiffEngineVersionIsDowngrade/downgrade_major_6.digit
=== RUN   TestCustomizeDiffEngineVersionIsDowngrade/upgrade_major_versions
=== PAUSE TestCustomizeDiffEngineVersionIsDowngrade/upgrade_major_versions
=== RUN   TestCustomizeDiffEngineVersionIsDowngrade/downgrade_from_major_6.x
=== PAUSE TestCustomizeDiffEngineVersionIsDowngrade/downgrade_from_major_6.x
=== RUN   TestCustomizeDiffEngineVersionIsDowngrade/switch_major_6.digit_to_6.x
=== PAUSE TestCustomizeDiffEngineVersionIsDowngrade/switch_major_6.digit_to_6.x
=== RUN   TestCustomizeDiffEngineVersionIsDowngrade/downgrade_from_major_7.digit_to_6.x
=== PAUSE TestCustomizeDiffEngineVersionIsDowngrade/downgrade_from_major_7.digit_to_6.x
=== RUN   TestCustomizeDiffEngineVersionIsDowngrade/upgrade_major_6.x
=== PAUSE TestCustomizeDiffEngineVersionIsDowngrade/upgrade_major_6.x
=== RUN   TestCustomizeDiffEngineVersionIsDowngrade/downgrade_from_major_7.x_to_6.x
=== PAUSE TestCustomizeDiffEngineVersionIsDowngrade/downgrade_from_major_7.x_to_6.x
=== CONT  TestCustomizeDiffEngineVersionIsDowngrade/upgrade_major_3.0
=== CONT  TestCustomizeDiffEngineVersionIsDowngrade/downgrade_major_6.digit
=== CONT  TestCustomizeDiffEngineVersionIsDowngrade/downgrade_minor_versions
=== CONT  TestCustomizeDiffEngineVersionIsDowngrade/downgrade_from_major_7.digit_to_6.x
=== CONT  TestCustomizeDiffEngineVersionIsDowngrade/upgrade_major_6.digit
=== CONT  TestCustomizeDiffEngineVersionIsDowngrade/upgrade_minor_versions
=== CONT  TestCustomizeDiffEngineVersionIsDowngrade/downgrade_major_versions
=== CONT  TestCustomizeDiffEngineVersionIsDowngrade/switch_major_6.digit_to_6.x
=== CONT  TestCustomizeDiffEngineVersionIsDowngrade/downgrade_from_major_7.x_to_6.x
=== CONT  TestCustomizeDiffEngineVersionIsDowngrade/upgrade_major_versions
=== CONT  TestCustomizeDiffEngineVersionIsDowngrade/upgrade_minor_6.x
=== CONT  TestCustomizeDiffEngineVersionIsDowngrade/upgrade_major_6.x
=== CONT  TestCustomizeDiffEngineVersionIsDowngrade/downgrade_from_major_6.x
=== CONT  TestCustomizeDiffEngineVersionIsDowngrade/no_change
--- PASS: TestCustomizeDiffEngineVersionIsDowngrade (0.00s)
    --- PASS: TestCustomizeDiffEngineVersionIsDowngrade/upgrade_major_3.0 (0.00s)
    --- PASS: TestCustomizeDiffEngineVersionIsDowngrade/downgrade_minor_versions (0.00s)
    --- PASS: TestCustomizeDiffEngineVersionIsDowngrade/upgrade_major_6.digit (0.00s)
    --- PASS: TestCustomizeDiffEngineVersionIsDowngrade/downgrade_major_6.digit (0.00s)
    --- PASS: TestCustomizeDiffEngineVersionIsDowngrade/downgrade_from_major_7.digit_to_6.x (0.00s)
    --- PASS: TestCustomizeDiffEngineVersionIsDowngrade/switch_major_6.digit_to_6.x (0.00s)
    --- PASS: TestCustomizeDiffEngineVersionIsDowngrade/upgrade_minor_versions (0.00s)
    --- PASS: TestCustomizeDiffEngineVersionIsDowngrade/upgrade_major_versions (0.00s)
    --- PASS: TestCustomizeDiffEngineVersionIsDowngrade/downgrade_from_major_7.x_to_6.x (0.00s)
    --- PASS: TestCustomizeDiffEngineVersionIsDowngrade/upgrade_minor_6.x (0.00s)
    --- PASS: TestCustomizeDiffEngineVersionIsDowngrade/upgrade_major_6.x (0.00s)
    --- PASS: TestCustomizeDiffEngineVersionIsDowngrade/downgrade_from_major_6.x (0.00s)
    --- PASS: TestCustomizeDiffEngineVersionIsDowngrade/downgrade_major_versions (0.00s)
    --- PASS: TestCustomizeDiffEngineVersionIsDowngrade/no_change (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        4.340s
```
