### PR TITLE
Remove Python 3.9 from supported versions.

### DIFF
--- a/website/docs/r/glue_job.html.markdown
+++ b/website/docs/r/glue_job.html.markdown
@@ -106,7 +106,7 @@ The following arguments are supported:
 
 * `name` - (Optional) The name of the job command. Defaults to `glueetl`. Use `pythonshell` for Python Shell Job Type, or `gluestreaming` for Streaming Job Type. `max_capacity` needs to be set if `pythonshell` is chosen.
 * `script_location` - (Required) Specifies the S3 path to a script that executes a job.
-* `python_version` - (Optional) The Python version being used to execute a Python shell job. Allowed values are 2, 3 or 3.9. Version 3 refers to Python 3.6.
+* `python_version` - (Optional) The Python version being used to execute a Python shell job. Allowed values are 2 or 3. Version 3 refers to Python 3.6. Python 3.9 is not supported.
 
 ### execution_property Argument Reference
 


### PR DESCRIPTION
**Description**
Updated the documentation to reflect that Python 3.9 is not supported for aws_glue_jobs.

**Relations**
Closes #29123 (https://github.com/hashicorp/terraform-provider-aws/issues/29123)

**References**
Issue Link: https://github.com/hashicorp/terraform-provider-aws/issues/29123
