### PR TITLE
Retries finding SQS Queue in tests to handle eventual consistency

### DIFF
--- a/internal/service/sqs/exports_test.go
+++ b/internal/service/sqs/exports_test.go
@@ -1,0 +1,6 @@
+package sqs
+
+// Exports for use in tests only.
+var (
+	QueueDeletedTimeout = queueDeletedTimeout
+)

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -84,7 +84,7 @@ func RetryWhenIsAErrorMessageContains[T errs.ErrorWithErrorMessage](ctx context.
 	})
 }
 
-var errFoundResource = errors.New(`found resource`)
+var ErrFoundResource = errors.New(`found resource`)
 
 // RetryUntilNotFound retries the specified function until it returns a resource.NotFoundError.
 func RetryUntilNotFound(ctx context.Context, timeout time.Duration, f func() (interface{}, error)) (interface{}, error) {
@@ -97,7 +97,7 @@ func RetryUntilNotFound(ctx context.Context, timeout time.Duration, f func() (in
 			return false, err
 		}
 
-		return true, errFoundResource
+		return true, ErrFoundResource
 	})
 }
 


### PR DESCRIPTION
### Description

SQS Queues appear to be strongly eventually consistent, especially across different connections: One connection may report the queue is not found, while another will show it as still existing.

This was causing intermittent "dangling resource" errors in acceptance tests.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=sqs TESTS=TestAccSQSQueue_

--- PASS: TestAccSQSQueue_FIFOQueue_expectNameError (5.75s)
--- PASS: TestAccSQSQueue_StandardQueue_expectContentBasedDeduplicationError (6.89s)
--- PASS: TestAccSQSQueue_basic (68.17s)
--- PASS: TestAccSQSQueue_NameGenerated_fifoQueue (68.17s)
--- PASS: TestAccSQSQueue_FIFOQueue_contentBasedDeduplication (68.32s)
--- PASS: TestAccSQSQueue_Name_generated (68.42s)
--- PASS: TestAccSQSQueue_zeroVisibilityTimeoutSeconds (68.75s)
--- PASS: TestAccSQSQueue_fifoQueue (68.94s)
--- PASS: TestAccSQSQueue_NamePrefix_fifoQueue (69.01s)
--- PASS: TestAccSQSQueue_namePrefix (69.15s)
--- PASS: TestAccSQSQueue_defaultKMSDataKeyReusePeriodSeconds (69.38s)
--- PASS: TestAccSQSQueue_disappears (74.35s)
--- PASS: TestAccSQSQueue_redrivePolicy (79.90s)
--- PASS: TestAccSQSQueue_redriveAllowPolicy (80.23s)
--- PASS: TestAccSQSQueue_tags (84.91s)
--- PASS: TestAccSQSQueue_update (97.89s)
--- PASS: TestAccSQSQueue_Policy_basic (104.76s)
--- PASS: TestAccSQSQueue_Policy_ignoreEquivalent (109.51s)
--- PASS: TestAccSQSQueue_FIFOQueue_highThroughputMode (110.24s)
--- PASS: TestAccSQSQueue_managedEncryption (142.37s)
--- PASS: TestAccSQSQueue_encryption (142.50s)
--- PASS: TestAccSQSQueue_recentlyDeleted (142.48s)
```
