### PR TITLE
Update nullable bool

### DIFF
--- a/.ci/semgrep/types/nullable.yml
+++ b/.ci/semgrep/types/nullable.yml
@@ -23,3 +23,22 @@ rules:
             Computed: true,
           }
     severity: ERROR
+
+  - id: nullable-bool-parsing
+    languages: [go]
+    message: Prefer using `nullable.Bool(...).Value()` for checking nullable boolean values
+    patterns:
+      - pattern-either:
+        - pattern: |
+            if $V, $OK := $MAP["..."].(string); $OK && $V != "" {
+              $B, _ := strconv.ParseBool($V)
+              ...
+              $X = aws.Bool($B)
+            }
+        - pattern: |
+            if $V, $OK := d.GetOk("..."); $OK {
+              $B, _ := strconv.ParseBool($V.(string))
+              ...
+              $X = aws.Bool($B)
+            }
+    severity: ERROR

--- a/.ci/semgrep/types/nullable.yml
+++ b/.ci/semgrep/types/nullable.yml
@@ -29,16 +29,16 @@ rules:
     message: Prefer using `nullable.Bool(...).Value()` for checking nullable boolean values
     patterns:
       - pattern-either:
-        - pattern: |
-            if $V, $OK := $MAP["..."].(string); $OK && $V != "" {
-              $B, _ := strconv.ParseBool($V)
-              ...
-              $X = aws.Bool($B)
-            }
-        - pattern: |
-            if $V, $OK := d.GetOk("..."); $OK {
-              $B, _ := strconv.ParseBool($V.(string))
-              ...
-              $X = aws.Bool($B)
-            }
+          - pattern: |
+              if $V, $OK := $MAP["..."].(string); $OK && $V != "" {
+                $B, _ := strconv.ParseBool($V)
+                ...
+                $X = aws.Bool($B)
+              }
+          - pattern: |
+              if $V, $OK := d.GetOk("..."); $OK {
+                $B, _ := strconv.ParseBool($V.(string))
+                ...
+                $X = aws.Bool($B)
+              }
     severity: ERROR

--- a/.ci/semgrep/types/nullable.yml
+++ b/.ci/semgrep/types/nullable.yml
@@ -1,0 +1,25 @@
+rules:
+  - id: valid-nullable-bool
+    languages: [go]
+    message: Uses of `nullable.TypeNullableBool` must be paired with `nullable.ValidateTypeStringNullableBool` unless they are strictly `Computed`.
+    patterns:
+      - pattern: |
+          {
+            ...,
+            Type: nullable.TypeNullableBool,
+            ...,
+          }
+      - pattern-not: |
+          {
+            ...,
+            Type: nullable.TypeNullableBool,
+            ...,
+            ValidateFunc: nullable.ValidateTypeStringNullableBool,
+            ...,
+          }
+      - pattern-not: |
+          {
+            Type: nullable.TypeNullableBool,
+            Computed: true,
+          }
+    severity: ERROR

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -27,9 +27,7 @@ jobs:
       - run: |
           semgrep $COMMON_PARAMS \
             --config .ci/.semgrep.yml \
-            --config .ci/semgrep/acctest/ \
-            --config .ci/semgrep/aws/ \
-            --config .ci/semgrep/migrate/ \
+            --config .ci/semgrep/ \
             --config 'r/dgryski.semgrep-go.badnilguard' \
             --config 'r/dgryski.semgrep-go.errnilcheck' \
             --config 'r/dgryski.semgrep-go.marshaljson' \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -291,9 +291,7 @@ semall:
 		--config .ci/.semgrep-service-name1.yml \
 		--config .ci/.semgrep-service-name2.yml \
 		--config .ci/.semgrep-service-name3.yml \
-		--config .ci/semgrep/acctest/ \
-		--config .ci/semgrep/aws/ \
-		--config .ci/semgrep/migrate/ \
+		--config .ci/semgrep/ \
 		--config 'r/dgryski.semgrep-go.badnilguard' \
 		--config 'r/dgryski.semgrep-go.errnilcheck' \
 		--config 'r/dgryski.semgrep-go.marshaljson' \

--- a/internal/experimental/nullable/bool.go
+++ b/internal/experimental/nullable/bool.go
@@ -42,12 +42,13 @@ func ValidateTypeStringNullableBool(v interface{}, k string) (ws []string, es []
 		return
 	}
 
-	switch value {
-	case "", "1", "true", "0", "false":
+	if value == "" {
 		return
 	}
 
-	es = append(es, fmt.Errorf("%s: cannot parse '%s' as boolean", k, value))
+	if _, err := strconv.ParseBool(value); err != nil {
+		es = append(es, fmt.Errorf("%s: cannot parse '%s' as boolean: %w", k, value, err))
+	}
 
 	return
 }

--- a/internal/experimental/nullable/bool.go
+++ b/internal/experimental/nullable/bool.go
@@ -42,20 +42,33 @@ func ValidateTypeStringNullableBool(v interface{}, k string) (ws []string, es []
 		return
 	}
 
-	if value == "" {
+	switch value {
+	case "", "1", "true", "0", "false":
 		return
 	}
 
-	if _, err := strconv.ParseBool(value); err != nil {
-		es = append(es, fmt.Errorf("%s: cannot parse '%s' as boolean: %w", k, value, err))
-	}
+	es = append(es, fmt.Errorf("%s: cannot parse '%s' as boolean", k, value))
 
 	return
+}
+
+func DiffSuppressNullableBool(k, o, n string, d *schema.ResourceData) bool {
+	ov, onull, _ := Bool(o).Value()
+	nv, nnull, _ := Bool(n).Value()
+	if onull && nnull {
+		return true
+	}
+	if !onull && !nnull {
+		return ov == nv
+	}
+	return false
 }
 
 // DiffSuppressNullableBoolFalseAsNull allows false to be treated equivalently to null.
 // This can be used to allow a practitioner to set false when the API requires a null value,
 // as a convenience.
+// This is typically not what you want: it is indended for cases where a parameter is optional
+// in some cases and must be set in others.
 func DiffSuppressNullableBoolFalseAsNull(k, o, n string, d *schema.ResourceData) bool {
 	ov, onull, _ := Bool(o).Value()
 	nv, nnull, _ := Bool(n).Value()

--- a/internal/experimental/nullable/bool_test.go
+++ b/internal/experimental/nullable/bool_test.go
@@ -67,7 +67,7 @@ func TestNullableBool(t *testing.T) {
 func TestValidationBool(t *testing.T) {
 	t.Parallel()
 
-	runTestCases(t, []testCase{
+	runValidationTestCases(t, []testCase{
 		{
 			val: "true",
 			f:   ValidateTypeStringNullableBool,

--- a/internal/experimental/nullable/bool_test.go
+++ b/internal/experimental/nullable/bool_test.go
@@ -27,6 +27,16 @@ func TestNullableBool(t *testing.T) {
 			expectedValue: false,
 		},
 		{
+			val:           "1",
+			expectNull:    false,
+			expectedValue: true,
+		},
+		{
+			val:           "0",
+			expectNull:    false,
+			expectedValue: false,
+		},
+		{
 			val:           "",
 			expectNull:    true,
 			expectedValue: false,
@@ -73,9 +83,13 @@ func TestValidationBool(t *testing.T) {
 			f:   ValidateTypeStringNullableBool,
 		},
 		{
+			val: "1",
+			f:   ValidateTypeStringNullableBool,
+		},
+		{
 			val:         "A",
 			f:           ValidateTypeStringNullableBool,
-			expectedErr: regexp.MustCompile(`[\w]+: cannot parse 'A' as boolean: .*`),
+			expectedErr: regexp.MustCompile(`[\w]+: cannot parse 'A' as boolean`),
 		},
 		{
 			val:         1,
@@ -83,4 +97,292 @@ func TestValidationBool(t *testing.T) {
 			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be string`),
 		},
 	})
+}
+
+func TestDiffSuppressBool(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		old, new   string
+		equivalent bool
+	}{
+		// Truthy values
+		{
+			old:        "true",
+			new:        "1",
+			equivalent: true,
+		},
+		{
+			old:        "1",
+			new:        "true",
+			equivalent: true,
+		},
+
+		// Falsey values
+		{
+			old:        "false",
+			new:        "0",
+			equivalent: true,
+		},
+		{
+			old:        "0",
+			new:        "false",
+			equivalent: true,
+		},
+
+		// Truthy -> Falsey
+		{
+			old:        "true",
+			new:        "false",
+			equivalent: false,
+		},
+		{
+			old:        "true",
+			new:        "0",
+			equivalent: false,
+		},
+		{
+			old:        "1",
+			new:        "false",
+			equivalent: false,
+		},
+		{
+			old:        "1",
+			new:        "0",
+			equivalent: false,
+		},
+
+		// Falsey -> Truthy
+		{
+			old:        "false",
+			new:        "true",
+			equivalent: false,
+		},
+		{
+			old:        "false",
+			new:        "1",
+			equivalent: false,
+		},
+		{
+			old:        "0",
+			new:        "true",
+			equivalent: false,
+		},
+		{
+			old:        "0",
+			new:        "1",
+			equivalent: false,
+		},
+
+		// Null -> Truthy
+		{
+			old:        "",
+			new:        "true",
+			equivalent: false,
+		},
+		{
+			old:        "",
+			new:        "1",
+			equivalent: false,
+		},
+
+		// Null -> Falsey
+		{
+			old:        "",
+			new:        "false",
+			equivalent: false,
+		},
+		{
+			old:        "",
+			new:        "0",
+			equivalent: false,
+		},
+
+		// Truthy -> Null
+		{
+			old:        "true",
+			new:        "",
+			equivalent: false,
+		},
+		{
+			old:        "1",
+			new:        "",
+			equivalent: false,
+		},
+
+		// Falsey -> Null
+		{
+			old:        "false",
+			new:        "",
+			equivalent: false,
+		},
+		{
+			old:        "0",
+			new:        "",
+			equivalent: false,
+		},
+
+		// Null => Null
+		{
+			old:        "",
+			new:        "",
+			equivalent: true,
+		},
+	}
+
+	for i, tc := range cases {
+		v := DiffSuppressNullableBool("test_property", tc.old, tc.new, nil)
+
+		if tc.equivalent && !v {
+			t.Fatalf("expected test case %d to be equivalent", i)
+		}
+
+		if !tc.equivalent && v {
+			t.Fatalf("expected test case %d to not be equivalent", i)
+		}
+	}
+}
+
+func TestDiffSuppressBoolFalseAsNull(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		old, new   string
+		equivalent bool
+	}{
+		// Falsey -> Null
+		{
+			old:        "false",
+			new:        "",
+			equivalent: true,
+		},
+		{
+			old:        "0",
+			new:        "",
+			equivalent: true,
+		},
+
+		// Null -> Falsey
+		{
+			old:        "",
+			new:        "false",
+			equivalent: true,
+		},
+		{
+			old:        "",
+			new:        "0",
+			equivalent: true,
+		},
+
+		// Null => Null
+		{
+			old:        "",
+			new:        "",
+			equivalent: true,
+		},
+
+		// Truthy values
+		{
+			old:        "true",
+			new:        "1",
+			equivalent: false,
+		},
+		{
+			old:        "1",
+			new:        "true",
+			equivalent: false,
+		},
+
+		// Falsey values
+		{
+			old:        "false",
+			new:        "0",
+			equivalent: false,
+		},
+		{
+			old:        "0",
+			new:        "false",
+			equivalent: false,
+		},
+
+		// Truthy -> Falsey
+		{
+			old:        "true",
+			new:        "false",
+			equivalent: false,
+		},
+		{
+			old:        "true",
+			new:        "0",
+			equivalent: false,
+		},
+		{
+			old:        "1",
+			new:        "false",
+			equivalent: false,
+		},
+		{
+			old:        "1",
+			new:        "0",
+			equivalent: false,
+		},
+
+		// Falsey -> Truthy
+		{
+			old:        "false",
+			new:        "true",
+			equivalent: false,
+		},
+		{
+			old:        "false",
+			new:        "1",
+			equivalent: false,
+		},
+		{
+			old:        "0",
+			new:        "true",
+			equivalent: false,
+		},
+		{
+			old:        "0",
+			new:        "1",
+			equivalent: false,
+		},
+
+		// Null -> Truthy
+		{
+			old:        "",
+			new:        "true",
+			equivalent: false,
+		},
+		{
+			old:        "",
+			new:        "1",
+			equivalent: false,
+		},
+
+		// Truthy -> Null
+		{
+			old:        "true",
+			new:        "",
+			equivalent: false,
+		},
+		{
+			old:        "1",
+			new:        "",
+			equivalent: false,
+		},
+	}
+
+	for i, tc := range cases {
+		v := DiffSuppressNullableBoolFalseAsNull("test_property", tc.old, tc.new, nil)
+
+		if tc.equivalent && !v {
+			t.Fatalf("expected test case %d to be equivalent", i)
+		}
+
+		if !tc.equivalent && v {
+			t.Fatalf("expected test case %d to not be equivalent", i)
+		}
+	}
 }

--- a/internal/experimental/nullable/float_test.go
+++ b/internal/experimental/nullable/float_test.go
@@ -72,7 +72,7 @@ func TestNullableFloat(t *testing.T) {
 func TestValidationFloat(t *testing.T) {
 	t.Parallel()
 
-	runTestCases(t, []testCase{
+	runValidationTestCases(t, []testCase{
 		{
 			val: "1",
 			f:   ValidateTypeStringNullableFloat,

--- a/internal/experimental/nullable/int_test.go
+++ b/internal/experimental/nullable/int_test.go
@@ -62,7 +62,7 @@ func TestNullableInt(t *testing.T) {
 func TestValidationInt(t *testing.T) {
 	t.Parallel()
 
-	runTestCases(t, []testCase{
+	runValidationTestCases(t, []testCase{
 		{
 			val: "1",
 			f:   ValidateTypeStringNullableInt,
@@ -83,7 +83,7 @@ func TestValidationInt(t *testing.T) {
 func TestValidationIntAtLeast(t *testing.T) {
 	t.Parallel()
 
-	runTestCases(t, []testCase{
+	runValidationTestCases(t, []testCase{
 		{
 			val: "1",
 			f:   ValidateTypeStringNullableIntAtLeast(1),

--- a/internal/experimental/nullable/testing.go
+++ b/internal/experimental/nullable/testing.go
@@ -13,7 +13,7 @@ type testCase struct {
 	expectedErr *regexp.Regexp
 }
 
-func runTestCases(t *testing.T, cases []testCase) {
+func runValidationTestCases(t *testing.T, cases []testCase) {
 	t.Helper()
 
 	matchErr := func(errs []error, r *regexp.Regexp) bool {

--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -1191,9 +1191,7 @@ func expandRequestLaunchTemplateData(ctx context.Context, conn *ec2.EC2, d *sche
 		apiObject.DisableApiTermination = aws.Bool(v.(bool))
 	}
 
-	if v, ok := d.GetOk("ebs_optimized"); ok {
-		v, _ := strconv.ParseBool(v.(string))
-
+	if v, null, _ := nullable.Bool(d.Get("ebs_optimized").(string)).Value(); !null {
 		apiObject.EbsOptimized = aws.Bool(v)
 	}
 

--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/experimental/nullable"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -57,24 +58,16 @@ func ResourceLaunchTemplate() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"delete_on_termination": {
-										// Use TypeString to allow an "unspecified" value,
-										// since TypeBool only has true/false with false default.
-										// The conversion from bare true/false values in
-										// configurations to TypeString value is currently safe.
-										Type:             schema.TypeString,
+										Type:             nullable.TypeNullableBool,
 										Optional:         true,
-										DiffSuppressFunc: verify.SuppressEquivalentTypeStringBoolean,
-										ValidateFunc:     verify.ValidTypeStringNullableBoolean,
+										DiffSuppressFunc: nullable.DiffSuppressNullableBool,
+										ValidateFunc:     nullable.ValidateTypeStringNullableBool,
 									},
 									"encrypted": {
-										// Use TypeString to allow an "unspecified" value,
-										// since TypeBool only has true/false with false default.
-										// The conversion from bare true/false values in
-										// configurations to TypeString value is currently safe.
-										Type:             schema.TypeString,
+										Type:             nullable.TypeNullableBool,
 										Optional:         true,
-										DiffSuppressFunc: verify.SuppressEquivalentTypeStringBoolean,
-										ValidateFunc:     verify.ValidTypeStringNullableBoolean,
+										DiffSuppressFunc: nullable.DiffSuppressNullableBool,
+										ValidateFunc:     nullable.ValidateTypeStringNullableBool,
 									},
 									"iops": {
 										Type:     schema.TypeInt,
@@ -207,14 +200,10 @@ func ResourceLaunchTemplate() *schema.Resource {
 				Optional: true,
 			},
 			"ebs_optimized": {
-				// Use TypeString to allow an "unspecified" value,
-				// since TypeBool only has true/false with false default.
-				// The conversion from bare true/false values in
-				// configurations to TypeString value is currently safe.
-				Type:             schema.TypeString,
+				Type:             nullable.TypeNullableBool,
 				Optional:         true,
-				DiffSuppressFunc: verify.SuppressEquivalentTypeStringBoolean,
-				ValidateFunc:     verify.ValidTypeStringNullableBoolean,
+				DiffSuppressFunc: nullable.DiffSuppressNullableBool,
+				ValidateFunc:     nullable.ValidateTypeStringNullableBool,
 			},
 			"elastic_gpu_specifications": {
 				Type:     schema.TypeList,
@@ -707,26 +696,22 @@ func ResourceLaunchTemplate() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"associate_carrier_ip_address": {
-							Type:             schema.TypeString,
+							Type:             nullable.TypeNullableBool,
 							Optional:         true,
-							DiffSuppressFunc: verify.SuppressEquivalentTypeStringBoolean,
-							ValidateFunc:     verify.ValidTypeStringNullableBoolean,
+							DiffSuppressFunc: nullable.DiffSuppressNullableBool,
+							ValidateFunc:     nullable.ValidateTypeStringNullableBool,
 						},
 						"associate_public_ip_address": {
-							Type:             schema.TypeString,
+							Type:             nullable.TypeNullableBool,
 							Optional:         true,
-							DiffSuppressFunc: verify.SuppressEquivalentTypeStringBoolean,
-							ValidateFunc:     verify.ValidTypeStringNullableBoolean,
+							DiffSuppressFunc: nullable.DiffSuppressNullableBool,
+							ValidateFunc:     nullable.ValidateTypeStringNullableBool,
 						},
 						"delete_on_termination": {
-							// Use TypeString to allow an "unspecified" value,
-							// since TypeBool only has true/false with false default.
-							// The conversion from bare true/false values in
-							// configurations to TypeString value is currently safe.
-							Type:             schema.TypeString,
+							Type:             nullable.TypeNullableBool,
 							Optional:         true,
-							DiffSuppressFunc: verify.SuppressEquivalentTypeStringBoolean,
-							ValidateFunc:     verify.ValidTypeStringNullableBoolean,
+							DiffSuppressFunc: nullable.DiffSuppressNullableBool,
+							ValidateFunc:     nullable.ValidateTypeStringNullableBool,
 						},
 						"description": {
 							Type:     schema.TypeString,
@@ -1374,15 +1359,11 @@ func expandLaunchTemplateEBSBlockDeviceRequest(tfMap map[string]interface{}) *ec
 
 	apiObject := &ec2.LaunchTemplateEbsBlockDeviceRequest{}
 
-	if v, ok := tfMap["delete_on_termination"].(string); ok && v != "" {
-		v, _ := strconv.ParseBool(v)
-
+	if v, null, _ := nullable.Bool(tfMap["delete_on_termination"].(string)).Value(); !null {
 		apiObject.DeleteOnTermination = aws.Bool(v)
 	}
 
-	if v, ok := tfMap["encrypted"].(string); ok && v != "" {
-		v, _ := strconv.ParseBool(v)
-
+	if v, null, _ := nullable.Bool(tfMap["encrypted"].(string)).Value(); !null {
 		apiObject.Encrypted = aws.Bool(v)
 	}
 
@@ -1945,21 +1926,15 @@ func expandLaunchTemplateInstanceNetworkInterfaceSpecificationRequest(tfMap map[
 
 	apiObject := &ec2.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest{}
 
-	if v, ok := tfMap["associate_carrier_ip_address"].(string); ok && v != "" {
-		v, _ := strconv.ParseBool(v)
-
+	if v, null, _ := nullable.Bool(tfMap["associate_carrier_ip_address"].(string)).Value(); !null {
 		apiObject.AssociateCarrierIpAddress = aws.Bool(v)
 	}
 
-	if v, ok := tfMap["associate_public_ip_address"].(string); ok && v != "" {
-		v, _ := strconv.ParseBool(v)
-
+	if v, null, _ := nullable.Bool(tfMap["associate_public_ip_address"].(string)).Value(); !null {
 		apiObject.AssociatePublicIpAddress = aws.Bool(v)
 	}
 
-	if v, ok := tfMap["delete_on_termination"].(string); ok && v != "" {
-		v, _ := strconv.ParseBool(v)
-
+	if v, null, _ := nullable.Bool(tfMap["delete_on_termination"].(string)).Value(); !null {
 		apiObject.DeleteOnTermination = aws.Bool(v)
 	}
 

--- a/internal/service/ec2/ec2_launch_template_test.go
+++ b/internal/service/ec2/ec2_launch_template_test.go
@@ -180,8 +180,11 @@ func TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.device_name", "/dev/xvda"),
 					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.0.delete_on_termination", ""),
+					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.0.encrypted", ""),
 					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.0.throughput", "0"),
 					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.0.volume_size", "15"),
+					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.0.ebs.0.volume_type", ""),
 				),
 			},
 			{

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -167,15 +167,11 @@ func ResourceTargetGroup() *schema.Resource {
 				ValidateFunc: validation.IntBetween(1, 65535),
 			},
 			"preserve_client_ip": {
-				// Use TypeString to allow an "unspecified" value,
-				// since TypeBool only has true/false with false default.
-				// The conversion from bare true/false values in
-				// configurations to TypeString value is currently safe.
-				Type:             schema.TypeString,
+				Type:             nullable.TypeNullableBool,
 				Optional:         true,
 				Computed:         true,
-				DiffSuppressFunc: verify.SuppressEquivalentTypeStringBoolean,
-				ValidateFunc:     verify.ValidTypeStringNullableBoolean,
+				DiffSuppressFunc: nullable.DiffSuppressNullableBool,
+				ValidateFunc:     nullable.ValidateTypeStringNullableBool,
 			},
 			"protocol": {
 				Type:         schema.TypeString,

--- a/internal/service/elbv2/target_group_test.go
+++ b/internal/service/elbv2/target_group_test.go
@@ -429,6 +429,7 @@ func TestAccELBV2TargetGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.healthy_threshold", "3"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.unhealthy_threshold", "3"),
 					resource.TestCheckResourceAttr(resourceName, "health_check.0.matcher", "200-299"),
+					resource.TestCheckNoResourceAttr(resourceName, "preserve_client_ip"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),

--- a/internal/service/imagebuilder/container_recipe.go
+++ b/internal/service/imagebuilder/container_recipe.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/experimental/nullable"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
@@ -128,26 +129,18 @@ func ResourceContainerRecipe() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"delete_on_termination": {
-													// Use TypeString to allow an "unspecified" value,
-													// since TypeBool only has true/false with false default.
-													// The conversion from bare true/false values in
-													// configurations to TypeString value is currently safe.
-													Type:             schema.TypeString,
+													Type:             nullable.TypeNullableBool,
 													Optional:         true,
 													ForceNew:         true,
-													DiffSuppressFunc: verify.SuppressEquivalentTypeStringBoolean,
-													ValidateFunc:     verify.ValidTypeStringNullableBoolean,
+													DiffSuppressFunc: nullable.DiffSuppressNullableBool,
+													ValidateFunc:     nullable.ValidateTypeStringNullableBool,
 												},
 												"encrypted": {
-													// Use TypeString to allow an "unspecified" value,
-													// since TypeBool only has true/false with false default.
-													// The conversion from bare true/false values in
-													// configurations to TypeString value is currently safe.
-													Type:             schema.TypeString,
+													Type:             nullable.TypeNullableBool,
 													Optional:         true,
 													ForceNew:         true,
-													DiffSuppressFunc: verify.SuppressEquivalentTypeStringBoolean,
-													ValidateFunc:     verify.ValidTypeStringNullableBoolean,
+													DiffSuppressFunc: nullable.DiffSuppressNullableBool,
+													ValidateFunc:     nullable.ValidateTypeStringNullableBool,
 												},
 												"iops": {
 													Type:         schema.TypeInt,

--- a/internal/service/imagebuilder/image_recipe.go
+++ b/internal/service/imagebuilder/image_recipe.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/experimental/nullable"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
@@ -54,26 +55,18 @@ func ResourceImageRecipe() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"delete_on_termination": {
-										// Use TypeString to allow an "unspecified" value,
-										// since TypeBool only has true/false with false default.
-										// The conversion from bare true/false values in
-										// configurations to TypeString value is currently safe.
-										Type:             schema.TypeString,
+										Type:             nullable.TypeNullableBool,
 										Optional:         true,
 										ForceNew:         true,
-										DiffSuppressFunc: verify.SuppressEquivalentTypeStringBoolean,
-										ValidateFunc:     verify.ValidTypeStringNullableBoolean,
+										DiffSuppressFunc: nullable.DiffSuppressNullableBool,
+										ValidateFunc:     nullable.ValidateTypeStringNullableBool,
 									},
 									"encrypted": {
-										// Use TypeString to allow an "unspecified" value,
-										// since TypeBool only has true/false with false default.
-										// The conversion from bare true/false values in
-										// configurations to TypeString value is currently safe.
-										Type:             schema.TypeString,
+										Type:             nullable.TypeNullableBool,
 										Optional:         true,
 										ForceNew:         true,
-										DiffSuppressFunc: verify.SuppressEquivalentTypeStringBoolean,
-										ValidateFunc:     verify.ValidTypeStringNullableBoolean,
+										DiffSuppressFunc: nullable.DiffSuppressNullableBool,
+										ValidateFunc:     nullable.ValidateTypeStringNullableBool,
 									},
 									"iops": {
 										Type:         schema.TypeInt,
@@ -511,14 +504,12 @@ func expandEBSInstanceBlockDeviceSpecification(tfMap map[string]interface{}) *im
 
 	apiObject := &imagebuilder.EbsInstanceBlockDeviceSpecification{}
 
-	if v, ok := tfMap["delete_on_termination"].(string); ok && v != "" {
-		vBool, _ := strconv.ParseBool(v) // ignore error as previously validatated
-		apiObject.DeleteOnTermination = aws.Bool(vBool)
+	if v, null, _ := nullable.Bool(tfMap["delete_on_termination"].(string)).Value(); !null {
+		apiObject.DeleteOnTermination = aws.Bool(v)
 	}
 
-	if v, ok := tfMap["encrypted"].(string); ok && v != "" {
-		vBool, _ := strconv.ParseBool(v) // ignore error as previously validatated
-		apiObject.Encrypted = aws.Bool(vBool)
+	if v, null, _ := nullable.Bool(tfMap["encrypted"].(string)).Value(); !null {
+		apiObject.Encrypted = aws.Bool(v)
 	}
 
 	if v, ok := tfMap["iops"].(int); ok && v != 0 {

--- a/internal/verify/diff.go
+++ b/internal/verify/diff.go
@@ -75,19 +75,6 @@ func SuppressEquivalentRoundedTime(layout string, d time.Duration) schema.Schema
 	}
 }
 
-// SuppressEquivalentTypeStringBoolean provides custom difference suppression for TypeString booleans
-// Some arguments require three values: true, false, and "" (unspecified), but
-// confusing behavior exists when converting bare true/false values with state.
-func SuppressEquivalentTypeStringBoolean(k, old, new string, d *schema.ResourceData) bool {
-	if old == "false" && new == "0" {
-		return true
-	}
-	if old == "true" && new == "1" {
-		return true
-	}
-	return false
-}
-
 // SuppressMissingOptionalConfigurationBlock handles configuration block attributes in the following scenario:
 //   - The resource schema includes an optional configuration block with defaults
 //   - The API response includes those defaults to refresh into the Terraform state

--- a/internal/verify/diff_test.go
+++ b/internal/verify/diff_test.go
@@ -61,49 +61,6 @@ func TestSuppressEquivalentRoundedTime(t *testing.T) {
 	}
 }
 
-func TestSuppressEquivalentTypeStringBoolean(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		old        string
-		new        string
-		equivalent bool
-	}{
-		{
-			old:        "false",
-			new:        "0",
-			equivalent: true,
-		},
-		{
-			old:        "true",
-			new:        "1",
-			equivalent: true,
-		},
-		{
-			old:        "",
-			new:        "0",
-			equivalent: false,
-		},
-		{
-			old:        "",
-			new:        "1",
-			equivalent: false,
-		},
-	}
-
-	for i, tc := range testCases {
-		value := SuppressEquivalentTypeStringBoolean("test_property", tc.old, tc.new, nil)
-
-		if tc.equivalent && !value {
-			t.Fatalf("expected test case %d to be equivalent", i)
-		}
-
-		if !tc.equivalent && value {
-			t.Fatalf("expected test case %d to not be equivalent", i)
-		}
-	}
-}
-
 func TestDiffStringMaps(t *testing.T) {
 	t.Parallel()
 

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -308,28 +308,6 @@ func ValidStringIsJSONOrYAML(v interface{}, k string) (ws []string, errors []err
 	return
 }
 
-// ValidTypeStringNullableBoolean provides custom error messaging for TypeString booleans
-// Some arguments require three values: true, false, and "" (unspecified).
-// This ValidateFunc returns a custom message since the message with
-// validation.StringInSlice([]string{"", "false", "true"}, false) is confusing:
-// to be one of [ false true], got 1
-func ValidTypeStringNullableBoolean(v interface{}, k string) (ws []string, es []error) {
-	value, ok := v.(string)
-	if !ok {
-		es = append(es, fmt.Errorf("expected type of %s to be string", k))
-		return
-	}
-
-	for _, str := range []string{"", "0", "1", "false", "true"} {
-		if value == str {
-			return
-		}
-	}
-
-	es = append(es, fmt.Errorf("expected %s to be one of [\"\", false, true], got %s", k, value))
-	return
-}
-
 // ValidTypeStringNullableFloat provides custom error messaging for TypeString floats
 // Some arguments require a floating point value or an unspecified, empty field.
 func ValidTypeStringNullableFloat(v interface{}, k string) (ws []string, es []error) {

--- a/internal/verify/validate_test.go
+++ b/internal/verify/validate_test.go
@@ -42,62 +42,6 @@ func TestValid4ByteASNString(t *testing.T) {
 	}
 }
 
-func TestValidTypeStringNullableBoolean(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		val         interface{}
-		expectedErr *regexp.Regexp
-	}{
-		{
-			val: "",
-		},
-		{
-			val: "0",
-		},
-		{
-			val: "1",
-		},
-		{
-			val: "true",
-		},
-		{
-			val: "false",
-		},
-		{
-			val:         "invalid",
-			expectedErr: regexp.MustCompile(`to be one of \["", false, true\]`),
-		},
-	}
-
-	matchErr := func(errs []error, r *regexp.Regexp) bool {
-		// err must match one provided
-		for _, err := range errs {
-			if r.MatchString(err.Error()) {
-				return true
-			}
-		}
-
-		return false
-	}
-
-	for i, tc := range testCases {
-		_, errs := ValidTypeStringNullableBoolean(tc.val, "test_property")
-
-		if len(errs) == 0 && tc.expectedErr == nil {
-			continue
-		}
-
-		if len(errs) != 0 && tc.expectedErr == nil {
-			t.Fatalf("expected test case %d to produce no errors, got %v", i, errs)
-		}
-
-		if !matchErr(errs, tc.expectedErr) {
-			t.Fatalf("expected test case %d to produce error matching \"%s\", got %v", i, tc.expectedErr, errs)
-		}
-	}
-}
-
 func TestValidTypeStringNullableFloat(t *testing.T) {
 	t.Parallel()
 

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -168,27 +168,28 @@ To find out more information for an existing AMI to override the configuration, 
 
 Each `block_device_mappings` supports the following:
 
-* `device_name` - The name of the device to mount.
-* `ebs` - Configure EBS volume properties.
-* `no_device` - Suppresses the specified device included in the AMI's block device mapping.
-* `virtual_name` - The [Instance Store Device
+* `device_name` - (Optional) The name of the device to mount.
+* `ebs` - (Optional) Configure EBS volume properties.
+* `no_device` - (Optional) Suppresses the specified device included in the AMI's block device mapping.
+* `virtual_name` - (Optional) The [Instance Store Device
   Name](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStoreDeviceNames)
   (e.g., `"ephemeral0"`).
 
 The `ebs` block supports the following:
 
-* `delete_on_termination` - Whether the volume should be destroyed on instance termination. Defaults to `false` if not set. See [Preserving Amazon EBS Volumes on Instance Termination](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#preserving-volumes-on-termination) for more information.
-* `encrypted` - Enables [EBS encryption](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html)
-  on the volume (Default: `false`). Cannot be used with `snapshot_id`.
-* `iops` - The amount of provisioned
-  [IOPS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html).
+* `delete_on_termination` - (Optional) Whether the volume should be destroyed on instance termination.
+  See [Preserving Amazon EBS Volumes on Instance Termination](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#preserving-volumes-on-termination) for more information.
+* `encrypted` - (Optional) Enables [EBS encryption](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html) on the volume.
+  Cannot be used with `snapshot_id`.
+* `iops` - (Optional) The amount of provisioned [IOPS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html).
   This must be set with a `volume_type` of `"io1/io2"`.
-* `kms_key_id` - The ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) to use when creating the encrypted volume.
- `encrypted` must be set to `true` when this is set.
-* `snapshot_id` - The Snapshot ID to mount.
-* `throughput` - The throughput to provision for a `gp3` volume in MiB/s (specified as an integer, e.g., 500), with a maximum of 1,000 MiB/s.
-* `volume_size` - The size of the volume in gigabytes.
-* `volume_type` - The volume type. Can be `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1` or `st1` (Default: `gp2`).
+* `kms_key_id` - (Optional) The ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) to use when creating the encrypted volume.
+  `encrypted` must be set to `true` when this is set.
+* `snapshot_id` - (Optional) The Snapshot ID to mount.
+* `throughput` - (Optional) The throughput to provision for a `gp3` volume in MiB/s (specified as an integer, e.g., 500), with a maximum of 1,000 MiB/s.
+* `volume_size` - (Optional) The size of the volume in gigabytes.
+* `volume_type` - (Optional) The volume type.
+  Can be one of `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1` or `st1`.
 
 ### Capacity Reservation Specification
 
@@ -421,25 +422,28 @@ Check limitations for autoscaling group in [Creating an Auto Scaling Group Using
 
 Each `network_interfaces` block supports the following:
 
-* `associate_carrier_ip_address` - Associate a Carrier IP address with `eth0` for a new network interface. Use this option when you launch an instance in a Wavelength Zone and want to associate a Carrier IP address with the network interface. Boolean value.
-* `associate_public_ip_address` - Associate a public ip address with the network interface.  Boolean value.
-* `delete_on_termination` - Whether the network interface should be destroyed on instance termination. Defaults to `false` if not set.
-* `description` - Description of the network interface.
-* `device_index` - The integer index of the network interface attachment.
-* `interface_type` - The type of network interface. To create an Elastic Fabric Adapter (EFA), specify `efa`.
-* `ipv4_prefix_count` - The number of IPv4 prefixes to be automatically assigned to the network interface. Conflicts with `ipv4_prefixes`
-* `ipv4_prefixes` - One or more IPv4 prefixes to be assigned to the network interface. Conflicts with `ipv4_prefix_count`
-* `ipv6_addresses` - One or more specific IPv6 addresses from the IPv6 CIDR block range of your subnet. Conflicts with `ipv6_address_count`
-* `ipv6_address_count` - The number of IPv6 addresses to assign to a network interface. Conflicts with `ipv6_addresses`
-* `ipv6_prefix_count` - The number of IPv6 prefixes to be automatically assigned to the network interface. Conflicts with `ipv6_prefixes`
-* `ipv6_prefixes` - One or more IPv6 prefixes to be assigned to the network interface. Conflicts with `ipv6_prefix_count`
-* `network_interface_id` - The ID of the network interface to attach.
-* `network_card_index` - The index of the network card. Some instance types support multiple network cards. The primary network interface must be assigned to network card index 0. The default is network card index 0.
-* `private_ip_address` - The primary private IPv4 address.
-* `ipv4_address_count` - The number of secondary private IPv4 addresses to assign to a network interface. Conflicts with `ipv4_addresses`
-* `ipv4_addresses` - One or more private IPv4 addresses to associate. Conflicts with `ipv4_address_count`
-* `security_groups` - A list of security group IDs to associate.
-* `subnet_id` - The VPC Subnet ID to associate.
+* `associate_carrier_ip_address` - (Optional) Associate a Carrier IP address with `eth0` for a new network interface.
+  Use this option when you launch an instance in a Wavelength Zone and want to associate a Carrier IP address with the network interface.
+  Boolean value, can be left unset.
+* `associate_public_ip_address` - (Optional) Associate a public ip address with the network interface.
+  Boolean value, can be left unset.
+* `delete_on_termination` - (Optional) Whether the network interface should be destroyed on instance termination.
+* `description` - (Optional) Description of the network interface.
+* `device_index` - (Optional) The integer index of the network interface attachment.
+* `interface_type` - (Optional) The type of network interface. To create an Elastic Fabric Adapter (EFA), specify `efa`.
+* `ipv4_prefix_count` - (Optional) The number of IPv4 prefixes to be automatically assigned to the network interface. Conflicts with `ipv4_prefixes`
+* `ipv4_prefixes` - (Optional) One or more IPv4 prefixes to be assigned to the network interface. Conflicts with `ipv4_prefix_count`
+* `ipv6_addresses` - (Optional) One or more specific IPv6 addresses from the IPv6 CIDR block range of your subnet. Conflicts with `ipv6_address_count`
+* `ipv6_address_count` - (Optional) The number of IPv6 addresses to assign to a network interface. Conflicts with `ipv6_addresses`
+* `ipv6_prefix_count` - (Optional) The number of IPv6 prefixes to be automatically assigned to the network interface. Conflicts with `ipv6_prefixes`
+* `ipv6_prefixes` - (Optional) One or more IPv6 prefixes to be assigned to the network interface. Conflicts with `ipv6_prefix_count`
+* `network_interface_id` - (Optional) The ID of the network interface to attach.
+* `network_card_index` - (Optional) The index of the network card. Some instance types support multiple network cards. The primary network interface must be assigned to network card index 0. The default is network card index 0.
+* `private_ip_address` - (Optional) The primary private IPv4 address.
+* `ipv4_address_count` - (Optional) The number of secondary private IPv4 addresses to assign to a network interface. Conflicts with `ipv4_addresses`
+* `ipv4_addresses` - (Optional) One or more private IPv4 addresses to associate. Conflicts with `ipv4_address_count`
+* `security_groups` - (Optional) A list of security group IDs to associate.
+* `subnet_id` - (Optional) The VPC Subnet ID to associate.
 
 ### Placement
 
@@ -447,22 +451,22 @@ The [Placement Group](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placem
 
 The `placement` block supports the following:
 
-* `affinity` - The affinity setting for an instance on a Dedicated Host.
-* `availability_zone` - The Availability Zone for the instance.
-* `group_name` - The name of the placement group for the instance.
-* `host_id` - The ID of the Dedicated Host for the instance.
-* `host_resource_group_arn` - The ARN of the Host Resource Group in which to launch instances.
-* `spread_domain` - Reserved for future use.
-* `tenancy` - The tenancy of the instance (if the instance is running in a VPC). Can be `default`, `dedicated`, or `host`.
-* `partition_number` - The number of the partition the instance should launch in. Valid only if the placement group strategy is set to partition.
+* `affinity` - (Optional) The affinity setting for an instance on a Dedicated Host.
+* `availability_zone` - (Optional) The Availability Zone for the instance.
+* `group_name` - (Optional) The name of the placement group for the instance.
+* `host_id` - (Optional) The ID of the Dedicated Host for the instance.
+* `host_resource_group_arn` - (Optional) The ARN of the Host Resource Group in which to launch instances.
+* `spread_domain` - (Optional) Reserved for future use.
+* `tenancy` - (Optional) The tenancy of the instance (if the instance is running in a VPC). Can be `default`, `dedicated`, or `host`.
+* `partition_number` - (Optional) The number of the partition the instance should launch in. Valid only if the placement group strategy is set to partition.
 
 ### Private DNS Name Options
 
 The `private_dns_name_options` block supports the following:
 
-* `enable_resource_name_dns_aaaa_record` - Indicates whether to respond to DNS queries for instance hostnames with DNS AAAA records.
-* `enable_resource_name_dns_a_record` - Indicates whether to respond to DNS queries for instance hostnames with DNS A records.
-* `hostname_type` - The type of hostname for Amazon EC2 instances. For IPv4 only subnets, an instance DNS name must be based on the instance IPv4 address. For IPv6 native subnets, an instance DNS name must be based on the instance ID. For dual-stack subnets, you can specify whether DNS names use the instance IPv4 address or the instance ID. Valid values: `ip-name` and `resource-name`.
+* `enable_resource_name_dns_aaaa_record` - (Optional) Indicates whether to respond to DNS queries for instance hostnames with DNS AAAA records.
+* `enable_resource_name_dns_a_record` - (Optional) Indicates whether to respond to DNS queries for instance hostnames with DNS A records.
+* `hostname_type` - (Optional) The type of hostname for Amazon EC2 instances. For IPv4 only subnets, an instance DNS name must be based on the instance IPv4 address. For IPv6 native subnets, an instance DNS name must be based on the instance ID. For dual-stack subnets, you can specify whether DNS names use the instance IPv4 address or the instance ID. Valid values: `ip-name` and `resource-name`.
 
 ### Tag Specifications
 
@@ -470,8 +474,8 @@ The tags to apply to the resources during launch. You can tag instances, volumes
 
 Each `tag_specifications` block supports the following:
 
-* `resource_type` - The type of resource to tag.
-* `tags` - A map of tags to assign to the resource.
+* `resource_type` - (Optional) The type of resource to tag.
+* `tags` -(Optional)  A map of tags to assign to the resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
In `aws_launch_template` replaces type and validation functions with `nullable.TypeNullableBool` and associated functions to make intention more clear. Updates documentation to correct parameters that take nullable bool values.

Also updates nullable bool values in `aws_imagebuilder_container_recipe` and `aws_imagebuilder_image_recipe`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #27716

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=ec2 TESTS=TestAccEC2LaunchTemplate_

--- PASS: TestAccEC2LaunchTemplate_cpuOptions (53.19s)
--- PASS: TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock (58.68s)
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes (61.72s)
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_t4g (63.02s)
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes (63.14s)
--- PASS: TestAccEC2LaunchTemplate_basic (63.94s)
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceType (63.94s)
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceCardIndex (64.05s)
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount (64.06s)
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount (65.11s)
--- PASS: TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN (69.77s)
--- PASS: TestAccEC2LaunchTemplate_networkInterface (71.03s)
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceAddresses (73.26s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes (109.67s)
--- PASS: TestAccEC2LaunchTemplate_CapacityReservation_target (52.71s)
--- PASS: TestAccEC2LaunchTemplate_CapacityReservation_preference (50.44s)
--- PASS: TestAccEC2LaunchTemplate_data (51.07s)
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_t2 (45.69s)
--- PASS: TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs (61.05s)
--- PASS: TestAccEC2LaunchTemplate_hibernation (127.50s)
--- PASS: TestAccEC2LaunchTemplate_enclaveOptions (127.92s)
--- PASS: TestAccEC2LaunchTemplate_defaultVersion (128.81s)
--- PASS: TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_gp3 (63.05s)
--- PASS: TestAccEC2LaunchTemplate_elasticInferenceAccelerator (80.76s)
--- PASS: TestAccEC2LaunchTemplate_associatePublicIPAddress (140.20s)
--- PASS: TestAccEC2LaunchTemplate_associateCarrierIPAddress (141.49s)
--- PASS: TestAccEC2LaunchTemplate_description (80.14s)
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_t3 (44.14s)
--- PASS: TestAccEC2LaunchTemplate_updateDefaultVersion (158.51s)
--- PASS: TestAccEC2LaunchTemplate_update (108.01s)
--- PASS: TestAccEC2LaunchTemplate_tags (110.28s)
--- PASS: TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_deleteOnTermination (105.22s)
--- PASS: TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount (43.58s)
--- PASS: TestAccEC2LaunchTemplate_disappears (30.91s)
--- PASS: TestAccEC2LaunchTemplate_Name_prefix (43.53s)
--- PASS: TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination (135.01s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers (88.30s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers (89.21s)
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_nonBurstable (44.71s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes (86.36s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames (88.84s)
--- PASS: TestAccEC2LaunchTemplate_Name_generated (47.43s)
--- PASS: TestAccEC2LaunchTemplate_privateDNSNameOptions (48.24s)
--- PASS: TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses (47.41s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice (50.60s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount (91.01s)
--- PASS: TestAccEC2LaunchTemplate_ebsOptimized (168.15s)
--- PASS: TestAccEC2LaunchTemplate_licenseSpecification (46.41s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps (123.18s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance (127.20s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice (44.30s)
--- PASS: TestAccEC2LaunchTemplate_instanceMarketOptions (107.29s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB (121.14s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_bareMetal (126.14s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount (118.69s)
--- PASS: TestAccEC2LaunchTemplate_Placement_partitionNum (56.28s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport (62.91s)
--- PASS: TestAccEC2LaunchTemplate_metadataOptions (82.85s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes (54.54s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations (49.08s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB (79.67s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU (64.47s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_localStorage (62.10s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount (66.24s)
```

```
$ make testacc PKG=ec2 TESTS=TestAccEC2LaunchTemplate_

--- PASS: TestAccImageBuilderImageRecipe_disappears (44.90s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName (48.08s)
--- PASS: TestAccImageBuilderContainerRecipe_kmsKeyID (48.73s)
--- PASS: TestAccImageBuilderContainerRecipe_basic (48.77s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName (48.81s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping_virtualName (48.85s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping_noDevice (49.46s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_volumeSize (49.50s)
--- PASS: TestAccImageBuilderImageRecipe_description (50.04s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID (50.16s)
--- PASS: TestAccImageBuilderContainerRecipe_workingDirectory (50.30s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_throughput (50.70s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_Image (50.87s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_volumeType (51.00s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops (51.05s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3 (51.09s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_throughput (51.21s)
--- PASS: TestAccImageBuilderImageRecipe_basic (57.32s)
--- FAIL: TestAccImageBuilderImageRecipe_component (25.66s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID (83.76s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice (44.26s)
--- PASS: TestAccImageBuilderImageRecipe_componentParameter (41.39s)
--- PASS: TestAccImageBuilderImageRecipe_pipelineUpdateDependency (94.56s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping_deviceName (45.30s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_deleteOnTermination (46.19s)
--- PASS: TestAccImageBuilderContainerRecipe_description (46.23s)
--- PASS: TestAccImageBuilderImageRecipe_windowsBaseImage (49.14s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_encrypted (47.77s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_iops (48.18s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2 (49.23s)
--- PASS: TestAccImageBuilderContainerRecipe_component (42.47s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted (48.79s)
--- PASS: TestAccImageBuilderImageRecipe_userDataBase64 (51.36s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_kmsKeyID (50.23s)
--- PASS: TestAccImageBuilderContainerRecipe_componentParameter (52.15s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination (35.78s)
--- PASS: TestAccImageBuilderContainerRecipe_disappears (23.88s)
--- PASS: TestAccImageBuilderImageRecipe_systemsManagerAgent (33.43s)
--- PASS: TestAccImageBuilderImageRecipe_workingDirectory (26.85s)
--- PASS: TestAccImageBuilderContainerRecipe_dockerfileTemplateURI (27.08s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_snapshotID (71.95s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize (25.15s)
--- PASS: TestAccImageBuilderContainerRecipe_tags (74.79s)
--- PASS: TestAccImageBuilderImageRecipe_tags (75.95s)
--- PASS: TestAccImageBuilderImageRecipe_updateDependency (43.01s)
```

`TestAccImageBuilderImageRecipe_component` is a pre-existing failure