### PR TITLE
resource/aws_batch_job_description: Ignore diffs on `container_properties` environment variables with an empty value

### DIFF
--- a/.changelog/29820.txt
+++ b/.changelog/29820.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_batch_job_definition: Prevents perpetual diff when container properties environment variable has emtpy value.
+resource/aws_batch_job_definition: Prevents perpetual diff when container properties environment variable has empty value.
 ```

--- a/.changelog/29820.txt
+++ b/.changelog/29820.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_batch_job_definition: Prevents perpetual diff when container properties environment variable has emtpy value.
+```

--- a/internal/errs/diag.go
+++ b/internal/errs/diag.go
@@ -42,9 +42,24 @@ func NewAttributeErrorDiagnostic(path cty.Path, summary, detail string) diag.Dia
 	)
 }
 
+func NewAttributeWarningDiagnostic(path cty.Path, summary, detail string) diag.Diagnostic {
+	return withPath(
+		NewWarningDiagnostic(summary, detail),
+		path,
+	)
+}
+
 func NewErrorDiagnostic(summary, detail string) diag.Diagnostic {
 	return diag.Diagnostic{
 		Severity: diag.Error,
+		Summary:  summary,
+		Detail:   detail,
+	}
+}
+
+func NewWarningDiagnostic(summary, detail string) diag.Diagnostic {
+	return diag.Diagnostic{
+		Severity: diag.Warning,
 		Summary:  summary,
 		Detail:   detail,
 	}

--- a/internal/service/batch/container_properties.go
+++ b/internal/service/batch/container_properties.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
 	"github.com/aws/aws-sdk-go/service/batch"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 )
 
 type containerProperties batch.ContainerProperties
@@ -23,6 +24,14 @@ func (cp *containerProperties) Reduce() error {
 	if len(cp.Command) == 0 {
 		cp.Command = nil
 	}
+
+	// Remove environment variables with empty values
+	cp.Environment = tfslices.Filter(cp.Environment, func(kvp *batch.KeyValuePair) bool {
+		if kvp == nil {
+			return false
+		}
+		return aws.StringValue(kvp.Value) != ""
+	})
 
 	// Prevent difference of API response that adds an empty array when not configured during the request
 	if len(cp.Environment) == 0 {

--- a/internal/service/batch/container_properties_test.go
+++ b/internal/service/batch/container_properties_test.go
@@ -9,21 +9,18 @@ import (
 func TestEquivalentContainerPropertiesJSON(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct {
-		Name              string
+	testCases := map[string]struct {
 		ApiJson           string
 		ConfigurationJson string
 		ExpectEquivalent  bool
 		ExpectError       bool
 	}{
-		{
-			Name:              "empty",
+		"empty": {
 			ApiJson:           ``,
 			ConfigurationJson: ``,
 			ExpectEquivalent:  true,
 		},
-		{
-			Name: "empty ResourceRequirements",
+		"empty ResourceRequirements": {
 			ApiJson: `
 {
 	"command": ["ls", "-la"],
@@ -99,8 +96,7 @@ func TestEquivalentContainerPropertiesJSON(t *testing.T) {
 `,
 			ExpectEquivalent: true,
 		},
-		{
-			Name: "reordered Environment",
+		"reordered Environment": {
 			ApiJson: `
 {
 	"command": ["ls", "-la"],
@@ -185,8 +181,7 @@ func TestEquivalentContainerPropertiesJSON(t *testing.T) {
 `,
 			ExpectEquivalent: true,
 		},
-		{
-			Name: "empty environment, mountPoints, ulimits, and volumes",
+		"empty environment, mountPoints, ulimits, and volumes": {
 			//lintignore:AWSAT005
 			ApiJson: `
 {
@@ -214,8 +209,7 @@ func TestEquivalentContainerPropertiesJSON(t *testing.T) {
 `,
 			ExpectEquivalent: true,
 		},
-		{
-			Name: "empty command, logConfiguration.secretOptions, mountPoints, resourceRequirements, secrets, ulimits, volumes",
+		"empty command, logConfiguration.secretOptions, mountPoints, resourceRequirements, secrets, ulimits, volumes": {
 			//lintignore:AWSAT003,AWSAT005
 			ApiJson: `
 {
@@ -256,8 +250,7 @@ func TestEquivalentContainerPropertiesJSON(t *testing.T) {
 `,
 			ExpectEquivalent: true,
 		},
-		{
-			Name: "no fargatePlatformConfiguration",
+		"no fargatePlatformConfiguration": {
 			//lintignore:AWSAT003,AWSAT005
 			ApiJson: `
 {
@@ -295,8 +288,7 @@ func TestEquivalentContainerPropertiesJSON(t *testing.T) {
 `,
 			ExpectEquivalent: true,
 		},
-		{
-			Name: "empty linuxParameters.devices, linuxParameters.tmpfs, logConfiguration.options",
+		"empty linuxParameters.devices, linuxParameters.tmpfs, logConfiguration.options": {
 			//lintignore:AWSAT003,AWSAT005
 			ApiJson: `
 {
@@ -334,8 +326,7 @@ func TestEquivalentContainerPropertiesJSON(t *testing.T) {
 `,
 			ExpectEquivalent: true,
 		},
-		{
-			Name: "empty linuxParameters.devices.permissions, linuxParameters.tmpfs.mountOptions",
+		"empty linuxParameters.devices.permissions, linuxParameters.tmpfs.mountOptions": {
 			//lintignore:AWSAT003,AWSAT005
 			ApiJson: `
 {
@@ -384,9 +375,9 @@ func TestEquivalentContainerPropertiesJSON(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
+	for name, testCase := range testCases {
 		testCase := testCase
-		t.Run(testCase.Name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
 			got, err := tfbatch.EquivalentContainerPropertiesJSON(testCase.ConfigurationJson, testCase.ApiJson)

--- a/internal/service/batch/container_properties_test.go
+++ b/internal/service/batch/container_properties_test.go
@@ -373,6 +373,79 @@ func TestEquivalentContainerPropertiesJSON(t *testing.T) {
 `,
 			ExpectEquivalent: true,
 		},
+		"empty environment variables": {
+			//lintignore:AWSAT005
+			ApiJson: `
+{
+	"image": "example:image",
+	"vcpus": 8,
+	"memory": 2048,
+	"command": ["start.py", "Ref::S3bucket", "Ref::S3key"],
+	"environment": [
+		{
+			"name": "VALUE",
+			"value": "test"
+		}
+	],
+	"jobRoleArn": "arn:aws:iam::123456789012:role/example",
+	"volumes": [],
+	"mountPoints": [],
+	"ulimits": [],
+	"resourceRequirements": []
+}`,
+			//lintignore:AWSAT005
+			ConfigurationJson: `
+{
+	"command": ["start.py", "Ref::S3bucket", "Ref::S3key"],
+	"image": "example:image",
+	"memory": 2048,
+	"vcpus": 8,
+	"environment": [
+		{
+			"name": "EMPTY",
+			"value": ""
+		},
+		{
+			"name": "VALUE",
+			"value": "test"
+		}
+	],
+	"jobRoleArn": "arn:aws:iam::123456789012:role/example"
+}`,
+			ExpectEquivalent: true,
+		},
+		"empty environment variable": {
+			//lintignore:AWSAT005
+			ApiJson: `
+{
+	"image": "example:image",
+	"vcpus": 8,
+	"memory": 2048,
+	"command": ["start.py", "Ref::S3bucket", "Ref::S3key"],
+	"environment": [],
+	"jobRoleArn": "arn:aws:iam::123456789012:role/example",
+	"volumes": [],
+	"mountPoints": [],
+	"ulimits": [],
+	"resourceRequirements": []
+}`,
+			//lintignore:AWSAT005
+			ConfigurationJson: `
+{
+	"command": ["start.py", "Ref::S3bucket", "Ref::S3key"],
+	"image": "example:image",
+	"memory": 2048,
+	"vcpus": 8,
+	"environment": [
+		{
+			"name": "EMPTY",
+			"value": ""
+		}
+	],
+	"jobRoleArn": "arn:aws:iam::123456789012:role/example"
+}`,
+			ExpectEquivalent: true,
+		},
 	}
 
 	for name, testCase := range testCases {

--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -35,11 +35,9 @@ func ResourceJobDefinition() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validName,
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"container_properties": {
 				Type:     schema.TypeString,
@@ -56,6 +54,12 @@ func ResourceJobDefinition() *schema.Resource {
 				},
 				ValidateFunc: validJobContainerProperties,
 			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validName,
+			},
 			"parameters": {
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -70,6 +74,12 @@ func ResourceJobDefinition() *schema.Resource {
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringInSlice(batch.PlatformCapability_Values(), false),
 				},
+			},
+			"propagate_tags": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
 			},
 			"retry_strategy": {
 				Type:     schema.TypeList,
@@ -134,14 +144,12 @@ func ResourceJobDefinition() *schema.Resource {
 					},
 				},
 			},
+			"revision": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
-			"propagate_tags": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Default:  false,
-			},
 			"timeout": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -163,14 +171,6 @@ func ResourceJobDefinition() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice([]string{batch.JobDefinitionTypeContainer}, true),
-			},
-			"revision": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"arn": {
-				Type:     schema.TypeString,
-				Computed: true,
 			},
 		},
 

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -33,17 +33,29 @@ func TestAccBatchJobDefinition_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccJobDefinitionConfig_name(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexp.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
-					resource.TestCheckResourceAttrSet(resourceName, "container_properties"),
+					acctest.CheckResourceAttrEquivalentJSON(resourceName, "container_properties", `{
+						"command": ["echo", "test"],
+						"image": "busybox",
+						"memory": 128,
+						"vcpus": 1,
+						"environment": [],
+						"mountPoints": [],
+						"resourceRequirements": [],
+						"secrets": [],
+						"ulimits": [],
+						"volumes": []
+						}`),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "platform_capabilities.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "propagate_tags", "false"),
 					resource.TestCheckResourceAttr(resourceName, "retry_strategy.#", "0"),
-					resource.TestCheckResourceAttrSet(resourceName, "revision"),
+					resource.TestCheckResourceAttr(resourceName, "revision", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "timeout.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "type", "container"),
 				),
@@ -71,7 +83,7 @@ func TestAccBatchJobDefinition_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccJobDefinitionConfig_name(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfbatch.ResourceJobDefinition(), resourceName),
 				),
@@ -95,17 +107,28 @@ func TestAccBatchJobDefinition_PlatformCapabilities_ec2(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccJobDefinitionConfig_capabilitiesEC2(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexp.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
-					resource.TestCheckResourceAttrSet(resourceName, "container_properties"),
+					acctest.CheckResourceAttrEquivalentJSON(resourceName, "container_properties", `{
+						"command": ["echo", "test"],
+						"image": "busybox",
+						"memory": 128,
+						"vcpus": 1,
+						"environment": [],
+						"mountPoints": [],
+						"resourceRequirements": [],
+						"secrets": [],
+						"ulimits": [],
+						"volumes": []
+						}`),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "platform_capabilities.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "platform_capabilities.*", "EC2"),
 					resource.TestCheckResourceAttr(resourceName, "propagate_tags", "false"),
 					resource.TestCheckResourceAttr(resourceName, "retry_strategy.#", "0"),
-					resource.TestCheckResourceAttrSet(resourceName, "revision"),
+					resource.TestCheckResourceAttr(resourceName, "revision", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "timeout.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "type", "container"),
@@ -134,17 +157,22 @@ func TestAccBatchJobDefinition_PlatformCapabilitiesFargate_containerPropertiesDe
 		Steps: []resource.TestStep{
 			{
 				Config: testAccJobDefinitionConfig_capabilitiesFargateContainerPropertiesDefaults(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexp.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
-					resource.TestCheckResourceAttrSet(resourceName, "container_properties"),
+					acctest.CheckResourceAttrJMES(resourceName, "container_properties", "length(command)", "0"),
+					acctest.CheckResourceAttrJMESPair(resourceName, "container_properties", "executionRoleArn", "aws_iam_role.ecs_task_execution_role", "arn"),
+					acctest.CheckResourceAttrJMES(resourceName, "container_properties", "fargatePlatformConfiguration.platformVersion", "LATEST"),
+					acctest.CheckResourceAttrJMES(resourceName, "container_properties", "length(resourceRequirements)", "2"),
+					acctest.CheckResourceAttrJMES(resourceName, "container_properties", "resourceRequirements[?type=='VCPU'].value | [0]", "0.25"),
+					acctest.CheckResourceAttrJMES(resourceName, "container_properties", "resourceRequirements[?type=='MEMORY'].value | [0]", "512"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "platform_capabilities.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "platform_capabilities.*", "FARGATE"),
 					resource.TestCheckResourceAttr(resourceName, "propagate_tags", "false"),
 					resource.TestCheckResourceAttr(resourceName, "retry_strategy.#", "0"),
-					resource.TestCheckResourceAttrSet(resourceName, "revision"),
+					resource.TestCheckResourceAttr(resourceName, "revision", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "timeout.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "type", "container"),
@@ -173,17 +201,22 @@ func TestAccBatchJobDefinition_PlatformCapabilities_fargate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccJobDefinitionConfig_capabilitiesFargate(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexp.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
-					resource.TestCheckResourceAttrSet(resourceName, "container_properties"),
+					acctest.CheckResourceAttrJMESPair(resourceName, "container_properties", "executionRoleArn", "aws_iam_role.ecs_task_execution_role", "arn"),
+					acctest.CheckResourceAttrJMES(resourceName, "container_properties", "fargatePlatformConfiguration.platformVersion", "LATEST"),
+					acctest.CheckResourceAttrJMES(resourceName, "container_properties", "networkConfiguration.assignPublicIp", "DISABLED"),
+					acctest.CheckResourceAttrJMES(resourceName, "container_properties", "length(resourceRequirements)", "2"),
+					acctest.CheckResourceAttrJMES(resourceName, "container_properties", "resourceRequirements[?type=='VCPU'].value | [0]", "0.25"),
+					acctest.CheckResourceAttrJMES(resourceName, "container_properties", "resourceRequirements[?type=='MEMORY'].value | [0]", "512"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "platform_capabilities.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "platform_capabilities.*", "FARGATE"),
 					resource.TestCheckResourceAttr(resourceName, "propagate_tags", "false"),
 					resource.TestCheckResourceAttr(resourceName, "retry_strategy.#", "0"),
-					resource.TestCheckResourceAttrSet(resourceName, "revision"),
+					resource.TestCheckResourceAttr(resourceName, "revision", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "timeout.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "type", "container"),
@@ -251,7 +284,7 @@ func TestAccBatchJobDefinition_ContainerProperties_advanced(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccJobDefinitionConfig_containerPropertiesAdvanced(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					testAccCheckJobDefinitionAttributes(&jd, &compare),
 				),
@@ -279,14 +312,14 @@ func TestAccBatchJobDefinition_updateForcesNewResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccJobDefinitionConfig_containerPropertiesAdvanced(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &before),
 					testAccCheckJobDefinitionAttributes(&before, nil),
 				),
 			},
 			{
 				Config: testAccJobDefinitionConfig_containerPropertiesAdvancedUpdate(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &after),
 					testAccCheckJobDefinitionRecreated(t, &before, &after),
 				),
@@ -314,7 +347,7 @@ func TestAccBatchJobDefinition_tags(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccJobDefinitionConfig_tags1(rName, "key1", "value1"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
@@ -327,7 +360,7 @@ func TestAccBatchJobDefinition_tags(t *testing.T) {
 			},
 			{
 				Config: testAccJobDefinitionConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
@@ -336,7 +369,7 @@ func TestAccBatchJobDefinition_tags(t *testing.T) {
 			},
 			{
 				Config: testAccJobDefinitionConfig_tags1(rName, "key2", "value2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -360,16 +393,27 @@ func TestAccBatchJobDefinition_propagateTags(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccJobDefinitionConfig_propagateTags(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "batch", regexp.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
-					resource.TestCheckResourceAttrSet(resourceName, "container_properties"),
+					acctest.CheckResourceAttrEquivalentJSON(resourceName, "container_properties", `{
+						"command": ["echo", "test"],
+						"image": "busybox",
+						"memory": 128,
+						"vcpus": 1,
+						"environment": [],
+						"mountPoints": [],
+						"resourceRequirements": [],
+						"secrets": [],
+						"ulimits": [],
+						"volumes": []
+						}`),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "platform_capabilities.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "propagate_tags", "true"),
 					resource.TestCheckResourceAttr(resourceName, "retry_strategy.#", "0"),
-					resource.TestCheckResourceAttrSet(resourceName, "revision"),
+					resource.TestCheckResourceAttr(resourceName, "revision", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "timeout.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "type", "container"),


### PR DESCRIPTION
### Description

The AWS API accepts container properties environment variables with empty values, but ignores them. They do not get set on the Batch Job Description, and therefore do not get returned. This causes a perpetual diff, and since the field is marked `ForceNew`, the recreation of the resource.

In the AWS Console, a user can create a variable with an empty value, but is not persisted.

This PR ignores the diff when an environment variable has an empty value.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #26960

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=batch TESTS=TestAccBatchJobDefinition_

--- PASS: TestAccBatchJobDefinition_disappears (13.95s)
--- PASS: TestAccBatchJobDefinition_ContainerProperties_EmptyField (18.50s)
--- PASS: TestAccBatchJobDefinition_ContainerProperties_advanced (18.83s)
--- PASS: TestAccBatchJobDefinition_PlatformCapabilities_ec2 (18.91s)
--- PASS: TestAccBatchJobDefinition_basic (19.21s)
--- PASS: TestAccBatchJobDefinition_PlatformCapabilitiesFargate_containerPropertiesDefaults (22.27s)
--- PASS: TestAccBatchJobDefinition_propagateTags (22.40s)
--- PASS: TestAccBatchJobDefinition_PlatformCapabilities_fargate (22.56s)
--- PASS: TestAccBatchJobDefinition_updateForcesNewResource (26.20s)
--- PASS: TestAccBatchJobDefinition_tags (32.79s)
```
