### PR TITLE
`[r|d]/aws_lambda_function`: Migrate to AWS SDK v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.11.5
 	github.com/aws/aws-sdk-go-v2/service/ivschat v1.3.4
 	github.com/aws/aws-sdk-go-v2/service/kendra v1.38.5
+	github.com/aws/aws-sdk-go-v2/service/lambda v1.29.4
 	github.com/aws/aws-sdk-go-v2/service/medialive v1.29.4
 	github.com/aws/aws-sdk-go-v2/service/oam v1.1.5
 	github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/aws/aws-sdk-go-v2/service/ivschat v1.3.4 h1:nGVv8RFgC4P7BsnL/NPGhT8W0
 github.com/aws/aws-sdk-go-v2/service/ivschat v1.3.4/go.mod h1:Ic/51aMt0SrY+rLEBYCMW6iuORW0wQJ/rhV0PGg07mQ=
 github.com/aws/aws-sdk-go-v2/service/kendra v1.38.5 h1:vYyn1h1+/eRL8UxfzRgxhH8tm+Jd6ujsyXmUFztfnks=
 github.com/aws/aws-sdk-go-v2/service/kendra v1.38.5/go.mod h1:PMq9hXXhaNxmBMIolmknhJ9gXi4PYDsZwsFBaJs7Zak=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.29.4 h1:gYGaEptCzFTlw91ETLla+d33SilaGnuJIT2ksJYXoVc=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.29.4/go.mod h1:iPDYs5hrSZ+/8Ifoq9ZpoiuHZXDEJx9Udurdoq20958=
 github.com/aws/aws-sdk-go-v2/service/medialive v1.29.4 h1:1K+jiIQQdFGgYUmITnQRTRFQSCv0fUIH/X//Kgq0m/8=
 github.com/aws/aws-sdk-go-v2/service/medialive v1.29.4/go.mod h1:MDHSj74ylVyTusJYPIoFhNXqwaD8W8cIf8yTEI7+ccc=
 github.com/aws/aws-sdk-go-v2/service/oam v1.1.5 h1:b4IaVHpAfwj2cOmTUgoIFTjLjTuC1yh3Ml3K7cjZFaU=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/inspector2"
 	"github.com/aws/aws-sdk-go-v2/service/ivschat"
 	"github.com/aws/aws-sdk-go-v2/service/kendra"
+	lambda_sdkv2 "github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/medialive"
 	"github.com/aws/aws-sdk-go-v2/service/oam"
 	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless"
@@ -339,6 +340,7 @@ type AWSClient struct {
 	httpClient *http.Client
 
 	ec2Client       lazyClient[*ec2_sdkv2.Client]
+	lambdaClient    lazyClient[*lambda_sdkv2.Client]
 	logsClient      lazyClient[*cloudwatchlogs_sdkv2.Client]
 	rdsClient       lazyClient[*rds_sdkv2.Client]
 	s3controlClient lazyClient[*s3control_sdkv2.Client]
@@ -1319,6 +1321,10 @@ func (client *AWSClient) LakeFormationConn() *lakeformation.LakeFormation {
 
 func (client *AWSClient) LambdaConn() *lambda.Lambda {
 	return client.lambdaConn
+}
+
+func (client *AWSClient) LambdaClient() *lambda_sdkv2.Client {
+	return client.lambdaClient.Client()
 }
 
 func (client *AWSClient) LexModelsConn() *lexmodelbuildingservice.LexModelBuildingService {

--- a/internal/conns/config_gen.go
+++ b/internal/conns/config_gen.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/inspector2"
 	"github.com/aws/aws-sdk-go-v2/service/ivschat"
 	"github.com/aws/aws-sdk-go-v2/service/kendra"
+	lambda_sdkv2 "github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/medialive"
 	"github.com/aws/aws-sdk-go-v2/service/oam"
 	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless"
@@ -705,6 +706,13 @@ func (c *Config) sdkv2LazyConns(client *AWSClient, cfg aws_sdkv2.Config) {
 		return ec2_sdkv2.NewFromConfig(cfg, func(o *ec2_sdkv2.Options) {
 			if endpoint := c.Endpoints[names.EC2]; endpoint != "" {
 				o.EndpointResolver = ec2_sdkv2.EndpointResolverFromURL(endpoint)
+			}
+		})
+	})
+	client.lambdaClient.init(&cfg, func() *lambda_sdkv2.Client {
+		return lambda_sdkv2.NewFromConfig(cfg, func(o *lambda_sdkv2.Options) {
+			if endpoint := c.Endpoints[names.Lambda]; endpoint != "" {
+				o.EndpointResolver = lambda_sdkv2.EndpointResolverFromURL(endpoint)
 			}
 		})
 	})

--- a/internal/service/lambda/flex.go
+++ b/internal/service/lambda/flex.go
@@ -1,6 +1,7 @@
 package lambda
 
 import (
+	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
@@ -18,7 +19,7 @@ func flattenAliasRoutingConfiguration(arc *lambda.AliasRoutingConfiguration) []i
 	return []interface{}{m}
 }
 
-func flattenLayers(layers []*lambda.Layer) []interface{} {
+func flattenLayers(layers []types.Layer) []interface{} {
 	arns := make([]*string, len(layers))
 	for i, layer := range layers {
 		arns[i] = layer.Arn
@@ -26,7 +27,7 @@ func flattenLayers(layers []*lambda.Layer) []interface{} {
 	return flex.FlattenStringList(arns)
 }
 
-func flattenVPCConfigResponse(s *lambda.VpcConfigResponse) []map[string]interface{} {
+func flattenVPCConfigResponse(s *types.VpcConfigResponse) []map[string]interface{} {
 	settings := make(map[string]interface{})
 
 	if s == nil {
@@ -41,8 +42,8 @@ func flattenVPCConfigResponse(s *lambda.VpcConfigResponse) []map[string]interfac
 		return nil
 	}
 
-	settings["subnet_ids"] = flex.FlattenStringSet(s.SubnetIds)
-	settings["security_group_ids"] = flex.FlattenStringSet(s.SecurityGroupIds)
+	settings["subnet_ids"] = flex.FlattenStringValueSet(s.SubnetIds)
+	settings["security_group_ids"] = flex.FlattenStringValueSet(s.SecurityGroupIds)
 	if s.VpcId != nil {
 		settings["vpc_id"] = aws.StringValue(s.VpcId)
 	}

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -2,24 +2,27 @@ package lambda
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/lambda"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
@@ -60,8 +63,8 @@ func ResourceFunction() *schema.Resource {
 				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.StringInSlice(lambda.Architecture_Values(), false),
+					Type:             schema.TypeString,
+					ValidateDiagFunc: enum.Validate[types.Architecture](),
 				},
 			},
 			"arn": {
@@ -217,11 +220,11 @@ func ResourceFunction() *schema.Resource {
 				Default:  128,
 			},
 			"package_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      lambda.PackageTypeZip,
-				ValidateFunc: validation.StringInSlice(lambda.PackageType_Values(), false),
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Default:          types.PackageTypeZip,
+				ValidateDiagFunc: enum.Validate[types.PackageType](),
 			},
 			"publish": {
 				Type:     schema.TypeBool,
@@ -257,9 +260,9 @@ func ResourceFunction() *schema.Resource {
 				Required: true,
 			},
 			"runtime": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice(lambda.Runtime_Values(), false),
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: enum.Validate[types.Runtime](),
 			},
 			"s3_bucket": {
 				Type:         schema.TypeString,
@@ -292,9 +295,9 @@ func ResourceFunction() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"apply_on": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice(lambda.SnapStartApplyOn_Values(), true),
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: enum.Validate[types.SnapStartApplyOn](),
 						},
 						"optimization_status": {
 							Type:     schema.TypeString,
@@ -327,9 +330,9 @@ func ResourceFunction() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"mode": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice(lambda.TracingMode_Values(), true),
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: enum.Validate[types.TracingMode](),
 						},
 					},
 				},
@@ -395,21 +398,21 @@ const (
 
 func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).LambdaConn()
+	conn := meta.(*conns.AWSClient).LambdaClient()
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	functionName := d.Get("function_name").(string)
-	packageType := d.Get("package_type").(string)
+	packageType := types.PackageType(d.Get("package_type").(string))
 	input := &lambda.CreateFunctionInput{
-		Code:         &lambda.FunctionCode{},
+		Code:         &types.FunctionCode{},
 		Description:  aws.String(d.Get("description").(string)),
 		FunctionName: aws.String(functionName),
-		MemorySize:   aws.Int64(int64(d.Get("memory_size").(int))),
-		PackageType:  aws.String(packageType),
-		Publish:      aws.Bool(d.Get("publish").(bool)),
+		MemorySize:   aws.Int32(int32(d.Get("memory_size").(int))),
+		PackageType:  packageType,
+		Publish:      d.Get("publish").(bool),
 		Role:         aws.String(d.Get("role").(string)),
-		Timeout:      aws.Int64(int64(d.Get("timeout").(int))),
+		Timeout:      aws.Int32(int32(d.Get("timeout").(int))),
 	}
 
 	if v, ok := d.GetOk("filename"); ok {
@@ -436,7 +439,7 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if v, ok := d.GetOk("architectures"); ok && len(v.([]interface{})) > 0 {
-		input.Architectures = flex.ExpandStringList(v.([]interface{}))
+		input.Architectures = expandArchitectures(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("code_signing_config_arn"); ok {
@@ -448,22 +451,22 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 			return sdkdiag.AppendErrorf(diags, "nil dead_letter_config supplied for function: %s", functionName)
 		}
 
-		input.DeadLetterConfig = &lambda.DeadLetterConfig{
+		input.DeadLetterConfig = &types.DeadLetterConfig{
 			TargetArn: aws.String(v.([]interface{})[0].(map[string]interface{})["target_arn"].(string)),
 		}
 	}
 
 	if v, ok := d.GetOk("environment"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		if v, ok := v.([]interface{})[0].(map[string]interface{})["variables"].(map[string]interface{}); ok && len(v) > 0 {
-			input.Environment = &lambda.Environment{
-				Variables: flex.ExpandStringMap(v),
+			input.Environment = &types.Environment{
+				Variables: flex.ExpandStringValueMap(v),
 			}
 		}
 	}
 
 	if v, ok := d.GetOk("ephemeral_storage"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.EphemeralStorage = &lambda.EphemeralStorage{
-			Size: aws.Int64(int64(v.([]interface{})[0].(map[string]interface{})["size"].(int))),
+		input.EphemeralStorage = &types.EphemeralStorage{
+			Size: aws.Int32(int32(v.([]interface{})[0].(map[string]interface{})["size"].(int))),
 		}
 	}
 
@@ -471,9 +474,9 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 		input.FileSystemConfigs = expandFileSystemConfigs(v.([]interface{}))
 	}
 
-	if packageType == lambda.PackageTypeZip {
+	if packageType == types.PackageTypeZip {
 		input.Handler = aws.String(d.Get("handler").(string))
-		input.Runtime = aws.String(d.Get("runtime").(string))
+		input.Runtime = types.Runtime(d.Get("runtime").(string))
 	}
 
 	if v, ok := d.GetOk("image_config"); ok && len(v.([]interface{})) > 0 {
@@ -485,7 +488,7 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if v, ok := d.GetOk("layers"); ok && len(v.([]interface{})) > 0 {
-		input.Layers = flex.ExpandStringList(v.([]interface{}))
+		input.Layers = flex.ExpandStringValueList(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("snap_start"); ok {
@@ -493,16 +496,16 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if v, ok := d.GetOk("tracing_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.TracingConfig = &lambda.TracingConfig{
-			Mode: aws.String(v.([]interface{})[0].(map[string]interface{})["mode"].(string)),
+		input.TracingConfig = &types.TracingConfig{
+			Mode: types.TracingMode(v.([]interface{})[0].(map[string]interface{})["mode"].(string)),
 		}
 	}
 
 	if v, ok := d.GetOk("vpc_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		tfMap := v.([]interface{})[0].(map[string]interface{})
-		input.VpcConfig = &lambda.VpcConfig{
-			SecurityGroupIds: flex.ExpandStringSet(tfMap["security_group_ids"].(*schema.Set)),
-			SubnetIds:        flex.ExpandStringSet(tfMap["subnet_ids"].(*schema.Set)),
+		input.VpcConfig = &types.VpcConfig{
+			SecurityGroupIds: flex.ExpandStringValueSet(tfMap["security_group_ids"].(*schema.Set)),
+			SubnetIds:        flex.ExpandStringValueSet(tfMap["subnet_ids"].(*schema.Set)),
 		}
 	}
 
@@ -511,7 +514,7 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	_, err := retryFunctionOp(ctx, func() (interface{}, error) {
-		return conn.CreateFunctionWithContext(ctx, input)
+		return conn.CreateFunction(ctx, input)
 	})
 
 	if err != nil {
@@ -533,9 +536,9 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if v, ok := d.Get("reserved_concurrent_executions").(int); ok && v >= 0 {
-		_, err := conn.PutFunctionConcurrencyWithContext(ctx, &lambda.PutFunctionConcurrencyInput{
+		_, err := conn.PutFunctionConcurrency(ctx, &lambda.PutFunctionConcurrencyInput{
 			FunctionName:                 aws.String(d.Id()),
-			ReservedConcurrentExecutions: aws.Int64(int64(v)),
+			ReservedConcurrentExecutions: aws.Int32(int32(v)),
 		})
 
 		if err != nil {
@@ -548,7 +551,7 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).LambdaConn()
+	conn := meta.(*conns.AWSClient).LambdaClient()
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -575,13 +578,13 @@ func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	function := output.Configuration
-	d.Set("architectures", aws.StringValueSlice(function.Architectures))
-	functionARN := aws.StringValue(function.FunctionArn)
+	d.Set("architectures", flattenArchitectures(function.Architectures))
+	functionARN := aws.ToString(function.FunctionArn)
 	d.Set("arn", functionARN)
 	if function.DeadLetterConfig != nil && function.DeadLetterConfig.TargetArn != nil {
 		if err := d.Set("dead_letter_config", []interface{}{
 			map[string]interface{}{
-				"target_arn": aws.StringValue(function.DeadLetterConfig.TargetArn),
+				"target_arn": aws.ToString(function.DeadLetterConfig.TargetArn),
 			},
 		}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting dead_letter_config: %s", err)
@@ -629,13 +632,13 @@ func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("source_code_hash", function.CodeSha256)
 	d.Set("source_code_size", function.CodeSize)
 	d.Set("timeout", function.Timeout)
-	tracingConfigMode := lambda.TracingModePassThrough
+	tracingConfigMode := types.TracingModePassThrough
 	if function.TracingConfig != nil {
-		tracingConfigMode = aws.StringValue(function.TracingConfig.Mode)
+		tracingConfigMode = function.TracingConfig.Mode
 	}
 	if err := d.Set("tracing_config", []interface{}{
 		map[string]interface{}{
-			"mode": tracingConfigMode,
+			"mode": string(tracingConfigMode),
 		},
 	}); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting tracing_config: %s", err)
@@ -655,7 +658,7 @@ func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta inte
 			return sdkdiag.AppendErrorf(diags, "reading Lambda Function (%s) latest version: %s", d.Id(), err)
 		}
 
-		qualifiedARN := aws.StringValue(latest.FunctionArn)
+		qualifiedARN := aws.ToString(latest.FunctionArn)
 		d.Set("qualified_arn", qualifiedARN)
 		d.Set("qualified_invoke_arn", functionInvokeARN(qualifiedARN, meta))
 		d.Set("version", latest.Version)
@@ -683,8 +686,8 @@ func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta inte
 		var codeSigningConfigArn string
 
 		// Code Signing is only supported on zip packaged lambda functions.
-		if aws.StringValue(function.PackageType) == lambda.PackageTypeZip {
-			output, err := conn.GetFunctionCodeSigningConfigWithContext(ctx, &lambda.GetFunctionCodeSigningConfigInput{
+		if function.PackageType == types.PackageTypeZip {
+			output, err := conn.GetFunctionCodeSigningConfig(ctx, &lambda.GetFunctionCodeSigningConfigInput{
 				FunctionName: aws.String(d.Id()),
 			})
 
@@ -693,7 +696,7 @@ func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta inte
 			}
 
 			if output != nil {
-				codeSigningConfigArn = aws.StringValue(output.CodeSigningConfigArn)
+				codeSigningConfigArn = aws.ToString(output.CodeSigningConfigArn)
 			}
 		}
 
@@ -705,11 +708,11 @@ func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).LambdaConn()
+	conn := meta.(*conns.AWSClient).LambdaClient()
 
 	if d.HasChange("code_signing_config_arn") {
 		if v, ok := d.GetOk("code_signing_config_arn"); ok {
-			_, err := conn.PutFunctionCodeSigningConfigWithContext(ctx, &lambda.PutFunctionCodeSigningConfigInput{
+			_, err := conn.PutFunctionCodeSigningConfig(ctx, &lambda.PutFunctionCodeSigningConfigInput{
 				CodeSigningConfigArn: aws.String(v.(string)),
 				FunctionName:         aws.String(d.Id()),
 			})
@@ -718,7 +721,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 				return sdkdiag.AppendErrorf(diags, "setting Lambda Function (%s) code signing config: %s", d.Id(), err)
 			}
 		} else {
-			_, err := conn.DeleteFunctionCodeSigningConfigWithContext(ctx, &lambda.DeleteFunctionCodeSigningConfigInput{
+			_, err := conn.DeleteFunctionCodeSigningConfig(ctx, &lambda.DeleteFunctionCodeSigningConfigInput{
 				FunctionName: aws.String(d.Id()),
 			})
 
@@ -749,11 +752,11 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 					return sdkdiag.AppendErrorf(diags, "nil dead_letter_config supplied for function: %s", d.Id())
 				}
 
-				input.DeadLetterConfig = &lambda.DeadLetterConfig{
+				input.DeadLetterConfig = &types.DeadLetterConfig{
 					TargetArn: aws.String(v.([]interface{})[0].(map[string]interface{})["target_arn"].(string)),
 				}
 			} else {
-				input.DeadLetterConfig = &lambda.DeadLetterConfig{
+				input.DeadLetterConfig = &types.DeadLetterConfig{
 					TargetArn: aws.String(""),
 				}
 			}
@@ -764,14 +767,14 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if d.HasChanges("environment", "kms_key_arn") {
-			input.Environment = &lambda.Environment{
-				Variables: map[string]*string{},
+			input.Environment = &types.Environment{
+				Variables: map[string]string{},
 			}
 
 			if v, ok := d.GetOk("environment"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 				if v, ok := v.([]interface{})[0].(map[string]interface{})["variables"].(map[string]interface{}); ok && len(v) > 0 {
-					input.Environment = &lambda.Environment{
-						Variables: flex.ExpandStringMap(v),
+					input.Environment = &types.Environment{
+						Variables: flex.ExpandStringValueMap(v),
 					}
 				}
 			}
@@ -779,8 +782,8 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 		if d.HasChange("ephemeral_storage") {
 			if v, ok := d.GetOk("ephemeral_storage"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.EphemeralStorage = &lambda.EphemeralStorage{
-					Size: aws.Int64(int64(v.([]interface{})[0].(map[string]interface{})["size"].(int))),
+				input.EphemeralStorage = &types.EphemeralStorage{
+					Size: aws.Int32(int32(v.([]interface{})[0].(map[string]interface{})["size"].(int))),
 				}
 			}
 		}
@@ -789,7 +792,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			if v, ok := d.GetOk("file_system_config"); ok && len(v.([]interface{})) > 0 {
 				input.FileSystemConfigs = expandFileSystemConfigs(v.([]interface{}))
 			} else {
-				input.FileSystemConfigs = []*lambda.FileSystemConfig{}
+				input.FileSystemConfigs = []types.FileSystemConfig{}
 			}
 		}
 
@@ -801,7 +804,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			if v, ok := d.GetOk("image_config"); ok && len(v.([]interface{})) > 0 {
 				input.ImageConfig = expandImageConfigs(v.([]interface{}))
 			} else {
-				input.ImageConfig = &lambda.ImageConfig{}
+				input.ImageConfig = &types.ImageConfig{}
 			}
 		}
 
@@ -810,11 +813,11 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if d.HasChange("layers") {
-			input.Layers = flex.ExpandStringList(d.Get("layers").([]interface{}))
+			input.Layers = flex.ExpandStringValueList(d.Get("layers").([]interface{}))
 		}
 
 		if d.HasChange("memory_size") {
-			input.MemorySize = aws.Int64(int64(d.Get("memory_size").(int)))
+			input.MemorySize = aws.Int32(int32(d.Get("memory_size").(int)))
 		}
 
 		if d.HasChange("role") {
@@ -822,7 +825,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if d.HasChange("runtime") {
-			input.Runtime = aws.String(d.Get("runtime").(string))
+			input.Runtime = types.Runtime(d.Get("runtime").(string))
 		}
 
 		if d.HasChange("snap_start") {
@@ -830,13 +833,13 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if d.HasChange("timeout") {
-			input.Timeout = aws.Int64(int64(d.Get("timeout").(int)))
+			input.Timeout = aws.Int32(int32(d.Get("timeout").(int)))
 		}
 
 		if d.HasChange("tracing_config") {
 			if v, ok := d.GetOk("tracing_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.TracingConfig = &lambda.TracingConfig{
-					Mode: aws.String(v.([]interface{})[0].(map[string]interface{})["mode"].(string)),
+				input.TracingConfig = &types.TracingConfig{
+					Mode: types.TracingMode(v.([]interface{})[0].(map[string]interface{})["mode"].(string)),
 				}
 			}
 		}
@@ -844,20 +847,20 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		if d.HasChanges("vpc_config.0.security_group_ids", "vpc_config.0.subnet_ids") {
 			if v, ok := d.GetOk("vpc_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 				tfMap := v.([]interface{})[0].(map[string]interface{})
-				input.VpcConfig = &lambda.VpcConfig{
-					SecurityGroupIds: flex.ExpandStringSet(tfMap["security_group_ids"].(*schema.Set)),
-					SubnetIds:        flex.ExpandStringSet(tfMap["subnet_ids"].(*schema.Set)),
+				input.VpcConfig = &types.VpcConfig{
+					SecurityGroupIds: flex.ExpandStringValueSet(tfMap["security_group_ids"].(*schema.Set)),
+					SubnetIds:        flex.ExpandStringValueSet(tfMap["subnet_ids"].(*schema.Set)),
 				}
 			} else {
-				input.VpcConfig = &lambda.VpcConfig{
-					SecurityGroupIds: []*string{},
-					SubnetIds:        []*string{},
+				input.VpcConfig = &types.VpcConfig{
+					SecurityGroupIds: []string{},
+					SubnetIds:        []string{},
 				}
 			}
 		}
 
 		_, err := retryFunctionOp(ctx, func() (interface{}, error) {
-			return conn.UpdateFunctionConfigurationWithContext(ctx, input)
+			return conn.UpdateFunctionConfiguration(ctx, input)
 		})
 
 		if err != nil {
@@ -877,7 +880,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 		if d.HasChange("architectures") {
 			if v, ok := d.GetOk("architectures"); ok && len(v.([]interface{})) > 0 {
-				input.Architectures = flex.ExpandStringList(v.([]interface{}))
+				input.Architectures = expandArchitectures(v.([]interface{}))
 			}
 		}
 
@@ -908,10 +911,11 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			}
 		}
 
-		_, err := conn.UpdateFunctionCodeWithContext(ctx, input)
+		_, err := conn.UpdateFunctionCode(ctx, input)
 
 		if err != nil {
-			if tfawserr.ErrMessageContains(err, lambda.ErrCodeInvalidParameterValueException, "Error occurred while GetObject.") {
+			var ipve *types.InvalidParameterValueException
+			if errors.As(err, &ipve) && strings.Contains(ipve.ErrorMessage(), "Error occurred while GetObject.") {
 				// As s3_bucket, s3_key and s3_object_version aren't set in resourceFunctionRead(), don't ovewrite the last known good values.
 				for _, key := range []string{"s3_bucket", "s3_key", "s3_object_version"} {
 					old, _ := d.GetChange(key)
@@ -929,16 +933,16 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 	if d.HasChange("reserved_concurrent_executions") {
 		if v, ok := d.Get("reserved_concurrent_executions").(int); ok && v >= 0 {
-			_, err := conn.PutFunctionConcurrencyWithContext(ctx, &lambda.PutFunctionConcurrencyInput{
+			_, err := conn.PutFunctionConcurrency(ctx, &lambda.PutFunctionConcurrencyInput{
 				FunctionName:                 aws.String(d.Id()),
-				ReservedConcurrentExecutions: aws.Int64(int64(v)),
+				ReservedConcurrentExecutions: aws.Int32(int32(v)),
 			})
 
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "setting Lambda Function (%s) concurrency: %s", d.Id(), err)
 			}
 		} else {
-			_, err := conn.DeleteFunctionConcurrencyWithContext(ctx, &lambda.DeleteFunctionConcurrencyInput{
+			_, err := conn.DeleteFunctionConcurrency(ctx, &lambda.DeleteFunctionConcurrencyInput{
 				FunctionName: aws.String(d.Id()),
 			})
 
@@ -953,20 +957,29 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			FunctionName: aws.String(d.Id()),
 		}
 
-		outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
-			return conn.PublishVersionWithContext(ctx, input)
-		}, lambda.ErrCodeResourceConflictException, "in progress")
+		outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
+			func() (interface{}, error) {
+				return conn.PublishVersion(ctx, input)
+			},
+			func(err error) (bool, error) {
+				var rce *types.ResourceConflictException
+				if errors.As(err, &rce) && strings.Contains(rce.ErrorMessage(), "in progress") {
+					return true, err
+				}
+				return false, err
+			},
+		)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "publishing Lambda Function (%s) version: %s", d.Id(), err)
 		}
 
-		output := outputRaw.(*lambda.FunctionConfiguration)
+		output := outputRaw.(*lambda.PublishVersionOutput)
 
-		err = conn.WaitUntilFunctionUpdatedWithContext(ctx, &lambda.GetFunctionConfigurationInput{
+		err = lambda.NewFunctionUpdatedWaiter(conn).Wait(ctx, &lambda.GetFunctionConfigurationInput{
 			FunctionName: output.FunctionArn,
 			Qualifier:    output.Version,
-		})
+		}, d.Timeout(schema.TimeoutUpdate))
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "publishing Lambda Function (%s) version: waiting for completion: %s", d.Id(), err)
@@ -978,18 +991,17 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 func resourceFunctionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).LambdaConn()
+	conn := meta.(*conns.AWSClient).LambdaClient()
 
 	log.Printf("[INFO] Deleting Lambda Function: %s", d.Id())
-	_, err := conn.DeleteFunctionWithContext(ctx, &lambda.DeleteFunctionInput{
+	_, err := conn.DeleteFunction(ctx, &lambda.DeleteFunctionInput{
 		FunctionName: aws.String(d.Id()),
 	})
-
-	if tfawserr.ErrCodeEquals(err, lambda.ErrCodeResourceNotFoundException) {
-		return diags
-	}
-
 	if err != nil {
+		var nfe *types.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return diags
+		}
 		return sdkdiag.AppendErrorf(diags, "deleting Lambda Function (%s): %s", d.Id(), err)
 	}
 
@@ -1002,7 +1014,7 @@ func resourceFunctionDelete(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func FindFunctionByName(ctx context.Context, conn *lambda.Lambda, name string) (*lambda.GetFunctionOutput, error) {
+func FindFunctionByName(ctx context.Context, conn *lambda.Client, name string) (*lambda.GetFunctionOutput, error) {
 	input := &lambda.GetFunctionInput{
 		FunctionName: aws.String(name),
 	}
@@ -1010,17 +1022,16 @@ func FindFunctionByName(ctx context.Context, conn *lambda.Lambda, name string) (
 	return findFunction(ctx, conn, input)
 }
 
-func findFunction(ctx context.Context, conn *lambda.Lambda, input *lambda.GetFunctionInput) (*lambda.GetFunctionOutput, error) {
-	output, err := conn.GetFunctionWithContext(ctx, input)
-
-	if tfawserr.ErrCodeEquals(err, lambda.ErrCodeResourceNotFoundException) {
-		return nil, &resource.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
-		}
-	}
-
+func findFunction(ctx context.Context, conn *lambda.Client, input *lambda.GetFunctionInput) (*lambda.GetFunctionOutput, error) {
+	output, err := conn.GetFunction(ctx, input)
 	if err != nil {
+		var nfe *types.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return nil, &resource.NotFoundError{
+				LastError:   err,
+				LastRequest: input,
+			}
+		}
 		return nil, err
 	}
 
@@ -1031,28 +1042,23 @@ func findFunction(ctx context.Context, conn *lambda.Lambda, input *lambda.GetFun
 	return output, nil
 }
 
-func findLatestFunctionVersionByName(ctx context.Context, conn *lambda.Lambda, name string) (*lambda.FunctionConfiguration, error) {
+func findLatestFunctionVersionByName(ctx context.Context, conn *lambda.Client, name string) (*types.FunctionConfiguration, error) {
 	input := &lambda.ListVersionsByFunctionInput{
 		FunctionName: aws.String(name),
-		MaxItems:     aws.Int64(10000),
+		MaxItems:     aws.Int32(10000),
 	}
-	var output *lambda.FunctionConfiguration
+	var output *types.FunctionConfiguration
 
-	err := conn.ListVersionsByFunctionPagesWithContext(ctx, input, func(page *lambda.ListVersionsByFunctionOutput, lastPage bool) bool {
-		if page == nil {
-			return !lastPage
+	pages := lambda.NewListVersionsByFunctionPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			return output, err
 		}
-
-		// List is sorted from oldest to latest.
-		if lastPage {
-			output = page.Versions[len(page.Versions)-1]
+		if len(page.Versions) > 0 && page.NextMarker == nil {
+			// List is sorted from oldest to latest.
+			output = &page.Versions[len(page.Versions)-1]
 		}
-
-		return !lastPage
-	})
-
-	if err != nil {
-		return nil, err
 	}
 
 	if output == nil {
@@ -1112,7 +1118,7 @@ func replaceSecurityGroups(ctx context.Context, d *schema.ResourceData, meta int
 	return nil
 }
 
-func statusFunctionLastUpdateStatus(ctx context.Context, conn *lambda.Lambda, name string) resource.StateRefreshFunc {
+func statusFunctionLastUpdateStatus(ctx context.Context, conn *lambda.Client, name string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindFunctionByName(ctx, conn, name)
 
@@ -1124,11 +1130,11 @@ func statusFunctionLastUpdateStatus(ctx context.Context, conn *lambda.Lambda, na
 			return nil, "", err
 		}
 
-		return output.Configuration, aws.StringValue(output.Configuration.LastUpdateStatus), nil
+		return output.Configuration, string(output.Configuration.LastUpdateStatus), nil
 	}
 }
 
-func statusFunctionState(ctx context.Context, conn *lambda.Lambda, name string) resource.StateRefreshFunc {
+func statusFunctionState(ctx context.Context, conn *lambda.Client, name string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindFunctionByName(ctx, conn, name)
 
@@ -1140,14 +1146,14 @@ func statusFunctionState(ctx context.Context, conn *lambda.Lambda, name string) 
 			return nil, "", err
 		}
 
-		return output.Configuration, aws.StringValue(output.Configuration.State), nil
+		return output.Configuration, string(output.Configuration.State), nil
 	}
 }
 
-func waitFunctionCreated(ctx context.Context, conn *lambda.Lambda, name string, timeout time.Duration) (*lambda.FunctionConfiguration, error) {
+func waitFunctionCreated(ctx context.Context, conn *lambda.Client, name string, timeout time.Duration) (*types.FunctionConfiguration, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{lambda.StatePending},
-		Target:  []string{lambda.StateActive},
+		Pending: []string{string(types.StatePending)},
+		Target:  []string{string(types.StateActive)},
 		Refresh: statusFunctionState(ctx, conn, name),
 		Timeout: timeout,
 		Delay:   5 * time.Second,
@@ -1155,8 +1161,8 @@ func waitFunctionCreated(ctx context.Context, conn *lambda.Lambda, name string, 
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-	if output, ok := outputRaw.(*lambda.FunctionConfiguration); ok {
-		tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.StringValue(output.StateReasonCode), aws.StringValue(output.StateReason)))
+	if output, ok := outputRaw.(*types.FunctionConfiguration); ok {
+		tfresource.SetLastError(err, fmt.Errorf("%s: %s", string(output.StateReasonCode), aws.ToString(output.StateReason)))
 
 		return output, err
 	}
@@ -1164,10 +1170,10 @@ func waitFunctionCreated(ctx context.Context, conn *lambda.Lambda, name string, 
 	return nil, err
 }
 
-func waitFunctionUpdated(ctx context.Context, conn *lambda.Lambda, functionName string, timeout time.Duration) (*lambda.FunctionConfiguration, error) { //nolint:unparam
+func waitFunctionUpdated(ctx context.Context, conn *lambda.Client, functionName string, timeout time.Duration) (*types.FunctionConfiguration, error) { //nolint:unparam
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{lambda.LastUpdateStatusInProgress},
-		Target:  []string{lambda.LastUpdateStatusSuccessful},
+		Pending: []string{string(types.LastUpdateStatusInProgress)},
+		Target:  []string{string(types.LastUpdateStatusSuccessful)},
 		Refresh: statusFunctionLastUpdateStatus(ctx, conn, functionName),
 		Timeout: timeout,
 		Delay:   5 * time.Second,
@@ -1175,8 +1181,8 @@ func waitFunctionUpdated(ctx context.Context, conn *lambda.Lambda, functionName 
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-	if output, ok := outputRaw.(*lambda.FunctionConfiguration); ok {
-		tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.StringValue(output.LastUpdateStatusReasonCode), aws.StringValue(output.LastUpdateStatusReason)))
+	if output, ok := outputRaw.(*types.FunctionConfiguration); ok {
+		tfresource.SetLastError(err, fmt.Errorf("%s: %s", string(output.LastUpdateStatusReasonCode), aws.ToString(output.LastUpdateStatusReason)))
 
 		return output, err
 	}
@@ -1190,51 +1196,57 @@ func retryFunctionOp(ctx context.Context, f func() (interface{}, error)) (interf
 	output, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		f,
 		func(err error) (bool, error) {
-			if tfawserr.ErrMessageContains(err, lambda.ErrCodeInvalidParameterValueException, "The role defined for the function cannot be assumed by Lambda") {
-				return true, err
+			var ipve *types.InvalidParameterValueException
+			if errors.As(err, &ipve) {
+				msg := ipve.ErrorMessage()
+				if strings.Contains(msg, "The role defined for the function cannot be assumed by Lambda") {
+					return true, err
+				}
+				if strings.Contains(msg, "The provided execution role does not have permissions") {
+					return true, err
+				}
+				if strings.Contains(msg, "throttled by EC2") {
+					return true, err
+				}
+				if strings.Contains(msg, "Lambda was unable to configure access to your environment variables because the KMS key is invalid for CreateGrant") {
+					return true, err
+				}
 			}
 
-			if tfawserr.ErrMessageContains(err, lambda.ErrCodeInvalidParameterValueException, "The provided execution role does not have permissions") {
-				return true, err
-			}
-
-			if tfawserr.ErrMessageContains(err, lambda.ErrCodeInvalidParameterValueException, "throttled by EC2") {
-				return true, err
-			}
-
-			if tfawserr.ErrMessageContains(err, lambda.ErrCodeInvalidParameterValueException, "Lambda was unable to configure access to your environment variables because the KMS key is invalid for CreateGrant") {
-				return true, err
-			}
-
-			if tfawserr.ErrCodeEquals(err, lambda.ErrCodeResourceConflictException) {
+			var rce *types.ResourceConflictException
+			if errors.As(err, &rce) {
 				return true, err
 			}
 
 			return false, err
-		})
+		},
+	)
 
 	// Additional retries when throttled.
-	if tfawserr.ErrMessageContains(err, lambda.ErrCodeInvalidParameterValueException, "throttled by EC2") {
+	var ipve *types.InvalidParameterValueException
+	if errors.As(err, &ipve) && strings.Contains(ipve.ErrorMessage(), "throttled by EC2") {
 		output, err = tfresource.RetryWhen(ctx, functionExtraThrottlingTimeout,
 			f,
 			func(err error) (bool, error) {
-				if tfawserr.ErrMessageContains(err, lambda.ErrCodeInvalidParameterValueException, "throttled by EC2") {
+				var ipve *types.InvalidParameterValueException
+				if errors.As(err, &ipve) && strings.Contains(ipve.ErrorMessage(), "throttled by EC2") {
 					return true, err
 				}
 
 				return false, err
-			})
+			},
+		)
 	}
 
 	return output, err
 }
 
 func checkHandlerRuntimeForZipFunction(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
-	packageType := d.Get("package_type")
+	packageType := d.Get("package_type").(string)
 	_, handlerOk := d.GetOk("handler")
 	_, runtimeOk := d.GetOk("runtime")
 
-	if packageType == lambda.PackageTypeZip && (!handlerOk || !runtimeOk) {
+	if packageType == string(types.PackageTypeZip) && (!handlerOk || !runtimeOk) {
 		return fmt.Errorf("handler and runtime must be set when PackageType is Zip")
 	}
 	return nil
@@ -1339,7 +1351,7 @@ func SignerServiceIsAvailable(region string) bool {
 	return ok
 }
 
-func flattenEnvironment(apiObject *lambda.EnvironmentResponse) []interface{} {
+func flattenEnvironment(apiObject *types.EnvironmentResponse) []interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -1347,29 +1359,29 @@ func flattenEnvironment(apiObject *lambda.EnvironmentResponse) []interface{} {
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.Variables; v != nil {
-		tfMap["variables"] = aws.StringValueMap(v)
+		tfMap["variables"] = aws.StringMap(v)
 	}
 
 	return []interface{}{tfMap}
 }
 
-func flattenFileSystemConfigs(fscList []*lambda.FileSystemConfig) []map[string]interface{} {
+func flattenFileSystemConfigs(fscList []types.FileSystemConfig) []map[string]interface{} {
 	results := make([]map[string]interface{}, 0, len(fscList))
 	for _, fsc := range fscList {
 		f := make(map[string]interface{})
-		f["arn"] = aws.StringValue(fsc.Arn)
-		f["local_mount_path"] = aws.StringValue(fsc.LocalMountPath)
+		f["arn"] = aws.ToString(fsc.Arn)
+		f["local_mount_path"] = aws.ToString(fsc.LocalMountPath)
 
 		results = append(results, f)
 	}
 	return results
 }
 
-func expandFileSystemConfigs(fscMaps []interface{}) []*lambda.FileSystemConfig {
-	fileSystemConfigs := make([]*lambda.FileSystemConfig, 0, len(fscMaps))
+func expandFileSystemConfigs(fscMaps []interface{}) []types.FileSystemConfig {
+	fileSystemConfigs := make([]types.FileSystemConfig, 0, len(fscMaps))
 	for _, fsc := range fscMaps {
 		fscMap := fsc.(map[string]interface{})
-		fileSystemConfigs = append(fileSystemConfigs, &lambda.FileSystemConfig{
+		fileSystemConfigs = append(fileSystemConfigs, types.FileSystemConfig{
 			Arn:            aws.String(fscMap["arn"].(string)),
 			LocalMountPath: aws.String(fscMap["local_mount_path"].(string)),
 		})
@@ -1377,7 +1389,7 @@ func expandFileSystemConfigs(fscMaps []interface{}) []*lambda.FileSystemConfig {
 	return fileSystemConfigs
 }
 
-func FlattenImageConfig(response *lambda.ImageConfigResponse) []map[string]interface{} {
+func FlattenImageConfig(response *types.ImageConfigResponse) []map[string]interface{} {
 	settings := make(map[string]interface{})
 
 	if response == nil || response.Error != nil || response.ImageConfig == nil {
@@ -1391,53 +1403,69 @@ func FlattenImageConfig(response *lambda.ImageConfigResponse) []map[string]inter
 	return []map[string]interface{}{settings}
 }
 
-func expandImageConfigs(imageConfigMaps []interface{}) *lambda.ImageConfig {
-	imageConfig := &lambda.ImageConfig{}
+func expandImageConfigs(imageConfigMaps []interface{}) *types.ImageConfig {
+	imageConfig := &types.ImageConfig{}
 	// only one image_config block is allowed
 	if len(imageConfigMaps) == 1 && imageConfigMaps[0] != nil {
 		config := imageConfigMaps[0].(map[string]interface{})
 		if len(config["entry_point"].([]interface{})) > 0 {
-			imageConfig.EntryPoint = flex.ExpandStringList(config["entry_point"].([]interface{}))
+			imageConfig.EntryPoint = flex.ExpandStringValueList(config["entry_point"].([]interface{}))
 		}
 		if len(config["command"].([]interface{})) > 0 {
-			imageConfig.Command = flex.ExpandStringList(config["command"].([]interface{}))
+			imageConfig.Command = flex.ExpandStringValueList(config["command"].([]interface{}))
 		}
 		imageConfig.WorkingDirectory = aws.String(config["working_directory"].(string))
 	}
 	return imageConfig
 }
 
-func flattenEphemeralStorage(response *lambda.EphemeralStorage) []map[string]interface{} {
+func flattenEphemeralStorage(response *types.EphemeralStorage) []map[string]interface{} {
 	if response == nil {
 		return nil
 	}
 
 	m := make(map[string]interface{})
-	m["size"] = aws.Int64Value(response.Size)
+	m["size"] = aws.ToInt32(response.Size)
 
 	return []map[string]interface{}{m}
 }
 
-func expandSnapStart(tfList []interface{}) *lambda.SnapStart {
-	snapStart := &lambda.SnapStart{ApplyOn: aws.String(lambda.SnapStartApplyOnNone)}
+func expandSnapStart(tfList []interface{}) *types.SnapStart {
+	snapStart := &types.SnapStart{ApplyOn: types.SnapStartApplyOnNone}
 	if len(tfList) == 1 && tfList[0] != nil {
 		item := tfList[0].(map[string]interface{})
-		snapStart.ApplyOn = aws.String(item["apply_on"].(string))
+		snapStart.ApplyOn = types.SnapStartApplyOn(item["apply_on"].(string))
 	}
 	return snapStart
 }
 
-func flattenSnapStart(apiObject *lambda.SnapStartResponse) []interface{} {
-	if apiObject == nil || apiObject.ApplyOn == nil {
+func flattenSnapStart(apiObject *types.SnapStartResponse) []interface{} {
+	if apiObject == nil {
 		return nil
 	}
-	if aws.StringValue(apiObject.ApplyOn) == lambda.SnapStartApplyOnNone {
+	if apiObject.ApplyOn == types.SnapStartApplyOnNone {
 		return nil
 	}
 	m := map[string]interface{}{
-		"apply_on":            aws.StringValue(apiObject.ApplyOn),
-		"optimization_status": aws.StringValue(apiObject.OptimizationStatus),
+		"apply_on":            string(apiObject.ApplyOn),
+		"optimization_status": string(apiObject.OptimizationStatus),
 	}
 
 	return []interface{}{m}
+}
+
+func expandArchitectures(tfList []interface{}) []types.Architecture {
+	vs := make([]types.Architecture, 0, len(tfList))
+	for _, v := range tfList {
+		vs = append(vs, types.Architecture(v.(string)))
+	}
+	return vs
+}
+
+func flattenArchitectures(apiObject []types.Architecture) []interface{} {
+	vs := make([]interface{}, 0, len(apiObject))
+	for _, v := range apiObject {
+		vs = append(vs, string(v))
+	}
+	return vs
 }

--- a/internal/service/lambda/function_data_source.go
+++ b/internal/service/lambda/function_data_source.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -212,7 +213,7 @@ func DataSourceFunction() *schema.Resource {
 
 func dataSourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).LambdaConn()
+	conn := meta.(*conns.AWSClient).LambdaClient()
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	functionName := d.Get("function_name").(string)
@@ -231,7 +232,7 @@ func dataSourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		// If no published version exists, AWS returns '$LATEST' for latestVersion
-		if v := aws.StringValue(latest.Version); v != FunctionVersionLatest {
+		if v := aws.ToString(latest.Version); v != FunctionVersionLatest {
 			input.Qualifier = aws.String(v)
 		}
 	}
@@ -243,9 +244,9 @@ func dataSourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	function := output.Configuration
-	functionARN := aws.StringValue(function.FunctionArn)
-	qualifierSuffix := fmt.Sprintf(":%s", aws.StringValue(input.Qualifier))
-	versionSuffix := fmt.Sprintf(":%s", aws.StringValue(function.Version))
+	functionARN := aws.ToString(function.FunctionArn)
+	qualifierSuffix := fmt.Sprintf(":%s", aws.ToString(input.Qualifier))
+	versionSuffix := fmt.Sprintf(":%s", aws.ToString(function.Version))
 	qualifiedARN := functionARN
 	if !strings.HasSuffix(functionARN, qualifierSuffix) && !strings.HasSuffix(functionARN, versionSuffix) {
 		qualifiedARN = functionARN + versionSuffix
@@ -253,12 +254,12 @@ func dataSourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta in
 	unqualifiedARN := strings.TrimSuffix(functionARN, qualifierSuffix)
 
 	d.SetId(functionName)
-	d.Set("architectures", aws.StringValueSlice(function.Architectures))
+	d.Set("architectures", flattenArchitectures(function.Architectures))
 	d.Set("arn", unqualifiedARN)
 	if function.DeadLetterConfig != nil && function.DeadLetterConfig.TargetArn != nil {
 		if err := d.Set("dead_letter_config", []interface{}{
 			map[string]interface{}{
-				"target_arn": aws.StringValue(function.DeadLetterConfig.TargetArn),
+				"target_arn": aws.ToString(function.DeadLetterConfig.TargetArn),
 			},
 		}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting dead_letter_config: %s", err)
@@ -301,13 +302,13 @@ func dataSourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta in
 	d.Set("source_code_hash", function.CodeSha256)
 	d.Set("source_code_size", function.CodeSize)
 	d.Set("timeout", function.Timeout)
-	tracingConfigMode := lambda.TracingModePassThrough
+	tracingConfigMode := types.TracingModePassThrough
 	if function.TracingConfig != nil {
-		tracingConfigMode = aws.StringValue(function.TracingConfig.Mode)
+		tracingConfigMode = function.TracingConfig.Mode
 	}
 	if err := d.Set("tracing_config", []interface{}{
 		map[string]interface{}{
-			"mode": tracingConfigMode,
+			"mode": string(tracingConfigMode),
 		},
 	}); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting tracing_config: %s", err)
@@ -325,8 +326,8 @@ func dataSourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta in
 	if partition := meta.(*conns.AWSClient).Partition; partition == endpoints.AwsPartitionID && SignerServiceIsAvailable(meta.(*conns.AWSClient).Region) {
 		var codeSigningConfigArn string
 
-		if aws.StringValue(function.PackageType) == lambda.PackageTypeZip {
-			output, err := conn.GetFunctionCodeSigningConfigWithContext(ctx, &lambda.GetFunctionCodeSigningConfigInput{
+		if function.PackageType == types.PackageTypeZip {
+			output, err := conn.GetFunctionCodeSigningConfig(ctx, &lambda.GetFunctionCodeSigningConfigInput{
 				FunctionName: aws.String(d.Id()),
 			})
 
@@ -335,7 +336,7 @@ func dataSourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta in
 			}
 
 			if output != nil {
-				codeSigningConfigArn = aws.StringValue(output.CodeSigningConfigArn)
+				codeSigningConfigArn = aws.ToString(output.CodeSigningConfigArn)
 			}
 		}
 

--- a/internal/service/lambda/function_event_invoke_config_test.go
+++ b/internal/service/lambda/function_event_invoke_config_test.go
@@ -2,18 +2,20 @@ package lambda_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/lambda"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tflambda "github.com/hashicorp/terraform-provider-aws/internal/service/lambda"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccLambdaFunctionEventInvokeConfig_basic(t *testing.T) {
@@ -28,7 +30,7 @@ func TestAccLambdaFunctionEventInvokeConfig_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFunctionEventInvokeConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -61,7 +63,7 @@ func TestAccLambdaFunctionEventInvokeConfig_Disappears_lambdaFunction(t *testing
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFunctionEventInvokeConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -85,7 +87,7 @@ func TestAccLambdaFunctionEventInvokeConfig_Disappears_lambdaFunctionEventInvoke
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFunctionEventInvokeConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -114,7 +116,7 @@ func TestAccLambdaFunctionEventInvokeConfig_DestinationOnFailure_destination(t *
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFunctionEventInvokeConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -158,7 +160,7 @@ func TestAccLambdaFunctionEventInvokeConfig_DestinationOnSuccess_destination(t *
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFunctionEventInvokeConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -201,7 +203,7 @@ func TestAccLambdaFunctionEventInvokeConfig_Destination_remove(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFunctionEventInvokeConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -242,7 +244,7 @@ func TestAccLambdaFunctionEventInvokeConfig_Destination_swap(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFunctionEventInvokeConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -285,7 +287,7 @@ func TestAccLambdaFunctionEventInvokeConfig_FunctionName_arn(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFunctionEventInvokeConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -318,7 +320,7 @@ func TestAccLambdaFunctionEventInvokeConfig_QualifierFunctionName_arn(t *testing
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFunctionEventInvokeConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -350,7 +352,7 @@ func TestAccLambdaFunctionEventInvokeConfig_maximumEventAgeInSeconds(t *testing.
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFunctionEventInvokeConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -388,7 +390,7 @@ func TestAccLambdaFunctionEventInvokeConfig_maximumRetryAttempts(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFunctionEventInvokeConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -430,7 +432,7 @@ func TestAccLambdaFunctionEventInvokeConfig_Qualifier_aliasName(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFunctionEventInvokeConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -458,7 +460,7 @@ func TestAccLambdaFunctionEventInvokeConfig_Qualifier_functionVersion(t *testing
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFunctionEventInvokeConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -486,7 +488,7 @@ func TestAccLambdaFunctionEventInvokeConfig_Qualifier_latest(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckFunctionEventInvokeConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -508,7 +510,7 @@ func TestAccLambdaFunctionEventInvokeConfig_Qualifier_latest(t *testing.T) {
 
 func testAccCheckFunctionEventInvokeConfigDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaConn()
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaClient()
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_lambda_function_event_invoke_config" {
@@ -529,13 +531,12 @@ func testAccCheckFunctionEventInvokeConfigDestroy(ctx context.Context) resource.
 				input.Qualifier = aws.String(qualifier)
 			}
 
-			output, err := conn.GetFunctionEventInvokeConfigWithContext(ctx, input)
-
-			if tfawserr.ErrCodeEquals(err, lambda.ErrCodeResourceNotFoundException) {
-				continue
-			}
-
+			output, err := conn.GetFunctionEventInvokeConfig(ctx, input)
 			if err != nil {
+				var nfe *types.ResourceNotFoundException
+				if errors.As(err, &nfe) {
+					continue
+				}
 				return err
 			}
 
@@ -550,13 +551,13 @@ func testAccCheckFunctionEventInvokeConfigDestroy(ctx context.Context) resource.
 
 func testAccCheckFunctionDisappears(ctx context.Context, function *lambda.GetFunctionOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaConn()
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaClient()
 
 		input := &lambda.DeleteFunctionInput{
 			FunctionName: function.Configuration.FunctionName,
 		}
 
-		_, err := conn.DeleteFunctionWithContext(ctx, input)
+		_, err := conn.DeleteFunction(ctx, input)
 
 		return err
 	}
@@ -573,7 +574,7 @@ func testAccCheckFunctionEventInvokeDisappearsConfig(ctx context.Context, resour
 			return fmt.Errorf("Resource (%s) ID not set", resourceName)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaConn()
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaClient()
 
 		functionName, qualifier, err := tflambda.FunctionEventInvokeConfigParseID(rs.Primary.ID)
 
@@ -589,7 +590,7 @@ func testAccCheckFunctionEventInvokeDisappearsConfig(ctx context.Context, resour
 			input.Qualifier = aws.String(qualifier)
 		}
 
-		_, err = conn.DeleteFunctionEventInvokeConfigWithContext(ctx, input)
+		_, err = conn.DeleteFunctionEventInvokeConfig(ctx, input)
 
 		return err
 	}
@@ -606,7 +607,7 @@ func testAccCheckFunctionEventInvokeExistsConfig(ctx context.Context, resourceNa
 			return fmt.Errorf("Resource (%s) ID not set", resourceName)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaConn()
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaClient()
 
 		functionName, qualifier, err := tflambda.FunctionEventInvokeConfigParseID(rs.Primary.ID)
 
@@ -622,7 +623,7 @@ func testAccCheckFunctionEventInvokeExistsConfig(ctx context.Context, resourceNa
 			input.Qualifier = aws.String(qualifier)
 		}
 
-		_, err = conn.GetFunctionEventInvokeConfigWithContext(ctx, input)
+		_, err = conn.GetFunctionEventInvokeConfig(ctx, input)
 
 		return err
 	}

--- a/internal/service/lambda/generate.go
+++ b/internal/service/lambda/generate.go
@@ -1,4 +1,4 @@
-//go:generate go run ../../generate/tags/main.go -ServiceTagsMap -TagInIDElem=Resource -UpdateTags -ContextOnly
+//go:generate go run ../../generate/tags/main.go -ServiceTagsMap -TagInIDElem=Resource -UpdateTags -ContextOnly -AWSSDKVersion=2 -KVTValues -SkipTypesImp
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package lambda

--- a/internal/service/lambda/provisioned_concurrency_config_test.go
+++ b/internal/service/lambda/provisioned_concurrency_config_test.go
@@ -2,18 +2,20 @@ package lambda_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/lambda"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tflambda "github.com/hashicorp/terraform-provider-aws/internal/service/lambda"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccLambdaProvisionedConcurrencyConfig_basic(t *testing.T) {
@@ -24,7 +26,7 @@ func TestAccLambdaProvisionedConcurrencyConfig_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProvisionedConcurrencyConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -55,7 +57,7 @@ func TestAccLambdaProvisionedConcurrencyConfig_Disappears_lambdaFunction(t *test
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProvisionedConcurrencyConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -79,7 +81,7 @@ func TestAccLambdaProvisionedConcurrencyConfig_Disappears_lambdaProvisionedConcu
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProvisionedConcurrencyConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -106,7 +108,7 @@ func TestAccLambdaProvisionedConcurrencyConfig_provisionedConcurrentExecutions(t
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProvisionedConcurrencyConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -145,7 +147,7 @@ func TestAccLambdaProvisionedConcurrencyConfig_Qualifier_aliasName(t *testing.T)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, lambda.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckProvisionedConcurrencyConfigDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -167,7 +169,7 @@ func TestAccLambdaProvisionedConcurrencyConfig_Qualifier_aliasName(t *testing.T)
 
 func testAccCheckProvisionedConcurrencyConfigDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaConn()
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaClient()
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_lambda_provisioned_concurrency_config" {
@@ -185,13 +187,16 @@ func testAccCheckProvisionedConcurrencyConfigDestroy(ctx context.Context) resour
 				Qualifier:    aws.String(qualifier),
 			}
 
-			output, err := conn.GetProvisionedConcurrencyConfigWithContext(ctx, input)
-
-			if tfawserr.ErrCodeEquals(err, lambda.ErrCodeProvisionedConcurrencyConfigNotFoundException) || tfawserr.ErrCodeEquals(err, lambda.ErrCodeResourceNotFoundException) {
-				continue
-			}
-
+			output, err := conn.GetProvisionedConcurrencyConfig(ctx, input)
 			if err != nil {
+				var pccnfe *types.ProvisionedConcurrencyConfigNotFoundException
+				if errors.As(err, &pccnfe) {
+					continue
+				}
+				var nfe *types.ResourceNotFoundException
+				if errors.As(err, &nfe) {
+					continue
+				}
 				return err
 			}
 
@@ -215,7 +220,7 @@ func testAccCheckProvisionedConcurrencyDisappearsConfig(ctx context.Context, res
 			return fmt.Errorf("Resource (%s) ID not set", resourceName)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaConn()
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaClient()
 
 		functionName, qualifier, err := tflambda.ProvisionedConcurrencyConfigParseID(rs.Primary.ID)
 
@@ -228,7 +233,7 @@ func testAccCheckProvisionedConcurrencyDisappearsConfig(ctx context.Context, res
 			Qualifier:    aws.String(qualifier),
 		}
 
-		_, err = conn.DeleteProvisionedConcurrencyConfigWithContext(ctx, input)
+		_, err = conn.DeleteProvisionedConcurrencyConfig(ctx, input)
 
 		return err
 	}
@@ -245,7 +250,7 @@ func testAccCheckProvisionedConcurrencyExistsConfig(ctx context.Context, resourc
 			return fmt.Errorf("Resource (%s) ID not set", resourceName)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaConn()
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaClient()
 
 		functionName, qualifier, err := tflambda.ProvisionedConcurrencyConfigParseID(rs.Primary.ID)
 
@@ -258,13 +263,13 @@ func testAccCheckProvisionedConcurrencyExistsConfig(ctx context.Context, resourc
 			Qualifier:    aws.String(qualifier),
 		}
 
-		output, err := conn.GetProvisionedConcurrencyConfigWithContext(ctx, input)
+		output, err := conn.GetProvisionedConcurrencyConfig(ctx, input)
 
 		if err != nil {
 			return err
 		}
 
-		if got, want := aws.StringValue(output.Status), lambda.ProvisionedConcurrencyStatusEnumReady; got != want {
+		if got, want := output.Status, types.ProvisionedConcurrencyStatusEnumReady; got != want {
 			return fmt.Errorf("Lambda Provisioned Concurrency Config (%s) expected status (%s), got: %s", rs.Primary.ID, want, got)
 		}
 

--- a/internal/service/lambda/tags_gen.go
+++ b/internal/service/lambda/tags_gen.go
@@ -5,38 +5,37 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/lambda"
-	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
-// map[string]*string handling
+// map[string]string handling
 
 // Tags returns lambda service tags.
-func Tags(tags tftags.KeyValueTags) map[string]*string {
-	return aws.StringMap(tags.Map())
+func Tags(tags tftags.KeyValueTags) map[string]string {
+	return tags.Map()
 }
 
 // KeyValueTags creates KeyValueTags from lambda service tags.
-func KeyValueTags(ctx context.Context, tags map[string]*string) tftags.KeyValueTags {
+func KeyValueTags(ctx context.Context, tags map[string]string) tftags.KeyValueTags {
 	return tftags.New(ctx, tags)
 }
 
 // UpdateTags updates lambda service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func UpdateTags(ctx context.Context, conn lambdaiface.LambdaAPI, identifier string, oldTagsMap interface{}, newTagsMap interface{}) error {
+func UpdateTags(ctx context.Context, conn *lambda.Client, identifier string, oldTagsMap interface{}, newTagsMap interface{}) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
 	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
 		input := &lambda.UntagResourceInput{
 			Resource: aws.String(identifier),
-			TagKeys:  aws.StringSlice(removedTags.IgnoreAWS().Keys()),
+			TagKeys:  removedTags.IgnoreAWS().Keys(),
 		}
 
-		_, err := conn.UntagResourceWithContext(ctx, input)
+		_, err := conn.UntagResource(ctx, input)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -49,7 +48,7 @@ func UpdateTags(ctx context.Context, conn lambdaiface.LambdaAPI, identifier stri
 			Tags:     Tags(updatedTags.IgnoreAWS()),
 		}
 
-		_, err := conn.TagResourceWithContext(ctx, input)
+		_, err := conn.TagResource(ctx, input)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/names/names.go
+++ b/names/names.go
@@ -31,6 +31,7 @@ const (
 	Inspector2EndpointID           = "inspector2"
 	IVSChatEndpointID              = "ivschat"
 	KendraEndpointID               = "kendra"
+	LambdaEndpointID               = "lambda"
 	MediaLiveEndpointID            = "medialive"
 	OpenSearchServerlessEndpointID = "aoss"
 	PipesEndpointID                = "pipes"

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -205,7 +205,7 @@ kinesis-video-media,kinesisvideomedia,kinesisvideomedia,kinesisvideomedia,,kines
 kinesis-video-signaling,kinesisvideosignaling,kinesisvideosignalingchannels,kinesisvideosignaling,,kinesisvideosignaling,,kinesisvideosignalingchannels,KinesisVideoSignaling,KinesisVideoSignalingChannels,,1,,,aws_kinesisvideosignaling_,,kinesisvideosignaling_,Kinesis Video Signaling,Amazon,,,,,
 kms,kms,kms,kms,,kms,,,KMS,KMS,,1,,,aws_kms_,,kms_,KMS (Key Management),AWS,,,,,
 lakeformation,lakeformation,lakeformation,lakeformation,,lakeformation,,,LakeFormation,LakeFormation,,1,,,aws_lakeformation_,,lakeformation_,Lake Formation,AWS,,,,,
-lambda,lambda,lambda,lambda,,lambda,,,Lambda,Lambda,,1,,,aws_lambda_,,lambda_,Lambda,AWS,,,,,
+lambda,lambda,lambda,lambda,,lambda,,,Lambda,Lambda,,1,2,,aws_lambda_,,lambda_,Lambda,AWS,,,,,
 ,,,,,,,,,,,,,,,,,Launch Wizard,AWS,x,,,,No SDK support
 lex-models,lexmodels,lexmodelbuildingservice,lexmodelbuildingservice,,lexmodels,,lexmodelbuilding;lexmodelbuildingservice;lex,LexModels,LexModelBuildingService,,1,,aws_lex_,aws_lexmodels_,,lex_,Lex Model Building,Amazon,,,,,
 lexv2-models,lexv2models,lexmodelsv2,lexmodelsv2,,lexmodelsv2,,lexv2models,LexModelsV2,LexModelsV2,,1,,,aws_lexmodelsv2_,,lexmodelsv2_,Lex Models V2,Amazon,,,,,


### PR DESCRIPTION
### Description
Migrates the `aws_lambda_function` resource and data source to AWS SDK V2. This primary benefit of this migration is the improved error messaging for `ValidationException`s (see #13709 and https://github.com/aws/aws-sdk-go/issues/4733). Below are examples of the error message returned from an invalid configuration before and after this change:

**AWS SDK V1:**
```
aws_lambda_function.test: Creating...
╷
│ Error: creating Lambda Function (jb-test-persistent-diffs): ValidationException:
│       status code: 400, request id: 0531f106-dea6-40d5-93c5-d3785112d583
│
│   with aws_lambda_function.test,
│   on main.tf line 28, in resource "aws_lambda_function" "test":
│   28: resource "aws_lambda_function" "test" {
│
╵
```

**AWS SDK V2 (this PR):**
```
aws_lambda_function.test: Creating...
╷
│ Error: creating Lambda Function (jb-test-persistent-diffs): operation error Lambda: CreateFunction, https response error StatusCode: 400, RequestID: 2d5e0c1b-7d35-47a8-bbd7-76224fb2416a, api error ValidationException: 1 validation error detected: Value '2000' at 'timeout' failed to satisfy constraint: Member must have value less than or equal to 900
│
│   with aws_lambda_function.test,
│   on main.tf line 28, in resource "aws_lambda_function" "test":
│   28: resource "aws_lambda_function" "test" {
│
╵
```


### Relations
Closes #13709 


### Output from Acceptance Testing

```console
$ make testacc PKG=lambda TESTS="TestAccLambdaFunction_"
<snip>
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunction_'  -timeout 180m
--- PASS: TestAccLambdaFunction_Zip_validation (9.25s)
=== CONT  TestAccLambdaFunction_tracing
=== CONT  TestAccLambdaFunction_layers
--- PASS: TestAccLambdaFunction_basic (47.42s)
--- PASS: TestAccLambdaFunction_S3Update_unversioned (57.99s)
=== CONT  TestAccLambdaFunction_layersUpdate
--- PASS: TestAccLambdaFunction_S3Update_basic (60.87s)
=== CONT  TestAccLambdaFunction_deadLetter
--- PASS: TestAccLambdaFunction_versioned (66.04s)
=== CONT  TestAccLambdaFunction_nilDeadLetter
--- PASS: TestAccLambdaFunction_snapStart (72.20s)
=== CONT  TestAccLambdaFunction_deadLetterUpdated
--- PASS: TestAccLambdaFunction_architectures (83.66s)
=== CONT  TestAccLambdaFunction_fileSystem
--- PASS: TestAccLambdaFunction_ephemeralStorage (96.25s)
=== CONT  TestAccLambdaFunction_LocalUpdate_nameOnly
--- PASS: TestAccLambdaFunction_VPC_properIAMDependencies (294.67s)
=== CONT  TestAccLambdaFunction_concurrencyCycle
--- PASS: TestAccLambdaFunction_tracing (290.65s)
=== CONT  TestAccLambdaFunction_localUpdate
--- PASS: TestAccLambdaFunction_runtimes (325.95s)
=== CONT  TestAccLambdaFunction_nameValidation
--- PASS: TestAccLambdaFunction_nameValidation (0.77s)
=== CONT  TestAccLambdaFunction_envVariables
--- PASS: TestAccLambdaFunction_VPC_withInvocation (690.19s)
=== CONT  TestAccLambdaFunction_expectFilenameAndS3Attributes
--- PASS: TestAccLambdaFunction_expectFilenameAndS3Attributes (0.81s)
=== CONT  TestAccLambdaFunction_enablePublish
--- PASS: TestAccLambdaFunction_vpc (1043.18s)
=== CONT  TestAccLambdaFunction_disablePublish
--- PASS: TestAccLambdaFunction_vpcRemoval (1083.07s)
=== CONT  TestAccLambdaFunction_EnvironmentVariables_noValue
--- PASS: TestAccLambdaFunction_VPC_replaceSGWithDefault (1570.73s)
=== CONT  TestAccLambdaFunction_versionedUpdate
--- PASS: TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables (1635.09s)
=== CONT  TestAccLambdaFunction_encryptedEnvVariables
--- PASS: TestAccLambdaFunction_layers (1597.45s)
=== CONT  TestAccLambdaFunction_emptyVPC
--- PASS: TestAccLambdaFunction_vpcUpdate (1647.26s)
=== CONT  TestAccLambdaFunction_unpublishedCodeUpdate
--- PASS: TestAccLambdaFunction_nilDeadLetter (1586.18s)
=== CONT  TestAccLambdaFunction_concurrency
--- PASS: TestAccLambdaFunction_deadLetter (1609.07s)
=== CONT  TestAccLambdaFunction_VPC_replaceSGWithCustom
--- PASS: TestAccLambdaFunction_architecturesUpdate (1670.76s)
=== CONT  TestAccLambdaFunction_tags
--- PASS: TestAccLambdaFunction_layersUpdate (1626.39s)
=== CONT  TestAccLambdaFunction_codeSigning
--- PASS: TestAccLambdaFunction_deadLetterUpdated (1613.49s)
=== CONT  TestAccLambdaFunction_disappears
--- PASS: TestAccLambdaFunction_VPCPublishHas_changes (1733.39s)
=== CONT  TestAccLambdaFunction_s3
--- PASS: TestAccLambdaFunction_s3 (32.25s)
--- PASS: TestAccLambdaFunction_concurrencyCycle (1609.38s)
--- PASS: TestAccLambdaFunction_EnvironmentVariables_noValue (825.44s)
--- PASS: TestAccLambdaFunction_disablePublish (871.29s)
--- PASS: TestAccLambdaFunction_architecturesWithLayer (1916.00s)
--- PASS: TestAccLambdaFunction_enablePublish (1229.08s)
--- PASS: TestAccLambdaFunction_emptyVPC (292.03s)
--- PASS: TestAccLambdaFunction_envVariables (1616.92s)
--- PASS: TestAccLambdaFunction_LocalUpdate_nameOnly (1859.83s)
--- PASS: TestAccLambdaFunction_concurrency (309.62s)
--- PASS: TestAccLambdaFunction_encryptedEnvVariables (332.97s)
--- PASS: TestAccLambdaFunction_tags (310.46s)
--- PASS: TestAccLambdaFunction_disappears (477.87s)
--- PASS: TestAccLambdaFunction_localUpdate (1866.11s)
--- PASS: TestAccLambdaFunction_VPC_replaceSGWithCustom (503.19s)
--- PASS: TestAccLambdaFunction_codeSigning (496.12s)
--- PASS: TestAccLambdaFunction_unpublishedCodeUpdate (536.40s)
--- PASS: TestAccLambdaFunction_versionedUpdate (625.45s)
--- PASS: TestAccLambdaFunction_fileSystem (2145.77s)
--- PASS: TestAccLambdaFunction_VPCPublishNo_changes (3064.83s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     3068.071s
```
