### PR TITLE
Add support for auto-enabling lambda scanning on aws_inspector2_organization_configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ ENHANCEMENTS:
 * resource/aws_grafana_workspace: Add `configuration` argument ([#28569](https://github.com/hashicorp/terraform-provider-aws/issues/28569))
 * resource/aws_imagbuilder_component: Add `skip_destroy` argument ([#28905](https://github.com/hashicorp/terraform-provider-aws/issues/28905))
 * resource/aws_lambda_event_source_mapping: Add `scaling_config` argument ([#28876](https://github.com/hashicorp/terraform-provider-aws/issues/28876))
+* resource/aws_inspector2_organization_configuration: Add `lambda` attribute in `auto_enable` ([#28823](https://github.com/hashicorp/terraform-provider-aws/issues/28823))
 
 BUG FIXES:
 

--- a/internal/service/inspector2/organization_configuration.go
+++ b/internal/service/inspector2/organization_configuration.go
@@ -47,6 +47,10 @@ func ResourceOrganizationConfiguration() *schema.Resource {
 							Type:     schema.TypeBool,
 							Required: true,
 						},
+						"lambda": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
 					},
 				},
 			},
@@ -117,7 +121,7 @@ func resourceOrganizationConfigurationUpdate(ctx context.Context, d *schema.Reso
 		return create.DiagError(names.Inspector2, create.ErrActionUpdating, ResNameOrganizationConfiguration, d.Id(), err)
 	}
 
-	if err := waitOrganizationConfigurationUpdated(ctx, conn, d.Get("auto_enable.0.ec2").(bool), d.Get("auto_enable.0.ecr").(bool), d.Timeout(schema.TimeoutUpdate)); err != nil {
+	if err := waitOrganizationConfigurationUpdated(ctx, conn, d.Get("auto_enable.0.ec2").(bool), d.Get("auto_enable.0.ecr").(bool), d.Get("auto_enable.0.lambda").(bool), d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return create.DiagError(names.Inspector2, create.ErrActionWaitingForUpdate, ResNameOrganizationConfiguration, d.Id(), err)
 	}
 
@@ -132,8 +136,9 @@ func resourceOrganizationConfigurationDelete(ctx context.Context, d *schema.Reso
 
 	in := &inspector2.UpdateOrganizationConfigurationInput{
 		AutoEnable: &types.AutoEnable{
-			Ec2: aws.Bool(false),
-			Ecr: aws.Bool(false),
+			Ec2:    aws.Bool(false),
+			Ecr:    aws.Bool(false),
+			Lambda: aws.Bool(false),
 		},
 	}
 
@@ -143,15 +148,15 @@ func resourceOrganizationConfigurationDelete(ctx context.Context, d *schema.Reso
 		return create.DiagError(names.Inspector2, create.ErrActionUpdating, ResNameOrganizationConfiguration, d.Id(), err)
 	}
 
-	if err := waitOrganizationConfigurationUpdated(ctx, conn, false, false, d.Timeout(schema.TimeoutUpdate)); err != nil {
+	if err := waitOrganizationConfigurationUpdated(ctx, conn, false, false, false, d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return create.DiagError(names.Inspector2, create.ErrActionWaitingForUpdate, ResNameOrganizationConfiguration, d.Id(), err)
 	}
 
 	return nil
 }
 
-func waitOrganizationConfigurationUpdated(ctx context.Context, conn *inspector2.Client, ec2, ecr bool, timeout time.Duration) error {
-	needle := fmt.Sprintf("%t:%t", ec2, ecr)
+func waitOrganizationConfigurationUpdated(ctx context.Context, conn *inspector2.Client, ec2, ecr, lambda bool, timeout time.Duration) error {
+	needle := fmt.Sprintf("%t:%t:%t", ec2, ecr, lambda)
 
 	all := []string{
 		fmt.Sprintf("%t:%t", false, false),
@@ -193,7 +198,7 @@ func statusOrganizationConfiguration(ctx context.Context, conn *inspector2.Clien
 			return nil, "", err
 		}
 
-		return out, fmt.Sprintf("%t:%t", aws.ToBool(out.AutoEnable.Ec2), aws.ToBool(out.AutoEnable.Ecr)), nil
+		return out, fmt.Sprintf("%t:%t:%t", aws.ToBool(out.AutoEnable.Ec2), aws.ToBool(out.AutoEnable.Ecr), aws.ToBool(out.AutoEnable.Lambda)), nil
 	}
 }
 
@@ -212,6 +217,10 @@ func flattenAutoEnable(apiObject *types.AutoEnable) map[string]interface{} {
 		m["ecr"] = aws.ToBool(v)
 	}
 
+	if v := apiObject.Lambda; v != nil {
+		m["lambda"] = aws.ToBool(v)
+	}
+
 	return m
 }
 
@@ -228,6 +237,10 @@ func expandAutoEnable(tfMap map[string]interface{}) *types.AutoEnable {
 
 	if v, ok := tfMap["ecr"].(bool); ok {
 		a.Ecr = aws.Bool(v)
+	}
+
+	if v, ok := tfMap["lambda"].(bool); ok {
+		a.Lambda = aws.Bool(v)
 	}
 
 	return a

--- a/internal/service/inspector2/organization_configuration_test.go
+++ b/internal/service/inspector2/organization_configuration_test.go
@@ -23,9 +23,9 @@ func TestAccInspector2OrganizationConfiguration_serial(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]func(t *testing.T){
-		"basic":      testAccOrganizationConfiguration_basic,
-		"disappears": testAccOrganizationConfiguration_disappears,
-		"ec2ECR":     testAccOrganizationConfiguration_ec2ECR,
+		"basic":        testAccOrganizationConfiguration_basic,
+		"disappears":   testAccOrganizationConfiguration_disappears,
+		"ec2ECRLambda": testAccOrganizationConfiguration_ec2ECRLambda,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)
@@ -46,11 +46,12 @@ func testAccOrganizationConfiguration_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckOrganizationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOrganizationConfigurationConfig_basic(true, false),
+				Config: testAccOrganizationConfigurationConfig_basic(true, false, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOrganizationConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "auto_enable.0.ec2", "true"),
 					resource.TestCheckResourceAttr(resourceName, "auto_enable.0.ecr", "false"),
+					resource.TestCheckResourceAttr(resourceName, "auto_enable.0.lambda", "true"),
 				),
 			},
 		},
@@ -72,7 +73,7 @@ func testAccOrganizationConfiguration_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckOrganizationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOrganizationConfigurationConfig_basic(true, false),
+				Config: testAccOrganizationConfigurationConfig_basic(true, false, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOrganizationConfigurationExists(resourceName),
 					acctest.CheckResourceDisappears(acctest.Provider, tfinspector2.ResourceOrganizationConfiguration(), resourceName),
@@ -83,7 +84,7 @@ func testAccOrganizationConfiguration_disappears(t *testing.T) {
 	})
 }
 
-func testAccOrganizationConfiguration_ec2ECR(t *testing.T) {
+func testAccOrganizationConfiguration_ec2ECRLambda(t *testing.T) {
 	resourceName := "aws_inspector2_organization_configuration.test"
 
 	resource.Test(t, resource.TestCase{
@@ -98,11 +99,12 @@ func testAccOrganizationConfiguration_ec2ECR(t *testing.T) {
 		CheckDestroy:             testAccCheckOrganizationConfigurationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOrganizationConfigurationConfig_basic(true, true),
+				Config: testAccOrganizationConfigurationConfig_basic(true, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOrganizationConfigurationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "auto_enable.0.ec2", "true"),
 					resource.TestCheckResourceAttr(resourceName, "auto_enable.0.ecr", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auto_enable.0.lambda", "true"),
 				),
 			},
 		},
@@ -142,7 +144,7 @@ func testAccCheckOrganizationConfigurationDestroy(s *terraform.State) error {
 			return create.Error(names.Inspector2, create.ErrActionCheckingDestroyed, tfinspector2.ResNameOrganizationConfiguration, rs.Primary.ID, err)
 		}
 
-		if out != nil && out.AutoEnable != nil && !aws.ToBool(out.AutoEnable.Ec2) && !aws.ToBool(out.AutoEnable.Ecr) {
+		if out != nil && out.AutoEnable != nil && !aws.ToBool(out.AutoEnable.Ec2) && !aws.ToBool(out.AutoEnable.Ecr) && !aws.ToBool(out.AutoEnable.Lambda) {
 			if enabledDelAdAcct {
 				if err := testDisableDelegatedAdminAccount(ctx, conn, acctest.AccountID()); err != nil {
 					return err
@@ -217,7 +219,7 @@ func testAccCheckOrganizationConfigurationExists(name string) resource.TestCheck
 	}
 }
 
-func testAccOrganizationConfigurationConfig_basic(ec2, ecr bool) string {
+func testAccOrganizationConfigurationConfig_basic(ec2, ecr, lambda bool) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
@@ -227,11 +229,12 @@ resource "aws_inspector2_delegated_admin_account" "test" {
 
 resource "aws_inspector2_organization_configuration" "test" {
   auto_enable {
-    ec2 = %[1]t
-    ecr = %[2]t
+    ec2    = %[1]t
+    ecr    = %[2]t
+    lambda = %[3]t
   }
 
   depends_on = [aws_inspector2_delegated_admin_account.test]
 }
-`, ec2, ecr)
+`, ec2, ecr, lambda)
 }


### PR DESCRIPTION
 <!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
```
Add support for auto-enabling lambda:

resource "aws_inspector2_organization_configuration" "example" {
  auto_enable {
    ec2    = true
    ecr    = false
    lambda = true
  }
}
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28823

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccInspector2OrganizationConfiguration PKG=inspector2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/inspector2/... -v -count 1 -parallel 20 -run='TestAccInspector2OrganizationConfiguration'  -timeout 180m
=== RUN   TestAccInspector2OrganizationConfiguration_serial
=== PAUSE TestAccInspector2OrganizationConfiguration_serial
=== CONT  TestAccInspector2OrganizationConfiguration_serial
=== RUN   TestAccInspector2OrganizationConfiguration_serial/basic
=== RUN   TestAccInspector2OrganizationConfiguration_serial/disappears
=== RUN   TestAccInspector2OrganizationConfiguration_serial/ec2ECRLambda
--- PASS: TestAccInspector2OrganizationConfiguration_serial (98.41s)
    --- PASS: TestAccInspector2OrganizationConfiguration_serial/basic (30.73s)
    --- PASS: TestAccInspector2OrganizationConfiguration_serial/disappears (36.11s)
    --- PASS: TestAccInspector2OrganizationConfiguration_serial/ec2ECRLambda (31.57s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/inspector2 103.872s

...
```
