### PR TITLE
AWS Organizations Policy Attachment: Add `ignore_last_policy_exception` attribute

### DIFF
--- a/internal/service/organizations/organizations_test.go
+++ b/internal/service/organizations/organizations_test.go
@@ -60,10 +60,11 @@ func TestAccOrganizations_serial(t *testing.T) {
 			"ImportAwsManagedPolicy": testAccPolicy_importManagedPolicy,
 		},
 		"PolicyAttachment": {
-			"Account":            testAccPolicyAttachment_Account,
-			"OrganizationalUnit": testAccPolicyAttachment_OrganizationalUnit,
-			"Root":               testAccPolicyAttachment_Root,
-			"disappears":         testAccPolicyAttachment_disappears,
+			"Account":                           testAccPolicyAttachment_Account,
+			"OrganizationalUnit":                testAccPolicyAttachment_OrganizationalUnit,
+			"Root":                              testAccPolicyAttachment_Root,
+			"Account_IgnoreLastPolicyException": testAccPolicyAttachment_Account_ignoreLastPolicyException,
+			"disappears":                        testAccPolicyAttachment_disappears,
 		},
 		"DelegatedAdministrator": {
 			"basic":      testAccDelegatedAdministrator_basic,

--- a/internal/service/organizations/policy_attachment_test.go
+++ b/internal/service/organizations/policy_attachment_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -118,6 +119,36 @@ func testAccPolicyAttachment_Root(t *testing.T) {
 	})
 }
 
+func testAccPolicyAttachment_Account_ignoreLastPolicyException(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_organizations_policy_attachment.test"
+	policyIdResourceName := "aws_organizations_policy.test"
+	targetIdResourceName := "aws_organizations_organization.test"
+
+	serviceControlPolicyContent := `{"Version": "2012-10-17", "Statement": { "Effect": "Allow", "Action": "*", "Resource": "*"}}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckOrganizationsAccount(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, organizations.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyAttachmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyAttachmentConfig_account_ignoreLastPolicyException(rName, organizations.PolicyTypeServiceControlPolicy, serviceControlPolicyContent),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyAttachmentExists(ctx, resourceName),
+					// remove all other SCPs in order to generate a contraint violation on destroy which
+					// should be handled gracefully
+					testAccRemoveAllOrganizationMasterAccountSCPsExcept(ctx, rName),
+					resource.TestCheckResourceAttrPair(resourceName, "policy_id", policyIdResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_id", targetIdResourceName, "master_account_id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccPolicyAttachment_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -139,6 +170,46 @@ func testAccPolicyAttachment_disappears(t *testing.T) {
 			},
 		},
 	})
+}
+
+// testAccRemoveAllOrganizationMasterAccountSCPsExcept removes all SCP's associated with the organization
+// master account except for the provided policy name.
+//
+// This allows the ignore_last_policy_exception attribute to be exercised during destroy
+func testAccRemoveAllOrganizationMasterAccountSCPsExcept(ctx context.Context, rName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).OrganizationsConn()
+		out, err := conn.DescribeOrganizationWithContext(ctx, &organizations.DescribeOrganizationInput{})
+		if err != nil {
+			return fmt.Errorf("describe organization: %s", err)
+		}
+		if out == nil || out.Organization == nil {
+			return fmt.Errorf("describe organization: empty output")
+		}
+
+		accountID := out.Organization.MasterAccountId
+		scps, err := conn.ListPoliciesForTargetWithContext(ctx, &organizations.ListPoliciesForTargetInput{
+			Filter:   aws.String(organizations.PolicyTypeServiceControlPolicy),
+			TargetId: accountID,
+		})
+		if err != nil {
+			return fmt.Errorf("list policies for target: %s", err)
+		}
+
+		for _, p := range scps.Policies {
+			if aws.StringValue(p.Name) != rName {
+				_, err := conn.DetachPolicyWithContext(ctx, &organizations.DetachPolicyInput{
+					TargetId: accountID,
+					PolicyId: p.Id,
+				})
+				if err != nil {
+					return fmt.Errorf("detach policy: %s", err)
+				}
+			}
+		}
+
+		return nil
+	}
 }
 
 func testAccCheckPolicyAttachmentDestroy(ctx context.Context) resource.TestCheckFunc {
@@ -286,4 +357,27 @@ resource "aws_organizations_policy_attachment" "test" {
   target_id = aws_organizations_organization.test.roots[0].id
 }
 `, rName)
+}
+
+func testAccPolicyAttachmentConfig_account_ignoreLastPolicyException(rName, policyType, policyContent string) string {
+	return fmt.Sprintf(`
+resource "aws_organizations_organization" "test" {
+  enabled_policy_types = ["SERVICE_CONTROL_POLICY", "TAG_POLICY"]
+}
+
+resource "aws_organizations_policy" "test" {
+  depends_on = [aws_organizations_organization.test]
+
+  name    = "%s"
+  type    = "%s"
+  content = %s
+}
+
+resource "aws_organizations_policy_attachment" "test" {
+  policy_id = aws_organizations_policy.test.id
+  target_id = aws_organizations_organization.test.master_account_id
+
+  ignore_last_policy_exception = true
+}
+`, rName, policyType, strconv.Quote(policyContent))
 }

--- a/website/docs/r/organizations_policy_attachment.html.markdown
+++ b/website/docs/r/organizations_policy_attachment.html.markdown
@@ -45,6 +45,7 @@ The following arguments are supported:
 
 * `policy_id` - (Required) The unique identifier (ID) of the policy that you want to attach to the target.
 * `target_id` - (Required) The unique identifier (ID) of the root, organizational unit, or account number that you want to attach the policy to.
+* `ignore_last_policy_exception` - (Optional) If set to `true`, destroy will ignore errors when the attachment is the last for the associated target. The resource will be removed from state, but the attachment will be preserved to meet the AWS minimum requirement of 1 attached policy.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Description
Adds an optional `ignore_last_policy_exception` attribute, which when set to `true` will allow the resource to gracefully handle cases where the policy is the last attached to a given target. Instead of throwing an error, the resource is simply removed from state, allowing other related account destruction operations to complete.


### Relations
Relates #26797


### Output from Acceptance Testing
```
$ make testacc TESTS=TestAccOrganizations_serial PKG=organizations

...
```
