### PR TITLE
Fixes custom Framework types

### DIFF
--- a/internal/framework/types/arn.go
+++ b/internal/framework/types/arn.go
@@ -174,7 +174,18 @@ func (a ARN) Type(_ context.Context) attr.Type {
 }
 
 func (a ARN) ToStringValue(ctx context.Context) (types.String, diag.Diagnostics) {
-	return types.StringValue(a.value.String()), nil
+	switch a.state {
+	case attr.ValueStateKnown:
+		return types.StringValue(a.value.String()), nil
+	case attr.ValueStateNull:
+		return types.StringNull(), nil
+	case attr.ValueStateUnknown:
+		return types.StringUnknown(), nil
+	default:
+		return types.StringUnknown(), diag.Diagnostics{
+			diag.NewErrorDiagnostic(fmt.Sprintf("unhandled ARN state in ToStringValue: %s", a.state), ""),
+		}
+	}
 }
 
 func (a ARN) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {

--- a/internal/framework/types/arn.go
+++ b/internal/framework/types/arn.go
@@ -68,7 +68,7 @@ func (t arnType) ValueFromTerraform(_ context.Context, in tftypes.Value) (attr.V
 	v, err := arn.Parse(s)
 
 	if err != nil {
-		return nil, err
+		return ARNUnknown(), nil //nolint: nilerr // Must not return validation errors
 	}
 
 	return ARNValue(v), nil

--- a/internal/framework/types/arn_test.go
+++ b/internal/framework/types/arn_test.go
@@ -17,9 +17,8 @@ func TestARNTypeValueFromTerraform(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		val         tftypes.Value
-		expected    attr.Value
-		expectError bool
+		val      tftypes.Value
+		expected attr.Value
 	}{
 		"null value": {
 			val:      tftypes.NewValue(tftypes.String, nil),
@@ -39,9 +38,9 @@ func TestARNTypeValueFromTerraform(t *testing.T) {
 				Resource:  "db:test",
 			}),
 		},
-		"invalid duration": {
-			val:         tftypes.NewValue(tftypes.String, "not ok"),
-			expectError: true,
+		"invalid ARN": {
+			val:      tftypes.NewValue(tftypes.String, "not ok"),
+			expected: fwtypes.ARNUnknown(),
 		},
 	}
 
@@ -53,10 +52,7 @@ func TestARNTypeValueFromTerraform(t *testing.T) {
 			ctx := context.Background()
 			val, err := fwtypes.ARNType.ValueFromTerraform(ctx, test.val)
 
-			if err == nil && test.expectError {
-				t.Fatal("expected error, got no error")
-			}
-			if err != nil && !test.expectError {
+			if err != nil {
 				t.Fatalf("got unexpected error: %s", err)
 			}
 

--- a/internal/framework/types/cidr_block.go
+++ b/internal/framework/types/cidr_block.go
@@ -55,7 +55,7 @@ func (t cidrBlockType) ValueFromTerraform(_ context.Context, in tftypes.Value) (
 	}
 
 	if err := verify.ValidateCIDRBlock(s); err != nil {
-		return nil, err
+		return CIDRBlockUnknown(), nil //nolint: nilerr // Must not return validation errors
 	}
 
 	return CIDRBlockValue(s), nil

--- a/internal/framework/types/cidr_block.go
+++ b/internal/framework/types/cidr_block.go
@@ -152,7 +152,18 @@ func (c CIDRBlock) Type(_ context.Context) attr.Type {
 }
 
 func (c CIDRBlock) ToStringValue(ctx context.Context) (types.String, diag.Diagnostics) {
-	return types.StringValue(c.value), nil
+	switch c.state {
+	case attr.ValueStateKnown:
+		return types.StringValue(c.value), nil
+	case attr.ValueStateNull:
+		return types.StringNull(), nil
+	case attr.ValueStateUnknown:
+		return types.StringUnknown(), nil
+	default:
+		return types.StringUnknown(), diag.Diagnostics{
+			diag.NewErrorDiagnostic(fmt.Sprintf("unhandled CIDRBlock state in ToStringValue: %s", c.state), ""),
+		}
+	}
 }
 
 func (c CIDRBlock) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {

--- a/internal/framework/types/cidr_block_test.go
+++ b/internal/framework/types/cidr_block_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 )
@@ -108,6 +109,43 @@ func TestCIDRBlockTypeValidate(t *testing.T) {
 
 			if diags.HasError() && !test.expectError {
 				t.Fatalf("got unexpected error: %#v", diags)
+			}
+		})
+	}
+}
+
+func TestCIDRBlockToStringValue(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		cidrBlock fwtypes.CIDRBlock
+		expected  types.String
+	}{
+		"value": {
+			cidrBlock: fwtypes.CIDRBlockValue("10.2.2.0/24"),
+			expected:  types.StringValue("10.2.2.0/24"),
+		},
+		"null": {
+			cidrBlock: fwtypes.CIDRBlockNull(),
+			expected:  types.StringNull(),
+		},
+		"unknown": {
+			cidrBlock: fwtypes.CIDRBlockUnknown(),
+			expected:  types.StringUnknown(),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			s, _ := test.cidrBlock.ToStringValue(ctx)
+
+			if !test.expected.Equal(s) {
+				t.Fatalf("expected %#v to equal %#v", s, test.expected)
 			}
 		})
 	}

--- a/internal/framework/types/cidr_block_test.go
+++ b/internal/framework/types/cidr_block_test.go
@@ -16,9 +16,8 @@ func TestCIDRBlockTypeValueFromTerraform(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		val         tftypes.Value
-		expected    attr.Value
-		expectError bool
+		val      tftypes.Value
+		expected attr.Value
 	}{
 		"null value": {
 			val:      tftypes.NewValue(tftypes.String, nil),
@@ -33,8 +32,8 @@ func TestCIDRBlockTypeValueFromTerraform(t *testing.T) {
 			expected: fwtypes.CIDRBlockValue("0.0.0.0/0"),
 		},
 		"invalid CIDR block": {
-			val:         tftypes.NewValue(tftypes.String, "not ok"),
-			expectError: true,
+			val:      tftypes.NewValue(tftypes.String, "not ok"),
+			expected: fwtypes.CIDRBlockUnknown(),
 		},
 	}
 
@@ -46,10 +45,7 @@ func TestCIDRBlockTypeValueFromTerraform(t *testing.T) {
 			ctx := context.Background()
 			val, err := fwtypes.CIDRBlockType.ValueFromTerraform(ctx, test.val)
 
-			if err == nil && test.expectError {
-				t.Fatal("expected error, got no error")
-			}
-			if err != nil && !test.expectError {
+			if err != nil {
 				t.Fatalf("got unexpected error: %s", err)
 			}
 

--- a/internal/framework/types/duration.go
+++ b/internal/framework/types/duration.go
@@ -69,7 +69,7 @@ func (d durationType) ValueFromTerraform(_ context.Context, in tftypes.Value) (a
 	v, err := time.ParseDuration(s)
 
 	if err != nil {
-		return nil, err
+		return DurationUnknown(), nil //nolint: nilerr // Must not return validation errors
 	}
 
 	return DurationValue(v), nil

--- a/internal/framework/types/duration.go
+++ b/internal/framework/types/duration.go
@@ -177,7 +177,18 @@ func (d Duration) Type(_ context.Context) attr.Type {
 }
 
 func (d Duration) ToStringValue(ctx context.Context) (types.String, diag.Diagnostics) {
-	return types.StringValue(d.value.String()), nil
+	switch d.state {
+	case attr.ValueStateKnown:
+		return types.StringValue(d.value.String()), nil
+	case attr.ValueStateNull:
+		return types.StringNull(), nil
+	case attr.ValueStateUnknown:
+		return types.StringUnknown(), nil
+	default:
+		return types.StringUnknown(), diag.Diagnostics{
+			diag.NewErrorDiagnostic(fmt.Sprintf("unhandled Duration state in ToStringValue: %s", d.state), ""),
+		}
+	}
 }
 
 // ToTerraformValue returns the data contained in the *String as a string. If

--- a/internal/framework/types/duration_test.go
+++ b/internal/framework/types/duration_test.go
@@ -17,9 +17,8 @@ func TestDurationTypeValueFromTerraform(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		val         tftypes.Value
-		expected    attr.Value
-		expectError bool
+		val      tftypes.Value
+		expected attr.Value
 	}{
 		"null value": {
 			val:      tftypes.NewValue(tftypes.String, nil),
@@ -34,8 +33,8 @@ func TestDurationTypeValueFromTerraform(t *testing.T) {
 			expected: fwtypes.DurationValue(2 * time.Hour),
 		},
 		"invalid duration": {
-			val:         tftypes.NewValue(tftypes.String, "not ok"),
-			expectError: true,
+			val:      tftypes.NewValue(tftypes.String, "not ok"),
+			expected: fwtypes.DurationUnknown(),
 		},
 	}
 
@@ -47,10 +46,7 @@ func TestDurationTypeValueFromTerraform(t *testing.T) {
 			ctx := context.Background()
 			val, err := fwtypes.DurationType.ValueFromTerraform(ctx, test.val)
 
-			if err == nil && test.expectError {
-				t.Fatal("expected error, got no error")
-			}
-			if err != nil && !test.expectError {
+			if err != nil {
 				t.Fatalf("got unexpected error: %s", err)
 			}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Fixes the following errors in `ARN`, `CIDRBlock` and `Duration`:

* `ToStringValue` was returning a `attr.ValueStateKnown` string value, even if the underlying value was null or unknown
* `ValueFromTerraform` was returning an error if parsing failed. [Custom type documentation](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/custom-types#attr-type-interface) says that errors should not be returned for invalid data

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29618
Closes #29619
