### PR TITLE
resource/aws_dms_endpoint: Updates acceptance tests to use valid `extra_connection_attributes` values

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,3 +1,3 @@
 # Needed for testing our workflows
--P ubuntu-latest=ghcr.io/catthehacker/ubuntu:full-18.04
--P medium=ghcr.io/catthehacker/ubuntu:full-18.04
+-P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-22.04
+-P medium=ghcr.io/catthehacker/ubuntu:act-22.04

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -752,14 +752,20 @@ func TestAccDMSEndpoint_MongoDB_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfig_mongoDB(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointExists(ctx, resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+					resource.TestCheckResourceAttr(resourceName, "server_name", "tftest"),
+					resource.TestCheckResourceAttr(resourceName, "port", "27017"),
+					resource.TestCheckResourceAttr(resourceName, "username", "tftest"),
+					resource.TestCheckResourceAttr(resourceName, "password", "tftest"),
+					resource.TestCheckResourceAttr(resourceName, "database_name", "tftest"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_mode", "none"),
 				),
 			},
 			{
 				Config: testAccEndpointConfig_mongoDBUpdate(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "server_name", "tftest-new-server_name"),
 					resource.TestCheckResourceAttr(resourceName, "port", "27018"),
@@ -767,7 +773,6 @@ func TestAccDMSEndpoint_MongoDB_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "password", "tftest-new-password"),
 					resource.TestCheckResourceAttr(resourceName, "database_name", "tftest-new-database_name"),
 					resource.TestCheckResourceAttr(resourceName, "ssl_mode", "require"),
-					resource.TestMatchResourceAttr(resourceName, "extra_connection_attributes", regexp.MustCompile(`key=value;`)),
 					resource.TestCheckResourceAttr(resourceName, "mongodb_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "mongodb_settings.0.auth_mechanism", "scram-sha-1"),
 					resource.TestCheckResourceAttr(resourceName, "mongodb_settings.0.nesting_level", "one"),
@@ -993,6 +998,7 @@ func TestAccDMSEndpoint_Oracle_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointExists(ctx, resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+					resource.TestCheckResourceAttr(resourceName, "extra_connection_attributes", ""),
 				),
 			},
 			{
@@ -1048,6 +1054,13 @@ func TestAccDMSEndpoint_Oracle_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointExists(ctx, resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+					resource.TestCheckResourceAttr(resourceName, "server_name", "tftest"),
+					resource.TestCheckResourceAttr(resourceName, "port", "27017"),
+					resource.TestCheckResourceAttr(resourceName, "username", "tftest"),
+					resource.TestCheckResourceAttr(resourceName, "password", "tftest"),
+					resource.TestCheckResourceAttr(resourceName, "database_name", "tftest"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_mode", "none"),
+					resource.TestCheckResourceAttr(resourceName, "extra_connection_attributes", ""),
 				),
 			},
 			{
@@ -1060,7 +1073,7 @@ func TestAccDMSEndpoint_Oracle_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "password", "tftest-new-password"),
 					resource.TestCheckResourceAttr(resourceName, "database_name", "tftest-new-database_name"),
 					resource.TestCheckResourceAttr(resourceName, "ssl_mode", "none"),
-					resource.TestMatchResourceAttr(resourceName, "extra_connection_attributes", regexp.MustCompile(`key=value;`)),
+					resource.TestMatchResourceAttr(resourceName, "extra_connection_attributes", regexp.MustCompile(`charLengthSemantics=CHAR;`)),
 				),
 			},
 			{
@@ -1379,14 +1392,21 @@ func TestAccDMSEndpoint_Sybase_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfig_sybase(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointExists(ctx, resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "endpoint_arn"),
+					resource.TestCheckResourceAttr(resourceName, "server_name", "tftest"),
+					resource.TestCheckResourceAttr(resourceName, "port", "27017"),
+					resource.TestCheckResourceAttr(resourceName, "username", "tftest"),
+					resource.TestCheckResourceAttr(resourceName, "password", "tftest"),
+					resource.TestCheckResourceAttr(resourceName, "database_name", "tftest"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_mode", "none"),
+					resource.TestCheckResourceAttr(resourceName, "extra_connection_attributes", ""),
 				),
 			},
 			{
 				Config: testAccEndpointConfig_sybaseUpdate(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "server_name", "tftest-new-server_name"),
 					resource.TestCheckResourceAttr(resourceName, "port", "27018"),
@@ -1394,7 +1414,7 @@ func TestAccDMSEndpoint_Sybase_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "password", "tftest-new-password"),
 					resource.TestCheckResourceAttr(resourceName, "database_name", "tftest-new-database_name"),
 					resource.TestCheckResourceAttr(resourceName, "ssl_mode", "none"),
-					resource.TestMatchResourceAttr(resourceName, "extra_connection_attributes", regexp.MustCompile(`key=value;`)),
+					resource.TestCheckResourceAttr(resourceName, "extra_connection_attributes", ""),
 				),
 			},
 			{
@@ -2743,17 +2763,16 @@ data "aws_kms_alias" "dms" {
 }
 
 resource "aws_dms_endpoint" "test" {
-  endpoint_id                 = %[1]q
-  endpoint_type               = "source"
-  engine_name                 = "mongodb"
-  server_name                 = "tftest-new-server_name"
-  port                        = 27018
-  username                    = "tftest-new-username"
-  password                    = "tftest-new-password"
-  database_name               = "tftest-new-database_name"
-  ssl_mode                    = "require"
-  extra_connection_attributes = "key=value;"
-  kms_key_arn                 = data.aws_kms_alias.dms.target_key_arn
+  endpoint_id   = %[1]q
+  endpoint_type = "source"
+  engine_name   = "mongodb"
+  server_name   = "tftest-new-server_name"
+  port          = 27018
+  username      = "tftest-new-username"
+  password      = "tftest-new-password"
+  database_name = "tftest-new-database_name"
+  ssl_mode      = "require"
+  kms_key_arn   = data.aws_kms_alias.dms.target_key_arn
 
   tags = {
     Name   = %[1]q
@@ -2902,16 +2921,15 @@ resource "aws_dms_endpoint" "test" {
 func testAccEndpointConfig_oracle(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_dms_endpoint" "test" {
-  endpoint_id                 = %[1]q
-  endpoint_type               = "source"
-  engine_name                 = "oracle"
-  server_name                 = "tftest"
-  port                        = 27017
-  username                    = "tftest"
-  password                    = "tftest"
-  database_name               = "tftest"
-  ssl_mode                    = "none"
-  extra_connection_attributes = ""
+  endpoint_id   = %[1]q
+  endpoint_type = "source"
+  engine_name   = "oracle"
+  server_name   = "tftest"
+  port          = 27017
+  username      = "tftest"
+  password      = "tftest"
+  database_name = "tftest"
+  ssl_mode      = "none"
 
   tags = {
     Name   = %[1]q
@@ -2934,7 +2952,7 @@ resource "aws_dms_endpoint" "test" {
   password                    = "tftest-new-password"
   database_name               = "tftest-new-database_name"
   ssl_mode                    = "none"
-  extra_connection_attributes = "key=value;"
+  extra_connection_attributes = "charLengthSemantics=CHAR;"
 
   tags = {
     Name   = %[1]q
@@ -3106,16 +3124,15 @@ resource "aws_dms_endpoint" "test" {
 func testAccEndpointConfig_sybase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_dms_endpoint" "test" {
-  endpoint_id                 = %[1]q
-  endpoint_type               = "source"
-  engine_name                 = "sybase"
-  server_name                 = "tftest"
-  port                        = 27017
-  username                    = "tftest"
-  password                    = "tftest"
-  database_name               = "tftest"
-  ssl_mode                    = "none"
-  extra_connection_attributes = ""
+  endpoint_id   = %[1]q
+  endpoint_type = "source"
+  engine_name   = "sybase"
+  server_name   = "tftest"
+  port          = 27017
+  username      = "tftest"
+  password      = "tftest"
+  database_name = "tftest"
+  ssl_mode      = "none"
 
   tags = {
     Name   = %[1]q
@@ -3129,16 +3146,15 @@ resource "aws_dms_endpoint" "test" {
 func testAccEndpointConfig_sybaseUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_dms_endpoint" "test" {
-  endpoint_id                 = %[1]q
-  endpoint_type               = "source"
-  engine_name                 = "sybase"
-  server_name                 = "tftest-new-server_name"
-  port                        = 27018
-  username                    = "tftest-new-username"
-  password                    = "tftest-new-password"
-  database_name               = "tftest-new-database_name"
-  ssl_mode                    = "none"
-  extra_connection_attributes = "key=value;"
+  endpoint_id   = %[1]q
+  endpoint_type = "source"
+  engine_name   = "sybase"
+  server_name   = "tftest-new-server_name"
+  port          = 27018
+  username      = "tftest-new-username"
+  password      = "tftest-new-password"
+  database_name = "tftest-new-database_name"
+  ssl_mode      = "none"
 
   tags = {
     Name   = %[1]q


### PR DESCRIPTION
Some acceptance tests passed invalid values to `extra_connection_attributes`, resulting in

> InvalidParameterValueException: Unsupported value 'key' for extra connection attributes

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=dms TESTS=TestAccDMSEndpoint_ 

--- PASS: TestAccDMSEndpoint_MySQL_basic (44.03s)
--- PASS: TestAccDMSEndpoint_Sybase_basic (44.92s)
--- PASS: TestAccDMSEndpoint_PostgreSQL_basic (45.12s)
--- PASS: TestAccDMSEndpoint_Oracle_basic (45.63s)
--- PASS: TestAccDMSEndpoint_Sybase_kmsKey (47.90s)
--- PASS: TestAccDMSEndpoint_SQLServer_kmsKey (48.08s)
--- PASS: TestAccDMSEndpoint_OpenSearch_basic (54.55s)
--- PASS: TestAccDMSEndpoint_MongoDB_secretID (55.40s)
--- PASS: TestAccDMSEndpoint_PostgreSQL_secretID (56.09s)
--- PASS: TestAccDMSEndpoint_OpenSearch_extraConnectionAttributes (56.31s)
--- PASS: TestAccDMSEndpoint_S3_extraConnectionAttributes (56.63s)
--- PASS: TestAccDMSEndpoint_MySQL_secretID (56.86s)
--- PASS: TestAccDMSEndpoint_Oracle_secretID (57.24s)
--- PASS: TestAccDMSEndpoint_Sybase_secretID (57.63s)
--- PASS: TestAccDMSEndpoint_MySQL_update (64.27s)
--- PASS: TestAccDMSEndpoint_Sybase_update (64.36s)
--- PASS: TestAccDMSEndpoint_db2 (65.90s)
--- PASS: TestAccDMSEndpoint_basic (66.74s)
--- PASS: TestAccDMSEndpoint_docDB (67.31s)
--- PASS: TestAccDMSEndpoint_dynamoDB (78.71s)
--- PASS: TestAccDMSEndpoint_Redshift_secretID (47.93s)
--- PASS: TestAccDMSEndpoint_MariaDB_secretID (46.67s)
--- PASS: TestAccDMSEndpoint_MariaDB_basic (44.63s)
--- PASS: TestAccDMSEndpoint_MariaDB_update (54.55s)
--- PASS: TestAccDMSEndpoint_AuroraPostgreSQL_secretID (46.04s)
--- PASS: TestAccDMSEndpoint_S3_key (44.61s)
--- PASS: TestAccDMSEndpoint_SQLServer_basic (34.12s)
--- PASS: TestAccDMSEndpoint_MongoDB_update (62.23s)
--- PASS: TestAccDMSEndpoint_Oracle_update (46.05s)
--- PASS: TestAccDMSEndpoint_OpenSearch_errorRetryDuration (47.38s)
--- PASS: TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage (55.05s)
--- PASS: TestAccDMSEndpoint_kafka (56.87s)
--- PASS: TestAccDMSEndpoint_AuroraPostgreSQL_update (59.16s)
--- PASS: TestAccDMSEndpoint_AuroraPostgreSQL_basic (27.82s)
--- PASS: TestAccDMSEndpoint_PostgreSQL_kmsKey (29.22s)
--- PASS: TestAccDMSEndpoint_S3_basic (66.42s)
--- PASS: TestAccDMSEndpoint_redis (57.15s)
--- PASS: TestAccDMSEndpoint_SQLServer_update (56.16s)
--- PASS: TestAccDMSEndpoint_SQLServer_secretID (44.94s)
--- PASS: TestAccDMSEndpoint_Aurora_update (39.65s)
--- PASS: TestAccDMSEndpoint_PostgreSQL_update (31.82s)
--- PASS: TestAccDMSEndpoint_Aurora_basic (33.85s)
--- PASS: TestAccDMSEndpoint_MongoDB_basic (34.54s)
--- PASS: TestAccDMSEndpoint_Aurora_secretID (37.30s)
--- PASS: TestAccDMSEndpoint_kinesis (89.43s)
--- PASS: TestAccDMSEndpoint_Redshift_update (246.18s)
--- PASS: TestAccDMSEndpoint_Redshift_basic (478.15s)
```
