### PR TITLE
Fix file name reference for docs

### DIFF
--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -44,7 +44,7 @@ resource "aws_iam_role" "iam_for_lambda" {
 data "archive_file" "lambda" {
   type        = "zip"
   source_file = "lambda.js"
-  output_path = "lambda.zip"
+  output_path = "lambda_function_payload.zip"
 }
 
 resource "aws_lambda_function" "test_lambda" {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
--->
I [previously updated this doc](https://github.com/hashicorp/terraform-provider-aws/pull/26509/files), and realized I missed one reference to a filename. This change makes the output file generated by the `archive_file` match the name of the file ingested by `aws_lambda_function`. 

cc: @breathingdust since we worked together on the last one. 


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #26509

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a
