### PR TITLE
Add Contributors Slack Google Form

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ The [AWS Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/
 - [FAQ](https://hashicorp.github.io/terraform-provider-aws/faq/)
 - [Tutorials](https://learn.hashicorp.com/collections/terraform/aws-get-started)
 - [discuss.hashicorp.com](https://discuss.hashicorp.com/c/terraform-providers/tf-aws/)
-- [gitter](https://gitter.im/hashicorp-terraform/Lobby)
 - [Google Groups](http://groups.google.com/group/terraform-tool)
 
 _**Please note:** We take Terraform's security and our users' trust very seriously. If you believe you have found a security issue in the Terraform AWS Provider, please responsibly disclose it by contacting us at security@hashicorp.com._

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,4 +48,6 @@ In addition to contributions, we welcome [bug reports](https://github.com/hashic
 
 ### Join the Contributors Slack
 
-For frequent contributors, it's useful to join the contributors Slack channel hosted within the HashiCorp Slack workspace. To do so, fill out the [request form](https://forms.gle/Gf9ZAmUYXuzafkct6) to request to be added. Please allow time for the request to be reviewed and processed.
+For frequent contributors, it's useful to join the contributors Slack channel hosted within the HashiCorp Slack workspace. This Slack channel is used to discuss topics such as general contribution questions, suggestions for improving the contribution process, coordinating on pair programming sessions, etc. The channel is not intended as a place to request status updates on open issues or pull requests. For prioritization questions, instead refer to the [prioritization guide](prioritization.md).
+
+To request to join, fill out the [request form](https://forms.gle/Gf9ZAmUYXuzafkct6) and allow time for the request to be reviewed and processed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,3 +45,7 @@ Pull requests are usually triaged within a few days of creation and are prioriti
 ### Submit an Issue
 
 In addition to contributions, we welcome [bug reports](https://github.com/hashicorp/terraform-provider-aws/issues/new?assignees=&labels=&template=Bug_Report.md) and [feature requests](https://github.com/hashicorp/terraform-provider-aws/issues/new?assignees=&labels=enhancement&template=Feature_Request.md).
+
+### Join the Contributors Slack
+
+For frequent contributors, it's useful to join the contributors Slack channel hosted within the HashiCorp Slack workspace. To do so, fill out the [request form](https://forms.gle/Gf9ZAmUYXuzafkct6) to request to be added. Please allow time for the request to be reviewed and processed.


### PR DESCRIPTION
### Description

This PR adds a link to the Google Form that we've set up to request to be added to the Contributors Slack channel. While I was at it, removed the link to Gitter, since we no longer use this service.

### Relations

N/a

### References

N/a

### Output from Acceptance Testing

N/a, docs