### PR TITLE
Replace heredoc with aws_iam_policy_document datasource (d/*)

### DIFF
--- a/website/docs/d/billing_service_account.html.markdown
+++ b/website/docs/d/billing_service_account.html.markdown
@@ -24,40 +24,39 @@ resource "aws_s3_bucket_acl" "billing_logs_acl" {
   acl    = "private"
 }
 
+data "aws_iam_policy_document" "allow_billing_logging" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_billing_service_account.main.arn]
+    }
+
+    actions = [
+      "s3:GetBucketAcl",
+      "s3:GetBucketPolicy",
+    ]
+
+    resources = [aws_s3_bucket.billing_logs.arn]
+  }
+
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_billing_service_account.main.arn]
+    }
+
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.billing_logs.arn}/*"]
+  }
+}
+
 resource "aws_s3_bucket_policy" "allow_billing_logging" {
   bucket = aws_s3_bucket.billing_logs.id
-  policy = <<POLICY
-{
-  "Id": "Policy",
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:GetBucketAcl", "s3:GetBucketPolicy"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:s3:::my-billing-tf-test-bucket",
-      "Principal": {
-        "AWS": [
-          "${data.aws_billing_service_account.main.arn}"
-        ]
-      }
-    },
-    {
-      "Action": [
-        "s3:PutObject"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:s3:::my-billing-tf-test-bucket/*",
-      "Principal": {
-        "AWS": [
-          "${data.aws_billing_service_account.main.arn}"
-        ]
-      }
-    }
-  ]
-}
-POLICY
+  policy = data.aws_iam_policy_document.allow_billing_logging.json
 }
 ```
 

--- a/website/docs/d/cloudtrail_service_account.html.markdown
+++ b/website/docs/d/cloudtrail_service_account.html.markdown
@@ -21,33 +21,37 @@ resource "aws_s3_bucket" "bucket" {
   force_destroy = true
 }
 
+data "aws_iam_policy_document" "allow_cloudtrail_logging" {
+  statement {
+    sid    = "Put bucket policy needed for trails"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_cloudtrail_service_account.main.arn]
+    }
+
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.bucket.arn}/*"]
+  }
+
+  statement {
+    sid    = "Get bucket policy needed for trails"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_cloudtrail_service_account.main.arn]
+    }
+
+    actions   = ["s3:GetBucketAcl"]
+    resources = [aws_s3_bucket.bucket.arn]
+  }
+}
+
 resource "aws_s3_bucket_policy" "allow_cloudtrail_logging" {
   bucket = aws_s3_bucket.bucket.id
-  policy = <<EOF
-{
-  "Version": "2008-10-17",
-  "Statement": [
-    {
-      "Sid": "Put bucket policy needed for trails",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "${data.aws_cloudtrail_service_account.main.arn}"
-      },
-      "Action": "s3:PutObject",
-      "Resource": "arn:aws:s3:::tf-cloudtrail-logging-test-bucket/*"
-    },
-    {
-      "Sid": "Get bucket policy needed for trails",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "${data.aws_cloudtrail_service_account.main.arn}"
-      },
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:aws:s3:::tf-cloudtrail-logging-test-bucket"
-    }
-  ]
-}
-EOF
+  policy = data.aws_iam_policy_document.allow_cloudtrail_logging.json
 }
 ```
 

--- a/website/docs/d/redshift_service_account.html.markdown
+++ b/website/docs/d/redshift_service_account.html.markdown
@@ -21,33 +21,39 @@ resource "aws_s3_bucket" "bucket" {
   force_destroy = true
 }
 
+data "aws_iam_policy_document" "allow_audit_logging" {
+  statement {
+    sid    = "Put bucket policy needed for audit logging"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_redshift_service_account.main.arn]
+    }
+
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.bucket.arn}/*"]
+  }
+
+  statement {
+    sid    = "Get bucket policy needed for audit logging"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        data.aws_redshift_service_account.main.arn,
+      ]
+    }
+
+    actions   = ["s3:GetBucketAcl"]
+    resources = data.aws_s3_bucket.bucket.arn
+  }
+}
+
 resource "aws_s3_bucket_policy" "allow_audit_logging" {
   bucket = aws_s3_bucket.bucket.id
-  policy = <<EOF
-{
-	"Version": "2008-10-17",
-	"Statement": [
-		{
-            "Sid": "Put bucket policy needed for audit logging",
-            "Effect": "Allow",
-            "Principal": {
-		        "AWS": "${data.aws_redshift_service_account.main.arn}"
-            },
-            "Action": "s3:PutObject",
-            "Resource": "arn:aws:s3:::tf-redshift-logging-test-bucket/*"
-        },
-        {
-            "Sid": "Get bucket policy needed for audit logging ",
-            "Effect": "Allow",
-            "Principal": {
-		        "AWS": "${data.aws_redshift_service_account.main.arn}"
-            },
-            "Action": "s3:GetBucketAcl",
-            "Resource": "arn:aws:s3:::tf-redshift-logging-test-bucket"
-        }
-	]
-}
-EOF
+  policy = data.aws_iam_policy_document.allow_audit_logging.json
 }
 ```
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Replaces all instances of heredocs in datasource examples with an `aws_iam_policy_document` datasource so that users can take advantage of the validation and syntax highlighting that the latter provides.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #17714

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
