### PR TITLE
#29667 Fix example for API Gateway permissions

### DIFF
--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -122,9 +122,9 @@ resource "aws_lambda_permission" "lambda_permission" {
   function_name = "MyDemoFunction"
   principal     = "apigateway.amazonaws.com"
 
-  # The /*/*/* part allows invocation from any stage, method and resource path
-  # within API Gateway REST API.
-  source_arn = "${aws_api_gateway_rest_api.MyDemoAPI.execution_arn}/*/*/*"
+  # The /* part allows invocation from any stage, method and resource path
+  # within API Gateway.
+  source_arn = "${aws_api_gateway_rest_api.MyDemoAPI.execution_arn}/*"
 }
 ```
 


### PR DESCRIPTION
### Description

- The existing example `/*/*/*` works technically, but yields to a warning in AWS Lambda Console. The correct usage would be `/*` as suggested by AWS docs.
- Removed "REST API" from example, because this permission works the same for API Gateway HTTP API.

Documentation states:
```
# The /*/*/* part allows invocation from any stage, method and resource path
# within API Gateway REST API.
source_arn = "${aws_api_gateway_rest_api.MyDemoAPI.execution_arn}/*/*/*"
```
This configuration works, but produces an error message in the AWS Lambda Console.

The official AWS documentation for the format can be found here:
https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html#api-gateway-calling-api-permissions

The correct syntax is:
```
arn:aws:execute-api:*:*:* for any resource path in any stage, for any API in any AWS region.
```

The example should be rewritten to:
```
source_arn = "${aws_api_gateway_rest_api.MyDemoAPI.execution_arn}/*"
```


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29667
