### PR TITLE
New Resource: `aws_auditmanager_organization_admin_account_registration`

### DIFF
--- a/.changelog/29018.txt
+++ b/.changelog/29018.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_auditmanager_organization_admin_account_registration
+```

--- a/docs/acc-test-environment-variables.md
+++ b/docs/acc-test-environment-variables.md
@@ -38,6 +38,7 @@ Environment variables (beyond standard AWS Go SDK ones) used by acceptance testi
 | `APNS_VOIP_TOKEN_KEY_ID` | Identifier for VOIP Apple Push Notification Service Token Key in Pinpoint testing. |
 | `APPRUNNER_CUSTOM_DOMAIN` | A custom domain endpoint (root domain, subdomain, or wildcard) for AppRunner Custom Domain Association testing. |
 | `AUDITMANAGER_DEREGISTER_ACCOUNT_ON_DESTROY` | Flag to execute tests that will disable AuditManager in the account upon destruction. |
+| `AUDITMANAGER_ORGANIZATION_ADMIN_ACCOUNT_ID` | Organization admin account identifier for use in AuditManager testing. |
 | `AWS_ALTERNATE_ACCESS_KEY_ID` | AWS access key ID with access to a secondary AWS account for tests requiring multiple accounts. Requires `AWS_ALTERNATE_SECRET_ACCESS_KEY`. Conflicts with `AWS_ALTERNATE_PROFILE`. |
 | `AWS_ALTERNATE_SECRET_ACCESS_KEY` | AWS secret access key with access to a secondary AWS account for tests requiring multiple accounts. Requires `AWS_ALTERNATE_ACCESS_KEY_ID`. Conflicts with `AWS_ALTERNATE_PROFILE`. |
 | `AWS_ALTERNATE_PROFILE` | AWS profile with access to a secondary AWS account for tests requiring multiple accounts. Conflicts with `AWS_ALTERNATE_ACCESS_KEY_ID` and `AWS_ALTERNATE_SECRET_ACCESS_KEY`. |

--- a/internal/service/auditmanager/exports_test.go
+++ b/internal/service/auditmanager/exports_test.go
@@ -2,9 +2,10 @@ package auditmanager
 
 // Exports for use in tests only.
 var (
-	ResourceAccountRegistration = newResourceAccountRegistration
-	ResourceAssessment          = newResourceAssessment
-	ResourceAssessmentReport    = newResourceAssessmentReport
-	ResourceControl             = newResourceControl
-	ResourceFramework           = newResourceFramework
+	ResourceAccountRegistration                  = newResourceAccountRegistration
+	ResourceOrganizationAdminAccountRegistration = newResourceOrganizationAdminAccountRegistration
+	ResourceAssessment                           = newResourceAssessment
+	ResourceAssessmentReport                     = newResourceAssessmentReport
+	ResourceControl                              = newResourceControl
+	ResourceFramework                            = newResourceFramework
 )

--- a/internal/service/auditmanager/organization_admin_account_registration.go
+++ b/internal/service/auditmanager/organization_admin_account_registration.go
@@ -1,0 +1,146 @@
+package auditmanager
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/auditmanager"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func init() {
+	_sp.registerFrameworkResourceFactory(newResourceOrganizationAdminAccountRegistration)
+}
+
+func newResourceOrganizationAdminAccountRegistration(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceOrganizationAdminAccountRegistration{}, nil
+}
+
+const (
+	ResNameOrganizationAdminAccountRegistration = "OrganizationAdminAccountRegistration"
+)
+
+type resourceOrganizationAdminAccountRegistration struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceOrganizationAdminAccountRegistration) Metadata(_ context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = "aws_auditmanager_organization_admin_account_registration"
+}
+
+func (r *resourceOrganizationAdminAccountRegistration) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"admin_account_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"id": framework.IDAttribute(),
+			"organization_id": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+	}
+}
+
+func (r *resourceOrganizationAdminAccountRegistration) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().AuditManagerClient()
+
+	var plan resourceOrganizationAdminAccountRegistrationData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := auditmanager.RegisterOrganizationAdminAccountInput{
+		AdminAccountId: aws.String(plan.AdminAccountID.ValueString()),
+	}
+	out, err := conn.RegisterOrganizationAdminAccount(ctx, &in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.AuditManager, create.ErrActionCreating, ResNameOrganizationAdminAccountRegistration, plan.AdminAccountID.String(), nil),
+			err.Error(),
+		)
+		return
+	}
+
+	state := plan
+	state.AdminAccountID = flex.StringToFramework(ctx, out.AdminAccountId)
+	state.ID = flex.StringToFramework(ctx, out.AdminAccountId)
+	state.OrganizationID = flex.StringToFramework(ctx, out.OrganizationId)
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}
+
+func (r *resourceOrganizationAdminAccountRegistration) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().AuditManagerClient()
+
+	var state resourceOrganizationAdminAccountRegistrationData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := conn.GetOrganizationAdminAccount(ctx, &auditmanager.GetOrganizationAdminAccountInput{})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.AuditManager, create.ErrActionReading, ResNameOrganizationAdminAccountRegistration, state.ID.String(), nil),
+			err.Error(),
+		)
+		return
+	}
+	if out.AdminAccountId == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	state.AdminAccountID = flex.StringToFramework(ctx, out.AdminAccountId)
+	state.ID = flex.StringToFramework(ctx, out.AdminAccountId)
+	state.OrganizationID = flex.StringToFramework(ctx, out.OrganizationId)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// Update is a no-op. Changing admin accounts requires the existing admin to
+// be deregisterd first (destroy and replace).
+func (r *resourceOrganizationAdminAccountRegistration) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+}
+
+func (r *resourceOrganizationAdminAccountRegistration) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().AuditManagerClient()
+
+	var state resourceOrganizationAdminAccountRegistrationData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := conn.DeregisterOrganizationAdminAccount(ctx, &auditmanager.DeregisterOrganizationAdminAccountInput{
+		AdminAccountId: aws.String(state.AdminAccountID.ValueString()),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.AuditManager, create.ErrActionDeleting, ResNameOrganizationAdminAccountRegistration, state.ID.String(), nil),
+			err.Error(),
+		)
+	}
+}
+
+func (r *resourceOrganizationAdminAccountRegistration) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+type resourceOrganizationAdminAccountRegistrationData struct {
+	AdminAccountID types.String `tfsdk:"admin_account_id"`
+	ID             types.String `tfsdk:"id"`
+	OrganizationID types.String `tfsdk:"organization_id"`
+}

--- a/internal/service/auditmanager/organization_admin_account_registration_test.go
+++ b/internal/service/auditmanager/organization_admin_account_registration_test.go
@@ -1,0 +1,145 @@
+package auditmanager_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/auditmanager"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfauditmanager "github.com/hashicorp/terraform-provider-aws/internal/service/auditmanager"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccAuditManagerOrganizationAdminAccountRegistration_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]func(t *testing.T){
+		"basic":      testAccOrganizationAdminAccountRegistration_basic,
+		"disappears": testAccOrganizationAdminAccountRegistration_disappears,
+	}
+
+	acctest.RunSerialTests1Level(t, testCases, 0)
+}
+
+func testAccOrganizationAdminAccountRegistration_basic(t *testing.T) {
+	adminAccountID := os.Getenv("AUDITMANAGER_ORGANIZATION_ADMIN_ACCOUNT_ID")
+	if adminAccountID == "" {
+		t.Skip("Environment variable AUDITMANAGER_ORGANIZATION_ADMIN_ACCOUNT_ID is not set")
+	}
+
+	resourceName := "aws_auditmanager_organization_admin_account_registration.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.AuditManagerEndpointID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AuditManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOrganizationAdminAccountRegistrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOrganizationAdminAccountRegistrationConfig_basic(adminAccountID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOrganizationAdminAccountRegistrationExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccOrganizationAdminAccountRegistration_disappears(t *testing.T) {
+	adminAccountID := os.Getenv("AUDITMANAGER_ORGANIZATION_ADMIN_ACCOUNT_ID")
+	if adminAccountID == "" {
+		t.Skip("Environment variable AUDITMANAGER_ORGANIZATION_ADMIN_ACCOUNT_ID is not set")
+	}
+
+	resourceName := "aws_auditmanager_organization_admin_account_registration.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.AuditManagerEndpointID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AuditManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOrganizationAdminAccountRegistrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOrganizationAdminAccountRegistrationConfig_basic(adminAccountID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOrganizationAdminAccountRegistrationExists(resourceName),
+					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfauditmanager.ResourceOrganizationAdminAccountRegistration, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckOrganizationAdminAccountRegistrationDestroy(s *terraform.State) error {
+	ctx := context.Background()
+	conn := acctest.Provider.Meta().(*conns.AWSClient).AuditManagerClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_auditmanager_organization_admin_account_registration" {
+			continue
+		}
+
+		out, err := conn.GetOrganizationAdminAccount(ctx, &auditmanager.GetOrganizationAdminAccountInput{})
+		if err != nil {
+			return err
+		}
+		if out.AdminAccountId != nil {
+			return create.Error(names.AuditManager, create.ErrActionCheckingDestroyed, tfauditmanager.ResNameOrganizationAdminAccountRegistration, rs.Primary.ID, errors.New("not destroyed"))
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckOrganizationAdminAccountRegistrationExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.AuditManager, create.ErrActionCheckingExistence, tfauditmanager.ResNameOrganizationAdminAccountRegistration, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.AuditManager, create.ErrActionCheckingExistence, tfauditmanager.ResNameOrganizationAdminAccountRegistration, name, errors.New("not set"))
+		}
+
+		ctx := context.Background()
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AuditManagerClient()
+		out, err := conn.GetOrganizationAdminAccount(ctx, &auditmanager.GetOrganizationAdminAccountInput{})
+		if err != nil {
+			return create.Error(names.AuditManager, create.ErrActionCheckingExistence, tfauditmanager.ResNameOrganizationAdminAccountRegistration, rs.Primary.ID, err)
+		}
+		if out == nil || aws.ToString(out.AdminAccountId) != rs.Primary.ID {
+			return create.Error(names.AuditManager, create.ErrActionCheckingExistence, tfauditmanager.ResNameOrganizationAdminAccountRegistration, rs.Primary.ID, errors.New("unexpected admin account ID"))
+		}
+
+		return nil
+	}
+}
+
+func testAccOrganizationAdminAccountRegistrationConfig_basic(adminAccountID string) string {
+	return fmt.Sprintf(`
+resource "aws_auditmanager_organization_admin_account_registration" "test" {
+  admin_account_id = %[1]q
+}
+`, adminAccountID)
+}

--- a/website/docs/r/auditmanager_organization_admin_account_registration.html.markdown
+++ b/website/docs/r/auditmanager_organization_admin_account_registration.html.markdown
@@ -1,0 +1,42 @@
+---
+subcategory: "Audit Manager"
+layout: "aws"
+page_title: "AWS: aws_auditmanager_organization_admin_account_registration"
+description: |-
+  Terraform resource for managing AWS Audit Manager Organization Admin Account Registration.
+---
+
+# Resource: aws_auditmanager_organization_admin_account_registration
+
+Terraform resource for managing AWS Audit Manager Organization Admin Account Registration.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_auditmanager_organization_admin_account_registration" "example" {
+  admin_account_id = "012345678901"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `admin_account_id` - (Required) Identifier for the organization administrator account.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Identifier for the organization administrator account.
+* `organization_id` - Identifier for the organization.
+
+## Import
+
+Audit Manager Organization Admin Account Registration can be imported using the `id`, e.g.,
+
+```
+$ terraform import aws_auditmanager_organization_admin_account_registration.example 012345678901 
+```


### PR DESCRIPTION
### Description
The `aws_auditmanager_organization_admin_account_registration` resource will allow practitioners to manage their organizations assigned AuditManager admin account via terraform.


### Relations

Relates #17981 



### Output from Acceptance Testing

> Note: Testing must be done in an account under an organization with at least two accounts so the `AUDITMANAGER_ORGANIZATION_ADMIN_ACCOUNT_ID` can be set.

```console
$ AUDITMANAGER_ORGANIZATION_ADMIN_ACCOUNT_ID=012345678901 make testacc PKG=auditmanager TESTS=TestAccAuditManagerOrganizationAdminAccountRegistration_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/auditmanager/... -v -count 1 -parallel 20 -run='TestAccAuditManagerOrganizationAdminAccountRegistration_'  -timeout 180m
=== RUN   TestAccAuditManagerOrganizationAdminAccountRegistration_serial
=== PAUSE TestAccAuditManagerOrganizationAdminAccountRegistration_serial
=== CONT  TestAccAuditManagerOrganizationAdminAccountRegistration_serial
=== RUN   TestAccAuditManagerOrganizationAdminAccountRegistration_serial/basic
=== RUN   TestAccAuditManagerOrganizationAdminAccountRegistration_serial/disappears
--- PASS: TestAccAuditManagerOrganizationAdminAccountRegistration_serial (29.31s)
    --- PASS: TestAccAuditManagerOrganizationAdminAccountRegistration_serial/basic (16.89s)
    --- PASS: TestAccAuditManagerOrganizationAdminAccountRegistration_serial/disappears (12.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/auditmanager       32.215s
```
