### PR TITLE
aws_medialive_multiplex: fix test AZ

### DIFF
--- a/internal/service/medialive/multiplex_test.go
+++ b/internal/service/medialive/multiplex_test.go
@@ -295,8 +295,14 @@ func testAccMultiplexesPreCheck(ctx context.Context, t *testing.T) {
 
 func testAccMultiplexBaseConfig() string {
 	return `
-data "aws_availability_zones" "test" {
-  state = "available"
+data "aws_availability_zones" "available" {
+  state         = "available"
+  exclude_names = ["us-west-2-las-1a"]
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
 }
 `
 }
@@ -307,7 +313,7 @@ func testAccMultiplexConfig_basic(rName string, start bool) string {
 		fmt.Sprintf(`
 resource "aws_medialive_multiplex" "test" {
   name               = %[1]q
-  availability_zones = [data.aws_availability_zones.test.names[0], data.aws_availability_zones.test.names[1]]
+  availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 
   multiplex_settings {
     transport_stream_bitrate                = 1000000
@@ -331,7 +337,7 @@ func testAccMultiplexConfig_update(rName string, start bool) string {
 		fmt.Sprintf(`
 resource "aws_medialive_multiplex" "test" {
   name               = %[1]q
-  availability_zones = [data.aws_availability_zones.test.names[0], data.aws_availability_zones.test.names[1]]
+  availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 
   multiplex_settings {
     transport_stream_bitrate                = 1000001
@@ -355,7 +361,7 @@ func testAccMultiplexConfig_tags1(rName, key1, value1 string) string {
 		fmt.Sprintf(`
 resource "aws_medialive_multiplex" "test" {
   name               = %[1]q
-  availability_zones = [data.aws_availability_zones.test.names[0], data.aws_availability_zones.test.names[1]]
+  availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 
   multiplex_settings {
     transport_stream_bitrate                = 1000000
@@ -377,7 +383,7 @@ func testAccMultiplexConfig_tags2(rName, key1, value1, key2, value2 string) stri
 		fmt.Sprintf(`
 resource "aws_medialive_multiplex" "test" {
   name               = %[1]q
-  availability_zones = [data.aws_availability_zones.test.names[0], data.aws_availability_zones.test.names[1]]
+  availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 
   multiplex_settings {
     transport_stream_bitrate                = 1000000


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:
--->

Closes #29647 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=medialive TESTS="TestAccMediaLive_serial"

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/medialive/... -v -count 1 -parallel 20 -run='TestAccMediaLive_serial'  -timeout 180m
--- PASS: TestAccMediaLive_serial (736.19s)
    --- PASS: TestAccMediaLive_serial/Multiplex (544.62s)
        --- PASS: TestAccMediaLive_serial/Multiplex/update (97.74s)
        --- PASS: TestAccMediaLive_serial/Multiplex/updateTags (76.60s)
        --- PASS: TestAccMediaLive_serial/Multiplex/start (258.93s)
        --- PASS: TestAccMediaLive_serial/Multiplex/basic (56.66s)
        --- PASS: TestAccMediaLive_serial/Multiplex/disappears (54.69s)
    --- PASS: TestAccMediaLive_serial/MultiplexProgram (191.58s)
        --- PASS: TestAccMediaLive_serial/MultiplexProgram/basic (63.37s)
        --- PASS: TestAccMediaLive_serial/MultiplexProgram/update (66.52s)
        --- PASS: TestAccMediaLive_serial/MultiplexProgram/disappears (61.69s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	739.216s
...
```
