### PR TITLE
`aws_elasticsearch_domain`: Fix persistent IOPS diff

### DIFF
--- a/.changelog/28901.txt
+++ b/.changelog/28901.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticsearch_domain: Prevent persistent `iops` diff
+```

--- a/internal/service/elasticsearch/domain.go
+++ b/internal/service/elasticsearch/domain.go
@@ -385,6 +385,7 @@ func ResourceDomain() *schema.Resource {
 						"iops": {
 							Type:     schema.TypeInt,
 							Optional: true,
+							Computed: true,
 						},
 						"throughput": {
 							Type:         schema.TypeInt,

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -1340,7 +1340,7 @@ func TestAccElasticsearchDomain_update(t *testing.T) {
 		}})
 }
 
-func TestAccElasticsearchDomain_UpdateVolume_type(t *testing.T) {
+func TestAccElasticsearchDomain_VolumeType_update(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -1392,7 +1392,7 @@ func TestAccElasticsearchDomain_UpdateVolume_type(t *testing.T) {
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/13867
-func TestAccElasticsearchDomain_WithVolumeType_missing(t *testing.T) {
+func TestAccElasticsearchDomain_VolumeType_missing(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}


### PR DESCRIPTION
### Description
Marks the `aws_elasticsearch_domain` `ebs_options.iops` attribute as computed to prevent persistent diffs. This schema change brings the `ebs_options` definition into alignment with the `aws_opensearch_domain` resource.


### Relations

Closes #28895
Relates #27510 


### Output from Acceptance Testing

```console
$ make testacc PKG=elasticsearch TESTS=TestAccElasticsearchDomain_VolumeType
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticsearch/... -v -count 1 -parallel 20 -run='TestAccElasticsearchDomain_VolumeType'  -timeout 180m
=== RUN   TestAccElasticsearchDomain_VolumeType_update
=== PAUSE TestAccElasticsearchDomain_VolumeType_update
=== RUN   TestAccElasticsearchDomain_VolumeType_missing
=== PAUSE TestAccElasticsearchDomain_VolumeType_missing
=== CONT  TestAccElasticsearchDomain_VolumeType_update
=== CONT  TestAccElasticsearchDomain_VolumeType_missing
--- PASS: TestAccElasticsearchDomain_VolumeType_missing (1143.90s)
--- PASS: TestAccElasticsearchDomain_VolumeType_update (1671.28s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticsearch      1674.456s
```
