### PR TITLE
Moved RequiredWith from wrong attribute on an appmesh route

### DIFF
--- a/.changelog/29217.txt
+++ b/.changelog/29217.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_appmesh_route: Fix RequiredWith setting for `spec.0.grpc_route.0.match.0.method_name` attribute
+```

--- a/internal/service/appmesh/route.go
+++ b/internal/service/appmesh/route.go
@@ -201,6 +201,7 @@ func ResourceRoute() *schema.Resource {
 												"method_name": {
 													Type:     schema.TypeString,
 													Optional: true,
+													RequiredWith: []string{"spec.0.grpc_route.0.match.0.service_name"},
 												},
 
 												"prefix": {
@@ -212,7 +213,6 @@ func ResourceRoute() *schema.Resource {
 												"service_name": {
 													Type:         schema.TypeString,
 													Optional:     true,
-													RequiredWith: []string{"spec.0.grpc_route.0.match.0.method_name"},
 												},
 
 												"port": {

--- a/internal/service/appmesh/route.go
+++ b/internal/service/appmesh/route.go
@@ -199,8 +199,8 @@ func ResourceRoute() *schema.Resource {
 												},
 
 												"method_name": {
-													Type:     schema.TypeString,
-													Optional: true,
+													Type:         schema.TypeString,
+													Optional:     true,
 													RequiredWith: []string{"spec.0.grpc_route.0.match.0.service_name"},
 												},
 
@@ -211,8 +211,8 @@ func ResourceRoute() *schema.Resource {
 												},
 
 												"service_name": {
-													Type:         schema.TypeString,
-													Optional:     true,
+													Type:     schema.TypeString,
+													Optional: true,
 												},
 
 												"port": {


### PR DESCRIPTION
If you create an aws_appmesh_route and provide a spec.0.grpc_route.0.match.service_name it gives an error that you also need to specify a spec.0.grpc_route.0.match.method_name when it is actually the other way around.