### PR TITLE
dynamodb/table: error updating PITR, unexpected state

### DIFF
--- a/.changelog/29086.txt
+++ b/.changelog/29086.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Fix unexpected state 'DISABLED' error when waiting for PITR to update
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #24903

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 4 -run='TestAccDynamoDBTable_'  -timeout 180m
=== RUN   TestAccDynamoDBTable_basic
=== PAUSE TestAccDynamoDBTable_basic
=== RUN   TestAccDynamoDBTable_disappears
=== PAUSE TestAccDynamoDBTable_disappears
=== RUN   TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
=== PAUSE TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
=== RUN   TestAccDynamoDBTable_extended
=== PAUSE TestAccDynamoDBTable_extended
=== RUN   TestAccDynamoDBTable_enablePITR
=== PAUSE TestAccDynamoDBTable_enablePITR
=== RUN   TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== PAUSE TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== RUN   TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
=== PAUSE TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
=== RUN   TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
=== PAUSE TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
=== RUN   TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
=== PAUSE TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
=== RUN   TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
=== PAUSE TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
=== RUN   TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
=== PAUSE TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
=== RUN   TestAccDynamoDBTable_streamSpecification
=== PAUSE TestAccDynamoDBTable_streamSpecification
=== RUN   TestAccDynamoDBTable_streamSpecificationDiffs
=== PAUSE TestAccDynamoDBTable_streamSpecificationDiffs
=== RUN   TestAccDynamoDBTable_streamSpecificationValidation
=== PAUSE TestAccDynamoDBTable_streamSpecificationValidation
=== RUN   TestAccDynamoDBTable_tags
=== PAUSE TestAccDynamoDBTable_tags
=== RUN   TestAccDynamoDBTable_gsiUpdateCapacity
=== PAUSE TestAccDynamoDBTable_gsiUpdateCapacity
=== RUN   TestAccDynamoDBTable_gsiUpdateOtherAttributes
=== PAUSE TestAccDynamoDBTable_gsiUpdateOtherAttributes
=== RUN   TestAccDynamoDBTable_lsiNonKeyAttributes
=== PAUSE TestAccDynamoDBTable_lsiNonKeyAttributes
=== RUN   TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
=== PAUSE TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
=== RUN   TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
=== PAUSE TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
=== RUN   TestAccDynamoDBTable_TTL_enabled
=== PAUSE TestAccDynamoDBTable_TTL_enabled
=== RUN   TestAccDynamoDBTable_TTL_disabled
=== PAUSE TestAccDynamoDBTable_TTL_disabled
=== RUN   TestAccDynamoDBTable_attributeUpdate
=== PAUSE TestAccDynamoDBTable_attributeUpdate
=== RUN   TestAccDynamoDBTable_lsiUpdate
=== PAUSE TestAccDynamoDBTable_lsiUpdate
=== RUN   TestAccDynamoDBTable_attributeUpdateValidation
=== PAUSE TestAccDynamoDBTable_attributeUpdateValidation
=== RUN   TestAccDynamoDBTable_encryption
=== PAUSE TestAccDynamoDBTable_encryption
=== RUN   TestAccDynamoDBTable_Replica_multiple
=== PAUSE TestAccDynamoDBTable_Replica_multiple
=== RUN   TestAccDynamoDBTable_Replica_single
=== PAUSE TestAccDynamoDBTable_Replica_single
=== RUN   TestAccDynamoDBTable_Replica_singleWithCMK
=== PAUSE TestAccDynamoDBTable_Replica_singleWithCMK
=== RUN   TestAccDynamoDBTable_Replica_singleAddCMK
=== PAUSE TestAccDynamoDBTable_Replica_singleAddCMK
=== RUN   TestAccDynamoDBTable_Replica_pitr
=== PAUSE TestAccDynamoDBTable_Replica_pitr
=== RUN   TestAccDynamoDBTable_Replica_tagsOneOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_tagsOneOfTwo
=== RUN   TestAccDynamoDBTable_Replica_tagsTwoOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_tagsTwoOfTwo
=== RUN   TestAccDynamoDBTable_Replica_tagsNext
=== PAUSE TestAccDynamoDBTable_Replica_tagsNext
=== RUN   TestAccDynamoDBTable_Replica_tagsUpdate
=== PAUSE TestAccDynamoDBTable_Replica_tagsUpdate
=== RUN   TestAccDynamoDBTable_tableClassInfrequentAccess
=== PAUSE TestAccDynamoDBTable_tableClassInfrequentAccess
=== RUN   TestAccDynamoDBTable_backupEncryption
=== PAUSE TestAccDynamoDBTable_backupEncryption
=== RUN   TestAccDynamoDBTable_backup_overrideEncryption
=== PAUSE TestAccDynamoDBTable_backup_overrideEncryption
=== CONT  TestAccDynamoDBTable_basic
=== CONT  TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
=== CONT  TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
=== CONT  TestAccDynamoDBTable_Replica_singleAddCMK
--- PASS: TestAccDynamoDBTable_basic (29.44s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== CONT  TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (41.87s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (44.79s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (61.79s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
--- PASS: TestAccDynamoDBTable_Replica_singleAddCMK (307.77s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (42.27s)
=== CONT  TestAccDynamoDBTable_extended
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (435.57s)
=== CONT  TestAccDynamoDBTable_enablePITR
--- PASS: TestAccDynamoDBTable_enablePITR (60.19s)
=== CONT  TestAccDynamoDBTable_attributeUpdateValidation
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (4.08s)
=== CONT  TestAccDynamoDBTable_Replica_singleWithCMK
--- PASS: TestAccDynamoDBTable_Replica_singleWithCMK (200.90s)
=== CONT  TestAccDynamoDBTable_backup_overrideEncryption
--- PASS: TestAccDynamoDBTable_extended (496.70s)
=== CONT  TestAccDynamoDBTable_backupEncryption
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (858.67s)
=== CONT  TestAccDynamoDBTable_tableClassInfrequentAccess
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (50.53s)
=== CONT  TestAccDynamoDBTable_Replica_tagsUpdate
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (869.18s)
=== CONT  TestAccDynamoDBTable_Replica_tagsNext
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (331.75s)
=== CONT  TestAccDynamoDBTable_Replica_tagsTwoOfTwo
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (353.47s)
=== CONT  TestAccDynamoDBTable_Replica_tagsOneOfTwo
--- PASS: TestAccDynamoDBTable_Replica_tagsTwoOfTwo (236.07s)
=== CONT  TestAccDynamoDBTable_Replica_pitr
--- PASS: TestAccDynamoDBTable_Replica_tagsNext (436.44s)
=== CONT  TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (76.66s)
=== CONT  TestAccDynamoDBTable_Replica_multiple
--- PASS: TestAccDynamoDBTable_Replica_tagsOneOfTwo (257.86s)
=== CONT  TestAccDynamoDBTable_Replica_single
--- PASS: TestAccDynamoDBTable_Replica_pitr (371.39s)
=== CONT  TestAccDynamoDBTable_attributeUpdate
--- PASS: TestAccDynamoDBTable_backupEncryption (1020.44s)
=== CONT  TestAccDynamoDBTable_encryption
--- PASS: TestAccDynamoDBTable_Replica_single (354.03s)
=== CONT  TestAccDynamoDBTable_disappears
--- PASS: TestAccDynamoDBTable_disappears (22.76s)
=== CONT  TestAccDynamoDBTable_gsiUpdateCapacity
--- PASS: TestAccDynamoDBTable_gsiUpdateCapacity (59.37s)
=== CONT  TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
--- PASS: TestAccDynamoDBTable_encryption (117.06s)
=== CONT  TestAccDynamoDBTable_lsiNonKeyAttributes
--- PASS: TestAccDynamoDBTable_Replica_multiple (541.33s)
=== CONT  TestAccDynamoDBTable_gsiUpdateOtherAttributes
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (32.76s)
=== CONT  TestAccDynamoDBTable_TTL_disabled
--- PASS: TestAccDynamoDBTable_TTL_disabled (37.13s)
=== CONT  TestAccDynamoDBTable_streamSpecificationValidation
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (1.81s)
=== CONT  TestAccDynamoDBTable_tags
--- PASS: TestAccDynamoDBTable_tags (43.17s)
=== CONT  TestAccDynamoDBTable_TTL_enabled
--- PASS: TestAccDynamoDBTable_TTL_enabled (28.31s)
=== CONT  TestAccDynamoDBTable_lsiUpdate
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (195.68s)
=== CONT  TestAccDynamoDBTable_streamSpecification
--- PASS: TestAccDynamoDBTable_lsiUpdate (60.59s)
=== CONT  TestAccDynamoDBTable_streamSpecificationDiffs
--- PASS: TestAccDynamoDBTable_streamSpecification (58.36s)
--- PASS: TestAccDynamoDBTable_streamSpecificationDiffs (133.91s)
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (606.11s)
--- PASS: TestAccDynamoDBTable_attributeUpdate (873.76s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	2619.011s
```
