### PR TITLE
Tech debt: Tidy up some service-level `testAccPreCheck` functions

### DIFF
--- a/internal/service/amplify/app_test.go
+++ b/internal/service/amplify/app_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/amplify"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -642,9 +643,7 @@ func testAccCheckAppDestroy(ctx context.Context) resource.TestCheckFunc {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if acctest.Partition() == "aws-us-gov" {
-		t.Skip("AWS Amplify is not supported in GovCloud partition")
-	}
+	acctest.PreCheckPartitionNot(t, endpoints.AwsUsGovPartitionID)
 }
 
 func testAccCheckAppNotRecreated(before, after *amplify.App) resource.TestCheckFunc {

--- a/internal/service/eks/fargate_profile_test.go
+++ b/internal/service/eks/fargate_profile_test.go
@@ -175,11 +175,11 @@ func TestAccEKSFargateProfile_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckFargateProfileExists(ctx context.Context, resourceName string, fargateProfile *eks.FargateProfile) resource.TestCheckFunc {
+func testAccCheckFargateProfileExists(ctx context.Context, n string, v *eks.FargateProfile) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceName]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
@@ -200,7 +200,7 @@ func testAccCheckFargateProfileExists(ctx context.Context, resourceName string, 
 			return err
 		}
 
-		*fargateProfile = *output
+		*v = *output
 
 		return nil
 	}
@@ -268,30 +268,10 @@ func testAccPreCheckFargateProfile(t *testing.T) {
 		endpoints.UsWest1RegionID,
 		endpoints.UsWest2RegionID,
 	}
-	region := acctest.Provider.Meta().(*conns.AWSClient).Region
-
-	for _, allowedRegion := range allowedRegions {
-		if region == allowedRegion {
-			return
-		}
-	}
-
-	message := fmt.Sprintf(`Test provider region (%s) not found in allowed EKS Fargate regions: %v
-
-The allowed regions are hardcoded in the acceptance testing since dynamically determining the
-functionality requires creating and destroying a real EKS Cluster, which is a lengthy process.
-If this check is out of date, please create an issue in the Terraform AWS Provider
-repository (https://github.com/hashicorp/terraform-provider-aws) or submit a PR to update the
-check itself (testAccPreCheckFargateProfile).
-
-For the most up to date supported region information, see the EKS User Guide:
-https://docs.aws.amazon.com/eks/latest/userguide/fargate.html
-`, region, allowedRegions)
-
-	t.Skipf("skipping acceptance testing:\n\n%s", message)
+	acctest.PreCheckRegion(t, allowedRegions...)
 }
 
-func testAccFargateProfileBaseConfig(rName string) string {
+func testAccFargateProfileConfig_base(rName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
@@ -468,7 +448,7 @@ resource "aws_eks_cluster" "test" {
 }
 
 func testAccFargateProfileConfig_name(rName string) string {
-	return testAccFargateProfileBaseConfig(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccFargateProfileConfig_base(rName), fmt.Sprintf(`
 resource "aws_eks_fargate_profile" "test" {
   cluster_name           = aws_eks_cluster.test.name
   fargate_profile_name   = %[1]q
@@ -484,13 +464,11 @@ resource "aws_eks_fargate_profile" "test" {
     aws_route_table_association.private,
   ]
 }
-`, rName)
+`, rName))
 }
 
 func testAccFargateProfileConfig_multiple(rName string) string {
-	return acctest.ConfigCompose(
-		testAccFargateProfileBaseConfig(rName),
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccFargateProfileConfig_base(rName), fmt.Sprintf(`
 resource "aws_eks_fargate_profile" "test" {
   count = 2
 
@@ -512,7 +490,7 @@ resource "aws_eks_fargate_profile" "test" {
 }
 
 func testAccFargateProfileConfig_selectorLabels1(rName, labelKey1, labelValue1 string) string {
-	return testAccFargateProfileBaseConfig(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccFargateProfileConfig_base(rName), fmt.Sprintf(`
 resource "aws_eks_fargate_profile" "test" {
   cluster_name           = aws_eks_cluster.test.name
   fargate_profile_name   = %[1]q
@@ -531,11 +509,11 @@ resource "aws_eks_fargate_profile" "test" {
     aws_route_table_association.private,
   ]
 }
-`, rName, labelKey1, labelValue1)
+`, rName, labelKey1, labelValue1))
 }
 
 func testAccFargateProfileConfig_tags1(rName, tagKey1, tagValue1 string) string {
-	return testAccFargateProfileBaseConfig(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccFargateProfileConfig_base(rName), fmt.Sprintf(`
 resource "aws_eks_fargate_profile" "test" {
   cluster_name           = aws_eks_cluster.test.name
   fargate_profile_name   = %[1]q
@@ -555,11 +533,11 @@ resource "aws_eks_fargate_profile" "test" {
     aws_route_table_association.private,
   ]
 }
-`, rName, tagKey1, tagValue1)
+`, rName, tagKey1, tagValue1))
 }
 
 func testAccFargateProfileConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return testAccFargateProfileBaseConfig(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccFargateProfileConfig_base(rName), fmt.Sprintf(`
 resource "aws_eks_fargate_profile" "test" {
   cluster_name           = aws_eks_cluster.test.name
   fargate_profile_name   = %[1]q
@@ -580,5 +558,5 @@ resource "aws_eks_fargate_profile" "test" {
     aws_route_table_association.private,
   ]
 }
-`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/internal/service/elasticache/subnet_group_data_source_test.go
+++ b/internal/service/elasticache/subnet_group_data_source_test.go
@@ -12,9 +12,7 @@ import (
 )
 
 func testAccPreCheck(t *testing.T) {
-	if got, want := acctest.Partition(), endpoints.AwsUsGovPartitionID; got == want {
-		t.Skipf("ElastiCache is not supported in %s partition", got)
-	}
+	acctest.PreCheckPartitionNot(t, endpoints.AwsUsGovPartitionID)
 }
 
 func TestAccElastiCacheSubnetGroupDataSource_basic(t *testing.T) {

--- a/internal/service/mediaconvert/queue.go
+++ b/internal/service/mediaconvert/queue.go
@@ -102,7 +102,7 @@ func ResourceQueue() *schema.Resource {
 
 func resourceQueueCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn, err := GetAccountClient(meta.(*conns.AWSClient))
+	conn, err := GetAccountClient(ctx, meta.(*conns.AWSClient))
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "getting Media Convert Account Client: %s", err)
 	}
@@ -137,7 +137,7 @@ func resourceQueueCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 func resourceQueueRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn, err := GetAccountClient(meta.(*conns.AWSClient))
+	conn, err := GetAccountClient(ctx, meta.(*conns.AWSClient))
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "getting Media Convert Account Client: %s", err)
 	}
@@ -191,7 +191,7 @@ func resourceQueueRead(ctx context.Context, d *schema.ResourceData, meta interfa
 
 func resourceQueueUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn, err := GetAccountClient(meta.(*conns.AWSClient))
+	conn, err := GetAccountClient(ctx, meta.(*conns.AWSClient))
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "getting Media Convert Account Client: %s", err)
 	}
@@ -229,7 +229,7 @@ func resourceQueueUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 func resourceQueueDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn, err := GetAccountClient(meta.(*conns.AWSClient))
+	conn, err := GetAccountClient(ctx, meta.(*conns.AWSClient))
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "getting Media Convert Account Client: %s", err)
 	}
@@ -249,7 +249,7 @@ func resourceQueueDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func GetAccountClient(awsClient *conns.AWSClient) (*mediaconvert.MediaConvert, error) {
+func GetAccountClient(ctx context.Context, awsClient *conns.AWSClient) (*mediaconvert.MediaConvert, error) {
 	const mutexKey = `mediaconvertaccountconn`
 	conns.GlobalMutexKV.Lock(mutexKey)
 	defer conns.GlobalMutexKV.Unlock(mutexKey)
@@ -262,7 +262,7 @@ func GetAccountClient(awsClient *conns.AWSClient) (*mediaconvert.MediaConvert, e
 		Mode: aws.String(mediaconvert.DescribeEndpointsModeDefault),
 	}
 
-	output, err := awsClient.MediaConvertConn().DescribeEndpoints(input)
+	output, err := awsClient.MediaConvertConn().DescribeEndpointsWithContext(ctx, input)
 
 	if err != nil {
 		return nil, fmt.Errorf("error describing MediaConvert Endpoints: %w", err)

--- a/internal/service/mediaconvert/queue_test.go
+++ b/internal/service/mediaconvert/queue_test.go
@@ -24,7 +24,7 @@ func TestAccMediaConvertQueue_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, mediaconvert.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckQueueDestroy(ctx),
@@ -58,7 +58,7 @@ func TestAccMediaConvertQueue_reservationPlanSettings(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, mediaconvert.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckQueueDestroy(ctx),
@@ -101,7 +101,7 @@ func TestAccMediaConvertQueue_withStatus(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, mediaconvert.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckQueueDestroy(ctx),
@@ -136,7 +136,7 @@ func TestAccMediaConvertQueue_withTags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, mediaconvert.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckQueueDestroy(ctx),
@@ -182,7 +182,7 @@ func TestAccMediaConvertQueue_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, mediaconvert.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckQueueDestroy(ctx),
@@ -208,7 +208,7 @@ func TestAccMediaConvertQueue_withDescription(t *testing.T) {
 	description2 := sdkacctest.RandomWithPrefix("Description: ")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(t) },
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, mediaconvert.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckQueueDestroy(ctx),
@@ -237,7 +237,7 @@ func testAccCheckQueueDestroy(ctx context.Context) resource.TestCheckFunc {
 			if rs.Type != "aws_media_convert_queue" {
 				continue
 			}
-			conn, err := tfmediaconvert.GetAccountClient(acctest.Provider.Meta().(*conns.AWSClient))
+			conn, err := tfmediaconvert.GetAccountClient(ctx, acctest.Provider.Meta().(*conns.AWSClient))
 			if err != nil {
 				return fmt.Errorf("Error getting Media Convert Account Client: %s", err)
 			}
@@ -259,7 +259,7 @@ func testAccCheckQueueDestroy(ctx context.Context) resource.TestCheckFunc {
 
 func testAccCheckQueueDisappears(ctx context.Context, queue *mediaconvert.Queue) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn, err := tfmediaconvert.GetAccountClient(acctest.Provider.Meta().(*conns.AWSClient))
+		conn, err := tfmediaconvert.GetAccountClient(ctx, acctest.Provider.Meta().(*conns.AWSClient))
 		if err != nil {
 			return fmt.Errorf("Error getting Media Convert Account Client: %s", err)
 		}
@@ -285,7 +285,7 @@ func testAccCheckQueueExists(ctx context.Context, n string, queue *mediaconvert.
 			return fmt.Errorf("No Queue id is set")
 		}
 
-		conn, err := tfmediaconvert.GetAccountClient(acctest.Provider.Meta().(*conns.AWSClient))
+		conn, err := tfmediaconvert.GetAccountClient(ctx, acctest.Provider.Meta().(*conns.AWSClient))
 		if err != nil {
 			return fmt.Errorf("Error getting Media Convert Account Client: %s", err)
 		}
@@ -302,8 +302,8 @@ func testAccCheckQueueExists(ctx context.Context, n string, queue *mediaconvert.
 	}
 }
 
-func testAccPreCheck(t *testing.T) {
-	_, err := tfmediaconvert.GetAccountClient(acctest.Provider.Meta().(*conns.AWSClient))
+func testAccPreCheck(ctx context.Context, t *testing.T) {
+	_, err := tfmediaconvert.GetAccountClient(ctx, acctest.Provider.Meta().(*conns.AWSClient))
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)

--- a/internal/service/memorydb/subnet_group_test.go
+++ b/internal/service/memorydb/subnet_group_test.go
@@ -17,12 +17,7 @@ import (
 )
 
 func testAccPreCheck(t *testing.T) {
-	// Checking for service fails in all partitions!
-	// acctest.PreCheckPartitionHasService(memorydb.EndpointsID, t)
-
-	if got, want := acctest.Partition(), endpoints.AwsUsGovPartitionID; got == want {
-		t.Skipf("MemoryDB is not supported in %s partition", got)
-	}
+	acctest.PreCheckPartitionNot(t, endpoints.AwsUsGovPartitionID)
 }
 
 func TestAccMemoryDBSubnetGroup_basic(t *testing.T) {

--- a/internal/service/route53/traffic_policy_instance_test.go
+++ b/internal/service/route53/traffic_policy_instance_test.go
@@ -17,11 +17,7 @@ import (
 )
 
 func testAccPreCheckTrafficPolicy(t *testing.T) {
-	acctest.PreCheckPartitionHasService(t, route53.EndpointsID)
-
-	if got, want := acctest.Partition(), endpoints.AwsUsGovPartitionID; got == want {
-		t.Skipf("Route 53 Traffic Policies are not supported in %s partition", got)
-	}
+	acctest.PreCheckPartitionNot(t, endpoints.AwsUsGovPartitionID)
 }
 
 func TestAccRoute53TrafficPolicyInstance_basic(t *testing.T) {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Makes use of helpers in `acctest` and adds `Context` where missing.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccEKSFargateProfile_' PKG=eks ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/eks/... -v -count 1 -parallel 3  -run=TestAccEKSFargateProfile_ -timeout 180m
=== RUN   TestAccEKSFargateProfile_basic
=== PAUSE TestAccEKSFargateProfile_basic
=== RUN   TestAccEKSFargateProfile_disappears
=== PAUSE TestAccEKSFargateProfile_disappears
=== RUN   TestAccEKSFargateProfile_Multi_profile
=== PAUSE TestAccEKSFargateProfile_Multi_profile
=== RUN   TestAccEKSFargateProfile_Selector_labels
=== PAUSE TestAccEKSFargateProfile_Selector_labels
=== RUN   TestAccEKSFargateProfile_tags
=== PAUSE TestAccEKSFargateProfile_tags
=== CONT  TestAccEKSFargateProfile_basic
=== CONT  TestAccEKSFargateProfile_Selector_labels
=== CONT  TestAccEKSFargateProfile_tags
--- PASS: TestAccEKSFargateProfile_tags (910.60s)
=== CONT  TestAccEKSFargateProfile_Multi_profile
--- PASS: TestAccEKSFargateProfile_Selector_labels (1007.21s)
=== CONT  TestAccEKSFargateProfile_disappears
--- PASS: TestAccEKSFargateProfile_basic (1076.76s)
--- PASS: TestAccEKSFargateProfile_Multi_profile (1059.96s)
--- PASS: TestAccEKSFargateProfile_disappears (986.48s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/eks	1999.013s
```
