### PR TITLE
dynamodb/table_replica: Fix creation error when KMS

### DIFF
--- a/.changelog/29102.txt
+++ b/.changelog/29102.txt
@@ -6,6 +6,10 @@ resource/aws_dynamodb_table: Fix to allow updating of `replica.*.point_in_time_r
 resource/aws_dynamodb_table: Fix to allow updating of `replica.*.kms_key_arn`
 ```
 
+```release-note:bug
+resource/aws_dynamodb_table: Fix perpetual diffs when using default AWS-managed keys
+```
+
 ```release-note:note
 resource/aws_dynamodb_table: Updating `replica.*.kms_key_arn` or `replica.*.point_in_time_recovery`, when the `replica`'s `kms_key_arn` is set, requires recreating the replica.
 ```

--- a/.changelog/29102.txt
+++ b/.changelog/29102.txt
@@ -1,0 +1,23 @@
+```release-note:bug
+resource/aws_dynamodb_table: Fix to allow updating of `replica.*.point_in_time_recovery` when a `replica` has `kms_key_arn` set
+```
+
+```release-note:bug
+resource/aws_dynamodb_table: Fix to allow updating of `replica.*.kms_key_arn`
+```
+
+```release-note:note
+resource/aws_dynamodb_table: Updating `replica.*.kms_key_arn` or `replica.*.point_in_time_recovery`, when the `replica`'s `kms_key_arn` is set, requires recreating the replica.
+```
+
+```release-note:note
+resource/aws_dynamodb_table_replica: Updating `kms_key_arn` forces replacement of the replica now as required to re-encrypt the replica
+```
+
+```release-note:bug
+resource/aws_dynamodb_table_replica: Fix to allow updating of `kms_key_arn`
+```
+
+```release-note:bug
+resource/aws_dynamodb_table_replica: Fix to allow creation of the replica without errors when `kms_key_arn` is set
+```

--- a/.changelog/29102.txt
+++ b/.changelog/29102.txt
@@ -18,6 +18,18 @@ resource/aws_dynamodb_table: Updating `replica.*.kms_key_arn` or `replica.*.poin
 resource/aws_dynamodb_table_replica: Updating `kms_key_arn` forces replacement of the replica now as required to re-encrypt the replica
 ```
 
+```release-note:note
+resource/aws_dynamodb_table: In the past, in certain situations, `server_side_encryption.0.kms_key_arn` or `replica.*.kms_key_arn` could be populated with the default DynamoDB key `alias/aws/dynamodb`. This was an error because it would then be sent back to AWS and should not be.
+```
+
+```release-note:note
+resource/aws_dynamodb_table: In the past, in certain situations, `kms_key_arn` could be populated with the default DynamoDB key `alias/aws/dynamodb`. This was an error because it would then be sent back to AWS and should not be.
+```
+
+```release-note:note
+resource/aws_dynamodb_table_replica: Updating `kms_key_arn` forces replacement of the replica now as required to re-encrypt the replica
+```
+
 ```release-note:bug
 resource/aws_dynamodb_table_replica: Fix to allow updating of `kms_key_arn`
 ```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -1325,18 +1325,6 @@ func updateReplica(ctx context.Context, d *schema.ResourceData, conn *dynamodb.D
 	return nil
 }
 
-func replicaRegions(r *schema.Set) []string {
-	var regions []string
-	for _, tfMapRaw := range r.List() {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		regions = append(regions, tfMap["region_name"].(string))
-	}
-	return regions
-}
-
 func UpdateDiffGSI(oldGsi, newGsi []interface{}, billingMode string) (ops []*dynamodb.GlobalSecondaryIndexUpdate, e error) {
 	// Transform slices into maps
 	oldGsis := make(map[string]interface{})

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -265,6 +265,7 @@ func ResourceTable() *schema.Resource {
 							Optional:     true,
 							Computed:     true,
 							ValidateFunc: verify.ValidARN,
+							ForceNew:     true,
 						},
 						"point_in_time_recovery": {
 							Type:     schema.TypeBool,

--- a/internal/service/dynamodb/table_replica.go
+++ b/internal/service/dynamodb/table_replica.go
@@ -368,12 +368,12 @@ func resourceTableReplicaUpdate(ctx context.Context, d *schema.ResourceData, met
 
 	viaMainChanges := false
 	viaMainInput := &dynamodb.UpdateReplicationGroupMemberAction{
-		RegionName:     aws.String(replicaRegion),
-		KMSMasterKeyId: aws.String(d.Get("kms_key_arn").(string)),
+		RegionName: aws.String(replicaRegion),
 	}
 
-	if d.HasChange("kms_key_arn") && !d.IsNewResource() {
+	if d.HasChange("kms_key_arn") && !d.IsNewResource() { // create ends with update and sets kms_key_arn causing change that is not
 		viaMainChanges = true
+		viaMainInput.KMSMasterKeyId = aws.String(d.Get("kms_key_arn").(string))
 	}
 
 	if viaMainChanges {

--- a/internal/service/dynamodb/table_replica.go
+++ b/internal/service/dynamodb/table_replica.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/service/kms"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -249,7 +250,16 @@ func resourceTableReplicaRead(ctx context.Context, d *schema.ResourceData, meta 
 		return create.DiagError(names.DynamoDB, create.ErrActionReading, ResNameTableReplica, d.Id(), err)
 	}
 
-	d.Set("kms_key_arn", replica.KMSMasterKeyId)
+	dk, err := kms.FindDefaultKey(ctx, "dynamodb", replicaRegion, meta)
+	if err != nil {
+		return create.DiagError(names.DynamoDB, create.ErrActionReading, ResNameTableReplica, d.Id(), err)
+	}
+
+	if replica.KMSMasterKeyId == nil || aws.StringValue(replica.KMSMasterKeyId) == dk {
+		d.Set("kms_key_arn", nil)
+	} else {
+		d.Set("kms_key_arn", replica.KMSMasterKeyId)
+	}
 
 	if replica.ReplicaTableClassSummary != nil {
 		d.Set("table_class_override", replica.ReplicaTableClassSummary.TableClass)
@@ -372,8 +382,15 @@ func resourceTableReplicaUpdate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if d.HasChange("kms_key_arn") && !d.IsNewResource() { // create ends with update and sets kms_key_arn causing change that is not
-		viaMainChanges = true
-		viaMainInput.KMSMasterKeyId = aws.String(d.Get("kms_key_arn").(string))
+		dk, err := kms.FindDefaultKey(ctx, "dynamodb", replicaRegion, meta)
+		if err != nil {
+			return create.DiagError(names.DynamoDB, create.ErrActionUpdating, ResNameTableReplica, d.Id(), fmt.Errorf("region %s: %w", replicaRegion, err))
+		}
+
+		if d.Get("kms_key_arn").(string) != dk {
+			viaMainChanges = true
+			viaMainInput.KMSMasterKeyId = aws.String(d.Get("kms_key_arn").(string))
+		}
 	}
 
 	if viaMainChanges {

--- a/internal/service/dynamodb/table_replica_test.go
+++ b/internal/service/dynamodb/table_replica_test.go
@@ -564,7 +564,7 @@ resource "aws_dynamodb_table" "test" {
   }
 
   server_side_encryption {
-    enabled     = true
+    enabled = true
   }
 
   lifecycle {

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -1610,6 +1610,10 @@ func TestAccDynamoDBTable_Replica_single(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "1"),
 				),
 			},
+			{
+				Config:   testAccTableConfig_replica1(rName),
+				PlanOnly: true,
+			},
 		},
 	})
 }

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -221,7 +221,7 @@ Optional arguments:
 
 ### `replica`
 
-* `kms_key_arn` - (Optional) ARN of the CMK that should be used for the AWS KMS encryption.
+* `kms_key_arn` - (Optional, Forces new resource) ARN of the CMK that should be used for the AWS KMS encryption.
 * `point_in_time_recovery` - (Optional) Whether to enable Point In Time Recovery for the replica. Default is `false`.
 * `propagate_tags` - (Optional) Whether to propagate the global table's tags to a replica. Default is `false`. Changes to tags only move in one direction: from global (source) to replica. In other words, tag drift on a replica will not trigger an update. Tag or replica changes on the global table, whether from drift or configuration changes, are propagated to replicas. Changing from `true` to `false` on a subsequent `apply` means replica tags are left as they were, unmanaged, not deleted.
 * `region_name` - (Required) Region name of the replica.

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -221,15 +221,15 @@ Optional arguments:
 
 ### `replica`
 
-* `kms_key_arn` - (Optional, Forces new resource) ARN of the CMK that should be used for the AWS KMS encryption.
+* `kms_key_arn` - (Optional, Forces new resource) ARN of the CMK that should be used for the AWS KMS encryption. This argument should only be used if the key is different from the default KMS-managed DynamoDB key, `alias/aws/dynamodb`. **Note:** This attribute will _not_ be populated with the ARN of _default_ keys.
 * `point_in_time_recovery` - (Optional) Whether to enable Point In Time Recovery for the replica. Default is `false`.
 * `propagate_tags` - (Optional) Whether to propagate the global table's tags to a replica. Default is `false`. Changes to tags only move in one direction: from global (source) to replica. In other words, tag drift on a replica will not trigger an update. Tag or replica changes on the global table, whether from drift or configuration changes, are propagated to replicas. Changing from `true` to `false` on a subsequent `apply` means replica tags are left as they were, unmanaged, not deleted.
 * `region_name` - (Required) Region name of the replica.
 
 ### `server_side_encryption`
 
-* `enabled` - (Required) Whether or not to enable encryption at rest using an AWS managed KMS customer master key (CMK). If `enabled` is `false` then server-side encryption is set to AWS owned CMK (shown as `DEFAULT` in the AWS console). If `enabled` is `true` and no `kms_key_arn` is specified then server-side encryption is set to AWS managed CMK (shown as `KMS` in the AWS console). The [AWS KMS documentation](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html) explains the difference between AWS owned and AWS managed CMKs.
-* `kms_key_arn` - (Optional) ARN of the CMK that should be used for the AWS KMS encryption. This attribute should only be specified if the key is different from the default DynamoDB CMK, `alias/aws/dynamodb`.
+* `enabled` - (Required) Whether or not to enable encryption at rest using an AWS managed KMS customer master key (CMK). If `enabled` is `false` then server-side encryption is set to AWS-_owned_ key (shown as `DEFAULT` in the AWS console). Potentially confusingly, if `enabled` is `true` and no `kms_key_arn` is specified then server-side encryption is set to the _default_ KMS-_managed_ key (shown as `KMS` in the AWS console). The [AWS KMS documentation](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html) explains the difference between AWS-_owned_ and KMS-_managed_ keys.
+* `kms_key_arn` - (Optional) ARN of the CMK that should be used for the AWS KMS encryption. This argument should only be used if the key is different from the default KMS-managed DynamoDB key, `alias/aws/dynamodb`. **Note:** This attribute will _not_ be populated with the ARN of _default_ keys.
 
 ### `ttl`
 

--- a/website/docs/r/dynamodb_table_replica.html.markdown
+++ b/website/docs/r/dynamodb_table_replica.html.markdown
@@ -66,7 +66,7 @@ Required arguments:
 
 Optional arguments:
 
-* `kms_key_arn` - (Optional) ARN of the CMK that should be used for the AWS KMS encryption.
+* `kms_key_arn` - (Optional, Forces new resource) ARN of the CMK that should be used for the AWS KMS encryption.
 * `point_in_time_recovery` - (Optional) Whether to enable Point In Time Recovery for the replica. Default is `false`.
 * `table_class_override` - (Optional, Forces new resource) Storage class of the table replica. Valid values are `STANDARD` and `STANDARD_INFREQUENT_ACCESS`. If not used, the table replica will use the same class as the global table.
 * `tags` - (Optional) Map of tags to populate on the created table. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.

--- a/website/docs/r/dynamodb_table_replica.html.markdown
+++ b/website/docs/r/dynamodb_table_replica.html.markdown
@@ -66,7 +66,7 @@ Required arguments:
 
 Optional arguments:
 
-* `kms_key_arn` - (Optional, Forces new resource) ARN of the CMK that should be used for the AWS KMS encryption.
+* `kms_key_arn` - (Optional, Forces new resource) ARN of the CMK that should be used for the AWS KMS encryption. This argument should only be used if the key is different from the default KMS-managed DynamoDB key, `alias/aws/dynamodb`. **Note:** This attribute will _not_ be populated with the ARN of _default_ keys.
 * `point_in_time_recovery` - (Optional) Whether to enable Point In Time Recovery for the replica. Default is `false`.
 * `table_class_override` - (Optional, Forces new resource) Storage class of the table replica. Valid values are `STANDARD` and `STANDARD_INFREQUENT_ACCESS`. If not used, the table replica will use the same class as the global table.
 * `tags` - (Optional) Map of tags to populate on the created table. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

* `aws_dynamodb_table_replica`: Fix to allow creation of the replica without errors when `kms_key_arn` is set
* `aws_dynamodb_table_replica`: Fix to allow updating of `kms_key_arn`
* `aws_dynamodb_table_replica`: Updating `kms_key_arn` forces replacement of the replica now as required to re-encrypt the replica
* `aws_dynamodb_table`: Fix to allow updating of `replica.*.kms_key_arn`
* `aws_dynamodb_table`: Fix to allow updating of `replica.*.point_in_time_recovery` when a `replica` has `kms_key_arn` set
* `aws_dynamodb_table`: Updating `replica.*.kms_key_arn` or `replica.*.point_in_time_recovery`, when the `replica`'s `kms_key_arn` is set, requires recreating the replica.

The error message `ValidationException: One or more parameter values were invalid: KMSMasterKeyId must be specified for each replica.` actually means at least two pretty much unrelated things:

1. That you’re trying to update something that cannot be modified (you cannot update CMKs - you have to recreate the replica)
2. That you’re attempting to update the replica without making any actual changes

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #26552
Closes #28814
Closes #28010
Closes #27850
Closes #25812

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccDynamoDBTableReplica_ PKG=dynamodb
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTableReplica_'  -timeout 180m
=== RUN   TestAccDynamoDBTableReplica_basic
=== PAUSE TestAccDynamoDBTableReplica_basic
=== RUN   TestAccDynamoDBTableReplica_disappears
=== PAUSE TestAccDynamoDBTableReplica_disappears
=== RUN   TestAccDynamoDBTableReplica_pitr
=== PAUSE TestAccDynamoDBTableReplica_pitr
=== RUN   TestAccDynamoDBTableReplica_pitrKMS
=== PAUSE TestAccDynamoDBTableReplica_pitrKMS
=== RUN   TestAccDynamoDBTableReplica_pitrDefault
=== PAUSE TestAccDynamoDBTableReplica_pitrDefault
=== RUN   TestAccDynamoDBTableReplica_tags
=== PAUSE TestAccDynamoDBTableReplica_tags
=== RUN   TestAccDynamoDBTableReplica_tableClass
=== PAUSE TestAccDynamoDBTableReplica_tableClass
=== RUN   TestAccDynamoDBTableReplica_keys
=== PAUSE TestAccDynamoDBTableReplica_keys
=== CONT  TestAccDynamoDBTableReplica_basic
=== CONT  TestAccDynamoDBTableReplica_pitrDefault
=== CONT  TestAccDynamoDBTableReplica_pitrKMS
=== CONT  TestAccDynamoDBTableReplica_tableClass
=== CONT  TestAccDynamoDBTableReplica_keys
=== CONT  TestAccDynamoDBTableReplica_tags
=== CONT  TestAccDynamoDBTableReplica_pitr
=== CONT  TestAccDynamoDBTableReplica_disappears
--- PASS: TestAccDynamoDBTableReplica_pitr (220.29s)
--- PASS: TestAccDynamoDBTableReplica_basic (224.38s)
--- PASS: TestAccDynamoDBTableReplica_disappears (225.20s)
--- PASS: TestAccDynamoDBTableReplica_pitrDefault (228.33s)
--- PASS: TestAccDynamoDBTableReplica_tags (388.56s)
--- PASS: TestAccDynamoDBTableReplica_pitrKMS (399.01s)
--- PASS: TestAccDynamoDBTableReplica_keys (438.29s)
--- PASS: TestAccDynamoDBTableReplica_tableClass (444.02s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	446.027s
% TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 4 -run='TestAccDynamoDBTable_'  -timeout 180m
=== RUN   TestAccDynamoDBTable_basic
=== PAUSE TestAccDynamoDBTable_basic
=== RUN   TestAccDynamoDBTable_disappears
=== PAUSE TestAccDynamoDBTable_disappears
=== RUN   TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
=== PAUSE TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
=== RUN   TestAccDynamoDBTable_extended
=== PAUSE TestAccDynamoDBTable_extended
=== RUN   TestAccDynamoDBTable_enablePITR
=== PAUSE TestAccDynamoDBTable_enablePITR
=== RUN   TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== PAUSE TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== RUN   TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
=== PAUSE TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
=== RUN   TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
=== PAUSE TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
=== RUN   TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
=== PAUSE TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
=== RUN   TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
=== PAUSE TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
=== RUN   TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
=== PAUSE TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
=== RUN   TestAccDynamoDBTable_streamSpecification
=== PAUSE TestAccDynamoDBTable_streamSpecification
=== RUN   TestAccDynamoDBTable_streamSpecificationDiffs
=== PAUSE TestAccDynamoDBTable_streamSpecificationDiffs
=== RUN   TestAccDynamoDBTable_streamSpecificationValidation
=== PAUSE TestAccDynamoDBTable_streamSpecificationValidation
=== RUN   TestAccDynamoDBTable_tags
=== PAUSE TestAccDynamoDBTable_tags
=== RUN   TestAccDynamoDBTable_gsiUpdateCapacity
=== PAUSE TestAccDynamoDBTable_gsiUpdateCapacity
=== RUN   TestAccDynamoDBTable_gsiUpdateOtherAttributes
=== PAUSE TestAccDynamoDBTable_gsiUpdateOtherAttributes
=== RUN   TestAccDynamoDBTable_lsiNonKeyAttributes
=== PAUSE TestAccDynamoDBTable_lsiNonKeyAttributes
=== RUN   TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
=== PAUSE TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
=== RUN   TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
=== PAUSE TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
=== RUN   TestAccDynamoDBTable_TTL_enabled
=== PAUSE TestAccDynamoDBTable_TTL_enabled
=== RUN   TestAccDynamoDBTable_TTL_disabled
=== PAUSE TestAccDynamoDBTable_TTL_disabled
=== RUN   TestAccDynamoDBTable_attributeUpdate
=== PAUSE TestAccDynamoDBTable_attributeUpdate
=== RUN   TestAccDynamoDBTable_lsiUpdate
=== PAUSE TestAccDynamoDBTable_lsiUpdate
=== RUN   TestAccDynamoDBTable_attributeUpdateValidation
=== PAUSE TestAccDynamoDBTable_attributeUpdateValidation
=== RUN   TestAccDynamoDBTable_encryption
=== PAUSE TestAccDynamoDBTable_encryption
=== RUN   TestAccDynamoDBTable_Replica_multiple
=== PAUSE TestAccDynamoDBTable_Replica_multiple
=== RUN   TestAccDynamoDBTable_Replica_single
=== PAUSE TestAccDynamoDBTable_Replica_single
=== RUN   TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted
=== PAUSE TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted
=== RUN   TestAccDynamoDBTable_Replica_singleCMK
=== PAUSE TestAccDynamoDBTable_Replica_singleCMK
=== RUN   TestAccDynamoDBTable_Replica_singleAddCMK
=== PAUSE TestAccDynamoDBTable_Replica_singleAddCMK
=== RUN   TestAccDynamoDBTable_Replica_pitr
=== PAUSE TestAccDynamoDBTable_Replica_pitr
=== RUN   TestAccDynamoDBTable_Replica_pitrKMS
=== PAUSE TestAccDynamoDBTable_Replica_pitrKMS
=== RUN   TestAccDynamoDBTable_Replica_tagsOneOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_tagsOneOfTwo
=== RUN   TestAccDynamoDBTable_Replica_tagsTwoOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_tagsTwoOfTwo
=== RUN   TestAccDynamoDBTable_Replica_tagsNext
=== PAUSE TestAccDynamoDBTable_Replica_tagsNext
=== RUN   TestAccDynamoDBTable_Replica_tagsUpdate
=== PAUSE TestAccDynamoDBTable_Replica_tagsUpdate
=== RUN   TestAccDynamoDBTable_tableClassInfrequentAccess
=== PAUSE TestAccDynamoDBTable_tableClassInfrequentAccess
=== RUN   TestAccDynamoDBTable_backupEncryption
=== PAUSE TestAccDynamoDBTable_backupEncryption
=== RUN   TestAccDynamoDBTable_backup_overrideEncryption
=== PAUSE TestAccDynamoDBTable_backup_overrideEncryption
=== CONT  TestAccDynamoDBTable_basic
=== CONT  TestAccDynamoDBTable_TTL_enabled
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== CONT  TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
--- PASS: TestAccDynamoDBTable_basic (27.99s)
=== CONT  TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
--- PASS: TestAccDynamoDBTable_TTL_enabled (29.15s)
=== CONT  TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (45.91s)
=== CONT  TestAccDynamoDBTable_lsiNonKeyAttributes
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (41.98s)
=== CONT  TestAccDynamoDBTable_gsiUpdateOtherAttributes
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (32.62s)
=== CONT  TestAccDynamoDBTable_gsiUpdateCapacity
--- PASS: TestAccDynamoDBTable_gsiUpdateCapacity (58.56s)
=== CONT  TestAccDynamoDBTable_tags
--- PASS: TestAccDynamoDBTable_tags (34.36s)
=== CONT  TestAccDynamoDBTable_streamSpecificationValidation
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (1.69s)
=== CONT  TestAccDynamoDBTable_streamSpecificationDiffs
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (174.86s)
=== CONT  TestAccDynamoDBTable_streamSpecification
--- PASS: TestAccDynamoDBTable_streamSpecification (41.63s)
=== CONT  TestAccDynamoDBTable_enablePITR
--- PASS: TestAccDynamoDBTable_streamSpecificationDiffs (129.97s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
--- PASS: TestAccDynamoDBTable_enablePITR (67.46s)
=== CONT  TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (61.23s)
=== CONT  TestAccDynamoDBTable_Replica_singleAddCMK
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (690.89s)
=== CONT  TestAccDynamoDBTable_backup_overrideEncryption
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (945.42s)
=== CONT  TestAccDynamoDBTable_backupEncryption
--- PASS: TestAccDynamoDBTable_Replica_singleAddCMK (724.48s)
=== CONT  TestAccDynamoDBTable_tableClassInfrequentAccess
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (49.34s)
=== CONT  TestAccDynamoDBTable_Replica_tagsUpdate
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (1094.36s)
=== CONT  TestAccDynamoDBTable_Replica_tagsNext
--- PASS: TestAccDynamoDBTable_backupEncryption (494.26s)
=== CONT  TestAccDynamoDBTable_Replica_tagsTwoOfTwo
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (859.56s)
=== CONT  TestAccDynamoDBTable_Replica_tagsOneOfTwo
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (426.21s)
=== CONT  TestAccDynamoDBTable_Replica_pitrKMS
--- PASS: TestAccDynamoDBTable_Replica_tagsTwoOfTwo (318.23s)
=== CONT  TestAccDynamoDBTable_Replica_pitr
--- PASS: TestAccDynamoDBTable_Replica_tagsOneOfTwo (379.07s)
=== CONT  TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
--- PASS: TestAccDynamoDBTable_Replica_tagsNext (535.86s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (83.68s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (42.17s)
=== CONT  TestAccDynamoDBTable_disappears
--- PASS: TestAccDynamoDBTable_disappears (21.17s)
=== CONT  TestAccDynamoDBTable_encryption
--- PASS: TestAccDynamoDBTable_Replica_pitr (290.92s)
=== CONT  TestAccDynamoDBTable_Replica_singleCMK
--- PASS: TestAccDynamoDBTable_Replica_pitrKMS (604.36s)
=== CONT  TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted
--- PASS: TestAccDynamoDBTable_encryption (120.09s)
=== CONT  TestAccDynamoDBTable_Replica_single
--- PASS: TestAccDynamoDBTable_Replica_singleCMK (184.09s)
=== CONT  TestAccDynamoDBTable_Replica_multiple
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted (235.21s)
=== CONT  TestAccDynamoDBTable_extended
--- PASS: TestAccDynamoDBTable_Replica_single (440.36s)
=== CONT  TestAccDynamoDBTable_lsiUpdate
--- PASS: TestAccDynamoDBTable_extended (227.30s)
=== CONT  TestAccDynamoDBTable_attributeUpdateValidation
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (4.21s)
=== CONT  TestAccDynamoDBTable_attributeUpdate
--- PASS: TestAccDynamoDBTable_lsiUpdate (56.00s)
=== CONT  TestAccDynamoDBTable_TTL_disabled
--- PASS: TestAccDynamoDBTable_TTL_disabled (43.50s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (819.36s)
--- PASS: TestAccDynamoDBTable_Replica_multiple (599.38s)
--- PASS: TestAccDynamoDBTable_attributeUpdate (806.04s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	3453.330s
```
