### PR TITLE
r/cloudfront_distribution: Mark custom_origin_config.origin_ssl_proto…

### DIFF
--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -559,7 +559,8 @@ func ResourceDistribution() *schema.Resource {
 									},
 									"origin_ssl_protocols": {
 										Type:     schema.TypeSet,
-										Required: true,
+										Optional: true,
+										Computed: true,
 										Elem: &schema.Schema{
 											Type:         schema.TypeString,
 											ValidateFunc: validation.StringInSlice(cloudfront.SslProtocol_Values(), false),

--- a/internal/service/cloudfront/distribution_configuration_structure.go
+++ b/internal/service/cloudfront/distribution_configuration_structure.go
@@ -1013,9 +1013,12 @@ func ExpandCustomOriginConfig(m map[string]interface{}) *cloudfront.CustomOrigin
 		OriginProtocolPolicy:   aws.String(m["origin_protocol_policy"].(string)),
 		HTTPPort:               aws.Int64(int64(m["http_port"].(int))),
 		HTTPSPort:              aws.Int64(int64(m["https_port"].(int))),
-		OriginSslProtocols:     ExpandCustomOriginConfigSSL(m["origin_ssl_protocols"].(*schema.Set).List()),
 		OriginReadTimeout:      aws.Int64(int64(m["origin_read_timeout"].(int))),
 		OriginKeepaliveTimeout: aws.Int64(int64(m["origin_keepalive_timeout"].(int))),
+	}
+
+	if v, ok := m["origin_ssl_protocols"].(*schema.Set); ok && len(v.List()) > 0 {
+		customOrigin.OriginSslProtocols = ExpandCustomOriginConfigSSL(v.List())
 	}
 
 	return customOrigin
@@ -1026,9 +1029,9 @@ func FlattenCustomOriginConfig(cor *cloudfront.CustomOriginConfig) map[string]in
 		"origin_protocol_policy":   aws.StringValue(cor.OriginProtocolPolicy),
 		"http_port":                int(aws.Int64Value(cor.HTTPPort)),
 		"https_port":               int(aws.Int64Value(cor.HTTPSPort)),
-		"origin_ssl_protocols":     FlattenCustomOriginConfigSSL(cor.OriginSslProtocols),
 		"origin_read_timeout":      int(aws.Int64Value(cor.OriginReadTimeout)),
 		"origin_keepalive_timeout": int(aws.Int64Value(cor.OriginKeepaliveTimeout)),
+		"origin_ssl_protocols":     FlattenCustomOriginConfigSSL(cor.OriginSslProtocols),
 	}
 
 	return customOrigin

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -683,7 +683,6 @@ func TestAccCloudFrontDistribution_noOptionalItems(t *testing.T) {
 						"custom_origin_config.0.origin_keepalive_timeout": "5",
 						"custom_origin_config.0.origin_protocol_policy":   "http-only",
 						"custom_origin_config.0.origin_read_timeout":      "30",
-						"custom_origin_config.0.origin_ssl_protocols.#":   "2",
 						"domain_name": "www.example.com",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "price_class", "PriceClass_All"),
@@ -2401,7 +2400,6 @@ resource "aws_cloudfront_distribution" "no_optional_items" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "http-only"
-      origin_ssl_protocols   = ["SSLv3", "TLSv1"]
     }
   }
 

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -470,7 +470,7 @@ argument should not be specified.
     `value` parameters that specify header data that will be sent to the origin
     (multiples allowed).
 
-* `origin_access_control_id` (Optional) - The unique identifier of a [CloudFront origin access control][8] for this origin.
+* `origin_access_control_id` (Optional) - The unique identifier of a [CloudFront origin access control][5] for this origin.
 
 * `origin_id` (Required) - A unique identifier for the origin.
 
@@ -494,13 +494,13 @@ argument should not be specified.
 * `origin_protocol_policy` (Required) - The origin protocol policy to apply to
     your origin. One of `http-only`, `https-only`, or `match-viewer`.
 
-* `origin_ssl_protocols` (Required) - The SSL/TLS protocols that you want
-    CloudFront to use when communicating with your origin over HTTPS. A list of
-    one or more of `SSLv3`, `TLSv1`, `TLSv1.1`, and `TLSv1.2`.
-
 * `origin_keepalive_timeout` - (Optional) The Custom KeepAlive timeout, in seconds. By default, AWS enforces a limit of `60`. But you can request an [increase](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-request-timeout).
 
 * `origin_read_timeout` - (Optional) The Custom Read timeout, in seconds. By default, AWS enforces a limit of `60`. But you can request an [increase](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-request-timeout).
+
+* `origin_ssl_protocols` (Optional) - The SSL/TLS protocols that you want
+    CloudFront to use when communicating with your origin over HTTPS. A list of
+    one or more of `SSLv3`, `TLSv1`, `TLSv1.1`, and `TLSv1.2`. Defaults to `["TLSv1", "TLSv1.1", "TLSv1.2"]`
 
 ##### Origin Shield Arguments
 
@@ -510,7 +510,7 @@ argument should not be specified.
 
 ##### S3 Origin Config Arguments
 
-* `origin_access_identity` (Required) - The [CloudFront origin access identity][5] to associate with the origin.
+* `origin_access_identity` (Required) - The [CloudFront origin access identity][3] to associate with the origin.
 
 #### Origin Group Arguments
 
@@ -620,14 +620,13 @@ In addition to all arguments above, the following attributes are exported:
      route an [Alias Resource Record Set][7] to. This attribute is simply an
      alias for the zone ID `Z2FDTNDATAQYW2`.
 
-[1]: http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Introduction.html
+[1]: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Introduction.html
 [2]: https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateDistribution.html
-[3]: http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html
-[4]: http://www.iso.org/iso/country_codes/iso_3166_code_lists/country_names_and_code_elements.htm
-[5]: /docs/providers/aws/r/cloudfront_origin_access_identity.html
+[3]: /docs/providers/aws/r/cloudfront_origin_access_identity.html
+[4]: https://www.iso.org/iso-3166-country-codes.html
+[5]: /docs/providers/aws/r/cloudfront_origin_access_control.html
 [6]: https://aws.amazon.com/certificate-manager/
-[7]: http://docs.aws.amazon.com/Route53/latest/APIReference/CreateAliasRRSAPI.html
-[8]: /docs/providers/aws/r/cloudfront_origin_access_control.html
+[7]: https://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html
 
 ## Import
 


### PR DESCRIPTION
…cols as optional

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
`CustomOriginConfig.OriginSslProtocols` is marked as optional in the [API docs](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CustomOriginConfig.html) and testing with the AWS CLI shows the docs are accurate.

Whilst here, I noticed that reference 3 in the docs wasn't referenced at all so the reference list has been updated with valid links and correct ordering.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28627 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccCloudFrontDistribution_noOptionalItems PKG=cloudfront
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontDistribution_noOptionalItems'  -timeout 180m
=== RUN   TestAccCloudFrontDistribution_noOptionalItems
=== PAUSE TestAccCloudFrontDistribution_noOptionalItems
=== CONT  TestAccCloudFrontDistribution_noOptionalItems
    distribution_test.go:638: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_cloudfront_distribution.no_optional_items will be updated in-place
          ~ resource "aws_cloudfront_distribution" "no_optional_items" {
                id                             = "E3UXZOGO4ES5GS"
                # (17 unchanged attributes hidden)
        
              + origin {
                  + connection_attempts = 3
                  + connection_timeout  = 10
                  + domain_name         = "www.example.com"
                  + origin_id           = "myCustomOrigin"
        
                  + custom_origin_config {
                      + http_port                = 80
                      + https_port               = 443
                      + origin_keepalive_timeout = 5
                      + origin_protocol_policy   = "http-only"
                      + origin_read_timeout      = 30
                      + origin_ssl_protocols     = (known after apply)
                    }
                }
              - origin {
                  - connection_attempts = 3 -> null
                  - connection_timeout  = 10 -> null
                  - domain_name         = "www.example.com" -> null
                  - origin_id           = "myCustomOrigin" -> null
        
                  - custom_origin_config {
                      - http_port                = 80 -> null
                      - https_port               = 443 -> null
                      - origin_keepalive_timeout = 5 -> null
                      - origin_protocol_policy   = "http-only" -> null
                      - origin_read_timeout      = 30 -> null
                      - origin_ssl_protocols     = [
                          - "TLSv1",
                          - "TLSv1.1",
                          - "TLSv1.2",
                        ] -> null
                    }
                }
        
                # (3 unchanged blocks hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccCloudFrontDistribution_noOptionalItems (396.47s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	396.549s
FAIL
make: *** [GNUmakefile:92: testacc] Error 1
```
