### PR TITLE
Fixes sweepers after `Context` migration

### DIFF
--- a/.ci/semgrep/migrate/context.yml
+++ b/.ci/semgrep/migrate/context.yml
@@ -73,3 +73,22 @@ rules:
     paths: *paths
     pattern: schema.Noop
     severity: ERROR
+  - id: direct-CRUD-calls
+    languages: [go]
+    message: Avoid direct calls to `schema.Resource` CRUD calls
+    paths: *paths
+    patterns:
+      - pattern-either:
+          - pattern: $D.Create($DATA, $META)
+          - pattern: $D.Read($DATA, $META)
+          - pattern: $D.Update($DATA, $META)
+          - pattern: $D.Delete($DATA, $META)
+          - pattern: $D.CreateContext($CTX, $DATA, $META)
+          - pattern: $D.ReadContext($CTX, $DATA, $META)
+          - pattern: $D.UpdateContext($CTX, $DATA, $META)
+          - pattern: $D.DeleteContext($CTX, $DATA, $META)
+          - pattern: $D.CreateWithoutTimeout($CTX, $DATA, $META)
+          - pattern: $D.ReadWithoutTimeout($CTX, $DATA, $META)
+          - pattern: $D.UpdateWithoutTimeout($CTX, $DATA, $META)
+          - pattern: $D.DeleteWithoutTimeout($CTX, $DATA, $META)
+    severity: ERROR

--- a/docs/running-and-writing-acceptance-tests.md
+++ b/docs/running-and-writing-acceptance-tests.md
@@ -1215,6 +1215,7 @@ Then add the actual implementation. Preferably, if a paginated SDK call is avail
 
 ```go
 func sweepThings(region string) error {
+  ctx := sweep.Context(region)
   client, err := sweep.SharedRegionalSweepClient(region)
 
   if err != nil {
@@ -1242,8 +1243,8 @@ func sweepThings(region string) error {
       // Perform resource specific pre-sweep setup.
       // For example, you may need to perform one or more of these types of pre-sweep tasks, specific to the resource:
       //
-      // err := r.Read(d, client)             // fill in data
-      // d.Set("skip_final_snapshot", true)   // set an argument in order to delete
+      // err := sweep.ReadResource(ctx, r, d, client) // fill in data
+      // d.Set("skip_final_snapshot", true)           // set an argument in order to delete
 
       // This "if" is only needed if the pre-sweep setup can produce errors.
       // Otherwise, do not include it.
@@ -1281,6 +1282,7 @@ Otherwise, if no paginated SDK call is available:
 
 ```go
 func sweepThings(region string) error {
+  ctx := sweep.Context(region)
   client, err := sweep.SharedRegionalSweepClient(region)
 
   if err != nil {
@@ -1306,8 +1308,8 @@ func sweepThings(region string) error {
       // Perform resource specific pre-sweep setup.
       // For example, you may need to perform one or more of these types of pre-sweep tasks, specific to the resource:
       //
-      // err := r.Read(d, client)             // fill in data
-      // d.Set("skip_final_snapshot", true)   // set an argument in order to delete
+      // err := sweep.ReadResource(ctx, r, d, client) // fill in data
+      // d.Set("skip_final_snapshot", true)           // set an argument in order to delete
 
       // This "if" is only needed if the pre-sweep setup can produce errors.
       // Otherwise, do not include it.

--- a/internal/service/dms/event_subscription_test.go
+++ b/internal/service/dms/event_subscription_test.go
@@ -69,7 +69,7 @@ func TestAccDMSEventSubscription_disappears(t *testing.T) {
 				Config: testAccEventSubscriptionConfig_enabled(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSubscriptionExists(ctx, resourceName, &eventSubscription),
-					testAccCheckEventSubscriptionDisappears(resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfdms.ResourceEventSubscription(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -231,23 +231,6 @@ func testAccCheckEventSubscriptionDestroy(ctx context.Context) resource.TestChec
 		}
 
 		return nil
-	}
-}
-
-func testAccCheckEventSubscriptionDisappears(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		resource := tfdms.ResourceEventSubscription()
-
-		return resource.Delete(resource.Data(rs.Primary), acctest.Provider.Meta())
 	}
 }
 

--- a/internal/service/dynamodb/sweep.go
+++ b/internal/service/dynamodb/sweep.go
@@ -61,7 +61,7 @@ func sweepTables(region string) error {
 			// read concurrently and gather errors
 			g.Go(func() error {
 				// Need to Read first to fill in `replica` attribute
-				err := r.Read(d, client)
+				err := sweep.ReadResource(ctx, r, d, client)
 
 				if err != nil {
 					return err

--- a/internal/service/ssoadmin/sweep.go
+++ b/internal/service/ssoadmin/sweep.go
@@ -48,7 +48,7 @@ func sweepAccountAssignments(region string) error {
 	ds := DataSourceInstances()
 	dsData := ds.Data(nil)
 
-	err = ds.Read(dsData, client)
+	err = sweep.ReadResource(ctx, ds, dsData, client)
 
 	if tfawserr.ErrCodeContains(err, "AccessDenied") {
 		log.Printf("[WARN] Skipping SSO Account Assignment sweep for %s: %s", region, err)
@@ -153,7 +153,7 @@ func sweepPermissionSets(region string) error {
 	ds := DataSourceInstances()
 	dsData := ds.Data(nil)
 
-	err = ds.Read(dsData, client)
+	err = sweep.ReadResource(ctx, ds, dsData, client)
 
 	if tfawserr.ErrCodeContains(err, "AccessDenied") {
 		log.Printf("[WARN] Skipping SSO Permission Set sweep for %s: %s", region, err)

--- a/internal/service/waf/sweep.go
+++ b/internal/service/waf/sweep.go
@@ -160,7 +160,7 @@ func sweepByteMatchSet(region string) error {
 			// read concurrently and gather errors
 			g.Go(func() error {
 				// Need to Read first to fill in byte_match_tuples attribute
-				err := r.Read(d, client)
+				err := sweep.ReadResource(ctx, r, d, client)
 
 				if err != nil {
 					sweeperErr := fmt.Errorf("error reading WAF Byte Match Set (%s): %w", id, err)
@@ -235,7 +235,7 @@ func sweepGeoMatchSet(region string) error {
 			// read concurrently and gather errors
 			g.Go(func() error {
 				// Need to Read first to fill in geo_match_constraint attribute
-				err := r.Read(d, client)
+				err := sweep.ReadResource(ctx, r, d, client)
 
 				if err != nil {
 					sweeperErr := fmt.Errorf("error reading WAF Geo Match Set (%s): %w", id, err)
@@ -310,7 +310,7 @@ func sweepIPSet(region string) error {
 			// read concurrently and gather errors
 			g.Go(func() error {
 				// Need to Read first to fill in ip_set_descriptors attribute
-				err := r.Read(d, client)
+				err := sweep.ReadResource(ctx, r, d, client)
 
 				if err != nil {
 					sweeperErr := fmt.Errorf("error reading WAF IP Set (%s): %w", id, err)
@@ -385,7 +385,7 @@ func sweepRateBasedRules(region string) error {
 			// read concurrently and gather errors
 			g.Go(func() error {
 				// Need to Read first to fill in predicates attribute
-				err := r.Read(d, client)
+				err := sweep.ReadResource(ctx, r, d, client)
 
 				if err != nil {
 					sweeperErr := fmt.Errorf("error reading WAF Rate Based Rule (%s): %w", id, err)
@@ -460,7 +460,7 @@ func sweepRegexMatchSet(region string) error {
 			// read concurrently and gather errors
 			g.Go(func() error {
 				// Need to Read first to fill in regex_match_tuple attribute
-				err := r.Read(d, client)
+				err := sweep.ReadResource(ctx, r, d, client)
 
 				if err != nil {
 					sweeperErr := fmt.Errorf("error reading WAF Regex Match Set (%s): %w", id, err)
@@ -535,7 +535,7 @@ func sweepRegexPatternSet(region string) error {
 			// read concurrently and gather errors
 			g.Go(func() error {
 				// Need to Read first to fill in regex_pattern_strings attribute
-				err := r.Read(d, client)
+				err := sweep.ReadResource(ctx, r, d, client)
 
 				if err != nil {
 					sweeperErr := fmt.Errorf("error reading WAF Regex Pattern Set (%s): %w", id, err)
@@ -610,7 +610,7 @@ func sweepRuleGroups(region string) error {
 			// read concurrently and gather errors
 			g.Go(func() error {
 				// Need to Read first to fill in activated_rule attribute
-				err := r.Read(d, client)
+				err := sweep.ReadResource(ctx, r, d, client)
 
 				if err != nil {
 					sweeperErr := fmt.Errorf("error reading WAF Rule Group (%s): %w", id, err)
@@ -689,7 +689,7 @@ func sweepRules(region string) error {
 			// read concurrently and gather errors
 			g.Go(func() error {
 				// Need to Read first to fill in predicates attribute
-				err := r.Read(d, client)
+				err := sweep.ReadResource(ctx, r, d, client)
 
 				if err != nil {
 					sweeperErr := fmt.Errorf("error reading WAF Rule (%s): %w", id, err)
@@ -764,7 +764,7 @@ func sweepSizeConstraintSet(region string) error {
 			// read concurrently and gather errors
 			g.Go(func() error {
 				// Need to Read first to fill in size_constraints attribute
-				err := r.Read(d, client)
+				err := sweep.ReadResource(ctx, r, d, client)
 
 				if err != nil {
 					sweeperErr := fmt.Errorf("error reading WAF Size Constraint Set (%s): %w", id, err)
@@ -839,7 +839,7 @@ func sweepSQLInjectionMatchSet(region string) error {
 			// read concurrently and gather errors
 			g.Go(func() error {
 				// Need to Read first to fill in sql_injection_match_tuples attribute
-				err := r.Read(d, client)
+				err := sweep.ReadResource(ctx, r, d, client)
 
 				if err != nil {
 					sweeperErr := fmt.Errorf("error reading WAF SQL Injection Match Set (%s): %w", id, err)
@@ -918,7 +918,7 @@ func sweepWebACLs(region string) error {
 			// read concurrently and gather errors
 			g.Go(func() error {
 				// Need to Read first to fill in rules argument
-				err := r.Read(d, client)
+				err := sweep.ReadResource(ctx, r, d, client)
 
 				if err != nil {
 					readErr := fmt.Errorf("error reading WAF Web ACL (%s): %w", id, err)
@@ -993,7 +993,7 @@ func sweepXSSMatchSet(region string) error {
 			// read concurrently and gather errors
 			g.Go(func() error {
 				// Need to Read first to fill in xss_match_tuples attribute
-				err := r.Read(d, client)
+				err := sweep.ReadResource(ctx, r, d, client)
 
 				if err != nil {
 					sweeperErr := fmt.Errorf("error reading WAF XSS Match Set (%s): %w", id, err)

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -232,7 +232,7 @@ func SkipSweepError(err error) bool {
 	return false
 }
 
-func DeleteResource(ctx context.Context, resource *schema.Resource, d *schema.ResourceData, meta interface{}) error {
+func DeleteResource(ctx context.Context, resource *schema.Resource, d *schema.ResourceData, meta any) error {
 	if resource.DeleteContext != nil || resource.DeleteWithoutTimeout != nil {
 		var diags diag.Diagnostics
 
@@ -246,6 +246,22 @@ func DeleteResource(ctx context.Context, resource *schema.Resource, d *schema.Re
 	}
 
 	return resource.Delete(d, meta)
+}
+
+func ReadResource(ctx context.Context, resource *schema.Resource, d *schema.ResourceData, meta any) error {
+	if resource.ReadContext != nil || resource.ReadWithoutTimeout != nil {
+		var diags diag.Diagnostics
+
+		if resource.ReadContext != nil {
+			diags = resource.ReadContext(ctx, d, meta)
+		} else {
+			diags = resource.ReadWithoutTimeout(ctx, d, meta)
+		}
+
+		return sdkdiag.DiagnosticsError(diags)
+	}
+
+	return resource.Read(d, meta)
 }
 
 func Partition(region string) string {


### PR DESCRIPTION
A few sweepers made direct calls to `schema.Resource`'s `Read` function. After the `Context` migration, the legacy CRUD functions are `nil`, so those sweepers panicked.

Closes https://github.com/hashicorp/terraform-provider-aws/issues/28556.