### PR TITLE
Update cloudfront_distribution.html.markdown

### DIFF
--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -10,15 +10,9 @@ description: |-
 
 Creates an Amazon CloudFront web distribution.
 
-For information about CloudFront distributions, see the
-[Amazon CloudFront Developer Guide][1]. For specific information about creating
-CloudFront web distributions, see the [POST Distribution][2] page in the Amazon
-CloudFront API Reference.
+For information about CloudFront distributions, see the [Amazon CloudFront Developer Guide][1]. For specific information about creating CloudFront web distributions, see the [POST Distribution][2] page in the Amazon CloudFront API Reference.
 
-~> **NOTE:** CloudFront distributions take about 15 minutes to reach a deployed
-state after creation or modification. During this time, deletes to resources will
-be blocked. If you need to delete a distribution that is enabled and you do not
-want to wait, you need to use the `retain_on_delete` flag.
+~> **NOTE:** CloudFront distributions take about 15 minutes to reach a deployed state after creation or modification. During this time, deletes to resources will be blocked. If you need to delete a distribution that is enabled and you do not want to wait, you need to use the `retain_on_delete` flag.
 
 ## Example Usage
 
@@ -194,160 +188,63 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 
 ## Argument Reference
 
-The CloudFront distribution argument layout is a complex structure composed
-of several sub-resources - these resources are laid out below.
+The CloudFront distribution argument layout is a complex structure composed of several sub-resources - these resources are laid out below.
 
 ### Top-Level Arguments
 
-* `aliases` (Optional) - Extra CNAMEs (alternate domain names), if any, for
-    this distribution.
-
-* `comment` (Optional) - Any comments you want to include about the
-    distribution.
-
+* `aliases` (Optional) - Extra CNAMEs (alternate domain names), if any, for this distribution.
+* `comment` (Optional) - Any comments you want to include about the distribution.
 * `custom_error_response` (Optional) - One or more [custom error response](#custom-error-response-arguments) elements (multiples allowed).
-
-* `default_cache_behavior` (Required) - The [default cache behavior](#default-cache-behavior-arguments) for this distribution (maximum
-    one).
-
-* `default_root_object` (Optional) - The object that you want CloudFront to
-    return (for example, index.html) when an end user requests the root URL.
-
-* `enabled` (Required) - Whether the distribution is enabled to accept end
-    user requests for content.
-
+* `default_cache_behavior` (Required) - The [default cache behavior](#default-cache-behavior-arguments) for this distribution (maximum one).
+* `default_root_object` (Optional) - Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL.
+* `enabled` (Required) - Whether the distribution is enabled to accept end user requests for content.
 * `is_ipv6_enabled` (Optional) - Whether the IPv6 is enabled for the distribution.
-
-* `http_version` (Optional) - The maximum HTTP version to support on the
-    distribution. Allowed values are `http1.1`, `http2`, `http2and3` and `http3`. The default is
-    `http2`.
-
-* `logging_config` (Optional) - The [logging
-    configuration](#logging-config-arguments) that controls how logs are written
-    to your distribution (maximum one).
-
-* `ordered_cache_behavior` (Optional) - An ordered list of [cache behaviors](#cache-behavior-arguments)
-    resource for this distribution. List from top to bottom
-    in order of precedence. The topmost cache behavior will have precedence 0.
-
-* `origin` (Required) - One or more [origins](#origin-arguments) for this
-    distribution (multiples allowed).
-
-* `origin_group` (Optional) - One or more [origin_group](#origin-group-arguments) for this
-  distribution (multiples allowed).
-
-* `price_class` (Optional) - The price class for this distribution. One of
-    `PriceClass_All`, `PriceClass_200`, `PriceClass_100`
-
-* `restrictions` (Required) - The [restriction
-    configuration](#restrictions-arguments) for this distribution (maximum one).
-
+* `http_version` (Optional) - Maximum HTTP version to support on the distribution. Allowed values are `http1.1`, `http2`, `http2and3` and `http3`. The default is `http2`.
+* `logging_config` (Optional) - The [logging configuration](#logging-config-arguments) that controls how logs are written to your distribution (maximum one).
+* `ordered_cache_behavior` (Optional) - Ordered list of [cache behaviors](#cache-behavior-arguments) resource for this distribution. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0.
+* `origin` (Required) - One or more [origins](#origin-arguments) for this distribution (multiples allowed).
+* `origin_group` (Optional) - One or more [origin_group](#origin-group-arguments) for this distribution (multiples allowed).
+* `price_class` (Optional) - Price class for this distribution. One of `PriceClass_All`, `PriceClass_200`, `PriceClass_100`.
+* `restrictions` (Required) - The [restriction configuration](#restrictions-arguments) for this distribution (maximum one).
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-
-* `viewer_certificate` (Required) - The [SSL
-    configuration](#viewer-certificate-arguments) for this distribution (maximum
-    one).
-
-* `web_acl_id` (Optional) - A unique identifier that specifies the AWS WAF web ACL,
-    if any, to associate with this distribution.
-    To specify a web ACL created using the latest version of AWS WAF (WAFv2), use the ACL ARN,
-    for example `aws_wafv2_web_acl.example.arn`. To specify a web
-    ACL created using AWS WAF Classic, use the ACL ID, for example `aws_waf_web_acl.example.id`.
-    The WAF Web ACL must exist in the WAF Global (CloudFront) region and the
-    credentials configuring this argument must have `waf:GetWebACL` permissions assigned.
-
-* `retain_on_delete` (Optional) - Disables the distribution instead of
-    deleting it when destroying the resource through Terraform. If this is set,
-    the distribution needs to be deleted manually afterwards. Default: `false`.
-
-* `wait_for_deployment` (Optional) - If enabled, the resource will wait for
-    the distribution status to change from `InProgress` to `Deployed`. Setting
-    this to`false` will skip the process. Default: `true`.
+* `viewer_certificate` (Required) - The [SSL configuration](#viewer-certificate-arguments) for this distribution (maximum one).
+* `web_acl_id` (Optional) - Unique identifier that specifies the AWS WAF web ACL, if any, to associate with this distribution. To specify a web ACL created using the latest version of AWS WAF (WAFv2), use the ACL ARN, for example `aws_wafv2_web_acl.example.arn`. To specify a web ACL created using AWS WAF Classic, use the ACL ID, for example `aws_waf_web_acl.example.id`. The WAF Web ACL must exist in the WAF Global (CloudFront) region and the credentials configuring this argument must have `waf:GetWebACL` permissions assigned.
+* `retain_on_delete` (Optional) - Disables the distribution instead of deleting it when destroying the resource through Terraform. If this is set, the distribution needs to be deleted manually afterwards. Default: `false`.
+* `wait_for_deployment` (Optional) - If enabled, the resource will wait for the distribution status to change from `InProgress` to `Deployed`. Setting this to`false` will skip the process. Default: `true`.
 
 #### Cache Behavior Arguments
 
-* `allowed_methods` (Required) - Controls which HTTP methods CloudFront
-    processes and forwards to your Amazon S3 bucket or your custom origin.
-
-* `cached_methods` (Required) - Controls whether CloudFront caches the
-    response to requests using the specified HTTP methods.
-
-* `cache_policy_id` (Optional) - The unique identifier of the cache policy that
-    is attached to the cache behavior. If configuring the `default_cache_behavior` either `cache_policy_id` or `forwarded_values` must be set.
-
-* `compress` (Optional) - Whether you want CloudFront to automatically
-    compress content for web requests that include `Accept-Encoding: gzip` in
-    the request header (default: `false`).
-
-* `default_ttl` (Optional) - The default amount of time (in seconds) that an
-    object is in a CloudFront cache before CloudFront forwards another request
-    in the absence of an `Cache-Control max-age` or `Expires` header.
-
-* `field_level_encryption_id` (Optional) - Field level encryption configuration ID
-
-* `forwarded_values` (Optional **Deprecated** use `cache_policy_id` or `origin_request_policy_id ` instead) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront handles query strings, cookies and headers (maximum one).
-
-* `lambda_function_association` (Optional) - A [config block](#lambda-function-association) that triggers a lambda
-    function with specific actions (maximum 4).
-
-* `function_association` (Optional) - A [config block](#function-association) that triggers a cloudfront
-    function with specific actions (maximum 2).
-
-* `max_ttl` (Optional) - The maximum amount of time (in seconds) that an
-    object is in a CloudFront cache before CloudFront forwards another request
-    to your origin to determine whether the object has been updated. Only
-    effective in the presence of `Cache-Control max-age`, `Cache-Control
-    s-maxage`, and `Expires` headers.
-
-* `min_ttl` (Optional) - The minimum amount of time that you want objects to
-    stay in CloudFront caches before CloudFront queries your origin to see
-    whether the object has been updated. Defaults to 0 seconds.
-
-* `origin_request_policy_id` (Optional) - The unique identifier of the origin request policy
-
-* `path_pattern` (Required) - The pattern (for example, `images/*.jpg`) that
-    specifies which requests you want this cache behavior to apply to.
-
-* `realtime_log_config_arn` (Optional) - The ARN of the [real-time log configuration](cloudfront_realtime_log_config.html)
-    that is attached to this cache behavior.
-
-* `response_headers_policy_id` (Optional) - The identifier for a response headers policy.
-
-* `smooth_streaming` (Optional) - Indicates whether you want to distribute
-    media files in Microsoft Smooth Streaming format using the origin that is
-    associated with this cache behavior.
-
-* `target_origin_id` (Required) - The value of ID for the origin that you want
-    CloudFront to route requests to when a request matches the path pattern
-    either for a cache behavior or for the default cache behavior.
-
-* `trusted_key_groups` (Optional) - A list of key group IDs that CloudFront can use to validate signed URLs or signed cookies.
+* `allowed_methods` (Required) - Controls which HTTP methods CloudFront processes and forwards to your Amazon S3 bucket or your custom origin.
+* `cached_methods` (Required) - Controls whether CloudFront caches the response to requests using the specified HTTP methods.
+* `cache_policy_id` (Optional) - Unique identifier of the cache policy that is attached to the cache behavior. If configuring the `default_cache_behavior` either `cache_policy_id` or `forwarded_values` must be set.
+* `compress` (Optional) - Whether you want CloudFront to automatically compress content for web requests that include `Accept-Encoding: gzip` in the request header (default: `false`).
+* `default_ttl` (Optional) - Default amount of time (in seconds) that an object is in a CloudFront cache before CloudFront forwards another request in the absence of an `Cache-Control max-age` or `Expires` header.
+* `field_level_encryption_id` (Optional) - Field level encryption configuration ID.
+* `forwarded_values` (Optional, **Deprecated** use `cache_policy_id` or `origin_request_policy_id ` instead) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront handles query strings, cookies and headers (maximum one).
+* `lambda_function_association` (Optional) - A [config block](#lambda-function-association) that triggers a lambda function with specific actions (maximum 4).
+* `function_association` (Optional) - A [config block](#function-association) that triggers a cloudfront function with specific actions (maximum 2).
+* `max_ttl` (Optional) - Maximum amount of time (in seconds) that an object is in a CloudFront cache before CloudFront forwards another request to your origin to determine whether the object has been updated. Only effective in the presence of `Cache-Control max-age`, `Cache-Control s-maxage`, and `Expires` headers.
+* `min_ttl` (Optional) - Minimum amount of time that you want objects to stay in CloudFront caches before CloudFront queries your origin to see whether the object has been updated. Defaults to 0 seconds.
+* `origin_request_policy_id` (Optional) - Unique identifier of the origin request policy.
+* `path_pattern` (Required) - Pattern (for example, `images/*.jpg`) that specifies which requests you want this cache behavior to apply to.
+* `realtime_log_config_arn` (Optional) - ARN of the [real-time log configuration](cloudfront_realtime_log_config.html) that is attached to this cache behavior.
+* `response_headers_policy_id` (Optional) - Identifier for a response headers policy.
+* `smooth_streaming` (Optional) - Indicates whether you want to distribute media files in Microsoft Smooth Streaming format using the origin that is associated with this cache behavior.
+* `target_origin_id` (Required) - Value of ID for the origin that you want CloudFront to route requests to when a request matches the path pattern either for a cache behavior or for the default cache behavior.
+* `trusted_key_groups` (Optional) - List of key group IDs that CloudFront can use to validate signed URLs or signed cookies.
 See the [CloudFront User Guide](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html) for more information about this feature.
 
 * `trusted_signers` (Optional) - List of AWS account IDs (or `self`) that you want to allow to create signed URLs for private content.
 See the [CloudFront User Guide](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html) for more information about this feature.
 
-* `viewer_protocol_policy` (Required) - Use this element to specify the
-    protocol that users can use to access the files in the origin specified by
-    TargetOriginId when a request matches the path pattern in PathPattern. One
-    of `allow-all`, `https-only`, or `redirect-to-https`.
+* `viewer_protocol_policy` (Required) - Use this element to specify the protocol that users can use to access the files in the origin specified by TargetOriginId when a request matches the path pattern in PathPattern. One of `allow-all`, `https-only`, or `redirect-to-https`.
 
 ##### Forwarded Values Arguments
 
-* `cookies` (Required) - The [forwarded values cookies](#cookies-arguments)
-    that specifies how CloudFront handles cookies (maximum one).
-
-* `headers` (Optional) - Headers, if any, that you want
-    CloudFront to vary upon for this cache behavior. Specify `*` to include all
-    headers.
-
-* `query_string` (Required) - Indicates whether you want CloudFront to forward
-    query strings to the origin that is associated with this cache behavior.
-
-* `query_string_cache_keys` (Optional) - When specified, along with a value of
-    `true` for `query_string`, all query strings are forwarded, however only the
-    query string keys listed in this argument are cached. When omitted with a
-    value of `true` for `query_string`, all query string keys are cached.
+* `cookies` (Required) - The [forwarded values cookies](#cookies-arguments) that specifies how CloudFront handles cookies (maximum one).
+* `headers` (Optional) - Headers, if any, that you want CloudFront to vary upon for this cache behavior. Specify `*` to include all headers.
+* `query_string` (Required) - Indicates whether you want CloudFront to forward query strings to the origin that is associated with this cache behavior.
+* `query_string_cache_keys` (Optional) - When specified, along with a value of `true` for `query_string`, all query strings are forwarded, however only the query string keys listed in this argument are cached. When omitted with a value of `true` for `query_string`, all query string keys are cached.
 
 ##### Lambda Function Association
 
@@ -375,9 +272,7 @@ resource "aws_cloudfront_distribution" "example" {
 }
 ```
 
-* `event_type` (Required) - The specific event to trigger this function.
-  Valid values: `viewer-request`, `origin-request`, `viewer-response`,
-  `origin-response`
+* `event_type` (Required) - Specific event to trigger this function. Valid values: `viewer-request`, `origin-request`, `viewer-response`, `origin-response`.
 * `lambda_arn` (Required) - ARN of the Lambda function.
 * `include_body` (Optional) - When set to true it exposes the request body to the lambda function. Defaults to false. Valid values: `true`, `false`.
 
@@ -404,35 +299,20 @@ resource "aws_cloudfront_distribution" "example" {
 }
 ```
 
-* `event_type` (Required) - The specific event to trigger this function.
-  Valid values: `viewer-request` or `viewer-response`
+* `event_type` (Required) - Specific event to trigger this function. Valid values: `viewer-request` or `viewer-response`.
 * `function_arn` (Required) - ARN of the Cloudfront function.
 
 ##### Cookies Arguments
 
-* `forward` (Required) - Whether you want CloudFront to forward
-    cookies to the origin that is associated with this cache behavior. You can
-    specify `all`, `none` or `whitelist`. If `whitelist`, you must include the
-    subsequent `whitelisted_names`
-
-* `whitelisted_names` (Optional) - If you have specified `whitelist` to
-    `forward`, the whitelisted cookies that you want CloudFront to forward to
-    your origin.
+* `forward` (Required) - Whether you want CloudFront to forward cookies to the origin that is associated with this cache behavior. You can specify `all`, `none` or `whitelist`. If `whitelist`, you must include the subsequent `whitelisted_names`.
+* `whitelisted_names` (Optional) - If you have specified `whitelist` to `forward`, the whitelisted cookies that you want CloudFront to forward to your origin.
 
 #### Custom Error Response Arguments
 
-* `error_caching_min_ttl` (Optional) - The minimum amount of time you want
-    HTTP error codes to stay in CloudFront caches before CloudFront queries your
-    origin to see whether the object has been updated.
-
-* `error_code` (Required) - The 4xx or 5xx HTTP status code that you want to
-    customize.
-
-* `response_code` (Optional) - The HTTP status code that you want CloudFront
-    to return with the custom error page to the viewer.
-
-* `response_page_path` (Optional) - The path of the custom error page (for
-    example, `/custom_404.html`).
+* `error_caching_min_ttl` (Optional) - Minimum amount of time you want HTTP error codes to stay in CloudFront caches before CloudFront queries your origin to see whether the object has been updated.
+* `error_code` (Required) - 4xx or 5xx HTTP status code that you want to customize.
+* `response_code` (Optional) - HTTP status code that you want CloudFront to return with the custom error page to the viewer.
+* `response_page_path` (Optional) - Path of the custom error page (for example, `/custom_404.html`).
 
 #### Default Cache Behavior Arguments
 
@@ -442,69 +322,36 @@ argument should not be specified.
 
 #### Logging Config Arguments
 
-* `bucket` (Required) - The Amazon S3 bucket to store the access logs in, for
-    example, `myawslogbucket.s3.amazonaws.com`.
-
-* `include_cookies` (Optional) - Specifies whether you want CloudFront to
-    include cookies in access logs (default: `false`).
-
-* `prefix` (Optional) - An optional string that you want CloudFront to prefix
-    to the access log filenames for this distribution, for example, `myprefix/`.
+* `bucket` (Required) - Amazon S3 bucket to store the access logs in, for example, `myawslogbucket.s3.amazonaws.com`.
+* `include_cookies` (Optional) - Specifies whether you want CloudFront to include cookies in access logs (default: `false`).
+* `prefix` (Optional) - Optional string that you want CloudFront to prefix to the access log filenames for this distribution, for example, `myprefix/`.
 
 #### Origin Arguments
 
-* `connection_attempts` (Optional) - The number of times that CloudFront attempts to connect to the origin. Must be between 1-3. Defaults to 3.
-
-* `connection_timeout` (Optional) - The number of seconds that CloudFront waits when trying to establish a connection to the origin. Must be between 1-10. Defaults to 10.
-
-* `custom_origin_config` - The [CloudFront custom
-    origin](#custom-origin-config-arguments) configuration information. If an S3
-    origin is required, use `origin_access_control_id` or `s3_origin_config` instead.
-
-* `domain_name` (Required) - The DNS domain name of either the S3 bucket, or
-    web site of your custom origin.
-
-* `custom_header` (Optional) - One or more sub-resources with `name` and
-    `value` parameters that specify header data that will be sent to the origin
-    (multiples allowed).
-
-* `origin_access_control_id` (Optional) - The unique identifier of a [CloudFront origin access control][8] for this origin.
-
-* `origin_id` (Required) - A unique identifier for the origin.
-
-* `origin_path` (Optional) - An optional element that causes CloudFront to
-    request your content from a directory in your Amazon S3 bucket or your
-    custom origin.
-
-* `origin_shield` - The [CloudFront Origin Shield](#origin-shield-arguments)
-    configuration information. Using Origin Shield can help reduce the load on your origin. For more information, see [Using Origin Shield](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-shield.html) in the Amazon CloudFront Developer Guide.
-
-* `s3_origin_config` - The [CloudFront S3 origin](#s3-origin-config-arguments)
-    configuration information. If a custom origin is required, use
-    `custom_origin_config` instead.
+* `connection_attempts` (Optional) - Number of times that CloudFront attempts to connect to the origin. Must be between 1-3. Defaults to 3.
+* `connection_timeout` (Optional) - Number of seconds that CloudFront waits when trying to establish a connection to the origin. Must be between 1-10. Defaults to 10.
+* `custom_origin_config` - The [CloudFront custom origin](#custom-origin-config-arguments) configuration information. If an S3 origin is required, use `origin_access_control_id` or `s3_origin_config` instead.
+* `domain_name` (Required) - DNS domain name of either the S3 bucket, or web site of your custom origin.
+* `custom_header` (Optional) - One or more sub-resources with `name` and `value` parameters that specify header data that will be sent to the origin (multiples allowed).
+* `origin_access_control_id` (Optional) - Unique identifier of a [CloudFront origin access control][8] for this origin.
+* `origin_id` (Required) - Unique identifier for the origin.
+* `origin_path` (Optional) - Optional element that causes CloudFront to request your content from a directory in your Amazon S3 bucket or your custom origin.
+* `origin_shield` - The [CloudFront Origin Shield](#origin-shield-arguments) configuration information. Using Origin Shield can help reduce the load on your origin. For more information, see [Using Origin Shield](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-shield.html) in the Amazon CloudFront Developer Guide.
+* `s3_origin_config` - The [CloudFront S3 origin](#s3-origin-config-arguments) configuration information. If a custom origin is required, use `custom_origin_config` instead.
 
 ##### Custom Origin Config Arguments
 
-* `http_port` (Required) - The HTTP port the custom origin listens on.
-
-* `https_port` (Required) - The HTTPS port the custom origin listens on.
-
-* `origin_protocol_policy` (Required) - The origin protocol policy to apply to
-    your origin. One of `http-only`, `https-only`, or `match-viewer`.
-
-* `origin_ssl_protocols` (Required) - The SSL/TLS protocols that you want
-    CloudFront to use when communicating with your origin over HTTPS. A list of
-    one or more of `SSLv3`, `TLSv1`, `TLSv1.1`, and `TLSv1.2`.
-
+* `http_port` (Required) - HTTP port the custom origin listens on.
+* `https_port` (Required) - HTTPS port the custom origin listens on.
+* `origin_protocol_policy` (Required) - Origin protocol policy to apply to your origin. One of `http-only`, `https-only`, or `match-viewer`.
+* `origin_ssl_protocols` (Required) - SSL/TLS protocols that you want CloudFront to use when communicating with your origin over HTTPS. A list of one or more of `SSLv3`, `TLSv1`, `TLSv1.1`, and `TLSv1.2`.
 * `origin_keepalive_timeout` - (Optional) The Custom KeepAlive timeout, in seconds. By default, AWS enforces a limit of `60`. But you can request an [increase](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-request-timeout).
-
 * `origin_read_timeout` - (Optional) The Custom Read timeout, in seconds. By default, AWS enforces a limit of `60`. But you can request an [increase](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-request-timeout).
 
 ##### Origin Shield Arguments
 
-* `enabled` (Required) - A flag that specifies whether Origin Shield is enabled.
-
-* `origin_shield_region` (Required) - The AWS Region for Origin Shield. To specify a region, use the region code, not the region name. For example, specify the US East (Ohio) region as us-east-2.
+* `enabled` (Required) - Flag that specifies whether Origin Shield is enabled.
+* `origin_shield_region` (Required) - AWS Region for Origin Shield. To specify a region, use the region code, not the region name. For example, specify the US East (Ohio) region as us-east-2.
 
 ##### S3 Origin Config Arguments
 
@@ -512,19 +359,17 @@ argument should not be specified.
 
 #### Origin Group Arguments
 
-* `origin_id` (Required) - A unique identifier for the origin group.
-
-* `failover_criteria` (Required) - The [failover criteria](#failover-criteria-arguments) for when to failover to the secondary origin
-
+* `origin_id` (Required) - Unique identifier for the origin group.
+* `failover_criteria` (Required) - The [failover criteria](#failover-criteria-arguments) for when to failover to the secondary origin.
 * `member` (Required) - Ordered [member](#member-arguments) configuration blocks assigned to the origin group, where the first member is the primary origin. You must specify two members.
 
 ##### Failover Criteria Arguments
 
-* `status_codes` (Required) - A list of HTTP status codes for the origin group
+* `status_codes` (Required) - List of HTTP status codes for the origin group.
 
 ##### Member Arguments
 
-* `origin_id` (Required) - The unique identifier of the member origin
+* `origin_id` (Required) - Unique identifier of the member origin.
 
 #### Restrictions Arguments
 
@@ -533,90 +378,41 @@ The `restrictions` sub-resource takes another single sub-resource named
 
 The arguments of `geo_restriction` are:
 
-* `locations` (Required) - The [ISO 3166-1-alpha-2 codes][4] for which you
-    want CloudFront either to distribute your content (`whitelist`) or not
-    distribute your content (`blacklist`). If the type is specified as `none` an empty array can be used.
-
-* `restriction_type` (Required) - The method that you want to use to restrict
-    distribution of your content by country: `none`, `whitelist`, or
-    `blacklist`.
+* `locations` (Required) - [ISO 3166-1-alpha-2 codes][4] for which you want CloudFront either to distribute your content (`whitelist`) or not distribute your content (`blacklist`). If the type is specified as `none` an empty array can be used.
+* `restriction_type` (Required) - Method that you want to use to restrict distribution of your content by country: `none`, `whitelist`, or `blacklist`.
 
 #### Viewer Certificate Arguments
 
-* `acm_certificate_arn` - The ARN of the [AWS Certificate Manager][6]
-    certificate that you wish to use with this distribution. Specify this,
-    `cloudfront_default_certificate`, or `iam_certificate_id`.  The ACM
-    certificate must be in  US-EAST-1.
-
-* `cloudfront_default_certificate` - `true` if you want viewers to use HTTPS
-    to request your objects and you're using the CloudFront domain name for your
-    distribution. Specify this, `acm_certificate_arn`, or `iam_certificate_id`.
-
-* `iam_certificate_id` - The IAM certificate identifier of the custom viewer
-    certificate for this distribution if you are using a custom domain. Specify
-    this, `acm_certificate_arn`, or `cloudfront_default_certificate`.
-
-* `minimum_protocol_version` - The minimum version of the SSL protocol that
-    you want CloudFront to use for HTTPS connections. Can only be set if
-    `cloudfront_default_certificate = false`. See all possible values in
-    [this](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html)
-    table under "Security policy." Some examples include: `TLSv1.2_2019` and
-    `TLSv1.2_2021`. Default: `TLSv1`. **NOTE**:
-    If you are using a custom certificate (specified with `acm_certificate_arn`
-    or `iam_certificate_id`), and have specified `sni-only` in
-    `ssl_support_method`, `TLSv1` or later must be specified. If you have
-    specified `vip` in `ssl_support_method`, only `SSLv3` or `TLSv1` can be
-    specified. If you have specified `cloudfront_default_certificate`, `TLSv1`
-    must be specified.
-
-* `ssl_support_method`: Specifies how you want CloudFront to serve HTTPS
-    requests. One of `vip` or `sni-only`. Required if you specify
-    `acm_certificate_arn` or `iam_certificate_id`. **NOTE:** `vip` causes
-    CloudFront to use a dedicated IP address and may incur extra charges.
+* `acm_certificate_arn` - ARN of the [AWS Certificate Manager][6] certificate that you wish to use with this distribution. Specify this, `cloudfront_default_certificate`, or `iam_certificate_id`.  The ACM certificate must be in  US-EAST-1.
+* `cloudfront_default_certificate` - `true` if you want viewers to use HTTPS to request your objects and you're using the CloudFront domain name for your distribution. Specify this, `acm_certificate_arn`, or `iam_certificate_id`.
+* `iam_certificate_id` - IAM certificate identifier of the custom viewer certificate for this distribution if you are using a custom domain. Specify this, `acm_certificate_arn`, or `cloudfront_default_certificate`.
+* `minimum_protocol_version` - Minimum version of the SSL protocol that you want CloudFront to use for HTTPS connections. Can only be set if `cloudfront_default_certificate = false`. See all possible values in [this](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html) table under "Security policy." Some examples include: `TLSv1.2_2019` and `TLSv1.2_2021`. Default: `TLSv1`. **NOTE**: If you are using a custom certificate (specified with `acm_certificate_arn` or `iam_certificate_id`), and have specified `sni-only` in `ssl_support_method`, `TLSv1` or later must be specified. If you have specified `vip` in `ssl_support_method`, only `SSLv3` or `TLSv1` can be specified. If you have specified `cloudfront_default_certificate`, `TLSv1` must be specified.
+* `ssl_support_method`: Specifies how you want CloudFront to serve HTTPS requests. One of `vip` or `sni-only`. Required if you specify `acm_certificate_arn` or `iam_certificate_id`. **NOTE:** `vip` causes CloudFront to use a dedicated IP address and may incur extra charges.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The identifier for the distribution. For example: `EDFDVBD632BHDS5`.
-
-* `arn` - The ARN (Amazon Resource Name) for the distribution. For example: `arn:aws:cloudfront::123456789012:distribution/EDFDVBD632BHDS5`, where `123456789012` is your AWS account ID.
-
-* `caller_reference` - Internal value used by CloudFront to allow future
-    updates to the distribution configuration.
-
-* `status` - The current status of the distribution. `Deployed` if the
-    distribution's information is fully propagated throughout the Amazon
-    CloudFront system.
-
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
-
-* `trusted_key_groups` - List of nested attributes for active trusted key groups, if the distribution is set up to serve private content with signed URLs
-    * `enabled` - `true` if any of the key groups have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies
-    * `items` - List of nested attributes for each key group
-        * `key_group_id` - The ID of the key group that contains the public keys
-        * `key_pair_ids` - Set of CloudFront key pair IDs
-
-* `trusted_signers` - List of nested attributes for active trusted signers, if the distribution is set up to serve private content with signed URLs
+* `id` - Identifier for the distribution. For example: `EDFDVBD632BHDS5`.
+* `arn` - ARN for the distribution. For example: `arn:aws:cloudfront::123456789012:distribution/EDFDVBD632BHDS5`, where `123456789012` is your AWS account ID.
+* `caller_reference` - Internal value used by CloudFront to allow future updates to the distribution configuration.
+* `status` - Current status of the distribution. `Deployed` if the distribution's information is fully propagated throughout the Amazon CloudFront system.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+* `trusted_key_groups` - List of nested attributes for active trusted key groups, if the distribution is set up to serve private content with signed URLs.
+    * `enabled` - `true` if any of the key groups have public keys that CloudFront can use to verify the signatures of signed URLs and signed cookies.
+    * `items` - List of nested attributes for each key group.
+        * `key_group_id` - ID of the key group that contains the public keys.
+        * `key_pair_ids` - Set of CloudFront key pair IDs.
+* `trusted_signers` - List of nested attributes for active trusted signers, if the distribution is set up to serve private content with signed URLs.
     * `enabled` - `true` if any of the AWS accounts listed as trusted signers have active CloudFront key pairs
     * `items` - List of nested attributes for each trusted signer
         * `aws_account_number` - AWS account ID or `self`
         * `key_pair_ids` - Set of active CloudFront key pairs associated with the signer account
-
-* `domain_name` - The domain name corresponding to the distribution. For
-    example: `d604721fxaaqy9.cloudfront.net`.
-
-* `last_modified_time` - The date and time the distribution was last modified.
-
-* `in_progress_validation_batches` - The number of invalidation batches
-    currently in progress.
-
-* `etag` - The current version of the distribution's information. For example:
-    `E2QWRUHAPOMQZL`.
-
-* `hosted_zone_id` - The CloudFront Route 53 zone ID that can be used to
-     route an [Alias Resource Record Set][7] to. This attribute is simply an
-     alias for the zone ID `Z2FDTNDATAQYW2`.
+* `domain_name` - Domain name corresponding to the distribution. For example: `d604721fxaaqy9.cloudfront.net`.
+* `last_modified_time` - Date and time the distribution was last modified.
+* `in_progress_validation_batches` - Number of invalidation batches currently in progress.
+* `etag` - Current version of the distribution's information. For example: `E2QWRUHAPOMQZL`.
+* `hosted_zone_id` - CloudFront Route 53 zone ID that can be used to route an [Alias Resource Record Set][7] to. This attribute is simply an alias for the zone ID `Z2FDTNDATAQYW2`.
 
 [1]: http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Introduction.html
 [2]: https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateDistribution.html

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -285,7 +285,7 @@ of several sub-resources - these resources are laid out below.
 
 * `field_level_encryption_id` (Optional) - Field level encryption configuration ID
 
-* `forwarded_values` (Optional) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront
+* `forwarded_values` (Optional **Deprecated** use `cache_policy_id` or `origin_request_policy_id ` instead) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront
     `forwarded_values` must be set. Note, AWS recommend that you use a cache policy or an 
     origin request policy instead of this field.
 

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -273,7 +273,7 @@ of several sub-resources - these resources are laid out below.
     response to requests using the specified HTTP methods.
 
 * `cache_policy_id` (Optional) - The unique identifier of the cache policy that
-    is attached to the cache behavior. Either [`cache_policy_id` and optional `origin_request_policy_id`] or
+    is attached to the cache behavior. If configuring the `default_cache_behavior` either `cache_policy_id` or `forwarded_values` must be set.
     `forwarded_values` must be set.
 
 * `compress` (Optional) - Whether you want CloudFront to automatically

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -286,7 +286,6 @@ of several sub-resources - these resources are laid out below.
 * `field_level_encryption_id` (Optional) - Field level encryption configuration ID
 
 * `forwarded_values` (Optional **Deprecated** use `cache_policy_id` or `origin_request_policy_id ` instead) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront
-    origin request policy instead of this field.
 
 * `lambda_function_association` (Optional) - A [config block](#lambda-function-association) that triggers a lambda
     function with specific actions (maximum 4).

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -285,7 +285,7 @@ of several sub-resources - these resources are laid out below.
 
 * `field_level_encryption_id` (Optional) - Field level encryption configuration ID
 
-* `forwarded_values` (Optional **Deprecated** use `cache_policy_id` or `origin_request_policy_id ` instead) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront
+* `forwarded_values` (Optional **Deprecated** use `cache_policy_id` or `origin_request_policy_id ` instead) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront handles query strings, cookies and headers (maximum one).
 
 * `lambda_function_association` (Optional) - A [config block](#lambda-function-association) that triggers a lambda
     function with specific actions (maximum 4).

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -273,7 +273,7 @@ of several sub-resources - these resources are laid out below.
     response to requests using the specified HTTP methods.
 
 * `cache_policy_id` (Optional) - The unique identifier of the cache policy that
-    is attached to the cache behavior. Either [`cache_policy_id` and or `origin_request_policy_id`] or
+    is attached to the cache behavior. Either [`cache_policy_id` and optional `origin_request_policy_id`] or
     `forwarded_values` must be set.
 
 * `compress` (Optional) - Whether you want CloudFront to automatically
@@ -287,7 +287,7 @@ of several sub-resources - these resources are laid out below.
 * `field_level_encryption_id` (Optional) - Field level encryption configuration ID
 
 * `forwarded_values` (Optional) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront
-    handles query strings, cookies and headers (maximum one). Either [`cache_policy_id` and or `origin_request_policy_id`] or
+    handles query strings, cookies and headers (maximum one). Either [`cache_policy_id` and optional `origin_request_policy_id`] or
     `forwarded_values` must be set. Note, AWS recommend that you use a cache policy or an 
     origin request policy instead of this field.
 
@@ -308,7 +308,7 @@ of several sub-resources - these resources are laid out below.
     whether the object has been updated. Defaults to 0 seconds.
 
 * `origin_request_policy_id` (Optional) - The unique identifier of the origin request policy
-    that is attached to the behavior. Either [`cache_policy_id` and or `origin_request_policy_id`] or
+    that is attached to the behavior. Either [`cache_policy_id` and optional `origin_request_policy_id`] or
     `forwarded_values` must be set.
 
 * `path_pattern` (Required) - The pattern (for example, `images/*.jpg`) that

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -304,7 +304,6 @@ of several sub-resources - these resources are laid out below.
     whether the object has been updated. Defaults to 0 seconds.
 
 * `origin_request_policy_id` (Optional) - The unique identifier of the origin request policy
-    `forwarded_values` must be set.
 
 * `path_pattern` (Required) - The pattern (for example, `images/*.jpg`) that
     specifies which requests you want this cache behavior to apply to.

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -274,7 +274,6 @@ of several sub-resources - these resources are laid out below.
 
 * `cache_policy_id` (Optional) - The unique identifier of the cache policy that
     is attached to the cache behavior. If configuring the `default_cache_behavior` either `cache_policy_id` or `forwarded_values` must be set.
-    `forwarded_values` must be set.
 
 * `compress` (Optional) - Whether you want CloudFront to automatically
     compress content for web requests that include `Accept-Encoding: gzip` in

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -286,7 +286,6 @@ of several sub-resources - these resources are laid out below.
 * `field_level_encryption_id` (Optional) - Field level encryption configuration ID
 
 * `forwarded_values` (Optional **Deprecated** use `cache_policy_id` or `origin_request_policy_id ` instead) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront
-    `forwarded_values` must be set. Note, AWS recommend that you use a cache policy or an 
     origin request policy instead of this field.
 
 * `lambda_function_association` (Optional) - A [config block](#lambda-function-association) that triggers a lambda

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -225,7 +225,7 @@ The CloudFront distribution argument layout is a complex structure composed of s
 * `function_association` (Optional) - A [config block](#function-association) that triggers a cloudfront function with specific actions (maximum 2).
 * `max_ttl` (Optional) - Maximum amount of time (in seconds) that an object is in a CloudFront cache before CloudFront forwards another request to your origin to determine whether the object has been updated. Only effective in the presence of `Cache-Control max-age`, `Cache-Control s-maxage`, and `Expires` headers.
 * `min_ttl` (Optional) - Minimum amount of time that you want objects to stay in CloudFront caches before CloudFront queries your origin to see whether the object has been updated. Defaults to 0 seconds.
-* `origin_request_policy_id` (Optional) - Unique identifier of the origin request policy.
+* `origin_request_policy_id` (Optional) - Unique identifier of the origin request policy that is attached to the behavior.
 * `path_pattern` (Required) - Pattern (for example, `images/*.jpg`) that specifies which requests you want this cache behavior to apply to.
 * `realtime_log_config_arn` (Optional) - ARN of the [real-time log configuration](cloudfront_realtime_log_config.html) that is attached to this cache behavior.
 * `response_headers_policy_id` (Optional) - Identifier for a response headers policy.
@@ -233,10 +233,8 @@ The CloudFront distribution argument layout is a complex structure composed of s
 * `target_origin_id` (Required) - Value of ID for the origin that you want CloudFront to route requests to when a request matches the path pattern either for a cache behavior or for the default cache behavior.
 * `trusted_key_groups` (Optional) - List of key group IDs that CloudFront can use to validate signed URLs or signed cookies.
 See the [CloudFront User Guide](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html) for more information about this feature.
-
 * `trusted_signers` (Optional) - List of AWS account IDs (or `self`) that you want to allow to create signed URLs for private content.
 See the [CloudFront User Guide](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html) for more information about this feature.
-
 * `viewer_protocol_policy` (Required) - Use this element to specify the protocol that users can use to access the files in the origin specified by TargetOriginId when a request matches the path pattern in PathPattern. One of `allow-all`, `https-only`, or `redirect-to-https`.
 
 ##### Forwarded Values Arguments

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -273,7 +273,8 @@ of several sub-resources - these resources are laid out below.
     response to requests using the specified HTTP methods.
 
 * `cache_policy_id` (Optional) - The unique identifier of the cache policy that
-    is attached to the cache behavior.
+    is attached to the cache behavior. Either [`cache_policy_id` and or `origin_request_policy_id`] or
+    `forwarded_values` must be set.
 
 * `compress` (Optional) - Whether you want CloudFront to automatically
     compress content for web requests that include `Accept-Encoding: gzip` in
@@ -286,7 +287,9 @@ of several sub-resources - these resources are laid out below.
 * `field_level_encryption_id` (Optional) - Field level encryption configuration ID
 
 * `forwarded_values` (Optional) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront
-    handles query strings, cookies and headers (maximum one).
+    handles query strings, cookies and headers (maximum one). Either [`cache_policy_id` and or `origin_request_policy_id`] or
+    `forwarded_values` must be set. Note, AWS recommend that you use a cache policy or an 
+    origin request policy instead of this field.
 
 * `lambda_function_association` (Optional) - A [config block](#lambda-function-association) that triggers a lambda
     function with specific actions (maximum 4).
@@ -305,7 +308,8 @@ of several sub-resources - these resources are laid out below.
     whether the object has been updated. Defaults to 0 seconds.
 
 * `origin_request_policy_id` (Optional) - The unique identifier of the origin request policy
-    that is attached to the behavior.
+    that is attached to the behavior. Either [`cache_policy_id` and or `origin_request_policy_id`] or
+    `forwarded_values` must be set.
 
 * `path_pattern` (Required) - The pattern (for example, `images/*.jpg`) that
     specifies which requests you want this cache behavior to apply to.

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -304,7 +304,6 @@ of several sub-resources - these resources are laid out below.
     whether the object has been updated. Defaults to 0 seconds.
 
 * `origin_request_policy_id` (Optional) - The unique identifier of the origin request policy
-    that is attached to the behavior. Either [`cache_policy_id` and optional `origin_request_policy_id`] or
     `forwarded_values` must be set.
 
 * `path_pattern` (Required) - The pattern (for example, `images/*.jpg`) that

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -286,7 +286,6 @@ of several sub-resources - these resources are laid out below.
 * `field_level_encryption_id` (Optional) - Field level encryption configuration ID
 
 * `forwarded_values` (Optional) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront
-    handles query strings, cookies and headers (maximum one). Either [`cache_policy_id` and optional `origin_request_policy_id`] or
     `forwarded_values` must be set. Note, AWS recommend that you use a cache policy or an 
     origin request policy instead of this field.
 

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -231,10 +231,8 @@ The CloudFront distribution argument layout is a complex structure composed of s
 * `response_headers_policy_id` (Optional) - Identifier for a response headers policy.
 * `smooth_streaming` (Optional) - Indicates whether you want to distribute media files in Microsoft Smooth Streaming format using the origin that is associated with this cache behavior.
 * `target_origin_id` (Required) - Value of ID for the origin that you want CloudFront to route requests to when a request matches the path pattern either for a cache behavior or for the default cache behavior.
-* `trusted_key_groups` (Optional) - List of key group IDs that CloudFront can use to validate signed URLs or signed cookies.
-See the [CloudFront User Guide](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html) for more information about this feature.
-* `trusted_signers` (Optional) - List of AWS account IDs (or `self`) that you want to allow to create signed URLs for private content.
-See the [CloudFront User Guide](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html) for more information about this feature.
+* `trusted_key_groups` (Optional) - List of key group IDs that CloudFront can use to validate signed URLs or signed cookies. See the [CloudFront User Guide](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html) for more information about this feature.
+* `trusted_signers` (Optional) - List of AWS account IDs (or `self`) that you want to allow to create signed URLs for private content. See the [CloudFront User Guide](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html) for more information about this feature.
 * `viewer_protocol_policy` (Required) - Use this element to specify the protocol that users can use to access the files in the origin specified by TargetOriginId when a request matches the path pattern in PathPattern. One of `allow-all`, `https-only`, or `redirect-to-https`.
 
 ##### Forwarded Values Arguments
@@ -321,8 +319,8 @@ argument should not be specified.
 #### Logging Config Arguments
 
 * `bucket` (Required) - Amazon S3 bucket to store the access logs in, for example, `myawslogbucket.s3.amazonaws.com`.
-* `include_cookies` (Optional) - Specifies whether you want CloudFront to include cookies in access logs (default: `false`).
-* `prefix` (Optional) - Optional string that you want CloudFront to prefix to the access log filenames for this distribution, for example, `myprefix/`.
+* `include_cookies` (Optional) - Whether to include cookies in access logs (default: `false`).
+* `prefix` (Optional) - Prefix to the access log filenames for this distribution, for example, `myprefix/`.
 
 #### Origin Arguments
 
@@ -348,7 +346,7 @@ argument should not be specified.
 
 ##### Origin Shield Arguments
 
-* `enabled` (Required) - Flag that specifies whether Origin Shield is enabled.
+* `enabled` (Required) - Whether Origin Shield is enabled.
 * `origin_shield_region` (Required) - AWS Region for Origin Shield. To specify a region, use the region code, not the region name. For example, specify the US East (Ohio) region as us-east-2.
 
 ##### S3 Origin Config Arguments
@@ -371,8 +369,7 @@ argument should not be specified.
 
 #### Restrictions Arguments
 
-The `restrictions` sub-resource takes another single sub-resource named
-`geo_restriction` (see the example for usage).
+The `restrictions` sub-resource takes another single sub-resource named `geo_restriction` (see the example for usage).
 
 The arguments of `geo_restriction` are:
 
@@ -385,7 +382,7 @@ The arguments of `geo_restriction` are:
 * `cloudfront_default_certificate` - `true` if you want viewers to use HTTPS to request your objects and you're using the CloudFront domain name for your distribution. Specify this, `acm_certificate_arn`, or `iam_certificate_id`.
 * `iam_certificate_id` - IAM certificate identifier of the custom viewer certificate for this distribution if you are using a custom domain. Specify this, `acm_certificate_arn`, or `cloudfront_default_certificate`.
 * `minimum_protocol_version` - Minimum version of the SSL protocol that you want CloudFront to use for HTTPS connections. Can only be set if `cloudfront_default_certificate = false`. See all possible values in [this](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html) table under "Security policy." Some examples include: `TLSv1.2_2019` and `TLSv1.2_2021`. Default: `TLSv1`. **NOTE**: If you are using a custom certificate (specified with `acm_certificate_arn` or `iam_certificate_id`), and have specified `sni-only` in `ssl_support_method`, `TLSv1` or later must be specified. If you have specified `vip` in `ssl_support_method`, only `SSLv3` or `TLSv1` can be specified. If you have specified `cloudfront_default_certificate`, `TLSv1` must be specified.
-* `ssl_support_method`: Specifies how you want CloudFront to serve HTTPS requests. One of `vip` or `sni-only`. Required if you specify `acm_certificate_arn` or `iam_certificate_id`. **NOTE:** `vip` causes CloudFront to use a dedicated IP address and may incur extra charges.
+* `ssl_support_method` - How you want CloudFront to serve HTTPS requests. One of `vip` or `sni-only`. Required if you specify `acm_certificate_arn` or `iam_certificate_id`. **NOTE:** `vip` causes CloudFront to use a dedicated IP address and may incur extra charges.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
1. [AWS docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-forwardedvalues.html) for ForwardedValues say:

> This field is deprecated. We recommend that you use a cache policy or an origin request policy instead of this field.

Updating docs to mention this recommendation.

2. Current tf docs mark all three fields as optional:

> `cache_policy_id` (Optional)
`forwarded_values` (Optional)
`origin_request_policy_id` (Optional)

But you need to specify `forwarded_values` OR (`origin_request_policy_id` AND OR `cache_policy_id`). 

We wanted caching disabled and incorrectly thought leaving out this optional field would achieve that. So we didn't set any of these three optional fields, however, we then saw this error:

> `InvalidArgument: The parameter ForwardedValues is required.`

Equally if you were to set both forwarded values and cache policy you would see
> ` InvalidArgument: The parameter ForwardedValues cannot be used when a cache policy is associated to the cache behavior.`

Updating docs to try to emphasise this X or (Y or Z) requirement on the optional arguments. (Might be helpful update the `InvalidArgument` error  
but going for small doc change as first step.)

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Couldn't find any open [issues](https://github.com/hashicorp/terraform-provider-aws/issues?q=is%3Aissue+is%3Aopen+cloudfront+distribution+forwarded+values+label%3Aservice%2Fcloudfront) relating to this.


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
