### PR TITLE
Adds context parameter to `acctest.CheckFrameworkResourceDisappears`

### DIFF
--- a/.ci/.golangci2.yml
+++ b/.ci/.golangci2.yml
@@ -12,7 +12,6 @@ issues:
     - path: _test\.go
       linters:
         - contextcheck
-        - errorlint
   max-per-linter: 0
   max-same-issues: 0
 

--- a/docs/resource-name-generation.md
+++ b/docs/resource-name-generation.md
@@ -52,6 +52,7 @@ d.Set("name_prefix", create.NamePrefixFromName(aws.StringValue(resp.Name)))
 
 ```go
 func TestAccServiceThing_nameGenerated(t *testing.T) {
+  ctx := acctest.Context(t)
   var thing service.ServiceThing
   resourceName := "aws_service_thing.test"
 
@@ -59,12 +60,12 @@ func TestAccServiceThing_nameGenerated(t *testing.T) {
     PreCheck:                 func() { acctest.PreCheck(t) },
     ErrorCheck:               acctest.ErrorCheck(t, service.EndpointsID),
     ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-    CheckDestroy:             testAccCheckThingDestroy,
+    CheckDestroy:             testAccCheckThingDestroy(ctx),
     Steps: []resource.TestStep{
       {
         Config: testAccThingConfig_nameGenerated(),
         Check: resource.ComposeTestCheckFunc(
-          testAccCheckThingExists(resourceName, &thing),
+          testAccCheckThingExists(ctx, resourceName, &thing),
           acctest.CheckResourceAttrNameGenerated(resourceName, "name"),
           resource.TestCheckResourceAttr(resourceName, "name_prefix", resource.UniqueIdPrefix),
         ),
@@ -80,6 +81,7 @@ func TestAccServiceThing_nameGenerated(t *testing.T) {
 }
 
 func TestAccServiceThing_namePrefix(t *testing.T) {
+  ctx := acctest.Context(t)
   var thing service.ServiceThing
   resourceName := "aws_service_thing.test"
 
@@ -87,12 +89,12 @@ func TestAccServiceThing_namePrefix(t *testing.T) {
     PreCheck:                 func() { acctest.PreCheck(t) },
     ErrorCheck:               acctest.ErrorCheck(t, service.EndpointsID),
     ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-    CheckDestroy:             testAccCheckThingDestroy,
+    CheckDestroy:             testAccCheckThingDestroy(ctx),
     Steps: []resource.TestStep{
       {
         Config: testAccThingConfig_namePrefix("tf-acc-test-prefix-"),
         Check: resource.ComposeTestCheckFunc(
-          testAccCheckThingExists(resourceName, &thing),
+          testAccCheckThingExists(ctx, resourceName, &thing),
           acctest.CheckResourceAttrNameFromPrefix(resourceName, "name", "tf-acc-test-prefix-"),
           resource.TestCheckResourceAttr(resourceName, "name_prefix", "tf-acc-test-prefix-"),
         ),

--- a/docs/resource-tagging.md
+++ b/docs/resource-tagging.md
@@ -337,6 +337,7 @@ In the resource testing, implement a new test named `_tags` with associated conf
 
 ```go
 func TestAccEKSCluster_tags(t *testing.T) {
+	ctx := acctest.Context(t)
   var cluster1, cluster2, cluster3 eks.Cluster
   rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
   resourceName := "aws_eks_cluster.test"
@@ -345,12 +346,12 @@ func TestAccEKSCluster_tags(t *testing.T) {
     PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(t) },
     ErrorCheck:               acctest.ErrorCheck(t, eks.EndpointsID),
     ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-    CheckDestroy:             testAccCheckClusterDestroy,
+    CheckDestroy:             testAccCheckClusterDestroy(ctx),
     Steps: []resource.TestStep{
       {
         Config: testAccClusterConfig_tags1(rName, "key1", "value1"),
         Check: resource.ComposeTestCheckFunc(
-          testAccCheckClusterExists(resourceName, &cluster1),
+          testAccCheckClusterExists(ctx, resourceName, &cluster1),
           resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
           resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
         ),
@@ -363,7 +364,7 @@ func TestAccEKSCluster_tags(t *testing.T) {
       {
         Config: testAccClusterConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
         Check: resource.ComposeTestCheckFunc(
-          testAccCheckClusterExists(resourceName, &cluster2),
+          testAccCheckClusterExists(ctx, resourceName, &cluster2),
           resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
           resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
           resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -372,7 +373,7 @@ func TestAccEKSCluster_tags(t *testing.T) {
       {
         Config: testAccClusterConfig_tags1(rName, "key2", "value2"),
         Check: resource.ComposeTestCheckFunc(
-          testAccCheckClusterExists(resourceName, &cluster3),
+          testAccCheckClusterExists(ctx, resourceName, &cluster3),
           resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
           resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
         ),

--- a/internal/acctest/framework.go
+++ b/internal/acctest/framework.go
@@ -18,9 +18,7 @@ import (
 
 // Terraform Plugin Framework variants of standard acceptance test helpers.
 
-func DeleteFrameworkResource(factory func(context.Context) (fwresource.ResourceWithConfigure, error), is *terraform.InstanceState, meta interface{}) error {
-	ctx := context.Background()
-
+func deleteFrameworkResource(ctx context.Context, factory func(context.Context) (fwresource.ResourceWithConfigure, error), is *terraform.InstanceState, meta interface{}) error {
 	resource, err := factory(ctx)
 
 	if err != nil {
@@ -58,7 +56,7 @@ func DeleteFrameworkResource(factory func(context.Context) (fwresource.ResourceW
 	return nil
 }
 
-func CheckFrameworkResourceDisappears(provo *schema.Provider, factory func(context.Context) (fwresource.ResourceWithConfigure, error), n string) resource.TestCheckFunc {
+func CheckFrameworkResourceDisappears(ctx context.Context, provo *schema.Provider, factory func(context.Context) (fwresource.ResourceWithConfigure, error), n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -69,6 +67,6 @@ func CheckFrameworkResourceDisappears(provo *schema.Provider, factory func(conte
 			return fmt.Errorf("resource ID missing: %s", n)
 		}
 
-		return DeleteFrameworkResource(factory, rs.Primary, provo.Meta())
+		return deleteFrameworkResource(ctx, factory, rs.Primary, provo.Meta())
 	}
 }

--- a/internal/service/auditmanager/account_registration_test.go
+++ b/internal/service/auditmanager/account_registration_test.go
@@ -80,7 +80,7 @@ func testAccAccountRegistration_disappears(t *testing.T) {
 				Config: testAccAccountRegistrationConfig_deregisterOnDestroy(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountRegisterationIsActive(ctx, resourceName),
-					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfauditmanager.ResourceAccountRegistration, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfauditmanager.ResourceAccountRegistration, resourceName),
 				),
 			},
 			{

--- a/internal/service/auditmanager/assessment_delegation_test.go
+++ b/internal/service/auditmanager/assessment_delegation_test.go
@@ -71,7 +71,7 @@ func TestAccAuditManagerAssessmentDelegation_disappears(t *testing.T) {
 				Config: testAccAssessmentDelegationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssessmentDelegationExists(ctx, resourceName, &delegation),
-					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfauditmanager.ResourceAssessmentDelegation, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfauditmanager.ResourceAssessmentDelegation, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/service/auditmanager/assessment_report_test.go
+++ b/internal/service/auditmanager/assessment_report_test.go
@@ -69,7 +69,7 @@ func TestAccAuditManagerAssessmentReport_disappears(t *testing.T) {
 				Config: testAccAssessmentReportConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssessmentReportExists(ctx, resourceName, &assessmentReport),
-					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfauditmanager.ResourceAssessmentReport, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfauditmanager.ResourceAssessmentReport, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/service/auditmanager/assessment_test.go
+++ b/internal/service/auditmanager/assessment_test.go
@@ -76,7 +76,7 @@ func TestAccAuditManagerAssessment_disappears(t *testing.T) {
 				Config: testAccAssessmentConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAssessmentExists(ctx, resourceName, &assessment),
-					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfauditmanager.ResourceAssessment, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfauditmanager.ResourceAssessment, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/service/auditmanager/control_test.go
+++ b/internal/service/auditmanager/control_test.go
@@ -73,7 +73,7 @@ func TestAccAuditManagerControl_disappears(t *testing.T) {
 				Config: testAccControlConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckControlExists(ctx, resourceName, &control),
-					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfauditmanager.ResourceControl, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfauditmanager.ResourceControl, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/service/auditmanager/framework_share_test.go
+++ b/internal/service/auditmanager/framework_share_test.go
@@ -103,7 +103,7 @@ func TestAccAuditManagerFrameworkShare_disappears(t *testing.T) {
 					// Sleep briefly to prevent intermittent validation errors when revoking
 					// a new framework share request
 					acctest.CheckSleep(t, 10*time.Second),
-					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfauditmanager.ResourceFrameworkShare, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfauditmanager.ResourceFrameworkShare, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/service/auditmanager/framework_test.go
+++ b/internal/service/auditmanager/framework_test.go
@@ -72,7 +72,7 @@ func TestAccAuditManagerFramework_disappears(t *testing.T) {
 				Config: testAccFrameworkConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFrameworkExists(ctx, resourceName, &framework),
-					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfauditmanager.ResourceFramework, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfauditmanager.ResourceFramework, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/service/auditmanager/organization_admin_account_registration_test.go
+++ b/internal/service/auditmanager/organization_admin_account_registration_test.go
@@ -30,6 +30,7 @@ func TestAccAuditManagerOrganizationAdminAccountRegistration_serial(t *testing.T
 }
 
 func testAccOrganizationAdminAccountRegistration_basic(t *testing.T) {
+	ctx := acctest.Context(t)
 	adminAccountID := os.Getenv("AUDITMANAGER_ORGANIZATION_ADMIN_ACCOUNT_ID")
 	if adminAccountID == "" {
 		t.Skip("Environment variable AUDITMANAGER_ORGANIZATION_ADMIN_ACCOUNT_ID is not set")
@@ -44,12 +45,12 @@ func testAccOrganizationAdminAccountRegistration_basic(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.AuditManagerEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckOrganizationAdminAccountRegistrationDestroy,
+		CheckDestroy:             testAccCheckOrganizationAdminAccountRegistrationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationAdminAccountRegistrationConfig_basic(adminAccountID),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOrganizationAdminAccountRegistrationExists(resourceName),
+					testAccCheckOrganizationAdminAccountRegistrationExists(ctx, resourceName),
 				),
 			},
 			{
@@ -62,6 +63,7 @@ func testAccOrganizationAdminAccountRegistration_basic(t *testing.T) {
 }
 
 func testAccOrganizationAdminAccountRegistration_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
 	adminAccountID := os.Getenv("AUDITMANAGER_ORGANIZATION_ADMIN_ACCOUNT_ID")
 	if adminAccountID == "" {
 		t.Skip("Environment variable AUDITMANAGER_ORGANIZATION_ADMIN_ACCOUNT_ID is not set")
@@ -76,13 +78,13 @@ func testAccOrganizationAdminAccountRegistration_disappears(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.AuditManagerEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckOrganizationAdminAccountRegistrationDestroy,
+		CheckDestroy:             testAccCheckOrganizationAdminAccountRegistrationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccOrganizationAdminAccountRegistrationConfig_basic(adminAccountID),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOrganizationAdminAccountRegistrationExists(resourceName),
-					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfauditmanager.ResourceOrganizationAdminAccountRegistration, resourceName),
+					testAccCheckOrganizationAdminAccountRegistrationExists(ctx, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfauditmanager.ResourceOrganizationAdminAccountRegistration, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -90,28 +92,29 @@ func testAccOrganizationAdminAccountRegistration_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckOrganizationAdminAccountRegistrationDestroy(s *terraform.State) error {
-	ctx := context.Background()
-	conn := acctest.Provider.Meta().(*conns.AWSClient).AuditManagerClient()
+func testAccCheckOrganizationAdminAccountRegistrationDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AuditManagerClient()
 
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_auditmanager_organization_admin_account_registration" {
-			continue
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_auditmanager_organization_admin_account_registration" {
+				continue
+			}
+
+			out, err := conn.GetOrganizationAdminAccount(ctx, &auditmanager.GetOrganizationAdminAccountInput{})
+			if err != nil {
+				return err
+			}
+			if out.AdminAccountId != nil {
+				return create.Error(names.AuditManager, create.ErrActionCheckingDestroyed, tfauditmanager.ResNameOrganizationAdminAccountRegistration, rs.Primary.ID, errors.New("not destroyed"))
+			}
 		}
 
-		out, err := conn.GetOrganizationAdminAccount(ctx, &auditmanager.GetOrganizationAdminAccountInput{})
-		if err != nil {
-			return err
-		}
-		if out.AdminAccountId != nil {
-			return create.Error(names.AuditManager, create.ErrActionCheckingDestroyed, tfauditmanager.ResNameOrganizationAdminAccountRegistration, rs.Primary.ID, errors.New("not destroyed"))
-		}
+		return nil
 	}
-
-	return nil
 }
 
-func testAccCheckOrganizationAdminAccountRegistrationExists(name string) resource.TestCheckFunc {
+func testAccCheckOrganizationAdminAccountRegistrationExists(ctx context.Context, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -122,7 +125,6 @@ func testAccCheckOrganizationAdminAccountRegistrationExists(name string) resourc
 			return create.Error(names.AuditManager, create.ErrActionCheckingExistence, tfauditmanager.ResNameOrganizationAdminAccountRegistration, name, errors.New("not set"))
 		}
 
-		ctx := context.Background()
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AuditManagerClient()
 		out, err := conn.GetOrganizationAdminAccount(ctx, &auditmanager.GetOrganizationAdminAccountInput{})
 		if err != nil {

--- a/internal/service/ec2/vpc_security_group_egress_rule_test.go
+++ b/internal/service/ec2/vpc_security_group_egress_rule_test.go
@@ -69,7 +69,7 @@ func TestAccVPCSecurityGroupEgressRule_disappears(t *testing.T) {
 				Config: testAccVPCSecurityGroupEgressRuleConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupEgressRuleExists(ctx, resourceName, &v),
-					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfec2.ResourceSecurityGroupEgressRule, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfec2.ResourceSecurityGroupEgressRule, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/service/ec2/vpc_security_group_ingress_rule_test.go
+++ b/internal/service/ec2/vpc_security_group_ingress_rule_test.go
@@ -134,7 +134,7 @@ func TestAccVPCSecurityGroupIngressRule_disappears(t *testing.T) {
 				Config: testAccVPCSecurityGroupIngressRuleConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecurityGroupIngressRuleExists(ctx, resourceName, &v),
-					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfec2.ResourceSecurityGroupIngressRule, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfec2.ResourceSecurityGroupIngressRule, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/service/medialive/multiplex_program_test.go
+++ b/internal/service/medialive/multiplex_program_test.go
@@ -177,7 +177,7 @@ func testAccMultiplexProgram_disappears(t *testing.T) {
 				Config: testAccMultiplexProgramConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMultiplexProgramExists(ctx, resourceName, &multiplexprogram),
-					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfmedialive.ResourceMultiplexProgram, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfmedialive.ResourceMultiplexProgram, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/service/resourceexplorer2/index_test.go
+++ b/internal/service/resourceexplorer2/index_test.go
@@ -56,7 +56,7 @@ func testAccIndex_disappears(t *testing.T) {
 				Config: testAccIndexConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIndexExists(ctx, resourceName),
-					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfresourceexplorer2.ResourceIndex, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfresourceexplorer2.ResourceIndex, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/service/resourceexplorer2/view_test.go
+++ b/internal/service/resourceexplorer2/view_test.go
@@ -108,7 +108,7 @@ func testAccView_disappears(t *testing.T) {
 				Config: testAccViewConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckViewExists(ctx, resourceName, &v),
-					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfresourceexplorer2.ResourceView, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfresourceexplorer2.ResourceView, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/service/route53/cidr_collection_test.go
+++ b/internal/service/route53/cidr_collection_test.go
@@ -61,7 +61,7 @@ func TestAccRoute53CIDRCollection_disappears(t *testing.T) {
 				Config: testAccCIDRCollection_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCIDRCollectionExists(ctx, resourceName, &v),
-					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfroute53.ResourceCIDRCollection, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfroute53.ResourceCIDRCollection, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/service/simpledb/domain_test.go
+++ b/internal/service/simpledb/domain_test.go
@@ -57,7 +57,7 @@ func TestAccSimpleDBDomain_disappears(t *testing.T) {
 				Config: testAccDomainConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(ctx, resourceName),
-					acctest.CheckFrameworkResourceDisappears(acctest.Provider, tfsimpledb.ResourceDomain, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfsimpledb.ResourceDomain, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/sweep/framework.go
+++ b/internal/sweep/framework.go
@@ -45,7 +45,7 @@ func NewSweepFrameworkResource(factory func(context.Context) (fwresource.Resourc
 
 func (sr *SweepFrameworkResource) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
 	err := tfresource.Retry(ctx, timeout, func() *resource.RetryError {
-		err := DeleteFrameworkResource(ctx, sr.factory, sr.id, sr.meta, sr.supplementalAttributes)
+		err := deleteFrameworkResource(ctx, sr.factory, sr.id, sr.meta, sr.supplementalAttributes)
 
 		if err != nil {
 			if strings.Contains(err.Error(), "Throttling") {
@@ -60,13 +60,13 @@ func (sr *SweepFrameworkResource) Delete(ctx context.Context, timeout time.Durat
 	}, optFns...)
 
 	if tfresource.TimedOut(err) {
-		err = DeleteFrameworkResource(ctx, sr.factory, sr.id, sr.meta, sr.supplementalAttributes)
+		err = deleteFrameworkResource(ctx, sr.factory, sr.id, sr.meta, sr.supplementalAttributes)
 	}
 
 	return err
 }
 
-func DeleteFrameworkResource(ctx context.Context, factory func(context.Context) (fwresource.ResourceWithConfigure, error), id string, meta interface{}, supplementalAttributes []FrameworkSupplementalAttribute) error {
+func deleteFrameworkResource(ctx context.Context, factory func(context.Context) (fwresource.ResourceWithConfigure, error), id string, meta interface{}, supplementalAttributes []FrameworkSupplementalAttribute) error {
 	resource, err := factory(ctx)
 
 	if err != nil {

--- a/internal/tfresource/retry_test.go
+++ b/internal/tfresource/retry_test.go
@@ -386,7 +386,7 @@ func TestRetryContext_error(t *testing.T) {
 
 	select {
 	case err := <-errCh:
-		if err != expected {
+		if err != expected { //nolint: errorlint // We are actually comparing equality
 			t.Fatalf("bad: %#v", err)
 		}
 	case <-time.After(5 * time.Second):


### PR DESCRIPTION
### Description

Adds missing `context.Context` parameter to `acctest.CheckFrameworkResourceDisappears`.

Also cleans up documentation, sweeper, and `errorlint`
