### PR TITLE
`r/aws_lambda_function`: Add `memory_size`, `role`, and `timeout` validation

### DIFF
--- a/.changelog/29721.txt
+++ b/.changelog/29721.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lambda_function: Add plan time validators for `memory_size`, `role`, and `timeout`
+```

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -260,8 +260,9 @@ func ResourceFunction() *schema.Resource {
 				ValidateFunc: validation.IntAtLeast(-1),
 			},
 			"role": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: verify.ValidARN,
 			},
 			"runtime": {
 				Type:             schema.TypeString,

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -218,9 +218,10 @@ func ResourceFunction() *schema.Resource {
 				},
 			},
 			"memory_size": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  128,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      128,
+				ValidateFunc: validation.IntBetween(128, 10240),
 			},
 			"package_type": {
 				Type:             schema.TypeString,

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -328,9 +328,10 @@ func ResourceFunction() *schema.Resource {
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 			"timeout": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  3,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      3,
+				ValidateFunc: validation.IntBetween(1, 900),
 			},
 			"tracing_config": {
 				Type:     schema.TypeList,


### PR DESCRIPTION
### Description
Adds additional plan time validators for the `aws_lambda_function` resource.

### Relations
Closes #22897
Relates #13709 

### References

- https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-MemorySize
- https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Role
- https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Timeout

### Output from Acceptance Testing

```
$ make testacc PKG=lambda TESTS=TestAccLambdaFunction_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunction_'  -timeout 180m
--- PASS: TestAccLambdaFunction_Zip_validation (8.32s)
=== CONT  TestAccLambdaFunction_nameValidation
--- PASS: TestAccLambdaFunction_nameValidation (3.12s)
=== CONT  TestAccLambdaFunction_VPCPublishNo_changes
--- PASS: TestAccLambdaFunction_basic (52.01s)
=== CONT  TestAccLambdaFunction_deadLetterUpdated
--- PASS: TestAccLambdaFunction_S3Update_unversioned (58.10s)
=== CONT  TestAccLambdaFunction_VPC_withInvocation
--- PASS: TestAccLambdaFunction_snapStart (64.12s)
=== CONT  TestAccLambdaFunction_architecturesUpdate
--- PASS: TestAccLambdaFunction_skipDestroy (68.07s)
=== CONT  TestAccLambdaFunction_VPC_properIAMDependencies
--- PASS: TestAccLambdaFunction_tracing (76.70s)
=== CONT  TestAccLambdaFunction_architectures
--- PASS: TestAccLambdaFunction_versioned (83.46s)
=== CONT  TestAccLambdaFunction_fileSystem
--- PASS: TestAccLambdaFunction_concurrencyCycle (102.26s)
=== CONT  TestAccLambdaFunction_nilDeadLetter
--- PASS: TestAccLambdaFunction_ephemeralStorage (107.11s)
=== CONT  TestAccLambdaFunction_disablePublish
--- PASS: TestAccLambdaFunction_VPC_replaceSGWithDefault (320.30s)
=== CONT  TestAccLambdaFunction_deadLetter
--- PASS: TestAccLambdaFunction_runtimes (334.49s)
=== CONT  TestAccLambdaFunction_enablePublish
--- PASS: TestAccLambdaFunction_VPC_replaceSGWithCustom (493.75s)
=== CONT  TestAccLambdaFunction_versionedUpdate
--- PASS: TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables (672.36s)
=== CONT  TestAccLambdaFunction_envVariables
--- PASS: TestAccLambdaFunction_VPCPublishHas_changes (868.91s)
=== CONT  TestAccLambdaFunction_expectFilenameAndS3Attributes
--- PASS: TestAccLambdaFunction_expectFilenameAndS3Attributes (0.85s)
=== CONT  TestAccLambdaFunction_EnvironmentVariables_noValue
--- PASS: TestAccLambdaFunction_vpcRemoval (1228.78s)
=== CONT  TestAccLambdaFunction_LocalUpdate_nameOnly
--- PASS: TestAccLambdaFunction_layersUpdate (1281.94s)
=== CONT  TestAccLambdaFunction_s3
--- PASS: TestAccLambdaFunction_s3 (32.62s)
=== CONT  TestAccLambdaFunction_emptyVPC
--- PASS: TestAccLambdaFunction_layers (1470.55s)
=== CONT  TestAccLambdaFunction_concurrency
--- PASS: TestAccLambdaFunction_deadLetterUpdated (1443.17s)
=== CONT  TestAccLambdaFunction_codeSigning
--- PASS: TestAccLambdaFunction_vpcUpdate (1499.79s)
=== CONT  TestAccLambdaFunction_tags
--- PASS: TestAccLambdaFunction_VPC_withInvocation (1797.51s)
=== CONT  TestAccLambdaFunction_disappears
--- PASS: TestAccLambdaFunction_nilDeadLetter (1762.21s)
=== CONT  TestAccLambdaFunction_encryptedEnvVariables
--- PASS: TestAccLambdaFunction_architectures (1807.61s)
=== CONT  TestAccLambdaFunction_localUpdate
--- PASS: TestAccLambdaFunction_disablePublish (1785.41s)
=== CONT  TestAccLambdaFunction_S3Update_basic
--- PASS: TestAccLambdaFunction_VPC_properIAMDependencies (1828.19s)
=== CONT  TestAccLambdaFunction_unpublishedCodeUpdate
--- PASS: TestAccLambdaFunction_S3Update_basic (55.44s)
--- PASS: TestAccLambdaFunction_deadLetter (1727.90s)
--- PASS: TestAccLambdaFunction_EnvironmentVariables_noValue (1184.21s)
--- PASS: TestAccLambdaFunction_enablePublish (1737.33s)
--- PASS: TestAccLambdaFunction_architecturesWithLayer (2073.30s)
--- PASS: TestAccLambdaFunction_emptyVPC (759.45s)
--- PASS: TestAccLambdaFunction_concurrency (625.84s)
--- PASS: TestAccLambdaFunction_architecturesUpdate (2033.73s)
--- PASS: TestAccLambdaFunction_disappears (249.91s)
--- PASS: TestAccLambdaFunction_envVariables (1437.73s)
--- PASS: TestAccLambdaFunction_tags (621.91s)
--- PASS: TestAccLambdaFunction_LocalUpdate_nameOnly (904.95s)
--- PASS: TestAccLambdaFunction_localUpdate (255.58s)
--- PASS: TestAccLambdaFunction_unpublishedCodeUpdate (254.88s)
--- PASS: TestAccLambdaFunction_encryptedEnvVariables (287.70s)
--- PASS: TestAccLambdaFunction_versionedUpdate (1659.23s)
--- PASS: TestAccLambdaFunction_fileSystem (2073.05s)
--- PASS: TestAccLambdaFunction_vpc (2187.54s)
--- PASS: TestAccLambdaFunction_VPCPublishNo_changes (2178.07s)
--- PASS: TestAccLambdaFunction_codeSigning (949.44s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     2447.793s
```
