### PR TITLE
`r/aws_organizations_account`: Test cleanup

### DIFF
--- a/internal/service/organizations/account.go
+++ b/internal/service/organizations/account.go
@@ -461,7 +461,7 @@ func statusAccountStatus(ctx context.Context, conn *organizations.Organizations,
 
 func waitAccountDeleted(ctx context.Context, conn *organizations.Organizations, id string) (*organizations.Account, error) {
 	stateConf := &resource.StateChangeConf{
-		Pending:      []string{organizations.AccountStatusPendingClosure},
+		Pending:      []string{organizations.AccountStatusPendingClosure, organizations.AccountStatusActive},
 		Target:       []string{},
 		Refresh:      statusAccountStatus(ctx, conn, id),
 		PollInterval: 10 * time.Second,

--- a/internal/service/organizations/account_test.go
+++ b/internal/service/organizations/account_test.go
@@ -125,7 +125,7 @@ func testAccAccount_ParentID(t *testing.T) {
 	parentIdResourceName2 := "aws_organizations_organizational_unit.test2"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckOrganizationsAccount(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckOrganizationsEnabled(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, organizations.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckAccountDestroy(ctx),
@@ -164,7 +164,7 @@ func testAccAccount_Tags(t *testing.T) {
 	resourceName := "aws_organizations_account.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckOrganizationsAccount(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckOrganizationsEnabled(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, organizations.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckAccountDestroy(ctx),
@@ -303,16 +303,16 @@ resource "aws_organizations_account" "test" {
 
 func testAccAccountConfig_parentId1(name, email string) string {
 	return fmt.Sprintf(`
-resource "aws_organizations_organization" "test" {}
+data "aws_organizations_organization" "test" {}
 
 resource "aws_organizations_organizational_unit" "test1" {
   name      = "test1"
-  parent_id = aws_organizations_organization.test.roots[0].id
+  parent_id = data.aws_organizations_organization.test.roots[0].id
 }
 
 resource "aws_organizations_organizational_unit" "test2" {
   name      = "test2"
-  parent_id = aws_organizations_organization.test.roots[0].id
+  parent_id = data.aws_organizations_organization.test.roots[0].id
 }
 
 resource "aws_organizations_account" "test" {
@@ -326,16 +326,16 @@ resource "aws_organizations_account" "test" {
 
 func testAccAccountConfig_parentId2(name, email string) string {
 	return fmt.Sprintf(`
-resource "aws_organizations_organization" "test" {}
+data "aws_organizations_organization" "test" {}
 
 resource "aws_organizations_organizational_unit" "test1" {
   name      = "test1"
-  parent_id = aws_organizations_organization.test.roots[0].id
+  parent_id = data.aws_organizations_organization.test.roots[0].id
 }
 
 resource "aws_organizations_organizational_unit" "test2" {
   name      = "test2"
-  parent_id = aws_organizations_organization.test.roots[0].id
+  parent_id = data.aws_organizations_organization.test.roots[0].id
 }
 
 resource "aws_organizations_account" "test" {
@@ -349,8 +349,6 @@ resource "aws_organizations_account" "test" {
 
 func testAccAccountConfig_tags1(name, email, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
-resource "aws_organizations_organization" "test" {}
-
 resource "aws_organizations_account" "test" {
   name              = %[1]q
   email             = %[2]q
@@ -365,8 +363,6 @@ resource "aws_organizations_account" "test" {
 
 func testAccAccountConfig_tags2(name, email, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
-resource "aws_organizations_organization" "test" {}
-
 resource "aws_organizations_account" "test" {
   name              = %[1]q
   email             = %[2]q


### PR DESCRIPTION
### Description

Updates "Accounts" acceptance test PreCheck to require an existing organization. This prevents the creation of a new organization and child account(s) within the same test, which would then require waiting 90 days before the child account(s) can be permanently deleted and the management account returned to a "non-organization" state.

### Output from Acceptance Testing
Test account is currently over the [quota for account closures](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_limits.html), so tests are failing while attempting to close child accounts.

```
$ TEST_AWS_ORGANIZATION_ACCOUNT_EMAIL_DOMAIN=hashicorp.com make testacc PKG=organizations TESTS="TestAccOrganizations_serial/Account/basic|TestAccOrganizations_serial/Account/CloseOnDeletion|TestAccOrganizations_serial/Account/ParentId|TestAccOrganizations_serial/Account/Tags"

...
```
