### PR TITLE
fix: apigatewayv2 error handling for ConflictException: Unable to complete operation due to concurrent modification.

### DIFF
--- a/.changelog/29735.txt
+++ b/.changelog/29735.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_apigatewayv2_integration: Fix ConflictException: Unable to complete operation due to concurrent modification.
+resource/aws_apigatewayv2_integration: Retry errors like `ConflictException: Unable to complete operation due to concurrent modification. Please try again later.`
 ```

--- a/.changelog/29735.txt
+++ b/.changelog/29735.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_apigatewayv2_integration: Fix ConflictException: Unable to complete operation due to concurrent modification.
+```

--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -267,8 +267,7 @@ func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWS
 			r.Retryable = aws.Bool(true)
 		}
 	})
-	
-	//Potential fix for https://github.com/hashicorp/terraform-provider-aws/issues/18018
+
 	client.apigatewayv2Conn.Handlers.Retry.PushBack(func(r *request.Request) {
 		// Many operations can return an error such as:
 		//   ConflictException: Unable to complete operation due to concurrent modification. Please try again later.

--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/aws/aws-sdk-go/service/apigatewayv2"
 	"github.com/aws/aws-sdk-go/service/appconfig"
 	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
 	"github.com/aws/aws-sdk-go/service/appsync"
@@ -263,6 +264,16 @@ func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWS
 		//   ConflictException: Unable to complete operation due to concurrent modification. Please try again later.
 		// Handle them all globally for the service client.
 		if tfawserr.ErrMessageContains(r.Error, apigateway.ErrCodeConflictException, "try again later") {
+			r.Retryable = aws.Bool(true)
+		}
+	})
+	
+	//Potential fix for https://github.com/hashicorp/terraform-provider-aws/issues/18018
+	client.apigatewayv2Conn.Handlers.Retry.PushBack(func(r *request.Request) {
+		// Many operations can return an error such as:
+		//   ConflictException: Unable to complete operation due to concurrent modification. Please try again later.
+		// Handle them all globally for the service client.
+		if tfawserr.ErrMessageContains(r.Error, apigatewayv2.ErrCodeConflictException, "try again later") {
 			r.Retryable = aws.Bool(true)
 		}
 	})


### PR DESCRIPTION
### Description
During automated CI/CD deployment of my application, I noticed the next error in my logs:
`ConflictException: Unable to complete operation due to concurrent modification. Please try again later.`

This error occurs when steps to add routes to APIGWV2 resource are started, after 6 routes this error happens.

Looking into the way this is handled in aws provider for apigateway (ver1), I have implemented the same error handling for apigatewayv2.


### Relations

Closes #18018.

### Output from Acceptance Testing
Since this is a simple change I believe tests are not needed.
