### PR TITLE
Data Source: EC2 Transit Gateway Attachments (plural)

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -564,6 +564,7 @@ func New(ctx context.Context) (*schema.Provider, error) {
 			"aws_ec2_spot_price":                             ec2.DataSourceSpotPrice(),
 			"aws_ec2_transit_gateway":                        ec2.DataSourceTransitGateway(),
 			"aws_ec2_transit_gateway_attachment":             ec2.DataSourceTransitGatewayAttachment(),
+			"aws_ec2_transit_gateway_attachments":            ec2.DataSourceTransitGatewayAttachments(),
 			"aws_ec2_transit_gateway_connect":                ec2.DataSourceTransitGatewayConnect(),
 			"aws_ec2_transit_gateway_connect_peer":           ec2.DataSourceTransitGatewayConnectPeer(),
 			"aws_ec2_transit_gateway_dx_gateway_attachment":  ec2.DataSourceTransitGatewayDxGatewayAttachment(),

--- a/internal/service/ec2/transitgateway_attachments_data_source.go
+++ b/internal/service/ec2/transitgateway_attachments_data_source.go
@@ -1,0 +1,68 @@
+package ec2
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+)
+
+func DataSourceTransitGatewayAttachments() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceTransitGatewayAttachmentsRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"filter": DataSourceFiltersSchema(),
+			"tags":   tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceTransitGatewayAttachmentsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).EC2Conn()
+
+	input := &ec2.DescribeTransitGatewayAttachmentsInput{}
+
+	input.Filters = append(input.Filters, BuildCustomFilterList(
+		d.Get("filter").(*schema.Set),
+	)...)
+
+	if v, ok := d.GetOk("tags"); ok {
+		input.Filters = append(input.Filters, BuildTagFilterList(
+			Tags(tftags.New(ctx, v.(map[string]interface{}))),
+		)...)
+	}
+
+	transitGatewayAttachments, err := FindTransitGatewayAttachments(ctx, conn, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading EC2 Transit Gateway Attachments: %s", err)
+	}
+
+	var attachmentIDs []string
+
+	for _, v := range transitGatewayAttachments {
+		attachmentIDs = append(attachmentIDs, aws.StringValue(v.TransitGatewayAttachmentId))
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region)
+	d.Set("ids", attachmentIDs)
+
+	return diags
+}

--- a/internal/service/ec2/transitgateway_attachments_data_source.go
+++ b/internal/service/ec2/transitgateway_attachments_data_source.go
@@ -27,7 +27,7 @@ func DataSourceTransitGatewayAttachments() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"filter": DataSourceFiltersSchema(),
+			"filter": CustomFiltersSchema(),
 			"tags":   tftags.TagsSchemaComputed(),
 		},
 	}

--- a/internal/service/ec2/transitgateway_attachments_data_source_test.go
+++ b/internal/service/ec2/transitgateway_attachments_data_source_test.go
@@ -1,208 +1,70 @@
 package ec2_test
-// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
-//
-// TIP: ==== INTRODUCTION ====
-// Thank you for trying the skaff tool!
-//
-// You have opted to include these helpful comments. They all include "TIP:"
-// to help you find and remove them when you're done with them.
-//
-// While some aspects of this file are customized to your input, the
-// scaffold tool does *not* look at the AWS API and ensure it has correct
-// function, structure, and variable names. It makes guesses based on
-// commonalities. You will need to make significant adjustments.
-//
-// In other words, as generated, this is a rough outline of the work you will
-// need to do. If something doesn't make sense for your situation, get rid of
-// it.
-//
-// Remember to register this new data source in the provider
-// (internal/provider/provider.go) once you finish. Otherwise, Terraform won't
-// know about it.
 
 import (
-	// TIP: ==== IMPORTS ====
-	// This is a common set of imports but not customized to your code since
-	// your code hasn't been written yet. Make sure you, your IDE, or
-	// goimports -w <file> fixes these imports.
-	//
-	// The provider linter wants your imports to be in two groups: first,
-	// standard library (i.e., "fmt" or "strings"), second, everything else.
-	//
-	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
-	// using the services/ec2/types package. If so, you'll
-	// need to import types and reference the nested types, e.g., as
-	// types.<Type Name>.
 	"fmt"
-	"regexp"
-	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
-
-	// TIP: You will often need to import the package that this test file lives
-    // in. Since it is in the "test" context, it must import the package to use
-    // any normal context constants, variables, or functions.
-	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
-	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// TIP: File Structure. The basic outline for all test files should be as
-// follows. Improve this data source's maintainability by following this
-// outline.
-//
-// 1. Package declaration (add "_test" since this is a test file)
-// 2. Imports
-// 3. Unit tests
-// 4. Basic test
-// 5. Disappears test
-// 6. All the other tests
-// 7. Helper functions (exists, destroy, check, etc.)
-// 8. Functions that return Terraform configurations
-
-
-// TIP: ==== UNIT TESTS ====
-// This is an example of a unit test. Its name is not prefixed with
-// "TestAcc" like an acceptance test.
-//
-// Unlike acceptance tests, unit tests do not access AWS and are focused on a
-// function (or method). Because of this, they are quick and cheap to run.
-//
-// In designing a data source's implementation, isolate complex bits from AWS bits
-// so that they can be tested through a unit test. We encourage more unit tests
-// in the provider.
-//
-// Cut and dry functions using well-used patterns, like typical flatteners and
-// expanders, don't need unit testing. However, if they are complex or
-// intricate, they should be unit tested.
-func TestTransitgatewayAttachmentsExampleUnitTest(t *testing.T) {
-	testCases := []struct {
-		TestName string
-		Input    string
-		Expected string
-		Error    bool
-	}{
-		{
-			TestName: "empty",
-			Input:    "",
-			Expected: "",
-			Error:    true,
-		},
-		{
-			TestName: "descriptive name",
-			Input:    "some input",
-			Expected: "some output",
-			Error:    false,
-		},
-		{
-			TestName: "another descriptive name",
-			Input:    "more input",
-			Expected: "more output",
-			Error:    false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.TestName, func(t *testing.T) {
-			got, err := tfec2.FunctionFromDataSource(testCase.Input)
-
-			if err != nil && !testCase.Error {
-				t.Errorf("got error (%s), expected no error", err)
-			}
-
-			if err == nil && testCase.Error {
-				t.Errorf("got (%s) and no error, expected error", got)
-			}
-
-			if got != testCase.Expected {
-				t.Errorf("got %s, expected %s", got, testCase.Expected)
-			}
-		})
-	}
-}
-
-
-// TIP: ==== ACCEPTANCE TESTS ====
-// This is an example of a basic acceptance test. This should test as much of
-// standard functionality of the data source as possible, and test importing, if
-// applicable. We prefix its name with "TestAcc", the service, and the
-// data source name.
-//
-// Acceptance test access AWS and cost money to run.
-func TestAccEC2TransitgatewayAttachmentsDataSource_basic(t *testing.T) {
+func TestAccTransitGatewayAttachmentsDataSource_Filter(t *testing.T) {
 	ctx := acctest.Context(t)
-    // TIP: This is a long-running test guard for tests that run longer than
-    // 300s (5 min) generally.
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
-	var transitgatewayattachments ec2.DescribeTransitgatewayAttachmentsResponse
+	dataSourceName := "data.aws_ec2_transit_gateway_attachments.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	dataSourceName := "data.aws_ec2_transitgateway_attachments.test"
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(t)
-			acctest.PreCheckPartitionHasService(ec2.EndpointsID, t)
-			testAccPreCheck(ctx, t)
-		},
-		ErrorCheck:               acctest.ErrorCheck(t, names.EC2EndpointID),
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckTransitGateway(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckTransitgatewayAttachmentsDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTransitgatewayAttachmentsDataSourceConfig_basic(rName),
+				Config: testAccTransitGatewayAttachmentsDataSourceConfig_filter(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTransitgatewayAttachmentsExists(ctx, dataSourceName, &transitgatewayattachments),
-					resource.TestCheckResourceAttr(dataSourceName, "auto_minor_version_upgrade", "false"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "maintenance_window_start_time.0.day_of_week"),
-					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "user.*", map[string]string{
-						"console_access": "false",
-						"groups.#":       "0",
-						"username":       "Test",
-						"password":       "TestTest1234",
-					}),
-					acctest.MatchResourceAttrRegionalARN(dataSourceName, "arn", "ec2", regexp.MustCompile(`transitgatewayattachments:+.`)),
+					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "1"),
 				),
 			},
 		},
 	})
 }
 
-func testAccTransitgatewayAttachmentsDataSourceConfig_basic(rName, version string) string {
-	return fmt.Sprintf(`
-data "aws_security_group" "test" {
-  name = %[1]q
-}
-
-data "aws_ec2_transitgateway_attachments" "test" {
-  transitgateway_attachments_name             = %[1]q
-  engine_type             = "ActiveEC2"
-  engine_version          = %[2]q
-  host_instance_type      = "ec2.t2.micro"
-  security_groups         = [aws_security_group.test.id]
-  authentication_strategy = "simple"
-  storage_type            = "efs"
-
-  logs {
-    general = true
-  }
-
-  user {
-    username = "Test"
-    password = "TestTest1234"
+func testAccTransitGatewayAttachmentsDataSourceConfig_filter(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
+resource "aws_ec2_transit_gateway" "test" {
+  tags = {
+    Name = %[1]q
   }
 }
-`, rName, version)
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
+  subnet_ids         = aws_subnet.test[*].id
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  vpc_id             = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_ec2_transit_gateway_attachments" "test" {
+  filter {
+    name   = "transit-gateway-id"
+    values = [aws_ec2_transit_gateway.test.id]
+  }
+
+  filter {
+    name   = "resource-type"
+    values = ["vpc"]
+  }
+
+  filter {
+    name   = "resource-id"
+    values = [aws_vpc.test.id]
+  }
+
+  depends_on = [aws_ec2_transit_gateway_vpc_attachment.test]
+}
+`, rName))
 }

--- a/internal/service/ec2/transitgateway_attachments_data_source_test.go
+++ b/internal/service/ec2/transitgateway_attachments_data_source_test.go
@@ -1,0 +1,208 @@
+package ec2_test
+// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
+//
+// TIP: ==== INTRODUCTION ====
+// Thank you for trying the skaff tool!
+//
+// You have opted to include these helpful comments. They all include "TIP:"
+// to help you find and remove them when you're done with them.
+//
+// While some aspects of this file are customized to your input, the
+// scaffold tool does *not* look at the AWS API and ensure it has correct
+// function, structure, and variable names. It makes guesses based on
+// commonalities. You will need to make significant adjustments.
+//
+// In other words, as generated, this is a rough outline of the work you will
+// need to do. If something doesn't make sense for your situation, get rid of
+// it.
+//
+// Remember to register this new data source in the provider
+// (internal/provider/provider.go) once you finish. Otherwise, Terraform won't
+// know about it.
+
+import (
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+	//
+	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
+	// using the services/ec2/types package. If so, you'll
+	// need to import types and reference the nested types, e.g., as
+	// types.<Type Name>.
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+
+	// TIP: You will often need to import the package that this test file lives
+    // in. Since it is in the "test" context, it must import the package to use
+    // any normal context constants, variables, or functions.
+	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// TIP: File Structure. The basic outline for all test files should be as
+// follows. Improve this data source's maintainability by following this
+// outline.
+//
+// 1. Package declaration (add "_test" since this is a test file)
+// 2. Imports
+// 3. Unit tests
+// 4. Basic test
+// 5. Disappears test
+// 6. All the other tests
+// 7. Helper functions (exists, destroy, check, etc.)
+// 8. Functions that return Terraform configurations
+
+
+// TIP: ==== UNIT TESTS ====
+// This is an example of a unit test. Its name is not prefixed with
+// "TestAcc" like an acceptance test.
+//
+// Unlike acceptance tests, unit tests do not access AWS and are focused on a
+// function (or method). Because of this, they are quick and cheap to run.
+//
+// In designing a data source's implementation, isolate complex bits from AWS bits
+// so that they can be tested through a unit test. We encourage more unit tests
+// in the provider.
+//
+// Cut and dry functions using well-used patterns, like typical flatteners and
+// expanders, don't need unit testing. However, if they are complex or
+// intricate, they should be unit tested.
+func TestTransitgatewayAttachmentsExampleUnitTest(t *testing.T) {
+	testCases := []struct {
+		TestName string
+		Input    string
+		Expected string
+		Error    bool
+	}{
+		{
+			TestName: "empty",
+			Input:    "",
+			Expected: "",
+			Error:    true,
+		},
+		{
+			TestName: "descriptive name",
+			Input:    "some input",
+			Expected: "some output",
+			Error:    false,
+		},
+		{
+			TestName: "another descriptive name",
+			Input:    "more input",
+			Expected: "more output",
+			Error:    false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			got, err := tfec2.FunctionFromDataSource(testCase.Input)
+
+			if err != nil && !testCase.Error {
+				t.Errorf("got error (%s), expected no error", err)
+			}
+
+			if err == nil && testCase.Error {
+				t.Errorf("got (%s) and no error, expected error", got)
+			}
+
+			if got != testCase.Expected {
+				t.Errorf("got %s, expected %s", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+
+// TIP: ==== ACCEPTANCE TESTS ====
+// This is an example of a basic acceptance test. This should test as much of
+// standard functionality of the data source as possible, and test importing, if
+// applicable. We prefix its name with "TestAcc", the service, and the
+// data source name.
+//
+// Acceptance test access AWS and cost money to run.
+func TestAccEC2TransitgatewayAttachmentsDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+    // TIP: This is a long-running test guard for tests that run longer than
+    // 300s (5 min) generally.
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var transitgatewayattachments ec2.DescribeTransitgatewayAttachmentsResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_ec2_transitgateway_attachments.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(ec2.EndpointsID, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTransitgatewayAttachmentsDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTransitgatewayAttachmentsDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTransitgatewayAttachmentsExists(ctx, dataSourceName, &transitgatewayattachments),
+					resource.TestCheckResourceAttr(dataSourceName, "auto_minor_version_upgrade", "false"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "maintenance_window_start_time.0.day_of_week"),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "user.*", map[string]string{
+						"console_access": "false",
+						"groups.#":       "0",
+						"username":       "Test",
+						"password":       "TestTest1234",
+					}),
+					acctest.MatchResourceAttrRegionalARN(dataSourceName, "arn", "ec2", regexp.MustCompile(`transitgatewayattachments:+.`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccTransitgatewayAttachmentsDataSourceConfig_basic(rName, version string) string {
+	return fmt.Sprintf(`
+data "aws_security_group" "test" {
+  name = %[1]q
+}
+
+data "aws_ec2_transitgateway_attachments" "test" {
+  transitgateway_attachments_name             = %[1]q
+  engine_type             = "ActiveEC2"
+  engine_version          = %[2]q
+  host_instance_type      = "ec2.t2.micro"
+  security_groups         = [aws_security_group.test.id]
+  authentication_strategy = "simple"
+  storage_type            = "efs"
+
+  logs {
+    general = true
+  }
+
+  user {
+    username = "Test"
+    password = "TestTest1234"
+  }
+}
+`, rName, version)
+}

--- a/website/docs/d/ec2_transit_gateway_attachments.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_attachments.html.markdown
@@ -1,0 +1,60 @@
+---
+subcategory: "Transit Gateway"
+layout: "aws"
+page_title: "AWS: aws_ec2_transit_gateway_attachments"
+description: |-
+  Get information on EC2 Transit Gateway Attachments
+---
+
+# Data Source: aws_ec2_transit_gateway_attachments
+
+Get information on EC2 Transit Gateway Attachments.
+
+## Example Usage
+
+### By Filter
+
+```hcl
+data "aws_ec2_transit_gateway_attachments" "filtered" {
+  filter {
+    name   = "state"
+    values = ["pendingAcceptance"]
+  }
+
+  filter {
+    name   = "resource-type"
+    values = ["vpc"]
+  }
+}
+
+data "aws_ec2_transit_gateway_attachment" "unit" {
+  count = length(data.aws_ec2_transit_gateway_attachments.filtered.ids)
+  id    = data.aws_ec2_transit_gateway_attachments.filtered.ids[count.index]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `filter` - (Optional) One or more configuration blocks containing name-values filters. Detailed below.
+
+### filter Argument Reference
+
+* `name` - (Required) Name of the filter check available value on [official documentation][1]
+* `values` - (Required) List of one or more values for the filter.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `ids` A list of all attachments ids matching the filter. You can retrieve more information about the attachment using the [aws_ec2_transit_gateway_attachment][2] data source, searching by identifier.
+
+[1]: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeTransitGatewayAttachments.html
+[2]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ec2_transit_gateway_attachment
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `read` - (Default `20m`)

--- a/website/docs/d/ec2_transitgateway_attachments.html.markdown
+++ b/website/docs/d/ec2_transitgateway_attachments.html.markdown
@@ -1,0 +1,37 @@
+---
+subcategory: "EC2 (Elastic Compute Cloud)"
+layout: "aws"
+page_title: "AWS: aws_ec2_transitgateway_attachments"
+description: |-
+  Terraform data source for managing an AWS EC2 (Elastic Compute Cloud) Transitgateway Attachments.
+---
+
+# Data Source: aws_ec2_transitgateway_attachments
+
+Terraform data source for managing an AWS EC2 (Elastic Compute Cloud) Transitgateway Attachments.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_ec2_transitgateway_attachments" "example" {
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `example_arg` - (Required) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+The following arguments are optional:
+
+* `optional_arg` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the Transitgateway Attachments. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.


### PR DESCRIPTION
### Description

This Pull request Implements a new data source: `aws_ec2_transitgateway_attachments` which returns (plural) informations about EC2 Transit Gateway Attachments


### Relations

Closes #25745


### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccTransitGatewayAttachmentsDataSource PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccTransitGatewayAttachmentsDataSource'  -timeout 180m
=== RUN   TestAccTransitGatewayAttachmentsDataSource_Filter
--- PASS: TestAccTransitGatewayAttachmentsDataSource_Filter (334.12s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	337.365s
```
