### PR TITLE
resource/aws_secretsmanager_secret: Retries reading resource until policy returns valid principals

### DIFF
--- a/internal/service/iam/policy_model_test.go
+++ b/internal/service/iam/policy_model_test.go
@@ -1,4 +1,4 @@
-package sns
+package iam
 
 import (
 	"encoding/json"
@@ -204,7 +204,7 @@ func TestPolicyHasValidAWSPrincipals(t *testing.T) { // nosemgrep:ci.aws-in-func
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			valid, err := policyHasValidAWSPrincipals(testcase.json)
+			valid, err := PolicyHasValidAWSPrincipals(testcase.json)
 
 			if testcase.err == nil {
 				if err != nil {
@@ -254,7 +254,7 @@ func TestIsValidAWSPrincipal(t *testing.T) { // nosemgrep:ci.aws-in-func-name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			a := isValidAWSPrincipal(testcase.value)
+			a := isValidPolicyAWSPrincipal(testcase.value)
 
 			if e := testcase.valid; a != e {
 				t.Fatalf("expected %t, got %t", e, a)

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -279,7 +279,7 @@ func resourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	role := outputRaw.(*iam.Role)
 
-	// occasionally, immediately after a role is created, AWS will give an ARN like AROAQ7SSZBKHRKPWRZUN6 (unique ID)
+	// occasionally, immediately after a role is created, AWS will give an ARN like AROAQ7SSZBKHREXAMPLE (unique ID)
 	if role, err = waitRoleARNIsNotUniqueID(ctx, conn, d.Id(), role); err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading IAM Role (%s): waiting for valid ARN: %s", d.Id(), err)
 	}

--- a/internal/service/sns/find.go
+++ b/internal/service/sns/find.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -47,7 +48,7 @@ func FindTopicAttributesByARN(ctx context.Context, conn *sns.SNS, arn string) (m
 			return resource.NonRetryableError(err)
 		}
 
-		valid, err := policyHasValidAWSPrincipals(attributes[TopicAttributeNamePolicy])
+		valid, err := tfiam.PolicyHasValidAWSPrincipals(attributes[TopicAttributeNamePolicy])
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}

--- a/internal/tfresource/retry_test.go
+++ b/internal/tfresource/retry_test.go
@@ -227,7 +227,7 @@ func TestRetryWhenNewResourceNotFound(t *testing.T) { //nolint:tparallel
 		t.Run(testCase.Name, func(t *testing.T) {
 			retryCount = 0
 
-			_, err := tfresource.RetryWhenNotFound(ctx, 5*time.Second, testCase.F)
+			_, err := tfresource.RetryWhenNewResourceNotFound(ctx, 5*time.Second, testCase.F, testCase.NewResource)
 
 			if testCase.ExpectError && err == nil {
 				t.Fatal("expected error")


### PR DESCRIPTION
In some cases, there is a race condition with Secrets Manager Secrets where an IAM unique id is returned instead of a valid principal ARN. Retry reading until the principals are valid.


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=secretsmanager TESTS=TestAccSecretsManagerSecret_

--- PASS: TestAccSecretsManagerSecret_withNamePrefix (38.93s)
--- PASS: TestAccSecretsManagerSecret_basic (40.79s)
--- PASS: TestAccSecretsManagerSecret_basicReplica (57.46s)
--- PASS: TestAccSecretsManagerSecret_description (63.58s)
--- PASS: TestAccSecretsManagerSecret_kmsKeyID (65.19s)
--- PASS: TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate (65.50s)
--- PASS: TestAccSecretsManagerSecret_policy (90.05s)
--- PASS: TestAccSecretsManagerSecret_rotationRules (95.67s)
--- PASS: TestAccSecretsManagerSecret_rotationLambdaARN (98.18s)
--- PASS: TestAccSecretsManagerSecret_tags (107.84s)
--- PASS: TestAccSecretsManagerSecret_overwriteReplica (178.41s)
```
