### PR TITLE
Don't do anything for Framework `tags_all` plan modification on Delete

### DIFF
--- a/internal/framework/base.go
+++ b/internal/framework/base.go
@@ -73,6 +73,11 @@ func (r *ResourceWithConfigure) FlattenTagsAll(ctx context.Context, apiTags tfta
 
 // SetTagsAll calculates the new value for the `tags_all` attribute.
 func (r *ResourceWithConfigure) SetTagsAll(ctx context.Context, request resource.ModifyPlanRequest, response *resource.ModifyPlanResponse) {
+	// If the entire plan is null, the resource is planned for destruction.
+	if request.Plan.Raw.IsNull() {
+		return
+	}
+
 	defaultTagsConfig := r.Meta().DefaultTagsConfig
 	ignoreTagsConfig := r.Meta().IgnoreTagsConfig
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Skip the Plugin Framework `tags_all` plan modification logic on resource Delete.
Since https://github.com/hashicorp/terraform-plugin-mux/pull/133 / https://github.com/hashicorp/terraform-provider-aws/pull/29313 Terraform CLI **v1.3**+ has been running plan modifiers on resource Delete for Framework resources.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/29541.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
```
