### PR TITLE
d/ec2_ami: Add ebs.kms_key_id attribute

### DIFF
--- a/internal/service/ec2/ec2_ami_data_source.go
+++ b/internal/service/ec2/ec2_ami_data_source.go
@@ -54,6 +54,10 @@ func DataSourceAMI() *schema.Resource {
 							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"kms_key_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"no_device": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -359,6 +363,7 @@ func flattenAMIBlockDeviceMappings(m []*ec2.BlockDeviceMapping) *schema.Set {
 				"delete_on_termination": fmt.Sprintf("%t", aws.BoolValue(v.Ebs.DeleteOnTermination)),
 				"encrypted":             fmt.Sprintf("%t", aws.BoolValue(v.Ebs.Encrypted)),
 				"iops":                  fmt.Sprintf("%d", aws.Int64Value(v.Ebs.Iops)),
+				"kms_key_id":            aws.StringValue(v.Ebs.KmsKeyId),
 				"throughput":            fmt.Sprintf("%d", aws.Int64Value(v.Ebs.Throughput)),
 				"volume_size":           fmt.Sprintf("%d", aws.Int64Value(v.Ebs.VolumeSize)),
 				"snapshot_id":           aws.StringValue(v.Ebs.SnapshotId),
@@ -430,6 +435,10 @@ func amiBlockDeviceMappingHash(v interface{}) int {
 			buf.WriteString(fmt.Sprintf("%s-", e["volume_size"].(string)))
 			buf.WriteString(fmt.Sprintf("%s-", e["volume_type"].(string)))
 		}
+	}
+
+	if d, ok := m["kms_key_id"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", d.(string)))
 	}
 	if d, ok := m["no_device"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", d.(string)))


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29027

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccEC2AMIDataSource PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2AMIDataSource'  -timeout 180m
=== RUN   TestAccEC2AMIDataSource_natInstance
=== PAUSE TestAccEC2AMIDataSource_natInstance
=== RUN   TestAccEC2AMIDataSource_windowsInstance
=== PAUSE TestAccEC2AMIDataSource_windowsInstance
=== RUN   TestAccEC2AMIDataSource_instanceStore
=== PAUSE TestAccEC2AMIDataSource_instanceStore
=== RUN   TestAccEC2AMIDataSource_localNameFilter
=== PAUSE TestAccEC2AMIDataSource_localNameFilter
=== RUN   TestAccEC2AMIDataSource_gp3BlockDevice
=== PAUSE TestAccEC2AMIDataSource_gp3BlockDevice
=== CONT  TestAccEC2AMIDataSource_natInstance
=== CONT  TestAccEC2AMIDataSource_localNameFilter
=== CONT  TestAccEC2AMIDataSource_gp3BlockDevice
=== CONT  TestAccEC2AMIDataSource_instanceStore
=== CONT  TestAccEC2AMIDataSource_windowsInstance
--- PASS: TestAccEC2AMIDataSource_natInstance (21.25s)
--- PASS: TestAccEC2AMIDataSource_localNameFilter (22.48s)
--- PASS: TestAccEC2AMIDataSource_windowsInstance (23.53s)
--- PASS: TestAccEC2AMIDataSource_instanceStore (24.66s)
--- PASS: TestAccEC2AMIDataSource_gp3BlockDevice (74.71s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	74.788s
```
