### PR TITLE
Update aws_redshiftserverless_workgroup.subnet_ids to reflect requirements

### DIFF
--- a/website/docs/r/redshiftserverless_workgroup.html.markdown
+++ b/website/docs/r/redshiftserverless_workgroup.html.markdown
@@ -33,7 +33,7 @@ The following arguments are optional:
 * `enhanced_vpc_routing` - (Optional) The value that specifies whether to turn on enhanced virtual private cloud (VPC) routing, which forces Amazon Redshift Serverless to route traffic through your VPC instead of over the internet.
 * `publicly_accessible` - (Optional) A value that specifies whether the workgroup can be accessed from a public network.
 * `security_group_ids` - (Optional) An array of security group IDs to associate with the workgroup.
-* `subnet_ids` - (Optional) An array of VPC subnet IDs to associate with the workgroup.
+* `subnet_ids` - (Optional) An array of VPC subnet IDs to associate with the workgroup. When set, must contain at least three subnets spanning three Availability Zones. A minimum number of IP addresses is required and scales with the Base Capacity. For more information, see the following [AWS document](https://docs.aws.amazon.com/redshift/latest/mgmt/serverless-known-issues.html).
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Config Parameter


### PR DESCRIPTION
### Description

This PR updates the `aws_redshiftserverless_workgroup` resource's `subnet_ids` argument description to provide a bit more clarity on the requirements (and link out to the associated AWS doc)

### Relations

Closes #28977

### References

- [AWS doc](https://docs.aws.amazon.com/redshift/latest/mgmt/serverless-known-issues.html)

### Output from Acceptance Testing

N/a, docs