### PR TITLE
Renames `tfresource.Retry...Context` and `tfresource.WaitUntilContext` functions

### DIFF
--- a/.ci/.semgrep.yml
+++ b/.ci/.semgrep.yml
@@ -469,7 +469,7 @@ rules:
 
   - id: helper-schema-TimeoutError-check-doesnt-return-output
     languages: [go]
-    message: If the resource.Retry(), resource.RetryContext(), or tfresource.RetryContext() function returns a value, ensure the isResourceTimeoutError() check does as well
+    message: If the resource.Retry(), resource.RetryContext(), or tfresource.Retry() function returns a value, ensure the isResourceTimeoutError() check does as well
     paths:
       exclude:
         - "*_test.go"
@@ -499,7 +499,7 @@ rules:
                   ...
                   if isResourceTimeoutError($ERR) { ... }
               - pattern-not-inside: |
-                  $ERR = tfresource.RetryContext(..., func() *resource.RetryError {
+                  $ERR = tfresource.Retry(..., func() *resource.RetryError {
                     ...
                     _, $ERR2 = $CONN.$FUNC(...)
                     ...
@@ -528,7 +528,7 @@ rules:
                   ...
                   if tfresource.TimedOut($ERR) { ... }
               - pattern-not-inside: |
-                  $ERR = tfresource.RetryContext(..., func() *resource.RetryError {
+                  $ERR = tfresource.Retry(..., func() *resource.RetryError {
                     ...
                     _, $ERR2 = $CONN.$FUNC(...)
                     ...

--- a/.ci/semgrep/migrate/context.yml
+++ b/.ci/semgrep/migrate/context.yml
@@ -53,9 +53,6 @@ rules:
       - pattern-either:
           - pattern: $X.WaitForState()
           - pattern: resource.Retry()
-          - pattern: tfresource.RetryUntilNotFound(...)
-          - pattern: tfresource.RetryWhenNotFound(...)
-          - pattern: tfresource.RetryWhenNewResourceNotFound(...)
           - pattern: tfresource.WaitUntil(...)
     severity: WARNING
   - id: context-todo

--- a/.ci/semgrep/migrate/context.yml
+++ b/.ci/semgrep/migrate/context.yml
@@ -53,7 +53,6 @@ rules:
       - pattern-either:
           - pattern: $X.WaitForState()
           - pattern: resource.Retry()
-          - pattern: tfresource.WaitUntil(...)
     severity: WARNING
   - id: context-todo
     languages: [go]

--- a/.ci/semgrep/migrate/context.yml
+++ b/.ci/semgrep/migrate/context.yml
@@ -53,7 +53,6 @@ rules:
       - pattern-either:
           - pattern: $X.WaitForState()
           - pattern: resource.Retry()
-          - pattern: tfresource.RetryWhen(...)
           - pattern: tfresource.RetryWhenAWSErrCodeEquals(...)
           - pattern: tfresource.RetryWhenAWSErrMessageContains(...)
           - pattern: tfresource.RetryUntilNotFound(...)

--- a/.ci/semgrep/migrate/context.yml
+++ b/.ci/semgrep/migrate/context.yml
@@ -53,7 +53,6 @@ rules:
       - pattern-either:
           - pattern: $X.WaitForState()
           - pattern: resource.Retry()
-          - pattern: tfresource.RetryWhenAWSErrMessageContains(...)
           - pattern: tfresource.RetryUntilNotFound(...)
           - pattern: tfresource.RetryWhenNotFound(...)
           - pattern: tfresource.RetryWhenNewResourceNotFound(...)

--- a/.ci/semgrep/migrate/context.yml
+++ b/.ci/semgrep/migrate/context.yml
@@ -53,7 +53,6 @@ rules:
       - pattern-either:
           - pattern: $X.WaitForState()
           - pattern: resource.Retry()
-          - pattern: tfresource.RetryWhenAWSErrCodeEquals(...)
           - pattern: tfresource.RetryWhenAWSErrMessageContains(...)
           - pattern: tfresource.RetryUntilNotFound(...)
           - pattern: tfresource.RetryWhenNotFound(...)

--- a/internal/service/acm/certificate.go
+++ b/internal/service/acm/certificate.go
@@ -560,7 +560,7 @@ func resourceCertificateDelete(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).ACMConn()
 
 	log.Printf("[INFO] Deleting ACM Certificate: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, certificateCrossServicePropagationTimeout,
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, certificateCrossServicePropagationTimeout,
 		func() (interface{}, error) {
 			return conn.DeleteCertificateWithContext(ctx, &acm.DeleteCertificateInput{
 				CertificateArn: aws.String(d.Id()),

--- a/internal/service/apigateway/method_response.go
+++ b/internal/service/apigateway/method_response.go
@@ -109,7 +109,7 @@ func resourceMethodResponseCreate(ctx context.Context, d *schema.ResourceData, m
 	resourceMethodResponseMutex.Lock()
 	defer resourceMethodResponseMutex.Unlock()
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.PutMethodResponseWithContext(ctx, &apigateway.PutMethodResponseInput{
 			HttpMethod:         aws.String(d.Get("http_method").(string)),
 			ResourceId:         aws.String(d.Get("resource_id").(string)),

--- a/internal/service/appautoscaling/target.go
+++ b/internal/service/appautoscaling/target.go
@@ -111,7 +111,7 @@ func resourceTargetRead(ctx context.Context, d *schema.ResourceData, meta interf
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppAutoScalingConn()
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, 2*time.Minute,
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, 2*time.Minute,
 		func() (interface{}, error) {
 			return FindTargetByThreePartKey(ctx, conn, d.Id(), d.Get("service_namespace").(string), d.Get("scalable_dimension").(string))
 		},

--- a/internal/service/appautoscaling/target.go
+++ b/internal/service/appautoscaling/target.go
@@ -161,7 +161,7 @@ func resourceTargetDelete(ctx context.Context, d *schema.ResourceData, meta inte
 		return sdkdiag.AppendErrorf(diags, "deleting Application AutoScaling Target (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFoundContext(ctx, 5*time.Minute, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, 5*time.Minute, func() (interface{}, error) {
 		return FindTargetByThreePartKey(ctx, conn, d.Id(), d.Get("service_namespace").(string), d.Get("scalable_dimension").(string))
 	})
 

--- a/internal/service/appstream/image_builder.go
+++ b/internal/service/appstream/image_builder.go
@@ -227,7 +227,7 @@ func resourceImageBuilderCreate(ctx context.Context, d *schema.ResourceData, met
 		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
-	outputRaw, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, iamPropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, iamPropagationTimeout, func() (interface{}, error) {
 		return conn.CreateImageBuilderWithContext(ctx, input)
 	}, appstream.ErrCodeInvalidRoleException, "encountered an error because your IAM role")
 

--- a/internal/service/appsync/resolver.go
+++ b/internal/service/appsync/resolver.go
@@ -226,7 +226,7 @@ func resourceResolverCreate(ctx context.Context, d *schema.ResourceData, meta in
 	conns.GlobalMutexKV.Lock(mutexKey)
 	defer conns.GlobalMutexKV.Unlock(mutexKey)
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.CreateResolverWithContext(ctx, input)
 	}, appsync.ErrCodeConcurrentModificationException)
 
@@ -352,7 +352,7 @@ func resourceResolverUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	conns.GlobalMutexKV.Lock(mutexKey)
 	defer conns.GlobalMutexKV.Unlock(mutexKey)
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.UpdateResolverWithContext(ctx, input)
 	}, appsync.ErrCodeConcurrentModificationException)
 
@@ -383,7 +383,7 @@ func resourceResolverDelete(ctx context.Context, d *schema.ResourceData, meta in
 	conns.GlobalMutexKV.Lock(mutexKey)
 	defer conns.GlobalMutexKV.Unlock(mutexKey)
 
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.DeleteResolverWithContext(ctx, input)
 	}, appsync.ErrCodeConcurrentModificationException)
 

--- a/internal/service/auditmanager/assessment.go
+++ b/internal/service/auditmanager/assessment.go
@@ -213,7 +213,7 @@ func (r *resourceAssessment) Create(ctx context.Context, req resource.CreateRequ
 	//   ResourceNotFoundException: The operation tried to access a nonexistent resource. The resource
 	//   might not be specified correctly, or its status might not be active. Check and try again.
 	var out *auditmanager.CreateAssessmentOutput
-	err := tfresource.RetryContext(ctx, iamPropagationTimeout, func() *sdkv2resource.RetryError {
+	err := tfresource.Retry(ctx, iamPropagationTimeout, func() *sdkv2resource.RetryError {
 		var err error
 		out, err = conn.CreateAssessment(ctx, &in)
 		if err != nil {

--- a/internal/service/auditmanager/assessment_report.go
+++ b/internal/service/auditmanager/assessment_report.go
@@ -163,7 +163,7 @@ func (r *resourceAssessmentReport) Delete(ctx context.Context, req resource.Dele
 	// Example:
 	//   ValidationException: The assessment report is currently being generated and can’t be
 	//   deleted. You can only delete assessment reports that are completed or failed
-	err := tfresource.RetryContext(ctx, reportCompletionTimeout, func() *sdkv2resource.RetryError {
+	err := tfresource.Retry(ctx, reportCompletionTimeout, func() *sdkv2resource.RetryError {
 		_, err := conn.DeleteAssessmentReport(ctx, &auditmanager.DeleteAssessmentReportInput{
 			AssessmentId:       aws.String(state.AssessmentID.ValueString()),
 			AssessmentReportId: aws.String(state.ID.ValueString()),

--- a/internal/service/autoscaling/attachment.go
+++ b/internal/service/autoscaling/attachment.go
@@ -62,7 +62,7 @@ func resourceAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta 
 			LoadBalancerNames:    aws.StringSlice([]string{lbName}),
 		}
 
-		_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, d.Timeout(schema.TimeoutCreate),
+		_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, d.Timeout(schema.TimeoutCreate),
 			func() (interface{}, error) {
 				return conn.AttachLoadBalancersWithContext(ctx, input)
 			},
@@ -85,7 +85,7 @@ func resourceAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta 
 			TargetGroupARNs:      aws.StringSlice([]string{targetGroupARN}),
 		}
 
-		_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, d.Timeout(schema.TimeoutCreate),
+		_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, d.Timeout(schema.TimeoutCreate),
 			func() (interface{}, error) {
 				return conn.AttachLoadBalancerTargetGroupsWithContext(ctx, input)
 			},
@@ -147,7 +147,7 @@ func resourceAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta 
 			LoadBalancerNames:    aws.StringSlice([]string{lbName}),
 		}
 
-		_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, d.Timeout(schema.TimeoutCreate),
+		_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, d.Timeout(schema.TimeoutCreate),
 			func() (interface{}, error) {
 				return conn.DetachLoadBalancersWithContext(ctx, input)
 			},
@@ -169,7 +169,7 @@ func resourceAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta 
 			TargetGroupARNs:      aws.StringSlice([]string{targetGroupARN}),
 		}
 
-		_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, d.Timeout(schema.TimeoutCreate),
+		_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, d.Timeout(schema.TimeoutCreate),
 			func() (interface{}, error) {
 				return conn.DetachLoadBalancerTargetGroupsWithContext(ctx, input)
 			},

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -962,7 +962,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		createInput.VPCZoneIdentifier = expandVPCZoneIdentifiers(v.(*schema.Set).List())
 	}
 
-	_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, propagationTimeout,
+	_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.CreateAutoScalingGroupWithContext(ctx, createInput)
 		},
@@ -977,7 +977,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	if twoPhases {
 		for _, input := range expandPutLifecycleHookInputs(asgName, initialLifecycleHooks) {
-			_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, 5*time.Minute,
+			_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, 5*time.Minute,
 				func() (interface{}, error) {
 					return conn.PutLifecycleHookWithContext(ctx, input)
 				},

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -1667,7 +1667,7 @@ func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta inter
 		return sdkdiag.AppendErrorf(diags, "deleting Auto Scaling Group (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFoundContext(ctx, d.Timeout(schema.TimeoutDelete),
+	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete),
 		func() (interface{}, error) {
 			return FindGroupByName(ctx, conn, d.Id())
 		})

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -1650,7 +1650,7 @@ func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	log.Printf("[DEBUG] Deleting Auto Scaling Group: %s", d.Id())
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutDelete),
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete),
 		func() (interface{}, error) {
 			return conn.DeleteAutoScalingGroupWithContext(ctx, &autoscaling.DeleteAutoScalingGroupInput{
 				AutoScalingGroupName: aws.String(d.Id()),
@@ -1739,7 +1739,7 @@ func deleteWarmPool(ctx context.Context, conn *autoscaling.AutoScaling, name str
 	}
 
 	log.Printf("[DEBUG] Deleting Auto Scaling Warm Pool: %s", name)
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, timeout,
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout,
 		func() (interface{}, error) {
 			return conn.DeleteWarmPoolWithContext(ctx, &autoscaling.DeleteWarmPoolInput{
 				AutoScalingGroupName: aws.String(name),

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -3597,7 +3597,7 @@ func cancelInstanceRefresh(ctx context.Context, conn *autoscaling.AutoScaling, n
 func startInstanceRefresh(ctx context.Context, conn *autoscaling.AutoScaling, input *autoscaling.StartInstanceRefreshInput) error {
 	name := aws.StringValue(input.AutoScalingGroupName)
 
-	_, err := tfresource.RetryWhenContext(ctx, instanceRefreshStartedTimeout,
+	_, err := tfresource.RetryWhen(ctx, instanceRefreshStartedTimeout,
 		func() (interface{}, error) {
 			return conn.StartInstanceRefreshWithContext(ctx, input)
 		},

--- a/internal/service/autoscaling/launch_configuration.go
+++ b/internal/service/autoscaling/launch_configuration.go
@@ -541,7 +541,7 @@ func resourceLaunchConfigurationDelete(ctx context.Context, d *schema.ResourceDa
 	conn := meta.(*conns.AWSClient).AutoScalingConn()
 
 	log.Printf("[DEBUG] Deleting Auto Scaling Launch Configuration: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, propagationTimeout,
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.DeleteLaunchConfigurationWithContext(ctx, &autoscaling.DeleteLaunchConfigurationInput{
 				LaunchConfigurationName: aws.String(d.Id()),

--- a/internal/service/autoscaling/launch_configuration.go
+++ b/internal/service/autoscaling/launch_configuration.go
@@ -425,7 +425,7 @@ func resourceLaunchConfigurationCreate(ctx context.Context, d *schema.ResourceDa
 	log.Printf("[DEBUG] Creating Auto Scaling Launch Configuration: %s", input)
 	// IAM profiles can take ~10 seconds to propagate in AWS:
 	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
-	_, err = tfresource.RetryWhenContext(ctx, propagationTimeout,
+	_, err = tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return autoscalingconn.CreateLaunchConfigurationWithContext(ctx, &input)
 		},

--- a/internal/service/autoscaling/lifecycle_hook.go
+++ b/internal/service/autoscaling/lifecycle_hook.go
@@ -76,7 +76,7 @@ func resourceLifecycleHookPut(ctx context.Context, d *schema.ResourceData, meta 
 	name := d.Get("name").(string)
 
 	log.Printf("[INFO] Putting Auto Scaling Lifecycle Hook: %s", input)
-	_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, 5*time.Minute,
+	_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, 5*time.Minute,
 		func() (interface{}, error) {
 			return conn.PutLifecycleHookWithContext(ctx, input)
 		},

--- a/internal/service/backup/framework.go
+++ b/internal/service/backup/framework.go
@@ -235,7 +235,7 @@ func resourceFrameworkUpdate(ctx context.Context, d *schema.ResourceData, meta i
 
 		log.Printf("[DEBUG] Updating Backup Framework: %#v", input)
 
-		_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
 			return conn.UpdateFrameworkWithContext(ctx, input)
 		}, backup.ErrCodeConflictException)
 
@@ -266,7 +266,7 @@ func resourceFrameworkDelete(ctx context.Context, d *schema.ResourceData, meta i
 		FrameworkName: aws.String(d.Id()),
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
 		return conn.DeleteFrameworkWithContext(ctx, input)
 	}, backup.ErrCodeConflictException)
 

--- a/internal/service/budgets/budget_action.go
+++ b/internal/service/budgets/budget_action.go
@@ -230,7 +230,7 @@ func resourceBudgetActionCreate(ctx context.Context, d *schema.ResourceData, met
 		Subscribers:      expandBudgetActionSubscriber(d.Get("subscriber").(*schema.Set)),
 	}
 
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
 		return conn.CreateBudgetActionWithContext(ctx, input)
 	}, budgets.ErrCodeAccessDeniedException)
 

--- a/internal/service/ce/cost_category.go
+++ b/internal/service/ce/cost_category.go
@@ -398,7 +398,7 @@ func resourceCostCategoryCreate(ctx context.Context, d *schema.ResourceData, met
 		input.ResourceTags = Tags(tags.IgnoreAWS())
 	}
 
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutCreate),
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate),
 		func() (interface{}, error) {
 			return conn.CreateCostCategoryDefinitionWithContext(ctx, input)
 		},

--- a/internal/service/cloudformation/stack.go
+++ b/internal/service/cloudformation/stack.go
@@ -188,7 +188,7 @@ func resourceStackCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	log.Printf("[DEBUG] Creating CloudFormation Stack: %s", input)
-	outputRaw, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.CreateStackWithContext(ctx, input)
 		},
@@ -383,7 +383,7 @@ func resourceStackUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	log.Printf("[DEBUG] Updating CloudFormation Stack: %s", input)
-	_, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+	_, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.UpdateStackWithContext(ctx, input)
 		},

--- a/internal/service/cloudformation/stack_set_instance.go
+++ b/internal/service/cloudformation/stack_set_instance.go
@@ -197,7 +197,7 @@ func resourceStackSetInstanceCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	log.Printf("[DEBUG] Creating CloudFormation StackSet Instance: %s", input)
-	_, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+	_, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			input.OperationId = aws.String(resource.UniqueId())
 

--- a/internal/service/codepipeline/codepipeline.go
+++ b/internal/service/codepipeline/codepipeline.go
@@ -229,7 +229,7 @@ func resourcePipelineCreate(ctx context.Context, d *schema.ResourceData, meta in
 		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
-	outputRaw, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
 		return conn.CreatePipelineWithContext(ctx, input)
 	}, codepipeline.ErrCodeInvalidStructureException, "not authorized")
 

--- a/internal/service/cognitoidp/user_pool_client.go
+++ b/internal/service/cognitoidp/user_pool_client.go
@@ -500,7 +500,7 @@ func resourceUserPoolClientUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	log.Printf("[DEBUG] Updating Cognito User Pool Client: %s", params)
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.UpdateUserPoolClientWithContext(ctx, params)
 	}, cognitoidentityprovider.ErrCodeConcurrentModificationException)
 	if err != nil {

--- a/internal/service/comprehend/document_classifier.go
+++ b/internal/service/comprehend/document_classifier.go
@@ -512,7 +512,7 @@ func documentClassifierPublishVersion(ctx context.Context, conn *comprehend.Clie
 	}
 
 	var out *comprehend.CreateDocumentClassifierOutput
-	err := tfresource.RetryContext(ctx, timeout, func() *resource.RetryError {
+	err := tfresource.Retry(ctx, timeout, func() *resource.RetryError {
 		var err error
 		out, err = conn.CreateDocumentClassifier(ctx, in)
 

--- a/internal/service/comprehend/entity_recognizer.go
+++ b/internal/service/comprehend/entity_recognizer.go
@@ -540,7 +540,7 @@ func entityRecognizerPublishVersion(ctx context.Context, conn *comprehend.Client
 	}
 
 	var out *comprehend.CreateEntityRecognizerOutput
-	err := tfresource.RetryContext(ctx, timeout, func() *resource.RetryError {
+	err := tfresource.Retry(ctx, timeout, func() *resource.RetryError {
 		var err error
 		out, err = conn.CreateEntityRecognizer(ctx, in)
 

--- a/internal/service/connect/bot_association.go
+++ b/internal/service/connect/bot_association.go
@@ -97,7 +97,7 @@ func resourceBotAssociationCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 	*/
 
-	_, err := tfresource.RetryWhenContext(ctx, botAssociationCreateTimeout,
+	_, err := tfresource.RetryWhen(ctx, botAssociationCreateTimeout,
 		func() (interface{}, error) {
 			return conn.AssociateBotWithContext(ctx, input)
 		},

--- a/internal/service/datasync/agent.go
+++ b/internal/service/datasync/agent.go
@@ -199,7 +199,7 @@ func resourceAgentCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	d.SetId(aws.StringValue(output.AgentArn))
 
-	_, err = tfresource.RetryWhenNotFoundContext(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
 		return FindAgentByARN(ctx, conn, d.Id())
 	})
 	if err != nil {

--- a/internal/service/directconnect/connection_association.go
+++ b/internal/service/directconnect/connection_association.go
@@ -95,7 +95,7 @@ func deleteConnectionLAGAssociation(ctx context.Context, conn *directconnect.Dir
 		LagId:        aws.String(lagID),
 	}
 
-	_, err := tfresource.RetryWhenContext(ctx, connectionDisassociatedTimeout,
+	_, err := tfresource.RetryWhen(ctx, connectionDisassociatedTimeout,
 		func() (interface{}, error) {
 			return conn.DisassociateConnectionFromLagWithContext(ctx, input)
 		},

--- a/internal/service/dlm/lifecycle_policy.go
+++ b/internal/service/dlm/lifecycle_policy.go
@@ -512,7 +512,7 @@ func resourceLifecyclePolicyCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	log.Printf("[INFO] Creating DLM lifecycle policy: %s", input)
-	out, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	out, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.CreateLifecyclePolicyWithContext(ctx, &input)
 	}, dlm.ErrCodeInvalidRequestException)
 

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -903,7 +903,7 @@ func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta in
 		expandTopLevelConnectionInfo(d, input)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutCreate),
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate),
 		func() (interface{}, error) {
 			return conn.CreateEndpointWithContext(ctx, input)
 		},

--- a/internal/service/ds/directory.go
+++ b/internal/service/ds/directory.go
@@ -438,7 +438,7 @@ func resourceDirectoryDelete(ctx context.Context, d *schema.ResourceData, meta i
 	conn := meta.(*conns.AWSClient).DSConn()
 
 	log.Printf("[DEBUG] Deleting Directory Service Directory: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, directoryApplicationDeauthorizedPropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, directoryApplicationDeauthorizedPropagationTimeout, func() (interface{}, error) {
 		return conn.DeleteDirectoryWithContext(ctx, &directoryservice.DeleteDirectoryInput{
 			DirectoryId: aws.String(d.Id()),
 		})

--- a/internal/service/ds/shared_directory_accepter.go
+++ b/internal/service/ds/shared_directory_accepter.go
@@ -115,7 +115,7 @@ func resourceSharedDirectoryAccepterDelete(ctx context.Context, d *schema.Resour
 	conn := meta.(*conns.AWSClient).DSConn()
 
 	log.Printf("[DEBUG] Deleting Directory Service Directory: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, directoryApplicationDeauthorizedPropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, directoryApplicationDeauthorizedPropagationTimeout, func() (interface{}, error) {
 		return conn.DeleteDirectoryWithContext(ctx, &directoryservice.DeleteDirectoryInput{
 			DirectoryId: aws.String(d.Id()),
 		})

--- a/internal/service/dynamodb/sweep.go
+++ b/internal/service/dynamodb/sweep.go
@@ -168,7 +168,7 @@ func (bs backupSweeper) Delete(ctx context.Context, timeout time.Duration, optFn
 	input := &dynamodb.DeleteBackupInput{
 		BackupArn: bs.arn,
 	}
-	err := tfresource.RetryContext(ctx, timeout, func() *resource.RetryError {
+	err := tfresource.Retry(ctx, timeout, func() *resource.RetryError {
 		_, err := bs.conn.DeleteBackupWithContext(ctx, input)
 		if tfawserr.ErrCodeEquals(err, dynamodb.ErrCodeBackupNotFoundException) {
 			return nil

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -442,7 +442,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 			input.SSESpecificationOverride = expandEncryptAtRestOptions(v.([]interface{}))
 		}
 
-		_, err := tfresource.RetryWhenContext(ctx, createTableTimeout, func() (interface{}, error) {
+		_, err := tfresource.RetryWhen(ctx, createTableTimeout, func() (interface{}, error) {
 			return conn.RestoreTableToPointInTimeWithContext(ctx, input)
 		}, func(err error) (bool, error) {
 			if tfawserr.ErrCodeEquals(err, "ThrottlingException") {
@@ -522,7 +522,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 			input.TableClass = aws.String(v.(string))
 		}
 
-		_, err := tfresource.RetryWhenContext(ctx, createTableTimeout, func() (interface{}, error) {
+		_, err := tfresource.RetryWhen(ctx, createTableTimeout, func() (interface{}, error) {
 			return conn.CreateTableWithContext(ctx, input)
 		}, func(err error) (bool, error) {
 			if tfawserr.ErrCodeEquals(err, "ThrottlingException") {
@@ -1436,7 +1436,7 @@ func deleteTable(ctx context.Context, conn *dynamodb.DynamoDB, tableName string)
 		TableName: aws.String(tableName),
 	}
 
-	_, err := tfresource.RetryWhenContext(ctx, deleteTableTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhen(ctx, deleteTableTimeout, func() (interface{}, error) {
 		return conn.DeleteTableWithContext(ctx, input)
 	}, func(err error) (bool, error) {
 		// Subscriber limit exceeded: Only 10 tables can be created, updated, or deleted simultaneously

--- a/internal/service/ec2/create_tags_gen.go
+++ b/internal/service/ec2/create_tags_gen.go
@@ -28,7 +28,7 @@ func CreateTags(ctx context.Context, conn ec2iface.EC2API, identifier string, ta
 		Tags:      Tags(tags.IgnoreAWS()),
 	}
 
-	_, err := tfresource.RetryWhenNotFoundContext(ctx, eventualConsistencyTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenNotFound(ctx, eventualConsistencyTimeout, func() (interface{}, error) {
 		output, err := conn.CreateTagsWithContext(ctx, input)
 
 		if tfawserr.ErrCodeContains(err, ".NotFound") {

--- a/internal/service/ec2/ebs_snapshot.go
+++ b/internal/service/ec2/ebs_snapshot.go
@@ -136,7 +136,7 @@ func resourceEBSSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	d.SetId(aws.StringValue(outputRaw.(*ec2.Snapshot).SnapshotId))
 
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutCreate),
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate),
 		func() (interface{}, error) {
 			return nil, conn.WaitUntilSnapshotCompletedWithContext(ctx, &ec2.DescribeSnapshotsInput{
 				SnapshotIds: aws.StringSlice([]string{d.Id()}),
@@ -272,7 +272,7 @@ func resourceEBSSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).EC2Conn()
 
 	log.Printf("[INFO] Deleting EBS Snapshot: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
 		return conn.DeleteSnapshotWithContext(ctx, &ec2.DeleteSnapshotInput{
 			SnapshotId: aws.String(d.Id()),
 		})

--- a/internal/service/ec2/ebs_snapshot.go
+++ b/internal/service/ec2/ebs_snapshot.go
@@ -124,7 +124,7 @@ func resourceEBSSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	log.Printf("[DEBUG] Creating EBS Snapshot: %s", input)
-	outputRaw, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, 1*time.Minute,
+	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, 1*time.Minute,
 		func() (interface{}, error) {
 			return conn.CreateSnapshotWithContext(ctx, input)
 		},

--- a/internal/service/ec2/ebs_snapshot_copy.go
+++ b/internal/service/ec2/ebs_snapshot_copy.go
@@ -136,7 +136,7 @@ func resourceEBSSnapshotCopyCreate(ctx context.Context, d *schema.ResourceData, 
 
 	d.SetId(aws.StringValue(output.SnapshotId))
 
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutCreate),
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate),
 		func() (interface{}, error) {
 			return nil, conn.WaitUntilSnapshotCompletedWithContext(ctx, &ec2.DescribeSnapshotsInput{
 				SnapshotIds: aws.StringSlice([]string{d.Id()}),

--- a/internal/service/ec2/ebs_snapshot_create_volume_permission.go
+++ b/internal/service/ec2/ebs_snapshot_create_volume_permission.go
@@ -71,7 +71,7 @@ func resourceSnapshotCreateVolumePermissionCreate(ctx context.Context, d *schema
 
 	d.SetId(id)
 
-	_, err = tfresource.RetryWhenNotFoundContext(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
 		return FindCreateSnapshotCreateVolumePermissionByTwoPartKey(ctx, conn, snapshotID, accountID)
 	})
 

--- a/internal/service/ec2/ebs_snapshot_create_volume_permission.go
+++ b/internal/service/ec2/ebs_snapshot_create_volume_permission.go
@@ -136,7 +136,7 @@ func resourceSnapshotCreateVolumePermissionDelete(ctx context.Context, d *schema
 		return sdkdiag.AppendErrorf(diags, "deleting EBS Snapshot CreateVolumePermission (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFoundContext(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
 		return FindCreateSnapshotCreateVolumePermissionByTwoPartKey(ctx, conn, snapshotID, accountID)
 	})
 

--- a/internal/service/ec2/ebs_snapshot_import.go
+++ b/internal/service/ec2/ebs_snapshot_import.go
@@ -220,7 +220,7 @@ func resourceEBSSnapshotImportCreate(ctx context.Context, d *schema.ResourceData
 		input.RoleName = aws.String(v.(string))
 	}
 
-	outputRaw, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.ImportSnapshotWithContext(ctx, input)
 		},

--- a/internal/service/ec2/ebs_volume.go
+++ b/internal/service/ec2/ebs_volume.go
@@ -313,7 +313,7 @@ func resourceEBSVolumeDelete(ctx context.Context, d *schema.ResourceData, meta i
 
 		snapshotID := aws.StringValue(outputRaw.(*ec2.Snapshot).SnapshotId)
 
-		_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutDelete),
+		_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete),
 			func() (interface{}, error) {
 				return nil, conn.WaitUntilSnapshotCompletedWithContext(ctx, &ec2.DescribeSnapshotsInput{
 					SnapshotIds: aws.StringSlice([]string{snapshotID}),
@@ -327,7 +327,7 @@ func resourceEBSVolumeDelete(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	log.Printf("[DEBUG] Deleting EBS Volume: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutDelete),
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete),
 		func() (interface{}, error) {
 			return conn.DeleteVolumeWithContext(ctx, &ec2.DeleteVolumeInput{
 				VolumeId: aws.String(d.Id()),

--- a/internal/service/ec2/ebs_volume.go
+++ b/internal/service/ec2/ebs_volume.go
@@ -301,7 +301,7 @@ func resourceEBSVolumeDelete(ctx context.Context, d *schema.ResourceData, meta i
 		}
 
 		log.Printf("[DEBUG] Creating EBS Snapshot: %s", input)
-		outputRaw, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, 1*time.Minute,
+		outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, 1*time.Minute,
 			func() (interface{}, error) {
 				return conn.CreateSnapshotWithContext(ctx, input)
 			},

--- a/internal/service/ec2/ec2_ami.go
+++ b/internal/service/ec2/ec2_ami.go
@@ -388,7 +388,7 @@ func resourceAMIRead(ctx context.Context, d *schema.ResourceData, meta interface
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindImageByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/ec2_eip.go
+++ b/internal/service/ec2/ec2_eip.go
@@ -182,7 +182,7 @@ func resourceEIPCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	eniID := d.Get("network_interface").(string)
 
 	if instanceID != "" || eniID != "" {
-		_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutCreate),
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate),
 			func() (interface{}, error) {
 				return nil, associateEIP(ctx, conn, d.Id(), instanceID, eniID, d.Get("associate_with_private_ip").(string))
 			}, errCodeInvalidAllocationIDNotFound)

--- a/internal/service/ec2/ec2_eip.go
+++ b/internal/service/ec2/ec2_eip.go
@@ -170,7 +170,7 @@ func resourceEIPCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	d.SetId(aws.StringValue(output.AllocationId))
 
-	_, err = tfresource.RetryWhenNotFoundContext(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
 		return FindEIPByAllocationID(ctx, conn, d.Id())
 	})
 

--- a/internal/service/ec2/ec2_eip.go
+++ b/internal/service/ec2/ec2_eip.go
@@ -372,7 +372,7 @@ func associateEIP(ctx context.Context, conn *ec2.EC2, id, instanceID, networkInt
 	}
 
 	if associationID := aws.StringValue(output.AssociationId); associationID != "" {
-		_, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+		_, err := tfresource.RetryWhen(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return FindEIPByAssociationID(ctx, conn, associationID)
 			},

--- a/internal/service/ec2/ec2_eip_association.go
+++ b/internal/service/ec2/ec2_eip_association.go
@@ -105,7 +105,7 @@ func resourceEIPAssociationCreate(ctx context.Context, d *schema.ResourceData, m
 	if output.AssociationId != nil {
 		d.SetId(aws.StringValue(output.AssociationId))
 
-		_, err = tfresource.RetryWhenContext(ctx, propagationTimeout,
+		_, err = tfresource.RetryWhen(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return FindEIPByAssociationID(ctx, conn, d.Id())
 			},

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1894,7 +1894,7 @@ func modifyInstanceAttributeWithStopStart(ctx context.Context, conn *ec2.EC2, in
 	}
 
 	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/16433.
-	_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, propagationTimeout,
+	_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.StartInstancesWithContext(ctx, &ec2.StartInstancesInput{
 				InstanceIds: aws.StringSlice([]string{id}),

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -856,7 +856,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	log.Printf("[DEBUG] Creating EC2 Instance: %s", input)
-	outputRaw, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.RunInstancesWithContext(ctx, input)
 		},

--- a/internal/service/ec2/ec2_spot_fleet_request.go
+++ b/internal/service/ec2/ec2_spot_fleet_request.go
@@ -1161,7 +1161,7 @@ func resourceSpotFleetRequestDelete(ctx context.Context, d *schema.ResourceData,
 		return diags
 	}
 
-	_, err = tfresource.RetryUntilNotFoundContext(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
 		input := &ec2.DescribeSpotFleetInstancesInput{
 			SpotFleetRequestId: aws.String(d.Id()),
 		}

--- a/internal/service/ec2/ec2_spot_fleet_request.go
+++ b/internal/service/ec2/ec2_spot_fleet_request.go
@@ -956,7 +956,7 @@ func resourceSpotFleetRequestCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	log.Printf("[DEBUG] Creating EC2 Spot Fleet Request: %s", input)
-	outputRaw, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.RequestSpotFleetWithContext(ctx, input)
 		},

--- a/internal/service/ec2/ec2_spot_instance_request.go
+++ b/internal/service/ec2/ec2_spot_instance_request.go
@@ -262,7 +262,7 @@ func resourceSpotInstanceRequestRead(ctx context.Context, d *schema.ResourceData
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindSpotInstanceRequestByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/generate/createtags/functions.tmpl
+++ b/internal/service/ec2/generate/createtags/functions.tmpl
@@ -49,7 +49,7 @@ func {{ .CreateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 
 	{{- if .RetryCreateOnNotFound }}
 
-	_, err := tfresource.RetryWhenNotFoundContext(ctx, eventualConsistencyTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenNotFound(ctx, eventualConsistencyTimeout, func() (interface{}, error) {
 		output, err := conn.{{ .TagOp }}WithContext(ctx, input)
 
 		{{ .ParentNotFoundError }}

--- a/internal/service/ec2/transitgateway_.go
+++ b/internal/service/ec2/transitgateway_.go
@@ -302,7 +302,7 @@ func resourceTransitGatewayDelete(ctx context.Context, d *schema.ResourceData, m
 	conn := meta.(*conns.AWSClient).EC2Conn()
 
 	log.Printf("[DEBUG] Deleting EC2 Transit Gateway: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, TransitGatewayIncorrectStateTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, TransitGatewayIncorrectStateTimeout, func() (interface{}, error) {
 		return conn.DeleteTransitGatewayWithContext(ctx, &ec2.DeleteTransitGatewayInput{
 			TransitGatewayId: aws.String(d.Id()),
 		})

--- a/internal/service/ec2/transitgateway_multicast_group_member.go
+++ b/internal/service/ec2/transitgateway_multicast_group_member.go
@@ -136,7 +136,7 @@ func deregisterTransitGatewayMulticastGroupMember(ctx context.Context, conn *ec2
 		return fmt.Errorf("deleting EC2 Transit Gateway Multicast Group Member (%s): %w", id, err)
 	}
 
-	_, err = tfresource.RetryUntilNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindTransitGatewayMulticastGroupMemberByThreePartKey(ctx, conn, multicastDomainID, groupIPAddress, eniID)
 	})
 

--- a/internal/service/ec2/transitgateway_multicast_group_member.go
+++ b/internal/service/ec2/transitgateway_multicast_group_member.go
@@ -77,7 +77,7 @@ func resourceTransitGatewayMulticastGroupMemberRead(ctx context.Context, d *sche
 		return diag.FromErr(err)
 	}
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindTransitGatewayMulticastGroupMemberByThreePartKey(ctx, conn, multicastDomainID, groupIPAddress, eniID)
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/transitgateway_multicast_group_source.go
+++ b/internal/service/ec2/transitgateway_multicast_group_source.go
@@ -77,7 +77,7 @@ func resourceTransitGatewayMulticastGroupSourceRead(ctx context.Context, d *sche
 		return diag.FromErr(err)
 	}
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindTransitGatewayMulticastGroupSourceByThreePartKey(ctx, conn, multicastDomainID, groupIPAddress, eniID)
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/transitgateway_multicast_group_source.go
+++ b/internal/service/ec2/transitgateway_multicast_group_source.go
@@ -136,7 +136,7 @@ func deregisterTransitGatewayMulticastGroupSource(ctx context.Context, conn *ec2
 		return fmt.Errorf("deleting EC2 Transit Gateway Multicast Group Source (%s): %w", id, err)
 	}
 
-	_, err = tfresource.RetryUntilNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindTransitGatewayMulticastGroupSourceByThreePartKey(ctx, conn, multicastDomainID, groupIPAddress, eniID)
 	})
 

--- a/internal/service/ec2/transitgateway_route.go
+++ b/internal/service/ec2/transitgateway_route.go
@@ -97,7 +97,7 @@ func resourceTransitGatewayRouteRead(ctx context.Context, d *schema.ResourceData
 		return sdkdiag.AppendErrorf(diags, "reading EC2 Transit Gateway Route (%s): %s", d.Id(), err)
 	}
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindTransitGatewayRoute(ctx, conn, transitGatewayRouteTableID, destination)
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/vpc_.go
+++ b/internal/service/ec2/vpc_.go
@@ -266,7 +266,7 @@ func resourceVPCRead(ctx context.Context, d *schema.ResourceData, meta interface
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindVPCByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/vpc_.go
+++ b/internal/service/ec2/vpc_.go
@@ -509,7 +509,7 @@ func resourceVPCDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 		return sdkdiag.AppendErrorf(diags, "deleting EC2 VPC (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFoundContext(ctx, vpcDeletedTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, vpcDeletedTimeout, func() (interface{}, error) {
 		return FindVPCByID(ctx, conn, d.Id())
 	})
 

--- a/internal/service/ec2/vpc_.go
+++ b/internal/service/ec2/vpc_.go
@@ -497,7 +497,7 @@ func resourceVPCDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	log.Printf("[INFO] Deleting EC2 VPC: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, vpcDeletedTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, vpcDeletedTimeout, func() (interface{}, error) {
 		return conn.DeleteVpcWithContext(ctx, input)
 	}, errCodeDependencyViolation)
 

--- a/internal/service/ec2/vpc_dhcp_options.go
+++ b/internal/service/ec2/vpc_dhcp_options.go
@@ -224,7 +224,7 @@ func resourceVPCDHCPOptionsDelete(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	log.Printf("[INFO] Deleting EC2 DHCP Options Set: %s", d.Id())
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, dhcpOptionSetDeletedTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, dhcpOptionSetDeletedTimeout, func() (interface{}, error) {
 		return conn.DeleteDhcpOptionsWithContext(ctx, input)
 	}, errCodeDependencyViolation)
 

--- a/internal/service/ec2/vpc_dhcp_options.go
+++ b/internal/service/ec2/vpc_dhcp_options.go
@@ -125,7 +125,7 @@ func resourceVPCDHCPOptionsRead(ctx context.Context, d *schema.ResourceData, met
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindDHCPOptionsByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/vpc_dhcp_options_association.go
+++ b/internal/service/ec2/vpc_dhcp_options_association.go
@@ -75,7 +75,7 @@ func resourceVPCDHCPOptionsAssociationRead(ctx context.Context, d *schema.Resour
 		return sdkdiag.AppendErrorf(diags, "reading EC2 VPC DHCP Options Set Association (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return nil, FindVPCDHCPOptionsAssociation(ctx, conn, vpcID, dhcpOptionsID)
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/vpc_egress_only_internet_gateway.go
+++ b/internal/service/ec2/vpc_egress_only_internet_gateway.go
@@ -71,7 +71,7 @@ func resourceEgressOnlyInternetGatewayRead(ctx context.Context, d *schema.Resour
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindEgressOnlyInternetGatewayByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/vpc_internet_gateway.go
+++ b/internal/service/ec2/vpc_internet_gateway.go
@@ -92,7 +92,7 @@ func resourceInternetGatewayRead(ctx context.Context, d *schema.ResourceData, me
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindInternetGatewayByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/vpc_internet_gateway.go
+++ b/internal/service/ec2/vpc_internet_gateway.go
@@ -186,7 +186,7 @@ func resourceInternetGatewayDelete(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	log.Printf("[INFO] Deleting Internet Gateway: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
 		return conn.DeleteInternetGatewayWithContext(ctx, input)
 	}, errCodeDependencyViolation)
 
@@ -208,7 +208,7 @@ func attachInternetGateway(ctx context.Context, conn *ec2.EC2, internetGatewayID
 	}
 
 	log.Printf("[INFO] Attaching EC2 Internet Gateway: %s", input)
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, timeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (interface{}, error) {
 		return conn.AttachInternetGatewayWithContext(ctx, input)
 	}, errCodeInvalidInternetGatewayIDNotFound)
 
@@ -232,7 +232,7 @@ func detachInternetGateway(ctx context.Context, conn *ec2.EC2, internetGatewayID
 	}
 
 	log.Printf("[INFO] Detaching EC2 Internet Gateway: %s", input)
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, timeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (interface{}, error) {
 		return conn.DetachInternetGatewayWithContext(ctx, input)
 	}, errCodeDependencyViolation)
 

--- a/internal/service/ec2/vpc_internet_gateway_attachment.go
+++ b/internal/service/ec2/vpc_internet_gateway_attachment.go
@@ -71,7 +71,7 @@ func resourceInternetGatewayAttachmentRead(ctx context.Context, d *schema.Resour
 		return sdkdiag.AppendErrorf(diags, "reading EC2 Internet Gateway Attachment (%s): %s", d.Id(), err)
 	}
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindInternetGatewayAttachment(ctx, conn, igwID, vpcID)
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/vpc_managed_prefix_list_entry.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_entry.go
@@ -61,7 +61,7 @@ func resourceManagedPrefixListEntryCreate(ctx context.Context, d *schema.Resourc
 		addPrefixListEntry.Description = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
 		mutexKey := fmt.Sprintf("vpc-managed-prefix-list-%s", plID)
 		conns.GlobalMutexKV.Lock(mutexKey)
 		defer conns.GlobalMutexKV.Unlock(mutexKey)
@@ -134,7 +134,7 @@ func resourceManagedPrefixListEntryDelete(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(err)
 	}
 
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
 		mutexKey := fmt.Sprintf("vpc-managed-prefix-list-%s", plID)
 		conns.GlobalMutexKV.Lock(mutexKey)
 		defer conns.GlobalMutexKV.Unlock(mutexKey)

--- a/internal/service/ec2/vpc_managed_prefix_list_entry.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_entry.go
@@ -103,7 +103,7 @@ func resourceManagedPrefixListEntryRead(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, ManagedPrefixListEntryCreateTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ManagedPrefixListEntryCreateTimeout, func() (interface{}, error) {
 		return FindManagedPrefixListEntryByIDAndCIDR(ctx, conn, plID, cidr)
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/vpc_network_acl.go
+++ b/internal/service/ec2/vpc_network_acl.go
@@ -291,7 +291,7 @@ func resourceNetworkACLDelete(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	log.Printf("[INFO] Deleting EC2 Network ACL: %s", d.Id())
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
 		return conn.DeleteNetworkAclWithContext(ctx, input)
 	}, errCodeDependencyViolation)
 

--- a/internal/service/ec2/vpc_network_acl.go
+++ b/internal/service/ec2/vpc_network_acl.go
@@ -183,7 +183,7 @@ func resourceNetworkACLRead(ctx context.Context, d *schema.ResourceData, meta in
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindNetworkACLByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/vpc_network_acl_association.go
+++ b/internal/service/ec2/vpc_network_acl_association.go
@@ -121,7 +121,7 @@ func networkACLAssociationCreate(ctx context.Context, conn *ec2.EC2, naclID, sub
 	}
 
 	log.Printf("[DEBUG] Creating EC2 Network ACL Association: %s", input)
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
 		return conn.ReplaceNetworkAclAssociationWithContext(ctx, input)
 	}, errCodeInvalidAssociationIDNotFound)
 

--- a/internal/service/ec2/vpc_network_acl_rule.go
+++ b/internal/service/ec2/vpc_network_acl_rule.go
@@ -180,7 +180,7 @@ func resourceNetworkACLRuleRead(ctx context.Context, d *schema.ResourceData, met
 	naclID := d.Get("network_acl_id").(string)
 	ruleNumber := d.Get("rule_number").(int)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindNetworkACLEntryByThreePartKey(ctx, conn, naclID, egress, ruleNumber)
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/vpc_network_interface.go
+++ b/internal/service/ec2/vpc_network_interface.go
@@ -487,7 +487,7 @@ func resourceNetworkInterfaceRead(ctx context.Context, d *schema.ResourceData, m
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindNetworkInterfaceByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/vpc_network_interface_sg_attachment.go
+++ b/internal/service/ec2/vpc_network_interface_sg_attachment.go
@@ -95,7 +95,7 @@ func resourceNetworkInterfaceSGAttachmentRead(ctx context.Context, d *schema.Res
 
 	networkInterfaceID := d.Get("network_interface_id").(string)
 	sgID := d.Get("security_group_id").(string)
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindNetworkInterfaceSecurityGroup(ctx, conn, networkInterfaceID, sgID)
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/vpc_route.go
+++ b/internal/service/ec2/vpc_route.go
@@ -238,7 +238,7 @@ func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	log.Printf("[DEBUG] Creating Route: %s", input)
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutCreate),
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate),
 		func() (interface{}, error) {
 			return conn.CreateRouteWithContext(ctx, input)
 		},
@@ -437,7 +437,7 @@ func resourceRouteDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	log.Printf("[DEBUG] Deleting Route: %s", input)
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutDelete),
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete),
 		func() (interface{}, error) {
 			return conn.DeleteRouteWithContext(ctx, input)
 		},

--- a/internal/service/ec2/vpc_route_table.go
+++ b/internal/service/ec2/vpc_route_table.go
@@ -517,7 +517,7 @@ func routeTableAddRoute(ctx context.Context, conn *ec2.EC2, routeTableID string,
 	input.RouteTableId = aws.String(routeTableID)
 
 	log.Printf("[DEBUG] Creating Route: %s", input)
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, timeout,
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout,
 		func() (interface{}, error) {
 			return conn.CreateRouteWithContext(ctx, input)
 		},
@@ -658,7 +658,7 @@ func routeTableEnableVGWRoutePropagation(ctx context.Context, conn *ec2.EC2, rou
 	}
 
 	log.Printf("[DEBUG] Enabling Route Table (%s) VPN Gateway (%s) route propagation", routeTableID, gatewayID)
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, timeout,
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout,
 		func() (interface{}, error) {
 			return conn.EnableVgwRoutePropagationWithContext(ctx, input)
 		},

--- a/internal/service/ec2/vpc_route_table_association.go
+++ b/internal/service/ec2/vpc_route_table_association.go
@@ -90,7 +90,7 @@ func resourceRouteTableAssociationRead(ctx context.Context, d *schema.ResourceDa
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindRouteTableAssociationByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/vpc_route_table_association.go
+++ b/internal/service/ec2/vpc_route_table_association.go
@@ -65,7 +65,7 @@ func resourceRouteTableAssociationCreate(ctx context.Context, d *schema.Resource
 	}
 
 	log.Printf("[DEBUG] Creating Route Table Association: %s", input)
-	output, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, RouteTableAssociationPropagationTimeout,
+	output, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, RouteTableAssociationPropagationTimeout,
 		func() (interface{}, error) {
 			return conn.AssociateRouteTableWithContext(ctx, input)
 		},

--- a/internal/service/ec2/vpc_security_group.go
+++ b/internal/service/ec2/vpc_security_group.go
@@ -380,7 +380,7 @@ func resourceSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	log.Printf("[DEBUG] Deleting Security Group: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(
 		ctx,
 		2*time.Minute, // short initial attempt followed by full length attempt
 		func() (interface{}, error) {
@@ -400,7 +400,7 @@ func resourceSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, me
 			}
 		}
 
-		_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(
+		_, err = tfresource.RetryWhenAWSErrCodeEquals(
 			ctx,
 			d.Timeout(schema.TimeoutDelete),
 			func() (interface{}, error) {

--- a/internal/service/ec2/vpc_security_group.go
+++ b/internal/service/ec2/vpc_security_group.go
@@ -420,7 +420,7 @@ func resourceSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("deleting Security Group (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindSecurityGroupByID(ctx, conn, d.Id())
 	})
 

--- a/internal/service/ec2/vpc_security_group_rule.go
+++ b/internal/service/ec2/vpc_security_group_rule.go
@@ -218,7 +218,7 @@ information and instructions for recovery. Error: %s`, securityGroupID, err)
 		return diag.Errorf("authorizing Security Group (%s) Rule (%s): %s", securityGroupID, id, err)
 	}
 
-	_, err = tfresource.RetryWhenNotFoundContext(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
 		sg, err := FindSecurityGroupByID(ctx, conn, securityGroupID)
 
 		if err != nil {

--- a/internal/service/ec2/vpc_subnet.go
+++ b/internal/service/ec2/vpc_subnet.go
@@ -372,7 +372,7 @@ func resourceSubnetDelete(ctx context.Context, d *schema.ResourceData, meta inte
 		return sdkdiag.AppendErrorf(diags, "deleting ENIs for EC2 Subnet (%s): %s", d.Id(), err)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
 		return conn.DeleteSubnetWithContext(ctx, &ec2.DeleteSubnetInput{
 			SubnetId: aws.String(d.Id()),
 		})

--- a/internal/service/ec2/vpc_subnet.go
+++ b/internal/service/ec2/vpc_subnet.go
@@ -221,7 +221,7 @@ func resourceSubnetRead(ctx context.Context, d *schema.ResourceData, meta interf
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, SubnetPropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, SubnetPropagationTimeout, func() (interface{}, error) {
 		return FindSubnetByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 

--- a/internal/service/ec2/vpnclient_route.go
+++ b/internal/service/ec2/vpnclient_route.go
@@ -84,7 +84,7 @@ func resourceClientVPNRouteCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	log.Printf("[DEBUG] Creating EC2 Client VPN Route: %s", input)
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
 		return conn.CreateClientVpnRouteWithContext(ctx, input)
 	}, errCodeInvalidClientVPNActiveAssociationNotFound)
 

--- a/internal/service/ec2/vpnsite_gateway.go
+++ b/internal/service/ec2/vpnsite_gateway.go
@@ -198,7 +198,7 @@ func resourceVPNGatewayDelete(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	log.Printf("[INFO] Deleting EC2 VPN Gateway: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, VPNGatewayDeletedTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, VPNGatewayDeletedTimeout, func() (interface{}, error) {
 		return conn.DeleteVpnGatewayWithContext(ctx, &ec2.DeleteVpnGatewayInput{
 			VpnGatewayId: aws.String(d.Id()),
 		})
@@ -222,7 +222,7 @@ func attachVPNGatewayToVPC(ctx context.Context, conn *ec2.EC2, vpnGatewayID, vpc
 	}
 
 	log.Printf("[INFO] Attaching EC2 VPN Gateway (%s) to VPC (%s)", vpnGatewayID, vpcID)
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
 		return conn.AttachVpnGatewayWithContext(ctx, input)
 	}, errCodeInvalidVPNGatewayIDNotFound)
 

--- a/internal/service/ec2/vpnsite_gateway.go
+++ b/internal/service/ec2/vpnsite_gateway.go
@@ -106,7 +106,7 @@ func resourceVPNGatewayRead(ctx context.Context, d *schema.ResourceData, meta in
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindVPNGatewayByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 

--- a/internal/service/ecrpublic/repository_policy.go
+++ b/internal/service/ecrpublic/repository_policy.go
@@ -75,7 +75,7 @@ func resourceRepositoryPolicyPut(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	log.Printf("[DEBUG] Setting ECR Public Repository Policy: %s", input)
-	outputRaw, err := tfresource.RetryWhenContext(ctx, policyPutTimeout,
+	outputRaw, err := tfresource.RetryWhen(ctx, policyPutTimeout,
 		func() (interface{}, error) {
 			return conn.SetRepositoryPolicyWithContext(ctx, input)
 		},

--- a/internal/service/ecs/task_set.go
+++ b/internal/service/ecs/task_set.go
@@ -572,7 +572,7 @@ func TaskSetParseID(id string) (string, string, string, error) {
 }
 
 func retryTaskSetCreate(ctx context.Context, conn *ecs.ECS, input *ecs.CreateTaskSetInput) (*ecs.CreateTaskSetOutput, error) {
-	outputRaw, err := tfresource.RetryWhenContext(ctx, propagationTimeout+taskSetCreateTimeout,
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout+taskSetCreateTimeout,
 		func() (interface{}, error) {
 			return conn.CreateTaskSetWithContext(ctx, input)
 		},

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -540,7 +540,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 
 	// If a cluster is scaling up due to load a delete request will fail
 	// This is a temporary workaround until EKS supports multiple parallel mutating operations
-	err := tfresource.RetryContext(ctx, clusterDeleteRetryTimeout, func() *resource.RetryError {
+	err := tfresource.Retry(ctx, clusterDeleteRetryTimeout, func() *resource.RetryError {
 		var err error
 
 		_, err = conn.DeleteClusterWithContext(ctx, input)

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -315,7 +315,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
-	outputRaw, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.CreateClusterWithContext(ctx, input)
 		},

--- a/internal/service/elasticache/user_group_association.go
+++ b/internal/service/elasticache/user_group_association.go
@@ -53,7 +53,7 @@ func resourceUserGroupAssociationCreate(ctx context.Context, d *schema.ResourceD
 
 	id := userGroupAssociationID(d.Get("user_group_id").(string), d.Get("user_id").(string))
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 10*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 10*time.Minute, func() (interface{}, error) {
 		return tfresource.RetryWhenNotFoundContext(ctx, 30*time.Second, func() (interface{}, error) {
 			return conn.ModifyUserGroupWithContext(ctx, input)
 		})
@@ -137,7 +137,7 @@ func resourceUserGroupAssociationDelete(ctx context.Context, d *schema.ResourceD
 		UserIdsToRemove: aws.StringSlice([]string{d.Get("user_id").(string)}),
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 10*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 10*time.Minute, func() (interface{}, error) {
 		return conn.ModifyUserGroupWithContext(ctx, input)
 	}, elasticache.ErrCodeInvalidUserGroupStateFault)
 

--- a/internal/service/elasticache/user_group_association.go
+++ b/internal/service/elasticache/user_group_association.go
@@ -54,7 +54,7 @@ func resourceUserGroupAssociationCreate(ctx context.Context, d *schema.ResourceD
 	id := userGroupAssociationID(d.Get("user_group_id").(string), d.Get("user_id").(string))
 
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 10*time.Minute, func() (interface{}, error) {
-		return tfresource.RetryWhenNotFoundContext(ctx, 30*time.Second, func() (interface{}, error) {
+		return tfresource.RetryWhenNotFound(ctx, 30*time.Second, func() (interface{}, error) {
 			return conn.ModifyUserGroupWithContext(ctx, input)
 		})
 	}, elasticache.ErrCodeInvalidUserGroupStateFault)

--- a/internal/service/elasticsearch/domain.go
+++ b/internal/service/elasticsearch/domain.go
@@ -659,7 +659,7 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	log.Printf("[DEBUG] Creating Elasticsearch Domain: %s", input)
 
-	outputRaw, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.CreateElasticsearchDomainWithContext(ctx, input)
 		},

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -869,7 +869,7 @@ func waitForNLBNetworkInterfacesToDetach(ctx context.Context, conn *ec2.EC2, lbA
 
 	errAttached := errors.New("attached")
 
-	_, err = tfresource.RetryWhenContext(ctx, loadBalancerNetworkInterfaceDetachTimeout,
+	_, err = tfresource.RetryWhen(ctx, loadBalancerNetworkInterfaceDetachTimeout,
 		func() (interface{}, error) {
 			networkInterfaces, err := tfec2.FindNetworkInterfacesByAttachmentInstanceOwnerIDAndDescription(ctx, conn, "amazon-aws", "ELB "+name)
 

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -605,7 +605,7 @@ func resourceTargetGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ELBV2Conn()
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindTargetGroupByARN(ctx, conn, d.Id())
 	}, d.IsNewResource())
 

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -451,7 +451,7 @@ func resourceTargetGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	d.SetId(aws.StringValue(output.TargetGroups[0].TargetGroupArn))
 
-	_, err = tfresource.RetryWhenNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindTargetGroupByARN(ctx, conn, d.Id())
 	})
 

--- a/internal/service/iam/policy_data_source.go
+++ b/internal/service/iam/policy_data_source.go
@@ -74,7 +74,7 @@ func dataSourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta inte
 	pathPrefix := d.Get("path_prefix").(string)
 
 	if arn == "" {
-		raw, err := tfresource.RetryWhenNotFoundContext(ctx, propagationTimeout,
+		raw, err := tfresource.RetryWhenNotFound(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return FindPolicyByName(ctx, conn, name, pathPrefix)
 			},

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -263,7 +263,7 @@ func resourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindRoleByName(ctx, conn, d.Id())
 	}, d.IsNewResource())
 

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -359,7 +359,7 @@ func resourceRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 			PolicyDocument: aws.String(assumeRolePolicy),
 		}
 
-		_, err = tfresource.RetryWhenContext(ctx, propagationTimeout,
+		_, err = tfresource.RetryWhen(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return conn.UpdateAssumeRolePolicyWithContext(ctx, input)
 			},
@@ -620,7 +620,7 @@ func deleteRoleInstanceProfiles(ctx context.Context, conn *iam.IAM, roleName str
 }
 
 func retryCreateRole(ctx context.Context, conn *iam.IAM, input *iam.CreateRoleInput) (*iam.CreateRoleOutput, error) {
-	outputRaw, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.CreateRoleWithContext(ctx, input)
 		},

--- a/internal/service/iam/service_linked_role.go
+++ b/internal/service/iam/service_linked_role.go
@@ -143,7 +143,7 @@ func resourceServiceLinkedRoleRead(ctx context.Context, d *schema.ResourceData, 
 		return sdkdiag.AppendErrorf(diags, "reading IAM Service Linked Role (%s): %s", d.Id(), err)
 	}
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindRoleByName(ctx, conn, roleName)
 	}, d.IsNewResource())
 

--- a/internal/service/iam/service_specific_credential.go
+++ b/internal/service/iam/service_specific_credential.go
@@ -106,7 +106,7 @@ func resourceServiceSpecificCredentialRead(ctx context.Context, d *schema.Resour
 		return sdkdiag.AppendErrorf(diags, "reading IAM Service Specific Credential (%s): %s", d.Id(), err)
 	}
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindServiceSpecificCredential(ctx, conn, serviceName, userName, credID)
 	}, d.IsNewResource())
 

--- a/internal/service/iam/signing_certificate.go
+++ b/internal/service/iam/signing_certificate.go
@@ -98,7 +98,7 @@ func resourceSigningCertificateRead(ctx context.Context, d *schema.ResourceData,
 		return sdkdiag.AppendErrorf(diags, "reading IAM Signing Certificate (%s): %s", d.Id(), err)
 	}
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindSigningCertificate(ctx, conn, userName, certId)
 	}, d.IsNewResource())
 

--- a/internal/service/iot/logging_options.go
+++ b/internal/service/iot/logging_options.go
@@ -56,7 +56,7 @@ func resourceLoggingOptionsPut(ctx context.Context, d *schema.ResourceData, meta
 		input.RoleArn = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, propagationTimeout,
+	_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.SetV2LoggingOptionsWithContext(ctx, input)
 		},

--- a/internal/service/iot/provisioning_template.go
+++ b/internal/service/iot/provisioning_template.go
@@ -140,7 +140,7 @@ func resourceProvisioningTemplateCreate(ctx context.Context, d *schema.ResourceD
 	}
 
 	log.Printf("[DEBUG] Creating IoT Provisioning Template: %s", input)
-	outputRaw, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.CreateProvisioningTemplateWithContext(ctx, input)
 		},
@@ -234,7 +234,7 @@ func resourceProvisioningTemplateUpdate(ctx context.Context, d *schema.ResourceD
 		}
 
 		log.Printf("[DEBUG] Updating IoT Provisioning Template: %s", input)
-		_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, propagationTimeout,
+		_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return conn.UpdateProvisioningTemplateWithContext(ctx, input)
 			},

--- a/internal/service/iot/thing_group.go
+++ b/internal/service/iot/thing_group.go
@@ -266,7 +266,7 @@ func resourceThingGroupDelete(ctx context.Context, d *schema.ResourceData, meta 
 	conn := meta.(*conns.AWSClient).IoTConn()
 
 	log.Printf("[DEBUG] Deleting IoT Thing Group: %s", d.Id())
-	_, err := tfresource.RetryWhenContext(ctx, thingGroupDeleteTimeout,
+	_, err := tfresource.RetryWhen(ctx, thingGroupDeleteTimeout,
 		func() (interface{}, error) {
 			return conn.DeleteThingGroupWithContext(ctx, &iot.DeleteThingGroupInput{
 				ThingGroupName: aws.String(d.Id()),

--- a/internal/service/iot/topic_rule.go
+++ b/internal/service/iot/topic_rule.go
@@ -1175,7 +1175,7 @@ func resourceTopicRuleCreate(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	log.Printf("[INFO] Creating IoT Topic Rule: %s", input)
-	_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, propagationTimeout,
+	_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.CreateTopicRuleWithContext(ctx, input)
 		},

--- a/internal/service/iot/topic_rule_destination.go
+++ b/internal/service/iot/topic_rule_destination.go
@@ -94,7 +94,7 @@ func resourceTopicRuleDestinationCreate(ctx context.Context, d *schema.ResourceD
 	}
 
 	log.Printf("[INFO] Creating IoT Topic Rule Destination: %s", input)
-	outputRaw, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.CreateTopicRuleDestinationWithContext(ctx, input)
 		},

--- a/internal/service/kendra/data_source.go
+++ b/internal/service/kendra/data_source.go
@@ -627,7 +627,7 @@ func resourceDataSourceCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	log.Printf("[DEBUG] Creating Kendra Data Source %#v", input)
 
-	outputRaw, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.CreateDataSource(ctx, input)
 		},
@@ -778,7 +778,7 @@ func resourceDataSourceUpdate(ctx context.Context, d *schema.ResourceData, meta 
 
 		log.Printf("[DEBUG] Updating Kendra Data Source (%s): %#v", d.Id(), input)
 
-		_, err = tfresource.RetryWhenContext(ctx, propagationTimeout,
+		_, err = tfresource.RetryWhen(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return conn.UpdateDataSource(ctx, input)
 			},

--- a/internal/service/kendra/faq.go
+++ b/internal/service/kendra/faq.go
@@ -174,7 +174,7 @@ func resourceFaqCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	log.Printf("[DEBUG] Creating Kendra Faq %#v", input)
 
-	outputRaw, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.CreateFaq(ctx, input)
 		},

--- a/internal/service/kendra/index.go
+++ b/internal/service/kendra/index.go
@@ -414,7 +414,7 @@ func resourceIndexCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	log.Printf("[DEBUG] Creating Kendra Index %#v", input)
 
-	outputRaw, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.CreateIndex(ctx, input)
 		},
@@ -577,7 +577,7 @@ func resourceIndexUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			input.UserTokenConfigurations = expandUserTokenConfigurations(d.Get("user_token_configurations").([]interface{}))
 		}
 
-		_, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+		_, err := tfresource.RetryWhen(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return conn.UpdateIndex(ctx, input)
 			},

--- a/internal/service/kendra/query_suggestions_block_list.go
+++ b/internal/service/kendra/query_suggestions_block_list.go
@@ -116,7 +116,7 @@ func resourceQuerySuggestionsBlockListCreate(ctx context.Context, d *schema.Reso
 		in.Tags = Tags(tags.IgnoreAWS())
 	}
 
-	outputRaw, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.CreateQuerySuggestionsBlockList(ctx, in)
 		},
@@ -245,7 +245,7 @@ func resourceQuerySuggestionsBlockListUpdate(ctx context.Context, d *schema.Reso
 
 		log.Printf("[DEBUG] Updating Kendra QuerySuggestionsBlockList (%s): %#v", d.Id(), input)
 
-		_, err = tfresource.RetryWhenContext(ctx, propagationTimeout,
+		_, err = tfresource.RetryWhen(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return conn.UpdateQuerySuggestionsBlockList(ctx, input)
 			},

--- a/internal/service/kendra/thesaurus.go
+++ b/internal/service/kendra/thesaurus.go
@@ -116,7 +116,7 @@ func resourceThesaurusCreate(ctx context.Context, d *schema.ResourceData, meta i
 		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
-	outputRaw, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.CreateThesaurus(ctx, input)
 		},
@@ -246,7 +246,7 @@ func resourceThesaurusUpdate(ctx context.Context, d *schema.ResourceData, meta i
 
 		log.Printf("[DEBUG] Updating Kendra Thesaurus (%s): %#v", d.Id(), input)
 
-		_, err = tfresource.RetryWhenContext(ctx, propagationTimeout,
+		_, err = tfresource.RetryWhen(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return conn.UpdateThesaurus(ctx, input)
 			},

--- a/internal/service/keyspaces/keyspace.go
+++ b/internal/service/keyspaces/keyspace.go
@@ -83,7 +83,7 @@ func resourceKeyspaceCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	d.SetId(name)
 
-	_, err = tfresource.RetryWhenNotFoundContext(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
 		return FindKeyspaceByName(ctx, conn, d.Id())
 	})
 

--- a/internal/service/keyspaces/keyspace.go
+++ b/internal/service/keyspaces/keyspace.go
@@ -152,7 +152,7 @@ func resourceKeyspaceDelete(ctx context.Context, d *schema.ResourceData, meta in
 	conn := meta.(*conns.AWSClient).KeyspacesConn()
 
 	log.Printf("[DEBUG] Deleting Keyspaces Keyspace: (%s)", d.Id())
-	_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, d.Timeout(schema.TimeoutDelete),
+	_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, d.Timeout(schema.TimeoutDelete),
 		func() (interface{}, error) {
 			return conn.DeleteKeyspaceWithContext(ctx, &keyspaces.DeleteKeyspaceInput{
 				KeyspaceName: aws.String(d.Id()),

--- a/internal/service/keyspaces/keyspace.go
+++ b/internal/service/keyspaces/keyspace.go
@@ -168,7 +168,7 @@ func resourceKeyspaceDelete(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("deleting Keyspaces Keyspace (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFoundContext(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
 		return FindKeyspaceByName(ctx, conn, d.Id())
 	})
 

--- a/internal/service/kms/alias.go
+++ b/internal/service/kms/alias.go
@@ -82,7 +82,7 @@ func resourceAliasCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	// KMS is eventually consistent.
 	log.Printf("[DEBUG] Creating KMS Alias: %s", input)
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, KeyRotationUpdatedTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, KeyRotationUpdatedTimeout, func() (interface{}, error) {
 		return conn.CreateAliasWithContext(ctx, input)
 	}, kms.ErrCodeNotFoundException)
 

--- a/internal/service/kms/alias.go
+++ b/internal/service/kms/alias.go
@@ -99,7 +99,7 @@ func resourceAliasRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KMSConn()
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, PropagationTimeout, func() (interface{}, error) {
 		return FindAliasByName(ctx, conn, d.Id())
 	}, d.IsNewResource())
 

--- a/internal/service/kms/external_key.go
+++ b/internal/service/kms/external_key.go
@@ -365,7 +365,7 @@ func resourceExternalKeyDelete(ctx context.Context, d *schema.ResourceData, meta
 
 func importExternalKeyMaterial(ctx context.Context, conn *kms.KMS, keyID, keyMaterialBase64, validTo string) error {
 	// Wait for propagation since KMS is eventually consistent.
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, PropagationTimeout, func() (interface{}, error) {
 		return conn.GetParametersForImportWithContext(ctx, &kms.GetParametersForImportInput{
 			KeyId:             aws.String(keyID),
 			WrappingAlgorithm: aws.String(kms.AlgorithmSpecRsaesOaepSha256),
@@ -416,7 +416,7 @@ func importExternalKeyMaterial(ctx context.Context, conn *kms.KMS, keyID, keyMat
 	}
 
 	// Wait for propagation since KMS is eventually consistent.
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, PropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, PropagationTimeout, func() (interface{}, error) {
 		return conn.ImportKeyMaterialWithContext(ctx, input)
 	}, kms.ErrCodeNotFoundException)
 

--- a/internal/service/kms/external_key_test.go
+++ b/internal/service/kms/external_key_test.go
@@ -559,7 +559,7 @@ func testAccCheckExternalKeyExists(ctx context.Context, name string, key *kms.Ke
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).KMSConn()
 
-		outputRaw, err := tfresource.RetryWhenNotFoundContext(ctx, tfkms.PropagationTimeout, func() (interface{}, error) {
+		outputRaw, err := tfresource.RetryWhenNotFound(ctx, tfkms.PropagationTimeout, func() (interface{}, error) {
 			return tfkms.FindKeyByID(ctx, conn, rs.Primary.ID)
 		})
 

--- a/internal/service/kms/key.go
+++ b/internal/service/kms/key.go
@@ -341,7 +341,7 @@ type kmsKey struct {
 
 func findKey(ctx context.Context, conn *kms.KMS, keyID string, isNewResource bool) (*kmsKey, error) {
 	// Wait for propagation since KMS is eventually consistent.
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, PropagationTimeout, func() (interface{}, error) {
 		var err error
 		var key kmsKey
 

--- a/internal/service/kms/key.go
+++ b/internal/service/kms/key.go
@@ -434,7 +434,7 @@ func updateKeyEnabled(ctx context.Context, conn *kms.KMS, keyID string, enabled 
 		return nil, err
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, PropagationTimeout, updateFunc, kms.ErrCodeNotFoundException)
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, PropagationTimeout, updateFunc, kms.ErrCodeNotFoundException)
 	if err != nil {
 		return fmt.Errorf("%s KMS Key: %w", action, err)
 	}
@@ -470,7 +470,7 @@ func updateKeyPolicy(ctx context.Context, conn *kms.KMS, keyID string, policy st
 		return nil, err
 	}
 
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, PropagationTimeout, updateFunc, kms.ErrCodeNotFoundException, kms.ErrCodeMalformedPolicyDocumentException)
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, PropagationTimeout, updateFunc, kms.ErrCodeNotFoundException, kms.ErrCodeMalformedPolicyDocumentException)
 	if err != nil {
 		return fmt.Errorf("updating policy: %w", err)
 	}
@@ -505,7 +505,7 @@ func updateKeyRotationEnabled(ctx context.Context, conn *kms.KMS, keyID string, 
 		return nil, err
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, KeyRotationUpdatedTimeout, updateFunc, kms.ErrCodeNotFoundException, kms.ErrCodeDisabledException)
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, KeyRotationUpdatedTimeout, updateFunc, kms.ErrCodeNotFoundException, kms.ErrCodeDisabledException)
 	if err != nil {
 		return fmt.Errorf("%s key rotation: %w", action, err)
 	}

--- a/internal/service/kms/key_test.go
+++ b/internal/service/kms/key_test.go
@@ -568,7 +568,7 @@ func testAccCheckKeyExists(ctx context.Context, name string, key *kms.KeyMetadat
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).KMSConn()
 
-		outputRaw, err := tfresource.RetryWhenNotFoundContext(ctx, tfkms.PropagationTimeout, func() (interface{}, error) {
+		outputRaw, err := tfresource.RetryWhenNotFound(ctx, tfkms.PropagationTimeout, func() (interface{}, error) {
 			return tfkms.FindKeyByID(ctx, conn, rs.Primary.ID)
 		})
 

--- a/internal/service/kms/wait.go
+++ b/internal/service/kms/wait.go
@@ -74,7 +74,7 @@ func WaitKeyDescriptionPropagated(ctx context.Context, conn *kms.KMS, id string,
 		MinTimeout:                2 * time.Second,
 	}
 
-	return tfresource.WaitUntilContext(ctx, KeyDescriptionPropagationTimeout, checkFunc, opts)
+	return tfresource.WaitUntil(ctx, KeyDescriptionPropagationTimeout, checkFunc, opts)
 }
 
 func WaitKeyMaterialImported(ctx context.Context, conn *kms.KMS, id string) (*kms.KeyMetadata, error) {
@@ -119,7 +119,7 @@ func WaitKeyPolicyPropagated(ctx context.Context, conn *kms.KMS, id, policy stri
 		MinTimeout:                1 * time.Second,
 	}
 
-	return tfresource.WaitUntilContext(ctx, KeyPolicyPropagationTimeout, checkFunc, opts)
+	return tfresource.WaitUntil(ctx, KeyPolicyPropagationTimeout, checkFunc, opts)
 }
 
 func WaitKeyRotationEnabledPropagated(ctx context.Context, conn *kms.KMS, id string, enabled bool) error {
@@ -141,7 +141,7 @@ func WaitKeyRotationEnabledPropagated(ctx context.Context, conn *kms.KMS, id str
 		MinTimeout:                1 * time.Second,
 	}
 
-	return tfresource.WaitUntilContext(ctx, KeyRotationUpdatedTimeout, checkFunc, opts)
+	return tfresource.WaitUntil(ctx, KeyRotationUpdatedTimeout, checkFunc, opts)
 }
 
 func WaitKeyStatePropagated(ctx context.Context, conn *kms.KMS, id string, enabled bool) error {
@@ -163,7 +163,7 @@ func WaitKeyStatePropagated(ctx context.Context, conn *kms.KMS, id string, enabl
 		MinTimeout:                2 * time.Second,
 	}
 
-	return tfresource.WaitUntilContext(ctx, KeyStatePropagationTimeout, checkFunc, opts)
+	return tfresource.WaitUntil(ctx, KeyStatePropagationTimeout, checkFunc, opts)
 }
 
 func WaitKeyValidToPropagated(ctx context.Context, conn *kms.KMS, id string, validTo string) error {
@@ -189,7 +189,7 @@ func WaitKeyValidToPropagated(ctx context.Context, conn *kms.KMS, id string, val
 		MinTimeout:                2 * time.Second,
 	}
 
-	return tfresource.WaitUntilContext(ctx, KeyValidToPropagationTimeout, checkFunc, opts)
+	return tfresource.WaitUntil(ctx, KeyValidToPropagationTimeout, checkFunc, opts)
 }
 
 func WaitTagsPropagated(ctx context.Context, conn *kms.KMS, id string, tags tftags.KeyValueTags) error {
@@ -211,7 +211,7 @@ func WaitTagsPropagated(ctx context.Context, conn *kms.KMS, id string, tags tfta
 		MinTimeout:                1 * time.Second,
 	}
 
-	return tfresource.WaitUntilContext(ctx, KeyTagsPropagationTimeout, checkFunc, opts)
+	return tfresource.WaitUntil(ctx, KeyTagsPropagationTimeout, checkFunc, opts)
 }
 
 func WaitReplicaExternalKeyCreated(ctx context.Context, conn *kms.KMS, id string) (*kms.KeyMetadata, error) {

--- a/internal/service/kms/wait.go
+++ b/internal/service/kms/wait.go
@@ -35,7 +35,7 @@ const (
 // WaitIAMPropagation retries the specified function if the returned error indicates an IAM eventual consistency issue.
 // If the retries time out the specified function is called one last time.
 func WaitIAMPropagation(ctx context.Context, f func() (interface{}, error)) (interface{}, error) {
-	return tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, propagationTimeout, f, kms.ErrCodeMalformedPolicyDocumentException)
+	return tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, f, kms.ErrCodeMalformedPolicyDocumentException)
 }
 
 func WaitKeyDeleted(ctx context.Context, conn *kms.KMS, id string) (*kms.KeyMetadata, error) {

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -941,7 +941,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			FunctionName: aws.String(d.Id()),
 		}
 
-		outputRaw, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, propagationTimeout, func() (interface{}, error) {
+		outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
 			return conn.PublishVersionWithContext(ctx, input)
 		}, lambda.ErrCodeResourceConflictException, "in progress")
 

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -508,7 +508,7 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	d.SetId(functionName)
 
-	_, err = tfresource.RetryWhenNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindFunctionByName(ctx, conn, d.Id())
 	})
 

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -1119,7 +1119,7 @@ func waitFunctionUpdated(ctx context.Context, conn *lambda.Lambda, functionName 
 // retryFunctionOp retries a Lambda Function Create or Update operation.
 // It handles IAM eventual consistency and EC2 throttling.
 func retryFunctionOp(ctx context.Context, f func() (interface{}, error)) (interface{}, error) { //nolint:unparam
-	output, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+	output, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		f,
 		func(err error) (bool, error) {
 			if tfawserr.ErrMessageContains(err, lambda.ErrCodeInvalidParameterValueException, "The role defined for the function cannot be assumed by Lambda") {
@@ -1147,7 +1147,7 @@ func retryFunctionOp(ctx context.Context, f func() (interface{}, error)) (interf
 
 	// Additional retries when throttled.
 	if tfawserr.ErrMessageContains(err, lambda.ErrCodeInvalidParameterValueException, "throttled by EC2") {
-		output, err = tfresource.RetryWhenContext(ctx, functionExtraThrottlingTimeout,
+		output, err = tfresource.RetryWhen(ctx, functionExtraThrottlingTimeout,
 			f,
 			func(err error) (bool, error) {
 				if tfawserr.ErrMessageContains(err, lambda.ErrCodeInvalidParameterValueException, "throttled by EC2") {

--- a/internal/service/lambda/permission.go
+++ b/internal/service/lambda/permission.go
@@ -153,7 +153,7 @@ func resourcePermissionCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	log.Printf("[DEBUG] Adding Lambda Permission: %s", input)
 	// Retry for IAM and Lambda eventual consistency.
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, propagationTimeout,
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.AddPermissionWithContext(ctx, input)
 		},

--- a/internal/service/lambda/permission.go
+++ b/internal/service/lambda/permission.go
@@ -173,7 +173,7 @@ func resourcePermissionRead(ctx context.Context, d *schema.ResourceData, meta in
 	conn := meta.(*conns.AWSClient).LambdaConn()
 
 	functionName := d.Get("function_name").(string)
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return FindPolicyStatementByTwoPartKey(ctx, conn, functionName, d.Id(), d.Get("qualifier").(string))
 		}, d.IsNewResource())

--- a/internal/service/lambda/permission.go
+++ b/internal/service/lambda/permission.go
@@ -269,7 +269,7 @@ func resourcePermissionDelete(ctx context.Context, d *schema.ResourceData, meta 
 		return sdkdiag.AppendErrorf(diags, "removing Lambda Permission (%s/%s): %s", functionName, d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindPolicyStatementByTwoPartKey(ctx, conn, functionName, d.Id(), d.Get("qualifier").(string))
 	})
 

--- a/internal/service/lexmodels/bot.go
+++ b/internal/service/lexmodels/bot.go
@@ -251,7 +251,7 @@ func resourceBotCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	var output *lexmodelbuildingservice.PutBotOutput
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
 		var err error
 
 		if output != nil {
@@ -374,7 +374,7 @@ func resourceBotUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 		input.VoiceId = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
 		return conn.PutBotWithContext(ctx, input)
 	}, lexmodelbuildingservice.ErrCodeConflictException)
 
@@ -398,7 +398,7 @@ func resourceBotDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	log.Printf("[DEBUG] Deleting Lex Bot: (%s)", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
 		return conn.DeleteBotWithContext(ctx, input)
 	}, lexmodelbuildingservice.ErrCodeConflictException)
 

--- a/internal/service/lexmodels/slot_type.go
+++ b/internal/service/lexmodels/slot_type.go
@@ -151,7 +151,7 @@ func resourceSlotTypeCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	var output *lexmodelbuildingservice.PutSlotTypeOutput
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
 		var err error
 
 		if output != nil {
@@ -225,7 +225,7 @@ func resourceSlotTypeUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		input.EnumerationValues = expandEnumerationValues(v.(*schema.Set).List())
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
 		return conn.PutSlotTypeWithContext(ctx, input)
 	}, lexmodelbuildingservice.ErrCodeConflictException)
 
@@ -245,7 +245,7 @@ func resourceSlotTypeDelete(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	log.Printf("[DEBUG] Deleting Lex Slot Type: (%s)", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
 		return conn.DeleteSlotTypeWithContext(ctx, input)
 	}, lexmodelbuildingservice.ErrCodeConflictException)
 

--- a/internal/service/logs/destination.go
+++ b/internal/service/logs/destination.go
@@ -81,7 +81,7 @@ func resourceDestinationCreate(ctx context.Context, d *schema.ResourceData, meta
 		TargetArn:       aws.String(d.Get("target_arn").(string)),
 	}
 
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
 		return conn.PutDestinationWithContext(ctx, input)
 	}, cloudwatchlogs.ErrCodeInvalidParameterException)
 
@@ -155,7 +155,7 @@ func resourceDestinationUpdate(ctx context.Context, d *schema.ResourceData, meta
 			TargetArn:       aws.String(d.Get("target_arn").(string)),
 		}
 
-		_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, propagationTimeout, func() (interface{}, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
 			return conn.PutDestinationWithContext(ctx, input)
 		}, cloudwatchlogs.ErrCodeInvalidParameterException)
 

--- a/internal/service/logs/stream.go
+++ b/internal/service/logs/stream.go
@@ -68,7 +68,7 @@ func resourceStreamCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	d.SetId(name)
 
-	_, err = tfresource.RetryWhenNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindLogStreamByTwoPartKey(ctx, conn, d.Get("log_group_name").(string), d.Id())
 	})
 

--- a/internal/service/logs/subscription_filter.go
+++ b/internal/service/logs/subscription_filter.go
@@ -95,7 +95,7 @@ func resourceSubscriptionFilterPut(ctx context.Context, d *schema.ResourceData, 
 		input.RoleArn = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenContext(ctx, 5*time.Minute,
+	_, err := tfresource.RetryWhen(ctx, 5*time.Minute,
 		func() (interface{}, error) {
 			return conn.PutSubscriptionFilterWithContext(ctx, input)
 		},

--- a/internal/service/medialive/input.go
+++ b/internal/service/medialive/input.go
@@ -224,7 +224,7 @@ func resourceInputCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	// IAM propagation
-	outputRaw, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.CreateInput(ctx, in)
 		},

--- a/internal/service/mwaa/environment.go
+++ b/internal/service/mwaa/environment.go
@@ -336,7 +336,7 @@ func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta
 		Execution roles created just before the MWAA Environment may result in ValidationExceptions
 		due to IAM permission propagation delays.
 	*/
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
 		return conn.CreateEnvironmentWithContext(ctx, input)
 	}, mwaa.ErrCodeValidationException, mwaa.ErrCodeInternalServerException)
 

--- a/internal/service/networkfirewall/firewall_policy.go
+++ b/internal/service/networkfirewall/firewall_policy.go
@@ -272,7 +272,7 @@ func resourceFirewallPolicyDelete(ctx context.Context, d *schema.ResourceData, m
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn()
 
 	log.Printf("[DEBUG] Deleting NetworkFirewall Firewall Policy: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, firewallPolicyTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, firewallPolicyTimeout, func() (interface{}, error) {
 		return conn.DeleteFirewallPolicyWithContext(ctx, &networkfirewall.DeleteFirewallPolicyInput{
 			FirewallPolicyArn: aws.String(d.Id()),
 		})

--- a/internal/service/networkfirewall/resource_policy.go
+++ b/internal/service/networkfirewall/resource_policy.go
@@ -118,7 +118,7 @@ func resourceResourcePolicyDelete(ctx context.Context, d *schema.ResourceData, m
 		ResourceArn: aws.String(d.Id()),
 	}
 
-	_, err := tfresource.RetryWhenContext(ctx, resourcePolicyDeleteTimeout,
+	_, err := tfresource.RetryWhen(ctx, resourcePolicyDeleteTimeout,
 		func() (interface{}, error) {
 			return conn.DeleteResourcePolicyWithContext(ctx, input)
 		},

--- a/internal/service/networkmanager/connect_attachment.go
+++ b/internal/service/networkmanager/connect_attachment.go
@@ -147,7 +147,7 @@ func resourceConnectAttachmentCreate(ctx context.Context, d *schema.ResourceData
 		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
-	outputRaw, err := tfresource.RetryWhenContext(ctx, d.Timeout(schema.TimeoutCreate),
+	outputRaw, err := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutCreate),
 		func() (interface{}, error) {
 			return conn.CreateConnectAttachmentWithContext(ctx, input)
 		},

--- a/internal/service/networkmanager/core_network.go
+++ b/internal/service/networkmanager/core_network.go
@@ -278,7 +278,7 @@ func resourceCoreNetworkUpdate(ctx context.Context, d *schema.ResourceData, meta
 		policyVersionID := aws.Int64Value(output.CoreNetworkPolicy.PolicyVersionId)
 
 		// new policy documents goes from Pending generation to Ready to execute
-		_, err = tfresource.RetryWhenContext(ctx, 4*time.Minute,
+		_, err = tfresource.RetryWhen(ctx, 4*time.Minute,
 			func() (interface{}, error) {
 				return conn.ExecuteCoreNetworkChangeSetWithContext(ctx, &networkmanager.ExecuteCoreNetworkChangeSetInput{
 					CoreNetworkId:   aws.String(d.Id()),

--- a/internal/service/networkmanager/customer_gateway_association.go
+++ b/internal/service/networkmanager/customer_gateway_association.go
@@ -76,7 +76,7 @@ func resourceCustomerGatewayAssociationCreate(ctx context.Context, d *schema.Res
 	}
 
 	log.Printf("[DEBUG] Creating Network Manager Customer Gateway Association: %s", input)
-	_, err := tfresource.RetryWhenContext(ctx, customerGatewayAssociationResourceNotFoundExceptionTimeout,
+	_, err := tfresource.RetryWhen(ctx, customerGatewayAssociationResourceNotFoundExceptionTimeout,
 		func() (interface{}, error) {
 			return conn.AssociateCustomerGatewayWithContext(ctx, input)
 		},

--- a/internal/service/networkmanager/global_network.go
+++ b/internal/service/networkmanager/global_network.go
@@ -166,7 +166,7 @@ func resourceGlobalNetworkDelete(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	log.Printf("[DEBUG] Deleting Network Manager Global Network: %s", d.Id())
-	_, err := tfresource.RetryWhenContext(ctx, globalNetworkValidationExceptionTimeout,
+	_, err := tfresource.RetryWhen(ctx, globalNetworkValidationExceptionTimeout,
 		func() (interface{}, error) {
 			return conn.DeleteGlobalNetworkWithContext(ctx, &networkmanager.DeleteGlobalNetworkInput{
 				GlobalNetworkId: aws.String(d.Id()),

--- a/internal/service/networkmanager/site.go
+++ b/internal/service/networkmanager/site.go
@@ -228,7 +228,7 @@ func resourceSiteDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	globalNetworkID := d.Get("global_network_id").(string)
 
 	log.Printf("[DEBUG] Deleting Network Manager Site: %s", d.Id())
-	_, err := tfresource.RetryWhenContext(ctx, siteValidationExceptionTimeout,
+	_, err := tfresource.RetryWhen(ctx, siteValidationExceptionTimeout,
 		func() (interface{}, error) {
 			return conn.DeleteSiteWithContext(ctx, &networkmanager.DeleteSiteInput{
 				GlobalNetworkId: aws.String(globalNetworkID),

--- a/internal/service/opsworks/stack.go
+++ b/internal/service/opsworks/stack.go
@@ -264,7 +264,7 @@ func resourceStackCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		input.VpcId = aws.String(v.(string))
 	}
 
-	outputRaw, err := tfresource.RetryWhenContext(ctx, d.Timeout(schema.TimeoutCreate),
+	outputRaw, err := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutCreate),
 		func() (interface{}, error) {
 			return conn.CreateStackWithContext(ctx, input)
 		},

--- a/internal/service/organizations/account.go
+++ b/internal/service/organizations/account.go
@@ -304,7 +304,7 @@ func createAccount(ctx context.Context, conn *organizations.Organizations, name,
 		}
 
 		log.Printf("[DEBUG] Creating AWS Organizations Account with GovCloud Account: %s", input)
-		outputRaw, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 4*time.Minute,
+		outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 4*time.Minute,
 			func() (interface{}, error) {
 				return conn.CreateGovCloudAccountWithContext(ctx, input)
 			},
@@ -336,7 +336,7 @@ func createAccount(ctx context.Context, conn *organizations.Organizations, name,
 	}
 
 	log.Printf("[DEBUG] Creating AWS Organizations Account: %s", input)
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 4*time.Minute,
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 4*time.Minute,
 		func() (interface{}, error) {
 			return conn.CreateAccountWithContext(ctx, input)
 		},

--- a/internal/service/organizations/policy_attachment.go
+++ b/internal/service/organizations/policy_attachment.go
@@ -54,7 +54,7 @@ func resourcePolicyAttachmentCreate(ctx context.Context, d *schema.ResourceData,
 		TargetId: aws.String(targetID),
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 4*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 4*time.Minute, func() (interface{}, error) {
 		return conn.AttachPolicyWithContext(ctx, input)
 	}, organizations.ErrCodeFinalizingOrganizationException)
 

--- a/internal/service/qldb/ledger.go
+++ b/internal/service/qldb/ledger.go
@@ -203,7 +203,7 @@ func resourceLedgerDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	log.Printf("[INFO] Deleting QLDB Ledger: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 5*time.Minute,
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute,
 		func() (interface{}, error) {
 			return conn.DeleteLedgerWithContext(ctx, input)
 		}, qldb.ErrCodeResourceInUseException)

--- a/internal/service/qldb/stream.go
+++ b/internal/service/qldb/stream.go
@@ -223,7 +223,7 @@ func resourceStreamDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	log.Printf("[INFO] Deleting QLDB Stream: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 5*time.Minute,
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute,
 		func() (interface{}, error) {
 			return conn.CancelJournalKinesisStreamWithContext(ctx, input)
 		}, qldb.ErrCodeResourceInUseException)

--- a/internal/service/rds/blue_green.go
+++ b/internal/service/rds/blue_green.go
@@ -64,7 +64,7 @@ func (o *blueGreenOrchestrator) switchover(ctx context.Context, identifier strin
 	input := &rds_sdkv2.SwitchoverBlueGreenDeploymentInput{
 		BlueGreenDeploymentIdentifier: aws.String(identifier),
 	}
-	_, err := tfresource.RetryWhenContext(ctx, 10*time.Minute,
+	_, err := tfresource.RetryWhen(ctx, 10*time.Minute,
 		func() (interface{}, error) {
 			return o.conn.SwitchoverBlueGreenDeployment(ctx, input)
 		},

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -575,7 +575,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 
 		log.Printf("[DEBUG] Creating RDS Cluster: %s", input)
-		_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, propagationTimeout,
+		_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return conn.RestoreDBClusterFromSnapshotWithContext(ctx, input)
 			},
@@ -933,7 +933,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			input.VpcSecurityGroupIds = flex.ExpandStringSet(v.(*schema.Set))
 		}
 
-		_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, propagationTimeout,
+		_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return conn.CreateDBClusterWithContext(ctx, input)
 			},

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -675,7 +675,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			input.VpcSecurityGroupIds = flex.ExpandStringSet(v.(*schema.Set))
 		}
 
-		_, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+		_, err := tfresource.RetryWhen(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return conn.RestoreDBClusterFromS3WithContext(ctx, input)
 			},
@@ -1223,7 +1223,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			}
 		}
 
-		_, err := tfresource.RetryWhenContext(ctx, 5*time.Minute,
+		_, err := tfresource.RetryWhen(ctx, 5*time.Minute,
 			func() (interface{}, error) {
 				return conn.ModifyDBClusterWithContext(ctx, input)
 			},
@@ -1347,14 +1347,14 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	log.Printf("[DEBUG] Deleting RDS Cluster: %s", d.Id())
-	_, err := tfresource.RetryWhenContext(ctx, clusterTimeoutDelete,
+	_, err := tfresource.RetryWhen(ctx, clusterTimeoutDelete,
 		func() (interface{}, error) {
 			return conn.DeleteDBClusterWithContext(ctx, input)
 		},
 		func(err error) (bool, error) {
 			if tfawserr.ErrMessageContains(err, "InvalidParameterCombination", "disable deletion pro") {
 				if v, ok := d.GetOk("deletion_protection"); (!ok || !v.(bool)) && d.Get("apply_immediately").(bool) {
-					_, err := tfresource.RetryWhenContext(ctx, d.Timeout(schema.TimeoutDelete),
+					_, err := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutDelete),
 						func() (interface{}, error) {
 							return conn.ModifyDBClusterWithContext(ctx, &rds.ModifyDBClusterInput{
 								ApplyImmediately:    aws.Bool(true),

--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -295,7 +295,7 @@ func resourceClusterInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	log.Printf("[DEBUG] Creating RDS Cluster Instance: %s", input)
-	outputRaw, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.CreateDBInstanceWithContext(ctx, input)
 		},
@@ -503,7 +503,7 @@ func resourceClusterInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 
 		log.Printf("[DEBUG] Updating RDS Cluster Instance: %s", input)
-		_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, propagationTimeout,
+		_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return conn.ModifyDBInstanceWithContext(ctx, input)
 			},
@@ -538,7 +538,7 @@ func resourceClusterInstanceDelete(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	log.Printf("[DEBUG] Deleting RDS Cluster Instance: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, d.Timeout(schema.TimeoutDelete),
+	_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, d.Timeout(schema.TimeoutDelete),
 		func() (interface{}, error) {
 			return conn.DeleteDBInstanceWithContext(ctx, input)
 		},

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -914,7 +914,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			input.VpcSecurityGroupIds = flex.ExpandStringSet(v.(*schema.Set))
 		}
 
-		_, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+		_, err := tfresource.RetryWhen(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return conn.RestoreDBInstanceFromS3WithContext(ctx, input)
 			},
@@ -1131,7 +1131,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			input.VpcSecurityGroupIds = flex.ExpandStringSet(v)
 		}
 
-		_, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+		_, err := tfresource.RetryWhen(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return conn.RestoreDBInstanceFromDBSnapshotWithContext(ctx, input)
 			},
@@ -1293,7 +1293,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			input.VpcSecurityGroupIds = flex.ExpandStringSet(v.(*schema.Set))
 		}
 
-		_, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+		_, err := tfresource.RetryWhen(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return conn.RestoreDBInstanceToPointInTimeWithContext(ctx, input)
 			},
@@ -1473,7 +1473,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			input.VpcSecurityGroupIds = flex.ExpandStringSet(v)
 		}
 
-		outputRaw, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+		outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return conn.CreateDBInstanceWithContext(ctx, input)
 			},
@@ -1813,7 +1813,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 				DBInstanceIdentifier: aws.String(sourceARN.Identifier),
 				SkipFinalSnapshot:    true,
 			}
-			_, err = tfresource.RetryWhenContext(ctx, 5*time.Minute,
+			_, err = tfresource.RetryWhen(ctx, 5*time.Minute,
 				func() (any, error) {
 					return conn.DeleteDBInstance(ctx, deleteInput)
 				},
@@ -2083,7 +2083,7 @@ func dbInstancePopulateModify(input *rds_sdkv2.ModifyDBInstanceInput, d *schema.
 }
 
 func dbInstanceModify(ctx context.Context, conn *rds_sdkv2.Client, input *rds_sdkv2.ModifyDBInstanceInput, timeout time.Duration) error {
-	_, err := tfresource.RetryWhenContext(ctx, timeout,
+	_, err := tfresource.RetryWhen(ctx, timeout,
 		func() (interface{}, error) {
 			return conn.ModifyDBInstance(ctx, input)
 		},
@@ -2137,7 +2137,7 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 
 	if tfawserr.ErrMessageContains(err, errCodeInvalidParameterCombination, "disable deletion pro") {
 		if v, ok := d.GetOk("deletion_protection"); (!ok || !v.(bool)) && d.Get("apply_immediately").(bool) {
-			_, ierr := tfresource.RetryWhenContext(ctx, d.Timeout(schema.TimeoutUpdate),
+			_, ierr := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutUpdate),
 				func() (interface{}, error) {
 					return conn.ModifyDBInstanceWithContext(ctx, &rds.ModifyDBInstanceInput{
 						ApplyImmediately:     aws.Bool(true),

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -710,7 +710,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			input.VpcSecurityGroupIds = flex.ExpandStringSet(v.(*schema.Set))
 		}
 
-		outputRaw, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, propagationTimeout,
+		outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return conn.CreateDBInstanceReadReplicaWithContext(ctx, input)
 			},

--- a/internal/service/rds/proxy_target.go
+++ b/internal/service/rds/proxy_target.go
@@ -107,7 +107,7 @@ func resourceProxyTargetCreate(ctx context.Context, d *schema.ResourceData, meta
 		input.DBInstanceIdentifiers = aws.StringSlice([]string{v.(string)})
 	}
 
-	outputRaw, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, 5*time.Minute,
+	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, 5*time.Minute,
 		func() (interface{}, error) {
 			return conn.RegisterDBProxyTargetsWithContext(ctx, input)
 		},

--- a/internal/service/rds/subnet_group.go
+++ b/internal/service/rds/subnet_group.go
@@ -196,7 +196,7 @@ func resourceSubnetGroupDelete(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendErrorf(diags, "deleting RDS Subnet Group (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFoundContext(ctx, 3*time.Minute, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, 3*time.Minute, func() (interface{}, error) {
 		return FindDBSubnetGroupByName(ctx, conn, d.Id())
 	})
 

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -846,7 +846,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 				ClusterIdentifier: aws.String(d.Id()),
 			}
 
-			_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, clusterInvalidClusterStateFaultTimeout,
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, clusterInvalidClusterStateFaultTimeout,
 				func() (interface{}, error) {
 					return conn.RebootClusterWithContext(ctx, rebootInput)
 				},
@@ -944,7 +944,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	log.Printf("[DEBUG] Deleting Redshift Cluster: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, clusterInvalidClusterStateFaultTimeout,
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, clusterInvalidClusterStateFaultTimeout,
 		func() (interface{}, error) {
 			return conn.DeleteClusterWithContext(ctx, input)
 		},
@@ -996,7 +996,7 @@ func enableLogging(ctx context.Context, conn *redshift.Redshift, clusterID strin
 		input.S3KeyPrefix = aws.String(v)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, clusterInvalidClusterStateFaultTimeout,
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, clusterInvalidClusterStateFaultTimeout,
 		func() (interface{}, error) {
 			return conn.EnableLoggingWithContext(ctx, input)
 		},
@@ -1015,7 +1015,7 @@ func disableLogging(ctx context.Context, conn *redshift.Redshift, clusterID stri
 		ClusterIdentifier: aws.String(clusterID),
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, clusterInvalidClusterStateFaultTimeout,
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, clusterInvalidClusterStateFaultTimeout,
 		func() (interface{}, error) {
 			return conn.DisableLoggingWithContext(ctx, input)
 		},

--- a/internal/service/redshift/scheduled_action.go
+++ b/internal/service/redshift/scheduled_action.go
@@ -174,7 +174,7 @@ func resourceScheduledActionCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	log.Printf("[DEBUG] Creating Redshift Scheduled Action: %s", input)
-	outputRaw, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.CreateScheduledActionWithContext(ctx, input)
 		},

--- a/internal/service/redshift/snapshot_copy_grant.go
+++ b/internal/service/redshift/snapshot_copy_grant.go
@@ -87,7 +87,7 @@ func resourceSnapshotCopyGrantCreate(ctx context.Context, d *schema.ResourceData
 	log.Printf("[DEBUG] Created new Redshift SnapshotCopyGrant: %s", *out.SnapshotCopyGrant.SnapshotCopyGrantName)
 	d.SetId(grantName)
 
-	_, err = tfresource.RetryWhenNotFoundContext(ctx, 3*time.Minute, func() (any, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, 3*time.Minute, func() (any, error) {
 		return findSnapshotCopyGrant(ctx, conn, grantName)
 	})
 	if err != nil {

--- a/internal/service/redshift/snapshot_copy_grant.go
+++ b/internal/service/redshift/snapshot_copy_grant.go
@@ -185,7 +185,7 @@ func resourceSnapshotCopyGrantDelete(ctx context.Context, d *schema.ResourceData
 
 // Used by the tests as well
 func WaitForSnapshotCopyGrantToBeDeleted(ctx context.Context, conn *redshift.Redshift, grantName string) error {
-	_, err := tfresource.RetryUntilNotFoundContext(ctx, 3*time.Minute, func() (any, error) {
+	_, err := tfresource.RetryUntilNotFound(ctx, 3*time.Minute, func() (any, error) {
 		return findSnapshotCopyGrant(ctx, conn, grantName)
 	})
 	return err

--- a/internal/service/redshiftserverless/namespace.go
+++ b/internal/service/redshiftserverless/namespace.go
@@ -258,7 +258,7 @@ func resourceNamespaceDelete(ctx context.Context, d *schema.ResourceData, meta i
 	conn := meta.(*conns.AWSClient).RedshiftServerlessConn()
 
 	log.Printf("[DEBUG] Deleting Redshift Serverless Namespace: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, 10*time.Minute,
+	_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, 10*time.Minute,
 		func() (interface{}, error) {
 			return conn.DeleteNamespaceWithContext(ctx, &redshiftserverless.DeleteNamespaceInput{
 				NamespaceName: aws.String(d.Id()),

--- a/internal/service/redshiftserverless/workgroup.go
+++ b/internal/service/redshiftserverless/workgroup.go
@@ -329,7 +329,7 @@ func resourceWorkgroupDelete(ctx context.Context, d *schema.ResourceData, meta i
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftServerlessConn()
 
-	_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, 10*time.Minute,
+	_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, 10*time.Minute,
 		func() (interface{}, error) {
 			return conn.DeleteWorkgroupWithContext(ctx, &redshiftserverless.DeleteWorkgroupInput{
 				WorkgroupName: aws.String(d.Id()),

--- a/internal/service/route53/traffic_policy.go
+++ b/internal/service/route53/traffic_policy.go
@@ -89,7 +89,7 @@ func resourceTrafficPolicyCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	log.Printf("[INFO] Creating Route53 Traffic Policy: %s", input)
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
 		return conn.CreateTrafficPolicyWithContext(ctx, input)
 	}, route53.ErrCodeNoSuchTrafficPolicy)
 

--- a/internal/service/route53/traffic_policy_instance.go
+++ b/internal/service/route53/traffic_policy_instance.go
@@ -75,7 +75,7 @@ func resourceTrafficPolicyInstanceCreate(ctx context.Context, d *schema.Resource
 	}
 
 	log.Printf("[INFO] Creating Route53 Traffic Policy Instance: %s", input)
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
 		return conn.CreateTrafficPolicyInstanceWithContext(ctx, input)
 	}, route53.ErrCodeNoSuchTrafficPolicy)
 

--- a/internal/service/route53/zone.go
+++ b/internal/service/route53/zone.go
@@ -428,7 +428,7 @@ func dnsSECStatus(ctx context.Context, conn *route53.Route53, hostedZoneID strin
 	}
 
 	var output *route53.GetDNSSECOutput
-	err := tfresource.RetryContext(ctx, 3*time.Minute, func() *resource.RetryError {
+	err := tfresource.Retry(ctx, 3*time.Minute, func() *resource.RetryError {
 		var err error
 
 		output, err = conn.GetDNSSECWithContext(ctx, input)
@@ -484,7 +484,7 @@ func disableDNSSECForZone(ctx context.Context, conn *route53.Route53, hostedZone
 	}
 
 	var output *route53.DisableHostedZoneDNSSECOutput
-	err = tfresource.RetryContext(ctx, 5*time.Minute, func() *resource.RetryError {
+	err = tfresource.Retry(ctx, 5*time.Minute, func() *resource.RetryError {
 		var err error
 
 		output, err = conn.DisableHostedZoneDNSSECWithContext(ctx, input)

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -820,7 +820,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		o, n := d.GetChange("tags_all")
 
 		// Retry due to S3 eventual consistency
-		_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
 			terr := BucketUpdateTags(ctx, conn, d.Id(), o, n)
 			return nil, terr
 		}, s3.ErrCodeNoSuchBucket)
@@ -976,7 +976,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("bucket_domain_name", meta.(*conns.AWSClient).PartitionHostname(fmt.Sprintf("%s.s3", d.Get("bucket").(string))))
 
 	// Read the policy if configured outside this resource e.g. with aws_s3_bucket_policy resource
-	pol, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
+	pol, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
 		return conn.GetBucketPolicyWithContext(ctx, &s3.GetBucketPolicyInput{
 			Bucket: aws.String(d.Id()),
 		})
@@ -1008,7 +1008,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	// Read the Grant ACL.
 	// In the event grants are not configured on the bucket, the API returns an empty array
-	apResponse, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
+	apResponse, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
 		return conn.GetBucketAclWithContext(ctx, &s3.GetBucketAclInput{
 			Bucket: aws.String(d.Id()),
 		})
@@ -1036,7 +1036,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	// Read the CORS
-	corsResponse, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
+	corsResponse, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
 		return conn.GetBucketCorsWithContext(ctx, &s3.GetBucketCorsInput{
 			Bucket: aws.String(d.Id()),
 		})
@@ -1064,7 +1064,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	// Read the website configuration
-	wsResponse, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
+	wsResponse, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
 		return conn.GetBucketWebsiteWithContext(ctx, &s3.GetBucketWebsiteInput{
 			Bucket: aws.String(d.Id()),
 		})
@@ -1102,7 +1102,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	// Read the versioning configuration
 
-	versioningResponse, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
+	versioningResponse, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
 		return conn.GetBucketVersioningWithContext(ctx, &s3.GetBucketVersioningInput{
 			Bucket: aws.String(d.Id()),
 		})
@@ -1129,7 +1129,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	// Read the acceleration status
 
-	accelerateResponse, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
+	accelerateResponse, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
 		return conn.GetBucketAccelerateConfigurationWithContext(ctx, &s3.GetBucketAccelerateConfigurationInput{
 			Bucket: aws.String(d.Id()),
 		})
@@ -1155,7 +1155,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	// Read the request payer configuration.
 
-	payerResponse, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
+	payerResponse, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
 		return conn.GetBucketRequestPaymentWithContext(ctx, &s3.GetBucketRequestPaymentInput{
 			Bucket: aws.String(d.Id()),
 		})
@@ -1179,7 +1179,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	// Read the logging configuration if configured outside this resource
-	loggingResponse, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
+	loggingResponse, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
 		return conn.GetBucketLoggingWithContext(ctx, &s3.GetBucketLoggingInput{
 			Bucket: aws.String(d.Id()),
 		})
@@ -1208,7 +1208,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	// Read the lifecycle configuration
 
-	lifecycleResponse, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
+	lifecycleResponse, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
 		return conn.GetBucketLifecycleConfigurationWithContext(ctx, &s3.GetBucketLifecycleConfigurationInput{
 			Bucket: aws.String(d.Id()),
 		})
@@ -1237,7 +1237,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	// Read the bucket replication configuration if configured outside this resource
 
-	replicationResponse, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
+	replicationResponse, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
 		return conn.GetBucketReplicationWithContext(ctx, &s3.GetBucketReplicationInput{
 			Bucket: aws.String(d.Id()),
 		})
@@ -1267,7 +1267,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	// Read the bucket server side encryption configuration
 
-	encryptionResponse, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
+	encryptionResponse, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
 		return conn.GetBucketEncryptionWithContext(ctx, &s3.GetBucketEncryptionInput{
 			Bucket: aws.String(d.Id()),
 		})
@@ -1295,7 +1295,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	// Object Lock configuration.
-	resp, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
+	resp, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
 		return conn.GetObjectLockConfigurationWithContext(ctx, &s3.GetObjectLockConfigurationInput{
 			Bucket: aws.String(d.Id()),
 		})
@@ -1332,7 +1332,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	// Add the region as an attribute
-	discoveredRegion, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
+	discoveredRegion, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
 		return s3manager.GetBucketRegionWithClient(ctx, conn, d.Id(), func(r *request.Request) {
 			// By default, GetBucketRegion forces virtual host addressing, which
 			// is not compatible with many non-AWS implementations. Instead, pass
@@ -1400,7 +1400,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	// Retry due to S3 eventual consistency
-	tagsRaw, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
+	tagsRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
 		return BucketListTags(ctx, conn, d.Id())
 	}, s3.ErrCodeNoSuchBucket)
 
@@ -1538,7 +1538,7 @@ func websiteEndpoint(ctx context.Context, client *conns.AWSClient, d *schema.Res
 
 	// Lookup the region for this bucket
 
-	locationResponse, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
+	locationResponse, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutRead), func() (interface{}, error) {
 		return client.S3Conn().GetBucketLocation(
 			&s3.GetBucketLocationInput{
 				Bucket: aws.String(bucket),
@@ -1597,7 +1597,7 @@ func resourceBucketInternalAccelerationUpdate(ctx context.Context, conn *s3.S3, 
 		},
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
 		return conn.PutBucketAccelerateConfigurationWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 
@@ -1616,7 +1616,7 @@ func resourceBucketInternalACLUpdate(ctx context.Context, conn *s3.S3, d *schema
 		ACL:    aws.String(acl),
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
 		return conn.PutBucketAclWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 
@@ -1628,7 +1628,7 @@ func resourceBucketInternalCorsUpdate(ctx context.Context, conn *s3.S3, d *schem
 
 	if len(rawCors) == 0 {
 		// Delete CORS
-		_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
 			return conn.DeleteBucketCorsWithContext(ctx, &s3.DeleteBucketCorsInput{
 				Bucket: aws.String(d.Id()),
 			})
@@ -1682,7 +1682,7 @@ func resourceBucketInternalCorsUpdate(ctx context.Context, conn *s3.S3, d *schem
 		},
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
 		return conn.PutBucketCorsWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 
@@ -1702,7 +1702,7 @@ func resourceBucketInternalGrantsUpdate(ctx context.Context, conn *s3.S3, d *sch
 		return nil
 	}
 
-	resp, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+	resp, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
 		return conn.GetBucketAclWithContext(ctx, &s3.GetBucketAclInput{
 			Bucket: aws.String(d.Id()),
 		})
@@ -1726,7 +1726,7 @@ func resourceBucketInternalGrantsUpdate(ctx context.Context, conn *s3.S3, d *sch
 		},
 	}
 
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
 		return conn.PutBucketAclWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 
@@ -1882,7 +1882,7 @@ func resourceBucketInternalLifecycleUpdate(ctx context.Context, conn *s3.S3, d *
 		},
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
 		return conn.PutBucketLifecycleConfigurationWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 
@@ -1912,7 +1912,7 @@ func resourceBucketInternalLoggingUpdate(ctx context.Context, conn *s3.S3, d *sc
 		BucketLoggingStatus: loggingStatus,
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
 		return conn.PutBucketLoggingWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 
@@ -1926,7 +1926,7 @@ func resourceBucketInternalObjectLockConfigurationUpdate(ctx context.Context, co
 		ObjectLockConfiguration: expandObjectLockConfiguration(d.Get("object_lock_configuration").([]interface{})),
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
 		return conn.PutObjectLockConfigurationWithContext(ctx, req)
 	}, s3.ErrCodeNoSuchBucket)
 
@@ -1940,7 +1940,7 @@ func resourceBucketInternalPolicyUpdate(ctx context.Context, conn *s3.S3, d *sch
 	}
 
 	if policy == "" {
-		_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
 			return conn.DeleteBucketPolicyWithContext(ctx, &s3.DeleteBucketPolicyInput{
 				Bucket: aws.String(d.Id()),
 			})
@@ -2040,7 +2040,7 @@ func resourceBucketInternalRequestPayerUpdate(ctx context.Context, conn *s3.S3, 
 		},
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
 		return conn.PutBucketRequestPaymentWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 
@@ -2099,7 +2099,7 @@ func resourceBucketInternalServerSideEncryptionConfigurationUpdate(ctx context.C
 		ServerSideEncryptionConfiguration: rc,
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutUpdate),
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate),
 		func() (interface{}, error) {
 			return conn.PutBucketEncryptionWithContext(ctx, input)
 		},
@@ -2116,7 +2116,7 @@ func resourceBucketInternalVersioningUpdate(ctx context.Context, conn *s3.S3, bu
 		VersioningConfiguration: versioningConfig,
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, timeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (interface{}, error) {
 		return conn.PutBucketVersioningWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 
@@ -2131,7 +2131,7 @@ func resourceBucketInternalWebsiteUpdate(ctx context.Context, conn *s3.S3, d *sc
 			Bucket: aws.String(d.Id()),
 		}
 
-		_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
 			return conn.DeleteBucketWebsiteWithContext(ctx, input)
 		}, s3.ErrCodeNoSuchBucket)
 
@@ -2155,7 +2155,7 @@ func resourceBucketInternalWebsiteUpdate(ctx context.Context, conn *s3.S3, d *sc
 		WebsiteConfiguration: websiteConfig,
 	}
 
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
 		return conn.PutBucketWebsiteWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_accelerate_configuration.go
+++ b/internal/service/s3/bucket_accelerate_configuration.go
@@ -66,7 +66,7 @@ func resourceBucketAccelerateConfigurationCreate(ctx context.Context, d *schema.
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.PutBucketAccelerateConfigurationWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_acl.go
+++ b/internal/service/s3/bucket_acl.go
@@ -149,7 +149,7 @@ func resourceBucketACLCreate(ctx context.Context, d *schema.ResourceData, meta i
 		input.AccessControlPolicy = expandBucketACLAccessControlPolicy(v.([]interface{}))
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.PutBucketAclWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_cors_configuration.go
+++ b/internal/service/s3/bucket_cors_configuration.go
@@ -100,7 +100,7 @@ func resourceBucketCorsConfigurationCreate(ctx context.Context, d *schema.Resour
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.PutBucketCorsWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 
@@ -129,7 +129,7 @@ func resourceBucketCorsConfigurationRead(ctx context.Context, d *schema.Resource
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	corsResponse, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	corsResponse, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.GetBucketCorsWithContext(ctx, input)
 	}, ErrCodeNoSuchCORSConfiguration)
 

--- a/internal/service/s3/bucket_cors_configuration_test.go
+++ b/internal/service/s3/bucket_cors_configuration_test.go
@@ -378,7 +378,7 @@ func testAccCheckBucketCorsConfigurationExists(ctx context.Context, resourceName
 			input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 		}
 
-		corsResponse, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+		corsResponse, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 			return conn.GetBucketCorsWithContext(ctx, input)
 		}, tfs3.ErrCodeNoSuchCORSConfiguration)
 

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -273,7 +273,7 @@ func resourceBucketLifecycleConfigurationCreate(ctx context.Context, d *schema.R
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.PutBucketLifecycleConfigurationWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 
@@ -378,7 +378,7 @@ func resourceBucketLifecycleConfigurationUpdate(ctx context.Context, d *schema.R
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.PutBucketLifecycleConfigurationWithContext(ctx, input)
 	}, ErrCodeNoSuchLifecycleConfiguration)
 

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -1012,7 +1012,7 @@ func testAccCheckBucketLifecycleConfigurationDestroy(ctx context.Context) resour
 				input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 			}
 
-			output, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+			output, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 				return conn.GetBucketLifecycleConfigurationWithContext(ctx, input)
 			}, s3.ErrCodeNoSuchBucket)
 
@@ -1059,7 +1059,7 @@ func testAccCheckBucketLifecycleConfigurationExists(ctx context.Context, n strin
 			input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 		}
 
-		output, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+		output, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 			return conn.GetBucketLifecycleConfigurationWithContext(ctx, input)
 		}, tfs3.ErrCodeNoSuchLifecycleConfiguration)
 

--- a/internal/service/s3/bucket_logging.go
+++ b/internal/service/s3/bucket_logging.go
@@ -121,7 +121,7 @@ func resourceBucketLoggingCreate(ctx context.Context, d *schema.ResourceData, me
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.PutBucketLoggingWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 
@@ -150,7 +150,7 @@ func resourceBucketLoggingRead(ctx context.Context, d *schema.ResourceData, meta
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	resp, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	resp, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.GetBucketLoggingWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 
@@ -217,7 +217,7 @@ func resourceBucketLoggingUpdate(ctx context.Context, d *schema.ResourceData, me
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.PutBucketLoggingWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_object.go
+++ b/internal/service/s3/bucket_object.go
@@ -284,7 +284,7 @@ func resourceBucketObjectRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	// Retry due to S3 eventual consistency
-	tagsRaw, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	tagsRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return ObjectListTags(ctx, conn, bucket, key)
 	}, s3.ErrCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_object_lock_configuration.go
+++ b/internal/service/s3/bucket_object_lock_configuration.go
@@ -118,7 +118,7 @@ func resourceBucketObjectLockConfigurationCreate(ctx context.Context, d *schema.
 		input.Token = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.PutObjectLockConfigurationWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_ownership_controls.go
+++ b/internal/service/s3/bucket_ownership_controls.go
@@ -148,7 +148,7 @@ func resourceBucketOwnershipControlsDelete(ctx context.Context, d *schema.Resour
 		Bucket: aws.String(d.Id()),
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 5*time.Minute,
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute,
 		func() (any, error) {
 			return conn.DeleteBucketOwnershipControlsWithContext(ctx, input)
 		},

--- a/internal/service/s3/bucket_replication_configuration_test.go
+++ b/internal/service/s3/bucket_replication_configuration_test.go
@@ -1189,7 +1189,7 @@ func testAccCheckBucketReplicationConfigurationDestroyWithProvider(ctx context.C
 			}
 			input := &s3.GetBucketReplicationInput{Bucket: aws.String(rs.Primary.ID)}
 
-			output, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+			output, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 				return conn.GetBucketReplicationWithContext(ctx, input)
 			}, s3.ErrCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_request_payment_configuration.go
+++ b/internal/service/s3/bucket_request_payment_configuration.go
@@ -66,7 +66,7 @@ func resourceBucketRequestPaymentConfigurationCreate(ctx context.Context, d *sch
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.PutBucketRequestPaymentWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_server_side_encryption_configuration.go
+++ b/internal/service/s3/bucket_server_side_encryption_configuration.go
@@ -90,7 +90,7 @@ func resourceBucketServerSideEncryptionConfigurationCreate(ctx context.Context, 
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, propagationTimeout,
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.PutBucketEncryptionWithContext(ctx, input)
 		},
@@ -123,7 +123,7 @@ func resourceBucketServerSideEncryptionConfigurationRead(ctx context.Context, d 
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	resp, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, propagationTimeout,
+	resp, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.GetBucketEncryptionWithContext(ctx, input)
 		},
@@ -181,7 +181,7 @@ func resourceBucketServerSideEncryptionConfigurationUpdate(ctx context.Context, 
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, propagationTimeout,
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.PutBucketEncryptionWithContext(ctx, input)
 		},

--- a/internal/service/s3/bucket_versioning.go
+++ b/internal/service/s3/bucket_versioning.go
@@ -115,7 +115,7 @@ func resourceBucketVersioningCreate(ctx context.Context, d *schema.ResourceData,
 			input.MFA = aws.String(v.(string))
 		}
 
-		_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 			return conn.PutBucketVersioningWithContext(ctx, input)
 		}, s3.ErrCodeNoSuchBucket)
 

--- a/internal/service/s3/bucket_website_configuration.go
+++ b/internal/service/s3/bucket_website_configuration.go
@@ -213,7 +213,7 @@ func resourceBucketWebsiteConfigurationCreate(ctx context.Context, d *schema.Res
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.PutBucketWebsiteWithContext(ctx, input)
 	}, s3.ErrCodeNoSuchBucket)
 

--- a/internal/service/s3/object.go
+++ b/internal/service/s3/object.go
@@ -281,7 +281,7 @@ func resourceObjectRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	// Retry due to S3 eventual consistency
-	tagsRaw, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	tagsRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return ObjectListTags(ctx, conn, bucket, key)
 	}, s3.ErrCodeNoSuchBucket)
 

--- a/internal/service/s3/object_copy.go
+++ b/internal/service/s3/object_copy.go
@@ -372,7 +372,7 @@ func resourceObjectCopyRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	// Retry due to S3 eventual consistency
-	tagsRaw, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	tagsRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return ObjectListTags(ctx, conn, bucket, key)
 	}, s3.ErrCodeNoSuchBucket)
 

--- a/internal/service/s3/wait.go
+++ b/internal/service/s3/wait.go
@@ -23,7 +23,7 @@ const (
 )
 
 func retryWhenBucketNotFound(ctx context.Context, f func() (interface{}, error)) (interface{}, error) {
-	return tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, propagationTimeout, f, s3.ErrCodeNoSuchBucket)
+	return tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, f, s3.ErrCodeNoSuchBucket)
 }
 
 func waitForLifecycleConfigurationRulesStatus(ctx context.Context, conn *s3.S3, bucket, expectedBucketOwner string, rules []*s3.LifecycleRule) error {

--- a/internal/service/s3control/account_public_access_block.go
+++ b/internal/service/s3control/account_public_access_block.go
@@ -90,7 +90,7 @@ func resourceAccountPublicAccessBlockCreate(ctx context.Context, d *schema.Resou
 
 	d.SetId(accountID)
 
-	_, err = tfresource.RetryWhenNotFoundContext(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindPublicAccessBlockByAccountID(ctx, conn, d.Id())
 	})
 

--- a/internal/service/s3control/bucket.go
+++ b/internal/service/s3control/bucket.go
@@ -198,7 +198,7 @@ func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	// can occur on deletion:
 	//   InvalidBucketState: Bucket is in an invalid state
 	log.Printf("[DEBUG] Deleting S3 Control Bucket: %s", d.Id())
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, bucketStatePropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketStatePropagationTimeout, func() (interface{}, error) {
 		return conn.DeleteBucketWithContext(ctx, input)
 	}, errCodeInvalidBucketState)
 

--- a/internal/service/sagemaker/device_fleet.go
+++ b/internal/service/sagemaker/device_fleet.go
@@ -112,7 +112,7 @@ func resourceDeviceFleetCreate(ctx context.Context, d *schema.ResourceData, meta
 		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.CreateDeviceFleetWithContext(ctx, input)
 	}, "ValidationException")
 	if err != nil {

--- a/internal/service/sagemaker/flow_definition.go
+++ b/internal/service/sagemaker/flow_definition.go
@@ -272,7 +272,7 @@ func resourceFlowDefinitionCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	log.Printf("[DEBUG] Creating SageMaker Flow Definition: %s", input)
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
 		return conn.CreateFlowDefinitionWithContext(ctx, input)
 	}, "ValidationException")
 

--- a/internal/service/sagemaker/model.go
+++ b/internal/service/sagemaker/model.go
@@ -286,7 +286,7 @@ func resourceModelCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	log.Printf("[DEBUG] SageMaker model create config: %#v", *createOpts)
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.CreateModelWithContext(ctx, createOpts)
 	}, "ValidationException")
 

--- a/internal/service/sagemaker/project.go
+++ b/internal/service/sagemaker/project.go
@@ -121,7 +121,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.CreateProjectWithContext(ctx, input)
 	}, "ValidationException")
 	if err != nil {

--- a/internal/service/sagemaker/workteam.go
+++ b/internal/service/sagemaker/workteam.go
@@ -154,7 +154,7 @@ func resourceWorkteamCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	log.Printf("[DEBUG] Updating SageMaker Workteam: %s", input)
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.CreateWorkteamWithContext(ctx, input)
 	}, "ValidationException")
 

--- a/internal/service/scheduler/retry.go
+++ b/internal/service/scheduler/retry.go
@@ -14,7 +14,7 @@ const (
 )
 
 func retryWhenIAMNotPropagated[T any](ctx context.Context, f func() (T, error)) (T, error) {
-	v, err := tfresource.RetryWhenContext(
+	v, err := tfresource.RetryWhen(
 		ctx,
 		iamPropagationTimeout,
 		func() (interface{}, error) {

--- a/internal/service/secretsmanager/secret.go
+++ b/internal/service/secretsmanager/secret.go
@@ -498,7 +498,7 @@ func resourceSecretDelete(ctx context.Context, d *schema.ResourceData, meta inte
 		return sdkdiag.AppendErrorf(diags, "deleting Secrets Manager Secret (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFoundContext(ctx, PropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, PropagationTimeout, func() (interface{}, error) {
 		return FindSecretByID(ctx, conn, d.Id())
 	})
 

--- a/internal/service/secretsmanager/secret.go
+++ b/internal/service/secretsmanager/secret.go
@@ -272,7 +272,7 @@ func resourceSecretRead(ctx context.Context, d *schema.ResourceData, meta interf
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, PropagationTimeout, func() (interface{}, error) {
 		return FindSecretByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 

--- a/internal/service/secretsmanager/secret.go
+++ b/internal/service/secretsmanager/secret.go
@@ -393,7 +393,7 @@ func resourceSecretUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			}
 
 			log.Printf("[DEBUG] Setting Secrets Manager Secret resource policy: %s", input)
-			_, err = tfresource.RetryWhenAWSErrMessageContainsContext(ctx, PropagationTimeout,
+			_, err = tfresource.RetryWhenAWSErrMessageContains(ctx, PropagationTimeout,
 				func() (interface{}, error) {
 					return conn.PutResourcePolicyWithContext(ctx, input)
 				},

--- a/internal/service/secretsmanager/secret_policy.go
+++ b/internal/service/secretsmanager/secret_policy.go
@@ -107,7 +107,7 @@ func resourceSecretPolicyRead(ctx context.Context, d *schema.ResourceData, meta 
 		SecretId: aws.String(d.Id()),
 	}
 
-	outputRaw, err := tfresource.RetryWhenNotFoundContext(ctx, PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNotFound(ctx, PropagationTimeout, func() (interface{}, error) {
 		return conn.GetResourcePolicyWithContext(ctx, input)
 	})
 

--- a/internal/service/servicediscovery/http_namespace.go
+++ b/internal/service/servicediscovery/http_namespace.go
@@ -164,7 +164,7 @@ func resourceHTTPNamespaceDelete(ctx context.Context, d *schema.ResourceData, me
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn()
 
 	log.Printf("[INFO] Deleting Service Discovery HTTP Namespace: %s", d.Id())
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, 2*time.Minute, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
 		return conn.DeleteNamespaceWithContext(ctx, &servicediscovery.DeleteNamespaceInput{
 			Id: aws.String(d.Id()),
 		})

--- a/internal/service/sfn/state_machine.go
+++ b/internal/service/sfn/state_machine.go
@@ -157,7 +157,7 @@ func resourceStateMachineCreate(ctx context.Context, d *schema.ResourceData, met
 	// Note: the instance may be in a deleting mode, hence the retry
 	// when creating the step function. This can happen when we are
 	// updating the resource (since there is no update API call).
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, stateMachineCreatedTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, stateMachineCreatedTimeout, func() (interface{}, error) {
 		return conn.CreateStateMachineWithContext(ctx, input)
 	}, sfn.ErrCodeStateMachineDeleting, "AccessDeniedException")
 

--- a/internal/service/sns/platform_application.go
+++ b/internal/service/sns/platform_application.go
@@ -128,7 +128,7 @@ func resourcePlatformApplicationCreate(ctx context.Context, d *schema.ResourceDa
 		Platform:   aws.String(d.Get("platform").(string)),
 	}
 
-	outputRaw, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
 		return conn.CreatePlatformApplicationWithContext(ctx, input)
 	}, sns.ErrCodeInvalidParameterException, "is not a valid role to allow SNS to write to Cloudwatch Logs")
 
@@ -221,7 +221,7 @@ func resourcePlatformApplicationUpdate(ctx context.Context, d *schema.ResourceDa
 		PlatformApplicationArn: aws.String(d.Id()),
 	}
 
-	_, err = tfresource.RetryWhenAWSErrMessageContainsContext(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
 		return conn.SetPlatformApplicationAttributesWithContext(ctx, input)
 	}, sns.ErrCodeInvalidParameterException, "is not a valid role to allow SNS to write to Cloudwatch Logs")
 

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -470,7 +470,7 @@ func putTopicAttribute(ctx context.Context, conn *sns.SNS, arn string, name, val
 		TopicArn:       aws.String(arn),
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, topicPutAttributeTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, topicPutAttributeTimeout, func() (interface{}, error) {
 		return conn.SetTopicAttributesWithContext(ctx, input)
 	}, sns.ErrCodeInvalidParameterException)
 

--- a/internal/service/sns/topic_subscription.go
+++ b/internal/service/sns/topic_subscription.go
@@ -202,7 +202,7 @@ func resourceTopicSubscriptionCreate(ctx context.Context, d *schema.ResourceData
 func resourceTopicSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).SNSConn()
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFoundContext(ctx, subscriptionCreateTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, subscriptionCreateTimeout, func() (interface{}, error) {
 		return FindSubscriptionAttributesByARN(ctx, conn, d.Id())
 	}, d.IsNewResource())
 

--- a/internal/service/sqs/attribute_funcs.go
+++ b/internal/service/sqs/attribute_funcs.go
@@ -57,7 +57,7 @@ func (h *queueAttributeHandler) Upsert(ctx context.Context, d *schema.ResourceDa
 func (h *queueAttributeHandler) Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).SQSConn()
 
-	outputRaw, err := tfresource.RetryWhenNotFoundContext(ctx, queueAttributeReadTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNotFound(ctx, queueAttributeReadTimeout, func() (interface{}, error) {
 		return FindQueueAttributeByURL(ctx, conn, d.Id(), h.AttributeName)
 	})
 

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -221,7 +221,7 @@ func resourceQueueCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	log.Printf("[DEBUG] Creating SQS Queue: %s", input)
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, queueCreatedTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, queueCreatedTimeout, func() (interface{}, error) {
 		return conn.CreateQueueWithContext(ctx, input)
 	}, sqs.ErrCodeQueueDeletedRecently)
 
@@ -230,7 +230,7 @@ func resourceQueueCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		log.Printf("[WARN] failed creating SQS Queue (%s) with tags: %s. Trying create without tags.", name, err)
 
 		input.Tags = nil
-		outputRaw, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, queueCreatedTimeout, func() (interface{}, error) {
+		outputRaw, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, queueCreatedTimeout, func() (interface{}, error) {
 			return conn.CreateQueueWithContext(ctx, input)
 		}, sqs.ErrCodeQueueDeletedRecently)
 	}
@@ -311,7 +311,7 @@ func resourceQueueRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 	d.Set("url", d.Id())
 
-	outputRaw, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, queueTagsTimeout, func() (interface{}, error) {
+	outputRaw, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, queueTagsTimeout, func() (interface{}, error) {
 		return ListTags(ctx, conn, d.Id())
 	}, sqs.ErrCodeQueueDoesNotExist)
 

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -270,7 +270,7 @@ func resourceQueueRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	outputRaw, err := tfresource.RetryWhenNotFoundContext(ctx, queueReadTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNotFound(ctx, queueReadTimeout, func() (interface{}, error) {
 		return FindQueueAttributesByURL(ctx, conn, d.Id())
 	})
 

--- a/internal/service/ssoadmin/customer_managed_policy_attachment.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment.go
@@ -90,7 +90,7 @@ func resourceCustomerManagedPolicyAttachmentCreate(ctx context.Context, d *schem
 	}
 
 	log.Printf("[INFO] Attaching customer managed policy reference to permission set: %s", input)
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, customerPolicyAttachmentTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, customerPolicyAttachmentTimeout, func() (interface{}, error) {
 		return conn.AttachCustomerManagedPolicyReferenceToPermissionSetWithContext(ctx, input)
 	}, ssoadmin.ErrCodeConflictException, ssoadmin.ErrCodeThrottlingException)
 
@@ -159,7 +159,7 @@ func resourceCustomerManagedPolicyAttachmentDelete(ctx context.Context, d *schem
 	}
 
 	log.Printf("[INFO] Detaching customer managed policy reference from permission set: %s", input)
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, customerPolicyAttachmentTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, customerPolicyAttachmentTimeout, func() (interface{}, error) {
 		return conn.DetachCustomerManagedPolicyReferenceFromPermissionSetWithContext(ctx, input)
 	}, ssoadmin.ErrCodeConflictException, ssoadmin.ErrCodeThrottlingException)
 

--- a/internal/service/ssoadmin/permissions_boundary_attachment.go
+++ b/internal/service/ssoadmin/permissions_boundary_attachment.go
@@ -105,7 +105,7 @@ func resourcePermissionsBoundaryAttachmentCreate(ctx context.Context, d *schema.
 	}
 
 	log.Printf("[INFO] Attaching permissions boundary to permission set: %s", input)
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, permissionsBoundaryAttachmentTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, permissionsBoundaryAttachmentTimeout, func() (interface{}, error) {
 		return conn.PutPermissionsBoundaryToPermissionSetWithContext(ctx, input)
 	}, ssoadmin.ErrCodeConflictException, ssoadmin.ErrCodeThrottlingException)
 
@@ -170,7 +170,7 @@ func resourcePermissionsBoundaryAttachmentDelete(ctx context.Context, d *schema.
 	}
 
 	log.Printf("[INFO] Detaching permissions boundary from permission set: %s", input)
-	_, err = tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, permissionsBoundaryAttachmentTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, permissionsBoundaryAttachmentTimeout, func() (interface{}, error) {
 		return conn.DeletePermissionsBoundaryFromPermissionSetWithContext(ctx, input)
 	}, ssoadmin.ErrCodeConflictException, ssoadmin.ErrCodeThrottlingException)
 

--- a/internal/service/synthetics/canary.go
+++ b/internal/service/synthetics/canary.go
@@ -328,7 +328,7 @@ func resourceCanaryCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	propagationTimeout := propagationTimeout * 2
 	iamwaiterStopTime := time.Now().Add(propagationTimeout)
 
-	_, err = tfresource.RetryWhenContext(ctx, propagationTimeout+canaryCreatedTimeout,
+	_, err = tfresource.RetryWhen(ctx, propagationTimeout+canaryCreatedTimeout,
 		func() (interface{}, error) {
 			return retryCreateCanary(ctx, conn, d, input)
 		},

--- a/internal/service/transcribe/language_model.go
+++ b/internal/service/transcribe/language_model.go
@@ -123,7 +123,7 @@ func resourceLanguageModelCreate(ctx context.Context, d *schema.ResourceData, me
 		in.Tags = Tags(tags.IgnoreAWS())
 	}
 
-	outputRaw, err := tfresource.RetryWhenContext(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
 			return conn.CreateLanguageModel(ctx, in)
 		},

--- a/internal/service/transfer/server.go
+++ b/internal/service/transfer/server.go
@@ -712,7 +712,7 @@ func resourceServerDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	log.Printf("[DEBUG] Deleting Transfer Server: (%s)", d.Id())
-	_, err := tfresource.RetryWhenAWSErrMessageContainsContext(ctx, 1*time.Minute,
+	_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, 1*time.Minute,
 		func() (interface{}, error) {
 			return conn.DeleteServerWithContext(ctx, &transfer.DeleteServerInput{
 				ServerId: aws.String(d.Id()),

--- a/internal/service/wafv2/ip_set.go
+++ b/internal/service/wafv2/ip_set.go
@@ -249,7 +249,7 @@ func resourceIPSetDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	log.Printf("[INFO] Deleting WAFv2 IPSet: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, ipSetDeleteTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ipSetDeleteTimeout, func() (interface{}, error) {
 		return conn.DeleteIPSetWithContext(ctx, input)
 	}, wafv2.ErrCodeWAFAssociatedItemException)
 

--- a/internal/service/wafv2/regex_pattern_set.go
+++ b/internal/service/wafv2/regex_pattern_set.go
@@ -232,7 +232,7 @@ func resourceRegexPatternSetDelete(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	log.Printf("[INFO] Deleting WAFv2 RegexPatternSet: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, regexPatternSetDeleteTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, regexPatternSetDeleteTimeout, func() (interface{}, error) {
 		return conn.DeleteRegexPatternSetWithContext(ctx, input)
 	}, wafv2.ErrCodeWAFAssociatedItemException)
 

--- a/internal/service/wafv2/rule_group.go
+++ b/internal/service/wafv2/rule_group.go
@@ -155,7 +155,7 @@ func resourceRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	log.Printf("[INFO] Creating WAFv2 RuleGroup: %s", input)
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, ruleGroupCreateTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ruleGroupCreateTimeout, func() (interface{}, error) {
 		return conn.CreateRuleGroupWithContext(ctx, input)
 	}, wafv2.ErrCodeWAFUnavailableEntityException)
 
@@ -246,7 +246,7 @@ func resourceRuleGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		}
 
 		log.Printf("[INFO] Updating WAFv2 RuleGroup: %s", input)
-		_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, ruleGroupUpdateTimeout, func() (interface{}, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ruleGroupUpdateTimeout, func() (interface{}, error) {
 			return conn.UpdateRuleGroupWithContext(ctx, input)
 		}, wafv2.ErrCodeWAFUnavailableEntityException)
 
@@ -278,7 +278,7 @@ func resourceRuleGroupDelete(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	log.Printf("[INFO] Deleting WAFv2 RuleGroup: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, ruleGroupDeleteTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ruleGroupDeleteTimeout, func() (interface{}, error) {
 		return conn.DeleteRuleGroupWithContext(ctx, input)
 	}, wafv2.ErrCodeWAFAssociatedItemException, wafv2.ErrCodeWAFUnavailableEntityException)
 

--- a/internal/service/wafv2/web_acl.go
+++ b/internal/service/wafv2/web_acl.go
@@ -176,7 +176,7 @@ func resourceWebACLCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	log.Printf("[INFO] Creating WAFv2 WebACL: %s", input)
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, webACLCreateTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, webACLCreateTimeout, func() (interface{}, error) {
 		return conn.CreateWebACLWithContext(ctx, input)
 	}, wafv2.ErrCodeWAFUnavailableEntityException)
 
@@ -271,7 +271,7 @@ func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 
 		log.Printf("[INFO] Updating WAFv2 WebACL: %s", input)
-		_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, webACLUpdateTimeout, func() (interface{}, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, webACLUpdateTimeout, func() (interface{}, error) {
 			return conn.UpdateWebACLWithContext(ctx, input)
 		}, wafv2.ErrCodeWAFUnavailableEntityException)
 
@@ -307,7 +307,7 @@ func resourceWebACLDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	log.Printf("[INFO] Deleting WAFv2 WebACL: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, webACLDeleteTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, webACLDeleteTimeout, func() (interface{}, error) {
 		return conn.DeleteWebACLWithContext(ctx, input)
 	}, wafv2.ErrCodeWAFAssociatedItemException, wafv2.ErrCodeWAFUnavailableEntityException)
 

--- a/internal/service/wafv2/web_acl_association.go
+++ b/internal/service/wafv2/web_acl_association.go
@@ -61,7 +61,7 @@ func resourceWebACLAssociationCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	log.Printf("[INFO] Creating WAFv2 WebACL Association: %s", input)
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, webACLAssociationCreateTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, webACLAssociationCreateTimeout, func() (interface{}, error) {
 		return conn.AssociateWebACLWithContext(ctx, input)
 	}, wafv2.ErrCodeWAFUnavailableEntityException)
 

--- a/internal/service/workspaces/directory.go
+++ b/internal/service/workspaces/directory.go
@@ -225,7 +225,7 @@ func resourceDirectoryCreate(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	log.Printf("[DEBUG] Registering WorkSpaces Directory: %s", input)
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, DirectoryRegisterInvalidResourceStateTimeout,
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, DirectoryRegisterInvalidResourceStateTimeout,
 		func() (interface{}, error) {
 			return conn.RegisterWorkspaceDirectoryWithContext(ctx, input)
 		},
@@ -454,7 +454,7 @@ func resourceDirectoryDelete(ctx context.Context, d *schema.ResourceData, meta i
 	conn := meta.(*conns.AWSClient).WorkSpacesConn()
 
 	log.Printf("[DEBUG] Deregistering WorkSpaces Directory: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEqualsContext(ctx, DirectoryDeregisterInvalidResourceStateTimeout,
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, DirectoryDeregisterInvalidResourceStateTimeout,
 		func() (interface{}, error) {
 			return conn.DeregisterWorkspaceDirectoryWithContext(ctx, &workspaces.DeregisterWorkspaceDirectoryInput{
 				DirectoryId: aws.String(d.Id()),

--- a/internal/sweep/framework.go
+++ b/internal/sweep/framework.go
@@ -32,7 +32,7 @@ func NewSweepFrameworkResource(factory func(context.Context) (fwresource.Resourc
 }
 
 func (sr *SweepFrameworkResource) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
-	err := tfresource.RetryContext(ctx, timeout, func() *resource.RetryError {
+	err := tfresource.Retry(ctx, timeout, func() *resource.RetryError {
 		err := DeleteFrameworkResource(sr.factory, sr.id, sr.meta)
 
 		if err != nil {

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -116,7 +116,7 @@ func NewSweepResource(resource *schema.Resource, d *schema.ResourceData, meta in
 }
 
 func (sr *SweepResource) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
-	err := tfresource.RetryContext(ctx, timeout, func() *resource.RetryError {
+	err := tfresource.Retry(ctx, timeout, func() *resource.RetryError {
 		err := DeleteResource(ctx, sr.resource, sr.d, sr.meta)
 
 		if err != nil {

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -17,9 +17,9 @@ import (
 // If the error is not retryable, returns a bool value of `false` and either no error (success state) or an error (not necessarily the error passed as the argument).
 type Retryable func(error) (bool, error)
 
-// RetryWhenContext retries the function `f` when the error it returns satisfies `predicate`.
+// RetryWhen retries the function `f` when the error it returns satisfies `predicate`.
 // `f` is retried until `timeout` expires.
-func RetryWhenContext(ctx context.Context, timeout time.Duration, f func() (interface{}, error), retryable Retryable) (interface{}, error) {
+func RetryWhen(ctx context.Context, timeout time.Duration, f func() (interface{}, error), retryable Retryable) (interface{}, error) {
 	var output interface{}
 
 	err := RetryContext(ctx, timeout, func() *resource.RetryError { // nosemgrep:ci.helper-schema-resource-Retry-without-TimeoutError-check
@@ -51,15 +51,9 @@ func RetryWhenContext(ctx context.Context, timeout time.Duration, f func() (inte
 	return output, nil
 }
 
-// RetryWhen retries the function `f` when the error it returns satisfies `predicate`.
-// `f` is retried until `timeout` expires.
-func RetryWhen(timeout time.Duration, f func() (interface{}, error), retryable Retryable) (interface{}, error) {
-	return RetryWhenContext(context.Background(), timeout, f, retryable)
-}
-
 // RetryWhenAWSErrCodeEqualsContext retries the specified function when it returns one of the specified AWS error code.
 func RetryWhenAWSErrCodeEqualsContext(ctx context.Context, timeout time.Duration, f func() (interface{}, error), codes ...string) (interface{}, error) { // nosemgrep:ci.aws-in-func-name
-	return RetryWhenContext(ctx, timeout, f, func(err error) (bool, error) {
+	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
 		if tfawserr.ErrCodeEquals(err, codes...) {
 			return true, err
 		}
@@ -75,7 +69,7 @@ func RetryWhenAWSErrCodeEquals(timeout time.Duration, f func() (interface{}, err
 
 // RetryWhenAWSErrMessageContainsContext retries the specified function when it returns an AWS error containing the specified message.
 func RetryWhenAWSErrMessageContainsContext(ctx context.Context, timeout time.Duration, f func() (interface{}, error), code, message string) (interface{}, error) { // nosemgrep:ci.aws-in-func-name
-	return RetryWhenContext(ctx, timeout, f, func(err error) (bool, error) {
+	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
 		if tfawserr.ErrMessageContains(err, code, message) {
 			return true, err
 		}
@@ -93,7 +87,7 @@ var errFoundResource = errors.New(`found resource`)
 
 // RetryUntilNotFoundContext retries the specified function until it returns a resource.NotFoundError.
 func RetryUntilNotFoundContext(ctx context.Context, timeout time.Duration, f func() (interface{}, error)) (interface{}, error) {
-	return RetryWhenContext(ctx, timeout, f, func(err error) (bool, error) {
+	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
 		if NotFound(err) {
 			return false, nil
 		}
@@ -113,7 +107,7 @@ func RetryUntilNotFound(timeout time.Duration, f func() (interface{}, error)) (i
 
 // RetryWhenNotFoundContext retries the specified function when it returns a resource.NotFoundError.
 func RetryWhenNotFoundContext(ctx context.Context, timeout time.Duration, f func() (interface{}, error)) (interface{}, error) {
-	return RetryWhenContext(ctx, timeout, f, func(err error) (bool, error) {
+	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
 		if NotFound(err) {
 			return true, err
 		}
@@ -129,7 +123,7 @@ func RetryWhenNotFound(timeout time.Duration, f func() (interface{}, error)) (in
 
 // RetryWhenNewResourceNotFoundContext retries the specified function when it returns a resource.NotFoundError and `isNewResource` is true.
 func RetryWhenNewResourceNotFoundContext(ctx context.Context, timeout time.Duration, f func() (interface{}, error), isNewResource bool) (interface{}, error) {
-	return RetryWhenContext(ctx, timeout, f, func(err error) (bool, error) {
+	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
 		if isNewResource && NotFound(err) {
 			return true, err
 		}

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -75,8 +75,8 @@ func RetryWhenAWSErrMessageContains(ctx context.Context, timeout time.Duration, 
 
 var errFoundResource = errors.New(`found resource`)
 
-// RetryUntilNotFoundContext retries the specified function until it returns a resource.NotFoundError.
-func RetryUntilNotFoundContext(ctx context.Context, timeout time.Duration, f func() (interface{}, error)) (interface{}, error) {
+// RetryUntilNotFound retries the specified function until it returns a resource.NotFoundError.
+func RetryUntilNotFound(ctx context.Context, timeout time.Duration, f func() (interface{}, error)) (interface{}, error) {
 	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
 		if NotFound(err) {
 			return false, nil
@@ -88,11 +88,6 @@ func RetryUntilNotFoundContext(ctx context.Context, timeout time.Duration, f fun
 
 		return true, errFoundResource
 	})
-}
-
-// RetryUntilNotFound retries the specified function until it returns a resource.NotFoundError.
-func RetryUntilNotFound(timeout time.Duration, f func() (interface{}, error)) (interface{}, error) {
-	return RetryUntilNotFoundContext(context.Background(), timeout, f)
 }
 
 // RetryWhenNotFoundContext retries the specified function when it returns a resource.NotFoundError.

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -90,8 +90,8 @@ func RetryUntilNotFound(ctx context.Context, timeout time.Duration, f func() (in
 	})
 }
 
-// RetryWhenNotFoundContext retries the specified function when it returns a resource.NotFoundError.
-func RetryWhenNotFoundContext(ctx context.Context, timeout time.Duration, f func() (interface{}, error)) (interface{}, error) {
+// RetryWhenNotFound retries the specified function when it returns a resource.NotFoundError.
+func RetryWhenNotFound(ctx context.Context, timeout time.Duration, f func() (interface{}, error)) (interface{}, error) {
 	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
 		if NotFound(err) {
 			return true, err
@@ -99,11 +99,6 @@ func RetryWhenNotFoundContext(ctx context.Context, timeout time.Duration, f func
 
 		return false, err
 	})
-}
-
-// RetryWhenNotFound retries the specified function when it returns a resource.NotFoundError.
-func RetryWhenNotFound(timeout time.Duration, f func() (interface{}, error)) (interface{}, error) {
-	return RetryWhenNotFoundContext(context.Background(), timeout, f)
 }
 
 // RetryWhenNewResourceNotFoundContext retries the specified function when it returns a resource.NotFoundError and `isNewResource` is true.

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -101,8 +101,8 @@ func RetryWhenNotFound(ctx context.Context, timeout time.Duration, f func() (int
 	})
 }
 
-// RetryWhenNewResourceNotFoundContext retries the specified function when it returns a resource.NotFoundError and `isNewResource` is true.
-func RetryWhenNewResourceNotFoundContext(ctx context.Context, timeout time.Duration, f func() (interface{}, error), isNewResource bool) (interface{}, error) {
+// RetryWhenNewResourceNotFound retries the specified function when it returns a resource.NotFoundError and `isNewResource` is true.
+func RetryWhenNewResourceNotFound(ctx context.Context, timeout time.Duration, f func() (interface{}, error), isNewResource bool) (interface{}, error) {
 	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
 		if isNewResource && NotFound(err) {
 			return true, err
@@ -110,11 +110,6 @@ func RetryWhenNewResourceNotFoundContext(ctx context.Context, timeout time.Durat
 
 		return false, err
 	})
-}
-
-// RetryWhenNewResourceNotFound retries the specified function when it returns a resource.NotFoundError and `isNewResource` is true.
-func RetryWhenNewResourceNotFound(timeout time.Duration, f func() (interface{}, error), isNewResource bool) (interface{}, error) {
-	return RetryWhenNewResourceNotFoundContext(context.Background(), timeout, f, isNewResource)
 }
 
 type Options struct {

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -62,8 +62,8 @@ func RetryWhenAWSErrCodeEquals(ctx context.Context, timeout time.Duration, f fun
 	})
 }
 
-// RetryWhenAWSErrMessageContainsContext retries the specified function when it returns an AWS error containing the specified message.
-func RetryWhenAWSErrMessageContainsContext(ctx context.Context, timeout time.Duration, f func() (interface{}, error), code, message string) (interface{}, error) { // nosemgrep:ci.aws-in-func-name
+// RetryWhenAWSErrMessageContains retries the specified function when it returns an AWS error containing the specified message.
+func RetryWhenAWSErrMessageContains(ctx context.Context, timeout time.Duration, f func() (interface{}, error), code, message string) (interface{}, error) { // nosemgrep:ci.aws-in-func-name
 	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
 		if tfawserr.ErrMessageContains(err, code, message) {
 			return true, err
@@ -71,11 +71,6 @@ func RetryWhenAWSErrMessageContainsContext(ctx context.Context, timeout time.Dur
 
 		return false, err
 	})
-}
-
-// RetryWhenAWSErrMessageContains retries the specified function when it returns an AWS error containing the specified message.
-func RetryWhenAWSErrMessageContains(timeout time.Duration, f func() (interface{}, error), code, message string) (interface{}, error) { // nosemgrep:ci.aws-in-func-name
-	return RetryWhenAWSErrMessageContainsContext(context.Background(), timeout, f, code, message)
 }
 
 var errFoundResource = errors.New(`found resource`)

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -51,8 +51,8 @@ func RetryWhen(ctx context.Context, timeout time.Duration, f func() (interface{}
 	return output, nil
 }
 
-// RetryWhenAWSErrCodeEqualsContext retries the specified function when it returns one of the specified AWS error code.
-func RetryWhenAWSErrCodeEqualsContext(ctx context.Context, timeout time.Duration, f func() (interface{}, error), codes ...string) (interface{}, error) { // nosemgrep:ci.aws-in-func-name
+// RetryWhenAWSErrCodeEquals retries the specified function when it returns one of the specified AWS error code.
+func RetryWhenAWSErrCodeEquals(ctx context.Context, timeout time.Duration, f func() (interface{}, error), codes ...string) (interface{}, error) { // nosemgrep:ci.aws-in-func-name
 	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
 		if tfawserr.ErrCodeEquals(err, codes...) {
 			return true, err
@@ -60,11 +60,6 @@ func RetryWhenAWSErrCodeEqualsContext(ctx context.Context, timeout time.Duration
 
 		return false, err
 	})
-}
-
-// RetryWhenAWSErrCodeEquals retries the specified function when it returns one of the specified AWS error code.
-func RetryWhenAWSErrCodeEquals(timeout time.Duration, f func() (interface{}, error), codes ...string) (interface{}, error) { // nosemgrep:ci.aws-in-func-name
-	return RetryWhenAWSErrCodeEqualsContext(context.Background(), timeout, f, codes...)
 }
 
 // RetryWhenAWSErrMessageContainsContext retries the specified function when it returns an AWS error containing the specified message.

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -22,7 +22,7 @@ type Retryable func(error) (bool, error)
 func RetryWhen(ctx context.Context, timeout time.Duration, f func() (interface{}, error), retryable Retryable) (interface{}, error) {
 	var output interface{}
 
-	err := RetryContext(ctx, timeout, func() *resource.RetryError { // nosemgrep:ci.helper-schema-resource-Retry-without-TimeoutError-check
+	err := Retry(ctx, timeout, func() *resource.RetryError { // nosemgrep:ci.helper-schema-resource-Retry-without-TimeoutError-check
 		var err error
 		var retry bool
 
@@ -181,10 +181,10 @@ func WithContinuousTargetOccurence(continuousTargetOccurence int) OptionsFunc {
 	}
 }
 
-// RetryContext allows configuration of StateChangeConf's various time arguments.
+// Retry allows configuration of StateChangeConf's various time arguments.
 // This is especially useful for AWS services that are prone to throttling, such as Route53, where
 // the default durations cause problems.
-func RetryContext(ctx context.Context, timeout time.Duration, f resource.RetryFunc, optFns ...OptionsFunc) error {
+func Retry(ctx context.Context, timeout time.Duration, f resource.RetryFunc, optFns ...OptionsFunc) error {
 	// These are used to pull the error out of the function; need a mutex to
 	// avoid a data race.
 	var resultErr error

--- a/internal/tfresource/retry_test.go
+++ b/internal/tfresource/retry_test.go
@@ -304,6 +304,7 @@ func TestRetryWhenNotFound(t *testing.T) { //nolint:tparallel
 }
 
 func TestRetryUntilNotFound(t *testing.T) { //nolint:tparallel
+	ctx := acctest.Context(t)
 	t.Parallel()
 
 	var retryCount int32
@@ -357,7 +358,7 @@ func TestRetryUntilNotFound(t *testing.T) { //nolint:tparallel
 		t.Run(testCase.Name, func(t *testing.T) {
 			retryCount = 0
 
-			_, err := tfresource.RetryUntilNotFound(5*time.Second, testCase.F)
+			_, err := tfresource.RetryUntilNotFound(ctx, 5*time.Second, testCase.F)
 
 			if testCase.ExpectError && err == nil {
 				t.Fatal("expected error")

--- a/internal/tfresource/retry_test.go
+++ b/internal/tfresource/retry_test.go
@@ -10,11 +10,13 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 //nolint:tparallel
 func TestRetryWhenAWSErrCodeEquals(t *testing.T) { // nosemgrep:ci.aws-in-func-name
+	ctx := acctest.Context(t)
 	t.Parallel()
 
 	var retryCount int32
@@ -68,7 +70,7 @@ func TestRetryWhenAWSErrCodeEquals(t *testing.T) { // nosemgrep:ci.aws-in-func-n
 		t.Run(testCase.Name, func(t *testing.T) {
 			retryCount = 0
 
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(5*time.Second, testCase.F, "TestCode1", "TestCode2")
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Second, testCase.F, "TestCode1", "TestCode2")
 
 			if testCase.ExpectError && err == nil {
 				t.Fatal("expected error")
@@ -81,6 +83,7 @@ func TestRetryWhenAWSErrCodeEquals(t *testing.T) { // nosemgrep:ci.aws-in-func-n
 
 //nolint:tparallel
 func TestRetryWhenAWSErrMessageContains(t *testing.T) { // nosemgrep:ci.aws-in-func-name
+	ctx := acctest.Context(t)
 	t.Parallel()
 
 	var retryCount int32
@@ -134,7 +137,7 @@ func TestRetryWhenAWSErrMessageContains(t *testing.T) { // nosemgrep:ci.aws-in-f
 		t.Run(testCase.Name, func(t *testing.T) {
 			retryCount = 0
 
-			_, err := tfresource.RetryWhenAWSErrMessageContains(5*time.Second, testCase.F, "TestCode1", "TestMessage1")
+			_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, 5*time.Second, testCase.F, "TestCode1", "TestMessage1")
 
 			if testCase.ExpectError && err == nil {
 				t.Fatal("expected error")

--- a/internal/tfresource/retry_test.go
+++ b/internal/tfresource/retry_test.go
@@ -149,6 +149,7 @@ func TestRetryWhenAWSErrMessageContains(t *testing.T) { // nosemgrep:ci.aws-in-f
 }
 
 func TestRetryWhenNewResourceNotFound(t *testing.T) { //nolint:tparallel
+	ctx := acctest.Context(t)
 	t.Parallel()
 
 	var retryCount int32
@@ -227,7 +228,7 @@ func TestRetryWhenNewResourceNotFound(t *testing.T) { //nolint:tparallel
 		t.Run(testCase.Name, func(t *testing.T) {
 			retryCount = 0
 
-			_, err := tfresource.RetryWhenNotFound(5*time.Second, testCase.F)
+			_, err := tfresource.RetryWhenNotFound(ctx, 5*time.Second, testCase.F)
 
 			if testCase.ExpectError && err == nil {
 				t.Fatal("expected error")
@@ -239,6 +240,7 @@ func TestRetryWhenNewResourceNotFound(t *testing.T) { //nolint:tparallel
 }
 
 func TestRetryWhenNotFound(t *testing.T) { //nolint:tparallel
+	ctx := acctest.Context(t)
 	t.Parallel()
 
 	var retryCount int32
@@ -292,7 +294,7 @@ func TestRetryWhenNotFound(t *testing.T) { //nolint:tparallel
 		t.Run(testCase.Name, func(t *testing.T) {
 			retryCount = 0
 
-			_, err := tfresource.RetryWhenNotFound(5*time.Second, testCase.F)
+			_, err := tfresource.RetryWhenNotFound(ctx, 5*time.Second, testCase.F)
 
 			if testCase.ExpectError && err == nil {
 				t.Fatal("expected error")

--- a/internal/tfresource/retry_test.go
+++ b/internal/tfresource/retry_test.go
@@ -1,7 +1,6 @@
 package tfresource_test
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sync/atomic"
@@ -372,6 +371,7 @@ func TestRetryUntilNotFound(t *testing.T) { //nolint:tparallel
 }
 
 func TestRetryContext_error(t *testing.T) {
+	ctx := acctest.Context(t)
 	t.Parallel()
 
 	expected := fmt.Errorf("nope")
@@ -381,7 +381,7 @@ func TestRetryContext_error(t *testing.T) {
 
 	errCh := make(chan error)
 	go func() {
-		errCh <- tfresource.RetryContext(context.Background(), 1*time.Second, f)
+		errCh <- tfresource.Retry(ctx, 1*time.Second, f)
 	}()
 
 	select {

--- a/internal/tfresource/wait.go
+++ b/internal/tfresource/wait.go
@@ -20,11 +20,11 @@ const (
 	targetStateTrue  = "TRUE"
 )
 
-// WaitUntilContext waits for the function `f` to return `true`.
+// WaitUntil waits for the function `f` to return `true`.
 // If `f` returns an error, return immediately with that error.
 // If `timeout` is exceeded before `f` returns `true`, return an error.
 // Waits between calls to `f` using exponential backoff, except when waiting for the target state to reoccur.
-func WaitUntilContext(ctx context.Context, timeout time.Duration, f func() (bool, error), opts WaitOpts) error {
+func WaitUntil(ctx context.Context, timeout time.Duration, f func() (bool, error), opts WaitOpts) error {
 	refresh := func() (interface{}, string, error) {
 		done, err := f()
 
@@ -53,12 +53,4 @@ func WaitUntilContext(ctx context.Context, timeout time.Duration, f func() (bool
 	_, err := stateConf.WaitForStateContext(ctx)
 
 	return err
-}
-
-// WaitUntil waits for the function `f` to return `true`.
-// If `f` returns an error, return immediately with that error.
-// If `timeout` is exceeded before `f` returns `true`, return an error.
-// Waits between calls to `f` using exponential backoff, except when waiting for the target state to reoccur.
-func WaitUntil(timeout time.Duration, f func() (bool, error), opts WaitOpts) error {
-	return WaitUntilContext(context.Background(), timeout, f, opts)
 }

--- a/internal/tfresource/wait_test.go
+++ b/internal/tfresource/wait_test.go
@@ -6,10 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestWaitUntil(t *testing.T) { //nolint:tparallel
+	ctx := acctest.Context(t)
 	t.Parallel()
 
 	var retryCount int32
@@ -55,7 +57,7 @@ func TestWaitUntil(t *testing.T) { //nolint:tparallel
 		t.Run(testCase.Name, func(t *testing.T) {
 			retryCount = 0
 
-			err := tfresource.WaitUntil(5*time.Second, testCase.F, tfresource.WaitOpts{})
+			err := tfresource.WaitUntil(ctx, 5*time.Second, testCase.F, tfresource.WaitOpts{})
 
 			if testCase.ExpectError && err == nil {
 				t.Fatal("expected error")


### PR DESCRIPTION
As part of using `context.Context` throughout the provider, renames the `tfresource.Retry...Context` and `tfresource.WaitUntilContext` functions to `tfresource.Retry...` and `tfresource.WaitUntil`.

Relates #29005 