### PR TITLE
feat: adding appsync opensearch config capabilities

### DIFF
--- a/.changelog/29576.txt
+++ b/.changelog/29576.txt
@@ -1,0 +1,3 @@
+```release-note:ehna:enhancement
+resource/aws_appsync_datasource: Add `opensearchservice_config` configuration block for OpenSearch Service data sources
+```

--- a/internal/service/appsync/datasource.go
+++ b/internal/service/appsync/datasource.go
@@ -134,7 +134,7 @@ func ResourceDataSource() *schema.Resource {
 						},
 					},
 				},
-				ConflictsWith: []string{"dynamodb_config", "http_config", "lambda_config", "elasticsearch_config", "opensearchservice_config"},
+				ConflictsWith: []string{"dynamodb_config", "http_config", "lambda_config", "elasticsearch_config"},
 			},
 			"http_config": {
 				Type:     schema.TypeList,


### PR DESCRIPTION
# The Problem
Elasticsearch is deprecated in the datasource AWS API as AWS is moving towards their fork, OpenSearch.  I realized upon attempting to apply this that opensearch is not currently supported by the provider, but it IS enabled in the aws-go-sdk as the exact same structure

# The Solution
I thought it prudent to support the new method.  Since as far as i can tell the two apis are largely the same...this is a lot of copy pasting w/ some name replacing


## References

[App Sync API Reference](https://docs.aws.amazon.com/appsync/latest/APIReference/API_CreateDataSource.html#API_CreateDataSource_RequestSyntax)

>As of September 2021, Amazon Elasticsearch service is Amazon OpenSearch Service. This configuration is deprecated. For new data sources, use [CreateDataSource:openSearchServiceConfig]


## Notes

- first time contributing to the repo, added tests, ran them (i think all of them?)
- added changelog