### PR TITLE
Replace deprecated AWSConfigRole with AWS_ConfigRole

### DIFF
--- a/website/docs/r/config_configuration_recorder_status.html.markdown
+++ b/website/docs/r/config_configuration_recorder_status.html.markdown
@@ -23,7 +23,7 @@ resource "aws_config_configuration_recorder_status" "foo" {
 
 resource "aws_iam_role_policy_attachment" "a" {
   role       = aws_iam_role.r.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRole"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
 }
 
 resource "aws_s3_bucket" "b" {


### PR DESCRIPTION
### Description

This PR updates the example in the `aws_config_configuration_recorder_status` documentation to replace the deprecated `AWSConfigRole` managed policy with the new `AWS_ConfigRole`.

### Relations

Closes #28904

### References

- [Announcement of deprecation](https://aws.amazon.com/blogs/mt/service-notice-upcoming-changes-required-for-aws-config/)
- [Managed policy docs](https://docs.aws.amazon.com/config/latest/developerguide/security-iam-awsmanpol.html#security-iam-awsmanpol-AWS_ConfigRole)

### Output from Acceptance Testing

N/a, docs