### PR TITLE
d/aws_identitystore_(group|user): Restore use of `List` API calls when `filter` is specified

### DIFF
--- a/.changelog/28937.txt
+++ b/.changelog/28937.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+data-source/aws_identitystore_group: Restore use of `ListGroups` API when `filter` is specified
+```
+
+```release-note:bug
+data-source/aws_identitystore_user: Restore use of `ListUsers` API when `filter` is specified
+```

--- a/internal/service/identitystore/group_data_source.go
+++ b/internal/service/identitystore/group_data_source.go
@@ -2,7 +2,6 @@ package identitystore
 
 import (
 	"context"
-	"errors"
 	"regexp"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -142,58 +141,89 @@ const (
 func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).IdentityStoreClient()
 
-	identityStoreId := d.Get("identity_store_id").(string)
+	identityStoreID := d.Get("identity_store_id").(string)
 
-	var getGroupIdInput *identitystore.GetGroupIdInput
-
-	if v, ok := d.GetOk("alternate_identifier"); ok && len(v.([]interface{})) > 0 {
-		getGroupIdInput = &identitystore.GetGroupIdInput{
-			AlternateIdentifier: expandAlternateIdentifier(v.([]interface{})[0].(map[string]interface{})),
-			IdentityStoreId:     aws.String(identityStoreId),
+	if v, ok := d.GetOk("filter"); ok && len(v.([]interface{})) > 0 {
+		// Use ListGroups for backwards compat.
+		input := &identitystore.ListGroupsInput{
+			IdentityStoreId: aws.String(identityStoreID),
+			Filters:         expandFilters(d.Get("filter").([]interface{})),
 		}
-	} else if v, ok := d.GetOk("filter"); ok && len(v.([]interface{})) > 0 {
-		getGroupIdInput = &identitystore.GetGroupIdInput{
-			AlternateIdentifier: &types.AlternateIdentifierMemberUniqueAttribute{
-				Value: *expandUniqueAttribute(v.([]interface{})[0].(map[string]interface{})),
-			},
-			IdentityStoreId: aws.String(identityStoreId),
-		}
-	}
+		paginator := identitystore.NewListGroupsPaginator(conn, input)
+		var results []types.Group
 
-	var groupId string
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
 
-	if getGroupIdInput != nil {
-		output, err := conn.GetGroupId(ctx, getGroupIdInput)
+			if err != nil {
+				return create.DiagError(names.IdentityStore, create.ErrActionReading, DSNameGroup, identityStoreID, err)
+			}
 
-		if err != nil {
-			var e *types.ResourceNotFoundException
-			if errors.As(err, &e) {
-				return diag.Errorf("no Identity Store Group found matching criteria; try different search")
-			} else {
-				return create.DiagError(names.IdentityStore, create.ErrActionReading, DSNameGroup, identityStoreId, err)
+			for _, group := range page.Groups {
+				if v, ok := d.GetOk("group_id"); ok && v.(string) != aws.ToString(group.GroupId) {
+					continue
+				}
+
+				results = append(results, group)
 			}
 		}
 
-		groupId = aws.ToString(output.GroupId)
+		if len(results) == 0 {
+			return diag.Errorf("no Identity Store Group found matching criteria\n%v; try different search", input.Filters)
+		}
+
+		if len(results) > 1 {
+			return diag.Errorf("multiple Identity Store Groups found matching criteria\n%v; try different search", input.Filters)
+		}
+
+		group := results[0]
+
+		d.SetId(aws.ToString(group.GroupId))
+		d.Set("description", group.Description)
+		d.Set("display_name", group.DisplayName)
+		d.Set("group_id", group.GroupId)
+
+		if err := d.Set("external_ids", flattenExternalIds(group.ExternalIds)); err != nil {
+			return create.DiagError(names.IdentityStore, create.ErrActionSetting, DSNameGroup, d.Id(), err)
+		}
+
+		return nil
+	}
+
+	var groupID string
+
+	if v, ok := d.GetOk("alternate_identifier"); ok && len(v.([]interface{})) > 0 {
+		input := &identitystore.GetGroupIdInput{
+			AlternateIdentifier: expandAlternateIdentifier(v.([]interface{})[0].(map[string]interface{})),
+			IdentityStoreId:     aws.String(identityStoreID),
+		}
+
+		output, err := conn.GetGroupId(ctx, input)
+
+		if err != nil {
+			return create.DiagError(names.IdentityStore, create.ErrActionReading, DSNameGroup, identityStoreID, err)
+		}
+
+		groupID = aws.ToString(output.GroupId)
 	}
 
 	if v, ok := d.GetOk("group_id"); ok && v.(string) != "" {
-		if groupId != "" && groupId != v.(string) {
+		if groupID != "" && groupID != v.(string) {
 			// We were given a filter, and it found a group different to this one.
 			return diag.Errorf("no Identity Store Group found matching criteria; try different search")
 		}
 
-		groupId = v.(string)
+		groupID = v.(string)
 	}
 
-	group, err := findGroupByID(ctx, conn, identityStoreId, groupId)
+	group, err := FindGroupByTwoPartKey(ctx, conn, identityStoreID, groupID)
 
 	if err != nil {
 		if tfresource.NotFound(err) {
 			return diag.Errorf("no Identity Store Group found matching criteria; try different search")
 		}
 
-		return create.DiagError(names.IdentityStore, create.ErrActionReading, DSNameGroup, identityStoreId, err)
+		return create.DiagError(names.IdentityStore, create.ErrActionReading, DSNameGroup, identityStoreID, err)
 	}
 
 	d.SetId(aws.ToString(group.GroupId))
@@ -207,4 +237,32 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	return nil
+}
+
+func expandFilters(l []interface{}) []types.Filter {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	filters := make([]types.Filter, 0, len(l))
+	for _, v := range l {
+		tfMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		filter := types.Filter{}
+
+		if v, ok := tfMap["attribute_path"].(string); ok && v != "" {
+			filter.AttributePath = aws.String(v)
+		}
+
+		if v, ok := tfMap["attribute_value"].(string); ok && v != "" {
+			filter.AttributeValue = aws.String(v)
+		}
+
+		filters = append(filters, filter)
+	}
+
+	return filters
 }

--- a/internal/service/identitystore/user_data_source.go
+++ b/internal/service/identitystore/user_data_source.go
@@ -282,58 +282,118 @@ const (
 func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).IdentityStoreClient()
 
-	identityStoreId := d.Get("identity_store_id").(string)
+	identityStoreID := d.Get("identity_store_id").(string)
 
-	var getUserIdInput *identitystore.GetUserIdInput
+	if v, ok := d.GetOk("filter"); ok && len(v.([]interface{})) > 0 {
+		// Use ListUsers for backwards compat.
+		input := &identitystore.ListUsersInput{
+			Filters:         expandFilters(d.Get("filter").([]interface{})),
+			IdentityStoreId: aws.String(identityStoreID),
+		}
+		paginator := identitystore.NewListUsersPaginator(conn, input)
+		var results []types.User
 
-	if v, ok := d.GetOk("alternate_identifier"); ok && len(v.([]interface{})) > 0 {
-		getUserIdInput = &identitystore.GetUserIdInput{
-			AlternateIdentifier: expandAlternateIdentifier(v.([]interface{})[0].(map[string]interface{})),
-			IdentityStoreId:     aws.String(identityStoreId),
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+
+			if err != nil {
+				return create.DiagError(names.IdentityStore, create.ErrActionReading, DSNameUser, identityStoreID, err)
+			}
+
+			for _, user := range page.Users {
+				if v, ok := d.GetOk("user_id"); ok && v.(string) != aws.ToString(user.UserId) {
+					continue
+				}
+
+				results = append(results, user)
+			}
 		}
-	} else if v, ok := d.GetOk("filter"); ok && len(v.([]interface{})) > 0 {
-		getUserIdInput = &identitystore.GetUserIdInput{
-			AlternateIdentifier: &types.AlternateIdentifierMemberUniqueAttribute{
-				Value: *expandUniqueAttribute(v.([]interface{})[0].(map[string]interface{})),
-			},
-			IdentityStoreId: aws.String(identityStoreId),
+
+		if len(results) == 0 {
+			return diag.Errorf("no Identity Store User found matching criteria\n%v; try different search", input.Filters)
 		}
+
+		if len(results) > 1 {
+			return diag.Errorf("multiple Identity Store Users found matching criteria\n%v; try different search", input.Filters)
+		}
+
+		user := results[0]
+
+		d.SetId(aws.ToString(user.UserId))
+		d.Set("display_name", user.DisplayName)
+		d.Set("identity_store_id", user.IdentityStoreId)
+		d.Set("locale", user.Locale)
+		d.Set("nickname", user.NickName)
+		d.Set("preferred_language", user.PreferredLanguage)
+		d.Set("profile_url", user.ProfileUrl)
+		d.Set("timezone", user.Timezone)
+		d.Set("title", user.Title)
+		d.Set("user_id", user.UserId)
+		d.Set("user_name", user.UserName)
+		d.Set("user_type", user.UserType)
+
+		if err := d.Set("addresses", flattenAddresses(user.Addresses)); err != nil {
+			return create.DiagError(names.IdentityStore, create.ErrActionSetting, DSNameUser, d.Id(), err)
+		}
+
+		if err := d.Set("emails", flattenEmails(user.Emails)); err != nil {
+			return create.DiagError(names.IdentityStore, create.ErrActionSetting, DSNameUser, d.Id(), err)
+		}
+
+		if err := d.Set("external_ids", flattenExternalIds(user.ExternalIds)); err != nil {
+			return create.DiagError(names.IdentityStore, create.ErrActionSetting, DSNameUser, d.Id(), err)
+		}
+
+		if err := d.Set("name", []interface{}{flattenName(user.Name)}); err != nil {
+			return create.DiagError(names.IdentityStore, create.ErrActionSetting, DSNameUser, d.Id(), err)
+		}
+
+		if err := d.Set("phone_numbers", flattenPhoneNumbers(user.PhoneNumbers)); err != nil {
+			return create.DiagError(names.IdentityStore, create.ErrActionSetting, DSNameUser, d.Id(), err)
+		}
+
+		return nil
 	}
 
-	var userId string
+	var userID string
 
-	if getUserIdInput != nil {
-		output, err := conn.GetUserId(ctx, getUserIdInput)
+	if v, ok := d.GetOk("alternate_identifier"); ok && len(v.([]interface{})) > 0 {
+		input := &identitystore.GetUserIdInput{
+			AlternateIdentifier: expandAlternateIdentifier(v.([]interface{})[0].(map[string]interface{})),
+			IdentityStoreId:     aws.String(identityStoreID),
+		}
+
+		output, err := conn.GetUserId(ctx, input)
 
 		if err != nil {
 			var e *types.ResourceNotFoundException
 			if errors.As(err, &e) {
 				return diag.Errorf("no Identity Store User found matching criteria; try different search")
 			} else {
-				return create.DiagError(names.IdentityStore, create.ErrActionReading, DSNameUser, identityStoreId, err)
+				return create.DiagError(names.IdentityStore, create.ErrActionReading, DSNameUser, identityStoreID, err)
 			}
 		}
 
-		userId = aws.ToString(output.UserId)
+		userID = aws.ToString(output.UserId)
 	}
 
 	if v, ok := d.GetOk("user_id"); ok && v.(string) != "" {
-		if userId != "" && userId != v.(string) {
+		if userID != "" && userID != v.(string) {
 			// We were given a filter, and it found a user different to this one.
 			return diag.Errorf("no Identity Store User found matching criteria; try different search")
 		}
 
-		userId = v.(string)
+		userID = v.(string)
 	}
 
-	user, err := findUserByID(ctx, conn, identityStoreId, userId)
+	user, err := FindUserByTwoPartKey(ctx, conn, identityStoreID, userID)
 
 	if err != nil {
 		if tfresource.NotFound(err) {
 			return diag.Errorf("no Identity Store User found matching criteria; try different search")
 		}
 
-		return create.DiagError(names.IdentityStore, create.ErrActionReading, DSNameUser, identityStoreId, err)
+		return create.DiagError(names.IdentityStore, create.ErrActionReading, DSNameUser, identityStoreID, err)
 	}
 
 	d.SetId(aws.ToString(user.UserId))

--- a/internal/service/identitystore/user_test.go
+++ b/internal/service/identitystore/user_test.go
@@ -20,6 +20,16 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+func init() {
+	acctest.RegisterServiceErrorCheckFunc(names.IdentityStoreEndpointID, testAccErrorCheckSkip)
+}
+
+func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
+	return acctest.ErrorCheckSkipMessagesContaining(t,
+		"is not authorized to perform: sso:ListInstances",
+	)
+}
+
 func TestAccIdentityStoreUser_basic(t *testing.T) {
 	var user identitystore.DescribeUserOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/identitystore/user_test.go
+++ b/internal/service/identitystore/user_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/identitystore"
-	"github.com/aws/aws-sdk-go-v2/service/identitystore/types"
 	"github.com/aws/aws-sdk-go/service/ssoadmin"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -17,18 +17,9 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfidentitystore "github.com/hashicorp/terraform-provider-aws/internal/service/identitystore"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
-
-func init() {
-	acctest.RegisterServiceErrorCheckFunc(names.IdentityStoreEndpointID, testAccErrorCheckSkip)
-}
-
-func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
-	return acctest.ErrorCheckSkipMessagesContaining(t,
-		"is not authorized to perform: sso:ListInstances",
-	)
-}
 
 func TestAccIdentityStoreUser_basic(t *testing.T) {
 	var user identitystore.DescribeUserOutput
@@ -978,47 +969,43 @@ func testAccCheckUserDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := conn.DescribeUser(ctx, &identitystore.DescribeUserInput{
-			IdentityStoreId: aws.String(rs.Primary.Attributes["identity_store_id"]),
-			UserId:          aws.String(rs.Primary.Attributes["user_id"]),
-		})
+		_, err := tfidentitystore.FindUserByTwoPartKey(ctx, conn, rs.Primary.Attributes["identity_store_id"], rs.Primary.Attributes["user_id"])
+
+		if tfresource.NotFound(err) {
+			continue
+		}
+
 		if err != nil {
-			var nfe *types.ResourceNotFoundException
-			if errors.As(err, &nfe) {
-				return nil
-			}
 			return err
 		}
 
-		return create.Error(names.IdentityStore, create.ErrActionCheckingDestroyed, tfidentitystore.ResNameUser, rs.Primary.ID, errors.New("not destroyed"))
+		return fmt.Errorf("IdentityStore User %s still exists", rs.Primary.ID)
 	}
 
 	return nil
 }
 
-func testAccCheckUserExists(name string, user *identitystore.DescribeUserOutput) resource.TestCheckFunc {
+func testAccCheckUserExists(n string, v *identitystore.DescribeUserOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return create.Error(names.IdentityStore, create.ErrActionCheckingExistence, tfidentitystore.ResNameUser, name, errors.New("not found"))
+			return create.Error(names.IdentityStore, create.ErrActionCheckingExistence, tfidentitystore.ResNameUser, n, errors.New("not found"))
 		}
 
 		if rs.Primary.ID == "" {
-			return create.Error(names.IdentityStore, create.ErrActionCheckingExistence, tfidentitystore.ResNameUser, name, errors.New("not set"))
+			return create.Error(names.IdentityStore, create.ErrActionCheckingExistence, tfidentitystore.ResNameUser, n, errors.New("not set"))
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IdentityStoreClient()
 		ctx := context.Background()
-		resp, err := conn.DescribeUser(ctx, &identitystore.DescribeUserInput{
-			IdentityStoreId: aws.String(rs.Primary.Attributes["identity_store_id"]),
-			UserId:          aws.String(rs.Primary.Attributes["user_id"]),
-		})
+
+		output, err := tfidentitystore.FindUserByTwoPartKey(ctx, conn, rs.Primary.Attributes["identity_store_id"], rs.Primary.Attributes["user_id"])
 
 		if err != nil {
-			return create.Error(names.IdentityStore, create.ErrActionCheckingExistence, tfidentitystore.ResNameUser, rs.Primary.ID, err)
+			return err
 		}
 
-		*user = *resp
+		*v = *output
 
 		return nil
 	}
@@ -1031,19 +1018,21 @@ func testAccPreCheck(t *testing.T) {
 
 	instances, err := ssoadminConn.ListInstances(&ssoadmin.ListInstancesInput{MaxResults: aws.Int64(1)})
 
+	if acctest.PreCheckSkipError(err) || tfawserr.ErrMessageContains(err, ssoadmin.ErrCodeAccessDeniedException, "is not authorized to perform: sso:ListInstances") {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
 	if err != nil {
-		t.Fatalf("failed to list SSO instances: %s", err)
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 
 	if len(instances.Instances) != 1 {
 		t.Fatalf("expected to find at least one SSO instance")
 	}
 
-	input := &identitystore.ListUsersInput{
+	_, err = conn.ListUsers(ctx, &identitystore.ListUsersInput{
 		IdentityStoreId: instances.Instances[0].IdentityStoreId,
-	}
-
-	_, err = conn.ListUsers(ctx, input)
+	})
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Restores use of the `ListGroups` and `ListUsers` APIs when `filter` is specified with the `aws_identitystore_group` and `aws_identitystore_user` data sources.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/28139.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/27830.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/27762.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/27053.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccIdentityStoreUserDataSource_' PKG=identitystore ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/identitystore/... -v -count 1 -parallel 3  -run=TestAccIdentityStoreUserDataSource_ -timeout 180m
=== RUN   TestAccIdentityStoreUserDataSource_basic
=== PAUSE TestAccIdentityStoreUserDataSource_basic
=== RUN   TestAccIdentityStoreUserDataSource_filterUserName
=== PAUSE TestAccIdentityStoreUserDataSource_filterUserName
=== RUN   TestAccIdentityStoreUserDataSource_uniqueAttributeUserName
=== PAUSE TestAccIdentityStoreUserDataSource_uniqueAttributeUserName
=== RUN   TestAccIdentityStoreUserDataSource_email
=== PAUSE TestAccIdentityStoreUserDataSource_email
=== RUN   TestAccIdentityStoreUserDataSource_userID
=== PAUSE TestAccIdentityStoreUserDataSource_userID
=== RUN   TestAccIdentityStoreUserDataSource_nonExistent
=== PAUSE TestAccIdentityStoreUserDataSource_nonExistent
=== RUN   TestAccIdentityStoreUserDataSource_userIdFilterMismatch
=== PAUSE TestAccIdentityStoreUserDataSource_userIdFilterMismatch
=== RUN   TestAccIdentityStoreUserDataSource_externalIdConflictsWithUniqueAttribute
=== PAUSE TestAccIdentityStoreUserDataSource_externalIdConflictsWithUniqueAttribute
=== RUN   TestAccIdentityStoreUserDataSource_filterConflictsWithExternalId
=== PAUSE TestAccIdentityStoreUserDataSource_filterConflictsWithExternalId
=== RUN   TestAccIdentityStoreUserDataSource_userIdConflictsWithExternalId
=== PAUSE TestAccIdentityStoreUserDataSource_userIdConflictsWithExternalId
=== CONT  TestAccIdentityStoreUserDataSource_basic
=== CONT  TestAccIdentityStoreUserDataSource_nonExistent
=== CONT  TestAccIdentityStoreUserDataSource_email
--- PASS: TestAccIdentityStoreUserDataSource_nonExistent (4.63s)
=== CONT  TestAccIdentityStoreUserDataSource_filterConflictsWithExternalId
--- PASS: TestAccIdentityStoreUserDataSource_filterConflictsWithExternalId (9.63s)
=== CONT  TestAccIdentityStoreUserDataSource_userIdConflictsWithExternalId
--- PASS: TestAccIdentityStoreUserDataSource_basic (19.32s)
=== CONT  TestAccIdentityStoreUserDataSource_userID
--- PASS: TestAccIdentityStoreUserDataSource_email (20.24s)
=== CONT  TestAccIdentityStoreUserDataSource_externalIdConflictsWithUniqueAttribute
=== CONT  TestAccIdentityStoreUserDataSource_uniqueAttributeUserName
--- PASS: TestAccIdentityStoreUserDataSource_externalIdConflictsWithUniqueAttribute (1.56s)
--- PASS: TestAccIdentityStoreUserDataSource_userIdConflictsWithExternalId (9.46s)
=== CONT  TestAccIdentityStoreUserDataSource_filterUserName
--- PASS: TestAccIdentityStoreUserDataSource_userID (17.71s)
=== CONT  TestAccIdentityStoreUserDataSource_userIdFilterMismatch
--- PASS: TestAccIdentityStoreUserDataSource_uniqueAttributeUserName (18.37s)
--- PASS: TestAccIdentityStoreUserDataSource_filterUserName (17.62s)
--- PASS: TestAccIdentityStoreUserDataSource_userIdFilterMismatch (9.14s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/identitystore	52.104s
% make testacc TESTARGS='-run=TestAccIdentityStoreUser_' PKG=identitystore ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/identitystore/... -v -count 1 -parallel 3  -run=TestAccIdentityStoreUser_ -timeout 180m
=== RUN   TestAccIdentityStoreUser_basic
=== PAUSE TestAccIdentityStoreUser_basic
=== RUN   TestAccIdentityStoreUser_disappears
=== PAUSE TestAccIdentityStoreUser_disappears
=== RUN   TestAccIdentityStoreUser_Addresses
=== PAUSE TestAccIdentityStoreUser_Addresses
=== RUN   TestAccIdentityStoreUser_Emails
=== PAUSE TestAccIdentityStoreUser_Emails
=== RUN   TestAccIdentityStoreUser_Locale
=== PAUSE TestAccIdentityStoreUser_Locale
=== RUN   TestAccIdentityStoreUser_NameFamilyName
=== PAUSE TestAccIdentityStoreUser_NameFamilyName
=== RUN   TestAccIdentityStoreUser_NameFormatted
=== PAUSE TestAccIdentityStoreUser_NameFormatted
=== RUN   TestAccIdentityStoreUser_NameGivenName
=== PAUSE TestAccIdentityStoreUser_NameGivenName
=== RUN   TestAccIdentityStoreUser_NameHonorificPrefix
=== PAUSE TestAccIdentityStoreUser_NameHonorificPrefix
=== RUN   TestAccIdentityStoreUser_NameHonorificSuffix
=== PAUSE TestAccIdentityStoreUser_NameHonorificSuffix
=== RUN   TestAccIdentityStoreUser_NameMiddleName
=== PAUSE TestAccIdentityStoreUser_NameMiddleName
=== RUN   TestAccIdentityStoreUser_NickName
=== PAUSE TestAccIdentityStoreUser_NickName
=== RUN   TestAccIdentityStoreUser_PhoneNumbers
=== PAUSE TestAccIdentityStoreUser_PhoneNumbers
=== RUN   TestAccIdentityStoreUser_PreferredLanguage
=== PAUSE TestAccIdentityStoreUser_PreferredLanguage
=== RUN   TestAccIdentityStoreUser_ProfileURL
=== PAUSE TestAccIdentityStoreUser_ProfileURL
=== RUN   TestAccIdentityStoreUser_Timezone
=== PAUSE TestAccIdentityStoreUser_Timezone
=== RUN   TestAccIdentityStoreUser_Title
=== PAUSE TestAccIdentityStoreUser_Title
=== RUN   TestAccIdentityStoreUser_UserType
=== PAUSE TestAccIdentityStoreUser_UserType
=== CONT  TestAccIdentityStoreUser_basic
=== CONT  TestAccIdentityStoreUser_NickName
=== CONT  TestAccIdentityStoreUser_Timezone
--- PASS: TestAccIdentityStoreUser_basic (20.96s)
=== CONT  TestAccIdentityStoreUser_UserType
--- PASS: TestAccIdentityStoreUser_NickName (50.48s)
=== CONT  TestAccIdentityStoreUser_Title
--- PASS: TestAccIdentityStoreUser_Timezone (51.28s)
=== CONT  TestAccIdentityStoreUser_PreferredLanguage
--- PASS: TestAccIdentityStoreUser_UserType (48.66s)
=== CONT  TestAccIdentityStoreUser_ProfileURL
--- PASS: TestAccIdentityStoreUser_Title (49.03s)
=== CONT  TestAccIdentityStoreUser_PhoneNumbers
--- PASS: TestAccIdentityStoreUser_PreferredLanguage (49.54s)
=== CONT  TestAccIdentityStoreUser_NameHonorificSuffix
--- PASS: TestAccIdentityStoreUser_ProfileURL (50.08s)
=== CONT  TestAccIdentityStoreUser_NameMiddleName
--- PASS: TestAccIdentityStoreUser_NameHonorificSuffix (47.67s)
=== CONT  TestAccIdentityStoreUser_Emails
--- PASS: TestAccIdentityStoreUser_PhoneNumbers (67.63s)
=== CONT  TestAccIdentityStoreUser_NameFamilyName
--- PASS: TestAccIdentityStoreUser_NameMiddleName (49.21s)
=== CONT  TestAccIdentityStoreUser_Locale
--- PASS: TestAccIdentityStoreUser_NameFamilyName (35.81s)
=== CONT  TestAccIdentityStoreUser_Addresses
--- PASS: TestAccIdentityStoreUser_Emails (72.48s)
=== CONT  TestAccIdentityStoreUser_NameFormatted
--- PASS: TestAccIdentityStoreUser_Locale (52.44s)
=== CONT  TestAccIdentityStoreUser_NameHonorificPrefix
--- PASS: TestAccIdentityStoreUser_NameHonorificPrefix (35.72s)
=== CONT  TestAccIdentityStoreUser_NameGivenName
--- PASS: TestAccIdentityStoreUser_NameFormatted (55.32s)
=== CONT  TestAccIdentityStoreUser_disappears
--- PASS: TestAccIdentityStoreUser_Addresses (76.54s)
--- PASS: TestAccIdentityStoreUser_disappears (15.51s)
--- PASS: TestAccIdentityStoreUser_NameGivenName (35.66s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/identitystore	297.802s
% make testacc TESTARGS='-run=TestAccIdentityStoreGroupDataSource_' PKG=identitystore ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/identitystore/... -v -count 1 -parallel 3  -run=TestAccIdentityStoreGroupDataSource_ -timeout 180m
=== RUN   TestAccIdentityStoreGroupDataSource_filterDisplayName
=== PAUSE TestAccIdentityStoreGroupDataSource_filterDisplayName
=== RUN   TestAccIdentityStoreGroupDataSource_uniqueAttributeDisplayName
=== PAUSE TestAccIdentityStoreGroupDataSource_uniqueAttributeDisplayName
=== RUN   TestAccIdentityStoreGroupDataSource_filterDisplayNameAndGroupId
=== PAUSE TestAccIdentityStoreGroupDataSource_filterDisplayNameAndGroupId
=== RUN   TestAccIdentityStoreGroupDataSource_nonExistent
=== PAUSE TestAccIdentityStoreGroupDataSource_nonExistent
=== RUN   TestAccIdentityStoreGroupDataSource_groupIdFilterMismatch
=== PAUSE TestAccIdentityStoreGroupDataSource_groupIdFilterMismatch
=== RUN   TestAccIdentityStoreGroupDataSource_externalIdConflictsWithUniqueAttribute
=== PAUSE TestAccIdentityStoreGroupDataSource_externalIdConflictsWithUniqueAttribute
=== RUN   TestAccIdentityStoreGroupDataSource_filterConflictsWithUniqueAttribute
=== PAUSE TestAccIdentityStoreGroupDataSource_filterConflictsWithUniqueAttribute
=== RUN   TestAccIdentityStoreGroupDataSource_groupIdConflictsWithUniqueAttribute
=== PAUSE TestAccIdentityStoreGroupDataSource_groupIdConflictsWithUniqueAttribute
=== RUN   TestAccIdentityStoreGroupDataSource_filterConflictsWithExternalId
=== PAUSE TestAccIdentityStoreGroupDataSource_filterConflictsWithExternalId
=== RUN   TestAccIdentityStoreGroupDataSource_groupIdConflictsWithExternalId
=== PAUSE TestAccIdentityStoreGroupDataSource_groupIdConflictsWithExternalId
=== CONT  TestAccIdentityStoreGroupDataSource_filterDisplayName
=== CONT  TestAccIdentityStoreGroupDataSource_externalIdConflictsWithUniqueAttribute
=== CONT  TestAccIdentityStoreGroupDataSource_nonExistent
--- PASS: TestAccIdentityStoreGroupDataSource_externalIdConflictsWithUniqueAttribute (2.85s)
=== CONT  TestAccIdentityStoreGroupDataSource_filterDisplayNameAndGroupId
--- PASS: TestAccIdentityStoreGroupDataSource_nonExistent (4.36s)
=== CONT  TestAccIdentityStoreGroupDataSource_filterConflictsWithExternalId
--- PASS: TestAccIdentityStoreGroupDataSource_filterConflictsWithExternalId (1.72s)
=== CONT  TestAccIdentityStoreGroupDataSource_groupIdConflictsWithExternalId
--- PASS: TestAccIdentityStoreGroupDataSource_groupIdConflictsWithExternalId (9.58s)
=== CONT  TestAccIdentityStoreGroupDataSource_groupIdFilterMismatch
--- PASS: TestAccIdentityStoreGroupDataSource_filterDisplayName (18.45s)
=== CONT  TestAccIdentityStoreGroupDataSource_uniqueAttributeDisplayName
--- PASS: TestAccIdentityStoreGroupDataSource_filterDisplayNameAndGroupId (17.52s)
=== CONT  TestAccIdentityStoreGroupDataSource_groupIdConflictsWithUniqueAttribute
--- PASS: TestAccIdentityStoreGroupDataSource_groupIdFilterMismatch (9.25s)
=== CONT  TestAccIdentityStoreGroupDataSource_filterConflictsWithUniqueAttribute
--- PASS: TestAccIdentityStoreGroupDataSource_groupIdConflictsWithUniqueAttribute (8.75s)
--- PASS: TestAccIdentityStoreGroupDataSource_filterConflictsWithUniqueAttribute (8.27s)
--- PASS: TestAccIdentityStoreGroupDataSource_uniqueAttributeDisplayName (17.43s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/identitystore	41.821s
% make testacc TESTARGS='-run=TestAccIdentityStoreGroup_' PKG=identitystore ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/identitystore/... -v -count 1 -parallel 3  -run=TestAccIdentityStoreGroup_ -timeout 180m
=== RUN   TestAccIdentityStoreGroup_basic
=== PAUSE TestAccIdentityStoreGroup_basic
=== RUN   TestAccIdentityStoreGroup_disappears
=== PAUSE TestAccIdentityStoreGroup_disappears
=== CONT  TestAccIdentityStoreGroup_basic
=== CONT  TestAccIdentityStoreGroup_disappears
--- PASS: TestAccIdentityStoreGroup_disappears (16.81s)
--- PASS: TestAccIdentityStoreGroup_basic (20.38s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/identitystore	25.590s
```
