### PR TITLE
elbv2/listener_certificate: Display errors on read

### DIFF
--- a/.changelog/28968.txt
+++ b/.changelog/28968.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_lb_listener_certificate: Show errors in certain cases where they were previously only logged and resource was removed from state
+```
+
+```release-note:bug
+resource/aws_iam_server_certificate: Avoid errors on delete when no error occurred
+```

--- a/internal/service/elbv2/listener_certificate.go
+++ b/internal/service/elbv2/listener_certificate.go
@@ -11,9 +11,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func ResourceListenerCertificate() *schema.Resource {
@@ -41,6 +42,11 @@ func ResourceListenerCertificate() *schema.Resource {
 		},
 	}
 }
+
+const (
+	ResNameListenerCertificate  = "Listener Certificate"
+	ListenerCertificateNotFound = "ListenerCertificateNotFound"
+)
 
 func resourceListenerCertificateCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*conns.AWSClient).ELBV2Conn()
@@ -97,19 +103,14 @@ func resourceListenerCertificateRead(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[DEBUG] Reading certificate: %s of listener: %s", certificateArn, listenerArn)
 
-	var certificate *elbv2.Certificate
 	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
 		var err error
-		certificate, err = findListenerCertificate(certificateArn, listenerArn, true, nil, conn)
-		if err != nil {
-			return resource.NonRetryableError(err)
+		err = findListenerCertificate(certificateArn, listenerArn, true, nil, conn)
+		if tfresource.NotFound(err) && d.IsNewResource() {
+			return resource.RetryableError(err)
 		}
 
-		if certificate == nil {
-			err = fmt.Errorf("certificate not found: %s", certificateArn)
-			if d.IsNewResource() {
-				return resource.RetryableError(err)
-			}
+		if err != nil {
 			return resource.NonRetryableError(err)
 		}
 
@@ -117,21 +118,17 @@ func resourceListenerCertificateRead(d *schema.ResourceData, meta interface{}) e
 	})
 
 	if tfresource.TimedOut(err) {
-		certificate, err = findListenerCertificate(certificateArn, listenerArn, true, nil, conn)
+		err = findListenerCertificate(certificateArn, listenerArn, true, nil, conn)
 	}
 
-	if !d.IsNewResource() && errs.Contains(err, "certificate not found") {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] ELBv2 Listener Certificate (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
-	if err == nil && certificate == nil {
-		return fmt.Errorf("reading ELB v2 Listener Certificate (%s): certificate not found", d.Id())
-	}
-
 	if err != nil {
-		return fmt.Errorf("reading ELB v2 Listener Certificate (%s): %w", d.Id(), err)
+		return create.Error(names.ELBV2, create.ErrActionReading, ResNameListenerCertificate, d.Id(), err)
 	}
 
 	d.Set("certificate_arn", certificateArn)
@@ -171,7 +168,7 @@ func resourceListenerCertificateDelete(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func findListenerCertificate(certificateArn, listenerArn string, skipDefault bool, nextMarker *string, conn *elbv2.ELBV2) (*elbv2.Certificate, error) {
+func findListenerCertificate(certificateArn, listenerArn string, skipDefault bool, nextMarker *string, conn *elbv2.ELBV2) error {
 	params := &elbv2.DescribeListenerCertificatesInput{
 		ListenerArn: aws.String(listenerArn),
 		PageSize:    aws.Int64(400),
@@ -182,7 +179,7 @@ func findListenerCertificate(certificateArn, listenerArn string, skipDefault boo
 
 	resp, err := conn.DescribeListenerCertificates(params)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, cert := range resp.Certificates {
@@ -191,12 +188,16 @@ func findListenerCertificate(certificateArn, listenerArn string, skipDefault boo
 		}
 
 		if aws.StringValue(cert.CertificateArn) == certificateArn {
-			return cert, nil
+			return nil
 		}
 	}
 
 	if resp.NextMarker != nil {
 		return findListenerCertificate(certificateArn, listenerArn, skipDefault, resp.NextMarker, conn)
 	}
-	return nil, nil
+
+	return &resource.NotFoundError{
+		LastRequest: params,
+		Message:     fmt.Sprintf("%s: certificate %s for listener %s not found", ListenerCertificateNotFound, certificateArn, listenerArn),
+	}
 }

--- a/internal/service/elbv2/listener_certificate.go
+++ b/internal/service/elbv2/listener_certificate.go
@@ -102,8 +102,7 @@ func resourceListenerCertificateRead(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[DEBUG] Reading certificate: %s of listener: %s", certificateArn, listenerArn)
 
 	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
-		var err error
-		err = findListenerCertificate(certificateArn, listenerArn, true, nil, conn)
+		err := findListenerCertificate(certificateArn, listenerArn, true, nil, conn)
 		if tfresource.NotFound(err) && d.IsNewResource() {
 			return resource.RetryableError(err)
 		}

--- a/internal/service/iam/server_certificate.go
+++ b/internal/service/iam/server_certificate.go
@@ -276,7 +276,11 @@ func resourceServerCertificateDelete(d *schema.ResourceData, meta interface{}) e
 		})
 	}
 
-	return fmt.Errorf("deleting IAM Server Certificate (%s): %w", d.Id(), err)
+	if err != nil {
+		return fmt.Errorf("deleting IAM Server Certificate (%s): %w", d.Id(), err)
+	}
+
+	return nil
 }
 
 func resourceServerCertificateImport(


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

* `aws_lb_listener_certificate` - Fix logic error where all errors during read would end up in remove from state branch rather than giving error. This causes problems when there are actual errors like not having the correct permissions. This is never visible except in log.
* `aws_iam_server_certificate` - Delete was returning an error no matter what, in many cases, rather than checking to see if there were an error to return `nil`.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #8751

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccELBV2ListenerCertificate_ PKG=elbv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2ListenerCertificate_'  -timeout 180m
=== RUN   TestAccELBV2ListenerCertificate_basic
=== PAUSE TestAccELBV2ListenerCertificate_basic
=== RUN   TestAccELBV2ListenerCertificate_CertificateARN_underscores
=== PAUSE TestAccELBV2ListenerCertificate_CertificateARN_underscores
=== RUN   TestAccELBV2ListenerCertificate_multiple
=== PAUSE TestAccELBV2ListenerCertificate_multiple
=== RUN   TestAccELBV2ListenerCertificate_disappears
=== PAUSE TestAccELBV2ListenerCertificate_disappears
=== CONT  TestAccELBV2ListenerCertificate_basic
=== CONT  TestAccELBV2ListenerCertificate_multiple
=== CONT  TestAccELBV2ListenerCertificate_CertificateARN_underscores
=== CONT  TestAccELBV2ListenerCertificate_disappears
--- PASS: TestAccELBV2ListenerCertificate_disappears (148.26s)
--- PASS: TestAccELBV2ListenerCertificate_basic (150.81s)
--- PASS: TestAccELBV2ListenerCertificate_CertificateARN_underscores (161.03s)
--- PASS: TestAccELBV2ListenerCertificate_multiple (248.19s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	250.086s
% make testacc TESTS=TestAccIAMServerCertificate_ PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMServerCertificate_'  -timeout 180m
=== RUN   TestAccIAMServerCertificate_basic
=== PAUSE TestAccIAMServerCertificate_basic
=== RUN   TestAccIAMServerCertificate_tags
=== PAUSE TestAccIAMServerCertificate_tags
=== RUN   TestAccIAMServerCertificate_Name_prefix
=== PAUSE TestAccIAMServerCertificate_Name_prefix
=== RUN   TestAccIAMServerCertificate_disappears
=== PAUSE TestAccIAMServerCertificate_disappears
=== RUN   TestAccIAMServerCertificate_file
=== PAUSE TestAccIAMServerCertificate_file
=== RUN   TestAccIAMServerCertificate_path
=== PAUSE TestAccIAMServerCertificate_path
=== CONT  TestAccIAMServerCertificate_basic
=== CONT  TestAccIAMServerCertificate_disappears
=== CONT  TestAccIAMServerCertificate_path
=== CONT  TestAccIAMServerCertificate_file
=== CONT  TestAccIAMServerCertificate_Name_prefix
=== CONT  TestAccIAMServerCertificate_tags
--- PASS: TestAccIAMServerCertificate_disappears (14.98s)
--- PASS: TestAccIAMServerCertificate_Name_prefix (17.56s)
--- PASS: TestAccIAMServerCertificate_path (19.49s)
--- PASS: TestAccIAMServerCertificate_basic (19.92s)
--- PASS: TestAccIAMServerCertificate_file (28.73s)
--- PASS: TestAccIAMServerCertificate_tags (38.88s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	41.494s
```
