### PR TITLE
Fix updates on empty env vars in aws_lambda_func

### DIFF
--- a/.changelog/29839.txt
+++ b/.changelog/29839.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lambda_function: Fix empty environment variable update
+```

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -112,6 +112,17 @@ func ResourceFunction() *schema.Resource {
 						},
 					},
 				},
+				// Suppress diff if change is to an empty list
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if old == "0" && new == "1" {
+						_, n := d.GetChange("environment.0.variables")
+						newn, ok := n.(map[string]interface{})
+						if ok && len(newn) == 0 {
+							return true
+						}
+					}
+					return false
+				},
 			},
 			"ephemeral_storage": {
 				Type:     schema.TypeList,

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -461,6 +461,52 @@ func TestAccLambdaFunction_EnvironmentVariables_noValue(t *testing.T) {
 	})
 }
 
+func TestAccLambdaFunction_EnvironmentVariables_emptyUpgrade(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf lambda.GetFunctionOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lambda_function.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.LambdaEndpointID),
+		CheckDestroy: testAccCheckFunctionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "4.56.0",
+					},
+				},
+				Config: testAccFunctionConfig_EmptyEnv_envVariables(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFunctionExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "environment.#", "0"),
+				),
+				// We know a persistent diff is present in this version
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccFunctionConfig_EmptyEnv_envVariables(rName),
+				ResourceName:             resourceName,
+				// Newer versions of the provider should suppress the diff without requiring an apply
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           true,
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccFunctionConfig_envVariables(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFunctionExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "environment.0.variables.foo", "bar"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccLambdaFunction_encryptedEnvVariables(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -2660,6 +2706,24 @@ resource "aws_lambda_function" "test" {
     variables = {
       foo = "bar"
     }
+  }
+}
+`, rName))
+}
+
+func testAccFunctionConfig_EmptyEnv_envVariables(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLambdaBase(rName, rName, rName),
+		fmt.Sprintf(`
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %[1]q
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "exports.example"
+  runtime       = "nodejs16.x"
+
+  environment {
+    variables = {}
   }
 }
 `, rName))


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
---> Resource wanted to repeatedly apply a change on an empty environment.variables. Now it will check that the variable is not empty before flattening.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
---> Closes #29255


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
> make testacc TESTARGS='-run=TestAccLambdaFunction_' PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20  -run=TestAccLambdaFunction_ -timeout 180m
=== RUN   TestAccLambdaFunction_basic
.......
--- PASS: TestAccLambdaFunction_VPCPublishHas_changes (2135.68s)
--- PASS: TestAccLambdaFunction_disappears (464.75s)
--- PASS: TestAccLambdaFunction_LocalUpdate_nameOnly (635.94s)
--- PASS: TestAccLambdaFunction_localUpdate (572.40s)
--- PASS: TestAccLambdaFunction_unpublishedCodeUpdate (538.12s)
--- PASS: TestAccLambdaFunction_VPC_replaceSGWithCustom (516.01s)
--- PASS: TestAccLambdaFunction_fileSystem (2193.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     2196.658s
...
```
