### PR TITLE
acctest/aws_imagebuilder_image_recipe: removes version restriction

### DIFF
--- a/internal/service/imagebuilder/image_recipe_test.go
+++ b/internal/service/imagebuilder/image_recipe_test.go
@@ -1075,11 +1075,11 @@ func testAccImageRecipeConfig_component(rName string) string {
 		testAccImageRecipeBaseConfig(rName),
 		fmt.Sprintf(`
 data "aws_imagebuilder_component" "aws-cli-version-2-linux" {
-  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/aws-cli-version-2-linux/1.0.0"
+  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/aws-cli-version-2-linux/x.x.x"
 }
 
 data "aws_imagebuilder_component" "update-linux" {
-  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/1.0.0"
+  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
 }
 
 resource "aws_imagebuilder_image_recipe" "test" {


### PR DESCRIPTION
The acceptance test `TestAccImageBuilderImageRecipe_component` currently has a version restriction that references a deprecated depency. This causes a test failure

> Error: creating Image Builder Image Recipe: InvalidParameterValueException: The value supplied for parameter 'components' is not valid. Component ARN 'arn:aws:imagebuilder:us-west-2:aws:component/aws-cli-version-2-linux/1.0.0/1' is deprecated and cannot be included in new Recipes.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=imagebuilder TESTS=TestAccImageBuilderImageRecipe_component

--- PASS: TestAccImageBuilderImageRecipe_componentParameter (15.30s)
--- PASS: TestAccImageBuilderImageRecipe_component (23.49s)
```
