### PR TITLE
Sweepers: Support supplemental framework attributes

### DIFF
--- a/internal/sweep/framework.go
+++ b/internal/sweep/framework.go
@@ -17,23 +17,35 @@ import (
 
 // Terraform Plugin Framework variants of sweeper helpers.
 
-type SweepFrameworkResource struct {
-	factory func(context.Context) (fwresource.ResourceWithConfigure, error)
-	id      string // TODO Currently we can only delete a resource if "id" is the only attribute used.
-	meta    interface{}
+type FrameworkSupplementalAttribute struct {
+	Path  string
+	Value string
 }
 
-func NewSweepFrameworkResource(factory func(context.Context) (fwresource.ResourceWithConfigure, error), id string, meta interface{}) *SweepFrameworkResource {
+type SweepFrameworkResource struct {
+	factory func(context.Context) (fwresource.ResourceWithConfigure, error)
+	id      string
+	meta    interface{}
+
+	// supplementalAttributes stores additional attributes to set in state.
+	//
+	// This can be used in situations where the Delete method requires multiple attributes
+	// to destroy the underlying resource.
+	supplementalAttributes []FrameworkSupplementalAttribute
+}
+
+func NewSweepFrameworkResource(factory func(context.Context) (fwresource.ResourceWithConfigure, error), id string, meta interface{}, supplementalAttributes ...FrameworkSupplementalAttribute) *SweepFrameworkResource {
 	return &SweepFrameworkResource{
-		factory: factory,
-		id:      id,
-		meta:    meta,
+		factory:                factory,
+		id:                     id,
+		meta:                   meta,
+		supplementalAttributes: supplementalAttributes,
 	}
 }
 
 func (sr *SweepFrameworkResource) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
 	err := tfresource.Retry(ctx, timeout, func() *resource.RetryError {
-		err := DeleteFrameworkResource(sr.factory, sr.id, sr.meta)
+		err := DeleteFrameworkResource(sr.factory, sr.id, sr.meta, sr.supplementalAttributes)
 
 		if err != nil {
 			if strings.Contains(err.Error(), "Throttling") {
@@ -48,13 +60,13 @@ func (sr *SweepFrameworkResource) Delete(ctx context.Context, timeout time.Durat
 	}, optFns...)
 
 	if tfresource.TimedOut(err) {
-		err = DeleteFrameworkResource(sr.factory, sr.id, sr.meta)
+		err = DeleteFrameworkResource(sr.factory, sr.id, sr.meta, sr.supplementalAttributes)
 	}
 
 	return err
 }
 
-func DeleteFrameworkResource(factory func(context.Context) (fwresource.ResourceWithConfigure, error), id string, meta interface{}) error {
+func DeleteFrameworkResource(factory func(context.Context) (fwresource.ResourceWithConfigure, error), id string, meta interface{}, supplementalAttributes []FrameworkSupplementalAttribute) error {
 	ctx := context.Background()
 
 	resource, err := factory(ctx)
@@ -74,6 +86,15 @@ func DeleteFrameworkResource(factory func(context.Context) (fwresource.ResourceW
 		Schema: schemaResp.Schema,
 	}
 	state.SetAttribute(ctx, path.Root("id"), id)
+
+	// Set supplemental attibutes, if provided
+	for _, attr := range supplementalAttributes {
+		d := state.SetAttribute(ctx, path.Root(attr.Path), attr.Value)
+		if d.HasError() {
+			return fwdiag.DiagnosticsError(d)
+		}
+	}
+
 	response := fwresource.DeleteResponse{}
 	resource.Delete(ctx, fwresource.DeleteRequest{State: state}, &response)
 


### PR DESCRIPTION
### Description
Adds the ability to specify additional (non-ID) attributes during creation of plugin-framework resource sweepers. This allows for cases where multiple attributes are required to perform deletion.

Also adds additional AuditManager sweepers.


### Output from Acceptance Testing

```console
$ SWEEPARGS=-sweep-run=aws_auditmanager_assessment_report make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2,us-east-1,us-east-2 -sweep-run=aws_auditmanager_assessment_report -timeout 60m
2023/01/26 21:05:12 [DEBUG] Running Sweepers for region (us-west-2):
2023/01/26 21:05:12 [DEBUG] Running Sweeper (aws_auditmanager_assessment_report) in region (us-west-2)
2023/01/26 21:05:12 [INFO] Retrieved credentials from "SharedConfigCredentials: /Users/jaredbaker/.aws/credentials"
2023/01/26 21:05:12 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2023/01/26 21:05:12 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2023/01/26 21:05:13 [INFO] Deleting AuditManager Assessment Report: 525dc5d8-2a47-4912-8aa1-427fa55deba9
2023/01/26 21:05:13 [DEBUG] Waiting for state to become: [success]
2023/01/26 21:05:13 [DEBUG] Waiting for state to become: [success]
2023/01/26 21:05:13 [DEBUG] Completed Sweeper (aws_auditmanager_assessment_report) in region (us-west-2) in 1.449992292s
2023/01/26 21:05:13 Completed Sweepers for region (us-west-2) in 1.450182333s
2023/01/26 21:05:13 Sweeper Tests for region (us-west-2) ran successfully:
        - aws_auditmanager_assessment_report
<snip>
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      5.212s
```
```console
$ SWEEPARGS=-sweep-run=aws_auditmanager_assessment_delegation make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2,us-east-1,us-east-2 -sweep-run=aws_auditmanager_assessment_delegation -timeout 60m
2023/01/27 10:48:56 [DEBUG] Running Sweepers for region (us-west-2):
2023/01/27 10:48:56 [DEBUG] Running Sweeper (aws_auditmanager_assessment_delegation) in region (us-west-2)
2023/01/27 10:48:56 [INFO] Retrieved credentials from "SharedConfigCredentials: /Users/jaredbaker/.aws/credentials"
2023/01/27 10:48:56 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2023/01/27 10:48:56 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2023/01/27 10:48:57 [INFO] Deleting AuditManager Assessment Delegation: 4fb24863-08e9-44a7-b0e9-8cbac80b184f
2023/01/27 10:48:57 [INFO] Deleting AuditManager Assessment Delegation: a3e89196-2624-4fd8-ae28-3a33e27c0640
2023/01/27 10:48:57 [DEBUG] Waiting for state to become: [success]
2023/01/27 10:48:57 [DEBUG] Waiting for state to become: [success]
2023/01/27 10:48:58 [DEBUG] Completed Sweeper (aws_auditmanager_assessment_delegation) in region (us-west-2) in 1.620822542s
2023/01/27 10:48:58 Completed Sweepers for region (us-west-2) in 1.620975375s
2023/01/27 10:48:58 Sweeper Tests for region (us-west-2) ran successfully:
        - aws_auditmanager_assessment_delegation
<snip>
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      5.171s
```
```console
$ SWEEPARGS=-sweep-run=aws_auditmanager_framework_share make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2,us-east-1,us-east-2 -sweep-run=aws_auditmanager_framework_share -timeout 60m
2023/01/27 11:04:28 [DEBUG] Running Sweepers for region (us-west-2):
2023/01/27 11:04:28 [DEBUG] Running Sweeper (aws_auditmanager_framework_share) in region (us-west-2)
2023/01/27 11:04:28 [INFO] Retrieved credentials from "SharedConfigCredentials: /Users/jaredbaker/.aws/credentials"
2023/01/27 11:04:28 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2023/01/27 11:04:28 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2023/01/27 11:04:29 [INFO] Deleting AuditManager Framework Share: a665ac94-e86a-4c42-9b35-c1cf78712351
2023/01/27 11:04:29 [INFO] Deleting AuditManager Framework Share: daebdc2f-264e-4c50-a6db-bac8c4777099
2023/01/27 11:04:29 [INFO] Deleting AuditManager Framework Share: 66551456-3abc-48fa-b09b-3208e80224a3
2023/01/27 11:04:29 [DEBUG] Waiting for state to become: [success]
2023/01/27 11:04:29 [DEBUG] Waiting for state to become: [success]
2023/01/27 11:04:29 [DEBUG] Waiting for state to become: [success]
2023/01/27 11:04:30 [DEBUG] Completed Sweeper (aws_auditmanager_framework_share) in region (us-west-2) in 2.033093542s
2023/01/27 11:04:30 Completed Sweepers for region (us-west-2) in 2.033297125s
2023/01/27 11:04:30 Sweeper Tests for region (us-west-2) ran successfully:
        - aws_auditmanager_framework_share
<snip>
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      5.865s
```