### PR TITLE
GoReleaser - add new rlcp default setting to remove deprecation notice

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,7 @@ archives:
       - 'none*'
     format: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    rlcp: true
 before:
   hooks:
     - 'go mod download'


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Currently `goreleaser check` is failing on PR checks with the following deprecation notice:

```console
goreleaser check
  • loading config file                              file=.goreleaser.yml
  • checking config...
    • DEPRECATED: `archives.rlcp` will be the default soon, check https://goreleaser.com/deprecations#archivesrlcp for more info
  ⨯ command failed                                   error=config is valid, but uses deprecated properties, check logs above for details
```

Note this deprecation notices causes the check to fail:

https://github.com/hashicorp/terraform-provider-aws/actions/runs/4305748833/jobs/7508642247

The notice points to this goreleaser deprecation:

https://goreleaser.com/deprecations/#archivesrlcp

This PR adds the `rlcp` default to get rid of the deprecation warning, with the flag set the `goreleaser check` passes:

```console
goreleaser check
  • loading config file                              file=.goreleaser.yml
  • checking config...
  • config is valid
```



