### PR TITLE
r/aws_ec2_client_vpn_endpoint: Change `authentication_options` to `TypeSet`

### DIFF
--- a/.changelog/29294.txt
+++ b/.changelog/29294.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_client_vpn_endpoint: Change `authentication_options` from `TypeList` to `TypeSet` as order is not significant
+```

--- a/internal/service/ec2/vpnclient_endpoint.go
+++ b/internal/service/ec2/vpnclient_endpoint.go
@@ -38,7 +38,7 @@ func ResourceClientVPNEndpoint() *schema.Resource {
 				Computed: true,
 			},
 			"authentication_options": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Required: true,
 				ForceNew: true,
 				MaxItems: 2,
@@ -236,8 +236,8 @@ func resourceClientVPNEndpointCreate(ctx context.Context, d *schema.ResourceData
 		VpnPort:              aws.Int64(int64(d.Get("vpn_port").(int))),
 	}
 
-	if v, ok := d.GetOk("authentication_options"); ok && len(v.([]interface{})) > 0 {
-		input.AuthenticationOptions = expandClientVPNAuthenticationRequests(v.([]interface{}))
+	if v, ok := d.GetOk("authentication_options"); ok && v.(*schema.Set).Len() > 0 {
+		input.AuthenticationOptions = expandClientVPNAuthenticationRequests(v.(*schema.Set).List())
 	}
 
 	if v, ok := d.GetOk("client_connect_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {

--- a/internal/service/ec2/vpnclient_endpoint_data_source_test.go
+++ b/internal/service/ec2/vpnclient_endpoint_data_source_test.go
@@ -92,7 +92,7 @@ func testAccClientVPNEndpointDataSource_basic(t *testing.T) {
 }
 
 func testAccClientVPNEndpointDataSourceConfig_basic(t *testing.T, rName string) string {
-	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_dnsServers(t, rName), `
+	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_basic(t, rName), `
 data "aws_ec2_client_vpn_endpoint" "by_id" {
   client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.test.id
 }

--- a/internal/service/ec2/vpnclient_endpoint_data_source_test.go
+++ b/internal/service/ec2/vpnclient_endpoint_data_source_test.go
@@ -92,7 +92,7 @@ func testAccClientVPNEndpointDataSource_basic(t *testing.T) {
 }
 
 func testAccClientVPNEndpointDataSourceConfig_basic(t *testing.T, rName string) string {
-	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_basic(t, rName), `
+	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_dnsServers(t, rName), `
 data "aws_ec2_client_vpn_endpoint" "by_id" {
   client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.test.id
 }

--- a/internal/service/ec2/vpnclient_endpoint_test.go
+++ b/internal/service/ec2/vpnclient_endpoint_test.go
@@ -108,11 +108,9 @@ func testAccClientVPNEndpoint_basic(t *testing.T) {
 					testAccCheckClientVPNEndpointExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`client-vpn-endpoint/cvpn-endpoint-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "authentication_options.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "authentication_options.0.type", "certificate-authentication"),
-					resource.TestCheckResourceAttr(resourceName, "authentication_options.0.active_directory_id", ""),
-					resource.TestCheckResourceAttrSet(resourceName, "authentication_options.0.root_certificate_chain_arn"),
-					resource.TestCheckResourceAttr(resourceName, "authentication_options.0.saml_provider_arn", ""),
-					resource.TestCheckResourceAttr(resourceName, "authentication_options.0.self_service_saml_provider_arn", ""),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "authentication_options.*", map[string]string{
+						"type": "certificate-authentication",
+					}),
 					resource.TestCheckResourceAttr(resourceName, "client_cidr_block", "10.0.0.0/16"),
 					resource.TestCheckResourceAttr(resourceName, "client_connect_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "client_connect_options.0.enabled", "false"),
@@ -221,7 +219,6 @@ func testAccClientVPNEndpoint_msADAuth(t *testing.T) {
 	var v ec2.ClientVpnEndpoint
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
-	dsDirectoryResourceName := "aws_directory_service_directory.test"
 	domainName := acctest.RandomDomainName()
 
 	if testing.Short() {
@@ -239,8 +236,9 @@ func testAccClientVPNEndpoint_msADAuth(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "authentication_options.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "authentication_options.0.type", "directory-service-authentication"),
-					resource.TestCheckResourceAttrPair(resourceName, "authentication_options.0.active_directory_id", dsDirectoryResourceName, "id"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "authentication_options.*", map[string]string{
+						"type": "directory-service-authentication",
+					}),
 				),
 			},
 			{
@@ -257,8 +255,6 @@ func testAccClientVPNEndpoint_msADAuthAndMutualAuth(t *testing.T) {
 	var v ec2.ClientVpnEndpoint
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
-	dsDirectoryResourceName := "aws_directory_service_directory.test"
-	serverCertificateResourceName := "aws_acm_certificate.test"
 	domainName := acctest.RandomDomainName()
 
 	if testing.Short() {
@@ -276,10 +272,12 @@ func testAccClientVPNEndpoint_msADAuthAndMutualAuth(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "authentication_options.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "authentication_options.0.type", "directory-service-authentication"),
-					resource.TestCheckResourceAttrPair(resourceName, "authentication_options.0.active_directory_id", dsDirectoryResourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "authentication_options.1.type", "certificate-authentication"),
-					resource.TestCheckResourceAttrPair(resourceName, "authentication_options.0.root_certificate_chain_arn", serverCertificateResourceName, "arn"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "authentication_options.*", map[string]string{
+						"type": "directory-service-authentication",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "authentication_options.*", map[string]string{
+						"type": "certificate-authentication",
+					}),
 				),
 			},
 			{
@@ -297,7 +295,6 @@ func testAccClientVPNEndpoint_federatedAuth(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	idpEntityID := fmt.Sprintf("https://%s", acctest.RandomDomainName())
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
-	samlProviderResourceName := "aws_iam_saml_provider.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckClientVPNSyncronize(t) },
@@ -310,8 +307,9 @@ func testAccClientVPNEndpoint_federatedAuth(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "authentication_options.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "authentication_options.0.type", "federated-authentication"),
-					resource.TestCheckResourceAttrPair(resourceName, "authentication_options.0.saml_provider_arn", samlProviderResourceName, "arn"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "authentication_options.*", map[string]string{
+						"type": "federated-authentication",
+					}),
 				),
 			},
 			{
@@ -329,8 +327,6 @@ func testAccClientVPNEndpoint_federatedAuthWithSelfServiceProvider(t *testing.T)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	idpEntityID := fmt.Sprintf("https://%s", acctest.RandomDomainName())
 	resourceName := "aws_ec2_client_vpn_endpoint.test"
-	samlProvider1ResourceName := "aws_iam_saml_provider.test1"
-	samlProvider2ResourceName := "aws_iam_saml_provider.test2"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckClientVPNSyncronize(t) },
@@ -343,9 +339,9 @@ func testAccClientVPNEndpoint_federatedAuthWithSelfServiceProvider(t *testing.T)
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClientVPNEndpointExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "authentication_options.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "authentication_options.0.type", "federated-authentication"),
-					resource.TestCheckResourceAttrPair(resourceName, "authentication_options.0.saml_provider_arn", samlProvider1ResourceName, "arn"),
-					resource.TestCheckResourceAttrPair(resourceName, "authentication_options.0.self_service_saml_provider_arn", samlProvider2ResourceName, "arn"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "authentication_options.*", map[string]string{
+						"type": "federated-authentication",
+					}),
 				),
 			},
 			{
@@ -789,9 +785,7 @@ resource "aws_acm_certificate" %[1]q {
 }
 
 func testAccClientVPNEndpointConfig_msADBase(rName, domain string) string {
-	return acctest.ConfigCompose(
-		acctest.ConfigAvailableAZsNoOptIn(),
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
 resource "aws_directory_service_directory" "test" {
   name     = %[2]q
   password = "SuperSecretPassw0rd"
@@ -800,25 +794,6 @@ resource "aws_directory_service_directory" "test" {
   vpc_settings {
     vpc_id     = aws_vpc.test.id
     subnet_ids = aws_subnet.test[*].id
-  }
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_subnet" "test" {
-  count             = 2
-  availability_zone = data.aws_availability_zones.available.names[count.index]
-  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
-  vpc_id            = aws_vpc.test.id
-
-  tags = {
-    Name = %[1]q
   }
 }
 `, rName, domain))
@@ -1044,7 +1019,7 @@ func testAccClientVPNEndpointConfig_microsoftAD(t *testing.T, rName, domain stri
 		fmt.Sprintf(`
 resource "aws_ec2_client_vpn_endpoint" "test" {
   server_certificate_arn = aws_acm_certificate.test.arn
-  client_cidr_block      = "10.0.0.0/16"
+  client_cidr_block      = "10.1.0.0/20"
 
   authentication_options {
     type                = "directory-service-authentication"
@@ -1069,7 +1044,7 @@ func testAccClientVPNEndpointConfig_mutualAuthAndMicrosoftAD(t *testing.T, rName
 		fmt.Sprintf(`
 resource "aws_ec2_client_vpn_endpoint" "test" {
   server_certificate_arn = aws_acm_certificate.test.arn
-  client_cidr_block      = "10.0.0.0/16"
+  client_cidr_block      = "10.1.0.0/20"
 
   authentication_options {
     type                = "directory-service-authentication"

--- a/internal/service/ec2/vpnclient_endpoint_test.go
+++ b/internal/service/ec2/vpnclient_endpoint_test.go
@@ -844,7 +844,7 @@ resource "aws_security_group" "test" {
 }
 
 func testAccClientVPNEndpointConfig_basic(t *testing.T, rName string) string {
-	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase(t, "test"), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase(t, "test"), `
 resource "aws_ec2_client_vpn_endpoint" "test" {
   server_certificate_arn = aws_acm_certificate.test.arn
   client_cidr_block      = "10.0.0.0/16"
@@ -857,12 +857,8 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
   connection_log_options {
     enabled = false
   }
-
-  tags = {
-    Name = %[1]q
-  }
 }
-`, rName))
+`)
 }
 
 func testAccClientVPNEndpointConfig_clientConnectOptions(t *testing.T, rName string, enabled bool, lambdaFunctionIndex int) string {

--- a/internal/service/ec2/vpnclient_endpoint_test.go
+++ b/internal/service/ec2/vpnclient_endpoint_test.go
@@ -130,7 +130,8 @@ func testAccClientVPNEndpoint_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "session_timeout_hours", "24"),
 					resource.TestCheckResourceAttr(resourceName, "split_tunnel", "false"),
 					resource.TestCheckResourceAttr(resourceName, "status", ec2.ClientVpnEndpointStatusCodePendingAssociate),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 					resource.TestCheckResourceAttr(resourceName, "transport_protocol", "udp"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "vpn_port", "443"),
@@ -819,7 +820,7 @@ resource "aws_security_group" "test" {
 }
 
 func testAccClientVPNEndpointConfig_basic(t *testing.T, rName string) string {
-	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase(t, "test"), `
+	return acctest.ConfigCompose(testAccClientVPNEndpointConfig_acmCertificateBase(t, "test"), fmt.Sprintf(`
 resource "aws_ec2_client_vpn_endpoint" "test" {
   server_certificate_arn = aws_acm_certificate.test.arn
   client_cidr_block      = "10.0.0.0/16"
@@ -832,8 +833,12 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
   connection_log_options {
     enabled = false
   }
+
+  tags = {
+    Name = %[1]q
+  }
 }
-`)
+`, rName))
 }
 
 func testAccClientVPNEndpointConfig_clientConnectOptions(t *testing.T, rName string, enabled bool, lambdaFunctionIndex int) string {

--- a/internal/service/ec2/vpnclient_endpoint_test.go
+++ b/internal/service/ec2/vpnclient_endpoint_test.go
@@ -1299,7 +1299,7 @@ locals {
 
 resource "aws_ec2_client_vpn_endpoint" "test" {
   server_certificate_arn = aws_acm_certificate.test.arn
-  client_cidr_block      = "10.0.0.0/16"
+  client_cidr_block      = "10.1.0.0/22"
 
   authentication_options {
     type                       = "certificate-authentication"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Changes `aws_ec2_client_vpn_endpoint .authentication_options` from `TypeList` to `TypeSet` as order is not significant.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/25800.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccClientVPNEndpoint_serial/Endpoint_' PKG=ec2 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccClientVPNEndpoint_serial/Endpoint_ -timeout 180m
=== RUN   TestAccClientVPNEndpoint_serial
=== PAUSE TestAccClientVPNEndpoint_serial
=== CONT  TestAccClientVPNEndpoint_serial
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_msADAuthAndMutualAuth
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_msADAuthAndMutualAuth
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_federatedAuthWithSelfService
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_federatedAuthWithSelfService
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_withDNSServers
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_withDNSServers
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_tags
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_tags
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_vpcSecurityGroups
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_vpcSecurityGroups
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_basicDataSource
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_basicDataSource
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_disappears
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_disappears
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_federatedAuth
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_federatedAuth
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_withClientConnect
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_withClientConnect
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_basic
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_basic
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_withClientLoginBanner
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_withClientLoginBanner
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_selfServicePortal
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_selfServicePortal
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_vpcNoSecurityGroups
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_vpcNoSecurityGroups
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_msADAuth
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_msADAuth
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_simpleAttributesUpdate
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_simpleAttributesUpdate
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_withLogGroup
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_withLogGroup
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_msADAuthAndMutualAuth
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_withClientConnect
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_vpcSecurityGroups
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_vpcNoSecurityGroups
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_msADAuth
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_basic
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_tags
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_disappears
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_federatedAuth
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_withClientLoginBanner
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_selfServicePortal
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_simpleAttributesUpdate
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_withLogGroup
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_withDNSServers
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_basicDataSource
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_federatedAuthWithSelfService
--- PASS: TestAccClientVPNEndpoint_serial (4.07s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_basic (22.60s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_disappears (39.80s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_vpcSecurityGroups (49.44s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_vpcNoSecurityGroups (77.02s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_tags (87.65s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_withClientConnect (110.46s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_selfServicePortal (123.00s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_withClientLoginBanner (128.70s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_simpleAttributesUpdate (147.24s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_basicDataSource (168.21s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_withDNSServers (178.45s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_withLogGroup (187.61s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_federatedAuth (189.33s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_federatedAuthWithSelfService (199.03s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_msADAuth (1669.97s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_msADAuthAndMutualAuth (1741.71s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	1750.681s
```
