### PR TITLE
dms/endpoint: Add s3 setting detachTargetOnLobLookupFailureParquet

### DIFF
--- a/.changelog/29772.txt
+++ b/.changelog/29772.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_dms_endpoint: Trigger updates based on adding new `extra_connection_attributes`
+```
+
+```release-note:enhancement
+resource/aws_dms_s3_endpoint: Add `detach_target_on_lob_lookup_failure_parquet` argument
+```

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -2110,3 +2110,79 @@ func RunSerialTests2Levels(t *testing.T, testCases map[string]map[string]func(t 
 		})
 	}
 }
+
+// TestNoMatchResourceAttr ensures a value matching a regular expression is
+// NOT stored in state for the given name and key combination. Same as resource.TestMatchResourceAttr()
+// except negative.
+func TestNoMatchResourceAttr(name, key string, r *regexp.Regexp) resource.TestCheckFunc {
+	return checkIfIndexesIntoTypeSet(key, func(s *terraform.State) error {
+		is, err := primaryInstanceState(s, name)
+		if err != nil {
+			return err
+		}
+
+		return testNoMatchResourceAttr(is, name, key, r)
+	})
+}
+
+// testNoMatchResourceAttr is same as testMatchResourceAttr in
+// github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource
+// except negative.
+func testNoMatchResourceAttr(is *terraform.InstanceState, name string, key string, r *regexp.Regexp) error {
+	if r.MatchString(is.Attributes[key]) {
+		return fmt.Errorf(
+			"%s: Attribute '%s' did match %q and should not, got %#v",
+			name,
+			key,
+			r.String(),
+			is.Attributes[key])
+	}
+
+	return nil
+}
+
+// checkIfIndexesIntoTypeSet is copied from
+// github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource
+func checkIfIndexesIntoTypeSet(key string, f resource.TestCheckFunc) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		err := f(s)
+		if err != nil && s.IsBinaryDrivenTest && indexesIntoTypeSet(key) {
+			return fmt.Errorf("Error in test check: %s\nTest check address %q likely indexes into TypeSet\nThis is currently not possible in the SDK", err, key)
+		}
+		return err
+	}
+}
+
+// indexesIntoTypeSet is copied from
+// github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource
+func indexesIntoTypeSet(key string) bool {
+	for _, part := range strings.Split(key, ".") {
+		if i, err := strconv.Atoi(part); err == nil && i > 100 {
+			return true
+		}
+	}
+	return false
+}
+
+// primaryInstanceState is copied from
+// github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource
+func primaryInstanceState(s *terraform.State, name string) (*terraform.InstanceState, error) {
+	ms := s.RootModule()
+	return modulePrimaryInstanceState(ms, name)
+}
+
+// modulePrimaryInstanceState is copied from
+// github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource
+func modulePrimaryInstanceState(ms *terraform.ModuleState, name string) (*terraform.InstanceState, error) {
+	rs, ok := ms.Resources[name]
+	if !ok {
+		return nil, fmt.Errorf("Not found: %s in %s", name, ms.Path)
+	}
+
+	is := rs.Primary
+	if is == nil {
+		return nil, fmt.Errorf("No primary instance: %s in %s", name, ms.Path)
+	}
+
+	return is, nil
+}

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -1597,7 +1597,6 @@ func resourceEndpointSetState(d *schema.ResourceData, endpoint *dms.Endpoint) er
 		}
 	default:
 		d.Set("database_name", endpoint.DatabaseName)
-		d.Set("extra_connection_attributes", endpoint.ExtraConnectionAttributes)
 		d.Set("port", endpoint.Port)
 		d.Set("server_name", endpoint.ServerName)
 		d.Set("username", endpoint.Username)
@@ -2238,8 +2237,9 @@ func suppressExtraConnectionAttributesDiffs(_, old, new string, d *schema.Resour
 
 		if o != nil && config != nil {
 			diff := o.Difference(config)
+			diff2 := n.Difference(config)
 
-			return diff.Len() == 0 || diff.Equal(n)
+			return (diff.Len() == 0 && diff2.Len() == 0) || diff.Equal(n)
 		}
 	}
 	return false

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -2586,7 +2586,7 @@ resource "aws_dms_endpoint" "test" {
     bucket_name             = "bucket_name"
     bucket_folder           = "bucket_folder"
     compression_type        = "GZIP"
-	csv_delimiter           = %[3]q
+    csv_delimiter           = %[3]q
   }
 
   tags = {

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -288,6 +288,10 @@ func TestAccDMSEndpoint_S3_basic(t *testing.T) {
 				),
 			},
 			{
+				Config:   testAccEndpointConfig_s3(rName),
+				PlanOnly: true,
+			},
+			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -295,6 +299,57 @@ func TestAccDMSEndpoint_S3_basic(t *testing.T) {
 			},
 			{
 				Config: testAccEndpointConfig_s3Update(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.external_table_definition", "new-external_table_definition"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.csv_row_delimiter", "\\r"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.csv_delimiter", "."),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.bucket_folder", "new-bucket_folder"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.bucket_name", "new-bucket_name"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.compression_type", "GZIP"),
+				),
+			},
+			{
+				Config:   testAccEndpointConfig_s3Update(rName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccDMSEndpoint_S3_detachTargetOnLobLookupFailureParquet(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_dms_endpoint.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfig_s3DetachTargetOnLobLookupFailureParquet(rName, ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, resourceName),
+					acctest.TestNoMatchResourceAttr(resourceName, "extra_connection_attributes", regexp.MustCompile(`detachTargetOnLobLookupFailureParquet`)),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.external_table_definition", "new-external_table_definition"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.csv_row_delimiter", "\\r"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.csv_delimiter", "."),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.bucket_folder", "new-bucket_folder"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.bucket_name", "new-bucket_name"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.compression_type", "GZIP"),
+				),
+			},
+			{
+				Config:             testAccEndpointConfig_s3DetachTargetOnLobLookupFailureParquet(rName, "detachTargetOnLobLookupFailureParquet=false;"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccEndpointConfig_s3DetachTargetOnLobLookupFailureParquet(rName, "detachTargetOnLobLookupFailureParquet=false"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointExists(ctx, resourceName),
 					resource.TestMatchResourceAttr(resourceName, "extra_connection_attributes", regexp.MustCompile(`detachTargetOnLobLookupFailureParquet=false`)),
@@ -306,6 +361,24 @@ func TestAccDMSEndpoint_S3_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.bucket_name", "new-bucket_name"),
 					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.compression_type", "GZIP"),
 				),
+			},
+			{
+				Config: testAccEndpointConfig_s3DetachTargetOnLobLookupFailureParquet(rName, "detachTargetOnLobLookupFailureParquet=true"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, resourceName),
+					resource.TestMatchResourceAttr(resourceName, "extra_connection_attributes", regexp.MustCompile(`detachTargetOnLobLookupFailureParquet=true`)),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.external_table_definition", "new-external_table_definition"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.csv_row_delimiter", "\\r"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.csv_delimiter", "."),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.bucket_folder", "new-bucket_folder"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.bucket_name", "new-bucket_name"),
+					resource.TestCheckResourceAttr(resourceName, "s3_settings.0.compression_type", "GZIP"),
+				),
+			},
+			{
+				Config:   testAccEndpointConfig_s3DetachTargetOnLobLookupFailureParquet(rName, "detachTargetOnLobLookupFailureParquet=true"),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -342,7 +415,31 @@ func TestAccDMSEndpoint_S3_extraConnectionAttributes(t *testing.T) {
 		CheckDestroy:             testAccCheckEndpointDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointConfig_s3ExtraConnectionAttributes(rName),
+				Config: testAccEndpointConfig_s3ExtraConnectionAttributes(rName, "", ","),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEndpointExists(ctx, resourceName),
+					acctest.TestNoMatchResourceAttr(resourceName, "extra_connection_attributes", regexp.MustCompile(`dataFormat=parquet;`)),
+				),
+			},
+			{
+				// settings-only change should trigger diff
+				Config:             testAccEndpointConfig_s3ExtraConnectionAttributes(rName, "", "."),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				// inconsequential eca change should not trigger diff
+				Config:   testAccEndpointConfig_s3ExtraConnectionAttributes(rName, "csv_delimiter=,", ","),
+				PlanOnly: true,
+			},
+			{
+				// eca-only change should trigger diff
+				Config:             testAccEndpointConfig_s3ExtraConnectionAttributes(rName, "dataFormat=parquet;", ","),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccEndpointConfig_s3ExtraConnectionAttributes(rName, "dataFormat=parquet;", "."),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointExists(ctx, resourceName),
 					resource.TestMatchResourceAttr(resourceName, "extra_connection_attributes", regexp.MustCompile(`dataFormat=parquet;`)),
@@ -2473,7 +2570,7 @@ resource "aws_iam_role_policy" "dms_s3_access" {
 `, rName)
 }
 
-func testAccEndpointConfig_s3ExtraConnectionAttributes(rName string) string {
+func testAccEndpointConfig_s3ExtraConnectionAttributes(rName, eca, csvDelimiter string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -2482,13 +2579,14 @@ resource "aws_dms_endpoint" "test" {
   endpoint_type               = "target"
   engine_name                 = "s3"
   ssl_mode                    = "none"
-  extra_connection_attributes = "dataFormat=parquet;"
+  extra_connection_attributes = %[2]q
 
   s3_settings {
     service_access_role_arn = aws_iam_role.iam_role.arn
     bucket_name             = "bucket_name"
     bucket_folder           = "bucket_folder"
     compression_type        = "GZIP"
+	csv_delimiter           = %[3]q
   }
 
   tags = {
@@ -2548,7 +2646,7 @@ resource "aws_iam_role_policy" "dms_s3_access" {
 }
 EOF
 }
-`, rName)
+`, rName, eca, csvDelimiter)
 }
 
 func testAccEndpointConfig_s3ConnSSEKMSKeyARN(rName string) string {
@@ -2718,7 +2816,7 @@ resource "aws_dms_endpoint" "test" {
   endpoint_type               = "target"
   engine_name                 = "s3"
   ssl_mode                    = "none"
-  extra_connection_attributes = "detachTargetOnLobLookupFailureParquet=false"
+  extra_connection_attributes = ""
 
   tags = {
     Name   = %[1]q
@@ -2786,6 +2884,85 @@ resource "aws_iam_role_policy" "dms_s3_access" {
 EOF
 }
 `, rName)
+}
+
+func testAccEndpointConfig_s3DetachTargetOnLobLookupFailureParquet(rName string, eca string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_dms_endpoint" "test" {
+  endpoint_id                 = %[1]q
+  endpoint_type               = "target"
+  engine_name                 = "s3"
+  ssl_mode                    = "none"
+  extra_connection_attributes = %[2]q
+
+  tags = {
+    Name   = %[1]q
+    Update = "updated"
+    Add    = "added"
+  }
+
+  s3_settings {
+    service_access_role_arn   = aws_iam_role.iam_role.arn
+    external_table_definition = "new-external_table_definition"
+    csv_row_delimiter         = "\\r"
+    csv_delimiter             = "."
+    bucket_folder             = "new-bucket_folder"
+    bucket_name               = "new-bucket_name"
+    compression_type          = "GZIP"
+  }
+}
+
+resource "aws_iam_role" "iam_role" {
+  name = %[1]q
+
+  assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Action": "sts:AssumeRole",
+			"Principal": {
+				"Service": "dms.${data.aws_partition.current.dns_suffix}"
+			},
+			"Effect": "Allow"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "dms_s3_access" {
+  name = %[1]q
+  role = aws_iam_role.iam_role.name
+
+  policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Action": [
+				"s3:CreateBucket",
+				"s3:ListBucket",
+				"s3:DeleteBucket",
+				"s3:GetBucketLocation",
+				"s3:GetObject",
+				"s3:PutObject",
+				"s3:DeleteObject",
+				"s3:GetObjectVersion",
+				"s3:GetBucketPolicy",
+				"s3:PutBucketPolicy",
+				"s3:DeleteBucketPolicy"
+			],
+			"Resource": "*"
+		}
+	]
+}
+EOF
+}
+`, rName, eca)
 }
 
 func testAccEndpointConfig_openSearchBase(rName string) string {

--- a/internal/service/dms/s3_endpoint.go
+++ b/internal/service/dms/s3_endpoint.go
@@ -203,6 +203,10 @@ func ResourceS3Endpoint() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"detach_target_on_lob_lookup_failure_parquet": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"dict_page_size_limit": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -416,6 +420,8 @@ func resourceS3EndpointRead(ctx context.Context, d *schema.ResourceData, meta in
 	// d.Set("service_access_role_arn", endpoint.ServiceAccessRoleArn) // set from s3 settings
 	d.Set("ssl_mode", endpoint.SslMode)
 	d.Set("status", endpoint.Status)
+
+	setDetachTargetOnLobLookupFailureParquet(d, aws.StringValue(endpoint.ExtraConnectionAttributes))
 
 	s3settings := endpoint.S3Settings
 	d.Set("add_column_name", s3settings.AddColumnName)
@@ -751,10 +757,29 @@ func s3Settings(d *schema.ResourceData, target bool) *dms.S3Settings {
 func extraConnectionAnomalies(d *schema.ResourceData) *string {
 	// not all attributes work in the data structures and must be passed via ex conn attr
 
-	// add a loop to compose the string of ;-sep pairs, if this becomes more than one
+	var anoms []string
+
 	if v, ok := d.GetOk("cdc_path"); ok {
-		return aws.String(fmt.Sprintf("%s=%s", "CdcPath", v.(string)))
+		anoms = append(anoms, fmt.Sprintf("%s=%s", "CdcPath", v.(string)))
 	}
 
-	return nil
+	if v, ok := d.GetOk("detach_target_on_lob_lookup_failure_parquet"); ok {
+		anoms = append(anoms, fmt.Sprintf("%s=%t", "detachTargetOnLobLookupFailureParquet", v.(bool)))
+	}
+
+	if len(anoms) == 0 {
+		return nil
+	}
+
+	return aws.String(strings.Join(anoms, ";"))
+}
+
+func setDetachTargetOnLobLookupFailureParquet(d *schema.ResourceData, eca string) {
+	if strings.Contains(eca, "detachTargetOnLobLookupFailureParquet=false") {
+		d.Set("detach_target_on_lob_lookup_failure_parquet", false)
+	}
+
+	if strings.Contains(eca, "detachTargetOnLobLookupFailureParquet=true") {
+		d.Set("detach_target_on_lob_lookup_failure_parquet", true)
+	}
 }

--- a/website/docs/r/dms_s3_endpoint.html.markdown
+++ b/website/docs/r/dms_s3_endpoint.html.markdown
@@ -123,6 +123,7 @@ The following arguments are optional:
 * `date_partition_enabled` - (Optional) Partition S3 bucket folders based on transaction commit dates. Default is `false`. (Ignored for source endpoints.)
 * `date_partition_sequence` - (Optional) Date format to use during folder partitioning. Use this parameter when `date_partition_enabled` is set to true. Valid values are `YYYYMMDD`, `YYYYMMDDHH`, `YYYYMM`, `MMYYYYDD`, and `DDMMYYYY`. (AWS default is `YYYYMMDD`.) (Ignored for source endpoints.)
 * `date_partition_timezone` - (Optional) Convert the current UTC time to a timezone. The conversion occurs when a date partition folder is created and a CDC filename is generated. The timezone format is Area/Location (_e.g._, `Europe/Paris`). Use this when `date_partition_enabled` is `true`. (Ignored for source endpoints.)
+* `detach_target_on_lob_lookup_failure_parquet` - (Optional) Undocumented argument for use as directed by AWS Support.
 * `dict_page_size_limit` - (Optional) Maximum size in bytes of an encoded dictionary page of a column. (AWS default is 1 MiB, _i.e._, `1048576`.)
 * `enable_statistics` - (Optional) Whether to enable statistics for Parquet pages and row groups. Default is `true`.
 * `encoding_type` - (Optional) Type of encoding to use. Value values are `rle_dictionary`, `plain`, and `plain_dictionary`. (AWS default is `rle_dictionary`.)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccDMSS3Endpoint_ K=dms                                     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dms/... -v -count 1 -parallel 20 -run='TestAccDMSS3Endpoint_'  -timeout 180m
=== RUN   TestAccDMSS3Endpoint_basic
=== PAUSE TestAccDMSS3Endpoint_basic
=== RUN   TestAccDMSS3Endpoint_update
=== PAUSE TestAccDMSS3Endpoint_update
=== RUN   TestAccDMSS3Endpoint_simple
=== PAUSE TestAccDMSS3Endpoint_simple
=== RUN   TestAccDMSS3Endpoint_sourceSimple
=== PAUSE TestAccDMSS3Endpoint_sourceSimple
=== RUN   TestAccDMSS3Endpoint_source
=== PAUSE TestAccDMSS3Endpoint_source
=== RUN   TestAccDMSS3Endpoint_detachTargetOnLobLookupFailureParquet
=== PAUSE TestAccDMSS3Endpoint_detachTargetOnLobLookupFailureParquet
=== CONT  TestAccDMSS3Endpoint_basic
=== CONT  TestAccDMSS3Endpoint_sourceSimple
=== CONT  TestAccDMSS3Endpoint_detachTargetOnLobLookupFailureParquet
=== CONT  TestAccDMSS3Endpoint_simple
=== CONT  TestAccDMSS3Endpoint_source
=== CONT  TestAccDMSS3Endpoint_update
--- PASS: TestAccDMSS3Endpoint_simple (40.04s)
--- PASS: TestAccDMSS3Endpoint_basic (45.59s)
--- PASS: TestAccDMSS3Endpoint_update (52.91s)
--- PASS: TestAccDMSS3Endpoint_sourceSimple (53.25s)
--- PASS: TestAccDMSS3Endpoint_source (55.37s)
--- PASS: TestAccDMSS3Endpoint_detachTargetOnLobLookupFailureParquet (72.15s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dms	73.872s
% make t T=TestAccDMSEndpoint_ K=dms                                       
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dms/... -v -count 1 -parallel 20 -run='TestAccDMSEndpoint_'  -timeout 180m
=== RUN   TestAccDMSEndpoint_basic
=== PAUSE TestAccDMSEndpoint_basic
=== RUN   TestAccDMSEndpoint_Aurora_basic
=== PAUSE TestAccDMSEndpoint_Aurora_basic
=== RUN   TestAccDMSEndpoint_Aurora_secretID
=== PAUSE TestAccDMSEndpoint_Aurora_secretID
=== RUN   TestAccDMSEndpoint_Aurora_update
=== PAUSE TestAccDMSEndpoint_Aurora_update
=== RUN   TestAccDMSEndpoint_AuroraPostgreSQL_basic
=== PAUSE TestAccDMSEndpoint_AuroraPostgreSQL_basic
=== RUN   TestAccDMSEndpoint_AuroraPostgreSQL_secretID
=== PAUSE TestAccDMSEndpoint_AuroraPostgreSQL_secretID
=== RUN   TestAccDMSEndpoint_AuroraPostgreSQL_update
=== PAUSE TestAccDMSEndpoint_AuroraPostgreSQL_update
=== RUN   TestAccDMSEndpoint_S3_basic
=== PAUSE TestAccDMSEndpoint_S3_basic
=== RUN   TestAccDMSEndpoint_S3_detachTargetOnLobLookupFailureParquet
=== PAUSE TestAccDMSEndpoint_S3_detachTargetOnLobLookupFailureParquet
=== RUN   TestAccDMSEndpoint_S3_key
=== PAUSE TestAccDMSEndpoint_S3_key
=== RUN   TestAccDMSEndpoint_S3_extraConnectionAttributes
=== PAUSE TestAccDMSEndpoint_S3_extraConnectionAttributes
=== RUN   TestAccDMSEndpoint_S3_SSEKMSKeyARN
=== PAUSE TestAccDMSEndpoint_S3_SSEKMSKeyARN
=== RUN   TestAccDMSEndpoint_S3_SSEKMSKeyId
=== PAUSE TestAccDMSEndpoint_S3_SSEKMSKeyId
=== RUN   TestAccDMSEndpoint_dynamoDB
=== PAUSE TestAccDMSEndpoint_dynamoDB
=== RUN   TestAccDMSEndpoint_OpenSearch_basic
=== PAUSE TestAccDMSEndpoint_OpenSearch_basic
=== RUN   TestAccDMSEndpoint_OpenSearch_extraConnectionAttributes
=== PAUSE TestAccDMSEndpoint_OpenSearch_extraConnectionAttributes
=== RUN   TestAccDMSEndpoint_OpenSearch_errorRetryDuration
=== PAUSE TestAccDMSEndpoint_OpenSearch_errorRetryDuration
=== RUN   TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage
=== PAUSE TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage
=== RUN   TestAccDMSEndpoint_kafka
=== PAUSE TestAccDMSEndpoint_kafka
=== RUN   TestAccDMSEndpoint_kinesis
=== PAUSE TestAccDMSEndpoint_kinesis
=== RUN   TestAccDMSEndpoint_MongoDB_basic
=== PAUSE TestAccDMSEndpoint_MongoDB_basic
=== RUN   TestAccDMSEndpoint_MongoDB_secretID
=== PAUSE TestAccDMSEndpoint_MongoDB_secretID
=== RUN   TestAccDMSEndpoint_MongoDB_update
=== PAUSE TestAccDMSEndpoint_MongoDB_update
=== RUN   TestAccDMSEndpoint_MariaDB_basic
=== PAUSE TestAccDMSEndpoint_MariaDB_basic
=== RUN   TestAccDMSEndpoint_MariaDB_secretID
=== PAUSE TestAccDMSEndpoint_MariaDB_secretID
=== RUN   TestAccDMSEndpoint_MariaDB_update
=== PAUSE TestAccDMSEndpoint_MariaDB_update
=== RUN   TestAccDMSEndpoint_MySQL_basic
=== PAUSE TestAccDMSEndpoint_MySQL_basic
=== RUN   TestAccDMSEndpoint_MySQL_secretID
=== PAUSE TestAccDMSEndpoint_MySQL_secretID
=== RUN   TestAccDMSEndpoint_MySQL_update
=== PAUSE TestAccDMSEndpoint_MySQL_update
=== RUN   TestAccDMSEndpoint_Oracle_basic
=== PAUSE TestAccDMSEndpoint_Oracle_basic
=== RUN   TestAccDMSEndpoint_Oracle_secretID
=== PAUSE TestAccDMSEndpoint_Oracle_secretID
=== RUN   TestAccDMSEndpoint_Oracle_update
=== PAUSE TestAccDMSEndpoint_Oracle_update
=== RUN   TestAccDMSEndpoint_PostgreSQL_basic
=== PAUSE TestAccDMSEndpoint_PostgreSQL_basic
=== RUN   TestAccDMSEndpoint_PostgreSQL_secretID
=== PAUSE TestAccDMSEndpoint_PostgreSQL_secretID
=== RUN   TestAccDMSEndpoint_PostgreSQL_update
=== PAUSE TestAccDMSEndpoint_PostgreSQL_update
=== RUN   TestAccDMSEndpoint_PostgreSQL_kmsKey
=== PAUSE TestAccDMSEndpoint_PostgreSQL_kmsKey
=== RUN   TestAccDMSEndpoint_SQLServer_basic
=== PAUSE TestAccDMSEndpoint_SQLServer_basic
=== RUN   TestAccDMSEndpoint_SQLServer_secretID
=== PAUSE TestAccDMSEndpoint_SQLServer_secretID
=== RUN   TestAccDMSEndpoint_SQLServer_update
=== PAUSE TestAccDMSEndpoint_SQLServer_update
=== RUN   TestAccDMSEndpoint_SQLServer_kmsKey
=== PAUSE TestAccDMSEndpoint_SQLServer_kmsKey
=== RUN   TestAccDMSEndpoint_Sybase_basic
=== PAUSE TestAccDMSEndpoint_Sybase_basic
=== RUN   TestAccDMSEndpoint_Sybase_secretID
=== PAUSE TestAccDMSEndpoint_Sybase_secretID
=== RUN   TestAccDMSEndpoint_Sybase_update
=== PAUSE TestAccDMSEndpoint_Sybase_update
=== RUN   TestAccDMSEndpoint_Sybase_kmsKey
=== PAUSE TestAccDMSEndpoint_Sybase_kmsKey
=== RUN   TestAccDMSEndpoint_docDB
=== PAUSE TestAccDMSEndpoint_docDB
=== RUN   TestAccDMSEndpoint_db2_basic
=== PAUSE TestAccDMSEndpoint_db2_basic
=== RUN   TestAccDMSEndpoint_azureSQLManagedInstance
=== PAUSE TestAccDMSEndpoint_azureSQLManagedInstance
=== RUN   TestAccDMSEndpoint_db2_secretID
=== PAUSE TestAccDMSEndpoint_db2_secretID
=== RUN   TestAccDMSEndpoint_redis
=== PAUSE TestAccDMSEndpoint_redis
=== RUN   TestAccDMSEndpoint_Redshift_basic
=== PAUSE TestAccDMSEndpoint_Redshift_basic
=== RUN   TestAccDMSEndpoint_Redshift_secretID
=== PAUSE TestAccDMSEndpoint_Redshift_secretID
=== RUN   TestAccDMSEndpoint_Redshift_update
=== PAUSE TestAccDMSEndpoint_Redshift_update
=== RUN   TestAccDMSEndpoint_Redshift_kmsKey
=== PAUSE TestAccDMSEndpoint_Redshift_kmsKey
=== RUN   TestAccDMSEndpoint_Redshift_SSEKMSKeyARN
=== PAUSE TestAccDMSEndpoint_Redshift_SSEKMSKeyARN
=== RUN   TestAccDMSEndpoint_Redshift_SSEKMSKeyId
=== PAUSE TestAccDMSEndpoint_Redshift_SSEKMSKeyId
=== CONT  TestAccDMSEndpoint_basic
=== CONT  TestAccDMSEndpoint_Sybase_update
=== CONT  TestAccDMSEndpoint_Oracle_basic
=== CONT  TestAccDMSEndpoint_OpenSearch_basic
=== CONT  TestAccDMSEndpoint_MySQL_update
=== CONT  TestAccDMSEndpoint_Redshift_basic
=== CONT  TestAccDMSEndpoint_Sybase_secretID
=== CONT  TestAccDMSEndpoint_Sybase_basic
=== CONT  TestAccDMSEndpoint_SQLServer_kmsKey
=== CONT  TestAccDMSEndpoint_SQLServer_update
=== CONT  TestAccDMSEndpoint_SQLServer_secretID
=== CONT  TestAccDMSEndpoint_SQLServer_basic
=== CONT  TestAccDMSEndpoint_PostgreSQL_kmsKey
=== CONT  TestAccDMSEndpoint_PostgreSQL_update
=== CONT  TestAccDMSEndpoint_PostgreSQL_secretID
=== CONT  TestAccDMSEndpoint_PostgreSQL_basic
=== CONT  TestAccDMSEndpoint_Oracle_update
=== CONT  TestAccDMSEndpoint_Oracle_secretID
=== CONT  TestAccDMSEndpoint_Redshift_SSEKMSKeyId
=== CONT  TestAccDMSEndpoint_Redshift_SSEKMSKeyARN
--- PASS: TestAccDMSEndpoint_SQLServer_kmsKey (40.25s)
=== CONT  TestAccDMSEndpoint_Redshift_kmsKey
--- PASS: TestAccDMSEndpoint_PostgreSQL_kmsKey (41.08s)
=== CONT  TestAccDMSEndpoint_Redshift_update
--- PASS: TestAccDMSEndpoint_PostgreSQL_secretID (51.08s)
=== CONT  TestAccDMSEndpoint_Redshift_secretID
--- PASS: TestAccDMSEndpoint_Oracle_basic (51.28s)
=== CONT  TestAccDMSEndpoint_MongoDB_secretID
--- PASS: TestAccDMSEndpoint_Sybase_secretID (52.90s)
=== CONT  TestAccDMSEndpoint_MySQL_secretID
--- PASS: TestAccDMSEndpoint_Oracle_secretID (54.65s)
=== CONT  TestAccDMSEndpoint_MySQL_basic
--- PASS: TestAccDMSEndpoint_SQLServer_secretID (54.74s)
=== CONT  TestAccDMSEndpoint_MariaDB_update
--- PASS: TestAccDMSEndpoint_SQLServer_basic (56.69s)
=== CONT  TestAccDMSEndpoint_MariaDB_secretID
--- PASS: TestAccDMSEndpoint_PostgreSQL_basic (57.02s)
=== CONT  TestAccDMSEndpoint_MariaDB_basic
--- PASS: TestAccDMSEndpoint_Sybase_basic (57.53s)
=== CONT  TestAccDMSEndpoint_MongoDB_update
--- PASS: TestAccDMSEndpoint_OpenSearch_basic (65.70s)
=== CONT  TestAccDMSEndpoint_kafka
--- PASS: TestAccDMSEndpoint_Oracle_update (75.18s)
=== CONT  TestAccDMSEndpoint_MongoDB_basic
--- PASS: TestAccDMSEndpoint_Sybase_update (76.90s)
=== CONT  TestAccDMSEndpoint_kinesis
--- PASS: TestAccDMSEndpoint_basic (77.92s)
=== CONT  TestAccDMSEndpoint_redis
--- PASS: TestAccDMSEndpoint_PostgreSQL_update (78.06s)
=== CONT  TestAccDMSEndpoint_db2_secretID
--- PASS: TestAccDMSEndpoint_SQLServer_update (78.70s)
=== CONT  TestAccDMSEndpoint_OpenSearch_errorRetryDuration
--- PASS: TestAccDMSEndpoint_MySQL_update (78.73s)
=== CONT  TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage
--- PASS: TestAccDMSEndpoint_Redshift_secretID (35.45s)
=== CONT  TestAccDMSEndpoint_docDB
--- PASS: TestAccDMSEndpoint_MongoDB_secretID (37.12s)
=== CONT  TestAccDMSEndpoint_db2_basic
--- PASS: TestAccDMSEndpoint_MariaDB_secretID (41.21s)
=== CONT  TestAccDMSEndpoint_azureSQLManagedInstance
--- PASS: TestAccDMSEndpoint_MySQL_basic (45.28s)
=== CONT  TestAccDMSEndpoint_OpenSearch_extraConnectionAttributes
--- PASS: TestAccDMSEndpoint_MariaDB_basic (44.16s)
=== CONT  TestAccDMSEndpoint_S3_basic
--- PASS: TestAccDMSEndpoint_MySQL_secretID (48.54s)
=== CONT  TestAccDMSEndpoint_dynamoDB
--- PASS: TestAccDMSEndpoint_MariaDB_update (55.37s)
=== CONT  TestAccDMSEndpoint_Sybase_kmsKey
--- PASS: TestAccDMSEndpoint_MongoDB_basic (45.89s)
=== CONT  TestAccDMSEndpoint_S3_SSEKMSKeyId
--- PASS: TestAccDMSEndpoint_kafka (55.73s)
=== CONT  TestAccDMSEndpoint_Aurora_secretID
--- PASS: TestAccDMSEndpoint_MongoDB_update (67.73s)
=== CONT  TestAccDMSEndpoint_Aurora_update
--- PASS: TestAccDMSEndpoint_db2_secretID (47.47s)
=== CONT  TestAccDMSEndpoint_S3_SSEKMSKeyARN
--- PASS: TestAccDMSEndpoint_redis (51.87s)
=== CONT  TestAccDMSEndpoint_AuroraPostgreSQL_update
--- PASS: TestAccDMSEndpoint_OpenSearch_fullLoadErrorPercentage (55.62s)
=== CONT  TestAccDMSEndpoint_S3_extraConnectionAttributes
--- PASS: TestAccDMSEndpoint_OpenSearch_errorRetryDuration (55.98s)
=== CONT  TestAccDMSEndpoint_S3_key
--- PASS: TestAccDMSEndpoint_OpenSearch_extraConnectionAttributes (44.11s)
=== CONT  TestAccDMSEndpoint_S3_detachTargetOnLobLookupFailureParquet
--- PASS: TestAccDMSEndpoint_docDB (60.53s)
=== CONT  TestAccDMSEndpoint_AuroraPostgreSQL_basic
--- PASS: TestAccDMSEndpoint_db2_basic (59.42s)
=== CONT  TestAccDMSEndpoint_Aurora_basic
--- PASS: TestAccDMSEndpoint_S3_key (13.19s)
=== CONT  TestAccDMSEndpoint_AuroraPostgreSQL_secretID
--- PASS: TestAccDMSEndpoint_Sybase_kmsKey (38.71s)
--- PASS: TestAccDMSEndpoint_azureSQLManagedInstance (54.77s)
--- PASS: TestAccDMSEndpoint_kinesis (87.04s)
--- PASS: TestAccDMSEndpoint_Aurora_secretID (47.12s)
--- PASS: TestAccDMSEndpoint_dynamoDB (87.06s)
--- PASS: TestAccDMSEndpoint_AuroraPostgreSQL_basic (42.14s)
--- PASS: TestAccDMSEndpoint_Aurora_basic (41.81s)
--- PASS: TestAccDMSEndpoint_AuroraPostgreSQL_update (60.33s)
--- PASS: TestAccDMSEndpoint_S3_basic (89.21s)
--- PASS: TestAccDMSEndpoint_AuroraPostgreSQL_secretID (43.90s)
--- PASS: TestAccDMSEndpoint_S3_SSEKMSKeyARN (66.59s)
--- PASS: TestAccDMSEndpoint_Aurora_update (72.24s)
--- PASS: TestAccDMSEndpoint_S3_SSEKMSKeyId (77.50s)
--- PASS: TestAccDMSEndpoint_S3_extraConnectionAttributes (90.97s)
--- PASS: TestAccDMSEndpoint_S3_detachTargetOnLobLookupFailureParquet (89.07s)
--- PASS: TestAccDMSEndpoint_Redshift_SSEKMSKeyARN (255.76s)
--- PASS: TestAccDMSEndpoint_Redshift_SSEKMSKeyId (257.23s)
--- PASS: TestAccDMSEndpoint_Redshift_basic (294.02s)
--- PASS: TestAccDMSEndpoint_Redshift_kmsKey (263.84s)
--- PASS: TestAccDMSEndpoint_Redshift_update (282.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dms	325.067s
```
