### PR TITLE
r/aws_ami: Remove `kms_key_id` from docs

### DIFF
--- a/website/docs/r/ami.html.markdown
+++ b/website/docs/r/ami.html.markdown
@@ -88,9 +88,6 @@ Nested `ebs_block_device` blocks have the following structure:
   If `snapshot_id` is set and `volume_size` is omitted then the volume will have the same size
   as the selected snapshot.
 * `volume_type` - (Optional) Type of EBS volume to create. Can be `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1` or `st1` (Default: `standard`).
-* `kms_key_id` - (Optional) Full ARN of the AWS Key Management Service (AWS KMS) CMK to use when encrypting the snapshots of
-an image during a copy operation. This parameter is only required if you want to use a non-default CMK;
-if this parameter is not specified, the default CMK for EBS is used
 * `outpost_arn` - (Optional) ARN of the Outpost on which the snapshot is stored.
 
 ~> **Note:** You can specify `encrypted` or `snapshot_id` but not both.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This parameter isn't valid when creating an AMI. See https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html.

Looks to have been a simple copy-pasteo from `aws_ami_copy`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29027

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
* https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html

> KmsKeyId (request), kmsKeyId (response)
>
>    Identifier (key ID, key alias, ID ARN, or alias ARN) for a customer managed CMK under which the EBS volume is encrypted.
>
>    This parameter is only supported on BlockDeviceMapping objects called by [RunInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html), [RequestSpotFleet](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotFleet.html), and [RequestSpotInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotInstances.html).

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
