### PR TITLE
r/aws_kms_grant: Tweak invalid principal error message

### DIFF
--- a/internal/service/kms/grant.go
+++ b/internal/service/kms/grant.go
@@ -312,7 +312,7 @@ func FindGrantByTwoPartKey(ctx context.Context, conn *kms.KMS, keyID, grantID st
 func findGrantByTwoPartKeyWithRetry(ctx context.Context, conn *kms.KMS, keyID, grantID string, timeout time.Duration) (*kms.GrantListEntry, error) {
 	var output *kms.GrantListEntry
 
-	err := resource.RetryContext(ctx, 3*time.Minute, func() *resource.RetryError {
+	err := resource.RetryContext(ctx, timeout, func() *resource.RetryError {
 		grant, err := FindGrantByTwoPartKey(ctx, conn, keyID, grantID)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/kms/grant.go
+++ b/internal/service/kms/grant.go
@@ -27,11 +27,10 @@ import (
 
 func ResourceGrant() *schema.Resource {
 	return &schema.Resource{
-		// There is no API for updating/modifying grants, hence no Update
-		// Instead changes to most fields will force a new resource
 		CreateWithoutTimeout: resourceGrantCreate,
 		ReadWithoutTimeout:   resourceGrantRead,
 		DeleteWithoutTimeout: resourceGrantDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				keyId, grantId, err := decodeGrantID(d.Id())
@@ -47,36 +46,8 @@ func ResourceGrant() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validGrantName,
-			},
-			"key_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"grantee_principal": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"operations": {
-				Type: schema.TypeSet,
-				Set:  schema.HashString,
-				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.StringInSlice(kms.GrantOperation_Values(), false),
-				},
-				Required: true,
-				ForceNew: true,
-			},
 			"constraints": {
 				Type:     schema.TypeSet,
-				Set:      resourceGrantConstraintsHash,
 				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
@@ -97,24 +68,14 @@ func ResourceGrant() *schema.Resource {
 						},
 					},
 				},
+				Set: resourceGrantConstraintsHash,
 			},
-			"retiring_principal": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidARN,
-			},
+
 			"grant_creation_tokens": {
 				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
-				ForceNew: true,
-			},
-			"retire_on_delete": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-				ForceNew: true,
 			},
 			"grant_id": {
 				Type:     schema.TypeString,
@@ -123,6 +84,44 @@ func ResourceGrant() *schema.Resource {
 			"grant_token": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"grantee_principal": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"key_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validGrantName,
+			},
+			"operations": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice(kms.GrantOperation_Values(), false),
+				},
+			},
+			"retire_on_delete": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+			"retiring_principal": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
 			},
 		},
 	}

--- a/internal/service/kms/grant.go
+++ b/internal/service/kms/grant.go
@@ -179,6 +179,9 @@ func resourceGrantCreate(ctx context.Context, d *schema.ResourceData, meta inter
 }
 
 func resourceGrantRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	const (
+		timeout = 3 * time.Minute
+	)
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KMSConn()
 
@@ -188,7 +191,7 @@ func resourceGrantRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		return sdkdiag.AppendErrorf(diags, "parsing resource ID: %s", err)
 	}
 
-	grant, err := findGrantByTwoPartKeyWithRetry(ctx, conn, keyID, grantID, 3*time.Minute)
+	grant, err := findGrantByTwoPartKeyWithRetry(ctx, conn, keyID, grantID, timeout)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] KMS Grant (%s) not found, removing from state", d.Id())

--- a/internal/service/kms/grant.go
+++ b/internal/service/kms/grant.go
@@ -33,7 +33,7 @@ func ResourceGrant() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-				keyId, grantId, err := decodeGrantID(d.Id())
+				keyId, grantId, err := GrantParseResourceID(d.Id())
 				if err != nil {
 					return nil, err
 				}
@@ -130,59 +130,50 @@ func ResourceGrant() *schema.Resource {
 func resourceGrantCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KMSConn()
-	keyId := d.Get("key_id").(string)
 
-	input := kms.CreateGrantInput{
+	keyID := d.Get("key_id").(string)
+	input := &kms.CreateGrantInput{
 		GranteePrincipal: aws.String(d.Get("grantee_principal").(string)),
-		KeyId:            aws.String(keyId),
+		KeyId:            aws.String(keyID),
 		Operations:       flex.ExpandStringSet(d.Get("operations").(*schema.Set)),
+	}
+
+	if v, ok := d.GetOk("constraints"); ok && v.(*schema.Set).Len() > 0 {
+		if !grantConstraintsIsValid(v.(*schema.Set)) {
+			return sdkdiag.AppendErrorf(diags, "A grant constraint can't have both encryption_context_equals and encryption_context_subset set")
+		}
+
+		input.Constraints = expandGrantConstraints(v.(*schema.Set))
+	}
+
+	if v, ok := d.GetOk("grant_creation_tokens"); ok && v.(*schema.Set).Len() > 0 {
+		input.GrantTokens = flex.ExpandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("name"); ok {
 		input.Name = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("constraints"); ok {
-		if !grantConstraintsIsValid(v.(*schema.Set)) {
-			return sdkdiag.AppendErrorf(diags, "A grant constraint can't have both encryption_context_equals and encryption_context_subset set")
-		}
-		input.Constraints = expandGrantConstraints(v.(*schema.Set))
-	}
+
 	if v, ok := d.GetOk("retiring_principal"); ok {
 		input.RetiringPrincipal = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("grant_creation_tokens"); ok {
-		input.GrantTokens = flex.ExpandStringSet(v.(*schema.Set))
-	}
 
-	var out *kms.CreateGrantOutput
-
-	err := resource.RetryContext(ctx, 3*time.Minute, func() *resource.RetryError {
-		var err error
-		out, err = conn.CreateGrantWithContext(ctx, &input)
-
-		if err != nil {
-			// Error Codes: https://docs.aws.amazon.com/sdk-for-go/api/service/kms/#KMS.CreateGrant
-			// Under some circumstances a newly created IAM Role doesn't show up and causes
-			// an InvalidArnException to be thrown.
-			if tfawserr.ErrCodeEquals(err, kms.ErrCodeDependencyTimeoutException, kms.ErrCodeInternalException, kms.ErrCodeInvalidArnException) {
-				return resource.RetryableError(err)
-			}
-			return resource.NonRetryableError(err)
-		}
-		return nil
-	})
-
-	if tfresource.TimedOut(err) {
-		out, err = conn.CreateGrantWithContext(ctx, &input)
-	}
+	// Error Codes: https://docs.aws.amazon.com/sdk-for-go/api/service/kms/#KMS.CreateGrant
+	// Under some circumstances a newly created IAM Role doesn't show up and causes
+	// an InvalidArnException to be thrown.
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 3*time.Minute, func() (interface{}, error) {
+		return conn.CreateGrantWithContext(ctx, input)
+	}, kms.ErrCodeDependencyTimeoutException, kms.ErrCodeInternalException, kms.ErrCodeInvalidArnException)
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating KMS Grant for Key (%s): %s", keyId, err)
+		return sdkdiag.AppendErrorf(diags, "creating KMS Grant for Key (%s): %s", keyID, err)
 	}
 
-	d.SetId(fmt.Sprintf("%s:%s", keyId, aws.StringValue(out.GrantId)))
-	d.Set("grant_id", out.GrantId)
-	d.Set("grant_token", out.GrantToken)
+	output := outputRaw.(*kms.CreateGrantOutput)
+	grantID := aws.StringValue(output.GrantId)
+	GrantCreateResourceID(keyID, grantID)
+	d.SetId(GrantCreateResourceID(keyID, grantID))
+	d.Set("grant_token", output.GrantToken)
 
 	return append(diags, resourceGrantRead(ctx, d, meta)...)
 }
@@ -191,45 +182,40 @@ func resourceGrantRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KMSConn()
 
-	keyId, grantId, err := decodeGrantID(d.Id())
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading KMS Grant (%s): %s", d.Id(), err)
-	}
-
-	grant, err := findGrantByIdRetry(ctx, conn, keyId, grantId)
+	keyID, grantID, err := GrantParseResourceID(d.Id())
 
 	if err != nil {
-		if tfresource.NotFound(err) {
-			log.Printf("[WARN] KMS Grant (%s) not found for Key (%s), removing from state", grantId, keyId)
-			d.SetId("")
-			return diags
-		}
-		return sdkdiag.AppendErrorf(diags, "reading KMS Grant (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "parsing resource ID: %s", err)
 	}
 
-	if grant == nil {
-		log.Printf("[WARN] KMS Grant (%s) not found for Key (%s), removing from state", grantId, keyId)
+	grant, err := findGrantByTwoPartKeyWithRetry(ctx, conn, keyID, grantID, 3*time.Minute)
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] KMS Grant (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return diags
+		return nil
 	}
 
-	if grant.GranteePrincipal != nil { // nosemgrep:ci.helper-schema-ResourceData-Set-extraneous-nil-check
-		d.Set("grantee_principal", grant.GranteePrincipal)
-	}
-	if grant.RetiringPrincipal != nil { // nosemgrep:ci.helper-schema-ResourceData-Set-extraneous-nil-check
-		d.Set("retiring_principal", grant.RetiringPrincipal)
+	if err != nil {
+		return diag.Errorf("reading KMS Grant (%s): %s", d.Id(), err)
 	}
 
-	if err := d.Set("operations", aws.StringValueSlice(grant.Operations)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting operations: %s", err)
-	}
-	if aws.StringValue(grant.Name) != "" {
-		d.Set("name", grant.Name)
-	}
 	if grant.Constraints != nil {
 		if err := d.Set("constraints", flattenGrantConstraints(grant.Constraints)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting constraints: %s", err)
 		}
+	}
+	d.Set("grant_id", grant.GrantId)
+	if grant.GranteePrincipal != nil { // nosemgrep:ci.helper-schema-ResourceData-Set-extraneous-nil-check
+		d.Set("grantee_principal", grant.GranteePrincipal)
+	}
+	d.Set("key_id", keyID)
+	if aws.StringValue(grant.Name) != "" {
+		d.Set("name", grant.Name)
+	}
+	d.Set("operations", aws.StringValueSlice(grant.Operations))
+	if grant.RetiringPrincipal != nil { // nosemgrep:ci.helper-schema-ResourceData-Set-extraneous-nil-check
+		d.Set("retiring_principal", grant.RetiringPrincipal)
 	}
 
 	return diags
@@ -239,66 +225,95 @@ func resourceGrantDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KMSConn()
 
-	keyId, grantId, err := decodeGrantID(d.Id())
+	keyID, grantID, err := GrantParseResourceID(d.Id())
+
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting KMS Grant (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "parsing resource ID: %s", err)
 	}
-	doRetire := d.Get("retire_on_delete").(bool)
 
-	if doRetire {
-		retireInput := kms.RetireGrantInput{
-			GrantId: aws.String(grantId),
-			KeyId:   aws.String(keyId),
-		}
-
-		log.Printf("[DEBUG] Retiring KMS grant: %s", grantId)
-		_, err = conn.RetireGrantWithContext(ctx, &retireInput)
+	if d.Get("retire_on_delete").(bool) {
+		log.Printf("[DEBUG] Retiring KMS Grant: %s", d.Id())
+		_, err = conn.RetireGrantWithContext(ctx, &kms.RetireGrantInput{
+			GrantId: aws.String(grantID),
+			KeyId:   aws.String(keyID),
+		})
 	} else {
-		revokeInput := kms.RevokeGrantInput{
-			GrantId: aws.String(grantId),
-			KeyId:   aws.String(keyId),
-		}
+		log.Printf("[DEBUG] Revoking KMS Grant: %s", d.Id())
+		_, err = conn.RevokeGrantWithContext(ctx, &kms.RevokeGrantInput{
+			GrantId: aws.String(grantID),
+			KeyId:   aws.String(keyID),
+		})
+	}
 
-		log.Printf("[DEBUG] Revoking KMS grant: %s", grantId)
-		_, err = conn.RevokeGrantWithContext(ctx, &revokeInput)
+	if tfawserr.ErrCodeEquals(err, kms.ErrCodeNotFoundException) {
+		return diags
 	}
 
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, kms.ErrCodeNotFoundException) {
-			return diags
-		}
 		return sdkdiag.AppendErrorf(diags, "deleting KMS Grant (%s): %s", d.Id(), err)
 	}
 
-	if err := WaitForGrantToBeRevoked(ctx, conn, keyId, grantId); err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting KMS Grant (%s): waiting for completion: %s", d.Id(), err)
+	_, err = tfresource.RetryUntilNotFound(ctx, 3*time.Minute, func() (interface{}, error) {
+		return FindGrantByTwoPartKey(ctx, conn, keyID, grantID)
+	})
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for KMS Grant (%s) delete: %s", d.Id(), err)
 	}
+
 	return diags
 }
 
-func getGrantByID(grants []*kms.GrantListEntry, grantIdentifier string) *kms.GrantListEntry {
-	for _, grant := range grants {
-		if aws.StringValue(grant.GrantId) == grantIdentifier {
-			return grant
+func FindGrantByTwoPartKey(ctx context.Context, conn *kms.KMS, keyID, grantID string) (*kms.GrantListEntry, error) {
+	input := &kms.ListGrantsInput{
+		KeyId: aws.String(keyID),
+		Limit: aws.Int64(100),
+	}
+	var output *kms.GrantListEntry
+
+	err := conn.ListGrantsPagesWithContext(ctx, input, func(page *kms.ListGrantsResponse, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.Grants {
+			if v == nil {
+				continue
+			}
+
+			if aws.StringValue(v.GrantId) == grantID {
+				output = v
+
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+
+	if tfawserr.ErrCodeEquals(err, kms.ErrCodeNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
 		}
 	}
 
-	return nil
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
 }
 
-/*
-In the functions below it is not possible to use retryOnAwsCodes function, as there
-is no describe grants call, so an error has to be created if the grant is or isn't returned
-by the list grants call when expected.
-*/
+func findGrantByTwoPartKeyWithRetry(ctx context.Context, conn *kms.KMS, keyID, grantID string, timeout time.Duration) (*kms.GrantListEntry, error) {
+	var output *kms.GrantListEntry
 
-// NB: This function only retries the grant not being returned and some edge cases, while AWS Errors
-// are handled by the findGrantByID function
-func findGrantByIdRetry(ctx context.Context, conn *kms.KMS, keyId string, grantId string) (*kms.GrantListEntry, error) {
-	var grant *kms.GrantListEntry
 	err := resource.RetryContext(ctx, 3*time.Minute, func() *resource.RetryError {
-		var err error
-		grant, err = findGrantByID(ctx, conn, keyId, grantId, nil)
+		grant, err := FindGrantByTwoPartKey(ctx, conn, keyID, grantID)
 
 		if tfresource.NotFound(err) {
 			return resource.RetryableError(err)
@@ -310,102 +325,30 @@ func findGrantByIdRetry(ctx context.Context, conn *kms.KMS, keyId string, grantI
 
 		if principal := aws.StringValue(grant.GranteePrincipal); principal != "" {
 			if !arn.IsARN(principal) {
-				return resource.RetryableError(fmt.Errorf("grantee principal is invalid: %q", principal))
+				return resource.RetryableError(fmt.Errorf("grantee principal (%s) is invalid. Perhaps the principal has been deleted or recreated", principal))
 			}
 		}
 
 		if principal := aws.StringValue(grant.RetiringPrincipal); principal != "" {
 			if !arn.IsARN(principal) {
-				return resource.RetryableError(fmt.Errorf("retiring principal is invalid: %q", principal))
+				return resource.RetryableError(fmt.Errorf("retiring principal (%s) is invalid. Perhaps the principal has been deleted or recreated", principal))
 			}
 		}
 
-		return nil
-	})
-	if tfresource.TimedOut(err) {
-		grant, err = findGrantByID(ctx, conn, keyId, grantId, nil)
-	}
-
-	return grant, err
-}
-
-// Used by the tests as well
-func WaitForGrantToBeRevoked(ctx context.Context, conn *kms.KMS, keyId string, grantId string) error {
-	var grant *kms.GrantListEntry
-	err := resource.RetryContext(ctx, 3*time.Minute, func() *resource.RetryError {
-		var err error
-		grant, err = findGrantByID(ctx, conn, keyId, grantId, nil)
-
-		if tfresource.NotFound(err) {
-			return nil
-		}
-
-		if grant != nil {
-			// Force a retry if the grant still exists
-			return resource.RetryableError(
-				fmt.Errorf("Grant still exists while expected to be revoked, retyring revocation check: %s", *grant.GrantId))
-		}
-
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-		return nil
-	})
-	if tfresource.TimedOut(err) {
-		grant, err = findGrantByID(ctx, conn, keyId, grantId, nil)
-	}
-
-	return err
-}
-
-// The ListGrants API defaults to listing only 50 grants
-// Use a marker to iterate over all grants in "pages"
-// NB: This function only retries on AWS Errors
-func findGrantByID(ctx context.Context, conn *kms.KMS, keyId string, grantId string, marker *string) (*kms.GrantListEntry, error) {
-	input := kms.ListGrantsInput{
-		KeyId:  aws.String(keyId),
-		Limit:  aws.Int64(100),
-		Marker: marker,
-	}
-
-	var out *kms.ListGrantsResponse
-	var err error
-	var grant *kms.GrantListEntry
-
-	err = resource.RetryContext(ctx, 3*time.Minute, func() *resource.RetryError {
-		out, err = conn.ListGrantsWithContext(ctx, &input)
-
-		if err != nil {
-			if tfawserr.ErrCodeEquals(err, kms.ErrCodeDependencyTimeoutException) ||
-				tfawserr.ErrCodeEquals(err, kms.ErrCodeInternalException) ||
-				tfawserr.ErrCodeEquals(err, kms.ErrCodeInvalidArnException) {
-				return resource.RetryableError(err)
-			}
-			return resource.NonRetryableError(err)
-		}
+		output = grant
 
 		return nil
 	})
+
 	if tfresource.TimedOut(err) {
-		out, err = conn.ListGrantsWithContext(ctx, &input)
+		output, err = FindGrantByTwoPartKey(ctx, conn, keyID, grantID)
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("listing KMS Grants: %w", err)
+		return nil, err
 	}
 
-	grant = getGrantByID(out.Grants, grantId)
-	if grant != nil {
-		return grant, nil
-	}
-	if aws.BoolValue(out.Truncated) {
-		log.Printf("[DEBUG] KMS Grant list truncated, getting next page via marker: %s", aws.StringValue(out.NextMarker))
-		return findGrantByID(ctx, conn, keyId, grantId, out.NextMarker)
-	}
-
-	return nil, &resource.NotFoundError{
-		Message: fmt.Sprintf("grant %s not found for key id: %s", grantId, keyId),
-	}
+	return output, nil
 }
 
 // Can't have both constraint options set:
@@ -518,20 +461,29 @@ func flattenGrantConstraints(constraint *kms.GrantConstraints) *schema.Set {
 	return constraints
 }
 
-func decodeGrantID(id string) (string, string, error) {
+const grantIDSeparator = ":"
+
+func GrantCreateResourceID(keyID, grantID string) string {
+	parts := []string{keyID, grantID}
+	id := strings.Join(parts, grantIDSeparator)
+
+	return id
+}
+
+func GrantParseResourceID(id string) (string, string, error) {
 	if arn.IsARN(id) {
 		arnParts := strings.Split(id, "/")
 		if len(arnParts) != 2 {
 			return "", "", fmt.Errorf("unexpected format of ARN (%q), expected KeyID:GrantID", id)
 		}
 		arnPrefix := arnParts[0]
-		parts := strings.Split(arnParts[1], ":")
+		parts := strings.Split(arnParts[1], grantIDSeparator)
 		if len(parts) != 2 {
 			return "", "", fmt.Errorf("unexpected format of ID (%q), expected KeyID:GrantID", id)
 		}
 		return fmt.Sprintf("%s/%s", arnPrefix, parts[0]), parts[1], nil
 	} else {
-		parts := strings.Split(id, ":")
+		parts := strings.Split(id, grantIDSeparator)
 		if len(parts) != 2 {
 			return "", "", fmt.Errorf("unexpected format of ID (%q), expected KeyID:GrantID", id)
 		}

--- a/internal/service/kms/grant_test.go
+++ b/internal/service/kms/grant_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -230,7 +229,7 @@ func TestAccKMSGrant_disappears(t *testing.T) {
 				Config: testAccGrantConfig_basic(rName, "\"Encrypt\", \"Decrypt\""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGrantExists(resourceName),
-					testAccCheckGrantDisappears(ctx, resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfkms.ResourceGrant(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -299,25 +298,6 @@ func testAccCheckGrantExists(name string) resource.TestCheckFunc {
 		}
 
 		return nil
-	}
-}
-
-func testAccCheckGrantDisappears(ctx context.Context, name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		conn := acctest.Provider.Meta().(*conns.AWSClient).KMSConn()
-
-		revokeInput := kms.RevokeGrantInput{
-			GrantId: aws.String(rs.Primary.Attributes["grant_id"]),
-			KeyId:   aws.String(rs.Primary.Attributes["key_id"]),
-		}
-
-		_, err := conn.RevokeGrantWithContext(ctx, &revokeInput)
-		return err
 	}
 }
 

--- a/internal/service/kms/key_data_source_test.go
+++ b/internal/service/kms/key_data_source_test.go
@@ -321,7 +321,7 @@ data "aws_kms_key" "test" {
 }
 
 func testAccKeyDataSourceConfig_grantToken(rName string) string {
-	return acctest.ConfigCompose(testAccGrantBaseConfig(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccGrantConfig_base(rName), fmt.Sprintf(`
 resource "aws_kms_grant" "test" {
   name              = %[1]q
   key_id            = aws_kms_key.test.key_id


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Tweaks the error message returned on refresh if a principal is not an ARN.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/29340.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccKMSGrant_' PKG=kms ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kms/... -v -count 1 -parallel 3  -run=TestAccKMSGrant_ -timeout 180m
=== RUN   TestAccKMSGrant_basic
=== PAUSE TestAccKMSGrant_basic
=== RUN   TestAccKMSGrant_withConstraints
=== PAUSE TestAccKMSGrant_withConstraints
=== RUN   TestAccKMSGrant_withRetiringPrincipal
=== PAUSE TestAccKMSGrant_withRetiringPrincipal
=== RUN   TestAccKMSGrant_bare
=== PAUSE TestAccKMSGrant_bare
=== RUN   TestAccKMSGrant_arn
=== PAUSE TestAccKMSGrant_arn
=== RUN   TestAccKMSGrant_asymmetricKey
=== PAUSE TestAccKMSGrant_asymmetricKey
=== RUN   TestAccKMSGrant_disappears
=== PAUSE TestAccKMSGrant_disappears
=== RUN   TestAccKMSGrant_crossAccountARN
=== PAUSE TestAccKMSGrant_crossAccountARN
=== CONT  TestAccKMSGrant_basic
=== CONT  TestAccKMSGrant_arn
=== CONT  TestAccKMSGrant_disappears
--- PASS: TestAccKMSGrant_basic (27.91s)
=== CONT  TestAccKMSGrant_crossAccountARN
    acctest.go:703: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccKMSGrant_crossAccountARN (0.00s)
=== CONT  TestAccKMSGrant_asymmetricKey
--- PASS: TestAccKMSGrant_arn (36.10s)
=== CONT  TestAccKMSGrant_withRetiringPrincipal
--- PASS: TestAccKMSGrant_asymmetricKey (26.31s)
=== CONT  TestAccKMSGrant_bare
--- PASS: TestAccKMSGrant_withRetiringPrincipal (32.95s)
=== CONT  TestAccKMSGrant_withConstraints
--- PASS: TestAccKMSGrant_bare (24.26s)
--- PASS: TestAccKMSGrant_withConstraints (35.03s)
--- PASS: TestAccKMSGrant_disappears (204.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	211.903s
```
