### PR TITLE
d/aws_ecs_cluster: add capacity_provider attributes

### DIFF
--- a/.changelog/29639.txt
+++ b/.changelog/29639.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_ecs_cluster: Add `default_capacity_provider_strategy` and `capacity_providers` attributes
+```

--- a/internal/service/ecs/cluster_data_source.go
+++ b/internal/service/ecs/cluster_data_source.go
@@ -24,9 +24,34 @@ func DataSourceCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"capacity_providers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"cluster_name": {
 				Type:     schema.TypeString,
 				Required: true,
+			},
+			"default_capacity_provider_strategy": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"base": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"capacity_provider": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"weight": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
 			},
 			"pending_tasks_count": {
 				Type:     schema.TypeInt,
@@ -100,6 +125,22 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 	tags := KeyValueTags(ctx, cluster.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
+	}
+
+	if cluster.DefaultCapacityProviderStrategy != nil {
+		if err := d.Set("default_capacity_provider_strategy", flattenCapacityProviderStrategy(cluster.DefaultCapacityProviderStrategy)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting default_capacity_provider_strategy: %s", err)
+		}
+	} else {
+		d.Set("default_capacity_provider_strategy", nil)
+	}
+
+	if cluster.CapacityProviders != nil {
+		if err := d.Set("capacity_providers", aws.StringValueSlice(cluster.CapacityProviders)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting capacity_providers: %s", err)
+		}
+	} else {
+		d.Set("capacity_providers", nil)
 	}
 
 	if cluster.ServiceConnectDefaults != nil {

--- a/website/docs/d/ecs_cluster.html.markdown
+++ b/website/docs/d/ecs_cluster.html.markdown
@@ -36,4 +36,6 @@ This data source exports the following attributes in addition to the arguments a
 * `registered_container_instances_count` - The number of registered container instances for the ECS Cluster
 * `service_connect_defaults` - The default Service Connect namespace
 * `setting` - Settings associated with the ECS Cluster
+* `capacity_providers` - The capacity providers associated with the ECS Cluster
+* `default_capacity_provider_strategy` - The default capacity provider strategy for the ECS Cluster
 * `tags` - Key-value map of resource tags


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
data-source/aws_ecs_cluster: Add `default_capacity_provider_strategy` and `capacity_providers` attributes

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #26533
New workaround for #22823 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=ecs TESTS=TestAccECSClusterDataSource
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSClusterDataSource'  -timeout 180m
=== RUN   TestAccECSClusterDataSource_ecsCluster
=== PAUSE TestAccECSClusterDataSource_ecsCluster
=== RUN   TestAccECSClusterDataSource_ecsClusterContainerInsights
=== PAUSE TestAccECSClusterDataSource_ecsClusterContainerInsights
=== RUN   TestAccECSClusterDataSource_tags
=== PAUSE TestAccECSClusterDataSource_tags
=== RUN   TestAccECSClusterDataSource_ecsClusterCapacityProvider
=== PAUSE TestAccECSClusterDataSource_ecsClusterCapacityProvider
=== CONT  TestAccECSClusterDataSource_ecsCluster
=== CONT  TestAccECSClusterDataSource_tags
=== CONT  TestAccECSClusterDataSource_ecsClusterCapacityProvider
=== CONT  TestAccECSClusterDataSource_ecsClusterContainerInsights
--- PASS: TestAccECSClusterDataSource_tags (42.19s)
--- PASS: TestAccECSClusterDataSource_ecsClusterCapacityProvider (42.51s)
--- PASS: TestAccECSClusterDataSource_ecsClusterContainerInsights (43.18s)
--- PASS: TestAccECSClusterDataSource_ecsCluster (43.80s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        46.490s
```
