### PR TITLE
Fix example for `aws_eks_cluster_auth` datasource

### DIFF
--- a/website/docs/d/eks_cluster_auth.html.markdown
+++ b/website/docs/d/eks_cluster_auth.html.markdown
@@ -32,7 +32,6 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.example.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.example.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.example.token
-  load_config_file       = false
 }
 ```
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Just stumbled upon this! As of `hashicorp/kubernetes` version 2.0.0 the `load_config_file` attribute has been removed and is not required any more.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://github.com/hashicorp/terraform-provider-kubernetes/issues/1223#issuecomment-824117215

### Output from Acceptance Testing
`n/a`