### PR TITLE
implement metrics of target tracking policy customized metric specification

### DIFF
--- a/.changelog/29148.txt
+++ b/.changelog/29148.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_autoscaling_policy: Add `metrics` argument to `target_tracking_configuration.customized_metric_specification`
+```

--- a/internal/service/autoscaling/policy.go
+++ b/internal/service/autoscaling/policy.go
@@ -264,13 +264,6 @@ func ResourcePolicy() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"metrics": func() *schema.Schema {
 										schema := customizedMetricDataQuerySchema()
-										schema.ConflictsWith = []string{
-											"target_tracking_configuration.0.customized_metric_specification.0.metric_dimension",
-											"target_tracking_configuration.0.customized_metric_specification.0.metric_name",
-											"target_tracking_configuration.0.customized_metric_specification.0.namespace",
-											"target_tracking_configuration.0.customized_metric_specification.0.statistic",
-											"target_tracking_configuration.0.customized_metric_specification.0.unit",
-										}
 										schema.Required = false
 										schema.Optional = true
 										return schema
@@ -292,19 +285,16 @@ func ResourcePolicy() *schema.Resource {
 										},
 									},
 									"metric_name": {
-										Type:          schema.TypeString,
-										Optional:      true,
-										ConflictsWith: []string{"target_tracking_configuration.0.customized_metric_specification.0.metrics"},
+										Type:     schema.TypeString,
+										Optional: true,
 									},
 									"namespace": {
-										Type:          schema.TypeString,
-										Optional:      true,
-										ConflictsWith: []string{"target_tracking_configuration.0.customized_metric_specification.0.metrics"},
+										Type:     schema.TypeString,
+										Optional: true,
 									},
 									"statistic": {
-										Type:          schema.TypeString,
-										Optional:      true,
-										ConflictsWith: []string{"target_tracking_configuration.0.customized_metric_specification.0.metrics"},
+										Type:     schema.TypeString,
+										Optional: true,
 									},
 									"unit": {
 										Type:     schema.TypeString,

--- a/internal/service/autoscaling/policy_test.go
+++ b/internal/service/autoscaling/policy_test.go
@@ -868,9 +868,9 @@ resource "aws_autoscaling_policy" "test" {
   target_tracking_configuration {
     customized_metric_specification {
       metrics {
-        id = "e1"
-        expression = "m1 / m2"
-        label = "e1 label"
+        id          = "e1"
+        expression  = "m1 / m2"
+        label       = "e1 label"
         return_data = true
       }
 
@@ -887,7 +887,7 @@ resource "aws_autoscaling_policy" "test" {
           }
           stat = "Sum"
         }
-        label = "m1 metric stat"
+        label       = "m1 metric stat"
         return_data = false
       }
 
@@ -904,7 +904,7 @@ resource "aws_autoscaling_policy" "test" {
           }
           stat = "Average"
         }
-        label = "m2 metric stat"
+        label       = "m2 metric stat"
         return_data = false
       }
     }

--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -269,11 +269,42 @@ The following arguments are supported:
 
 The following arguments are supported:
 
+* `metrics` - (Optional) The metrics to include in the target tracking scaling policy, as a metric data query. This can include both raw metric and metric math expressions.
 * `metric_dimension` - (Optional) Dimensions of the metric.
+* `metric_name` - (Optional) Name of the metric.
+* `namespace` - (Optional) Namespace of the metric.
+* `statistic` - (Optional) Statistic of the metric.
+* `unit` - (Optional) Unit of the metric.
+
+#### metrics
+
+The following arguments are supported:
+
+* `expression` - (Optional) Math expression used on the returned metric. You must specify either `expression` or `metric_stat`, but not both.
+* `id` - (Required) Short name for the metric used in target tracking scaling policy.
+* `label` - (Optional) Human-readable label for this metric or expression.
+* `metric_stat` - (Optional) Structure that defines CloudWatch metric to be used in target tracking scaling policy. You must specify either `expression` or `metric_stat`, but not both.
+* `return_data` - (Optional) Boolean that indicates whether to return the timestamps and raw data values of this metric, the default it true
+
+##### metric_stat
+The following arguments are supported:
+
+* `metric` - (Required) Structure that defines the CloudWatch metric to return, including the metric name, namespace, and dimensions.
+* `stat` - (Required) Statistic of the metrics to return.
+* `unit` - (Optional) Unit of the metrics to return.
+
+##### metric
+The following arguments are supported:
+
+* `dimensions` - (Optional) Dimensions of the metric.
 * `metric_name` - (Required) Name of the metric.
 * `namespace` - (Required) Namespace of the metric.
-* `statistic` - (Required) Statistic of the metric.
-* `unit` - (Optional) Unit of the metric.
+
+##### dimensions
+The following arguments are supported:
+
+* `name` - (Required) Name of the dimension.
+* `value` - (Required) Value of the dimension.
 
 #### metric_dimension
 

--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -119,6 +119,62 @@ resource "aws_autoscaling_policy" "example" {
 }
 ```
 
+### Create target tracking policy using customized metrics
+
+```terraform
+resource "aws_autoscaling_policy" "example" {
+  autoscaling_group_name = "my-test-asg"
+  name                   = "foo"
+  policy_type            = "PredictiveScaling"
+  target_tracking_configuration {
+    customized_metric_specification {
+      metrics {
+        id = "e1"
+        expression = "m1 / m2"
+        label = "Calculate the backlog per instance"
+        return_data = true
+      }
+
+      metrics {
+        id = "m1"
+        metric_stat {
+          metric {
+            namespace   = "AWS/SQS"
+            metric_name = "ApproximateNumberOfMessagesVisible"
+            dimensions {
+              name  = "QueueName"
+              value = "my-queue"
+            }
+          }
+          stat = "Sum"
+        }
+        label = "Get the queue size (the number of messages waiting to be processed)"
+        return_data = false
+      }
+
+      metrics {
+        id = "m2"
+        metric_stat {
+          metric {
+            namespace   = "AWS/AutoScaling"
+            metric_name = "GroupInServiceInstances"
+            dimensions {
+              name  = "AutoScalingGroupName"
+              value = "my-asg"
+            }
+          }
+          stat = "Average"
+        }
+        label = "Get the group size (the number of InService instances)"
+        return_data = false
+      }
+    }
+
+    target_value = 10
+  }
+}
+```
+
 ## Argument Reference
 
 * `name` - (Required) Name of the policy.

--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -129,9 +129,9 @@ resource "aws_autoscaling_policy" "example" {
   target_tracking_configuration {
     customized_metric_specification {
       metrics {
-        id = "e1"
-        expression = "m1 / m2"
-        label = "Calculate the backlog per instance"
+        id          = "e1"
+        expression  = "m1 / m2"
+        label       = "Calculate the backlog per instance"
         return_data = true
       }
 
@@ -148,7 +148,7 @@ resource "aws_autoscaling_policy" "example" {
           }
           stat = "Sum"
         }
-        label = "Get the queue size (the number of messages waiting to be processed)"
+        label       = "Get the queue size (the number of messages waiting to be processed)"
         return_data = false
       }
 
@@ -165,7 +165,7 @@ resource "aws_autoscaling_policy" "example" {
           }
           stat = "Average"
         }
-        label = "Get the group size (the number of InService instances)"
+        label       = "Get the group size (the number of InService instances)"
         return_data = false
       }
     }


### PR DESCRIPTION
### Description
Implement `Metrics` of `aws_autoscaling_policy`'s `target_tracking_configuration.customized_metric_specification`

### Relations
Closes #29145

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccAutoScalingPolicy_Target PKG=autoscaling
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/autoscaling/... -v -count 1 -parallel 20 -run='TestAccAutoScalingPolicy_Target'  -timeout 180m
=== RUN   TestAccAutoScalingPolicy_TargetTrack_predefined
=== PAUSE TestAccAutoScalingPolicy_TargetTrack_predefined
=== RUN   TestAccAutoScalingPolicy_TargetTrack_custom
=== PAUSE TestAccAutoScalingPolicy_TargetTrack_custom
=== RUN   TestAccAutoScalingPolicy_TargetTrack_advance
=== PAUSE TestAccAutoScalingPolicy_TargetTrack_advance
=== CONT  TestAccAutoScalingPolicy_TargetTrack_predefined
=== CONT  TestAccAutoScalingPolicy_TargetTrack_advance
=== CONT  TestAccAutoScalingPolicy_TargetTrack_custom
--- PASS: TestAccAutoScalingPolicy_TargetTrack_predefined (53.75s)
--- PASS: TestAccAutoScalingPolicy_TargetTrack_custom (67.20s)
--- PASS: TestAccAutoScalingPolicy_TargetTrack_advance (67.80s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling	69.788s
...
```
