### PR TITLE
sweeper/aws_rds_global_cluster: Fixes dependency errors

### DIFF
--- a/internal/service/neptune/sweep.go
+++ b/internal/service/neptune/sweep.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func init() {
@@ -33,6 +34,9 @@ func init() {
 	resource.AddTestSweepers("aws_neptune_cluster_instance", &resource.Sweeper{
 		Name: "aws_neptune_cluster_instance",
 		F:    sweepClusterInstances,
+		Dependencies: []string{
+			"aws_rds_global_cluster",
+		},
 	})
 }
 
@@ -123,8 +127,10 @@ func sweepClusters(region string) error {
 			globalCluster, err := findGlobalClusterByClusterARN(ctx, conn, arn)
 
 			if err != nil {
-				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("reading Neptune Global Cluster information for Neptune Cluster (%s): %s", id, err))
-				continue
+				if !tfresource.NotFound(err) {
+					sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("reading Neptune Global Cluster information for Neptune Cluster (%s): %s", id, err))
+					continue
+				}
 			}
 
 			if globalCluster != nil && globalCluster.GlobalClusterIdentifier != nil {

--- a/internal/service/rds/blue_green.go
+++ b/internal/service/rds/blue_green.go
@@ -156,17 +156,3 @@ func (h *instanceHandler) modifyTarget(ctx context.Context, identifier string, d
 
 	return nil
 }
-
-type deadline time.Time
-
-func NewDeadline(duration time.Duration) deadline {
-	return deadline(time.Now().Add(duration))
-}
-
-func (d deadline) remaining() time.Duration {
-	if v := time.Until(time.Time(d)); v < 0 {
-		return 0
-	} else {
-		return v
-	}
-}

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -22,9 +22,14 @@ import (
 )
 
 const (
-	GlobalClusterRemovalTimeout = 30 * time.Minute
-	globalClusterCreateTimeout  = 30 * time.Minute
-	globalClusterUpdateTimeout  = 90 * time.Minute
+	globalClusterCreateTimeout = 30 * time.Minute
+	globalClusterUpdateTimeout = 90 * time.Minute
+	// globalClusterDeleteTimeout is the overall timeout for detaching cluster members if needed
+	// and deleting the cluster
+	globalClusterDeleteTimeout = 30 * time.Minute
+	// GlobalClusterClusterDeleteTimeout is the timeout for actual deletion of the cluster
+	// This operation will be quick if successful
+	GlobalClusterClusterDeleteTimeout = 5 * time.Minute
 )
 
 func ResourceGlobalCluster() *schema.Resource {
@@ -40,7 +45,7 @@ func ResourceGlobalCluster() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(globalClusterCreateTimeout),
 			Update: schema.DefaultTimeout(globalClusterUpdateTimeout),
-			Delete: schema.DefaultTimeout(GlobalClusterRemovalTimeout),
+			Delete: schema.DefaultTimeout(globalClusterDeleteTimeout),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -273,10 +278,12 @@ func resourceGlobalClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 func resourceGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSConn()
+	deadline := tfresource.NewDeadline(d.Timeout(schema.TimeoutDelete))
 
 	if d.Get("force_destroy").(bool) {
 		log.Printf("[DEBUG] Removing cluster members from  RDS Global Cluster: %s", d.Id())
 
+		// The writer cluster must be removed last
 		var writerARN string
 		for _, globalClusterMemberRaw := range d.Get("global_cluster_members").(*schema.Set).List() {
 			globalClusterMember, ok := globalClusterMemberRaw.(map[string]interface{})
@@ -311,7 +318,7 @@ func resourceGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, me
 				return sdkdiag.AppendErrorf(diags, "removing RDS DB Cluster (%s) from Global Cluster (%s): %s", dbClusterArn, d.Id(), err)
 			}
 
-			if err := waitForGlobalClusterRemoval(ctx, conn, dbClusterArn, d.Timeout(schema.TimeoutDelete)); err != nil {
+			if err := waitForGlobalClusterRemoval(ctx, conn, dbClusterArn, deadline.Remaining()); err != nil {
 				return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Cluster (%s) removal from RDS Global Cluster (%s): %s", dbClusterArn, d.Id(), err)
 			}
 		}
@@ -329,7 +336,7 @@ func resourceGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, me
 			}
 		}
 
-		if err := waitForGlobalClusterRemoval(ctx, conn, writerARN, d.Timeout(schema.TimeoutDelete)); err != nil {
+		if err := waitForGlobalClusterRemoval(ctx, conn, writerARN, deadline.Remaining()); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Cluster (%s) removal from RDS Global Cluster (%s): %s", writerARN, d.Id(), err)
 		}
 	}
@@ -342,7 +349,13 @@ func resourceGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, me
 
 	// Allow for eventual consistency
 	// InvalidGlobalClusterStateFault: Global Cluster arn:aws:rds::123456789012:global-cluster:tf-acc-test-5618525093076697001-0 is not empty
-	err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+	var timeout time.Duration
+	if x, y := deadline.Remaining(), GlobalClusterClusterDeleteTimeout; x < y {
+		timeout = x
+	} else {
+		timeout = y
+	}
+	err := resource.RetryContext(ctx, timeout, func() *resource.RetryError {
 		_, err := conn.DeleteGlobalClusterWithContext(ctx, input)
 
 		if tfawserr.ErrMessageContains(err, rds.ErrCodeInvalidGlobalClusterStateFault, "is not empty") {
@@ -368,7 +381,7 @@ func resourceGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, me
 		return sdkdiag.AppendErrorf(diags, "deleting RDS Global Cluster: %s", err)
 	}
 
-	if err := WaitForGlobalClusterDeletion(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+	if err := WaitForGlobalClusterDeletion(ctx, conn, d.Id(), deadline.Remaining()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for RDS Global Cluster (%s) deletion: %s", d.Id(), err)
 	}
 

--- a/internal/service/rds/global_cluster_test.go
+++ b/internal/service/rds/global_cluster_test.go
@@ -662,7 +662,7 @@ func testAccCheckGlobalClusterDisappears(ctx context.Context, globalCluster *rds
 			return err
 		}
 
-		return tfrds.WaitForGlobalClusterDeletion(ctx, conn, aws.StringValue(globalCluster.GlobalClusterIdentifier), tfrds.GlobalClusterRemovalTimeout)
+		return tfrds.WaitForGlobalClusterDeletion(ctx, conn, aws.StringValue(globalCluster.GlobalClusterIdentifier), tfrds.GlobalClusterClusterDeleteTimeout)
 	}
 }
 

--- a/internal/service/rds/sweep.go
+++ b/internal/service/rds/sweep.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func init() {
@@ -50,15 +51,14 @@ func init() {
 	resource.AddTestSweepers("aws_rds_global_cluster", &resource.Sweeper{
 		Name: "aws_rds_global_cluster",
 		F:    sweepGlobalClusters,
-		Dependencies: []string{
-			"aws_rds_cluster",
-			"aws_neptune_cluster",
-		},
 	})
 
 	resource.AddTestSweepers("aws_db_instance", &resource.Sweeper{
 		Name: "aws_db_instance",
 		F:    sweepInstances,
+		Dependencies: []string{
+			"aws_rds_global_cluster",
+		},
 	})
 
 	resource.AddTestSweepers("aws_db_option_group", &resource.Sweeper{
@@ -240,8 +240,10 @@ func sweepClusters(region string) error {
 				globalCluster, err := DescribeGlobalClusterFromClusterARN(ctx, conn, arn)
 
 				if err != nil {
-					sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("reading RDS Global Cluster information for DB Cluster (%s): %s", id, err))
-					continue
+					if !tfresource.NotFound(err) {
+						sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("reading RDS Global Cluster information for DB Cluster (%s): %s", id, err))
+						continue
+					}
 				}
 
 				if globalCluster != nil && globalCluster.GlobalClusterIdentifier != nil {
@@ -333,6 +335,8 @@ func sweepGlobalClusters(region string) error {
 			r := ResourceGlobalCluster()
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(v.GlobalClusterIdentifier))
+			d.Set("force_destroy", true)
+			d.Set("global_cluster_members", flattenGlobalClusterMembers(v.GlobalClusterMembers))
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -239,3 +239,17 @@ func Retry(ctx context.Context, timeout time.Duration, f resource.RetryFunc, opt
 	// more likely to be useful
 	return resultErr
 }
+
+type deadline time.Time
+
+func NewDeadline(duration time.Duration) deadline {
+	return deadline(time.Now().Add(duration))
+}
+
+func (d deadline) Remaining() time.Duration {
+	if v := time.Until(time.Time(d)); v < 0 {
+		return 0
+	} else {
+		return v
+	}
+}


### PR DESCRIPTION
Currently, deleting an RDS Global Cluster can fail with either

> error deleting DB Instance (...): InvalidDBClusterStateFault: Cannot delete the last instance of the master cluster. Delete the replica cluster before deleting the last master cluster instance.

or

> Failed to delete RDS DB Cluster (...): InvalidGlobalClusterStateFault: Unable to delete cluster that is a primary member of global cluster while there are other global cluster members

This PR updates the RDS Global Cluster Delete operation to remove all member clusters from the global cluster.

### Relations

Closes #26234
Closes #26236

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make sweep SWEEPARGS=-sweep-run=aws_rds_global_cluster

2023/02/16 17:45:37 [DEBUG] Running Sweepers for region (us-west-2):
2023/02/16 17:45:37 [DEBUG] Running Sweeper (aws_rds_global_cluster) in region (us-west-2)
2023/02/16 17:45:37 [DEBUG] Completed Sweeper (aws_rds_global_cluster) in region (us-west-2) in 493.334833ms
2023/02/16 17:45:37 [DEBUG] Sweeper (aws_rds_cluster_parameter_group) has dependency (aws_rds_cluster), running..
2023/02/16 17:45:37 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
2023/02/16 17:45:37 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_rds_global_cluster), running..
2023/02/16 17:45:37 [DEBUG] Sweeper (aws_rds_global_cluster) already ran in region (us-west-2)
2023/02/16 17:45:37 [DEBUG] Running Sweeper (aws_db_instance) in region (us-west-2)
2023/02/16 17:45:37 [DEBUG] Completed Sweeper (aws_db_instance) in region (us-west-2) in 48.134125ms
2023/02/16 17:45:37 [DEBUG] Running Sweeper (aws_rds_cluster) in region (us-west-2)
2023/02/16 17:45:38 [DEBUG] Completed Sweeper (aws_rds_cluster) in region (us-west-2) in 45.59775ms
2023/02/16 17:45:38 [DEBUG] Running Sweeper (aws_rds_cluster_parameter_group) in region (us-west-2)
2023/02/16 17:45:38 [DEBUG] Completed Sweeper (aws_rds_cluster_parameter_group) in region (us-west-2) in 56.894875ms
2023/02/16 17:45:38 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
2023/02/16 17:45:38 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_rds_global_cluster), running..
2023/02/16 17:45:38 [DEBUG] Sweeper (aws_rds_global_cluster) already ran in region (us-west-2)
2023/02/16 17:45:38 [DEBUG] Sweeper (aws_db_instance) already ran in region (us-west-2)
2023/02/16 17:45:38 [DEBUG] Sweeper (aws_rds_cluster) already ran in region (us-west-2)
2023/02/16 17:45:38 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_rds_global_cluster), running..
2023/02/16 17:45:38 [DEBUG] Sweeper (aws_rds_global_cluster) already ran in region (us-west-2)
2023/02/16 17:45:38 [DEBUG] Sweeper (aws_db_instance) already ran in region (us-west-2)
2023/02/16 17:45:38 [DEBUG] Sweeper (aws_db_instance_automated_backups_replication) has dependency (aws_db_instance), running..
2023/02/16 17:45:38 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_rds_global_cluster), running..
2023/02/16 17:45:38 [DEBUG] Sweeper (aws_rds_global_cluster) already ran in region (us-west-2)
2023/02/16 17:45:38 [DEBUG] Sweeper (aws_db_instance) already ran in region (us-west-2)
2023/02/16 17:45:38 [DEBUG] Running Sweeper (aws_db_instance_automated_backups_replication) in region (us-west-2)
2023/02/16 17:45:38 [DEBUG] Waiting for state to become: [success]
2023/02/16 17:45:38 [DEBUG] Waiting for state to become: [success]
2023/02/16 17:45:38 [DEBUG] Waiting for state to become: [success]
2023/02/16 17:45:38 [DEBUG] Waiting for state to become: [success]
2023/02/16 17:45:38 [DEBUG] Waiting for state to become: [success]
2023/02/16 17:45:38 [DEBUG] Waiting for state to become: [success]
2023/02/16 17:45:38 [DEBUG] Waiting for state to become: [success]
2023/02/16 17:45:38 [DEBUG] Stopping RDS Instance Automated Backups Replication: arn:aws:rds:us-west-2:123456789012:auto-backup:ab-srqgk6fdu6hghmeciso2xfyzat2akho3aqu632y
2023/02/16 17:45:38 [DEBUG] Stopping RDS Instance Automated Backups Replication: arn:aws:rds:us-west-2:123456789012:auto-backup:ab-dkedyvwfa2niqxut6p23q3yaz2jli2utyoobf3q
2023/02/16 17:45:38 [DEBUG] Stopping RDS Instance Automated Backups Replication: arn:aws:rds:us-west-2:123456789012:auto-backup:ab-pxokasoxjknalh3xd6qqyve7zcqxz2m6txij7iq
2023/02/16 17:45:38 [DEBUG] Stopping RDS Instance Automated Backups Replication: arn:aws:rds:us-west-2:123456789012:auto-backup:ab-rvdjvrrsiydqdespjwrlitkiqdf5yxhuoraqnky
2023/02/16 17:45:38 [DEBUG] Stopping RDS Instance Automated Backups Replication: arn:aws:rds:us-west-2:123456789012:auto-backup:ab-7i4nrfgq2mhatsqzhoe55xpvulboatceapoqp6y
2023/02/16 17:45:38 [DEBUG] Stopping RDS Instance Automated Backups Replication: arn:aws:rds:us-west-2:123456789012:auto-backup:ab-dikxdana362y7pmwlq2mku7gyyhwj4bbp5vducq
2023/02/16 17:45:38 [DEBUG] Stopping RDS Instance Automated Backups Replication: arn:aws:rds:us-west-2:123456789012:auto-backup:ab-25xuy5dumde6sme4x7x3sjldw64cgoaacsusbyi
2023/02/16 17:45:38 [DEBUG] Deleting RDS Instance Automated Backup: arn:aws:rds:us-west-2:123456789012:auto-backup:ab-25xuy5dumde6sme4x7x3sjldw64cgoaacsusbyi
2023/02/16 17:45:39 [ERROR] deleting RDS Instance Automated Backup (arn:aws:rds:us-west-2:123456789012:auto-backup:ab-25xuy5dumde6sme4x7x3sjldw64cgoaacsusbyi): InvalidDBInstanceAutomatedBackupState: You can't delete automated backups.
	status code: 400, request id: 84faaf79-6557-495f-bc0e-a4d37fd73b9a
2023/02/16 17:45:39 [DEBUG] Deleting RDS Instance Automated Backup: arn:aws:rds:us-west-2:123456789012:auto-backup:ab-7i4nrfgq2mhatsqzhoe55xpvulboatceapoqp6y
2023/02/16 17:45:39 [ERROR] deleting RDS Instance Automated Backup (arn:aws:rds:us-west-2:123456789012:auto-backup:ab-7i4nrfgq2mhatsqzhoe55xpvulboatceapoqp6y): InvalidDBInstanceAutomatedBackupState: You can't delete automated backups.
	status code: 400, request id: 84ae31a8-6e96-4c80-a44e-e57efea20eee
2023/02/16 17:45:39 [DEBUG] Deleting RDS Instance Automated Backup: arn:aws:rds:us-west-2:123456789012:auto-backup:ab-dikxdana362y7pmwlq2mku7gyyhwj4bbp5vducq
2023/02/16 17:45:39 [ERROR] deleting RDS Instance Automated Backup (arn:aws:rds:us-west-2:123456789012:auto-backup:ab-dikxdana362y7pmwlq2mku7gyyhwj4bbp5vducq): InvalidDBInstanceAutomatedBackupState: You can't delete automated backups.
	status code: 400, request id: 0b323345-04dd-40b7-a53b-658cc2f49e35
2023/02/16 17:45:39 [DEBUG] Deleting RDS Instance Automated Backup: arn:aws:rds:us-west-2:123456789012:auto-backup:ab-dkedyvwfa2niqxut6p23q3yaz2jli2utyoobf3q
2023/02/16 17:45:39 [ERROR] deleting RDS Instance Automated Backup (arn:aws:rds:us-west-2:123456789012:auto-backup:ab-dkedyvwfa2niqxut6p23q3yaz2jli2utyoobf3q): InvalidDBInstanceAutomatedBackupState: You can't delete automated backups.
	status code: 400, request id: 84ccbbd5-5534-46c5-af13-169875a9a7a7
2023/02/16 17:45:39 [DEBUG] Deleting RDS Instance Automated Backup: arn:aws:rds:us-west-2:123456789012:auto-backup:ab-pxokasoxjknalh3xd6qqyve7zcqxz2m6txij7iq
2023/02/16 17:45:39 [ERROR] deleting RDS Instance Automated Backup (arn:aws:rds:us-west-2:123456789012:auto-backup:ab-pxokasoxjknalh3xd6qqyve7zcqxz2m6txij7iq): InvalidDBInstanceAutomatedBackupState: You can't delete automated backups.
	status code: 400, request id: e9894be5-ca3a-4185-b390-3e0235612f09
2023/02/16 17:45:39 [DEBUG] Deleting RDS Instance Automated Backup: arn:aws:rds:us-west-2:123456789012:auto-backup:ab-rvdjvrrsiydqdespjwrlitkiqdf5yxhuoraqnky
2023/02/16 17:45:39 [ERROR] deleting RDS Instance Automated Backup (arn:aws:rds:us-west-2:123456789012:auto-backup:ab-rvdjvrrsiydqdespjwrlitkiqdf5yxhuoraqnky): InvalidDBInstanceAutomatedBackupState: You can't delete automated backups.
	status code: 400, request id: 5d5c3f11-8357-4dfc-8aab-c27088c01fe2
2023/02/16 17:45:39 [DEBUG] Deleting RDS Instance Automated Backup: arn:aws:rds:us-west-2:123456789012:auto-backup:ab-srqgk6fdu6hghmeciso2xfyzat2akho3aqu632y
2023/02/16 17:45:39 [ERROR] deleting RDS Instance Automated Backup (arn:aws:rds:us-west-2:123456789012:auto-backup:ab-srqgk6fdu6hghmeciso2xfyzat2akho3aqu632y): InvalidDBInstanceAutomatedBackupState: You can't delete automated backups.
	status code: 400, request id: fdfa5a0a-4233-4ae1-bf9a-7ed3b5a8359b
2023/02/16 17:45:39 [DEBUG] Completed Sweeper (aws_db_instance_automated_backups_replication) in region (us-west-2) in 1.908803167s
2023/02/16 17:45:39 [DEBUG] Sweeper (aws_neptune_cluster_instance) has dependency (aws_rds_global_cluster), running..
2023/02/16 17:45:39 [DEBUG] Sweeper (aws_rds_global_cluster) already ran in region (us-west-2)
2023/02/16 17:45:39 [DEBUG] Running Sweeper (aws_neptune_cluster_instance) in region (us-west-2)
2023/02/16 17:45:40 [DEBUG] Completed Sweeper (aws_neptune_cluster_instance) in region (us-west-2) in 54.151083ms
2023/02/16 17:45:40 [DEBUG] Sweeper (aws_neptune_cluster) has dependency (aws_neptune_cluster_instance), running..
2023/02/16 17:45:40 [DEBUG] Sweeper (aws_neptune_cluster_instance) has dependency (aws_rds_global_cluster), running..
2023/02/16 17:45:40 [DEBUG] Sweeper (aws_rds_global_cluster) already ran in region (us-west-2)
2023/02/16 17:45:40 [DEBUG] Sweeper (aws_neptune_cluster_instance) already ran in region (us-west-2)
2023/02/16 17:45:40 [DEBUG] Running Sweeper (aws_neptune_cluster) in region (us-west-2)
2023/02/16 17:45:40 [DEBUG] Completed Sweeper (aws_neptune_cluster) in region (us-west-2) in 42.231125ms
2023/02/16 17:45:40 Completed Sweepers for region (us-west-2) in 2.649851208s
2023/02/16 17:45:40 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_rds_cluster_parameter_group
	- aws_db_instance_automated_backups_replication
	- aws_neptune_cluster_instance
	- aws_neptune_cluster
	- aws_rds_global_cluster
	- aws_db_instance
	- aws_rds_cluster
```

```console
$ make testacc PKG=rds TESTS=TestAccRDSGlobalCluster_

--- PASS: TestAccRDSGlobalCluster_disappears (21.91s)
--- PASS: TestAccRDSGlobalCluster_basic (27.25s)
--- PASS: TestAccRDSGlobalCluster_Engine_aurora (27.27s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_auroraPostgreSQL (27.40s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_auroraMySQL (27.51s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_aurora (27.64s)
--- PASS: TestAccRDSGlobalCluster_storageEncrypted (34.78s)
--- PASS: TestAccRDSGlobalCluster_databaseName (37.00s)
--- PASS: TestAccRDSGlobalCluster_deletionProtection (63.78s)
--- PASS: TestAccRDSGlobalCluster_sourceDBClusterIdentifier (124.87s)
--- PASS: TestAccRDSGlobalCluster_SourceDBClusterIdentifier_storageEncrypted (144.70s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_updateMinor (1713.59s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_updateMajor (2004.62s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_updateMinorMultiRegion (3318.77s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_updateMajorMultiRegion (6336.05s)
```
