### PR TITLE
Fix semgrep `ci.bare-error-returns`

### DIFF
--- a/internal/service/datasync/location_object_storage.go
+++ b/internal/service/datasync/location_object_storage.go
@@ -162,7 +162,7 @@ func resourceLocationObjectStorageRead(d *schema.ResourceData, meta interface{})
 	subdirectory, err := SubdirectoryFromLocationURI(aws.StringValue(output.LocationUri))
 
 	if err != nil {
-		return err
+		return fmt.Errorf("parsing DataSync Location Object Storage (%s) location URI: %w", d.Id(), err)
 	}
 
 	d.Set("agent_arns", flex.FlattenStringSet(output.AgentArns))
@@ -178,7 +178,7 @@ func resourceLocationObjectStorageRead(d *schema.ResourceData, meta interface{})
 	hostname, bucketName, err := decodeObjectStorageURI(uri)
 
 	if err != nil {
-		return err
+		return fmt.Errorf("parsing DataSync Location Object Storage (%s) object-storage URI: %w", d.Id(), err)
 	}
 
 	d.Set("server_hostname", hostname)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes https://github.com/hashicorp/terraform-provider-aws/actions/runs/3942502778/jobs/6746234053:

```
Findings:

  internal/service/datasync/location_object_storage.go 
     ci.bare-error-returns
        API errors should be wrapped with the CRUD info

        165┆ return err
          ⋮┆----------------------------------------
        181┆ return err
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/23154.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28894.
