### PR TITLE
Fix route53_delegation_set argument description

### DIFF
--- a/website/docs/d/route53_delegation_set.html.markdown
+++ b/website/docs/d/route53_delegation_set.html.markdown
@@ -24,7 +24,7 @@ data "aws_route53_delegation_set" "dset" {
 
 ## Argument Reference
 
-* `id` - (Required) Hosted Zone id of the desired delegation set.
+* `id` - (Required) Delegation set ID.
 
 The following attribute is additionally exported:
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR fixes route53_delegation_set argument description.
Argument `id` is of delegation set, not zone.


