### PR TITLE
Adds sweepers for `aws_neptune_cluster` and `aws_neptune_cluster_instance`

### DIFF
--- a/internal/service/neptune/cluster_instance.go
+++ b/internal/service/neptune/cluster_instance.go
@@ -529,10 +529,6 @@ func resourceInstanceStateRefreshFunc(ctx context.Context, id string, conn *nept
 			return nil, "", nil
 		}
 
-		if v.DBInstanceStatus != nil {
-			log.Printf("[DEBUG] Neptune Cluster Instance status for instance %s: %s", id, aws.StringValue(v.DBInstanceStatus))
-		}
-
 		return v, aws.StringValue(v.DBInstanceStatus), nil
 	}
 }

--- a/internal/service/neptune/sweep.go
+++ b/internal/service/neptune/sweep.go
@@ -21,6 +21,19 @@ func init() {
 		Name: "aws_neptune_event_subscription",
 		F:    sweepEventSubscriptions,
 	})
+
+	resource.AddTestSweepers("aws_neptune_cluster", &resource.Sweeper{
+		Name: "aws_neptune_cluster",
+		F:    sweepClusters,
+		Dependencies: []string{
+			"aws_neptune_cluster_instance",
+		},
+	})
+
+	resource.AddTestSweepers("aws_neptune_cluster_instance", &resource.Sweeper{
+		Name: "aws_neptune_cluster_instance",
+		F:    sweepClusterInstances,
+	})
 }
 
 func sweepEventSubscriptions(region string) error {
@@ -77,4 +90,110 @@ func sweepEventSubscriptions(region string) error {
 	}
 
 	return sweeperErrs.ErrorOrNil()
+}
+
+func sweepClusters(region string) error {
+	ctx := sweep.Context(region)
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("getting client: %s", err)
+	}
+	conn := client.(*conns.AWSClient).NeptuneConn()
+
+	var sweeperErrs *multierror.Error
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	input := &neptune.DescribeDBClustersInput{}
+	err = conn.DescribeDBClustersPagesWithContext(ctx, input, func(page *neptune.DescribeDBClustersOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.DBClusters {
+			arn := aws.StringValue(v.DBClusterArn)
+			id := aws.StringValue(v.DBClusterIdentifier)
+			r := ResourceCluster()
+			d := r.Data(nil)
+			d.SetId(id)
+			d.Set("apply_immediately", true)
+			d.Set("arn", arn)
+			d.Set("deletion_protection", false)
+			d.Set("skip_final_snapshot", true)
+
+			globalCluster, err := findGlobalClusterByARN(ctx, conn, arn)
+
+			if err != nil {
+				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("reading Neptune Global Cluster information for Neptune Cluster (%s): %s", id, err))
+				continue
+			}
+
+			if globalCluster != nil && globalCluster.GlobalClusterIdentifier != nil {
+				d.Set("global_cluster_identifier", globalCluster.GlobalClusterIdentifier)
+			}
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Neptune Cluster sweep for %s: %s", region, err)
+		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+	}
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("listing Neptune Clusters (%s): %w", region, err))
+	}
+
+	err = sweep.SweepOrchestratorWithContext(ctx, sweepResources)
+	if err != nil {
+		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("sweeping Neptune Clusters (%s): %w", region, err))
+	}
+
+	return sweeperErrs.ErrorOrNil()
+}
+
+func sweepClusterInstances(region string) error {
+	ctx := sweep.Context(region)
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("getting client: %s", err)
+	}
+	conn := client.(*conns.AWSClient).NeptuneConn()
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	input := &neptune.DescribeDBInstancesInput{}
+	err = conn.DescribeDBInstancesPagesWithContext(ctx, input, func(page *neptune.DescribeDBInstancesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.DBInstances {
+			log.Printf("Neptune Instance ID: %q", aws.StringValue(v.DBInstanceIdentifier))
+			r := ResourceClusterInstance()
+			d := r.Data(nil)
+			d.SetId(aws.StringValue(v.DBInstanceIdentifier))
+			d.Set("apply_immediately", true)
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if sweep.SkipSweepError(err) {
+		log.Printf("[WARN] Skipping Neptune Cluster Instance sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("listing Neptune Cluster Instances (%s): %w", region, err)
+	}
+
+	err = sweep.SweepOrchestratorWithContext(ctx, sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("sweeping Neptune Cluster Instances (%s): %w", region, err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Adds sweepers for `aws_neptune_cluster` and `aws_neptune_cluster_instance`. Adds `aws_nepture_cluster` as a dependency for `aws_rds_global_cluster`, as `rds.DescribeGlobalClusters` returns Neptune global clusters as well as RDS global clusters

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make sweep SWEEPARGS=-sweep-run=aws_rds_global_cluster

2023/01/30 17:16:13 [DEBUG] Running Sweepers for region (us-west-2):
2023/01/30 17:16:13 [DEBUG] Running Sweeper (aws_neptune_cluster_instance) in region (us-west-2)
2023/01/30 17:16:13 [DEBUG] Completed Sweeper (aws_neptune_cluster_instance) in region (us-west-2) in 589.251958ms
2023/01/30 17:16:13 [DEBUG] Sweeper (aws_neptune_cluster) has dependency (aws_neptune_cluster_instance), running..
2023/01/30 17:16:13 [DEBUG] Sweeper (aws_neptune_cluster_instance) already ran in region (us-west-2)
2023/01/30 17:16:13 [DEBUG] Running Sweeper (aws_neptune_cluster) in region (us-west-2)
2023/01/30 17:16:14 [DEBUG] Destroying Neptune Cluster (tf-acc-test-primary-7423526229883980831)
2023/01/30 17:16:14 [DEBUG] Waiting for state to become: [success]
2023/01/30 17:16:14 [DEBUG] Waiting for state to become: [NotFound]
2023/01/30 17:16:44 [TRACE] Waiting 10s before next try
2023/01/30 17:16:54 [TRACE] Waiting 10s before next try
2023/01/30 17:17:04 [TRACE] Waiting 10s before next try
2023/01/30 17:17:14 [DEBUG] Completed Sweeper (aws_neptune_cluster) in region (us-west-2) in 1m0.961212333s
2023/01/30 17:17:14 [DEBUG] Sweeper (aws_rds_global_cluster) has dependency (aws_rds_cluster), running..
2023/01/30 17:17:14 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
2023/01/30 17:17:14 [DEBUG] Running Sweeper (aws_db_instance) in region (us-west-2)
2023/01/30 17:17:14 [DEBUG] Completed Sweeper (aws_db_instance) in region (us-west-2) in 51.746541ms
2023/01/30 17:17:14 [DEBUG] Running Sweeper (aws_rds_cluster) in region (us-west-2)
2023/01/30 17:17:14 [DEBUG] Completed Sweeper (aws_rds_cluster) in region (us-west-2) in 35.388125ms
2023/01/30 17:17:14 [DEBUG] Sweeper (aws_rds_global_cluster) has dependency (aws_neptune_cluster), running..
2023/01/30 17:17:14 [DEBUG] Sweeper (aws_neptune_cluster) has dependency (aws_neptune_cluster_instance), running..
2023/01/30 17:17:14 [DEBUG] Sweeper (aws_neptune_cluster_instance) already ran in region (us-west-2)
2023/01/30 17:17:14 [DEBUG] Sweeper (aws_neptune_cluster) already ran in region (us-west-2)
2023/01/30 17:17:14 [DEBUG] Running Sweeper (aws_rds_global_cluster) in region (us-west-2)
2023/01/30 17:17:14 [DEBUG] Waiting for state to become: [success]
2023/01/30 17:17:14 [DEBUG] Deleting RDS Global Cluster: tf-acc-test-global-3777221148189679842
2023/01/30 17:17:14 [DEBUG] Waiting for state to become: [success]
2023/01/30 17:17:15 [DEBUG] Waiting for state to become: [deleted]
2023/01/30 17:17:15 [TRACE] Waiting 200ms before next try
2023/01/30 17:17:15 [TRACE] Waiting 400ms before next try
2023/01/30 17:17:16 [TRACE] Waiting 800ms before next try
2023/01/30 17:17:17 [TRACE] Waiting 1.6s before next try
2023/01/30 17:17:18 [DEBUG] Completed Sweeper (aws_rds_global_cluster) in region (us-west-2) in 4.048872583s
2023/01/30 17:17:18 [DEBUG] Sweeper (aws_db_instance) already ran in region (us-west-2)
2023/01/30 17:17:18 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
2023/01/30 17:17:18 [DEBUG] Sweeper (aws_db_instance) already ran in region (us-west-2)
2023/01/30 17:17:18 [DEBUG] Sweeper (aws_rds_cluster) already ran in region (us-west-2)
2023/01/30 17:17:18 Completed Sweepers for region (us-west-2) in 1m5.687003166s
2023/01/30 17:17:18 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_db_instance
	- aws_rds_cluster
	- aws_rds_global_cluster
	- aws_neptune_cluster_instance
	- aws_neptune_cluster
```
