### PR TITLE
aws_api_gateway_deployment - outdated link

### DIFF
--- a/website/docs/r/api_gateway_deployment.html.markdown
+++ b/website/docs/r/api_gateway_deployment.html.markdown
@@ -134,7 +134,7 @@ The following arguments are supported:
 * `description` - (Optional) Description of the deployment
 * `stage_name` - (Optional) Name of the stage to create with this deployment. If the specified stage already exists, it will be updated to point to the new deployment. We recommend using the [`aws_api_gateway_stage` resource](api_gateway_stage.html) instead to manage stages.
 * `stage_description` - (Optional) Description to set on the stage managed by the `stage_name` argument.
-* `triggers` - (Optional) Map of arbitrary keys and values that, when changed, will trigger a redeployment. To force a redeployment without changing these keys/values, use the [`terraform taint` command](https://www.terraform.io/docs/commands/taint.html).
+* `triggers` - (Optional) Map of arbitrary keys and values that, when changed, will trigger a redeployment. To force a redeployment without changing these keys/values, use the [`-replace` option](https://developer.hashicorp.com/terraform/cli/commands/plan#replace-address) with `terraform plan` or `terraform apply`.
 * `variables` - (Optional) Map to set on the stage managed by the `stage_name` argument.
 
 ## Attributes Reference


### PR DESCRIPTION
### Description
Doc is outdated referring to deprecated `taint` command, updating with `-replace` option and current link

### Relations
Closes #29113

### References
https://developer.hashicorp.com/terraform/cli/commands/taint
https://developer.hashicorp.com/terraform/cli/commands/plan#replace-address
