### PR TITLE
fix typo in arib_captions_pid and arib_captions_pid_control

### DIFF
--- a/.changelog/29467.txt
+++ b/.changelog/29467.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_medialive_channel: Fix setting of `m2ts_settings` `arib_captions_pid` and `arib_captions_pid_control` attributes
+```

--- a/internal/service/medialive/channel_encoder_settings_schema.go
+++ b/internal/service/medialive/channel_encoder_settings_schema.go
@@ -3962,7 +3962,7 @@ func expandM2tsSettings(tfList []interface{}) *types.M2tsSettings {
 	if v, ok := m["arib"].(string); ok && v != "" {
 		s.Arib = types.M2tsArib(v)
 	}
-	if v, ok := m["arib_caption_pid"].(string); ok && v != "" {
+	if v, ok := m["arib_captions_pid"].(string); ok && v != "" {
 		s.AribCaptionsPid = aws.String(v)
 	}
 	if v, ok := m["arib_caption_pid_control"].(string); ok && v != "" {

--- a/internal/service/medialive/channel_encoder_settings_schema.go
+++ b/internal/service/medialive/channel_encoder_settings_schema.go
@@ -3965,7 +3965,7 @@ func expandM2tsSettings(tfList []interface{}) *types.M2tsSettings {
 	if v, ok := m["arib_captions_pid"].(string); ok && v != "" {
 		s.AribCaptionsPid = aws.String(v)
 	}
-	if v, ok := m["arib_caption_pid_control"].(string); ok && v != "" {
+	if v, ok := m["arib_captions_pid_control"].(string); ok && v != "" {
 		s.AribCaptionsPidControl = types.M2tsAribCaptionsPidControl(v)
 	}
 	if v, ok := m["audio_buffer_model"].(string); ok && v != "" {

--- a/internal/service/medialive/channel_test.go
+++ b/internal/service/medialive/channel_test.go
@@ -127,6 +127,7 @@ func TestAccMediaLiveChannel_m2ts_settings(t *testing.T) {
 						"rate_mode":          "CBR",
 						"audio_pids":         "200",
 						"dvb_sub_pids":       "300",
+						"arib_captions_pid":  "100",
 					}),
 				),
 			},
@@ -787,6 +788,7 @@ resource "aws_medialive_channel" "test" {
                 rate_mode          = "CBR"
                 audio_pids         = "200"
                 dvb_sub_pids       = "300"
+                arib_captions_pid  = "100"
               }
             }
           }

--- a/internal/service/medialive/channel_test.go
+++ b/internal/service/medialive/channel_test.go
@@ -122,12 +122,13 @@ func TestAccMediaLiveChannel_m2ts_settings(t *testing.T) {
 						"name": "test-video-name",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "encoder_settings.0.output_groups.0.outputs.0.output_settings.0.archive_output_settings.0.container_settings.0.m2ts_settings.*", map[string]string{
-						"audio_buffer_model": "ATSC",
-						"buffer_model":       "MULTIPLEX",
-						"rate_mode":          "CBR",
-						"audio_pids":         "200",
-						"dvb_sub_pids":       "300",
-						"arib_captions_pid":  "100",
+						"audio_buffer_model":        "ATSC",
+						"buffer_model":              "MULTIPLEX",
+						"rate_mode":                 "CBR",
+						"audio_pids":                "200",
+						"dvb_sub_pids":              "300",
+						"arib_captions_pid":         "100",
+						"arib_captions_pid_control": "AUTO",
 					}),
 				),
 			},
@@ -783,12 +784,13 @@ resource "aws_medialive_channel" "test" {
             extension     = "m2ts"
             container_settings {
               m2ts_settings {
-                audio_buffer_model = "ATSC"
-                buffer_model       = "MULTIPLEX"
-                rate_mode          = "CBR"
-                audio_pids         = "200"
-                dvb_sub_pids       = "300"
-                arib_captions_pid  = "100"
+                audio_buffer_model        = "ATSC"
+                buffer_model              = "MULTIPLEX"
+                rate_mode                 = "CBR"
+                audio_pids                = "200"
+                dvb_sub_pids              = "300"
+                arib_captions_pid         = "100"
+                arib_captions_pid_control = "AUTO"
               }
             }
           }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Change `arib_caption_pid` to `arib_captions_pid` and `arib_caption_pid_control` to `arib_captions_pid_control` so the parameters can be assigned

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccMediaLiveChannel_m2ts_settings PKG=medialive
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/medialive/... -v -count 1 -parallel 20 -run='TestAccMediaLiveChannel_m2ts_settings'  -timeout 180m
=== RUN   TestAccMediaLiveChannel_m2ts_settings
=== PAUSE TestAccMediaLiveChannel_m2ts_settings
=== CONT  TestAccMediaLiveChannel_m2ts_settings
--- PASS: TestAccMediaLiveChannel_m2ts_settings (85.36s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	87.405s
```
