### PR TITLE
fix: [appmesh] fixed behavior when deleting sharing mesh

### DIFF
--- a/internal/service/appmesh/gateway_route.go
+++ b/internal/service/appmesh/gateway_route.go
@@ -666,11 +666,16 @@ func resourceGatewayRouteDelete(ctx context.Context, d *schema.ResourceData, met
 	conn := meta.(*conns.AWSClient).AppMeshConn()
 
 	log.Printf("[DEBUG] Deleting App Mesh Gateway Route (%s)", d.Id())
-	_, err := conn.DeleteGatewayRouteWithContext(ctx, &appmesh.DeleteGatewayRouteInput{
+	input := &appmesh.DeleteGatewayRouteInput{
 		GatewayRouteName:   aws.String(d.Get("name").(string)),
 		MeshName:           aws.String(d.Get("mesh_name").(string)),
 		VirtualGatewayName: aws.String(d.Get("virtual_gateway_name").(string)),
-	})
+	}
+	if v, ok := d.GetOk("mesh_owner"); ok {
+		input.MeshOwner = aws.String(v.(string))
+	}
+
+	_, err := conn.DeleteGatewayRouteWithContext(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, appmesh.ErrCodeNotFoundException) {
 		return diags

--- a/internal/service/appmesh/route.go
+++ b/internal/service/appmesh/route.go
@@ -913,11 +913,16 @@ func resourceRouteDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	conn := meta.(*conns.AWSClient).AppMeshConn()
 
 	log.Printf("[DEBUG] Deleting App Mesh Route: %s", d.Id())
-	_, err := conn.DeleteRouteWithContext(ctx, &appmesh.DeleteRouteInput{
+	req := &appmesh.DeleteRouteInput{
 		MeshName:          aws.String(d.Get("mesh_name").(string)),
 		RouteName:         aws.String(d.Get("name").(string)),
 		VirtualRouterName: aws.String(d.Get("virtual_router_name").(string)),
-	})
+	}
+	if v, ok := d.GetOk("mesh_owner"); ok {
+		req.MeshOwner = aws.String(v.(string))
+	}
+
+	_, err := conn.DeleteRouteWithContext(ctx, req)
 	if tfawserr.ErrCodeEquals(err, appmesh.ErrCodeNotFoundException) {
 		return diags
 	}
@@ -941,11 +946,16 @@ func resourceRouteImport(ctx context.Context, d *schema.ResourceData, meta inter
 
 	conn := meta.(*conns.AWSClient).AppMeshConn()
 
-	resp, err := conn.DescribeRouteWithContext(ctx, &appmesh.DescribeRouteInput{
+	req := &appmesh.DescribeRouteInput{
 		MeshName:          aws.String(mesh),
 		RouteName:         aws.String(name),
 		VirtualRouterName: aws.String(vrName),
-	})
+	}
+	if v, ok := d.GetOk("mesh_owner"); ok {
+		req.MeshOwner = aws.String(v.(string))
+	}
+
+	resp, err := conn.DescribeRouteWithContext(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/appmesh/virtual_gateway.go
+++ b/internal/service/appmesh/virtual_gateway.go
@@ -808,10 +808,15 @@ func resourceVirtualGatewayDelete(ctx context.Context, d *schema.ResourceData, m
 	conn := meta.(*conns.AWSClient).AppMeshConn()
 
 	log.Printf("[DEBUG] Deleting App Mesh Virtual Gateway: %s", d.Id())
-	_, err := conn.DeleteVirtualGatewayWithContext(ctx, &appmesh.DeleteVirtualGatewayInput{
+	input := &appmesh.DeleteVirtualGatewayInput{
 		MeshName:           aws.String(d.Get("mesh_name").(string)),
 		VirtualGatewayName: aws.String(d.Get("name").(string)),
-	})
+	}
+	if v, ok := d.GetOk("mesh_owner"); ok {
+		input.MeshOwner = aws.String(v.(string))
+	}
+
+	_, err := conn.DeleteVirtualGatewayWithContext(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, appmesh.ErrCodeNotFoundException) {
 		return diags

--- a/internal/service/appmesh/virtual_node.go
+++ b/internal/service/appmesh/virtual_node.go
@@ -1147,10 +1147,15 @@ func resourceVirtualNodeDelete(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).AppMeshConn()
 
 	log.Printf("[DEBUG] Deleting App Mesh Virtual Node: %s", d.Id())
-	_, err := conn.DeleteVirtualNodeWithContext(ctx, &appmesh.DeleteVirtualNodeInput{
+	req := &appmesh.DeleteVirtualNodeInput{
 		MeshName:        aws.String(d.Get("mesh_name").(string)),
 		VirtualNodeName: aws.String(d.Get("name").(string)),
-	})
+	}
+	if v, ok := d.GetOk("mesh_owner"); ok {
+		req.MeshOwner = aws.String(v.(string))
+	}
+
+	_, err := conn.DeleteVirtualNodeWithContext(ctx, req)
 
 	if tfawserr.ErrCodeEquals(err, appmesh.ErrCodeNotFoundException) {
 		return diags
@@ -1175,10 +1180,15 @@ func resourceVirtualNodeImport(ctx context.Context, d *schema.ResourceData, meta
 
 	conn := meta.(*conns.AWSClient).AppMeshConn()
 
-	resp, err := conn.DescribeVirtualNodeWithContext(ctx, &appmesh.DescribeVirtualNodeInput{
+	req := &appmesh.DescribeVirtualNodeInput{
 		MeshName:        aws.String(mesh),
 		VirtualNodeName: aws.String(name),
-	})
+	}
+	if v, ok := d.GetOk("mesh_owner"); ok {
+		req.MeshOwner = aws.String(v.(string))
+	}
+
+	resp, err := conn.DescribeVirtualNodeWithContext(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/appmesh/virtual_router.go
+++ b/internal/service/appmesh/virtual_router.go
@@ -287,10 +287,15 @@ func resourceVirtualRouterDelete(ctx context.Context, d *schema.ResourceData, me
 	conn := meta.(*conns.AWSClient).AppMeshConn()
 
 	log.Printf("[DEBUG] Deleting App Mesh Virtual Router: %s", d.Id())
-	_, err := conn.DeleteVirtualRouterWithContext(ctx, &appmesh.DeleteVirtualRouterInput{
+	req := &appmesh.DeleteVirtualRouterInput{
 		MeshName:          aws.String(d.Get("mesh_name").(string)),
 		VirtualRouterName: aws.String(d.Get("name").(string)),
-	})
+	}
+	if v, ok := d.GetOk("mesh_owner"); ok {
+		req.MeshOwner = aws.String(v.(string))
+	}
+
+	_, err := conn.DeleteVirtualRouterWithContext(ctx, req)
 	if tfawserr.ErrCodeEquals(err, appmesh.ErrCodeNotFoundException) {
 		return diags
 	}
@@ -313,10 +318,15 @@ func resourceVirtualRouterImport(ctx context.Context, d *schema.ResourceData, me
 
 	conn := meta.(*conns.AWSClient).AppMeshConn()
 
-	resp, err := conn.DescribeVirtualRouterWithContext(ctx, &appmesh.DescribeVirtualRouterInput{
+	req := &appmesh.DescribeVirtualRouterInput{
 		MeshName:          aws.String(mesh),
 		VirtualRouterName: aws.String(name),
-	})
+	}
+	if v, ok := d.GetOk("mesh_owner"); ok {
+		req.MeshOwner = aws.String(v.(string))
+	}
+
+	resp, err := conn.DescribeVirtualRouterWithContext(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/appmesh/virtual_service.go
+++ b/internal/service/appmesh/virtual_service.go
@@ -296,10 +296,15 @@ func resourceVirtualServiceDelete(ctx context.Context, d *schema.ResourceData, m
 	conn := meta.(*conns.AWSClient).AppMeshConn()
 
 	log.Printf("[DEBUG] Deleting App Mesh Virtual Service: %s", d.Id())
-	_, err := conn.DeleteVirtualServiceWithContext(ctx, &appmesh.DeleteVirtualServiceInput{
+	req := &appmesh.DeleteVirtualServiceInput{
 		MeshName:           aws.String(d.Get("mesh_name").(string)),
 		VirtualServiceName: aws.String(d.Get("name").(string)),
-	})
+	}
+	if v, ok := d.GetOk("mesh_owner"); ok {
+		req.MeshOwner = aws.String(v.(string))
+	}
+
+	_, err := conn.DeleteVirtualServiceWithContext(ctx, req)
 	if tfawserr.ErrCodeEquals(err, appmesh.ErrCodeNotFoundException) {
 		return diags
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When mesh was shared cross account, the resource was removed from tfstate but not the AWS resource.
I created a Pull Request because this problem was solved by giving the value of `meshOwner` as an `input` when executing the AWS SDK.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
