### PR TITLE
Fixed variant name in aws_sagemaker_endpoint_configuration to a required

### DIFF
--- a/.changelog/29118.txt
+++ b/.changelog/29118.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sagemaker_endpoint_configuration: Fix variant_name being optional
+```

--- a/internal/service/sagemaker/endpoint_configuration.go
+++ b/internal/service/sagemaker/endpoint_configuration.go
@@ -314,6 +314,10 @@ func ResourceEndpointConfiguration() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
+							ValidateFunc: validation.All(
+								validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](-*[a-zA-Z0-9])+$`), ""),
+								validation.StringLenBetween(1, 63),
+							),
 						},
 						"volume_size_in_gb": {
 							Type:         schema.TypeInt,
@@ -423,8 +427,7 @@ func ResourceEndpointConfiguration() *schema.Resource {
 						},
 						"variant_name": {
 							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
+							Required: true,
 							ForceNew: true,
 							ValidateFunc: validation.All(
 								validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](-*[a-zA-Z0-9])+$`), ""),

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 * `model_data_download_timeout_in_seconds` - (Optional) The timeout value, in seconds, to download and extract the model that you want to host from Amazon S3 to the individual inference instance associated with this production variant. Valid values between `60` and `3600`.
 * `model_name` - (Required) The name of the model to use.
 * `serverless_config` - (Optional) Specifies configuration for how an endpoint performs asynchronous inference.
-* `variant_name` - (Optional) The name of the variant. If omitted, Terraform will assign a random, unique name.
+* `variant_name` - (Required) The name of the variant.
 * `volume_size_in_gb` - (Optional) The size, in GB, of the ML storage volume attached to individual inference instance associated with the production variant. Valid values between `1` and `512`.
 
 #### core_dump_config


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fix variant name for production_variants and shadow_production_variants in aws_sagemaker_endpoint_configuration to required. Because it is required by the API.
https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ProductionVariant.html#sagemaker-Type-ProductionVariant-VariantName

https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ShadowModelVariantConfig.html#sagemaker-Type-ShadowModelVariantConfig-ShadowModelVariantName

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/20966

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccSageMakerEndpointConfiguration PKG=sagemaker
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerEndpointConfiguration'  -timeout 180m
=== RUN   TestAccSageMakerEndpointConfiguration_basic
=== PAUSE TestAccSageMakerEndpointConfiguration_basic
=== RUN   TestAccSageMakerEndpointConfiguration_shadowProductionVariants
=== PAUSE TestAccSageMakerEndpointConfiguration_shadowProductionVariants
=== RUN   TestAccSageMakerEndpointConfiguration_ProductionVariants_serverless
=== PAUSE TestAccSageMakerEndpointConfiguration_ProductionVariants_serverless
=== RUN   TestAccSageMakerEndpointConfiguration_ProductionVariants_initialVariantWeight
=== PAUSE TestAccSageMakerEndpointConfiguration_ProductionVariants_initialVariantWeight
=== RUN   TestAccSageMakerEndpointConfiguration_ProductionVariants_acceleratorType
=== PAUSE TestAccSageMakerEndpointConfiguration_ProductionVariants_acceleratorType
=== RUN   TestAccSageMakerEndpointConfiguration_kmsKeyID
=== PAUSE TestAccSageMakerEndpointConfiguration_kmsKeyID
=== RUN   TestAccSageMakerEndpointConfiguration_tags
=== PAUSE TestAccSageMakerEndpointConfiguration_tags
=== RUN   TestAccSageMakerEndpointConfiguration_dataCapture
=== PAUSE TestAccSageMakerEndpointConfiguration_dataCapture
=== RUN   TestAccSageMakerEndpointConfiguration_disappears
=== PAUSE TestAccSageMakerEndpointConfiguration_disappears
=== RUN   TestAccSageMakerEndpointConfiguration_async
=== PAUSE TestAccSageMakerEndpointConfiguration_async
=== RUN   TestAccSageMakerEndpointConfiguration_async_kms
=== PAUSE TestAccSageMakerEndpointConfiguration_async_kms
=== RUN   TestAccSageMakerEndpointConfiguration_Async_notif
=== PAUSE TestAccSageMakerEndpointConfiguration_Async_notif
=== RUN   TestAccSageMakerEndpointConfiguration_Async_client
=== PAUSE TestAccSageMakerEndpointConfiguration_Async_client
=== CONT  TestAccSageMakerEndpointConfiguration_basic
=== CONT  TestAccSageMakerEndpointConfiguration_dataCapture
=== CONT  TestAccSageMakerEndpointConfiguration_ProductionVariants_acceleratorType
=== CONT  TestAccSageMakerEndpointConfiguration_kmsKeyID
=== CONT  TestAccSageMakerEndpointConfiguration_tags
=== CONT  TestAccSageMakerEndpointConfiguration_async_kms
=== CONT  TestAccSageMakerEndpointConfiguration_ProductionVariants_serverless
=== CONT  TestAccSageMakerEndpointConfiguration_Async_client
=== CONT  TestAccSageMakerEndpointConfiguration_async
=== CONT  TestAccSageMakerEndpointConfiguration_Async_notif
=== CONT  TestAccSageMakerEndpointConfiguration_shadowProductionVariants
=== CONT  TestAccSageMakerEndpointConfiguration_ProductionVariants_initialVariantWeight
=== CONT  TestAccSageMakerEndpointConfiguration_disappears
--- PASS: TestAccSageMakerEndpointConfiguration_shadowProductionVariants (45.88s)
--- PASS: TestAccSageMakerEndpointConfiguration_async (51.18s)
--- PASS: TestAccSageMakerEndpointConfiguration_Async_client (51.47s)
--- PASS: TestAccSageMakerEndpointConfiguration_kmsKeyID (54.72s)
--- PASS: TestAccSageMakerEndpointConfiguration_disappears (57.09s)
--- PASS: TestAccSageMakerEndpointConfiguration_basic (57.25s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_acceleratorType (59.03s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_serverless (62.18s)
--- PASS: TestAccSageMakerEndpointConfiguration_dataCapture (62.49s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_initialVariantWeight (62.64s)
--- PASS: TestAccSageMakerEndpointConfiguration_async_kms (69.74s)
--- PASS: TestAccSageMakerEndpointConfiguration_Async_notif (74.12s)
--- PASS: TestAccSageMakerEndpointConfiguration_tags (83.66s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  107.854s
...
```
