### PR TITLE
r/aws_cloudwatch_log_group: Retry `PutRetentionPolicyWithContext` for IAM eventual consistency

### DIFF
--- a/.changelog/29325.txt
+++ b/.changelog/29325.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_log_group: Fix IAM eventual consistency error when setting a retention policy
+```

--- a/internal/service/logs/group.go
+++ b/internal/service/logs/group.go
@@ -103,10 +103,14 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	d.SetId(name)
 
 	if v, ok := d.GetOk("retention_in_days"); ok {
-		_, err := conn.PutRetentionPolicyWithContext(ctx, &cloudwatchlogs.PutRetentionPolicyInput{
+		input := &cloudwatchlogs.PutRetentionPolicyInput{
 			LogGroupName:    aws.String(d.Id()),
 			RetentionInDays: aws.Int64(int64(v.(int))),
-		})
+		}
+
+		_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
+			return conn.PutRetentionPolicyWithContext(ctx, input)
+		}, "AccessDeniedException", "no identity-based policy allows the logs:PutRetentionPolicy action")
 
 		if err != nil {
 			return diag.Errorf("setting CloudWatch Logs Log Group (%s) retention policy: %s", d.Id(), err)

--- a/internal/service/logs/group.go
+++ b/internal/service/logs/group.go
@@ -168,10 +168,14 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	if d.HasChange("retention_in_days") {
 		if v, ok := d.GetOk("retention_in_days"); ok {
-			_, err := conn.PutRetentionPolicyWithContext(ctx, &cloudwatchlogs.PutRetentionPolicyInput{
+			input := &cloudwatchlogs.PutRetentionPolicyInput{
 				LogGroupName:    aws.String(d.Id()),
 				RetentionInDays: aws.Int64(int64(v.(int))),
-			})
+			}
+
+			_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
+				return conn.PutRetentionPolicyWithContext(ctx, input)
+			}, "AccessDeniedException", "no identity-based policy allows the logs:PutRetentionPolicy action")
 
 			if err != nil {
 				return diag.Errorf("setting CloudWatch Logs Log Group (%s) retention policy: %s", d.Id(), err)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Retries the log group's `PutRetentionPolicyWithContext` API call if an IAM eventual consistency error is returned.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/27028.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccLogsGroup_' PKG=logs ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/logs/... -v -count 1 -parallel 3  -run=TestAccLogsGroup_ -timeout 180m
=== RUN   TestAccLogsGroup_basic
=== PAUSE TestAccLogsGroup_basic
=== RUN   TestAccLogsGroup_nameGenerate
=== PAUSE TestAccLogsGroup_nameGenerate
=== RUN   TestAccLogsGroup_namePrefix
=== PAUSE TestAccLogsGroup_namePrefix
=== RUN   TestAccLogsGroup_disappears
=== PAUSE TestAccLogsGroup_disappears
=== RUN   TestAccLogsGroup_tags
=== PAUSE TestAccLogsGroup_tags
=== RUN   TestAccLogsGroup_kmsKey
=== PAUSE TestAccLogsGroup_kmsKey
=== RUN   TestAccLogsGroup_retentionPolicy
=== PAUSE TestAccLogsGroup_retentionPolicy
=== RUN   TestAccLogsGroup_multiple
=== PAUSE TestAccLogsGroup_multiple
=== RUN   TestAccLogsGroup_skipDestroy
=== PAUSE TestAccLogsGroup_skipDestroy
=== CONT  TestAccLogsGroup_basic
=== CONT  TestAccLogsGroup_kmsKey
=== CONT  TestAccLogsGroup_multiple
--- PASS: TestAccLogsGroup_multiple (16.70s)
=== CONT  TestAccLogsGroup_skipDestroy
--- PASS: TestAccLogsGroup_basic (19.37s)
=== CONT  TestAccLogsGroup_disappears
--- PASS: TestAccLogsGroup_skipDestroy (14.46s)
=== CONT  TestAccLogsGroup_tags
--- PASS: TestAccLogsGroup_disappears (12.73s)
=== CONT  TestAccLogsGroup_namePrefix
--- PASS: TestAccLogsGroup_namePrefix (17.80s)
=== CONT  TestAccLogsGroup_nameGenerate
--- PASS: TestAccLogsGroup_kmsKey (50.26s)
=== CONT  TestAccLogsGroup_retentionPolicy
--- PASS: TestAccLogsGroup_nameGenerate (18.55s)
--- PASS: TestAccLogsGroup_tags (43.92s)
--- PASS: TestAccLogsGroup_retentionPolicy (30.74s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	86.222s
```
