### PR TITLE
Add warning about discouraged launch configuration resource

### DIFF
--- a/website/docs/r/launch_configuration.html.markdown
+++ b/website/docs/r/launch_configuration.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a resource to create a new launch configuration, used for autoscaling groups.
 
+!> **WARNING:** The use of launch configurations is discouraged in favour of launch templates. Read more in the [documentation](https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-configurations.html).
+
 -> **Note** When using `aws_launch_configuration` with `aws_autoscaling_group`, it is recommended to use the `name_prefix` (Optional) instead of the `name` (Optional) attribute. This will allow Terraform lifecycles to detect changes to the launch configuration and update the autoscaling group correctly.
 
 ## Example Usage

--- a/website/docs/r/launch_configuration.html.markdown
+++ b/website/docs/r/launch_configuration.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a resource to create a new launch configuration, used for autoscaling groups.
 
-!> **WARNING:** The use of launch configurations is discouraged in favour of launch templates. Read more in the [documentation](https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-configurations.html).
+!> **WARNING:** The use of launch configurations is discouraged in favour of launch templates. Read more in the [AWS EC2 Documentation](https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-configurations.html).
 
 -> **Note** When using `aws_launch_configuration` with `aws_autoscaling_group`, it is recommended to use the `name_prefix` (Optional) instead of the `name` (Optional) attribute. This will allow Terraform lifecycles to detect changes to the launch configuration and update the autoscaling group correctly.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Since AWS has deprecated this resource, this PR intends to adds a warning to discourage usage in the Terraform provider documentation, with a similar look and feel to the warning message displayed for [aws_kms_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_secret).


