### PR TITLE
Fix ACMPCA CRL attribute validation and docs

### DIFF
--- a/website/docs/r/acmpca_certificate_authority.html.markdown
+++ b/website/docs/r/acmpca_certificate_authority.html.markdown
@@ -149,8 +149,8 @@ the custom OCSP responder endpoint. Defined below.
 
 * `custom_cname` - (Optional) Name inserted into the certificate CRL Distribution Points extension that enables the use of an alias for the CRL distribution point. Use this value if you don't want the name of your S3 bucket to be public. Must be less than or equal to 253 characters in length.
 * `enabled` - (Optional) Boolean value that specifies whether certificate revocation lists (CRLs) are enabled. Defaults to `false`.
-* `expiration_in_days` - (Required) Number of days until a certificate expires. Must be between 1 and 5000.
-* `s3_bucket_name` - (Optional) Name of the S3 bucket that contains the CRL. If you do not provide a value for the `custom_cname` argument, the name of your S3 bucket is placed into the CRL Distribution Points extension of the issued certificate. You must specify a bucket policy that allows ACM PCA to write the CRL to your bucket. Must be less than or equal to 255 characters in length.
+* `expiration_in_days` - (Optional, Required if `enabled` is `true`) Number of days until a certificate expires. Must be between 1 and 5000.
+* `s3_bucket_name` - (Optional, Required if `enabled` is `true`) Name of the S3 bucket that contains the CRL. If you do not provide a value for the `custom_cname` argument, the name of your S3 bucket is placed into the CRL Distribution Points extension of the issued certificate. You must specify a bucket policy that allows ACM PCA to write the CRL to your bucket. Must be between 3 and 255 characters in length.
 * `s3_object_acl` - (Optional) Determines whether the CRL will be publicly readable or privately held in the CRL Amazon S3 bucket. Defaults to `PUBLIC_READ`.
 
 #### ocsp_configuration


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
`expiration_in_days` is only required if `enabled` is `true` so needs to be marked as `optional` so it can be omitted.
In addition, it's invalid to set any parameters if `enabled` is `false`. We therefore only send those parameters if `enabled` is set to `true`; this enables users to disable revocation by flipping `enabled` from `true` to `false` without additionally having to comment out/remove the additional parameters.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29088

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
* https://docs.aws.amazon.com/privateca/latest/APIReference/API_CrlConfiguration.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccACMPCACertificateAuthority_RevocationCrl_ PKG=acmpca
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/acmpca/... -v -count 1 -parallel 20 -run='TestAccACMPCACertificateAuthority_RevocationCrl_'  -timeout 180m
=== RUN   TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME
=== PAUSE TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME
=== RUN   TestAccACMPCACertificateAuthority_RevocationCrl_enabled
=== PAUSE TestAccACMPCACertificateAuthority_RevocationCrl_enabled
=== RUN   TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays
=== PAUSE TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays
=== RUN   TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL
=== PAUSE TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL
=== CONT  TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME
=== CONT  TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays
=== CONT  TestAccACMPCACertificateAuthority_RevocationCrl_enabled
=== CONT  TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_s3ObjectACL (42.62s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_expirationInDays (55.85s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_enabled (66.08s)
--- PASS: TestAccACMPCACertificateAuthority_RevocationCrl_customCNAME (76.46s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/acmpca	76.549s
```