### PR TITLE
r/aws_servicecatalog_provisioned_product: `outputs` refresh when resource updates

### DIFF
--- a/internal/service/servicecatalog/provisioned_product_test.go
+++ b/internal/service/servicecatalog/provisioned_product_test.go
@@ -142,6 +142,55 @@ func TestAccServiceCatalogProvisionedProduct_update(t *testing.T) {
 	})
 }
 
+func TestAccServiceCatalogProvisionedProduct_computedOutputs(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_servicecatalog_provisioned_product.test"
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, servicecatalog.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckProvisionedProductDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProvisionedProductConfig_computedOutputs(rName, domain, acctest.DefaultEmailAddress, "10.1.0.0/16"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProvisionedProductExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "3"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "outputs.*", map[string]string{
+						"description": "VPC ID",
+						"key":         "VpcID",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "outputs.*", map[string]string{
+						"description": "VPC CIDR",
+						"key":         "VPCPrimaryCIDR",
+						"value":       "10.1.0.0/16",
+					}),
+				),
+			},
+			{
+				Config: testAccProvisionedProductConfig_computedOutputs(rName, domain, acctest.DefaultEmailAddress, "10.1.0.1/16"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProvisionedProductExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "outputs.#", "3"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "outputs.*", map[string]string{
+						"description": "VPC ID",
+						"key":         "VpcID",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "outputs.*", map[string]string{
+						"description": "VPC CIDR",
+						"key":         "VPCPrimaryCIDR",
+						"value":       "10.1.0.1/16",
+					}),
+				),
+			},
+		},
+	})
+}
+
 func TestAccServiceCatalogProvisionedProduct_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_provisioned_product.test"
@@ -403,8 +452,154 @@ data "aws_servicecatalog_launch_paths" "test" {
 `, rName, domain, email)
 }
 
+func testAccProvisionedProductPhysicalTemplateIDBaseConfig(rName, domain, email string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudformation_stack" "test" {
+  name = %[1]q
+
+  template_body = jsonencode({
+    AWSTemplateFormatVersion = "2010-09-09"
+
+    Parameters = {
+      VPCPrimaryCIDR = {
+        Type    = "String"
+        Default = "10.0.0.0/16"
+      }
+      LeaveMeEmpty = {
+        Type        = "String"
+        Description = "Make sure that empty values come through. Issue #21349"
+        Default     = ""
+      }
+    }
+
+    "Conditions" = {
+      "IsEmptyParameter" = {
+        "Fn::Equals" = [
+          {
+            "Ref" = "LeaveMeEmpty"
+          },
+          "",
+        ]
+      }
+    }
+
+    Resources = {
+      MyVPC = {
+        Type      = "AWS::EC2::VPC"
+        Condition = "IsEmptyParameter"
+        Properties = {
+          CidrBlock = { Ref = "VPCPrimaryCIDR" }
+        }
+      }
+    }
+
+    Outputs = {
+      VpcID = {
+        Description = "VPC ID"
+        Value = {
+          Ref = "MyVPC"
+        }
+      }
+
+      VPCPrimaryCIDR = {
+        Description = "VPC CIDR"
+        Value = {
+          Ref = "VPCPrimaryCIDR"
+        }
+      }
+    }
+  })
+}
+
+resource "aws_servicecatalog_product" "test" {
+  description         = %[1]q
+  distributor         = "distributör"
+  name                = %[1]q
+  owner               = "ägare"
+  type                = "CLOUD_FORMATION_TEMPLATE"
+  support_description = %[1]q
+  support_email       = %[3]q
+  support_url         = %[2]q
+
+  provisioning_artifact_parameters {
+    description                 = "artefaktbeskrivning"
+    disable_template_validation = true
+    name                        = %[1]q
+    template_physical_id        = aws_cloudformation_stack.test.id
+    type                        = "CLOUD_FORMATION_TEMPLATE"
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_servicecatalog_portfolio" "test" {
+  name          = %[1]q
+  description   = %[1]q
+  provider_name = %[1]q
+}
+
+resource "aws_servicecatalog_constraint" "test" {
+  description  = %[1]q
+  portfolio_id = aws_servicecatalog_product_portfolio_association.test.portfolio_id
+  product_id   = aws_servicecatalog_product_portfolio_association.test.product_id
+  type         = "RESOURCE_UPDATE"
+
+  parameters = jsonencode({
+    Version = "2.0"
+    Properties = {
+      TagUpdateOnProvisionedProduct = "ALLOWED"
+    }
+  })
+}
+
+resource "aws_servicecatalog_product_portfolio_association" "test" {
+  portfolio_id = aws_servicecatalog_principal_portfolio_association.test.portfolio_id # avoid depends_on
+  product_id   = aws_servicecatalog_product.test.id
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_session_context" "current" {
+  arn = data.aws_caller_identity.current.arn
+}
+
+resource "aws_servicecatalog_principal_portfolio_association" "test" {
+  portfolio_id  = aws_servicecatalog_portfolio.test.id
+  principal_arn = data.aws_iam_session_context.current.issuer_arn # unfortunately, you cannot get launch_path for arbitrary role - only caller
+}
+
+data "aws_servicecatalog_launch_paths" "test" {
+  product_id = aws_servicecatalog_product_portfolio_association.test.product_id # avoid depends_on
+}
+`, rName, domain, email)
+}
+
 func testAccProvisionedProductConfig_basic(rName, domain, email, vpcCidr string) string {
 	return acctest.ConfigCompose(testAccProvisionedProductTemplateURLBaseConfig(rName, domain, email),
+		fmt.Sprintf(`
+resource "aws_servicecatalog_provisioned_product" "test" {
+  name                       = %[1]q
+  product_id                 = aws_servicecatalog_product.test.id
+  provisioning_artifact_name = %[1]q
+  path_id                    = data.aws_servicecatalog_launch_paths.test.summaries[0].path_id
+
+  provisioning_parameters {
+    key   = "VPCPrimaryCIDR"
+    value = %[2]q
+  }
+
+  provisioning_parameters {
+    key   = "LeaveMeEmpty"
+    value = ""
+  }
+}
+`, rName, vpcCidr))
+}
+
+func testAccProvisionedProductConfig_computedOutputs(rName, domain, email, vpcCidr string) string {
+	return acctest.ConfigCompose(testAccProvisionedProductPhysicalTemplateIDBaseConfig(rName, domain, email),
 		fmt.Sprintf(`
 resource "aws_servicecatalog_provisioned_product" "test" {
   name                       = %[1]q


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
