### PR TITLE
Move CODEOWNERS to root and add commented out default owner line

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-# There is no default owner for pull requests as reviews are scheduled based on community popularity.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Note: Default owner is commented out in order to reduce review requested noise for maintainers.
+# *       @hashicorp/terraform-aws


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds commented out default owner for attribution without review requested noise.

