### PR TITLE
Fix typo in dvb_sub_pids and audio_pids assignment

### DIFF
--- a/.changelog/29371.txt
+++ b/.changelog/29371.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_medialive_channel: Fix issue preventing `audio_pids` attribute from being configured in `m2ts_settings`
+```
+
+```release-note:bug
+resource/aws_medialive_channel: Fix issue causing `dbv_sub_pids` attribute to be configured incorrectly in `m2ts_settings`
+```

--- a/internal/service/medialive/channel_encoder_settings_schema.go
+++ b/internal/service/medialive/channel_encoder_settings_schema.go
@@ -3974,7 +3974,7 @@ func expandM2tsSettings(tfList []interface{}) *types.M2tsSettings {
 	if v, ok := m["audio_frames_per_pes"].(int); ok {
 		s.AudioFramesPerPes = int32(v)
 	}
-	if v, ok := m["audi_pids"].(string); ok && v != "" {
+	if v, ok := m["audio_pids"].(string); ok && v != "" {
 		s.AudioPids = aws.String(v)
 	}
 	if v, ok := m["audio_stream_type"].(string); ok && v != "" {
@@ -3996,7 +3996,7 @@ func expandM2tsSettings(tfList []interface{}) *types.M2tsSettings {
 		s.DvbSdtSettings = expandM2tsDvbSdtSettings(v)
 	}
 	if v, ok := m["dvb_sub_pids"].(string); ok && v != "" {
-		s.AudioPids = aws.String(v)
+		s.DvbSubPids = aws.String(v)
 	}
 	if v, ok := m["dvb_tdt_settings"].([]interface{}); ok && len(v) > 0 {
 		s.DvbTdtSettings = func(tfList []interface{}) *types.DvbTdtSettings {

--- a/internal/service/medialive/channel_test.go
+++ b/internal/service/medialive/channel_test.go
@@ -76,6 +76,70 @@ func TestAccMediaLiveChannel_basic(t *testing.T) {
 	})
 }
 
+func TestAccMediaLiveChannel_m2ts_settings(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var channel medialive.DescribeChannelOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_medialive_channel.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.MediaLiveEndpointID, t)
+			testAccChannelsPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckChannelDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccChannelConfig_m2tsSettings(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckChannelExists(ctx, resourceName, &channel),
+					resource.TestCheckResourceAttrSet(resourceName, "channel_id"),
+					resource.TestCheckResourceAttr(resourceName, "channel_class", "STANDARD"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "role_arn"),
+					resource.TestCheckResourceAttr(resourceName, "input_specification.0.codec", "AVC"),
+					resource.TestCheckResourceAttr(resourceName, "input_specification.0.input_resolution", "HD"),
+					resource.TestCheckResourceAttr(resourceName, "input_specification.0.maximum_bitrate", "MAX_20_MBPS"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "input_attachments.*", map[string]string{
+						"input_attachment_name": "example-input1",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "destinations.*", map[string]string{
+						"id": rName,
+					}),
+					resource.TestCheckResourceAttr(resourceName, "encoder_settings.0.timecode_config.0.source", "EMBEDDED"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "encoder_settings.0.audio_descriptions.*", map[string]string{
+						"audio_selector_name": rName,
+						"name":                rName,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "encoder_settings.0.video_descriptions.*", map[string]string{
+						"name": "test-video-name",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "encoder_settings.0.output_groups.0.outputs.0.output_settings.0.archive_output_settings.0.container_settings.0.m2ts_settings.*", map[string]string{
+						"audio_buffer_model": "ATSC",
+						"buffer_model":       "MULTIPLEX",
+						"rate_mode":          "CBR",
+						"audio_pids":         "200",
+						"dvb_sub_pids":       "300",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"start_channel"},
+			},
+		},
+	})
+}
+
 func TestAccMediaLiveChannel_audioDescriptions_codecSettings(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -635,6 +699,94 @@ resource "aws_medialive_channel" "test" {
                 audio_buffer_model = "ATSC"
                 buffer_model       = "MULTIPLEX"
                 rate_mode          = "CBR"
+	          }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, rName))
+}
+
+func testAccChannelConfig_m2tsSettings(rName string) string {
+	return acctest.ConfigCompose(
+		testAccChannelBaseConfig(rName),
+		testAccChannelBaseS3Config(rName),
+		testAccChannelBaseMultiplexConfig(rName),
+		fmt.Sprintf(`
+resource "aws_medialive_channel" "test" {
+  name          = %[1]q
+  channel_class = "STANDARD"
+  role_arn      = aws_iam_role.test.arn
+
+  input_specification {
+    codec            = "AVC"
+    input_resolution = "HD"
+    maximum_bitrate  = "MAX_20_MBPS"
+  }
+
+  input_attachments {
+    input_attachment_name = "example-input1"
+    input_id              = aws_medialive_input.test.id
+  }
+
+  destinations {
+    id = %[1]q
+
+    settings {
+      url = "s3://${aws_s3_bucket.test1.id}/test1"
+    }
+
+    settings {
+      url = "s3://${aws_s3_bucket.test2.id}/test2"
+    }
+  }
+
+  encoder_settings {
+    timecode_config {
+      source = "EMBEDDED"
+    }
+
+    audio_descriptions {
+      audio_selector_name = %[1]q
+      name                = %[1]q
+      codec_settings {
+        aac_settings {
+          rate_control_mode = "CBR"
+        }
+      }
+    }
+
+    video_descriptions {
+      name = "test-video-name"
+    }
+
+    output_groups {
+      output_group_settings {
+        archive_group_settings {
+          destination {
+            destination_ref_id = %[1]q
+          }
+        }
+      }
+
+      outputs {
+        output_name             = "test-output-name"
+        video_description_name  = "test-video-name"
+        audio_description_names = [%[1]q]
+        output_settings {
+          archive_output_settings {
+            name_modifier = "_1"
+            extension     = "m2ts"
+            container_settings {
+              m2ts_settings {
+                audio_buffer_model = "ATSC"
+                buffer_model       = "MULTIPLEX"
+                rate_mode          = "CBR"
+                audio_pids         = "200"
+                dvb_sub_pids       = "300"
               }
             }
           }

--- a/internal/service/medialive/channel_test.go
+++ b/internal/service/medialive/channel_test.go
@@ -699,7 +699,7 @@ resource "aws_medialive_channel" "test" {
                 audio_buffer_model = "ATSC"
                 buffer_model       = "MULTIPLEX"
                 rate_mode          = "CBR"
-	          }
+              }
             }
           }
         }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR fixes an issue where `dvb_sub_pids` is assigned to `audio_pids` and
a typo where `audio_pids` was misspelled `audi_pids`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccMediaLiveChannel_m2ts_settings PKG=medialive

... WIP (having a resource limit issue at the moment)
```
