### PR TITLE
aws_route53_hosted_zone_dnssec - match aws example

### DIFF
--- a/website/docs/r/route53_hosted_zone_dnssec.html.markdown
+++ b/website/docs/r/route53_hosted_zone_dnssec.html.markdown
@@ -32,35 +32,14 @@ resource "aws_kms_key" "example" {
           "kms:DescribeKey",
           "kms:GetPublicKey",
           "kms:Sign",
+          "kms:Verify",
         ],
         Effect = "Allow"
         Principal = {
           Service = "dnssec-route53.amazonaws.com"
         }
+        Resource = "*"
         Sid      = "Allow Route 53 DNSSEC Service",
-        Resource = "*"
-        Condition = {
-          StringEquals = {
-            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
-          }
-          ArnLike = {
-            "aws:SourceArn" = "arn:aws:route53:::hostedzone/*"
-          }
-        }
-      },
-      {
-        Action = "kms:CreateGrant",
-        Effect = "Allow"
-        Principal = {
-          Service = "dnssec-route53.amazonaws.com"
-        }
-        Sid      = "Allow Route 53 DNSSEC Service to CreateGrant",
-        Resource = "*"
-        Condition = {
-          Bool = {
-            "kms:GrantIsForAWSResource" = "true"
-          }
-        }
       },
       {
         Action = "kms:*"


### PR DESCRIPTION
### Description
Match example key policy to [AWS docs example](https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateKeySigningKey.html#API_CreateKeySigningKey_Examples)

### Relations
Closes #29778

### References
https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateKeySigningKey.html#API_CreateKeySigningKey_Examples
