### PR TITLE
Fix golangci-lint `paralleltest` errors

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,7 +28,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: v1.51.0
           args: --config .ci/.golangci.yml
   golangci-lintb:
     name: 2 of 2
@@ -42,5 +42,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: v1.51.0
           args: --config .ci/.golangci2.yml

--- a/internal/flex/flex_test.go
+++ b/internal/flex/flex_test.go
@@ -46,6 +46,8 @@ func TestExpandStringListEmptyItems(t *testing.T) {
 }
 
 func TestExpandResourceId(t *testing.T) {
+	t.Parallel()
+
 	resourceId := "foo,bar,baz"
 	expandedId, _ := ExpandResourceId(resourceId, 3)
 	expected := []string{
@@ -63,6 +65,8 @@ func TestExpandResourceId(t *testing.T) {
 }
 
 func TestExpandResourceIdEmptyPart(t *testing.T) {
+	t.Parallel()
+
 	resourceId := "foo,,baz"
 	_, err := ExpandResourceId(resourceId, 3)
 
@@ -72,6 +76,8 @@ func TestExpandResourceIdEmptyPart(t *testing.T) {
 }
 
 func TestExpandResourceIdIncorrectPartCount(t *testing.T) {
+	t.Parallel()
+
 	resourceId := "foo,bar,baz"
 	_, err := ExpandResourceId(resourceId, 2)
 
@@ -81,6 +87,8 @@ func TestExpandResourceIdIncorrectPartCount(t *testing.T) {
 }
 
 func TestExpandResourceIdSinglePart(t *testing.T) {
+	t.Parallel()
+
 	resourceId := "foo"
 	_, err := ExpandResourceId(resourceId, 2)
 
@@ -90,6 +98,8 @@ func TestExpandResourceIdSinglePart(t *testing.T) {
 }
 
 func TestFlattenResourceId(t *testing.T) {
+	t.Parallel()
+
 	idParts := []string{"foo", "bar", "baz"}
 	flattenedId, _ := FlattenResourceId(idParts, 3)
 	expected := "foo,bar,baz"
@@ -103,6 +113,8 @@ func TestFlattenResourceId(t *testing.T) {
 }
 
 func TestFlattenResourceIdEmptyPart(t *testing.T) {
+	t.Parallel()
+
 	idParts := []string{"foo", "", "baz"}
 	_, err := FlattenResourceId(idParts, 3)
 
@@ -112,6 +124,8 @@ func TestFlattenResourceIdEmptyPart(t *testing.T) {
 }
 
 func TestFlattenResourceIdIncorrectPartCount(t *testing.T) {
+	t.Parallel()
+
 	idParts := []string{"foo", "bar", "baz"}
 	_, err := FlattenResourceId(idParts, 2)
 
@@ -121,6 +135,8 @@ func TestFlattenResourceIdIncorrectPartCount(t *testing.T) {
 }
 
 func TestFlattenResourceIdSinglePart(t *testing.T) {
+	t.Parallel()
+
 	idParts := []string{"foo"}
 	_, err := FlattenResourceId(idParts, 2)
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes:

```console
% make golangci-lint
==> Checking source code with golangci-lint...
internal/flex/flex_test.go:48:1: Function TestExpandResourceId missing the call to method parallel (paralleltest)
func TestExpandResourceId(t *testing.T) {
^
internal/flex/flex_test.go:65:1: Function TestExpandResourceIdEmptyPart missing the call to method parallel (paralleltest)
func TestExpandResourceIdEmptyPart(t *testing.T) {
^
internal/flex/flex_test.go:74:1: Function TestExpandResourceIdIncorrectPartCount missing the call to method parallel (paralleltest)
func TestExpandResourceIdIncorrectPartCount(t *testing.T) {
^
internal/flex/flex_test.go:83:1: Function TestExpandResourceIdSinglePart missing the call to method parallel (paralleltest)
func TestExpandResourceIdSinglePart(t *testing.T) {
^
internal/flex/flex_test.go:92:1: Function TestFlattenResourceId missing the call to method parallel (paralleltest)
func TestFlattenResourceId(t *testing.T) {
^
internal/flex/flex_test.go:105:1: Function TestFlattenResourceIdEmptyPart missing the call to method parallel (paralleltest)
func TestFlattenResourceIdEmptyPart(t *testing.T) {
^
internal/flex/flex_test.go:114:1: Function TestFlattenResourceIdIncorrectPartCount missing the call to method parallel (paralleltest)
func TestFlattenResourceIdIncorrectPartCount(t *testing.T) {
^
internal/flex/flex_test.go:123:1: Function TestFlattenResourceIdSinglePart missing the call to method parallel (paralleltest)
func TestFlattenResourceIdSinglePart(t *testing.T) {
^
make: *** [golangci-lint] Error 1
```

Pins `golangci-lint` to **v1.51.0** in the GitHub Action (https://github.com/hashicorp/terraform-provider-aws/pull/29267).