### PR TITLE
Tech debt: Use paginators in EC2 finders

### DIFF
--- a/internal/service/ec2/ec2_host_data_source.go
+++ b/internal/service/ec2/ec2_host_data_source.go
@@ -85,7 +85,20 @@ func dataSourceHostRead(ctx context.Context, d *schema.ResourceData, meta interf
 	conn := meta.(*conns.AWSClient).EC2Conn()
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
-	host, err := FindHostByIDAndFilters(ctx, conn, d.Get("host_id").(string), BuildFiltersDataSource(d.Get("filter").(*schema.Set)))
+	input := &ec2.DescribeHostsInput{
+		Filter: BuildFiltersDataSource(d.Get("filter").(*schema.Set)),
+	}
+
+	if v, ok := d.GetOk("host_id"); ok {
+		input.HostIds = aws.StringSlice([]string{v.(string)})
+	}
+
+	if len(input.Filter) == 0 {
+		// Don't send an empty filters list; the EC2 API won't accept it.
+		input.Filter = nil
+	}
+
+	host, err := FindHost(ctx, conn, input)
 
 	if err != nil {
 		return sdkdiag.AppendFromErr(diags, tfresource.SingularDataSourceFindError("EC2 Host", err))

--- a/internal/service/ec2/ec2_host_data_source_test.go
+++ b/internal/service/ec2/ec2_host_data_source_test.go
@@ -78,7 +78,7 @@ func testAccHostDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_ec2_host" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
-  instance_type     = "a1.large"
+  instance_type     = "c5.large"
 
   tags = {
     Name = %[1]q
@@ -95,7 +95,7 @@ func testAccHostDataSourceConfig_filter(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_ec2_host" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
-  instance_type     = "a1.large"
+  instance_type     = "c5.large"
 
   tags = {
     %[1]q = "True"

--- a/internal/service/ec2/ec2_host_test.go
+++ b/internal/service/ec2/ec2_host_test.go
@@ -35,7 +35,7 @@ func TestAccEC2Host_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "auto_placement", "on"),
 					resource.TestCheckResourceAttr(resourceName, "host_recovery", "off"),
 					resource.TestCheckResourceAttr(resourceName, "instance_family", ""),
-					resource.TestCheckResourceAttr(resourceName, "instance_type", "a1.large"),
+					resource.TestCheckResourceAttr(resourceName, "instance_type", "c5.large"),
 					resource.TestCheckResourceAttr(resourceName, "outpost_arn", ""),
 					acctest.CheckResourceAttrAccountID(resourceName, "owner_id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -251,7 +251,7 @@ func testAccHostConfig_basic() string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), `
 resource "aws_ec2_host" "test" {
   availability_zone = data.aws_availability_zones.available.names[1]
-  instance_type     = "a1.large"
+  instance_type     = "c5.large"
 }
 `)
 }
@@ -290,7 +290,7 @@ func testAccHostConfig_tags1(tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_ec2_host" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
-  instance_type     = "a1.large"
+  instance_type     = "c5.large"
 
   tags = {
     %[1]q = %[2]q
@@ -303,7 +303,7 @@ func testAccHostConfig_tags2(tagKey1, tagValue1, tagKey2, tagValue2 string) stri
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_ec2_host" "test" {
   availability_zone = data.aws_availability_zones.available.names[0]
-  instance_type     = "a1.large"
+  instance_type     = "c5.large"
 
   tags = {
     %[1]q = %[2]q

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -3628,7 +3628,7 @@ func FindVPNConnectionByID(ctx context.Context, conn *ec2.EC2, id string) (*ec2.
 	return output, nil
 }
 
-func FindVPNConnection(ctx context.Context, conn *ec2.EC2, input *ec2.DescribeVpnConnectionsInput) (*ec2.VpnConnection, error) {
+func FindVPNConnections(ctx context.Context, conn *ec2.EC2, input *ec2.DescribeVpnConnectionsInput) ([]*ec2.VpnConnection, error) {
 	output, err := conn.DescribeVpnConnectionsWithContext(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, errCodeInvalidVPNConnectionIDNotFound) {
@@ -3642,15 +3642,25 @@ func FindVPNConnection(ctx context.Context, conn *ec2.EC2, input *ec2.DescribeVp
 		return nil, err
 	}
 
-	if output == nil || len(output.VpnConnections) == 0 || output.VpnConnections[0] == nil {
+	return output.VpnConnections, nil
+}
+
+func FindVPNConnection(ctx context.Context, conn *ec2.EC2, input *ec2.DescribeVpnConnectionsInput) (*ec2.VpnConnection, error) {
+	output, err := FindVPNConnections(ctx, conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output) == 0 || output[0] == nil {
 		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	if count := len(output.VpnConnections); count > 1 {
+	if count := len(output); count > 1 {
 		return nil, tfresource.NewTooManyResultsError(count, input)
 	}
 
-	return output.VpnConnections[0], nil
+	return output[0], nil
 }
 
 func FindVPNConnectionRouteByVPNConnectionIDAndCIDR(ctx context.Context, conn *ec2.EC2, vpnConnectionID, cidrBlock string) (*ec2.VpnStaticRoute, error) {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Use `DescribeXYZPages` in EC2 finders.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccSiteVPNConnection_basic\|TestAccSiteVPNConnection_disappears' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccSiteVPNConnection_basic\|TestAccSiteVPNConnection_disappears -timeout 180m
=== RUN   TestAccSiteVPNConnection_basic
=== PAUSE TestAccSiteVPNConnection_basic
=== RUN   TestAccSiteVPNConnection_disappears
=== PAUSE TestAccSiteVPNConnection_disappears
=== CONT  TestAccSiteVPNConnection_basic
=== CONT  TestAccSiteVPNConnection_disappears
--- PASS: TestAccSiteVPNConnection_disappears (194.14s)
--- PASS: TestAccSiteVPNConnection_basic (197.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	202.745s
% make testacc TESTARGS='-run=TestAccVPCFlowLog_vpcID\|TestAccVPCFlowLog_disappears' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccVPCFlowLog_vpcID\|TestAccVPCFlowLog_disappears -timeout 180m
=== RUN   TestAccVPCFlowLog_vpcID
=== PAUSE TestAccVPCFlowLog_vpcID
=== RUN   TestAccVPCFlowLog_disappears
=== PAUSE TestAccVPCFlowLog_disappears
=== CONT  TestAccVPCFlowLog_vpcID
=== CONT  TestAccVPCFlowLog_disappears
--- PASS: TestAccVPCFlowLog_disappears (23.36s)
--- PASS: TestAccVPCFlowLog_vpcID (38.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	43.385s
% make testacc TESTARGS='-run=TestAccEC2HostDataSource_basic\|TestAccEC2Host_basic\|TestAccEC2Host_disappears' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccEC2HostDataSource_basic\|TestAccEC2Host_basic\|TestAccEC2Host_disappears -timeout 180m
=== RUN   TestAccEC2HostDataSource_basic
=== PAUSE TestAccEC2HostDataSource_basic
=== RUN   TestAccEC2Host_basic
=== PAUSE TestAccEC2Host_basic
=== RUN   TestAccEC2Host_disappears
=== PAUSE TestAccEC2Host_disappears
=== CONT  TestAccEC2HostDataSource_basic
=== CONT  TestAccEC2Host_disappears
=== CONT  TestAccEC2Host_basic
--- PASS: TestAccEC2Host_disappears (20.08s)
--- PASS: TestAccEC2Host_basic (23.74s)
--- PASS: TestAccEC2HostDataSource_basic (38.37s)
PASS
```
