### PR TITLE
resource/aws_kms_grant: Retries read until principals return valid ARNs

### DIFF
--- a/.changelog/29245.txt
+++ b/.changelog/29245.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_kms_grant: Retries until valid principal ARNs are returned instead of not updating state
+```

--- a/.ci/.semgrep.yml
+++ b/.ci/.semgrep.yml
@@ -226,8 +226,6 @@ rules:
     paths:
       include:
         - internal/
-      exclude:
-        - internal/service/apigateway/integration.go
     patterns:
       - pattern-either:
           - pattern: |

--- a/.ci/semgrep/aws/arn.yml
+++ b/.ci/semgrep/aws/arn.yml
@@ -1,0 +1,7 @@
+rules:
+  - id: prefer-isarn-to-stringshasprefix
+    languages: [go]
+    message: Prefer `aws.IsARN` to `strings.HasPrefix`
+    patterns:
+      - pattern: strings.HasPrefix($STR, "arn:")
+    severity: WARNING

--- a/.ci/semgrep/aws/arn.yml
+++ b/.ci/semgrep/aws/arn.yml
@@ -3,5 +3,8 @@ rules:
     languages: [go]
     message: Prefer `aws.IsARN` to `strings.HasPrefix`
     patterns:
-      - pattern: strings.HasPrefix($STR, "arn:")
+      - pattern: strings.HasPrefix($STR, $ARN)
+      - metavariable-regex:
+          metavariable: $ARN
+          regex: ^\"arn:[^"]*\"$
     severity: WARNING

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -28,6 +28,8 @@ jobs:
           semgrep $COMMON_PARAMS \
             --config .ci/.semgrep.yml \
             --config .ci/semgrep/acctest/ \
+            --config .ci/semgrep/aws/ \
+            --config .ci/semgrep/migrate/ \
             --config 'r/dgryski.semgrep-go.badnilguard' \
             --config 'r/dgryski.semgrep-go.errnilcheck' \
             --config 'r/dgryski.semgrep-go.marshaljson' \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -275,6 +275,7 @@ semall:
 		--config .ci/.semgrep-service-name2.yml \
 		--config .ci/.semgrep-service-name3.yml \
 		--config .ci/semgrep/acctest/ \
+		--config .ci/semgrep/aws/ \
 		--config .ci/semgrep/migrate/ \
 		--config 'r/dgryski.semgrep-go.badnilguard' \
 		--config 'r/dgryski.semgrep-go.errnilcheck' \

--- a/internal/service/apigateway/integration.go
+++ b/internal/service/apigateway/integration.go
@@ -279,7 +279,7 @@ func resourceIntegrationRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("cache_namespace", integration.CacheNamespace)
 	d.Set("connection_id", integration.ConnectionId)
 	d.Set("connection_type", apigateway.ConnectionTypeInternet)
-	if integration.ConnectionType != nil {
+	if integration.ConnectionType != nil { // nosemgrep:ci.helper-schema-ResourceData-Set-extraneous-nil-check
 		d.Set("connection_type", integration.ConnectionType)
 	}
 	d.Set("content_handling", integration.ContentHandling)

--- a/internal/service/iam/group_policy_attachment_test.go
+++ b/internal/service/iam/group_policy_attachment_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -50,7 +51,7 @@ func TestAccIAMGroupPolicyAttachment_basic(t *testing.T) {
 						return fmt.Errorf("expected 1 state: %#v", s)
 					}
 					rs := s[0]
-					if !strings.HasPrefix(rs.Attributes["policy_arn"], "arn:") {
+					if !arn.IsARN(rs.Attributes["policy_arn"]) {
 						return fmt.Errorf("expected policy_arn attribute to be set and begin with arn:, received: %s", rs.Attributes["policy_arn"])
 					}
 					return nil

--- a/internal/service/iam/role_policy_attachment_test.go
+++ b/internal/service/iam/role_policy_attachment_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -52,7 +53,7 @@ func TestAccIAMRolePolicyAttachment_basic(t *testing.T) {
 
 					rs := s[0]
 
-					if !strings.HasPrefix(rs.Attributes["policy_arn"], "arn:") {
+					if !arn.IsARN(rs.Attributes["policy_arn"]) {
 						return fmt.Errorf("expected policy_arn attribute to be set and begin with arn:, received: %s", rs.Attributes["policy_arn"])
 					}
 

--- a/internal/service/iam/user_policy_attachment_test.go
+++ b/internal/service/iam/user_policy_attachment_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/iam"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -50,7 +51,7 @@ func TestAccIAMUserPolicyAttachment_basic(t *testing.T) {
 
 					rs := s[0]
 
-					if !strings.HasPrefix(rs.Attributes["policy_arn"], "arn:") {
+					if !arn.IsARN(rs.Attributes["policy_arn"]) {
 						return fmt.Errorf("expected policy_arn attribute to be set and begin with arn:, received: %s", rs.Attributes["policy_arn"])
 					}
 

--- a/internal/service/iam/wait.go
+++ b/internal/service/iam/wait.go
@@ -2,10 +2,10 @@ package iam
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -26,10 +26,14 @@ const (
 )
 
 func waitRoleARNIsNotUniqueID(ctx context.Context, conn *iam.IAM, id string, role *iam.Role) (*iam.Role, error) {
+	if arn.IsARN(aws.StringValue(role.Arn)) {
+		return role, nil
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending:                   []string{RoleStatusARNIsUniqueID, RoleStatusNotFound},
 		Target:                    []string{RoleStatusARNIsARN},
-		Refresh:                   statusRoleCreate(ctx, conn, id, role),
+		Refresh:                   statusRoleCreate(ctx, conn, id),
 		Timeout:                   propagationTimeout,
 		NotFoundChecks:            10,
 		ContinuousTargetOccurence: 5,
@@ -44,13 +48,9 @@ func waitRoleARNIsNotUniqueID(ctx context.Context, conn *iam.IAM, id string, rol
 	return nil, err
 }
 
-func statusRoleCreate(ctx context.Context, conn *iam.IAM, id string, role *iam.Role) resource.StateRefreshFunc {
+func statusRoleCreate(ctx context.Context, conn *iam.IAM, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		if strings.HasPrefix(aws.StringValue(role.Arn), "arn:") {
-			return role, RoleStatusARNIsARN, nil
-		}
-
-		output, err := FindRoleByName(ctx, conn, id)
+		role, err := FindRoleByName(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
 			return nil, RoleStatusNotFound, nil
@@ -60,11 +60,11 @@ func statusRoleCreate(ctx context.Context, conn *iam.IAM, id string, role *iam.R
 			return nil, "", err
 		}
 
-		if strings.HasPrefix(aws.StringValue(output.Arn), "arn:") {
-			return output, RoleStatusARNIsARN, nil
+		if arn.IsARN(aws.StringValue(role.Arn)) {
+			return role, RoleStatusARNIsARN, nil
 		}
 
-		return output, RoleStatusARNIsUniqueID, nil
+		return role, RoleStatusARNIsUniqueID, nil
 	}
 }
 

--- a/internal/service/kms/grant.go
+++ b/internal/service/kms/grant.go
@@ -214,10 +214,10 @@ func resourceGrantRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diags
 	}
 
-	if grant.GranteePrincipal != nil {
+	if grant.GranteePrincipal != nil { // nosemgrep:ci.helper-schema-ResourceData-Set-extraneous-nil-check
 		d.Set("grantee_principal", grant.GranteePrincipal)
 	}
-	if grant.RetiringPrincipal != nil {
+	if grant.RetiringPrincipal != nil { // nosemgrep:ci.helper-schema-ResourceData-Set-extraneous-nil-check
 		d.Set("retiring_principal", grant.RetiringPrincipal)
 	}
 

--- a/internal/service/kms/grant_test.go
+++ b/internal/service/kms/grant_test.go
@@ -34,8 +34,8 @@ func TestAccKMSGrant_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "operations.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "operations.*", "Encrypt"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "operations.*", "Decrypt"),
-					resource.TestCheckResourceAttrSet(resourceName, "grantee_principal"),
-					resource.TestCheckResourceAttrSet(resourceName, "key_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "grantee_principal", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "key_id", "aws_kms_key.test", "key_id"),
 				),
 			},
 			{
@@ -112,7 +112,7 @@ func TestAccKMSGrant_withRetiringPrincipal(t *testing.T) {
 				Config: testAccGrantConfig_retiringPrincipal(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGrantExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "retiring_principal"),
+					resource.TestCheckResourceAttrPair(resourceName, "retiring_principal", "aws_iam_role.test", "arn"),
 				),
 			},
 			{
@@ -174,8 +174,8 @@ func TestAccKMSGrant_arn(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "operations.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "operations.*", "Encrypt"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "operations.*", "Decrypt"),
-					resource.TestCheckResourceAttrSet(resourceName, "grantee_principal"),
-					resource.TestCheckResourceAttrSet(resourceName, "key_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "grantee_principal", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "key_id", "aws_kms_key.test", "arn"),
 				),
 			},
 			{


### PR DESCRIPTION
In some cases, there is a race condition with KMS Key Grants where an IAM unique id is returned instead of a valid principal ARN. Retry reading until the principals are valid. Previously, the state would not be updated.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=kms TESTS=TestAccKMSGrant_

--- PASS: TestAccKMSGrant_arn (22.03s)
--- PASS: TestAccKMSGrant_withRetiringPrincipal (22.07s)
--- PASS: TestAccKMSGrant_asymmetricKey (22.14s)
--- PASS: TestAccKMSGrant_basic (22.15s)
--- PASS: TestAccKMSGrant_bare (29.06s)
--- PASS: TestAccKMSGrant_withConstraints (37.19s)
--- PASS: TestAccKMSGrant_disappears (200.27s)
```
