### PR TITLE
New Data Source: `aws_auditmanager_framework`

### DIFF
--- a/internal/service/auditmanager/framework_data_source.go
+++ b/internal/service/auditmanager/framework_data_source.go
@@ -1,0 +1,172 @@
+package auditmanager
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/auditmanager"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/auditmanager/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	sdkv2resource "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+)
+
+func init() {
+	_sp.registerFrameworkDataSourceFactory(newDataSourceFramework)
+}
+
+func newDataSourceFramework(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceFramework{}, nil
+}
+
+type dataSourceFramework struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceFramework) Metadata(_ context.Context, request datasource.MetadataRequest, response *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
+	response.TypeName = "aws_auditmanager_framework"
+}
+
+func (d *dataSourceFramework) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"arn": framework.ARNAttributeComputedOnly(),
+			"compliance_type": schema.StringAttribute{
+				Computed: true,
+			},
+			"description": schema.StringAttribute{
+				Computed: true,
+			},
+			"framework_type": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					enum.FrameworkValidate[awstypes.FrameworkType](),
+				},
+			},
+			"id": framework.IDAttribute(),
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"tags": tftags.TagsAttributeComputedOnly(),
+		},
+		Blocks: map[string]schema.Block{
+			"control_sets": schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"id": framework.IDAttribute(),
+						"name": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"controls": schema.SetNestedBlock{
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"id": schema.StringAttribute{
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *dataSourceFramework) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().AuditManagerClient()
+
+	var data dataSourceFrameworkData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	frameworkMetadata, err := FindFrameworkByName(ctx, conn, data.Name.ValueString(), data.FrameworkType.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("finding framework by name", err.Error())
+		return
+	}
+
+	// Framework metadata from the ListFrameworks API does not contain all information available
+	// about a framework. Use framework ID to get complete information.
+	framework, err := FindFrameworkByID(ctx, conn, aws.ToString(frameworkMetadata.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("finding framework by ID", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(data.refreshFromOutput(ctx, d.Meta(), framework)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func FindFrameworkByName(ctx context.Context, conn *auditmanager.Client, name, frameworkType string) (*awstypes.AssessmentFrameworkMetadata, error) {
+	in := &auditmanager.ListAssessmentFrameworksInput{
+		FrameworkType: awstypes.FrameworkType(frameworkType),
+	}
+	pages := auditmanager.NewListAssessmentFrameworksPaginator(conn, in)
+
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, framework := range page.FrameworkMetadataList {
+			if name == aws.ToString(framework.Name) {
+				return &framework, nil
+			}
+		}
+	}
+
+	return nil, &sdkv2resource.NotFoundError{
+		LastRequest: in,
+	}
+}
+
+type dataSourceFrameworkData struct {
+	ARN            types.String `tfsdk:"arn"`
+	ComplianceType types.String `tfsdk:"compliance_type"`
+	ControlSets    types.Set    `tfsdk:"control_sets"`
+	Description    types.String `tfsdk:"description"`
+	FrameworkType  types.String `tfsdk:"framework_type"`
+	ID             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	Tags           types.Map    `tfsdk:"tags"`
+}
+
+// refreshFromOutput writes state data from an AWS response object
+func (rd *dataSourceFrameworkData) refreshFromOutput(ctx context.Context, meta *conns.AWSClient, out *awstypes.Framework) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if out == nil {
+		return diags
+	}
+
+	rd.ID = types.StringValue(aws.ToString(out.Id))
+	rd.Name = types.StringValue(aws.ToString(out.Name))
+	cs, d := flattenFrameworkControlSets(ctx, out.ControlSets)
+	diags.Append(d...)
+	rd.ControlSets = cs
+
+	rd.ComplianceType = flex.StringToFramework(ctx, out.ComplianceType)
+	rd.Description = flex.StringToFramework(ctx, out.Description)
+	rd.FrameworkType = flex.StringValueToFramework(ctx, out.Type)
+	rd.ARN = flex.StringToFramework(ctx, out.Arn)
+
+	ignoreTagsConfig := meta.IgnoreTagsConfig
+	tags := KeyValueTags(out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+	rd.Tags = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags.Map())
+
+	return diags
+}

--- a/internal/service/auditmanager/framework_data_source_test.go
+++ b/internal/service/auditmanager/framework_data_source_test.go
@@ -1,0 +1,100 @@
+package auditmanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccAuditManagerFrameworkDataSource_standard(t *testing.T) {
+	// Standard frameworks are managed by AWS and will exist in the account automatically
+	// once AuditManager is enabled.
+	name := "Essential Eight"
+	dataSourceName := "data.aws_auditmanager_framework.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.AuditManagerEndpointID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AuditManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFrameworkDataSourceConfig_standard(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "control_sets.#", "8"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAuditManagerFrameworkDataSource_custom(t *testing.T) {
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_auditmanager_framework.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.AuditManagerEndpointID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AuditManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFrameworkDataSourceConfig_custom(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "control_sets.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "control_sets.0.name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "control_sets.0.controls.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccFrameworkDataSourceConfig_standard(rName string) string {
+	return fmt.Sprintf(`
+data "aws_auditmanager_framework" "test" {
+  name           = %[1]q
+  framework_type = "Standard"
+}
+`, rName)
+}
+
+func testAccFrameworkDataSourceConfig_custom(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_auditmanager_control" "test" {
+  name = %[1]q
+
+  control_mapping_sources {
+    source_name          = %[1]q
+    source_set_up_option = "Procedural_Controls_Mapping"
+    source_type          = "MANUAL"
+  }
+}
+
+resource "aws_auditmanager_framework" "test" {
+  name = %[1]q
+
+  control_sets {
+    name = %[1]q
+    controls {
+      id = aws_auditmanager_control.test.id
+    }
+  }
+}
+
+data "aws_auditmanager_framework" "test" {
+  name           = aws_auditmanager_framework.test.name
+  framework_type = "Custom"
+}
+`, rName)
+}

--- a/website/docs/d/auditmanager_framework.html.markdown
+++ b/website/docs/d/auditmanager_framework.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "Audit Manager"
+layout: "aws"
+page_title: "AWS: aws_auditmanager_framework"
+description: |-
+  Terraform data source for managing an AWS Audit Manager Framework.
+---
+
+# Data Source: aws_auditmanager_framework
+
+Terraform data source for managing an AWS Audit Manager Framework.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_auditmanager_framework" "example" {
+  name           = "Essential Eight"
+  framework_type = "Standard"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Name of the framework.
+* `type` - (Required) Type of framework. Valid values are `Custom` and `Standard`.
+
+## Attributes Reference
+
+See the [`aws_auditmanager_framework` resource](/docs/providers/aws/r/auditmanager_framework.html) for details on the returned attributes - they are identical.


### PR DESCRIPTION
### Description
`aws_auditmanager_framework` will allow practitioners to utilize Standard (AWS-managed) assessment frameworks as inputs to other resources, such as Assessments.


### Relations
Relates #17981 

### Output from Acceptance Testing

```console
$ make testacc PKG=auditmanager TESTS=TestAccAuditManagerFrameworkDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/auditmanager/... -v -count 1 -parallel 20 -run='TestAccAuditManagerFrameworkDataSource_'  -timeout 180m
=== RUN   TestAccAuditManagerFrameworkDataSource_standard
=== PAUSE TestAccAuditManagerFrameworkDataSource_standard
=== RUN   TestAccAuditManagerFrameworkDataSource_custom
=== PAUSE TestAccAuditManagerFrameworkDataSource_custom
=== CONT  TestAccAuditManagerFrameworkDataSource_standard
=== CONT  TestAccAuditManagerFrameworkDataSource_custom
--- PASS: TestAccAuditManagerFrameworkDataSource_standard (12.19s)
--- PASS: TestAccAuditManagerFrameworkDataSource_custom (14.29s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/auditmanager       17.392s
```
