### PR TITLE
New Resource: `aws_lightsail_bucket_resource_access`

### DIFF
--- a/.changelog/29460.txt
+++ b/.changelog/29460.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_lightsail_bucket_resource_access
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1741,6 +1741,7 @@ func New(ctx context.Context) (*schema.Provider, error) {
 
 			"aws_lightsail_bucket":                               lightsail.ResourceBucket(),
 			"aws_lightsail_bucket_access_key":                    lightsail.ResourceBucketAccessKey(),
+			"aws_lightsail_bucket_resource_access":               lightsail.ResourceBucketResourceAccess(),
 			"aws_lightsail_certificate":                          lightsail.ResourceCertificate(),
 			"aws_lightsail_container_service":                    lightsail.ResourceContainerService(),
 			"aws_lightsail_container_service_deployment_version": lightsail.ResourceContainerServiceDeploymentVersion(),

--- a/internal/service/lightsail/bucket_resource_access.go
+++ b/internal/service/lightsail/bucket_resource_access.go
@@ -1,0 +1,147 @@
+package lightsail
+
+import (
+	"context"
+	"errors"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+const (
+	BucketResourceAccessIdPartsCount = 2
+)
+
+func ResourceBucketResourceAccess() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceBucketResourceAccessCreate,
+		ReadWithoutTimeout:   resourceBucketResourceAccessRead,
+		DeleteWithoutTimeout: resourceBucketResourceAccessDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"bucket_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,52}[a-z0-9]$`), "Invalid Bucket name. Must match regex: ^[a-z0-9][a-z0-9-]{1,52}[a-z0-9]$"),
+			},
+			"resource_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`\w[\w\-]*\w`), "Invalid resource name. Must match regex: \\w[\\w\\-]*\\w"),
+			},
+		},
+	}
+}
+
+func resourceBucketResourceAccessCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn()
+
+	in := lightsail.SetResourceAccessForBucketInput{
+		BucketName:   aws.String(d.Get("bucket_name").(string)),
+		ResourceName: aws.String(d.Get("resource_name").(string)),
+		Access:       aws.String(lightsail.ResourceBucketAccessAllow),
+	}
+
+	out, err := conn.SetResourceAccessForBucketWithContext(ctx, &in)
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeSetResourceAccessForBucket, ResBucketResourceAccess, d.Get("bucket_name").(string), err)
+	}
+
+	if len(out.Operations) == 0 {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeSetResourceAccessForBucket, ResBucketResourceAccess, d.Get("bucket_name").(string), errors.New("No operations found for request"))
+	}
+
+	op := out.Operations[0]
+
+	err = waitOperation(ctx, conn, op.Id)
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeSetResourceAccessForBucket, ResBucketResourceAccess, d.Get("bucket_name").(string), errors.New("Error waiting for request operation"))
+	}
+
+	idParts := []string{d.Get("bucket_name").(string), d.Get("resource_name").(string)}
+	id, err := flex.FlattenResourceId(idParts, BucketResourceAccessIdPartsCount)
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, create.ErrActionFlatteningResourceId, ResBucketResourceAccess, d.Get("bucket_name").(string), err)
+	}
+
+	d.SetId(id)
+
+	return resourceBucketResourceAccessRead(ctx, d, meta)
+}
+
+func resourceBucketResourceAccessRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn()
+
+	out, err := FindBucketResourceAccessById(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		create.LogNotFoundRemoveState(names.Lightsail, create.ErrActionReading, ResBucketResourceAccess, d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, create.ErrActionReading, ResBucketResourceAccess, d.Id(), err)
+	}
+
+	parts, err := flex.ExpandResourceId(d.Id(), BucketResourceAccessIdPartsCount)
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, create.ErrActionExpandingResourceId, ResBucketResourceAccess, d.Id(), err)
+	}
+
+	d.Set("bucket_name", parts[0])
+	d.Set("resource_name", out.Name)
+
+	return nil
+}
+
+func resourceBucketResourceAccessDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).LightsailConn()
+	parts, err := flex.ExpandResourceId(d.Id(), BucketResourceAccessIdPartsCount)
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, create.ErrActionExpandingResourceId, ResBucketResourceAccess, d.Id(), err)
+	}
+
+	out, err := conn.SetResourceAccessForBucketWithContext(ctx, &lightsail.SetResourceAccessForBucketInput{
+		BucketName:   aws.String(parts[0]),
+		ResourceName: aws.String(parts[1]),
+		Access:       aws.String(lightsail.ResourceBucketAccessDeny),
+	})
+
+	if err != nil && tfawserr.ErrCodeEquals(err, lightsail.ErrCodeNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeSetResourceAccessForBucket, ResBucketResourceAccess, d.Id(), err)
+	}
+
+	op := out.Operations[0]
+
+	err = waitOperation(ctx, conn, op.Id)
+
+	if err != nil {
+		return create.DiagError(names.Lightsail, lightsail.OperationTypeSetResourceAccessForBucket, ResBucketResourceAccess, d.Id(), err)
+	}
+
+	return nil
+}

--- a/internal/service/lightsail/bucket_resource_access_test.go
+++ b/internal/service/lightsail/bucket_resource_access_test.go
@@ -1,0 +1,169 @@
+package lightsail_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tflightsail "github.com/hashicorp/terraform-provider-aws/internal/service/lightsail"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccLightsailBucketResourceAccess_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lightsail_bucket_resource_access.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(lightsail.EndpointsID, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, lightsail.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBucketResourceAccessDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketResourceAccessConfig_basic(rName, bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketResourceAccessExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "bucket_name", bucketName),
+					resource.TestCheckResourceAttr(resourceName, "resource_name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLightsailBucketResourceAccess_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lightsail_bucket_resource_access.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(lightsail.EndpointsID, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, lightsail.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBucketResourceAccessDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketResourceAccessConfig_basic(rName, bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketResourceAccessExists(ctx, resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tflightsail.ResourceBucketResourceAccess(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckBucketResourceAccessExists(ctx context.Context, resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Resource not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Resource (%s) ID not set", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LightsailConn()
+
+		out, err := tflightsail.FindBucketResourceAccessById(ctx, conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if out == nil {
+			return fmt.Errorf("BucketResourceAccess %q does not exist", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckBucketResourceAccessDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LightsailConn()
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_lightsail_bucket_access_key" {
+				continue
+			}
+
+			_, err := tflightsail.FindBucketResourceAccessById(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return create.Error(names.Lightsail, create.ErrActionCheckingDestroyed, tflightsail.ResBucketResourceAccess, rs.Primary.ID, errors.New("still exists"))
+		}
+
+		return nil
+	}
+}
+
+func testAccBucketResourceAccessConfig_base(bucketName string) string {
+	return fmt.Sprintf(`
+resource "aws_lightsail_bucket" "test" {
+  name      = %[1]q
+  bundle_id = "small_1_0"
+}
+data "aws_availability_zones" "available" {
+  state = "available"
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+
+`, bucketName)
+}
+
+func testAccBucketResourceAccessConfig_basic(rName string, bucketName string) string {
+	return acctest.ConfigCompose(testAccBucketResourceAccessConfig_base(bucketName), fmt.Sprintf(`
+resource "aws_lightsail_instance" "test" {
+  name              = %[1]q
+  availability_zone = data.aws_availability_zones.available.names[0]
+  blueprint_id      = "amazon_linux_2"
+  bundle_id         = "nano_1_0"
+}
+
+resource "aws_lightsail_bucket_resource_access" "test" {
+  bucket_name   = aws_lightsail_bucket.test.id
+  resource_name = aws_lightsail_instance.test.id
+}
+
+
+`, rName))
+}

--- a/internal/service/lightsail/consts.go
+++ b/internal/service/lightsail/consts.go
@@ -3,6 +3,7 @@ package lightsail
 const (
 	ResBucket                             = "Bucket"
 	ResBucketAccessKey                    = "Bucket Access Key"
+	ResBucketResourceAccess               = "Bucket Resource Access"
 	ResCertificate                        = "Certificate"
 	ResDatabase                           = "Database"
 	ResDisk                               = "Disk"

--- a/website/docs/r/lightsail_bucket_resource_access.html.markdown
+++ b/website/docs/r/lightsail_bucket_resource_access.html.markdown
@@ -26,7 +26,7 @@ resource "aws_lightsail_instance" "test" {
 }
 
 resource "aws_lightsail_bucket_resource_access" "test" {
-  bucket_name = aws_lightsail_bucket_resource_access.test.id
+  bucket_name   = aws_lightsail_bucket_resource_access.test.id
   resource_name = aws_lightsail_instance.id
 }
 ```
@@ -37,7 +37,6 @@ The following arguments are supported:
 
 * `bucket_name` - (Required) The name of the bucket to grant access to.
 * `resource_name` - (Required) The name of the resource to be granted bucket access.
-
 
 ## Attributes Reference
 

--- a/website/docs/r/lightsail_bucket_resource_access.html.markdown
+++ b/website/docs/r/lightsail_bucket_resource_access.html.markdown
@@ -1,0 +1,54 @@
+---
+subcategory: "Lightsail"
+layout: "aws"
+page_title: "AWS: aws_lightsail_bucket_resource_access"
+description: |-
+  Provides a lightsail resource access to a bucket.
+---
+
+# Resource: aws_lightsail_bucket_resource_access
+
+Provides a lightsail resource access to a bucket.
+
+## Example Usage
+
+```terraform
+resource "aws_lightsail_bucket" "test" {
+  name      = "mytestbucket"
+  bundle_id = "small_1_0"
+}
+
+resource "aws_lightsail_instance" "test" {
+  name              = "mytestinstance"
+  availability_zone = "us-east-1b"
+  blueprint_id      = "amazon_linux_2"
+  bundle_id         = "nano_1_0"
+}
+
+resource "aws_lightsail_bucket_resource_access" "test" {
+  bucket_name = aws_lightsail_bucket_resource_access.test.id
+  resource_name = aws_lightsail_instance.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket_name` - (Required) The name of the bucket to grant access to.
+* `resource_name` - (Required) The name of the resource to be granted bucket access.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A combination of attributes separated by a `,` to create a unique id: `bucket_name`,`resource_name`
+
+## Import
+
+`aws_lightsail_bucket_resource_access` can be imported by using the `id` attribute, e.g.,
+
+```
+$ terraform import aws_lightsail_bucket_resource_access.test example-bucket,example-instance
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This pull request adds the ability to manage lightsail resource access to lightsail buckets. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

None

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccLightsailBucketResourceAccess' PKG=lightsail
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lightsail/... -v -count 1 -parallel 20  -run=TestAccLightsailBucketResourceAccess -timeout 180m
=== RUN   TestAccLightsailBucketResourceAccess_basic
=== PAUSE TestAccLightsailBucketResourceAccess_basic
=== RUN   TestAccLightsailBucketResourceAccess_disappears
=== PAUSE TestAccLightsailBucketResourceAccess_disappears
=== CONT  TestAccLightsailBucketResourceAccess_basic
=== CONT  TestAccLightsailBucketResourceAccess_disappears
--- PASS: TestAccLightsailBucketResourceAccess_disappears (65.08s)
--- PASS: TestAccLightsailBucketResourceAccess_basic (79.87s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  84.829s

...
```
