### PR TITLE
fix: add XNotImplemented error handling in resourceBucketRead

### DIFF
--- a/.changelog/29632.txt
+++ b/.changelog/29632.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket: Add error handling for `XNotImplemented` errors when reading `acceleration_status`, 'request_payer`, `lifecycle_rule`, `logging`, or `replication_configuration` into terraform state.
+```

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -1145,7 +1145,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	// Amazon S3 Transfer Acceleration might not be supported in the region
-	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeMethodNotAllowed, ErrCodeUnsupportedArgument, ErrCodeNotImplemented) {
+	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeMethodNotAllowed, ErrCodeUnsupportedArgument, ErrCodeNotImplemented, ErrCodeXNotImplemented) {
 		return sdkdiag.AppendErrorf(diags, "getting S3 Bucket (%s) accelerate configuration: %s", d.Id(), err)
 	}
 
@@ -1170,7 +1170,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diags
 	}
 
-	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNotImplemented) {
+	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNotImplemented, ErrCodeXNotImplemented) {
 		return sdkdiag.AppendErrorf(diags, "getting S3 Bucket request payment: %s", err)
 	}
 
@@ -1194,7 +1194,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diags
 	}
 
-	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNotImplemented) {
+	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNotImplemented, ErrCodeXNotImplemented) {
 		return sdkdiag.AppendErrorf(diags, "getting S3 Bucket logging: %s", err)
 	}
 
@@ -1223,7 +1223,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diags
 	}
 
-	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNoSuchLifecycleConfiguration, ErrCodeNotImplemented) {
+	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeNoSuchLifecycleConfiguration, ErrCodeNotImplemented, ErrCodeXNotImplemented) {
 		return sdkdiag.AppendErrorf(diags, "getting S3 Bucket (%s) Lifecycle Configuration: %s", d.Id(), err)
 	}
 
@@ -1252,7 +1252,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diags
 	}
 
-	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeReplicationConfigurationNotFound, ErrCodeNotImplemented) {
+	if err != nil && !tfawserr.ErrCodeEquals(err, ErrCodeReplicationConfigurationNotFound, ErrCodeNotImplemented, ErrCodeXNotImplemented) {
 		return sdkdiag.AppendErrorf(diags, "getting S3 Bucket replication: %s", err)
 	}
 


### PR DESCRIPTION
Hello,

The following patch third party S3 who does not support some bucket features like accelerate configuration.

Example of error message:

```
Error: getting S3 Bucket (my-bucket) accelerate configuration: XNotImplemented: The request you provided implies functionality that is not implemented.

Error: getting S3 Bucket request payment: XNotImplemented: The request you provided implies functionality that is not implemented.

Error: getting S3 Bucket logging: XNotImplemented: The request you provided implies functionality that is not implemented.

```
