### PR TITLE
r/aws_s3_bucket.logging: Fix `panic: interface conversion: interface {} is nil, not map[string]interface {}`

### DIFF
--- a/.changelog/29243.txt
+++ b/.changelog/29243.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket: Fix crash when `logging` is empty
+```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -1893,7 +1893,7 @@ func resourceBucketInternalLoggingUpdate(ctx context.Context, conn *s3.S3, d *sc
 	logging := d.Get("logging").([]interface{})
 	loggingStatus := &s3.BucketLoggingStatus{}
 
-	if len(logging) > 0 {
+	if len(logging) > 0 && logging[0] != nil {
 		c := logging[0].(map[string]interface{})
 
 		loggingEnabled := &s3.LoggingEnabled{}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes a reported crash (**v4.49.0**):

```
Error: The terraform-provider-aws_v4.49.0_x5 plugin crashed!

Stack trace from the terraform-provider-aws_v4.49.0_x5 plugin:

panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 406 [running]:
github.com/hashicorp/terraform-provider-aws/internal/service/s3.resourceBucketInternalLoggingUpdate(0xc0010a01e0, 0xc000da8c80)
github.com/hashicorp/terraform-provider-aws/internal/service/s3/bucket.go:1889 +0x41f
github.com/hashicorp/terraform-provider-aws/internal/service/s3.resourceBucketUpdate(0xc000da8c80, {0xca6d140?, 0xc0003b7800})
github.com/hashicorp/terraform-provider-aws/internal/service/s3/bucket.go:874 +0x129d
github.com/hashicorp/terraform-provider-aws/internal/service/s3.resourceBucketCreate(0x0?, {0xca6d140?, 0xc0003b7800})
github.com/hashicorp/terraform-provider-aws/internal/service/s3/bucket.go:805 +0xa65
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xddadaa0?, {0xddadaa0?, 0xc003d32de0?}, 0xd?, {0xca6d140?, 0xc0003b7800?})
github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.1/helper/schema/resource.go:695 +0x178
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc000f02000, {0xddadaa0, 0xc003d32de0}, 0xc002c36a90, 0xc000da8b00, {0xca6d140, 0xc0003b7800})
github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.1/helper/schema/resource.go:837 +0xa85
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc0002040a8, {0xddadaa0?, 0xc003d32b40?}, 0xc001013f90)
github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.1/helper/schema/grpc_provider.go:1021 +0xe8d
github.com/hashicorp/terraform-plugin-mux/tf5muxserver.muxServer.ApplyResourceChange({0xc00314be90, 0xc00314bef0, {0xc003908ea0, 0x2, 0x2}, {0x0, 0x0, 0x0}, {0x0, 0x0, ...}, ...}, ...)
github.com/hashicorp/terraform-plugin-mux@v0.8.0/tf5muxserver/mux_server_ApplyResourceChange.go:27 +0x102
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc001c0f900, {0xddadaa0?, 0xc003d1ea80?}, 0xc001c06230)
github.com/hashicorp/terraform-plugin-go@v0.14.2/tfprotov5/tf5server/server.go:818 +0x574
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0xc790420?, 0xc001c0f900}, {0xddadaa0, 0xc003d1ea80}, 0xc001c061c0, 0x0)
github.com/hashicorp/terraform-plugin-go@v0.14.2/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:385 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0035efc20, {0xddbc400, 0xc004546000}, 0xc003fcb440, 0xc0043e7d70, 0x1429d0e0, 0x0)
google.golang.org/grpc@v1.51.0/server.go:1340 +0xd23
google.golang.org/grpc.(*Server).handleStream(0xc0035efc20, {0xddbc400, 0xc004546000}, 0xc003fcb440, 0x0)
google.golang.org/grpc@v1.51.0/server.go:1713 +0xa2f
google.golang.org/grpc.(*Server).serveStreams.func1.2()
google.golang.org/grpc@v1.51.0/server.go:965 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
google.golang.org/grpc@v1.51.0/server.go:963 +0x28a

Error: The terraform-provider-aws_v4.49.0_x5 plugin crashed!
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccS3Bucket_Security_logging' PKG=s3 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 3  -run=TestAccS3Bucket_Security_logging -timeout 180m
=== RUN   TestAccS3Bucket_Security_logging
=== PAUSE TestAccS3Bucket_Security_logging
=== CONT  TestAccS3Bucket_Security_logging
--- PASS: TestAccS3Bucket_Security_logging (26.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	31.634s
```
