### PR TITLE
Added CloudFront managed policy example, added required note

### DIFF
--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -139,7 +139,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 }
 ```
 
-The following example below creates a Cloudfront distribution with an origin group for failover routing:
+The following example below creates a CloudFront distribution with an origin group for failover routing:
 
 ```terraform
 resource "aws_cloudfront_distribution" "s3_distribution" {
@@ -182,6 +182,50 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     target_origin_id = "groupS3"
   }
 
+  # ... other configuration ...
+}
+```
+
+CloudFront distribution using managed cache policy (CachingDisabled):
+
+```terraform
+locals {
+  s3_origin_id = "myS3Origin"
+}
+
+resource "aws_cloudfront_distribution" "s3_distribution" {
+  origin {
+    domain_name = aws_s3_bucket.primary.bucket_regional_domain_name
+    origin_id   = "myS3Origin"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.default.cloudfront_access_identity_path
+    }
+  }
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+  # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html#:~:text=Compression%20support.-,CachingDisabled,-View%20this%20policy
+  default_cache_behavior {
+    # Using the CachingDisabled managed policy ID:
+    cache_policy_id = "4135ea2d-6df8-44a3-9df3-4b5a84be39a"
+    allowed_methods = ["GET", "HEAD", "OPTIONS"]
+    path_pattern     = "/content/*"
+    target_origin_id = local.s3_origin_id
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["US", "CA", "GB", "DE"]
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
   # ... other configuration ...
 }
 ```
@@ -274,7 +318,7 @@ resource "aws_cloudfront_distribution" "example" {
 
 ##### Function Association
 
-With CloudFront Functions in Amazon CloudFront, you can write lightweight functions in JavaScript for high-scale, latency-sensitive CDN customizations. You can associate a single function per event type. See [Cloudfront Functions](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html)
+With CloudFront Functions in Amazon CloudFront, you can write lightweight functions in JavaScript for high-scale, latency-sensitive CDN customizations. You can associate a single function per event type. See [CloudFront Functions](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html)
 for more information.
 
 Example configuration:
@@ -296,7 +340,7 @@ resource "aws_cloudfront_distribution" "example" {
 ```
 
 * `event_type` (Required) - Specific event to trigger this function. Valid values: `viewer-request` or `viewer-response`.
-* `function_arn` (Required) - ARN of the Cloudfront function.
+* `function_arn` (Required) - ARN of the CloudFront function.
 
 ##### Cookies Arguments
 
@@ -420,7 +464,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Cloudfront Distributions can be imported using the `id`, e.g.,
+CloudFront Distributions can be imported using the `id`, e.g.,
 
 ```
 $ terraform import aws_cloudfront_distribution.distribution E74FTE3EXAMPLE

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -186,8 +186,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 }
 ```
 
-CloudFront distribution using managed policies (ex: CachingDisabled):
-https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html
+CloudFront distribution using [managed policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html) (ex: CachingDisabled):
 
 ```terraform
 locals {

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -139,7 +139,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 }
 ```
 
-The following example below creates a CloudFront distribution with an origin group for failover routing:
+The example below creates a CloudFront distribution with an origin group for failover routing:
 
 ```terraform
 resource "aws_cloudfront_distribution" "s3_distribution" {

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -186,7 +186,8 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 }
 ```
 
-CloudFront distribution using managed cache policy (CachingDisabled):
+CloudFront distribution using managed policies (ex: CachingDisabled):
+https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html
 
 ```terraform
 locals {
@@ -207,7 +208,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   comment             = "Some comment"
   default_root_object = "index.html"
 
-  # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html#:~:text=Compression%20support.-,CachingDisabled,-View%20this%20policy
+  # AWS Managed Caching Polify (CachingDisabled)
   default_cache_behavior {
     # Using the CachingDisabled managed policy ID:
     cache_policy_id = "4135ea2d-6df8-44a3-9df3-4b5a84be39a"
@@ -239,7 +240,7 @@ The CloudFront distribution argument layout is a complex structure composed of s
 * `aliases` (Optional) - Extra CNAMEs (alternate domain names), if any, for this distribution.
 * `comment` (Optional) - Any comments you want to include about the distribution.
 * `custom_error_response` (Optional) - One or more [custom error response](#custom-error-response-arguments) elements (multiples allowed).
-* `default_cache_behavior` (Required) - The [default cache behavior](#default-cache-behavior-arguments) for this distribution (maximum one).
+* `default_cache_behavior` (Required) - [Default cache behavior](#default-cache-behavior-arguments) for this distribution (maximum one). Requires either `cache_policy_id` (preferred) or `forwarded_values` (deprecated) be set.
 * `default_root_object` (Optional) - Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL.
 * `enabled` (Required) - Whether the distribution is enabled to accept end user requests for content.
 * `is_ipv6_enabled` (Optional) - Whether the IPv6 is enabled for the distribution.

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -210,8 +210,8 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   # AWS Managed Caching Polify (CachingDisabled)
   default_cache_behavior {
     # Using the CachingDisabled managed policy ID:
-    cache_policy_id = "4135ea2d-6df8-44a3-9df3-4b5a84be39a"
-    allowed_methods = ["GET", "HEAD", "OPTIONS"]
+    cache_policy_id  = "4135ea2d-6df8-44a3-9df3-4b5a84be39a"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     path_pattern     = "/content/*"
     target_origin_id = local.s3_origin_id
   }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

- Added example for using managed policies. 
- Updated default_cache_behavior attribute to specify 'Requires either `cache_policy_id` (prefered) or `forwarded_values` (deprecated) be set.'
- Fixed service names to be proper case.

### Relations
Relates #29015


### References


* Using managed policies: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html

