### PR TITLE
docs: improve detail for app runner secrets

### DIFF
--- a/website/docs/r/apprunner_service.html.markdown
+++ b/website/docs/r/apprunner_service.html.markdown
@@ -245,7 +245,7 @@ The `code_configuration_values` blocks supports the following arguments:
 The `image_configuration` block supports the following arguments:
 
 * `port` - (Optional) Port that your application listens to in the container. Defaults to `"8080"`.
-* `runtime_environment_secrets` - (Optional) Secrets and parameters available to your service as environment variables. A map of key/value pairs, where the key is the desired name of the Secret in this environment (i.e. it does not have to match the name of the secret in Secrets Manager or SSM Parameter Store), and the value is the ARN of the secret from either AWS Secrets Manager or AWS SSM Parameter Store.
+* `runtime_environment_secrets` - (Optional) Secrets and parameters available to your service as environment variables. A map of key/value pairs, where the key is the desired name of the Secret in the environment (i.e. it does not have to match the name of the secret in Secrets Manager or SSM Parameter Store), and the value is the ARN of the secret from AWS Secrets Manager or the ARN of the parameter in AWS SSM Parameter Store.
 * `runtime_environment_variables` - (Optional) Environment variables available to your running App Runner service. A map of key/value pairs. Keys with a prefix of `AWSAPPRUNNER` are reserved for system use and aren't valid.
 * `start_command` - (Optional) Command App Runner runs to start the application in the source image. If specified, this command overrides the Docker image’s default start command.
 

--- a/website/docs/r/apprunner_service.html.markdown
+++ b/website/docs/r/apprunner_service.html.markdown
@@ -236,7 +236,7 @@ The `code_configuration_values` blocks supports the following arguments:
 * `build_command` - (Optional) Command App Runner runs to build your application.
 * `port` - (Optional) Port that your application listens to in the container. Defaults to `"8080"`.
 * `runtime` - (Required) Runtime environment type for building and running an App Runner service. Represents a programming language runtime. Valid values: `PYTHON_3`, `NODEJS_12`, `NODEJS_14`, `NODEJS_16`, `CORRETTO_8`, `CORRETTO_11`, `GO_1`, `DOTNET_6`, `PHP_81`, `RUBY_31`.
-* `runtime_environment_secrets` - (Optional) Secrets and parameters available to your service as environment variables. A map of key/value pairs.
+* `runtime_environment_secrets` - (Optional) Secrets and parameters available to your service as environment variables. A map of key/value pairs, where the key is the desired name of the Secret in this environment (i.e. it does not have to match the name of the secret in Secrets Manager or SSM Parameter Store), and the value is the ARN of the secret from either AWS Secrets Manager or AWS SSM Parameter Store.
 * `runtime_environment_variables` - (Optional) Environment variables available to your running App Runner service. A map of key/value pairs. Keys with a prefix of `AWSAPPRUNNER` are reserved for system use and aren't valid.
 * `start_command` - (Optional) Command App Runner runs to start your application.
 
@@ -245,7 +245,7 @@ The `code_configuration_values` blocks supports the following arguments:
 The `image_configuration` block supports the following arguments:
 
 * `port` - (Optional) Port that your application listens to in the container. Defaults to `"8080"`.
-* `runtime_environment_secrets` - (Optional) Secrets and parameters available to your service as environment variables. A map of key/value pairs.
+* `runtime_environment_secrets` - (Optional) Secrets and parameters available to your service as environment variables. A map of key/value pairs, where the key is the desired name of the Secret in this environment (i.e. it does not have to match the name of the secret in Secrets Manager or SSM Parameter Store), and the value is the ARN of the secret from either AWS Secrets Manager or AWS SSM Parameter Store.
 * `runtime_environment_variables` - (Optional) Environment variables available to your running App Runner service. A map of key/value pairs. Keys with a prefix of `AWSAPPRUNNER` are reserved for system use and aren't valid.
 * `start_command` - (Optional) Command App Runner runs to start the application in the source image. If specified, this command overrides the Docker image’s default start command.
 

--- a/website/docs/r/apprunner_service.html.markdown
+++ b/website/docs/r/apprunner_service.html.markdown
@@ -236,7 +236,7 @@ The `code_configuration_values` blocks supports the following arguments:
 * `build_command` - (Optional) Command App Runner runs to build your application.
 * `port` - (Optional) Port that your application listens to in the container. Defaults to `"8080"`.
 * `runtime` - (Required) Runtime environment type for building and running an App Runner service. Represents a programming language runtime. Valid values: `PYTHON_3`, `NODEJS_12`, `NODEJS_14`, `NODEJS_16`, `CORRETTO_8`, `CORRETTO_11`, `GO_1`, `DOTNET_6`, `PHP_81`, `RUBY_31`.
-* `runtime_environment_secrets` - (Optional) Secrets and parameters available to your service as environment variables. A map of key/value pairs, where the key is the desired name of the Secret in this environment (i.e. it does not have to match the name of the secret in Secrets Manager or SSM Parameter Store), and the value is the ARN of the secret from either AWS Secrets Manager or AWS SSM Parameter Store.
+* `runtime_environment_secrets` - (Optional) Secrets and parameters available to your service as environment variables. A map of key/value pairs, where the key is the desired name of the Secret in the environment (i.e. it does not have to match the name of the secret in Secrets Manager or SSM Parameter Store), and the value is the ARN of the secret from AWS Secrets Manager or the ARN of the parameter in AWS SSM Parameter Store.
 * `runtime_environment_variables` - (Optional) Environment variables available to your running App Runner service. A map of key/value pairs. Keys with a prefix of `AWSAPPRUNNER` are reserved for system use and aren't valid.
 * `start_command` - (Optional) Command App Runner runs to start your application.
 


### PR DESCRIPTION
### Description

Improve the docs for App Runner service resource's `runtime_environment_secrets`, so that it is explicit and clear what the expected keys/values of the `runtime_environment_secrets` should be.

### Relations

Closes #29681 

### References

* [AWS App Runner docs on managing environment variables and secrets](https://docs.aws.amazon.com/apprunner/latest/dg/env-variable-manage.html#env-variable-manage.api)
* [AWS App Runner docs on referencing environment variables and secrets](https://docs.aws.amazon.com/apprunner/latest/dg/env-variable.html)

### Output from Acceptance Testing

No tests affected, purely a document change
