### PR TITLE
dynamodb/table: Not recreate on PITR enable

### DIFF
--- a/.changelog/29269.txt
+++ b/.changelog/29269.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_dynamodb_table: Avoid recreating table replicas when enabling PITR on them
+```
+
+```release-note:enhancement
+resource/aws_dynamodb_table: Add `arn`, `stream_arn`, and `stream_label` attributes to `replica` to obtain this information for replicas
+```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,6 +6,7 @@ SVC_DIR             ?= ./internal/service
 TEST_COUNT          ?= 1
 ACCTEST_TIMEOUT     ?= 180m
 ACCTEST_PARALLELISM ?= 20
+P                   ?= 20
 GO_VER              ?= go
 SWEEP_TIMEOUT       ?= 60m
 
@@ -55,6 +56,10 @@ endif
 ifeq ($(PKG_NAME), internal/service/wavelength)
 	PKG_NAME = internal/service/ec2
 	TEST = ./$(PKG_NAME)/...
+endif
+
+ifneq ($(P), 20)
+	ACCTEST_PARALLELISM = $(P)
 endif
 
 default: build

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,8 +15,17 @@ ifneq ($(origin PKG), undefined)
 	TEST = ./$(PKG_NAME)/...
 endif
 
+ifneq ($(origin K), undefined)
+	PKG_NAME = internal/service/$(K)
+	TEST = ./$(PKG_NAME)/...
+endif
+
 ifneq ($(origin TESTS), undefined)
 	RUNARGS = -run='$(TESTS)'
+endif
+
+ifneq ($(origin T), undefined)
+	RUNARGS = -run='$(T)'
 endif
 
 ifneq ($(origin SWEEPERS), undefined)
@@ -104,6 +113,9 @@ testacc: fmtcheck
 		echo "See the contributing guide for more information: https://hashicorp.github.io/terraform-provider-aws/running-and-writing-acceptance-tests"; \
 		exit 1; \
 	fi
+	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)
+
+t: fmtcheck
 	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)
 
 testacc-lint:
@@ -302,6 +314,7 @@ yamllint:
 	build \
 	gen \
 	sweep \
+	t \
 	test \
 	testacc \
 	testacc-lint \

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.3.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.9.0
 	github.com/hashicorp/terraform-plugin-go v0.14.3
-	github.com/hashicorp/terraform-plugin-log v0.7.0
+	github.com/hashicorp/terraform-plugin-log v0.8.0
 	github.com/hashicorp/terraform-plugin-mux v0.8.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/jmespath/go-jmespath v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,8 @@ github.com/hashicorp/terraform-plugin-framework-validators v0.9.0 h1:LYz4bXh3t7b
 github.com/hashicorp/terraform-plugin-framework-validators v0.9.0/go.mod h1:+BVERsnfdlhYR2YkXMBtPnmn9UsL19U3qUtSZ+Y/5MY=
 github.com/hashicorp/terraform-plugin-go v0.14.3 h1:nlnJ1GXKdMwsC8g1Nh05tK2wsC3+3BL/DBBxFEki+j0=
 github.com/hashicorp/terraform-plugin-go v0.14.3/go.mod h1:7ees7DMZ263q8wQ6E4RdIdR6nHHJtrdt4ogX5lPkX1A=
-github.com/hashicorp/terraform-plugin-log v0.7.0 h1:SDxJUyT8TwN4l5b5/VkiTIaQgY6R+Y2BQ0sRZftGKQs=
-github.com/hashicorp/terraform-plugin-log v0.7.0/go.mod h1:p4R1jWBXRTvL4odmEkFfDdhUjHf9zcs/BCoNHAc7IK4=
+github.com/hashicorp/terraform-plugin-log v0.8.0 h1:pX2VQ/TGKu+UU1rCay0OlzosNKe4Nz1pepLXj95oyy0=
+github.com/hashicorp/terraform-plugin-log v0.8.0/go.mod h1:1myFrhVsBLeylQzYYEV17VVjtG8oYPRFdaZs7xdW2xs=
 github.com/hashicorp/terraform-plugin-mux v0.8.0 h1:WCTP66mZ+iIaIrCNJnjPEYnVjawTshnDJu12BcXK1EI=
 github.com/hashicorp/terraform-plugin-mux v0.8.0/go.mod h1:vdW0daEi8Kd4RFJmet5Ot+SIVB/B8SwQVJiYKQwdCy8=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1 h1:zHcMbxY0+rFO9gY99elV/XC/UnQVg7FhRCbj1i5b7vM=

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -1353,13 +1353,6 @@ func updateReplica(ctx context.Context, d *schema.ResourceData, conn *dynamodb.D
 				break
 			}
 
-			// like "ForceNew" for the replica - PITR change when KMS present
-			/*if ma["kms_key_arn"].(string) == mr["kms_key_arn"].(string) && ma["kms_key_arn"].(string) != "" {
-				removeFirst = append(removeFirst, mr)
-				toAdd = append(toAdd, ma)
-				break
-			}*/
-
 			// just update PITR
 			if ma["point_in_time_recovery"].(bool) != mr["point_in_time_recovery"].(bool) {
 				if err := updatePITR(ctx, conn, d.Id(), ma["point_in_time_recovery"].(bool), ma["region_name"].(string), tfVersion, d.Timeout(schema.TimeoutUpdate)); err != nil {

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -1298,7 +1298,12 @@ func updateReplica(ctx context.Context, d *schema.ResourceData, conn *dynamodb.D
 			ma := a.(map[string]interface{})
 			mr := r.(map[string]interface{})
 
+			if ma["region_name"].(string) == mr["region_name"].(string) {
+				fmt.Printf("ma: %+v\nmr: %+v\n", ma, mr)
+			}
+
 			if ma["region_name"].(string) == mr["region_name"].(string) && (ma["kms_key_arn"].(string) != "" || mr["kms_key_arn"].(string) != "") {
+				fmt.Printf("ma %s, mr %s\n", ma["kms_key_arn"].(string), mr["kms_key_arn"].(string))
 				removeFirst = append(removeFirst, removed[j])
 				removed = append(removed[:j], removed[j+1:]...)
 				continue

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -1587,6 +1587,10 @@ func TestAccDynamoDBTable_Replica_single(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "replica.#", "1"),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "dynamodb", fmt.Sprintf("table/%s", rName)),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]*regexp.Regexp{
+						"arn": regexp.MustCompile(fmt.Sprintf(`:dynamodb:%s:`, acctest.AlternateRegion())),
+					}),
 				),
 			},
 			{
@@ -2423,7 +2427,7 @@ func testAccCheckReplicaExists(ctx context.Context, n string, region string, v *
 		output, err := tfdynamodb.FindTableByName(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
-			create.Error(names.DynamoDB, create.ErrActionChecking, tfdynamodb.ResNameTable, rs.Primary.ID, err)
+			return create.Error(names.DynamoDB, create.ErrActionChecking, tfdynamodb.ResNameTable, rs.Primary.ID, err)
 		}
 
 		*v = *output

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -4044,9 +4044,9 @@ data "aws_region" "alternate" {
 }
 
 resource "aws_dynamodb_table" "test" {
-  name           = %[1]q
-  hash_key       = "TestTableHashKey"
-  billing_mode   = "PAY_PER_REQUEST"
+  name         = %[1]q
+  hash_key     = "TestTableHashKey"
+  billing_mode = "PAY_PER_REQUEST"
 
   attribute {
     name = "TestTableHashKey"
@@ -4054,7 +4054,7 @@ resource "aws_dynamodb_table" "test" {
   }
 
   replica {
-    region_name    = data.aws_region.alternate.name
+    region_name = data.aws_region.alternate.name
   }
 
   stream_enabled   = %[2]t

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -242,8 +242,11 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - ARN of the table
 * `id` - Name of the table
+* `replica.*.arn` - ARN of the replica
+* `replica.*.stream_arn` - ARN of the replica Table Stream. Only available when `stream_enabled = true`.
+* `replica.*.stream_label` - Timestamp, in ISO 8601 format, for the replica stream. Note that this timestamp is not a unique identifier for the stream on its own. However, the combination of AWS customer ID, table name and this field is guaranteed to be unique. It can be used for creating CloudWatch Alarms. Only available when `stream_enabled = true`.
 * `stream_arn` - ARN of the Table Stream. Only available when `stream_enabled = true`
-* `stream_label` - Timestamp, in ISO 8601 format, for this stream. Note that this timestamp is not a unique identifier for the stream on its own. However, the combination of AWS customer ID, table name and this field is guaranteed to be unique. It can be used for creating CloudWatch Alarms. Only available when `stream_enabled = true`
+* `stream_label` - Timestamp, in ISO 8601 format, for this stream. Note that this timestamp is not a unique identifier for the stream on its own. However, the combination of AWS customer ID, table name and this field is guaranteed to be unique. It can be used for creating CloudWatch Alarms. Only available when `stream_enabled = true`.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29222 
Closes #15409

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccDynamoDBTable_ P=6 K=dynamodb
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 6 -run='TestAccDynamoDBTable_'  -timeout 180m
=== RUN   TestAccDynamoDBTable_basic
=== PAUSE TestAccDynamoDBTable_basic
=== RUN   TestAccDynamoDBTable_disappears
=== PAUSE TestAccDynamoDBTable_disappears
=== RUN   TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
=== PAUSE TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
=== RUN   TestAccDynamoDBTable_extended
=== PAUSE TestAccDynamoDBTable_extended
=== RUN   TestAccDynamoDBTable_enablePITR
=== PAUSE TestAccDynamoDBTable_enablePITR
=== RUN   TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== PAUSE TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== RUN   TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
=== PAUSE TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
=== RUN   TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
=== PAUSE TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
=== RUN   TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
=== PAUSE TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
=== RUN   TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
=== PAUSE TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
=== RUN   TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
=== PAUSE TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
=== RUN   TestAccDynamoDBTable_streamSpecification
=== PAUSE TestAccDynamoDBTable_streamSpecification
=== RUN   TestAccDynamoDBTable_streamSpecificationDiffs
=== PAUSE TestAccDynamoDBTable_streamSpecificationDiffs
=== RUN   TestAccDynamoDBTable_streamSpecificationValidation
=== PAUSE TestAccDynamoDBTable_streamSpecificationValidation
=== RUN   TestAccDynamoDBTable_tags
=== PAUSE TestAccDynamoDBTable_tags
=== RUN   TestAccDynamoDBTable_gsiUpdateCapacity
=== PAUSE TestAccDynamoDBTable_gsiUpdateCapacity
=== RUN   TestAccDynamoDBTable_gsiUpdateOtherAttributes
=== PAUSE TestAccDynamoDBTable_gsiUpdateOtherAttributes
=== RUN   TestAccDynamoDBTable_lsiNonKeyAttributes
=== PAUSE TestAccDynamoDBTable_lsiNonKeyAttributes
=== RUN   TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
=== PAUSE TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
=== RUN   TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
=== PAUSE TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
=== RUN   TestAccDynamoDBTable_TTL_enabled
=== PAUSE TestAccDynamoDBTable_TTL_enabled
=== RUN   TestAccDynamoDBTable_TTL_disabled
=== PAUSE TestAccDynamoDBTable_TTL_disabled
=== RUN   TestAccDynamoDBTable_attributeUpdate
=== PAUSE TestAccDynamoDBTable_attributeUpdate
=== RUN   TestAccDynamoDBTable_lsiUpdate
=== PAUSE TestAccDynamoDBTable_lsiUpdate
=== RUN   TestAccDynamoDBTable_attributeUpdateValidation
=== PAUSE TestAccDynamoDBTable_attributeUpdateValidation
=== RUN   TestAccDynamoDBTable_encryption
=== PAUSE TestAccDynamoDBTable_encryption
=== RUN   TestAccDynamoDBTable_Replica_multiple
=== PAUSE TestAccDynamoDBTable_Replica_multiple
=== RUN   TestAccDynamoDBTable_Replica_single
=== PAUSE TestAccDynamoDBTable_Replica_single
=== RUN   TestAccDynamoDBTable_Replica_singleStreamSpecification
=== PAUSE TestAccDynamoDBTable_Replica_singleStreamSpecification
=== RUN   TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted
=== PAUSE TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted
=== RUN   TestAccDynamoDBTable_Replica_singleCMK
=== PAUSE TestAccDynamoDBTable_Replica_singleCMK
=== RUN   TestAccDynamoDBTable_Replica_singleAddCMK
=== PAUSE TestAccDynamoDBTable_Replica_singleAddCMK
=== RUN   TestAccDynamoDBTable_Replica_pitr
=== PAUSE TestAccDynamoDBTable_Replica_pitr
=== RUN   TestAccDynamoDBTable_Replica_pitrKMS
=== PAUSE TestAccDynamoDBTable_Replica_pitrKMS
=== RUN   TestAccDynamoDBTable_Replica_tagsOneOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_tagsOneOfTwo
=== RUN   TestAccDynamoDBTable_Replica_tagsTwoOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_tagsTwoOfTwo
=== RUN   TestAccDynamoDBTable_Replica_tagsNext
=== PAUSE TestAccDynamoDBTable_Replica_tagsNext
=== RUN   TestAccDynamoDBTable_Replica_tagsUpdate
=== PAUSE TestAccDynamoDBTable_Replica_tagsUpdate
=== RUN   TestAccDynamoDBTable_tableClassInfrequentAccess
=== PAUSE TestAccDynamoDBTable_tableClassInfrequentAccess
=== RUN   TestAccDynamoDBTable_backupEncryption
=== PAUSE TestAccDynamoDBTable_backupEncryption
=== RUN   TestAccDynamoDBTable_backup_overrideEncryption
=== PAUSE TestAccDynamoDBTable_backup_overrideEncryption
=== CONT  TestAccDynamoDBTable_basic
=== CONT  TestAccDynamoDBTable_TTL_disabled
=== CONT  TestAccDynamoDBTable_backupEncryption
=== CONT  TestAccDynamoDBTable_Replica_singleAddCMK
=== CONT  TestAccDynamoDBTable_Replica_multiple
=== CONT  TestAccDynamoDBTable_backup_overrideEncryption
--- PASS: TestAccDynamoDBTable_basic (28.09s)
=== CONT  TestAccDynamoDBTable_Replica_singleCMK
--- PASS: TestAccDynamoDBTable_TTL_disabled (39.90s)
=== CONT  TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted (230.19s)
=== CONT  TestAccDynamoDBTable_Replica_singleStreamSpecification
--- PASS: TestAccDynamoDBTable_Replica_singleCMK (261.27s)
=== CONT  TestAccDynamoDBTable_Replica_single
--- PASS: TestAccDynamoDBTable_backupEncryption (334.59s)
=== CONT  TestAccDynamoDBTable_gsiUpdateOtherAttributes
--- PASS: TestAccDynamoDBTable_Replica_singleStreamSpecification (258.89s)
=== CONT  TestAccDynamoDBTable_TTL_enabled
--- PASS: TestAccDynamoDBTable_TTL_enabled (25.61s)
=== CONT  TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
--- PASS: TestAccDynamoDBTable_Replica_multiple (581.02s)
=== CONT  TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (41.62s)
=== CONT  TestAccDynamoDBTable_lsiNonKeyAttributes
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (31.58s)
=== CONT  TestAccDynamoDBTable_attributeUpdateValidation
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (4.14s)
=== CONT  TestAccDynamoDBTable_encryption
--- PASS: TestAccDynamoDBTable_encryption (116.14s)
=== CONT  TestAccDynamoDBTable_tags
--- PASS: TestAccDynamoDBTable_Replica_single (471.43s)
=== CONT  TestAccDynamoDBTable_gsiUpdateCapacity
--- PASS: TestAccDynamoDBTable_Replica_singleAddCMK (768.69s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
--- PASS: TestAccDynamoDBTable_tags (34.29s)
=== CONT  TestAccDynamoDBTable_streamSpecification
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (41.77s)
=== CONT  TestAccDynamoDBTable_streamSpecificationValidation
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (1.73s)
=== CONT  TestAccDynamoDBTable_streamSpecificationDiffs
--- PASS: TestAccDynamoDBTable_gsiUpdateCapacity (59.39s)
=== CONT  TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
--- PASS: TestAccDynamoDBTable_streamSpecification (41.78s)
=== CONT  TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (51.17s)
=== CONT  TestAccDynamoDBTable_Replica_tagsTwoOfTwo
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (928.48s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
--- PASS: TestAccDynamoDBTable_streamSpecificationDiffs (127.58s)
=== CONT  TestAccDynamoDBTable_tableClassInfrequentAccess
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (44.56s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (477.71s)
=== CONT  TestAccDynamoDBTable_Replica_tagsUpdate
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (729.66s)
=== CONT  TestAccDynamoDBTable_Replica_tagsNext
--- PASS: TestAccDynamoDBTable_Replica_tagsTwoOfTwo (298.66s)
=== CONT  TestAccDynamoDBTable_extended
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (359.26s)
=== CONT  TestAccDynamoDBTable_Replica_pitrKMS
--- PASS: TestAccDynamoDBTable_extended (296.50s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (46.43s)
=== CONT  TestAccDynamoDBTable_Replica_pitr
--- PASS: TestAccDynamoDBTable_Replica_tagsNext (561.64s)
=== CONT  TestAccDynamoDBTable_enablePITR
--- PASS: TestAccDynamoDBTable_enablePITR (54.52s)
=== CONT  TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (70.94s)
=== CONT  TestAccDynamoDBTable_lsiUpdate
--- PASS: TestAccDynamoDBTable_lsiUpdate (59.86s)
=== CONT  TestAccDynamoDBTable_disappears
--- PASS: TestAccDynamoDBTable_disappears (20.27s)
=== CONT  TestAccDynamoDBTable_attributeUpdate
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (859.29s)
=== CONT  TestAccDynamoDBTable_Replica_tagsOneOfTwo
--- PASS: TestAccDynamoDBTable_Replica_pitr (335.42s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (1072.62s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (1284.28s)
--- PASS: TestAccDynamoDBTable_Replica_tagsOneOfTwo (297.59s)
--- PASS: TestAccDynamoDBTable_attributeUpdate (866.79s)
--- PASS: TestAccDynamoDBTable_Replica_pitrKMS (364.51s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	3450.034s
```
