### PR TITLE
Add default_value to the cost category data source.

### DIFF
--- a/internal/service/ce/cost_category_data_source.go
+++ b/internal/service/ce/cost_category_data_source.go
@@ -24,6 +24,10 @@ func DataSourceCostCategory() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"default_value": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"effective_end": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -321,6 +325,7 @@ func dataSourceCostCategoryRead(ctx context.Context, d *schema.ResourceData, met
 		return create.DiagError(names.CE, create.ErrActionReading, ResNameCostCategory, d.Id(), err)
 	}
 
+	d.Set("default_value", costCategory.DefaultValue)
 	d.Set("effective_end", costCategory.EffectiveEnd)
 	d.Set("effective_start", costCategory.EffectiveStart)
 	d.Set("name", costCategory.Name)

--- a/internal/service/ce/cost_category_data_source_test.go
+++ b/internal/service/ce/cost_category_data_source_test.go
@@ -26,6 +26,7 @@ func TestAccCECostCategoryDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCostCategoryExists(ctx, resourceName, &output),
 					resource.TestCheckResourceAttrPair(dataSourceName, "cost_category_arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "default_value", resourceName, "default_value"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "rule_version", resourceName, "rule_version"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "rule.%", resourceName, "rule.%"),

--- a/website/docs/d/ce_cost_category.html.markdown
+++ b/website/docs/d/ce_cost_category.html.markdown
@@ -29,6 +29,7 @@ The following arguments are required:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - ARN of the cost category.
+* `default_value` - Default value for the cost category.
 * `effective_end` - Effective end data of your Cost Category.
 * `effective_start` - Effective state data of your Cost Category.
 * `id` - Unique ID of the cost category.


### PR DESCRIPTION
### Description
Adds 'default_value' to the cost category data source.

This is an important addition given that a default_value may be an instrumental part of a rule set. The 'default value' may be capturing material costs not explicitly categorized by other rules.

### Relations
NA

### References
NA

### Output from Acceptance Testing
I didn't run acceptance tests as I don't have an AWS management account suitable for testing. 
