### PR TITLE
r/grafana_workspace - add `network_access_control` support + removing VPCs

### DIFF
--- a/.changelog/29793.txt
+++ b/.changelog/29793.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_grafana_workspace: Add `network_access_control` argument
+```
+
+```release-note:bug
+resource/aws_grafana_workspace: Allow removing `vpc_configuration` 
+```

--- a/internal/service/grafana/workspace_test.go
+++ b/internal/service/grafana/workspace_test.go
@@ -698,16 +698,16 @@ resource "aws_vpc_endpoint" "test" {
 }
 
 resource "aws_grafana_workspace" "test" {
-  account_access_type       = "CURRENT_ACCOUNT"
-  authentication_providers  = ["SAML"]
-  permission_type           = "SERVICE_MANAGED"
-  name                      = %[1]q
-  description               = %[1]q
-  role_arn                  = aws_iam_role.test.arn
+  account_access_type      = "CURRENT_ACCOUNT"
+  authentication_providers = ["SAML"]
+  permission_type          = "SERVICE_MANAGED"
+  name                     = %[1]q
+  description              = %[1]q
+  role_arn                 = aws_iam_role.test.arn
 
   network_access_control {
     prefix_list_ids = [aws_ec2_managed_prefix_list.test.id]
-	vpce_ids        = aws_vpc_endpoint.test[*].id
+    vpce_ids        = aws_vpc_endpoint.test[*].id
   }
 }
 `, rName, endpoints))
@@ -738,12 +738,12 @@ resource "aws_vpc_endpoint" "test" {
 }
 
 resource "aws_grafana_workspace" "test" {
-  account_access_type       = "CURRENT_ACCOUNT"
-  authentication_providers  = ["SAML"]
-  permission_type           = "SERVICE_MANAGED"
-  name                      = %[1]q
-  description               = %[1]q
-  role_arn                  = aws_iam_role.test.arn
+  account_access_type      = "CURRENT_ACCOUNT"
+  authentication_providers = ["SAML"]
+  permission_type          = "SERVICE_MANAGED"
+  name                     = %[1]q
+  description              = %[1]q
+  role_arn                 = aws_iam_role.test.arn
 }
 `, rName))
 }

--- a/internal/service/grafana/workspace_test.go
+++ b/internal/service/grafana/workspace_test.go
@@ -31,6 +31,7 @@ func TestAccGrafana_serial(t *testing.T) {
 			"tags":                     testAccWorkspace_tags,
 			"vpc":                      testAccWorkspace_vpc,
 			"configuration":            testAccWorkspace_configuration,
+			"networkAccess":            testAccWorkspace_networkAccess,
 		},
 		"ApiKey": {
 			"basic": testAccWorkspaceAPIKey_basic,
@@ -93,6 +94,7 @@ func testAccWorkspace_saml(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stack_set_name", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "network_access_control.#", "0"),
 				),
 			},
 			{
@@ -136,6 +138,13 @@ func testAccWorkspace_vpc(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.0.security_group_ids.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.0.subnet_ids.#", "3"),
+				),
+			},
+			{
+				Config: testAccWorkspaceConfig_vpcRemoved(rName, 3),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckWorkspaceExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.#", "0"),
 				),
 			},
 		},
@@ -447,6 +456,51 @@ func testAccWorkspace_configuration(t *testing.T) {
 	})
 }
 
+func testAccWorkspace_networkAccess(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_grafana_workspace.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(t, managedgrafana.EndpointsID) },
+		ErrorCheck:               acctest.ErrorCheck(t, managedgrafana.EndpointsID),
+		CheckDestroy:             testAccCheckWorkspaceDestroy(ctx),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkspaceConfig_networkAccess(rName, 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckWorkspaceExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "network_access_control.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_access_control.0.prefix_list_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_access_control.0.vpce_ids.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccWorkspaceConfig_networkAccess(rName, 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckWorkspaceExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "network_access_control.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_access_control.0.prefix_list_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_access_control.0.vpce_ids.#", "2"),
+				),
+			},
+			{
+				Config: testAccWorkspaceConfig_networkAccessRemoved(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckWorkspaceExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "network_access_control.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckWorkspaceExists(ctx context.Context, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
@@ -617,6 +671,83 @@ resource "aws_grafana_workspace" "test" {
 `, rName))
 }
 
+func testAccWorkspaceConfig_networkAccess(rName string, endpoints int) string {
+	return acctest.ConfigCompose(testAccWorkspaceConfig_base(rName), acctest.ConfigVPCWithSubnets(rName, endpoints), fmt.Sprintf(`
+resource "aws_ec2_managed_prefix_list" "test" {
+  name           = %[1]q
+  address_family = "IPv4"
+  max_entries    = 5
+}
+
+resource "aws_security_group" "test" {
+  description = %[1]q
+  vpc_id      = aws_vpc.test.id
+}
+
+data "aws_region" "current" {}
+
+resource "aws_vpc_endpoint" "test" {
+  count = %[2]d
+
+  private_dns_enabled = false
+  security_group_ids  = [aws_security_group.test.id]
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.grafana-workspace"
+  subnet_ids          = [aws_subnet.test[count.index].id]
+  vpc_endpoint_type   = "Interface"
+  vpc_id              = aws_vpc.test.id
+}
+
+resource "aws_grafana_workspace" "test" {
+  account_access_type       = "CURRENT_ACCOUNT"
+  authentication_providers  = ["SAML"]
+  permission_type           = "SERVICE_MANAGED"
+  name                      = %[1]q
+  description               = %[1]q
+  role_arn                  = aws_iam_role.test.arn
+
+  network_access_control {
+    prefix_list_ids = [aws_ec2_managed_prefix_list.test.id]
+	vpce_ids        = aws_vpc_endpoint.test[*].id
+  }
+}
+`, rName, endpoints))
+}
+
+func testAccWorkspaceConfig_networkAccessRemoved(rName string) string {
+	return acctest.ConfigCompose(testAccWorkspaceConfig_base(rName), acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
+resource "aws_ec2_managed_prefix_list" "test" {
+  name           = %[1]q
+  address_family = "IPv4"
+  max_entries    = 5
+}
+
+resource "aws_security_group" "test" {
+  description = %[1]q
+  vpc_id      = aws_vpc.test.id
+}
+
+data "aws_region" "current" {}
+
+resource "aws_vpc_endpoint" "test" {
+  private_dns_enabled = false
+  security_group_ids  = [aws_security_group.test.id]
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.grafana-workspace"
+  subnet_ids          = aws_subnet.test[*].id
+  vpc_endpoint_type   = "Interface"
+  vpc_id              = aws_vpc.test.id
+}
+
+resource "aws_grafana_workspace" "test" {
+  account_access_type       = "CURRENT_ACCOUNT"
+  authentication_providers  = ["SAML"]
+  permission_type           = "SERVICE_MANAGED"
+  name                      = %[1]q
+  description               = %[1]q
+  role_arn                  = aws_iam_role.test.arn
+}
+`, rName))
+}
+
 func testAccWorkspaceConfig_vpc(rName string, subnets int) string {
 	return acctest.ConfigCompose(testAccWorkspaceConfig_base(rName), acctest.ConfigVPCWithSubnets(rName, subnets), fmt.Sprintf(`
 resource "aws_security_group" "test" {
@@ -634,6 +765,22 @@ resource "aws_grafana_workspace" "test" {
     subnet_ids         = aws_subnet.test[*].id
     security_group_ids = [aws_security_group.test.id]
   }
+}
+`, rName))
+}
+
+func testAccWorkspaceConfig_vpcRemoved(rName string, subnets int) string {
+	return acctest.ConfigCompose(testAccWorkspaceConfig_base(rName), acctest.ConfigVPCWithSubnets(rName, subnets), fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  description = %[1]q
+  vpc_id      = aws_vpc.test.id
+}
+
+resource "aws_grafana_workspace" "test" {
+  account_access_type      = "CURRENT_ACCOUNT"
+  authentication_providers = ["SAML"]
+  permission_type          = "SERVICE_MANAGED"
+  role_arn                 = aws_iam_role.test.arn
 }
 `, rName))
 }

--- a/website/docs/r/grafana_workspace.html.markdown
+++ b/website/docs/r/grafana_workspace.html.markdown
@@ -54,6 +54,7 @@ The following arguments are optional:
 * `data_sources` - (Optional) The data sources for the workspace. Valid values are `AMAZON_OPENSEARCH_SERVICE`, `ATHENA`, `CLOUDWATCH`, `PROMETHEUS`, `REDSHIFT`, `SITEWISE`, `TIMESTREAM`, `XRAY`
 * `description` - (Optional) The workspace description.
 * `name` - (Optional) The Grafana workspace name.
+* `network_access_control` - (Optional) Configuration for network access to your workspace.See [Network Access Control](#network-access-control) below.
 * `notification_destinations` - (Optional) The notification destinations. If a data source is specified here, Amazon Managed Grafana will create IAM roles and permissions needed to use these destinations. Must be set to `SNS`.
 * `organization_role_name` - (Optional) The role name that the workspace uses to access resources through Amazon Organizations.
 * `organizational_units` - (Optional) The Amazon Organizations organizational units that the workspace is authorized to use data sources from.
@@ -61,6 +62,11 @@ The following arguments are optional:
 * `stack_set_name` - (Optional) The AWS CloudFormation stack set name that provisions IAM roles to be used by the workspace.
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `vpc_configuration` - (Optional) The configuration settings for an Amazon VPC that contains data sources for your Grafana workspace to connect to. See [VPC Configuration](#vpc-configuration) below.
+
+### Network Access Control
+
+* `prefix_list_ids` - (Required) - An array of prefix list IDs.
+* `vpce_ids` - (Required) - An array of Amazon VPC endpoint IDs for the workspace. The only VPC endpoints that can be specified here are interface VPC endpoints for Grafana workspaces (using the com.amazonaws.[region].grafana-workspace service endpoint). Other VPC endpoints will be ignored.
 
 ### VPC Configuration
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29760

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccGrafana_serial/Workspace PKG=grafana
--- PASS: TestAccGrafana_serial (637.07s)
    --- PASS: TestAccGrafana_serial/Workspace (637.07s)
        --- PASS: TestAccGrafana_serial/Workspace/networkAccess (637.06s)
```
