### PR TITLE
[TechDebt]: Replace deprecated `AWSConfigRole` in acceptance tests

### DIFF
--- a/internal/service/configservice/config_rule_test.go
+++ b/internal/service/configservice/config_rule_test.go
@@ -420,7 +420,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "test" {
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSConfigRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWS_ConfigRole"
   role       = aws_iam_role.test.name
 }
 `, rName)

--- a/internal/service/configservice/conformance_pack_test.go
+++ b/internal/service/configservice/conformance_pack_test.go
@@ -522,7 +522,7 @@ POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "test" {
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSConfigRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWS_ConfigRole"
   role       = aws_iam_role.test.name
 }
 `, rName)

--- a/internal/service/configservice/organization_conformance_pack_test.go
+++ b/internal/service/configservice/organization_conformance_pack_test.go
@@ -523,7 +523,7 @@ POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "test" {
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSConfigRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWS_ConfigRole"
   role       = aws_iam_role.test.name
 }
 

--- a/internal/service/configservice/organization_custom_rule_test.go
+++ b/internal/service/configservice/organization_custom_rule_test.go
@@ -542,7 +542,7 @@ POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "config" {
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSConfigRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWS_ConfigRole"
   role       = aws_iam_role.config.name
 }
 

--- a/internal/service/configservice/organization_managed_rule_test.go
+++ b/internal/service/configservice/organization_managed_rule_test.go
@@ -500,7 +500,7 @@ POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "test" {
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSConfigRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWS_ConfigRole"
   role       = aws_iam_role.test.name
 }
 


### PR DESCRIPTION
### Description
Replaces the deprecated AWS-managed `AWSConfigRole` in acceptance tests.

### Relations
Closes #29129
Relates #28938

### References
- [Announcement of deprecation](https://aws.amazon.com/blogs/mt/service-notice-upcoming-changes-required-for-aws-config/)
- [Managed policy docs](https://docs.aws.amazon.com/config/latest/developerguide/security-iam-awsmanpol.html#security-iam-awsmanpol-AWS_ConfigRole)

### Output from Acceptance Testing

```console
$ make testacc PKG=configservice TESTS=TestAccConfigService_serial
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/configservice/... -v -count 1 -parallel 20 -run='TestAccConfigService_serial'  -timeout 180m
=== RUN   TestAccConfigService_serial
=== PAUSE TestAccConfigService_serial
=== CONT  TestAccConfigService_serial
=== RUN   TestAccConfigService_serial/Config
=== RUN   TestAccConfigService_serial/Config/ownerAws
=== RUN   TestAccConfigService_serial/Config/disappears
=== RUN   TestAccConfigService_serial/Config/scopeTagKeyEmpty
=== RUN   TestAccConfigService_serial/Config/scopeTagValue
=== RUN   TestAccConfigService_serial/Config/tags
=== RUN   TestAccConfigService_serial/Config/basic
=== RUN   TestAccConfigService_serial/Config/customlambda
=== RUN   TestAccConfigService_serial/Config/customPolicy
=== RUN   TestAccConfigService_serial/Config/scopeTagKey
=== RUN   TestAccConfigService_serial/OrganizationCustomRule
=== RUN   TestAccConfigService_serial/OrganizationCustomRule/TagKeyScope
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationCustomRule/TriggerTypes
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationCustomRule/errorHandling
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationCustomRule/Description
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationCustomRule/ExcludedAccounts
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationCustomRule/LambdaFunctionArn
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationCustomRule/MaximumExecutionFrequency
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationCustomRule/ResourceIdScope
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationCustomRule/basic
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationCustomRule/disappears
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationCustomRule/InputParameters
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationCustomRule/ResourceTypesScope
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationCustomRule/TagValueScope
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationManagedRule
=== RUN   TestAccConfigService_serial/OrganizationManagedRule/Description
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationManagedRule/InputParameters
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationManagedRule/TagKeyScope
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationManagedRule/MaximumExecutionFrequency
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationManagedRule/ResourceIdScope
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationManagedRule/ResourceTypesScope
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationManagedRule/RuleIdentifier
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationManagedRule/basic
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationManagedRule/disappears
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationManagedRule/errorHandling
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationManagedRule/ExcludedAccounts
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationManagedRule/TagValueScope
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/RemediationConfiguration
=== RUN   TestAccConfigService_serial/RemediationConfiguration/recreates
=== RUN   TestAccConfigService_serial/RemediationConfiguration/updates
=== RUN   TestAccConfigService_serial/RemediationConfiguration/values
=== RUN   TestAccConfigService_serial/RemediationConfiguration/basic
=== RUN   TestAccConfigService_serial/RemediationConfiguration/basicBackward
=== RUN   TestAccConfigService_serial/RemediationConfiguration/disappears
=== RUN   TestAccConfigService_serial/ConfigurationRecorderStatus
=== RUN   TestAccConfigService_serial/ConfigurationRecorderStatus/basic
=== RUN   TestAccConfigService_serial/ConfigurationRecorderStatus/startEnabled
=== RUN   TestAccConfigService_serial/ConfigurationRecorderStatus/importBasic
=== RUN   TestAccConfigService_serial/ConfigurationRecorder
=== RUN   TestAccConfigService_serial/ConfigurationRecorder/basic
=== RUN   TestAccConfigService_serial/ConfigurationRecorder/allParams
=== RUN   TestAccConfigService_serial/ConfigurationRecorder/importBasic
=== RUN   TestAccConfigService_serial/ConformancePack
=== RUN   TestAccConfigService_serial/ConformancePack/updateInputParameters
=== RUN   TestAccConfigService_serial/ConformancePack/updateTemplateBody
=== RUN   TestAccConfigService_serial/ConformancePack/forceNew
=== RUN   TestAccConfigService_serial/ConformancePack/inputParameters
=== RUN   TestAccConfigService_serial/ConformancePack/S3Delivery
=== RUN   TestAccConfigService_serial/ConformancePack/S3Template
=== RUN   TestAccConfigService_serial/ConformancePack/S3TemplateAndTemplateBody
=== RUN   TestAccConfigService_serial/ConformancePack/basic
=== RUN   TestAccConfigService_serial/ConformancePack/disappears
=== RUN   TestAccConfigService_serial/ConformancePack/updateS3Delivery
=== RUN   TestAccConfigService_serial/ConformancePack/updateS3Template
=== RUN   TestAccConfigService_serial/DeliveryChannel
=== RUN   TestAccConfigService_serial/DeliveryChannel/basic
=== RUN   TestAccConfigService_serial/DeliveryChannel/allParams
=== RUN   TestAccConfigService_serial/DeliveryChannel/importBasic
=== RUN   TestAccConfigService_serial/OrganizationConformancePack
=== RUN   TestAccConfigService_serial/OrganizationConformancePack/basic
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationConformancePack/inputParameters
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationConformancePack/S3Delivery
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationConformancePack/S3Template
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationConformancePack/updateS3Template
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationConformancePack/updateTemplateBody
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationConformancePack/disappears
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationConformancePack/excludedAccounts
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationConformancePack/forceNew
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationConformancePack/updateInputParameters
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccConfigService_serial/OrganizationConformancePack/updateS3Delivery
    acctest.go:766: skipping tests; this AWS account must not be an existing member of an AWS Organization
--- PASS: TestAccConfigService_serial (3373.69s)
    --- PASS: TestAccConfigService_serial/Config (792.38s)
        --- PASS: TestAccConfigService_serial/Config/ownerAws (82.41s)
        --- PASS: TestAccConfigService_serial/Config/disappears (78.93s)
        --- PASS: TestAccConfigService_serial/Config/scopeTagKeyEmpty (79.86s)
        --- PASS: TestAccConfigService_serial/Config/scopeTagValue (89.91s)
        --- PASS: TestAccConfigService_serial/Config/tags (103.13s)
        --- PASS: TestAccConfigService_serial/Config/basic (79.45s)
        --- PASS: TestAccConfigService_serial/Config/customlambda (106.65s)
        --- PASS: TestAccConfigService_serial/Config/customPolicy (81.61s)
        --- PASS: TestAccConfigService_serial/Config/scopeTagKey (90.43s)
    --- PASS: TestAccConfigService_serial/OrganizationCustomRule (13.11s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/TagKeyScope (0.23s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/TriggerTypes (0.07s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/errorHandling (2.44s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/Description (1.14s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/ExcludedAccounts (1.15s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/LambdaFunctionArn (1.00s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/MaximumExecutionFrequency (0.78s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/ResourceIdScope (0.81s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/basic (0.69s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/disappears (0.92s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/InputParameters (2.85s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/ResourceTypesScope (0.07s)
        --- SKIP: TestAccConfigService_serial/OrganizationCustomRule/TagValueScope (0.95s)
    --- PASS: TestAccConfigService_serial/OrganizationManagedRule (11.32s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/Description (0.12s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/InputParameters (2.54s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/TagKeyScope (0.06s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/MaximumExecutionFrequency (0.93s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/ResourceIdScope (0.07s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/ResourceTypesScope (2.97s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/RuleIdentifier (0.77s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/basic (0.07s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/disappears (2.38s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/errorHandling (0.20s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/ExcludedAccounts (1.13s)
        --- SKIP: TestAccConfigService_serial/OrganizationManagedRule/TagValueScope (0.07s)
    --- PASS: TestAccConfigService_serial/RemediationConfiguration (510.21s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/recreates (92.66s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/updates (91.25s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/values (81.86s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/basic (82.10s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/basicBackward (82.66s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/disappears (79.67s)
    --- PASS: TestAccConfigService_serial/ConfigurationRecorderStatus (108.79s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorderStatus/basic (28.58s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorderStatus/startEnabled (50.88s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorderStatus/importBasic (29.33s)
    --- PASS: TestAccConfigService_serial/ConfigurationRecorder (82.32s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/basic (27.31s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/allParams (27.19s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/importBasic (27.81s)
    --- PASS: TestAccConfigService_serial/ConformancePack (1758.19s)
        --- PASS: TestAccConfigService_serial/ConformancePack/updateInputParameters (205.29s)
        --- PASS: TestAccConfigService_serial/ConformancePack/updateTemplateBody (233.12s)
        --- PASS: TestAccConfigService_serial/ConformancePack/forceNew (247.87s)
        --- PASS: TestAccConfigService_serial/ConformancePack/inputParameters (115.65s)
        --- PASS: TestAccConfigService_serial/ConformancePack/S3Delivery (148.37s)
        --- PASS: TestAccConfigService_serial/ConformancePack/S3Template (118.61s)
        --- PASS: TestAccConfigService_serial/ConformancePack/S3TemplateAndTemplateBody (118.59s)
        --- PASS: TestAccConfigService_serial/ConformancePack/basic (126.56s)
        --- PASS: TestAccConfigService_serial/ConformancePack/disappears (113.58s)
        --- PASS: TestAccConfigService_serial/ConformancePack/updateS3Delivery (168.35s)
        --- PASS: TestAccConfigService_serial/ConformancePack/updateS3Template (162.19s)
    --- PASS: TestAccConfigService_serial/DeliveryChannel (86.14s)
        --- PASS: TestAccConfigService_serial/DeliveryChannel/basic (23.71s)
        --- PASS: TestAccConfigService_serial/DeliveryChannel/allParams (25.41s)
        --- PASS: TestAccConfigService_serial/DeliveryChannel/importBasic (37.02s)
    --- PASS: TestAccConfigService_serial/OrganizationConformancePack (11.22s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/basic (0.20s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/inputParameters (0.07s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/S3Delivery (2.15s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/S3Template (1.05s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/updateS3Template (1.09s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/updateTemplateBody (0.07s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/disappears (1.01s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/excludedAccounts (2.98s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/forceNew (0.07s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/updateInputParameters (0.76s)
        --- SKIP: TestAccConfigService_serial/OrganizationConformancePack/updateS3Delivery (1.78s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/configservice      3376.740s
```
