### PR TITLE
Fix default values for launch template metadata.

### DIFF
--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -642,7 +642,7 @@ func ResourceLaunchTemplate() *schema.Resource {
 						"http_endpoint": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							Computed:     true,
+							Default:      ec2.LaunchTemplateInstanceMetadataEndpointStateEnabled,
 							ValidateFunc: validation.StringInSlice(ec2.LaunchTemplateInstanceMetadataEndpointState_Values(), false),
 						},
 						"http_protocol_ipv6": {
@@ -654,13 +654,13 @@ func ResourceLaunchTemplate() *schema.Resource {
 						"http_put_response_hop_limit": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Computed:     true,
+							Default:      "1",
 							ValidateFunc: validation.IntBetween(1, 64),
 						},
 						"http_tokens": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							Computed:     true,
+							Default:      ec2.LaunchTemplateHttpTokensStateOptional,
 							ValidateFunc: validation.StringInSlice(ec2.LaunchTemplateHttpTokensState_Values(), false),
 						},
 						"instance_metadata_tags": {

--- a/internal/service/ec2/ec2_launch_template_test.go
+++ b/internal/service/ec2/ec2_launch_template_test.go
@@ -2797,6 +2797,23 @@ func TestAccEC2LaunchTemplate_metadataOptions(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.instance_metadata_tags", "enabled"),
 				),
 			},
+			{
+				Config: testAccLaunchTemplateConfig_metadataOptionsDefaults(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchTemplateExists(ctx, resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_endpoint", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_tokens", "optional"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_put_response_hop_limit", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_protocol_ipv6", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.instance_metadata_tags", "disabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -3936,6 +3953,15 @@ resource "aws_launch_template" "test" {
     http_protocol_ipv6          = "enabled"
     instance_metadata_tags      = "enabled"
   }
+}
+`, rName)
+}
+
+func testAccLaunchTemplateConfig_metadataOptionsDefaults(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = %[1]q
+  metadata_options {}
 }
 `, rName)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Launch Template metadata options does not use default values as [described in the docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-launchtemplatedata-metadataoptions.html#cfn-ec2-launchtemplate-launchtemplatedata-metadataoptions-httptokens).

Example (`4.50`):

```hcl
resource "aws_launch_template" "lt" {
  name                   = "test-lt"
  image_id               = "ami-0fe0b2cf0e1f25c8a"
  instance_type          = "t3.small"
  vpc_security_group_ids = ["sg-12345678"]

  metadata_options {
    http_tokens = "optional"
  }
}
```

Plan:
```hcl
  + metadata_options {
      + http_endpoint               = (known after apply)
      + http_protocol_ipv6          = "disabled"
      + http_put_response_hop_limit = (known after apply)
      + http_tokens                 = "optional"
      + instance_metadata_tags      = "disabled"
    }
```
Describe using AWS CLI after apply
```json
  "LaunchTemplateData": {
      "ImageId": "ami-0fe0b2cf0e1f25c8a",
      "InstanceType": "t3.small",
      "UserData": "",
      "SecurityGroupIds": [
          "sg-12345678"
      ],
      "MetadataOptions": {
          "HttpProtocolIpv6": "disabled"
      }
}
```

By using this PR + same TF code:
Plan:

```hcl
  + metadata_options {
      + http_endpoint               = "enabled"
      + http_protocol_ipv6          = "disabled"
      + http_put_response_hop_limit = 1
      + http_tokens                 = "optional"
      + instance_metadata_tags      = "disabled"
    }
```

Describe using CLI:
```json
    "LaunchTemplateData": {
        "ImageId": "ami-0fe0b2cf0e1f25c8a",
        "InstanceType": "t3.small",
        "UserData": "",
        "SecurityGroupIds": [
            "sg-12345678"
        ],
        "MetadataOptions": {
            "HttpTokens": "optional",
            "HttpPutResponseHopLimit": 1,
            "HttpEndpoint": "enabled",
            "HttpProtocolIpv6": "disabled",
            "InstanceMetadataTags": "disabled"
        }
    }
```

<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #12564

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccEC2LaunchTemplate_metadataOptions PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2LaunchTemplate_metadataOptions'  -timeout 180m
=== RUN   TestAccEC2LaunchTemplate_metadataOptions
=== PAUSE TestAccEC2LaunchTemplate_metadataOptions
=== CONT  TestAccEC2LaunchTemplate_metadataOptions
--- PASS: TestAccEC2LaunchTemplate_metadataOptions (62.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        67.316s

...
```
