### PR TITLE
Fix CodeQL `go/clear-text-logging` warnings

### DIFF
--- a/internal/service/rds/proxy.go
+++ b/internal/service/rds/proxy.go
@@ -163,7 +163,6 @@ func resourceProxyCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		input.VpcSecurityGroupIds = flex.ExpandStringSet(v)
 	}
 
-	log.Printf("[DEBUG] Creating RDS DB Proxy: %s", input)
 	output, err := conn.CreateDBProxyWithContext(ctx, &input)
 
 	if err != nil {
@@ -252,7 +251,6 @@ func resourceProxyUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			input.SecurityGroups = flex.ExpandStringSet(v)
 		}
 
-		log.Printf("[DEBUG] Updating RDS DB Proxy: %s", input)
 		_, err := conn.ModifyDBProxyWithContext(ctx, input)
 
 		if err != nil {

--- a/internal/service/wafv2/web_acl.go
+++ b/internal/service/wafv2/web_acl.go
@@ -175,7 +175,6 @@ func resourceWebACLCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
-	log.Printf("[INFO] Creating WAFv2 WebACL: %s", input)
 	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, webACLCreateTimeout, func() (interface{}, error) {
 		return conn.CreateWebACLWithContext(ctx, input)
 	}, wafv2.ErrCodeWAFUnavailableEntityException)
@@ -270,7 +269,6 @@ func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			input.Description = aws.String(v.(string))
 		}
 
-		log.Printf("[INFO] Updating WAFv2 WebACL: %s", input)
 		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, webACLUpdateTimeout, func() (interface{}, error) {
 			return conn.UpdateWebACLWithContext(ctx, input)
 		}, wafv2.ErrCodeWAFUnavailableEntityException)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fix [CodeQL _Clear-text logging of sensitive information_](https://codeql.github.com/codeql-query-help/go/go-clear-text-logging/) warnings.

* https://github.com/hashicorp/terraform-provider-aws/security/code-scanning/240
* https://github.com/hashicorp/terraform-provider-aws/security/code-scanning/239
* https://github.com/hashicorp/terraform-provider-aws/security/code-scanning/238
* https://github.com/hashicorp/terraform-provider-aws/security/code-scanning/232
