### PR TITLE
r/aws_amplify_domain_association: add enable_auto_sub_domain attribute

### DIFF
--- a/internal/service/amplify/domain_association_test.go
+++ b/internal/service/amplify/domain_association_test.go
@@ -36,7 +36,7 @@ func testAccDomainAssociation_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckDomainAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainAssociationConfig_basic(rName, domainName, false),
+				Config: testAccDomainAssociationConfig_basic(rName, domainName, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "amplify", regexp.MustCompile(`apps/.+/domains/.+`)),
@@ -46,6 +46,7 @@ func testAccDomainAssociation_basic(t *testing.T) {
 						"branch_name": rName,
 						"prefix":      "",
 					}),
+					resource.TestCheckResourceAttr(resourceName, "enable_auto_sub_domain", "false"),
 					resource.TestCheckResourceAttr(resourceName, "wait_for_verification", "false"),
 				),
 			},
@@ -78,7 +79,7 @@ func testAccDomainAssociation_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckDomainAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainAssociationConfig_basic(rName, domainName, false),
+				Config: testAccDomainAssociationConfig_basic(rName, domainName, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfamplify.ResourceDomainAssociation(), resourceName),
@@ -108,7 +109,7 @@ func testAccDomainAssociation_update(t *testing.T) {
 		CheckDestroy:             testAccCheckDomainAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainAssociationConfig_basic(rName, domainName, true),
+				Config: testAccDomainAssociationConfig_basic(rName, domainName, false, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "amplify", regexp.MustCompile(`apps/.+/domains/.+`)),
@@ -118,6 +119,7 @@ func testAccDomainAssociation_update(t *testing.T) {
 						"branch_name": rName,
 						"prefix":      "",
 					}),
+					resource.TestCheckResourceAttr(resourceName, "enable_auto_sub_domain", "false"),
 					resource.TestCheckResourceAttr(resourceName, "wait_for_verification", "true"),
 				),
 			},
@@ -128,7 +130,7 @@ func testAccDomainAssociation_update(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"wait_for_verification"},
 			},
 			{
-				Config: testAccDomainAssociationConfig_updated(rName, domainName, true),
+				Config: testAccDomainAssociationConfig_updated(rName, domainName, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "amplify", regexp.MustCompile(`apps/.+/domains/.+`)),
@@ -142,6 +144,7 @@ func testAccDomainAssociation_update(t *testing.T) {
 						"branch_name": fmt.Sprintf("%s-2", rName),
 						"prefix":      "www",
 					}),
+					resource.TestCheckResourceAttr(resourceName, "enable_auto_sub_domain", "true"),
 					resource.TestCheckResourceAttr(resourceName, "wait_for_verification", "true"),
 				),
 			},
@@ -212,7 +215,7 @@ func testAccCheckDomainAssociationDestroy(ctx context.Context) resource.TestChec
 	}
 }
 
-func testAccDomainAssociationConfig_basic(rName, domainName string, waitForVerification bool) string {
+func testAccDomainAssociationConfig_basic(rName, domainName string, enableAutoSubDomain bool, waitForVerification bool) string {
 	return fmt.Sprintf(`
 resource "aws_amplify_app" "test" {
   name = %[1]q
@@ -232,12 +235,13 @@ resource "aws_amplify_domain_association" "test" {
     prefix      = ""
   }
 
-  wait_for_verification = %[3]t
+  enable_auto_sub_domain = %[3]t
+  wait_for_verification = %[4]t
 }
-`, rName, domainName, waitForVerification)
+`, rName, domainName, enableAutoSubDomain, waitForVerification)
 }
 
-func testAccDomainAssociationConfig_updated(rName, domainName string, waitForVerification bool) string {
+func testAccDomainAssociationConfig_updated(rName, domainName string, enableAutoSubDomain bool, waitForVerification bool) string {
 	return fmt.Sprintf(`
 resource "aws_amplify_app" "test" {
   name = %[1]q
@@ -267,7 +271,8 @@ resource "aws_amplify_domain_association" "test" {
     prefix      = "www"
   }
 
-  wait_for_verification = %[3]t
+  enable_auto_sub_domain = %[3]t
+  wait_for_verification = %[4]t
 }
-`, rName, domainName, waitForVerification)
+`, rName, domainName, enableAutoSubDomain, waitForVerification)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds a new `enable_auto_sub_domain` attribute which matches the API and the rest of the schema (schema uses `sub_domain` already), which was something requested in the issue linked below. Added support for updating, as well as reading this value back from the API.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #20495

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

N/A

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Couldn't run the acceptance tests in the end - something seemed to stop me from running them (not related to my changes I don't think). 
