### PR TITLE
Handle `NotImplemented` errors for S3 Bucket `lifecycle_rule` and `replication_configuration` reads

### DIFF
--- a/.changelog/28790.txt
+++ b/.changelog/28790.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+resource/aws_s3_bucket: Add error handling for `NotImplemented` errors when reading `lifecycle_rule` or `replication_configuration` into terraform state.
+```
+

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -1223,7 +1223,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diags
 	}
 
-	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNoSuchLifecycleConfiguration) {
+	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNoSuchLifecycleConfiguration, ErrCodeNotImplemented) {
 		return sdkdiag.AppendErrorf(diags, "getting S3 Bucket (%s) Lifecycle Configuration: %s", d.Id(), err)
 	}
 
@@ -1252,7 +1252,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diags
 	}
 
-	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeReplicationConfigurationNotFound) {
+	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeReplicationConfigurationNotFound, ErrCodeNotImplemented) {
 		return sdkdiag.AppendErrorf(diags, "getting S3 Bucket replication: %s", err)
 	}
 


### PR DESCRIPTION
### Description
Ignores errors when a 3rd party S3 storage provider (such as EMC ECS) doesn't implement certain AWS S3 capabilities


### Relations

Replaces #28790 (maintainers not provided write permissions on remote)
Relates #23291

### References
Similar implementation to #23278


### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
