### PR TITLE
New Resource: `aws_auditmanager_framework_share`

### DIFF
--- a/.changelog/29049.txt
+++ b/.changelog/29049.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_auditmanager_framework_share
+```

--- a/internal/service/auditmanager/exports_test.go
+++ b/internal/service/auditmanager/exports_test.go
@@ -8,4 +8,5 @@ var (
 	ResourceAssessmentReport                     = newResourceAssessmentReport
 	ResourceControl                              = newResourceControl
 	ResourceFramework                            = newResourceFramework
+	ResourceFrameworkShare                       = newResourceFrameworkShare
 )

--- a/internal/service/auditmanager/framework_share.go
+++ b/internal/service/auditmanager/framework_share.go
@@ -1,0 +1,255 @@
+package auditmanager
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/auditmanager"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/auditmanager/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	sdkv2resource "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func init() {
+	_sp.registerFrameworkResourceFactory(newResourceFrameworkShare)
+}
+
+func newResourceFrameworkShare(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceFrameworkShare{}, nil
+}
+
+const (
+	ResNameFrameworkShare = "FrameworkShare"
+)
+
+type resourceFrameworkShare struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceFrameworkShare) Metadata(_ context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = "aws_auditmanager_framework_share"
+}
+
+func (r *resourceFrameworkShare) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"comment": schema.StringAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"destination_account": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"destination_region": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"framework_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"id": framework.IDAttribute(),
+			"status": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *resourceFrameworkShare) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().AuditManagerClient()
+
+	var plan resourceFrameworkShareData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := auditmanager.StartAssessmentFrameworkShareInput{
+		DestinationAccount: aws.String(plan.DestinationAccount.ValueString()),
+		DestinationRegion:  aws.String(plan.DestinationRegion.ValueString()),
+		FrameworkId:        aws.String(plan.FrameworkID.ValueString()),
+	}
+	if !plan.Comment.IsNull() {
+		in.Comment = aws.String(plan.Comment.ValueString())
+	}
+	out, err := conn.StartAssessmentFrameworkShare(ctx, &in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.AuditManager, create.ErrActionCreating, ResNameFrameworkShare, plan.FrameworkID.String(), nil),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil || out.AssessmentFrameworkShareRequest == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.AuditManager, create.ErrActionCreating, ResNameFrameworkShare, plan.FrameworkID.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	state := plan
+	state.refreshFromOutput(ctx, out.AssessmentFrameworkShareRequest)
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}
+
+func (r *resourceFrameworkShare) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().AuditManagerClient()
+
+	var state resourceFrameworkShareData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := FindFrameworkShareByID(ctx, conn, state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.AuditManager, create.ErrActionReading, ResNameFrameworkShare, state.ID.String(), nil),
+			err.Error(),
+		)
+		return
+	}
+
+	state.refreshFromOutput(ctx, out)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// Update is a no-op. Changing any of account, region, or framework_id will result
+// a destroy and replace.
+func (r *resourceFrameworkShare) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+}
+
+func (r *resourceFrameworkShare) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().AuditManagerClient()
+
+	var state resourceFrameworkShareData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Framework share requests in certain statuses must be revoked before deletion
+	if CanBeRevoked(state.Status.ValueString()) {
+		in := auditmanager.UpdateAssessmentFrameworkShareInput{
+			RequestId:   aws.String(state.ID.ValueString()),
+			RequestType: awstypes.ShareRequestTypeSent,
+			Action:      awstypes.ShareRequestActionRevoke,
+		}
+		_, err := conn.UpdateAssessmentFrameworkShare(ctx, &in)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.AuditManager, create.ErrActionDeleting, ResNameFrameworkShare, state.ID.String(), nil),
+				err.Error(),
+			)
+		}
+	}
+
+	in := auditmanager.DeleteAssessmentFrameworkShareInput{
+		RequestId:   aws.String(state.ID.ValueString()),
+		RequestType: awstypes.ShareRequestTypeSent,
+	}
+	_, err := conn.DeleteAssessmentFrameworkShare(ctx, &in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.AuditManager, create.ErrActionDeleting, ResNameFrameworkShare, state.ID.String(), nil),
+			err.Error(),
+		)
+	}
+}
+
+func (r *resourceFrameworkShare) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func FindFrameworkShareByID(ctx context.Context, conn *auditmanager.Client, id string) (*awstypes.AssessmentFrameworkShareRequest, error) {
+	in := &auditmanager.ListAssessmentFrameworkShareRequestsInput{
+		RequestType: awstypes.ShareRequestTypeSent,
+	}
+	pages := auditmanager.NewListAssessmentFrameworkShareRequestsPaginator(conn, in)
+
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, share := range page.AssessmentFrameworkShareRequests {
+			if id == aws.ToString(share.Id) {
+				return &share, nil
+			}
+		}
+	}
+
+	return nil, &sdkv2resource.NotFoundError{
+		LastRequest: in,
+	}
+}
+
+// CanBeRevoked verifies a framework share is in a status which can be revoked
+func CanBeRevoked(status string) bool {
+	nonRevokable := enum.Slice(
+		awstypes.ShareRequestStatusDeclined,
+		awstypes.ShareRequestStatusExpired,
+		awstypes.ShareRequestStatusFailed,
+		awstypes.ShareRequestStatusRevoked,
+	)
+	for _, s := range nonRevokable {
+		if s == status {
+			return false
+		}
+	}
+	return true
+}
+
+type resourceFrameworkShareData struct {
+	Comment            types.String `tfsdk:"comment"`
+	DestinationAccount types.String `tfsdk:"destination_account"`
+	DestinationRegion  types.String `tfsdk:"destination_region"`
+	FrameworkID        types.String `tfsdk:"framework_id"`
+	ID                 types.String `tfsdk:"id"`
+	Status             types.String `tfsdk:"status"`
+}
+
+// refreshFromOutput writes state data from an AWS response object
+func (rd *resourceFrameworkShareData) refreshFromOutput(ctx context.Context, out *awstypes.AssessmentFrameworkShareRequest) {
+	if out == nil {
+		return
+	}
+
+	rd.Comment = flex.StringToFramework(ctx, out.Comment)
+	rd.DestinationAccount = flex.StringToFramework(ctx, out.DestinationAccount)
+	rd.DestinationRegion = flex.StringToFramework(ctx, out.DestinationRegion)
+	rd.FrameworkID = flex.StringToFramework(ctx, out.FrameworkId)
+	rd.ID = flex.StringToFramework(ctx, out.Id)
+	rd.Status = flex.StringValueToFramework(ctx, out.Status)
+}

--- a/internal/service/auditmanager/framework_share_test.go
+++ b/internal/service/auditmanager/framework_share_test.go
@@ -1,0 +1,267 @@
+package auditmanager_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/auditmanager/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfauditmanager "github.com/hashicorp/terraform-provider-aws/internal/service/auditmanager"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestCanBeRevoked(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		status types.ShareRequestStatus
+		want   bool
+	}{
+		{"active", types.ShareRequestStatusActive, true},
+		{"declined", types.ShareRequestStatusDeclined, false},
+		{"expiring", types.ShareRequestStatusExpiring, true},
+		{"expired", types.ShareRequestStatusExpired, false},
+		{"failed", types.ShareRequestStatusFailed, false},
+		{"replicating", types.ShareRequestStatusReplicating, true},
+		{"revoked", types.ShareRequestStatusRevoked, false},
+		{"shared", types.ShareRequestStatusShared, true},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tfauditmanager.CanBeRevoked(string(testCase.status)); got != testCase.want {
+				t.Errorf("CanBeRevoked() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestAccAuditManagerFrameworkShare_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var frameworkShare types.AssessmentFrameworkShareRequest
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_auditmanager_framework_share.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.AuditManagerEndpointID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AuditManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFrameworkShareDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFrameworkShareConfig_basic(rName, acctest.AlternateRegion()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkShareExists(ctx, resourceName, &frameworkShare),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_account", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "destination_region", acctest.AlternateRegion()),
+					resource.TestCheckResourceAttrPair(resourceName, "framework_id", "aws_auditmanager_framework.test", "id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"status"},
+			},
+		},
+	})
+}
+
+func TestAccAuditManagerFrameworkShare_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	var frameworkShare types.AssessmentFrameworkShareRequest
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_auditmanager_framework_share.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.AuditManagerEndpointID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AuditManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFrameworkShareDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFrameworkShareConfig_basic(rName, acctest.AlternateRegion()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkShareExists(ctx, resourceName, &frameworkShare),
+					// Sleep briefly to prevent intermittent validation errors when revoking
+					// a new framework share request
+					acctest.CheckSleep(t, 10*time.Second),
+					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfauditmanager.ResourceFrameworkShare, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAuditManagerFrameworkShare_optional(t *testing.T) {
+	ctx := acctest.Context(t)
+	var frameworkShare types.AssessmentFrameworkShareRequest
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_auditmanager_framework_share.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.AuditManagerEndpointID, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AuditManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFrameworkShareDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFrameworkShareConfig_optional(rName, acctest.AlternateRegion(), "text"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkShareExists(ctx, resourceName, &frameworkShare),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_account", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "destination_region", acctest.AlternateRegion()),
+					resource.TestCheckResourceAttrPair(resourceName, "framework_id", "aws_auditmanager_framework.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "comment", "text"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"status"},
+			},
+			{
+				Config: testAccFrameworkShareConfig_basic(rName, acctest.AlternateRegion()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkShareExists(ctx, resourceName, &frameworkShare),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_account", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "destination_region", acctest.AlternateRegion()),
+					resource.TestCheckResourceAttrPair(resourceName, "framework_id", "aws_auditmanager_framework.test", "id"),
+				),
+			},
+			{
+				Config: testAccFrameworkShareConfig_optional(rName, acctest.AlternateRegion(), "text-updated"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFrameworkShareExists(ctx, resourceName, &frameworkShare),
+					resource.TestCheckResourceAttrPair(resourceName, "destination_account", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "destination_region", acctest.AlternateRegion()),
+					resource.TestCheckResourceAttrPair(resourceName, "framework_id", "aws_auditmanager_framework.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "comment", "text-updated"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFrameworkShareDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AuditManagerClient()
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_auditmanager_framework_share" {
+				continue
+			}
+
+			_, err := tfauditmanager.FindFrameworkShareByID(ctx, conn, rs.Primary.ID)
+			if err != nil {
+				var nfe *resource.NotFoundError
+				if errors.As(err, &nfe) {
+					return nil
+				}
+				return err
+			}
+
+			return create.Error(names.AuditManager, create.ErrActionCheckingDestroyed, tfauditmanager.ResNameFrameworkShare, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckFrameworkShareExists(ctx context.Context, name string, frameworkShare *types.AssessmentFrameworkShareRequest) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.AuditManager, create.ErrActionCheckingExistence, tfauditmanager.ResNameFrameworkShare, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.AuditManager, create.ErrActionCheckingExistence, tfauditmanager.ResNameFrameworkShare, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AuditManagerClient()
+		resp, err := tfauditmanager.FindFrameworkShareByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.AuditManager, create.ErrActionCheckingExistence, tfauditmanager.ResNameFrameworkShare, rs.Primary.ID, err)
+		}
+
+		*frameworkShare = *resp
+
+		return nil
+	}
+}
+
+func testAccFrameworkShareConfigBase(rName string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_auditmanager_control" "test" {
+  name = %[1]q
+
+  control_mapping_sources {
+    source_name          = %[1]q
+    source_set_up_option = "Procedural_Controls_Mapping"
+    source_type          = "MANUAL"
+  }
+}
+
+resource "aws_auditmanager_framework" "test" {
+  name = %[1]q
+
+  control_sets {
+    name = %[1]q
+    controls {
+      id = aws_auditmanager_control.test.id
+    }
+  }
+}
+`, rName)
+}
+
+func testAccFrameworkShareConfig_basic(rName, destinationRegion string) string {
+	return acctest.ConfigCompose(
+		testAccFrameworkShareConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_auditmanager_framework_share" "test" {
+  destination_account = data.aws_caller_identity.current.account_id
+  destination_region  = %[1]q
+  framework_id        = aws_auditmanager_framework.test.id
+}
+`, destinationRegion))
+}
+
+func testAccFrameworkShareConfig_optional(rName, destinationRegion, comment string) string {
+	return acctest.ConfigCompose(
+		testAccFrameworkShareConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_auditmanager_framework_share" "test" {
+  destination_account = data.aws_caller_identity.current.account_id
+  destination_region  = %[1]q
+  framework_id        = aws_auditmanager_framework.test.id
+
+  comment = %[2]q
+}
+`, destinationRegion, comment))
+}

--- a/website/docs/r/auditmanager_framework_share.html.markdown
+++ b/website/docs/r/auditmanager_framework_share.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "Audit Manager"
+layout: "aws"
+page_title: "AWS: aws_auditmanager_framework_share"
+description: |-
+  Terraform resource for managing an AWS Audit Manager Framework Share.
+---
+
+# Resource: aws_auditmanager_framework_share
+
+Terraform resource for managing an AWS Audit Manager Framework Share.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_auditmanager_framework_share" "example" {
+  destination_account = "012345678901"
+  destination_region  = "us-east-1"
+  framework_id        = aws_auditmanager_framework.example.id
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `destination_account` - (Required) Amazon Web Services account of the recipient.
+* `destination_region` - (Required) Amazon Web Services region of the recipient.
+* `framework_id` - (Required) Unique identifier for the shared custom framework.
+
+The following arguments are optional:
+
+* `comment` - (Optional) Comment from the sender about the share request.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Unique identifier for the share request.
+* `status` -  Status of the share request.
+
+## Import
+
+Audit Manager Framework Share can be imported using the `id`, e.g.,
+
+```
+$ terraform import aws_auditmanager_framework_share.example abcdef-123456
+```


### PR DESCRIPTION
### Description
`aws_auditmanager_framework_share` will allow practitioners to share assessment frameworks across accounts and regions via terraform.


### Relations
Relates #17981


### Output from Acceptance Testing

```console
$ make testacc PKG=auditmanager TESTS=TestAccAuditManagerFrameworkShare_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/auditmanager/... -v -count 1 -parallel 20 -run='TestAccAuditManagerFrameworkShare_'  -timeout 180m
=== RUN   TestAccAuditManagerFrameworkShare_basic
=== PAUSE TestAccAuditManagerFrameworkShare_basic
=== RUN   TestAccAuditManagerFrameworkShare_disappears
=== PAUSE TestAccAuditManagerFrameworkShare_disappears
=== RUN   TestAccAuditManagerFrameworkShare_optional
=== PAUSE TestAccAuditManagerFrameworkShare_optional
=== CONT  TestAccAuditManagerFrameworkShare_basic
=== CONT  TestAccAuditManagerFrameworkShare_optional
=== CONT  TestAccAuditManagerFrameworkShare_disappears
--- PASS: TestAccAuditManagerFrameworkShare_basic (17.19s)
--- PASS: TestAccAuditManagerFrameworkShare_disappears (24.85s)
--- PASS: TestAccAuditManagerFrameworkShare_optional (38.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/auditmanager       41.933s
```
