### PR TITLE
fix: :fire: removed http_header max limit

### DIFF
--- a/internal/service/elbv2/listener_rule.go
+++ b/internal/service/elbv2/listener_rule.go
@@ -366,7 +366,6 @@ func ResourceListenerRule() *schema.Resource {
 						},
 						"http_header": {
 							Type:     schema.TypeList,
-							MaxItems: 1,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{


### PR DESCRIPTION
### Description
This PR aims to fix an issue with the Terraform AWS Provider when creating an ELBv2 Listener Rule with more than 1 http_header condition.
Based on AWS documentation, there is no such limit for the http_header - both query_string and http_header can have zero or more.

### Relations
Closes #28040

### References
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-update-rules.html#update-rule-requirements
> Each rule can include zero or one of the following conditions: host-header, http-request-method, path-pattern, and source-ip, and zero or more of the following conditions:  _**http-header**_ and query-string.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```