### PR TITLE
aws_load_balancer_listener_policy: add triggers argument

### DIFF
--- a/.changelog/29482.txt
+++ b/.changelog/29482.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_load_balancer_listener_policy: Add `trigger` attribute to force resource updates
+```
+
+```release-note:enhancement
+resource/aws_lb_ssl_negotiation_policy: Add `trigger` attribute to force resource redeployment
+```

--- a/internal/service/elb/lb_ssl_negotiation_policy.go
+++ b/internal/service/elb/lb_ssl_negotiation_policy.go
@@ -55,6 +55,12 @@ func ResourceSSLNegotiationPolicy() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"triggers": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }

--- a/internal/service/elb/lb_ssl_negotiation_policy_test.go
+++ b/internal/service/elb/lb_ssl_negotiation_policy_test.go
@@ -39,6 +39,41 @@ func TestAccELBSSLNegotiationPolicy_basic(t *testing.T) {
 	})
 }
 
+func TestAccELBSSLNegotiationPolicy_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+	resourceName := "aws_lb_ssl_negotiation_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, elb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLBSSLNegotiationPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLBSSLNegotiationPolicyConfig_update(rName, key, certificate, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLBSSLNegotiationPolicy(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "attribute.#", "7"),
+				),
+			},
+			{
+				Config: testAccLBSSLNegotiationPolicyConfig_update(rName, key, certificate, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLBSSLNegotiationPolicy(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "attribute.#", "7"),
+				),
+			},
+			{
+				Config:   testAccLBSSLNegotiationPolicyConfig_update(rName, key, certificate, 1),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccELBSSLNegotiationPolicy_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -183,4 +218,73 @@ resource "aws_lb_ssl_negotiation_policy" "test" {
   }
 }
 `, rName, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key)))
+}
+
+func testAccLBSSLNegotiationPolicyConfig_update(rName, key, certificate string, certToUse int) string {
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+resource "aws_iam_server_certificate" "test" {
+  count            = 2
+  name_prefix      = %[1]q
+  certificate_body = "%[2]s"
+  private_key      = "%[3]s"
+}
+
+resource "aws_elb" "test" {
+  name               = %[1]q
+  availability_zones = [data.aws_availability_zones.available.names[0]]
+
+  listener {
+    instance_port      = 8000
+    instance_protocol  = "https"
+    lb_port            = 443
+    lb_protocol        = "https"
+    ssl_certificate_id = aws_iam_server_certificate.test[%[4]d].arn
+  }
+}
+
+resource "aws_lb_ssl_negotiation_policy" "test" {
+  name          = %[1]q
+  load_balancer = aws_elb.test.id
+  lb_port       = 443
+
+  attribute {
+    name  = "Protocol-TLSv1"
+    value = "false"
+  }
+
+  attribute {
+    name  = "Protocol-TLSv1.1"
+    value = "false"
+  }
+
+  attribute {
+    name  = "Protocol-TLSv1.2"
+    value = "true"
+  }
+
+  attribute {
+    name  = "Server-Defined-Cipher-Order"
+    value = "true"
+  }
+
+  attribute {
+    name  = "ECDHE-RSA-AES128-GCM-SHA256"
+    value = "true"
+  }
+
+  attribute {
+    name  = "AES128-GCM-SHA256"
+    value = "true"
+  }
+
+  attribute {
+    name  = "EDH-RSA-DES-CBC3-SHA"
+    value = "false"
+  }
+
+  triggers = {
+    certificate_arn = aws_iam_server_certificate.test[%[4]d].arn,
+  }
+}
+`, rName, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key), certToUse))
 }

--- a/internal/service/elb/listener_policy.go
+++ b/internal/service/elb/listener_policy.go
@@ -38,6 +38,11 @@ func ResourceListenerPolicy() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"triggers": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }

--- a/website/docs/r/lb_ssl_negotiation_policy.html.markdown
+++ b/website/docs/r/lb_ssl_negotiation_policy.html.markdown
@@ -81,6 +81,7 @@ balancer.
 * `attribute` - (Optional) An SSL Negotiation policy attribute. Each has two properties:
     * `name` - The name of the attribute
     * `value` - The value of the attribute
+* `triggers` - (Optional) Map of arbitrary keys and values that, when changed, will trigger a redeployment. To force a redeployment without changing these keys/values, use the [`terraform taint` command](https://www.terraform.io/docs/commands/taint.html).
 
 To set your attributes, please see the [AWS Elastic Load Balancing Developer Guide](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/elb-security-policy-table.html) for a listing of the supported SSL protocols, SSL options, and SSL ciphers.
 

--- a/website/docs/r/load_balancer_listener_policy.html.markdown
+++ b/website/docs/r/load_balancer_listener_policy.html.markdown
@@ -110,6 +110,7 @@ The following arguments are supported:
 * `load_balancer_name` - (Required) The load balancer to attach the policy to.
 * `load_balancer_port` - (Required) The load balancer listener port to apply the policy to.
 * `policy_names` - (Required) List of Policy Names to apply to the backend server.
+* `triggers` - (Optional) Map of arbitrary keys and values that, when changed, will trigger an update. To force an update without changing these keys/values, use the [`terraform taint` command](https://www.terraform.io/docs/commands/taint.html).
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #13628

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=elb TESTS="TestAccELBSSLNegotiationPolicy_|TestAccELBListenerPolicy_"

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elb/... -v -count 1 -parallel 20 -run='TestAccELBSSLNegotiationPolicy_|TestAccELBListenerPolicy_'  -timeout 180m
--- PASS: TestAccELBListenerPolicy_basic (19.67s)
--- PASS: TestAccELBListenerPolicy_disappears (20.03s)
--- PASS: TestAccELBSSLNegotiationPolicy_basic (66.53s)
--- PASS: TestAccELBSSLNegotiationPolicy_update (69.65s)
--- PASS: TestAccELBSSLNegotiationPolicy_disappears (78.85s)
--- PASS: TestAccELBListenerPolicy_update (83.03s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elb	86.537s
...
```
