### PR TITLE
r/aws_imagebuilder_component  - add skip_destroy argument

### DIFF
--- a/.changelog/28905.txt
+++ b/.changelog/28905.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_imagbuilder_component: Add `skip_destroy` argument
+```

--- a/internal/service/imagebuilder/component.go
+++ b/internal/service/imagebuilder/component.go
@@ -81,6 +81,11 @@ func ResourceComponent() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice(imagebuilder.Platform_Values(), false),
 			},
+			"skip_destroy": {
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+			},
 			"supported_os_versions": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -251,6 +256,11 @@ func resourceComponentUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceComponentDelete(d *schema.ResourceData, meta interface{}) error {
+	if v, ok := d.GetOk("skip_destroy"); ok && v.(bool) {
+		log.Printf("[DEBUG] Retaining Imagebuilder Component version %q", d.Id())
+		return nil
+	}
+
 	conn := meta.(*conns.AWSClient).ImageBuilderConn()
 
 	input := &imagebuilder.DeleteComponentInput{

--- a/internal/service/imagebuilder/component_test.go
+++ b/internal/service/imagebuilder/component_test.go
@@ -47,9 +47,10 @@ func TestAccImageBuilderComponent_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -95,9 +96,10 @@ func TestAccImageBuilderComponent_changeDescription(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -121,9 +123,10 @@ func TestAccImageBuilderComponent_description(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -148,9 +151,10 @@ func TestAccImageBuilderComponent_kmsKeyID(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -174,9 +178,10 @@ func TestAccImageBuilderComponent_Platform_windows(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -200,9 +205,10 @@ func TestAccImageBuilderComponent_supportedOsVersions(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -227,9 +233,10 @@ func TestAccImageBuilderComponent_tags(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 			{
 				Config: testAccComponentConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
@@ -272,7 +279,7 @@ func TestAccImageBuilderComponent_uri(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"uri"},
+				ImportStateVerifyIgnore: []string{"skip_destroy", "uri"},
 			},
 		},
 	})

--- a/website/docs/r/imagebuilder_component.html.markdown
+++ b/website/docs/r/imagebuilder_component.html.markdown
@@ -61,9 +61,12 @@ The following attributes are optional:
 * `data` - (Optional) Inline YAML string with data of the component. Exactly one of `data` and `uri` can be specified. Terraform will only perform drift detection of its value when present in a configuration.
 * `description` - (Optional) Description of the component.
 * `kms_key_id` - (Optional) Amazon Resource Name (ARN) of the Key Management Service (KMS) Key used to encrypt the component.
+* `skip_destroy` - (Optional) Whether to retain the old version when the resource is destroyed or replacement is necessary. Defaults to `false`.
 * `supported_os_versions` - (Optional) Set of Operating Systems (OS) supported by the component.
 * `tags` - (Optional) Key-value map of resource tags for the component. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `uri` - (Optional) S3 URI with data of the component. Exactly one of `data` and `uri` can be specified.
+
+~> **NOTE:** Updating `data` or `uri` requires specifying a new `version`. This causes replacement of the resource. The `skip_destroy` argument can be used to retain the old version.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Description
This PR adds the `skip_destroy` argument to the `aws_imagebuilder_component`. This allows creating the new component versions without removing the current one and affecting all resources relying on it.

Followed the approach of [`aws_ecs_task_definition`](https://github.com/hashicorp/terraform-provider-aws/blob/b898284784188426501ddf646cc30dbdc9b42979/internal/service/ecs/task_definition.go#L251-L255) and [`aws_lambda_layer_version`](https://github.com/hashicorp/terraform-provider-aws/blob/b898284784188426501ddf646cc30dbdc9b42979/internal/service/lambda/layer_version.go#L114-L119) facing similar problems.


### Relations
Closes #26117.

### Output from Acceptance Testing

```
$ make testacc TESTARGS="-run=TestAccImageBuilderComponent_" PKG=imagebuilder ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 2  -run=TestAccImageBuilderComponent_ -timeout 180m
=== RUN   TestAccImageBuilderComponent_basic
=== PAUSE TestAccImageBuilderComponent_basic
=== RUN   TestAccImageBuilderComponent_disappears
=== PAUSE TestAccImageBuilderComponent_disappears
=== RUN   TestAccImageBuilderComponent_changeDescription
=== PAUSE TestAccImageBuilderComponent_changeDescription
=== RUN   TestAccImageBuilderComponent_description
=== PAUSE TestAccImageBuilderComponent_description
=== RUN   TestAccImageBuilderComponent_kmsKeyID
=== PAUSE TestAccImageBuilderComponent_kmsKeyID
=== RUN   TestAccImageBuilderComponent_Platform_windows
=== PAUSE TestAccImageBuilderComponent_Platform_windows
=== RUN   TestAccImageBuilderComponent_supportedOsVersions
=== PAUSE TestAccImageBuilderComponent_supportedOsVersions
=== RUN   TestAccImageBuilderComponent_tags
=== PAUSE TestAccImageBuilderComponent_tags
=== RUN   TestAccImageBuilderComponent_uri
=== PAUSE TestAccImageBuilderComponent_uri
=== CONT  TestAccImageBuilderComponent_basic
=== CONT  TestAccImageBuilderComponent_Platform_windows
--- PASS: TestAccImageBuilderComponent_Platform_windows (25.38s)
=== CONT  TestAccImageBuilderComponent_tags
--- PASS: TestAccImageBuilderComponent_basic (26.71s)
=== CONT  TestAccImageBuilderComponent_uri
--- PASS: TestAccImageBuilderComponent_uri (34.53s)
=== CONT  TestAccImageBuilderComponent_supportedOsVersions
--- PASS: TestAccImageBuilderComponent_tags (54.77s)
=== CONT  TestAccImageBuilderComponent_description
--- PASS: TestAccImageBuilderComponent_supportedOsVersions (24.83s)
=== CONT  TestAccImageBuilderComponent_kmsKeyID
--- PASS: TestAccImageBuilderComponent_description (27.40s)
=== CONT  TestAccImageBuilderComponent_changeDescription
--- PASS: TestAccImageBuilderComponent_kmsKeyID (27.46s)
=== CONT  TestAccImageBuilderComponent_disappears
--- PASS: TestAccImageBuilderComponent_disappears (16.54s)
--- PASS: TestAccImageBuilderComponent_changeDescription (23.24s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       132.812s
```
