### PR TITLE
ELBv2: Fix CI acceptance test failures

### DIFF
--- a/internal/service/elbv2/listener_rule_test.go
+++ b/internal/service/elbv2/listener_rule_test.go
@@ -654,10 +654,9 @@ func TestAccELBV2ListenerRule_oidc(t *testing.T) {
 	var conf elbv2.Rule
 	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
-	lbName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-
-	resourceName := "aws_lb_listener_rule.oidc"
-	frontEndListenerResourceName := "aws_lb_listener.front_end"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lb_listener_rule.test"
+	listenerResourceName := "aws_lb_listener.test"
 	targetGroupResourceName := "aws_lb_target_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -667,11 +666,11 @@ func TestAccELBV2ListenerRule_oidc(t *testing.T) {
 		CheckDestroy:             testAccCheckListenerRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccListenerRuleConfig_oidc(lbName, key, certificate),
+				Config: testAccListenerRuleConfig_oidc(rName, key, certificate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckListenerRuleExists(ctx, resourceName, &conf),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexp.MustCompile(fmt.Sprintf(`listener-rule/app/%s/.+$`, lbName))),
-					resource.TestCheckResourceAttrPair(resourceName, "listener_arn", frontEndListenerResourceName, "arn"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "elasticloadbalancing", regexp.MustCompile(fmt.Sprintf(`listener-rule/app/%s/.+$`, rName))),
+					resource.TestCheckResourceAttrPair(resourceName, "listener_arn", listenerResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "priority", "100"),
 					resource.TestCheckResourceAttr(resourceName, "action.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "action.0.order", "1"),
@@ -1509,7 +1508,11 @@ resource "aws_lb_target_group" "test" {
     Name = %[1]q
   }
 }
+`, rName))
+}
 
+func testAccListenerRuleConfig_baseWithListener(rName string) string {
+	return acctest.ConfigCompose(testAccListenerRuleConfig_base(rName), fmt.Sprintf(`
 resource "aws_lb_listener" "test" {
   load_balancer_arn = aws_lb.test.id
   protocol          = "HTTP"
@@ -1528,7 +1531,7 @@ resource "aws_lb_listener" "test" {
 }
 
 func testAccListenerRuleConfig_basic(rName string) string {
-	return acctest.ConfigCompose(testAccListenerRuleConfig_base(rName), `
+	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithListener(rName), `
 resource "aws_lb_listener_rule" "test" {
   listener_arn = aws_lb_listener.test.arn
   priority     = 100
@@ -2344,7 +2347,7 @@ resource "aws_security_group" "alb_test" {
 }
 
 func testAccListenerRuleConfig_updatePriority(rName string) string {
-	return acctest.ConfigCompose(testAccListenerRuleConfig_base(rName), `
+	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithListener(rName), `
 resource "aws_lb_listener_rule" "test" {
   listener_arn = aws_lb_listener.test.arn
   priority     = 101
@@ -2364,7 +2367,7 @@ resource "aws_lb_listener_rule" "test" {
 }
 
 func testAccListenerRuleConfig_changeARN(rName string) string {
-	return acctest.ConfigCompose(testAccListenerRuleConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithListener(rName), fmt.Sprintf(`
 resource "aws_lb_listener_rule" "test" {
   listener_arn = aws_lb_listener.test2.arn
   priority     = 101
@@ -2825,9 +2828,9 @@ resource "aws_cognito_user_pool_domain" "test" {
 }
 
 func testAccListenerRuleConfig_oidc(rName, key, certificate string) string {
-	return fmt.Sprintf(`
-resource "aws_lb_listener_rule" "oidc" {
-  listener_arn = aws_lb_listener.front_end.arn
+	return acctest.ConfigCompose(testAccListenerRuleConfig_base(rName), fmt.Sprintf(`
+resource "aws_lb_listener_rule" "test" {
+  listener_arn = aws_lb_listener.test.arn
   priority     = 100
 
   action {
@@ -2857,6 +2860,10 @@ resource "aws_lb_listener_rule" "oidc" {
       values = ["/static/*"]
     }
   }
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_iam_server_certificate" "test" {
@@ -2865,8 +2872,8 @@ resource "aws_iam_server_certificate" "test" {
   private_key      = "%[3]s"
 }
 
-resource "aws_lb_listener" "front_end" {
-  load_balancer_arn = aws_lb.alb_test.id
+resource "aws_lb_listener" "test" {
+  load_balancer_arn = aws_lb.test.id
   protocol          = "HTTPS"
   port              = "443"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
@@ -2876,98 +2883,12 @@ resource "aws_lb_listener" "front_end" {
     target_group_arn = aws_lb_target_group.test.id
     type             = "forward"
   }
-}
-
-resource "aws_lb" "alb_test" {
-  name            = %[1]q
-  internal        = true
-  security_groups = [aws_security_group.alb_test.id]
-  subnets         = aws_subnet.alb_test[*].id
-
-  idle_timeout               = 30
-  enable_deletion_protection = false
 
   tags = {
     Name = %[1]q
   }
 }
-
-resource "aws_lb_target_group" "test" {
-  name     = %[1]q
-  port     = 8080
-  protocol = "HTTP"
-  vpc_id   = aws_vpc.alb_test.id
-
-  health_check {
-    path                = "/health"
-    interval            = 60
-    port                = 8081
-    protocol            = "HTTP"
-    timeout             = 3
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
-    matcher             = "200-299"
-  }
-}
-
-variable "subnets" {
-  default = ["10.0.1.0/24", "10.0.2.0/24"]
-  type    = list(string)
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
-resource "aws_vpc" "alb_test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = "terraform-testacc-lb-listener-rule-cognito"
-  }
-}
-
-resource "aws_subnet" "alb_test" {
-  count                   = 2
-  vpc_id                  = aws_vpc.alb_test.id
-  cidr_block              = element(var.subnets, count.index)
-  map_public_ip_on_launch = true
-  availability_zone       = element(data.aws_availability_zones.available.names, count.index)
-
-  tags = {
-    Name = "tf-acc-lb-listener-rule-cognito-${count.index}"
-  }
-}
-
-resource "aws_security_group" "alb_test" {
-  name        = "allow_all_alb_test"
-  description = "Used for ALB Testing"
-  vpc_id      = aws_vpc.alb_test.id
-
-  ingress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = {
-    Name = %[1]q
-  }
-}
-`, rName, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key))
+`, rName, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key)))
 }
 
 func testAccListenerRuleConfig_actionOrder(rName, key, certificate string) string {
@@ -3561,7 +3482,7 @@ condition {
 }
 
 func testAccListenerRuleConfig_tags1(rName, tagKey1, tagValue1 string) string {
-	return acctest.ConfigCompose(testAccListenerRuleConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithListener(rName), fmt.Sprintf(`
 resource "aws_lb_listener_rule" "test" {
   listener_arn = aws_lb_listener.test.arn
   priority     = 100
@@ -3585,7 +3506,7 @@ resource "aws_lb_listener_rule" "test" {
 }
 
 func testAccListenerRuleConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccListenerRuleConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccListenerRuleConfig_baseWithListener(rName), fmt.Sprintf(`
 resource "aws_lb_listener_rule" "test" {
   listener_arn = aws_lb_listener.test.arn
   priority     = 100


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes ELBv2 CI acceptance test failures:

```
=== RUN   TestAccELBV2ListenerRule_oidc
=== PAUSE TestAccELBV2ListenerRule_oidc
=== CONT  TestAccELBV2ListenerRule_oidc
listener_rule_test.go:647: Step 1/1 error: Error running apply: exit status 1
Error: creating IAM Server Certificate (tf-acc-test-877177919464001877): MalformedCertificate: Unable to parse certificate. Please ensure the certificate is in PEM format.
  status code: 400, request id: 8b3f55e2-5ab4-4967-924b-a7fd4c199356
with aws_iam_server_certificate.test,
on terraform_plugin_test.tf line 35, in resource "aws_iam_server_certificate" "test":
35: resource "aws_iam_server_certificate" "test" {
--- FAIL: TestAccELBV2ListenerRule_oidc (169.69s)
=== RUN   TestAccELBV2ListenerRule_cognito
=== PAUSE TestAccELBV2ListenerRule_cognito
=== CONT  TestAccELBV2ListenerRule_cognito
listener_rule_test.go:605: Step 1/1 error: Error running apply: exit status 1
Error: creating IAM Server Certificate (tf-acc-test-6580161443947995585): MalformedCertificate: Unable to parse certificate. Please ensure the certificate is in PEM format.
  status code: 400, request id: a2c46dff-3833-455f-bd32-0b03cf679ba1
with aws_iam_server_certificate.test,
on terraform_plugin_test.tf line 32, in resource "aws_iam_server_certificate" "test":
32: resource "aws_iam_server_certificate" "test" {
--- FAIL: TestAccELBV2ListenerRule_cognito (344.87s)
=== RUN   TestAccELBV2ListenerRule_priority
=== PAUSE TestAccELBV2ListenerRule_priority
=== CONT  TestAccELBV2ListenerRule_priority
listener_rule_test.go:522: Step 7/8, expected an error with pattern, no match on: Error running apply: exit status 1
Error: creating LB Listener Rule: ValidationError: 1 validation error detected: Value '50001' at 'priority' failed to satisfy constraint: Member must have value less than or equal to 50000
  status code: 400, request id: a74db38b-b2b9-424e-9734-4494ed2cb5cd
with aws_lb_listener_rule.priority50001,
on terraform_plugin_test.tf line 119, in resource "aws_lb_listener_rule" "priority50001":
119: resource "aws_lb_listener_rule" "priority50001" {
--- FAIL: TestAccELBV2ListenerRule_priority (563.00s)
```

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccELBV2ListenerRule_' PKG=elbv2 ACCTEST_PARALLELISM=3    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elbv2/... -v -count 1 -parallel 3  -run=TestAccELBV2ListenerRule_ -timeout 180m
=== RUN   TestAccELBV2ListenerRule_basic
=== PAUSE TestAccELBV2ListenerRule_basic
=== RUN   TestAccELBV2ListenerRule_disappears
=== PAUSE TestAccELBV2ListenerRule_disappears
=== RUN   TestAccELBV2ListenerRule_tags
=== PAUSE TestAccELBV2ListenerRule_tags
=== RUN   TestAccELBV2ListenerRule_forwardWeighted
=== PAUSE TestAccELBV2ListenerRule_forwardWeighted
=== RUN   TestAccELBV2ListenerRule_backwardsCompatibility
=== PAUSE TestAccELBV2ListenerRule_backwardsCompatibility
=== RUN   TestAccELBV2ListenerRule_redirect
=== PAUSE TestAccELBV2ListenerRule_redirect
=== RUN   TestAccELBV2ListenerRule_fixedResponse
=== PAUSE TestAccELBV2ListenerRule_fixedResponse
=== RUN   TestAccELBV2ListenerRule_updateFixedResponse
=== PAUSE TestAccELBV2ListenerRule_updateFixedResponse
=== RUN   TestAccELBV2ListenerRule_updateRulePriority
=== PAUSE TestAccELBV2ListenerRule_updateRulePriority
=== RUN   TestAccELBV2ListenerRule_changeListenerRuleARNForcesNew
=== PAUSE TestAccELBV2ListenerRule_changeListenerRuleARNForcesNew
=== RUN   TestAccELBV2ListenerRule_priority
=== PAUSE TestAccELBV2ListenerRule_priority
=== RUN   TestAccELBV2ListenerRule_cognito
=== PAUSE TestAccELBV2ListenerRule_cognito
=== RUN   TestAccELBV2ListenerRule_oidc
=== PAUSE TestAccELBV2ListenerRule_oidc
=== RUN   TestAccELBV2ListenerRule_Action_order
=== PAUSE TestAccELBV2ListenerRule_Action_order
=== RUN   TestAccELBV2ListenerRule_ActionOrder_recreates
=== PAUSE TestAccELBV2ListenerRule_ActionOrder_recreates
=== RUN   TestAccELBV2ListenerRule_conditionAttributesCount
=== PAUSE TestAccELBV2ListenerRule_conditionAttributesCount
=== RUN   TestAccELBV2ListenerRule_conditionHostHeader
=== PAUSE TestAccELBV2ListenerRule_conditionHostHeader
=== RUN   TestAccELBV2ListenerRule_conditionHTTPHeader
=== PAUSE TestAccELBV2ListenerRule_conditionHTTPHeader
=== RUN   TestAccELBV2ListenerRule_ConditionHTTPHeader_invalid
=== PAUSE TestAccELBV2ListenerRule_ConditionHTTPHeader_invalid
=== RUN   TestAccELBV2ListenerRule_conditionHTTPRequestMethod
=== PAUSE TestAccELBV2ListenerRule_conditionHTTPRequestMethod
=== RUN   TestAccELBV2ListenerRule_conditionPathPattern
=== PAUSE TestAccELBV2ListenerRule_conditionPathPattern
=== RUN   TestAccELBV2ListenerRule_conditionQueryString
=== PAUSE TestAccELBV2ListenerRule_conditionQueryString
=== RUN   TestAccELBV2ListenerRule_conditionSourceIP
=== PAUSE TestAccELBV2ListenerRule_conditionSourceIP
=== RUN   TestAccELBV2ListenerRule_conditionUpdateMixed
=== PAUSE TestAccELBV2ListenerRule_conditionUpdateMixed
=== RUN   TestAccELBV2ListenerRule_conditionMultiple
=== PAUSE TestAccELBV2ListenerRule_conditionMultiple
=== RUN   TestAccELBV2ListenerRule_conditionUpdateMultiple
=== PAUSE TestAccELBV2ListenerRule_conditionUpdateMultiple
=== CONT  TestAccELBV2ListenerRule_basic
=== CONT  TestAccELBV2ListenerRule_Action_order
=== CONT  TestAccELBV2ListenerRule_conditionPathPattern
--- PASS: TestAccELBV2ListenerRule_Action_order (171.88s)
=== CONT  TestAccELBV2ListenerRule_conditionUpdateMixed
--- PASS: TestAccELBV2ListenerRule_basic (172.78s)
=== CONT  TestAccELBV2ListenerRule_conditionUpdateMultiple
--- PASS: TestAccELBV2ListenerRule_conditionPathPattern (183.31s)
=== CONT  TestAccELBV2ListenerRule_conditionMultiple
--- PASS: TestAccELBV2ListenerRule_conditionMultiple (170.35s)
=== CONT  TestAccELBV2ListenerRule_conditionSourceIP
--- PASS: TestAccELBV2ListenerRule_conditionUpdateMultiple (190.78s)
=== CONT  TestAccELBV2ListenerRule_conditionQueryString
--- PASS: TestAccELBV2ListenerRule_conditionUpdateMixed (222.71s)
=== CONT  TestAccELBV2ListenerRule_conditionHTTPHeader
--- PASS: TestAccELBV2ListenerRule_conditionSourceIP (171.09s)
=== CONT  TestAccELBV2ListenerRule_conditionHTTPRequestMethod
--- PASS: TestAccELBV2ListenerRule_conditionQueryString (172.91s)
=== CONT  TestAccELBV2ListenerRule_ConditionHTTPHeader_invalid
--- PASS: TestAccELBV2ListenerRule_ConditionHTTPHeader_invalid (1.47s)
=== CONT  TestAccELBV2ListenerRule_conditionAttributesCount
--- PASS: TestAccELBV2ListenerRule_conditionAttributesCount (25.12s)
=== CONT  TestAccELBV2ListenerRule_conditionHostHeader
--- PASS: TestAccELBV2ListenerRule_conditionHTTPHeader (171.42s)
=== CONT  TestAccELBV2ListenerRule_updateFixedResponse
--- PASS: TestAccELBV2ListenerRule_conditionHTTPRequestMethod (168.99s)
=== CONT  TestAccELBV2ListenerRule_changeListenerRuleARNForcesNew
--- PASS: TestAccELBV2ListenerRule_conditionHostHeader (169.56s)
=== CONT  TestAccELBV2ListenerRule_updateRulePriority
--- PASS: TestAccELBV2ListenerRule_updateFixedResponse (196.88s)
=== CONT  TestAccELBV2ListenerRule_backwardsCompatibility
--- PASS: TestAccELBV2ListenerRule_changeListenerRuleARNForcesNew (198.42s)
=== CONT  TestAccELBV2ListenerRule_fixedResponse
--- PASS: TestAccELBV2ListenerRule_updateRulePriority (169.90s)
=== CONT  TestAccELBV2ListenerRule_redirect
--- PASS: TestAccELBV2ListenerRule_backwardsCompatibility (163.88s)
=== CONT  TestAccELBV2ListenerRule_oidc
--- PASS: TestAccELBV2ListenerRule_fixedResponse (178.76s)
=== CONT  TestAccELBV2ListenerRule_tags
--- PASS: TestAccELBV2ListenerRule_oidc (161.81s)
=== CONT  TestAccELBV2ListenerRule_forwardWeighted
--- PASS: TestAccELBV2ListenerRule_redirect (216.60s)
=== CONT  TestAccELBV2ListenerRule_priority
=== CONT  TestAccELBV2ListenerRule_cognito
--- PASS: TestAccELBV2ListenerRule_tags (196.94s)
--- PASS: TestAccELBV2ListenerRule_forwardWeighted (190.08s)
=== CONT  TestAccELBV2ListenerRule_ActionOrder_recreates
--- PASS: TestAccELBV2ListenerRule_cognito (161.41s)
=== CONT  TestAccELBV2ListenerRule_disappears
--- PASS: TestAccELBV2ListenerRule_priority (310.24s)
--- PASS: TestAccELBV2ListenerRule_ActionOrder_recreates (173.53s)
--- PASS: TestAccELBV2ListenerRule_disappears (169.50s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	1604.592s
```
