### PR TITLE
Update valid values for `aws_cur_report_definition.time_unit`

### DIFF
--- a/website/docs/r/cur_report_definition.html.markdown
+++ b/website/docs/r/cur_report_definition.html.markdown
@@ -34,7 +34,7 @@ resource "aws_cur_report_definition" "example_cur_report_definition" {
 The following arguments are supported:
 
 * `report_name` - (Required) Unique name for the report. Must start with a number/letter and is case sensitive. Limited to 256 characters.
-* `time_unit` - (Required) The frequency on which report data are measured and displayed.  Valid values are: `HOURLY`, `DAILY`.
+* `time_unit` - (Required) The frequency on which report data are measured and displayed.  Valid values are: `DAILY`, `HOURLY`, `MONTHLY`.
 * `format` - (Required) Format for report. Valid values are: `textORcsv`, `Parquet`. If `Parquet` is used, then Compression must also be `Parquet`.
 * `compression` - (Required) Compression format for report. Valid values are: `GZIP`, `ZIP`, `Parquet`. If `Parquet` is used, then format must also be `Parquet`.
 * `additional_schema_elements` - (Required) A list of schema elements. Valid values are: `RESOURCES`.


### PR DESCRIPTION
### Description

This PR updates the description of `aws_cur_report_defintion.time_unit` to include `MONTHLY` as a valid value.

### Relations

Closes #28910

### References

- [Resource Schema](https://github.com/hashicorp/terraform-provider-aws/blob/12d15d99c627e7243273eb6dc4495355d098677e/internal/service/cur/report_definition.go#L41-L46)
- [`cur.TimeUnit_Values()` definition](https://github.com/aws/aws-sdk-go/blob/d56fdbd838aaa42cbceb7acaeaeb3d7581c0e1c2/service/costandusagereportservice/api.go#L1404-L1411)

### Output from Acceptance Testing

N/a, docs