### PR TITLE
Add logging to acceptance tests

### DIFF
--- a/.ci/semgrep/migrate/context.yml
+++ b/.ci/semgrep/migrate/context.yml
@@ -9,8 +9,6 @@ rules:
       exclude:
         # `pattern-not` not working
         - internal/service/kafkaconnect
-        # WIP
-        - internal/acctest/acctest.go
     patterns:
       - pattern: |
           $CONN.$API(...)

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -220,10 +220,12 @@ func PreCheck(t *testing.T) {
 		region := Region()
 		os.Setenv(envvar.DefaultRegion, region)
 
-		err := sdkdiag.DiagnosticsError(Provider.Configure(context.Background(), terraform.NewResourceConfigRaw(nil)))
+		// TODO: take `ctx` as a parameter instead
+		ctx := Context(t)
 
-		if err != nil {
-			t.Fatal(err)
+		diags := Provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
+		if err := sdkdiag.DiagnosticsError(diags); err != nil {
+			t.Fatalf("configuring provider: %s", err)
 		}
 	})
 }

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1131,9 +1131,9 @@ func DeleteResource(ctx context.Context, resource *schema.Resource, d *schema.Re
 		var diags diag.Diagnostics
 
 		if resource.DeleteContext != nil {
-			diags = resource.DeleteContext(ctx, d, meta)
+			diags = resource.DeleteContext(ctx, d, meta) // nosemgrep:ci.semgrep.migrate.direct-CRUD-calls
 		} else {
-			diags = resource.DeleteWithoutTimeout(ctx, d, meta)
+			diags = resource.DeleteWithoutTimeout(ctx, d, meta) // nosemgrep:ci.semgrep.migrate.direct-CRUD-calls
 		}
 
 		for i := range diags {
@@ -1145,7 +1145,7 @@ func DeleteResource(ctx context.Context, resource *schema.Resource, d *schema.Re
 		return nil
 	}
 
-	return resource.Delete(d, meta)
+	return resource.Delete(d, meta) // nosemgrep:ci.semgrep.migrate.direct-CRUD-calls
 }
 
 func CheckResourceDisappears(ctx context.Context, provo *schema.Provider, resource *schema.Resource, n string) resource.TestCheckFunc {

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -878,7 +878,7 @@ func PreCheckHasIAMRole(ctx context.Context, t *testing.T, roleName string) {
 	input := &iam.GetRoleInput{
 		RoleName: aws.String(roleName),
 	}
-	
+
 	_, err := conn.GetRoleWithContext(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -878,7 +878,7 @@ func PreCheckHasIAMRole(ctx context.Context, t *testing.T, roleName string) {
 	input := &iam.GetRoleInput{
 		RoleName: aws.String(roleName),
 	}
-
+	
 	_, err := conn.GetRoleWithContext(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {

--- a/internal/acctest/context.go
+++ b/internal/acctest/context.go
@@ -3,8 +3,38 @@ package acctest
 import (
 	"context"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
+	helperlogging "github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 )
 
 func Context(t *testing.T) context.Context {
-	return context.Background()
+	helperlogging.SetOutput(t)
+
+	ctx := context.Background()
+
+	ctx = tfsdklog.RegisterTestSink(ctx, t)
+
+	ctx = logger(ctx, t, "acctest")
+
+	return ctx
+}
+
+func logger(ctx context.Context, t *testing.T, name string) context.Context {
+	ctx = tfsdklog.NewRootProviderLogger(ctx,
+		tfsdklog.WithLevelFromEnv("TF_LOG"),
+		tfsdklog.WithLogName(name),
+		tfsdklog.WithoutLocation(),
+	)
+	ctx = testNameContext(ctx, t.Name())
+
+	return ctx
+}
+
+// testNameContext adds the current test name to loggers.
+func testNameContext(ctx context.Context, testName string) context.Context {
+	ctx = tflog.SetField(ctx, "test_name", testName)
+
+	return ctx
 }

--- a/internal/service/transfer/acc_test.go
+++ b/internal/service/transfer/acc_test.go
@@ -1,0 +1,26 @@
+package transfer_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/transfer"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+func testAccPreCheck(ctx context.Context, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).TransferConn()
+
+	input := &transfer.ListServersInput{}
+
+	_, err := conn.ListServersWithContext(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}

--- a/internal/service/transfer/server_test.go
+++ b/internal/service/transfer/server_test.go
@@ -1099,22 +1099,6 @@ func testAccCheckServerDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).TransferConn()
-
-	input := &transfer.ListServersInput{}
-
-	_, err := conn.ListServersWithContext(ctx, input)
-
-	if acctest.PreCheckSkipError(err) {
-		t.Skipf("skipping acceptance testing: %s", err)
-	}
-
-	if err != nil {
-		t.Fatalf("unexpected PreCheck error: %s", err)
-	}
-}
-
 func testAccServerConfig_vpcBase(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_vpc" "test" {

--- a/internal/service/workspaces/workspace_data_source_test.go
+++ b/internal/service/workspaces/workspace_data_source_test.go
@@ -82,7 +82,7 @@ func testAccWorkspaceDataSource_byDirectoryID_userName(t *testing.T) {
 
 func testAccWorkspaceDataSource_workspaceIDAndDirectoryIDConflict(t *testing.T) {
 	ctx := acctest.Context(t)
-	
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckHasIAMRole(ctx, t, "workspaces_DefaultRole") },
 		ErrorCheck:               acctest.ErrorCheck(t, workspaces.EndpointsID),

--- a/internal/service/workspaces/workspace_data_source_test.go
+++ b/internal/service/workspaces/workspace_data_source_test.go
@@ -82,7 +82,7 @@ func testAccWorkspaceDataSource_byDirectoryID_userName(t *testing.T) {
 
 func testAccWorkspaceDataSource_workspaceIDAndDirectoryIDConflict(t *testing.T) {
 	ctx := acctest.Context(t)
-
+	
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckHasIAMRole(ctx, t, "workspaces_DefaultRole") },
 		ErrorCheck:               acctest.ErrorCheck(t, workspaces.EndpointsID),


### PR DESCRIPTION
### Description

Creates a logging context for acceptance test functions such as pre-checks and test checks.

Adds log field `test_name`.

### Output from Acceptance Testing

N/A