### PR TITLE
d/aws_kms_key: Allow multi-region key ID or ARN for `key_id` parameter value

### DIFF
--- a/internal/service/kms/diff.go
+++ b/internal/service/kms/diff.go
@@ -1,12 +1,10 @@
 package kms
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 func DiffSuppressKey(_, oldValue, newValue string, _ *schema.ResourceData) bool {
@@ -76,8 +74,7 @@ func keyIdFromARN(s string) string {
 }
 
 func keyIdFromARNResource(s string) string {
-	re := regexp.MustCompile(`^key/(` + verify.UUIDRegexPattern + ")$")
-	matches := re.FindStringSubmatch(s)
+	matches := keyIdResourceRegex.FindStringSubmatch(s)
 	if matches == nil || len(matches) != 2 {
 		return ""
 	}
@@ -95,8 +92,7 @@ func keyAliasFromARN(s string) string {
 }
 
 func keyAliasNameFromARNResource(s string) string {
-	re := regexp.MustCompile("^" + AliasNameRegexPattern + "$")
-	if re.MatchString(s) {
+	if aliasNameRegex.MatchString(s) {
 		return s
 	}
 

--- a/internal/service/kms/key_data_source_test.go
+++ b/internal/service/kms/key_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccKMSKeyDataSource_basic(t *testing.T) {
+func TestAccKMSKeyDataSource_byKeyARN(t *testing.T) {
 	resourceName := "aws_kms_key.test"
 	dataSourceName := "data.aws_kms_key.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -21,7 +21,109 @@ func TestAccKMSKeyDataSource_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyDataSourceConfig_basic(rName),
+				Config: testAccKeyDataSourceConfig_byKeyARN(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					acctest.CheckResourceAttrAccountID(dataSourceName, "aws_account_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "creation_date"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "customer_master_key_spec", resourceName, "customer_master_key_spec"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "deletion_date"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "enabled", resourceName, "is_enabled"),
+					resource.TestCheckResourceAttr(dataSourceName, "expiration_model", ""),
+					resource.TestCheckResourceAttr(dataSourceName, "key_manager", "CUSTOMER"),
+					resource.TestCheckResourceAttr(dataSourceName, "key_state", "Enabled"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "key_usage", resourceName, "key_usage"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "multi_region", resourceName, "multi_region"),
+					resource.TestCheckResourceAttr(dataSourceName, "multi_region_configuration.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "origin", "AWS_KMS"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "valid_to"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKMSKeyDataSource_byKeyID(t *testing.T) {
+	resourceName := "aws_kms_key.test"
+	dataSourceName := "data.aws_kms_key.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, kms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKeyDataSourceConfig_byKeyID(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					acctest.CheckResourceAttrAccountID(dataSourceName, "aws_account_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "creation_date"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "customer_master_key_spec", resourceName, "customer_master_key_spec"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "deletion_date"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "enabled", resourceName, "is_enabled"),
+					resource.TestCheckResourceAttr(dataSourceName, "expiration_model", ""),
+					resource.TestCheckResourceAttr(dataSourceName, "key_manager", "CUSTOMER"),
+					resource.TestCheckResourceAttr(dataSourceName, "key_state", "Enabled"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "key_usage", resourceName, "key_usage"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "multi_region", resourceName, "multi_region"),
+					resource.TestCheckResourceAttr(dataSourceName, "multi_region_configuration.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "origin", "AWS_KMS"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "valid_to"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKMSKeyDataSource_byAliasARN(t *testing.T) {
+	resourceName := "aws_kms_key.test"
+	dataSourceName := "data.aws_kms_key.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, kms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKeyDataSourceConfig_byAliasARN(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					acctest.CheckResourceAttrAccountID(dataSourceName, "aws_account_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "creation_date"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "customer_master_key_spec", resourceName, "customer_master_key_spec"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "deletion_date"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "enabled", resourceName, "is_enabled"),
+					resource.TestCheckResourceAttr(dataSourceName, "expiration_model", ""),
+					resource.TestCheckResourceAttr(dataSourceName, "key_manager", "CUSTOMER"),
+					resource.TestCheckResourceAttr(dataSourceName, "key_state", "Enabled"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "key_usage", resourceName, "key_usage"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "multi_region", resourceName, "multi_region"),
+					resource.TestCheckResourceAttr(dataSourceName, "multi_region_configuration.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "origin", "AWS_KMS"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "valid_to"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKMSKeyDataSource_byAliasID(t *testing.T) {
+	resourceName := "aws_kms_key.test"
+	dataSourceName := "data.aws_kms_key.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, kms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKeyDataSourceConfig_byAliasID(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					acctest.CheckResourceAttrAccountID(dataSourceName, "aws_account_id"),
@@ -78,7 +180,7 @@ func TestAccKMSKeyDataSource_grantToken(t *testing.T) {
 	})
 }
 
-func TestAccKMSKeyDataSource_multiRegionConfiguration(t *testing.T) {
+func TestAccKMSKeyDataSource_multiRegionConfigurationByARN(t *testing.T) {
 	resourceName := "aws_kms_key.test"
 	dataSourceName := "data.aws_kms_key.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -89,7 +191,7 @@ func TestAccKMSKeyDataSource_multiRegionConfiguration(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyDataSourceConfig_multiRegion(rName),
+				Config: testAccKeyDataSourceConfig_multiRegionByARN(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					acctest.CheckResourceAttrAccountID(dataSourceName, "aws_account_id"),
@@ -117,7 +219,59 @@ func TestAccKMSKeyDataSource_multiRegionConfiguration(t *testing.T) {
 	})
 }
 
-func testAccKeyDataSourceConfig_basic(rName string) string {
+func TestAccKMSKeyDataSource_multiRegionConfigurationByID(t *testing.T) {
+	resourceName := "aws_kms_key.test"
+	dataSourceName := "data.aws_kms_key.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, kms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKeyDataSourceConfig_multiRegionByID(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					acctest.CheckResourceAttrAccountID(dataSourceName, "aws_account_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "creation_date"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "customer_master_key_spec", resourceName, "customer_master_key_spec"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "deletion_date"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "enabled", resourceName, "is_enabled"),
+					resource.TestCheckResourceAttr(dataSourceName, "expiration_model", ""),
+					resource.TestCheckResourceAttr(dataSourceName, "key_manager", "CUSTOMER"),
+					resource.TestCheckResourceAttr(dataSourceName, "key_state", "Enabled"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "key_usage", resourceName, "key_usage"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "multi_region", resourceName, "multi_region"),
+					resource.TestCheckResourceAttr(dataSourceName, "multi_region_configuration.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "multi_region_configuration.0.multi_region_key_type", "PRIMARY"),
+					resource.TestCheckResourceAttr(dataSourceName, "multi_region_configuration.0.primary_key.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "multi_region_configuration.0.primary_key.0.arn", resourceName, "arn"),
+					resource.TestCheckResourceAttr(dataSourceName, "multi_region_configuration.0.primary_key.0.region", acctest.Region()),
+					resource.TestCheckResourceAttr(dataSourceName, "multi_region_configuration.0.replica_keys.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "origin", "AWS_KMS"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "valid_to"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKeyDataSourceConfig_byKeyARN(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+}
+
+data "aws_kms_key" "test" {
+  key_id = aws_kms_key.test.arn
+}
+`, rName)
+}
+
+func testAccKeyDataSourceConfig_byKeyID(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
@@ -126,6 +280,42 @@ resource "aws_kms_key" "test" {
 
 data "aws_kms_key" "test" {
   key_id = aws_kms_key.test.key_id
+}
+`, rName)
+}
+
+func testAccKeyDataSourceConfig_byAliasARN(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+}
+
+resource "aws_kms_alias" "test" {
+  name          = "alias/%[1]s"
+  target_key_id = aws_kms_key.test.id
+}
+
+data "aws_kms_key" "test" {
+  key_id = aws_kms_alias.test.arn
+}
+`, rName)
+}
+
+func testAccKeyDataSourceConfig_byAliasID(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+}
+
+resource "aws_kms_alias" "test" {
+  name          = "alias/%[1]s"
+  target_key_id = aws_kms_key.test.id
+}
+
+data "aws_kms_key" "test" {
+  key_id = aws_kms_alias.test.id
 }
 `, rName)
 }
@@ -146,7 +336,21 @@ data "aws_kms_key" "test" {
 `, rName))
 }
 
-func testAccKeyDataSourceConfig_multiRegion(rName string) string {
+func testAccKeyDataSourceConfig_multiRegionByARN(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+  multi_region            = true
+}
+
+data "aws_kms_key" "test" {
+  key_id = aws_kms_key.test.arn
+}
+`, rName)
+}
+
+func testAccKeyDataSourceConfig_multiRegionByID(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q

--- a/internal/service/kms/validate_test.go
+++ b/internal/service/kms/validate_test.go
@@ -148,6 +148,16 @@ func TestValidateKeyOrAlias(t *testing.T) {
 			valid:    true,
 		},
 		{
+			Value:    "mrk-f827515944fb43f9b902a09d2c8b554f",
+			ErrCount: 0,
+			valid:    true,
+		},
+		{
+			Value:    "arn:aws:kms:us-west-2:111122223333:key/mrk-a835af0b39c94b86a21a8fc9535df681", //lintignore:AWSAT003,AWSAT005
+			ErrCount: 0,
+			valid:    true,
+		},
+		{
 			Value:    "arn:aws:kms:us-west-2:111122223333:alias/arbitrary-key", //lintignore:AWSAT003,AWSAT005
 			ErrCount: 0,
 			valid:    true,
@@ -191,6 +201,10 @@ func TestValidateKeyARN(t *testing.T) {
 	}{
 		"kms key id": {
 			in:    "arn:aws:kms:us-west-2:123456789012:key/57ff7a43-341d-46b6-aee3-a450c9de6dc8", // lintignore:AWSAT003,AWSAT005
+			valid: true,
+		},
+		"kms mrk key id": {
+			in:    "arn:aws:kms:us-west-2:111122223333:key/mrk-a835af0b39c94b86a21a8fc9535df681", // lintignore:AWSAT003,AWSAT005
 			valid: true,
 		},
 		"kms non-key id": {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Reinstates support for [KMS multi-Region key](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) ID or ARN values for the `aws_kms_key.key_id` parameter. Support was mistakenly removed via https://github.com/hashicorp/terraform-provider-aws/pull/29189.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/29248.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccKMS' PKG=kms ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kms/... -v -count 1 -parallel 3  -run=TestAccKMS -timeout 180m
=== RUN   TestAccKMSAliasDataSource_service
=== PAUSE TestAccKMSAliasDataSource_service
=== RUN   TestAccKMSAliasDataSource_cmk
=== PAUSE TestAccKMSAliasDataSource_cmk
=== RUN   TestAccKMSAlias_basic
=== PAUSE TestAccKMSAlias_basic
=== RUN   TestAccKMSAlias_disappears
=== PAUSE TestAccKMSAlias_disappears
=== RUN   TestAccKMSAlias_Name_generated
=== PAUSE TestAccKMSAlias_Name_generated
=== RUN   TestAccKMSAlias_namePrefix
=== PAUSE TestAccKMSAlias_namePrefix
=== RUN   TestAccKMSAlias_updateKeyID
=== PAUSE TestAccKMSAlias_updateKeyID
=== RUN   TestAccKMSAlias_multipleAliasesForSameKey
=== PAUSE TestAccKMSAlias_multipleAliasesForSameKey
=== RUN   TestAccKMSAlias_arnDiffSuppress
=== PAUSE TestAccKMSAlias_arnDiffSuppress
=== RUN   TestAccKMSCiphertextDataSource_basic
=== PAUSE TestAccKMSCiphertextDataSource_basic
=== RUN   TestAccKMSCiphertextDataSource_validate
=== PAUSE TestAccKMSCiphertextDataSource_validate
=== RUN   TestAccKMSCiphertextDataSource_Validate_withContext
=== PAUSE TestAccKMSCiphertextDataSource_Validate_withContext
=== RUN   TestAccKMSCiphertext_Resource_basic
=== PAUSE TestAccKMSCiphertext_Resource_basic
=== RUN   TestAccKMSCiphertext_Resource_validate
=== PAUSE TestAccKMSCiphertext_Resource_validate
=== RUN   TestAccKMSCiphertext_ResourceValidate_withContext
=== PAUSE TestAccKMSCiphertext_ResourceValidate_withContext
=== RUN   TestAccKMSCustomKeyStoreDataSource_basic
    custom_key_store_data_source_test.go:16: CLOUD_HSM_CLUSTER_ID environment variable not set
--- SKIP: TestAccKMSCustomKeyStoreDataSource_basic (0.00s)
=== RUN   TestAccKMSExternalKey_basic
=== PAUSE TestAccKMSExternalKey_basic
=== RUN   TestAccKMSExternalKey_disappears
=== PAUSE TestAccKMSExternalKey_disappears
=== RUN   TestAccKMSExternalKey_multiRegion
=== PAUSE TestAccKMSExternalKey_multiRegion
=== RUN   TestAccKMSExternalKey_deletionWindowInDays
=== PAUSE TestAccKMSExternalKey_deletionWindowInDays
=== RUN   TestAccKMSExternalKey_description
=== PAUSE TestAccKMSExternalKey_description
=== RUN   TestAccKMSExternalKey_enabled
=== PAUSE TestAccKMSExternalKey_enabled
=== RUN   TestAccKMSExternalKey_keyMaterialBase64
=== PAUSE TestAccKMSExternalKey_keyMaterialBase64
=== RUN   TestAccKMSExternalKey_policy
=== PAUSE TestAccKMSExternalKey_policy
=== RUN   TestAccKMSExternalKey_policyBypass
=== PAUSE TestAccKMSExternalKey_policyBypass
=== RUN   TestAccKMSExternalKey_tags
=== PAUSE TestAccKMSExternalKey_tags
=== RUN   TestAccKMSExternalKey_validTo
=== PAUSE TestAccKMSExternalKey_validTo
=== RUN   TestAccKMSGrant_basic
=== PAUSE TestAccKMSGrant_basic
=== RUN   TestAccKMSGrant_withConstraints
=== PAUSE TestAccKMSGrant_withConstraints
=== RUN   TestAccKMSGrant_withRetiringPrincipal
=== PAUSE TestAccKMSGrant_withRetiringPrincipal
=== RUN   TestAccKMSGrant_bare
=== PAUSE TestAccKMSGrant_bare
=== RUN   TestAccKMSGrant_arn
=== PAUSE TestAccKMSGrant_arn
=== RUN   TestAccKMSGrant_asymmetricKey
=== PAUSE TestAccKMSGrant_asymmetricKey
=== RUN   TestAccKMSGrant_disappears
=== PAUSE TestAccKMSGrant_disappears
=== RUN   TestAccKMSKeyDataSource_byKeyARN
=== PAUSE TestAccKMSKeyDataSource_byKeyARN
=== RUN   TestAccKMSKeyDataSource_byKeyID
=== PAUSE TestAccKMSKeyDataSource_byKeyID
=== RUN   TestAccKMSKeyDataSource_byAliasARN
=== PAUSE TestAccKMSKeyDataSource_byAliasARN
=== RUN   TestAccKMSKeyDataSource_byAliasID
=== PAUSE TestAccKMSKeyDataSource_byAliasID
=== RUN   TestAccKMSKeyDataSource_grantToken
=== PAUSE TestAccKMSKeyDataSource_grantToken
=== RUN   TestAccKMSKeyDataSource_multiRegionConfigurationByARN
=== PAUSE TestAccKMSKeyDataSource_multiRegionConfigurationByARN
=== RUN   TestAccKMSKeyDataSource_multiRegionConfigurationByID
=== PAUSE TestAccKMSKeyDataSource_multiRegionConfigurationByID
=== RUN   TestAccKMSKey_basic
=== PAUSE TestAccKMSKey_basic
=== RUN   TestAccKMSKey_disappears
=== PAUSE TestAccKMSKey_disappears
=== RUN   TestAccKMSKey_multiRegion
=== PAUSE TestAccKMSKey_multiRegion
=== RUN   TestAccKMSKey_asymmetricKey
=== PAUSE TestAccKMSKey_asymmetricKey
=== RUN   TestAccKMSKey_hmacKey
=== PAUSE TestAccKMSKey_hmacKey
=== RUN   TestAccKMSKey_Policy_basic
=== PAUSE TestAccKMSKey_Policy_basic
=== RUN   TestAccKMSKey_Policy_bypass
=== PAUSE TestAccKMSKey_Policy_bypass
=== RUN   TestAccKMSKey_Policy_bypassUpdate
=== PAUSE TestAccKMSKey_Policy_bypassUpdate
=== RUN   TestAccKMSKey_Policy_iamRole
=== PAUSE TestAccKMSKey_Policy_iamRole
=== RUN   TestAccKMSKey_Policy_iamRoleUpdate
=== PAUSE TestAccKMSKey_Policy_iamRoleUpdate
=== RUN   TestAccKMSKey_Policy_iamRoleOrder
=== PAUSE TestAccKMSKey_Policy_iamRoleOrder
=== RUN   TestAccKMSKey_Policy_iamServiceLinkedRole
=== PAUSE TestAccKMSKey_Policy_iamServiceLinkedRole
=== RUN   TestAccKMSKey_Policy_booleanCondition
=== PAUSE TestAccKMSKey_Policy_booleanCondition
=== RUN   TestAccKMSKey_isEnabled
=== PAUSE TestAccKMSKey_isEnabled
=== RUN   TestAccKMSKey_tags
=== PAUSE TestAccKMSKey_tags
=== RUN   TestAccKMS_serial
=== PAUSE TestAccKMS_serial
=== RUN   TestAccKMSPublicKeyDataSource_basic
=== PAUSE TestAccKMSPublicKeyDataSource_basic
=== RUN   TestAccKMSPublicKeyDataSource_encrypt
=== PAUSE TestAccKMSPublicKeyDataSource_encrypt
=== RUN   TestAccKMSReplicaExternalKey_basic
=== PAUSE TestAccKMSReplicaExternalKey_basic
=== RUN   TestAccKMSReplicaExternalKey_descriptionAndEnabled
=== PAUSE TestAccKMSReplicaExternalKey_descriptionAndEnabled
=== RUN   TestAccKMSReplicaExternalKey_policy
=== PAUSE TestAccKMSReplicaExternalKey_policy
=== RUN   TestAccKMSReplicaExternalKey_tags
=== PAUSE TestAccKMSReplicaExternalKey_tags
=== RUN   TestAccKMSReplicaKey_basic
=== PAUSE TestAccKMSReplicaKey_basic
=== RUN   TestAccKMSReplicaKey_disappears
=== PAUSE TestAccKMSReplicaKey_disappears
=== RUN   TestAccKMSReplicaKey_descriptionAndEnabled
=== PAUSE TestAccKMSReplicaKey_descriptionAndEnabled
=== RUN   TestAccKMSReplicaKey_policy
=== PAUSE TestAccKMSReplicaKey_policy
=== RUN   TestAccKMSReplicaKey_tags
=== PAUSE TestAccKMSReplicaKey_tags
=== RUN   TestAccKMSReplicaKey_twoReplicas
=== PAUSE TestAccKMSReplicaKey_twoReplicas
=== RUN   TestAccKMSSecretDataSource_removed
=== PAUSE TestAccKMSSecretDataSource_removed
=== RUN   TestAccKMSSecretsDataSource_basic
=== PAUSE TestAccKMSSecretsDataSource_basic
=== RUN   TestAccKMSSecretsDataSource_asymmetric
=== PAUSE TestAccKMSSecretsDataSource_asymmetric
=== CONT  TestAccKMSAliasDataSource_service
=== CONT  TestAccKMSKeyDataSource_byAliasID
=== CONT  TestAccKMSExternalKey_deletionWindowInDays
--- PASS: TestAccKMSAliasDataSource_service (13.43s)
=== CONT  TestAccKMSKeyDataSource_byAliasARN
--- PASS: TestAccKMSKeyDataSource_byAliasID (16.35s)
=== CONT  TestAccKMSKeyDataSource_byKeyID
--- PASS: TestAccKMSKeyDataSource_byAliasARN (15.19s)
=== CONT  TestAccKMSKeyDataSource_byKeyARN
--- PASS: TestAccKMSExternalKey_deletionWindowInDays (29.26s)
=== CONT  TestAccKMSGrant_disappears
--- PASS: TestAccKMSKeyDataSource_byKeyID (14.45s)
=== CONT  TestAccKMSGrant_asymmetricKey
--- PASS: TestAccKMSKeyDataSource_byKeyARN (14.42s)
=== CONT  TestAccKMSGrant_arn
--- PASS: TestAccKMSGrant_asymmetricKey (24.58s)
=== CONT  TestAccKMSGrant_bare
--- PASS: TestAccKMSGrant_arn (24.32s)
=== CONT  TestAccKMSGrant_withRetiringPrincipal
--- PASS: TestAccKMSGrant_bare (24.36s)
=== CONT  TestAccKMSGrant_withConstraints
--- PASS: TestAccKMSGrant_withRetiringPrincipal (24.30s)
=== CONT  TestAccKMSGrant_basic
--- PASS: TestAccKMSGrant_basic (24.43s)
=== CONT  TestAccKMSExternalKey_validTo
--- PASS: TestAccKMSGrant_withConstraints (45.11s)
=== CONT  TestAccKMSExternalKey_tags
--- PASS: TestAccKMSExternalKey_tags (54.45s)
=== CONT  TestAccKMSExternalKey_policyBypass
--- PASS: TestAccKMSExternalKey_policyBypass (19.98s)
=== CONT  TestAccKMSExternalKey_policy
--- PASS: TestAccKMSGrant_disappears (202.40s)
=== CONT  TestAccKMSExternalKey_keyMaterialBase64
--- PASS: TestAccKMSExternalKey_policy (36.13s)
=== CONT  TestAccKMSExternalKey_enabled
--- PASS: TestAccKMSExternalKey_validTo (144.17s)
=== CONT  TestAccKMSExternalKey_description
--- PASS: TestAccKMSExternalKey_description (35.16s)
=== CONT  TestAccKMSReplicaKey_disappears
--- PASS: TestAccKMSReplicaKey_disappears (32.50s)
=== CONT  TestAccKMSSecretsDataSource_asymmetric
--- PASS: TestAccKMSExternalKey_keyMaterialBase64 (105.68s)
=== CONT  TestAccKMSSecretsDataSource_basic
--- PASS: TestAccKMSSecretsDataSource_asymmetric (28.54s)
=== CONT  TestAccKMSSecretDataSource_removed
--- PASS: TestAccKMSSecretDataSource_removed (1.99s)
=== CONT  TestAccKMSReplicaKey_twoReplicas
--- PASS: TestAccKMSSecretsDataSource_basic (27.88s)
=== CONT  TestAccKMSReplicaKey_tags
--- PASS: TestAccKMSExternalKey_enabled (137.40s)
=== CONT  TestAccKMSReplicaKey_policy
--- PASS: TestAccKMSReplicaKey_twoReplicas (38.51s)
=== CONT  TestAccKMSReplicaKey_descriptionAndEnabled
--- PASS: TestAccKMSReplicaKey_policy (63.39s)
=== CONT  TestAccKMSReplicaExternalKey_descriptionAndEnabled
--- PASS: TestAccKMSReplicaKey_tags (88.78s)
=== CONT  TestAccKMSReplicaKey_basic
--- PASS: TestAccKMSReplicaKey_basic (37.79s)
=== CONT  TestAccKMSReplicaExternalKey_tags
--- PASS: TestAccKMSReplicaKey_descriptionAndEnabled (177.54s)
=== CONT  TestAccKMSReplicaExternalKey_policy
--- PASS: TestAccKMSReplicaExternalKey_tags (112.90s)
=== CONT  TestAccKMSCiphertextDataSource_basic
--- PASS: TestAccKMSCiphertextDataSource_basic (14.37s)
=== CONT  TestAccKMSExternalKey_multiRegion
--- PASS: TestAccKMSReplicaExternalKey_descriptionAndEnabled (194.76s)
=== CONT  TestAccKMSExternalKey_disappears
--- PASS: TestAccKMSExternalKey_multiRegion (18.92s)
=== CONT  TestAccKMSExternalKey_basic
--- PASS: TestAccKMSExternalKey_disappears (13.01s)
=== CONT  TestAccKMSCiphertext_ResourceValidate_withContext
--- PASS: TestAccKMSExternalKey_basic (17.42s)
=== CONT  TestAccKMSCiphertext_Resource_validate
--- PASS: TestAccKMSCiphertext_ResourceValidate_withContext (15.35s)
=== CONT  TestAccKMSCiphertext_Resource_basic
--- PASS: TestAccKMSReplicaExternalKey_policy (93.56s)
=== CONT  TestAccKMSCiphertextDataSource_Validate_withContext
--- PASS: TestAccKMSCiphertext_Resource_validate (15.77s)
=== CONT  TestAccKMSCiphertextDataSource_validate
--- PASS: TestAccKMSCiphertext_Resource_basic (14.99s)
=== CONT  TestAccKMSKey_Policy_basic
--- PASS: TestAccKMSCiphertextDataSource_Validate_withContext (15.90s)
=== CONT  TestAccKMSKey_isEnabled
--- PASS: TestAccKMSCiphertextDataSource_validate (15.55s)
=== CONT  TestAccKMSKey_Policy_booleanCondition
--- PASS: TestAccKMSKey_Policy_booleanCondition (20.05s)
=== CONT  TestAccKMSKey_Policy_iamServiceLinkedRole
--- PASS: TestAccKMSKey_Policy_basic (32.89s)
=== CONT  TestAccKMSKey_Policy_iamRoleOrder
--- PASS: TestAccKMSKey_Policy_iamServiceLinkedRole (48.41s)
=== CONT  TestAccKMSKey_Policy_iamRoleUpdate
--- PASS: TestAccKMSKey_Policy_iamRoleOrder (62.91s)
=== CONT  TestAccKMSKey_Policy_iamRole
--- PASS: TestAccKMSKey_isEnabled (114.57s)
=== CONT  TestAccKMSKey_Policy_bypassUpdate
--- PASS: TestAccKMSKey_Policy_iamRole (30.86s)
=== CONT  TestAccKMSKey_Policy_bypass
--- PASS: TestAccKMSKey_Policy_iamRoleUpdate (53.04s)
=== CONT  TestAccKMSKey_disappears
--- PASS: TestAccKMSKey_disappears (11.84s)
=== CONT  TestAccKMSKey_hmacKey
--- PASS: TestAccKMSKey_Policy_bypassUpdate (31.59s)
=== CONT  TestAccKMSKey_asymmetricKey
--- PASS: TestAccKMSKey_hmacKey (14.47s)
=== CONT  TestAccKMSKey_multiRegion
--- PASS: TestAccKMSKey_asymmetricKey (14.35s)
=== CONT  TestAccKMSKeyDataSource_multiRegionConfigurationByID
--- PASS: TestAccKMSKey_multiRegion (17.82s)
=== CONT  TestAccKMSKey_basic
--- PASS: TestAccKMSKeyDataSource_multiRegionConfigurationByID (14.53s)
=== CONT  TestAccKMSKeyDataSource_multiRegionConfigurationByARN
--- PASS: TestAccKMSKey_basic (16.69s)
=== CONT  TestAccKMSPublicKeyDataSource_encrypt
--- PASS: TestAccKMSKeyDataSource_multiRegionConfigurationByARN (15.00s)
=== CONT  TestAccKMSReplicaExternalKey_basic
--- PASS: TestAccKMSPublicKeyDataSource_encrypt (14.62s)
=== CONT  TestAccKMSKeyDataSource_grantToken
--- PASS: TestAccKMSKeyDataSource_grantToken (31.28s)
=== CONT  TestAccKMSPublicKeyDataSource_basic
--- PASS: TestAccKMSReplicaExternalKey_basic (45.17s)
=== CONT  TestAccKMS_serial
=== RUN   TestAccKMS_serial/CustomKeyStore
=== RUN   TestAccKMS_serial/CustomKeyStore/basic
    custom_key_store_test.go:26: CLOUD_HSM_CLUSTER_ID environment variable not set
=== RUN   TestAccKMS_serial/CustomKeyStore/update
    custom_key_store_test.go:74: CLOUD_HSM_CLUSTER_ID environment variable not set
=== RUN   TestAccKMS_serial/CustomKeyStore/disappears
    custom_key_store_test.go:117: CLOUD_HSM_CLUSTER_ID environment variable not set
--- PASS: TestAccKMS_serial (0.00s)
    --- PASS: TestAccKMS_serial/CustomKeyStore (0.00s)
        --- SKIP: TestAccKMS_serial/CustomKeyStore/basic (0.00s)
        --- SKIP: TestAccKMS_serial/CustomKeyStore/update (0.00s)
        --- SKIP: TestAccKMS_serial/CustomKeyStore/disappears (0.00s)
=== CONT  TestAccKMSAlias_namePrefix
--- PASS: TestAccKMSPublicKeyDataSource_basic (14.16s)
=== CONT  TestAccKMSAlias_arnDiffSuppress
--- PASS: TestAccKMSAlias_namePrefix (16.86s)
=== CONT  TestAccKMSAlias_multipleAliasesForSameKey
--- PASS: TestAccKMSKey_Policy_bypass (147.37s)
=== CONT  TestAccKMSAlias_updateKeyID
--- PASS: TestAccKMSAlias_multipleAliasesForSameKey (17.95s)
=== CONT  TestAccKMSAlias_disappears
--- PASS: TestAccKMSAlias_arnDiffSuppress (25.63s)
=== CONT  TestAccKMSAlias_Name_generated
--- PASS: TestAccKMSAlias_disappears (14.82s)
=== CONT  TestAccKMSAlias_basic
--- PASS: TestAccKMSAlias_Name_generated (17.27s)
=== CONT  TestAccKMSAliasDataSource_cmk
--- PASS: TestAccKMSAlias_updateKeyID (30.53s)
=== CONT  TestAccKMSKey_tags
--- PASS: TestAccKMSAlias_basic (17.77s)
--- PASS: TestAccKMSAliasDataSource_cmk (15.77s)
--- PASS: TestAccKMSKey_tags (51.98s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	1035.850s
```
