### PR TITLE
Fix issue with include_fec attribute not being set

### DIFF
--- a/.changelog/29808.txt
+++ b/.changelog/29808.txt
@@ -1,0 +1,3 @@
+``release-note:bug
+ resource/aws_medialive_channel: Fix setting of the `include_fec` attribute in `fec_output_settings`
+ ```

--- a/.changelog/29808.txt
+++ b/.changelog/29808.txt
@@ -1,3 +1,3 @@
-``release-note:bug
- resource/aws_medialive_channel: Fix setting of the `include_fec` attribute in `fec_output_settings`
- ```
+```release-note:bug
+resource/aws_medialive_channel: Fix setting of the `include_fec` attribute in `fec_output_settings`
+```

--- a/internal/service/medialive/channel_encoder_settings_schema.go
+++ b/internal/service/medialive/channel_encoder_settings_schema.go
@@ -3938,7 +3938,7 @@ func expandFecOutputSettings(tfList []interface{}) *types.FecOutputSettings {
 	if v, ok := m["column_depth"].(int); ok {
 		settings.ColumnDepth = int32(v)
 	}
-	if v, ok := m["column_depth"].(string); ok && v != "" {
+	if v, ok := m["include_fec"].(string); ok && v != "" {
 		settings.IncludeFec = types.FecOutputIncludeFec(v)
 	}
 	if v, ok := m["row_length"].(int); ok {

--- a/internal/service/medialive/channel_test.go
+++ b/internal/service/medialive/channel_test.go
@@ -156,7 +156,7 @@ func TestAccMediaLiveChannel_udp_output_settings(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckPartitionHasService(names.MediaLiveEndpointID, t)
+			acctest.PreCheckPartitionHasService(t, names.MediaLiveEndpointID)
 			testAccChannelsPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveEndpointID),

--- a/internal/service/medialive/channel_test.go
+++ b/internal/service/medialive/channel_test.go
@@ -143,7 +143,7 @@ func TestAccMediaLiveChannel_m2ts_settings(t *testing.T) {
 	})
 }
 
-func TestAccMediaLiveChannel_udp_output_settings(t *testing.T) {
+func TestAccMediaLiveChannel_UDP_outputSettings(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")

--- a/internal/service/medialive/channel_test.go
+++ b/internal/service/medialive/channel_test.go
@@ -143,6 +143,68 @@ func TestAccMediaLiveChannel_m2ts_settings(t *testing.T) {
 	})
 }
 
+func TestAccMediaLiveChannel_udp_output_settings(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var channel medialive.DescribeChannelOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_medialive_channel.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckPartitionHasService(names.MediaLiveEndpointID, t)
+			testAccChannelsPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckChannelDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccChannelConfig_udpOutputSettings(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckChannelExists(ctx, resourceName, &channel),
+					resource.TestCheckResourceAttrSet(resourceName, "channel_id"),
+					resource.TestCheckResourceAttr(resourceName, "channel_class", "STANDARD"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "role_arn"),
+					resource.TestCheckResourceAttr(resourceName, "input_specification.0.codec", "AVC"),
+					resource.TestCheckResourceAttr(resourceName, "input_specification.0.input_resolution", "HD"),
+					resource.TestCheckResourceAttr(resourceName, "input_specification.0.maximum_bitrate", "MAX_20_MBPS"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "input_attachments.*", map[string]string{
+						"input_attachment_name": "example-input1",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "destinations.*", map[string]string{
+						"id": rName,
+					}),
+					resource.TestCheckResourceAttr(resourceName, "encoder_settings.0.timecode_config.0.source", "EMBEDDED"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "encoder_settings.0.audio_descriptions.*", map[string]string{
+						"audio_selector_name": rName,
+						"name":                rName,
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "encoder_settings.0.video_descriptions.*", map[string]string{
+						"name": "test-video-name",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "encoder_settings.0.output_groups.0.outputs.0.output_settings.0.udp_output_settings.0.fec_output_settings.*", map[string]string{
+						"include_fec":  "COLUMN_AND_ROW",
+						"column_depth": "5",
+						"row_length":   "5",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"start_channel"},
+			},
+		},
+	})
+}
+
 func TestAccMediaLiveChannel_audioDescriptions_codecSettings(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -705,6 +767,92 @@ resource "aws_medialive_channel" "test" {
               }
             }
           }
+        }
+      }
+    }
+  }
+}
+`, rName))
+}
+
+func testAccChannelConfig_udpOutputSettings(rName string) string {
+	return acctest.ConfigCompose(
+		testAccChannelBaseConfig(rName),
+		testAccChannelBaseMultiplexConfig(rName),
+		fmt.Sprintf(`
+resource "aws_medialive_channel" "test" {
+  name          = %[1]q
+  channel_class = "STANDARD"
+  role_arn      = aws_iam_role.test.arn
+
+  input_specification {
+    codec            = "AVC"
+    input_resolution = "HD"
+    maximum_bitrate  = "MAX_20_MBPS"
+  }
+
+  input_attachments {
+    input_attachment_name = "example-input1"
+    input_id              = aws_medialive_input.test.id
+  }
+
+  destinations {
+    id = %[1]q
+
+    settings {
+	  url = "rtp://localhost:8000"
+    }
+
+    settings {
+	  url = "rtp://localhost:8001"
+    }
+  }
+
+  encoder_settings {
+    timecode_config {
+      source = "EMBEDDED"
+    }
+
+    video_descriptions {
+      name = "test-video-name"
+    }
+
+    audio_descriptions {
+      audio_selector_name = %[1]q
+      name                = %[1]q
+    }
+
+    output_groups {
+      output_group_settings {
+        udp_group_settings {
+          input_loss_action = "DROP_TS"
+        }
+      }
+
+      outputs {
+        output_name             = "test-output-name"
+        video_description_name  = "test-video-name"
+        audio_description_names = [%[1]q]
+        output_settings {
+          udp_output_settings {
+            destination {
+              destination_ref_id = %[1]q
+            }
+
+            fec_output_settings {
+              include_fec  = "COLUMN_AND_ROW"
+              column_depth = 5
+              row_length   = 5
+            }
+
+            container_settings {
+              m2ts_settings {
+                audio_buffer_model = "ATSC"
+                buffer_model       = "MULTIPLEX"
+                rate_mode          = "CBR"
+			  }
+			}
+		  }
         }
       }
     }

--- a/internal/service/medialive/channel_test.go
+++ b/internal/service/medialive/channel_test.go
@@ -800,11 +800,11 @@ resource "aws_medialive_channel" "test" {
     id = %[1]q
 
     settings {
-	  url = "rtp://localhost:8000"
+      url = "rtp://localhost:8000"
     }
 
     settings {
-	  url = "rtp://localhost:8001"
+      url = "rtp://localhost:8001"
     }
   }
 
@@ -850,9 +850,9 @@ resource "aws_medialive_channel" "test" {
                 audio_buffer_model = "ATSC"
                 buffer_model       = "MULTIPLEX"
                 rate_mode          = "CBR"
-			  }
-			}
-		  }
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The `include_fec` attribute in `fec_output_settings` wasn't set correctly.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:
--->

Relates #27824

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccMediaLiveChannel_udp_output_settings PKG=medialive
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/medialive/... -v -count 1 -parallel 20 -run='TestAccMediaLiveChannel_udp_output_settings'  -timeout 180m
=== RUN   TestAccMediaLiveChannel_udp_output_settings
=== PAUSE TestAccMediaLiveChannel_udp_output_settings
=== CONT  TestAccMediaLiveChannel_udp_output_settings
--- PASS: TestAccMediaLiveChannel_udp_output_settings (83.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	85.575s
...
```
