### PR TITLE
B aws s3 bucket lifecycle configuration object size greater than 0

### DIFF
--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -169,6 +169,42 @@ func TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan(t *testi
 	})
 }
 
+func TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+	currTime := time.Now()
+	date := time.Date(currTime.Year(), currTime.Month()+1, currTime.Day(), 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBucketLifecycleConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfigurationConfig_filterObjectSizeGreaterThan(rName, date, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(ctx, resourceName),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"expiration.#":                      "1",
+						"expiration.0.date":                 date,
+						"filter.#":                          "1",
+						"filter.0.object_size_greater_than": "0",
+						"id":                                rName,
+						"status":                            tfs3.LifecycleRuleStatusEnabled,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/s3/flex.go
+++ b/internal/service/s3/flex.go
@@ -238,7 +238,7 @@ func ExpandLifecycleRuleFilter(ctx context.Context, l []interface{}) *s3.Lifecyc
 		result.And = ExpandLifecycleRuleFilterAndOperator(ctx, v[0].(map[string]interface{}))
 	}
 
-	if v, null, _ := nullable.Int(m["object_size_greater_than"].(string)).Value(); !null && v > 0 {
+	if v, null, _ := nullable.Int(m["object_size_greater_than"].(string)).Value(); !null && v >= 0 {
 		result.ObjectSizeGreaterThan = aws.Int64(v)
 	}
 


### PR DESCRIPTION
TODO: Changelog entry

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
`object_size_greater_than` can be 0 which is also clear in multiple parts of the code. However by allowing nullable arguments it seems this case was eliminated.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Closes #0000
--->

Closes #28851

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

#### Run of added test case prior to fix
```
export TF_LOG="ERROR" && export AWS_DEFAULT_REGION="eu-west-1" && export AWS_PROFILE="not-important-for-pr" && make testacc TESTS=TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero'  -timeout 180m
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero
2023-03-08T08:38:20.261+0100 [ERROR] sdk.helper_resource: Unexpected error: test_terraform_path=/usr/local/bin/terraform test_working_directory=/var/folders/tc/sq57fdvx3lx0xs9qr364m0rw0000gn/T/plugintest1307187574 error="Check failed: Check 2/2 error: \"aws_s3_bucket_lifecycle_configuration.test\" no TypeSet element \"rule.*\", with nested attrs map[string]string{\"expiration.#\":\"1\", \"expiration.0.date\":\"2023-04-08T00:00:00Z\", \"filter.#\":\"1\", \"filter.0.object_size_greater_than\":\"0\", \"id\":\"tf-acc-test-8805275617291579268\", \"status\":\"Enabled\"} in state: map[string]string{\"%\":\"4\", \"bucket\":\"tf-acc-test-8805275617291579268\", \"expected_bucket_owner\":\"\", \"id\":\"tf-acc-test-8805275617291579268\", \"rule.#\":\"1\", \"rule.0.%\":\"9\", \"rule.0.abort_incomplete_multipart_upload.#\":\"0\", \"rule.0.expiration.#\":\"1\", \"rule.0.expiration.0.%\":\"3\", \"rule.0.expiration.0.date\":\"2023-04-08T00:00:00Z\", \"rule.0.expiration.0.days\":\"0\", \"rule.0.expiration.0.expired_object_delete_marker\":\"false\", \"rule.0.filter.#\":\"1\", \"rule.0.filter.0.%\":\"5\", \"rule.0.filter.0.and.#\":\"0\", \"rule.0.filter.0.object_size_greater_than\":\"\", \"rule.0.filter.0.object_size_less_than\":\"\", \"rule.0.filter.0.prefix\":\"\", \"rule.0.filter.0.tag.#\":\"0\", \"rule.0.id\":\"tf-acc-test-8805275617291579268\", \"rule.0.noncurrent_version_expiration.#\":\"0\", \"rule.0.noncurrent_version_transition.#\":\"0\", \"rule.0.prefix\":\"\", \"rule.0.status\":\"Enabled\", \"rule.0.transition.#\":\"0\"}" test_step_number=1 test_name=TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero
    bucket_lifecycle_configuration_test.go:179: Step 1/2 error: Check failed: Check 2/2 error: "aws_s3_bucket_lifecycle_configuration.test" no TypeSet element "rule.*", with nested attrs map[string]string{"expiration.#":"1", "expiration.0.date":"2023-04-08T00:00:00Z", "filter.#":"1", "filter.0.object_size_greater_than":"0", "id":"tf-acc-test-8805275617291579268", "status":"Enabled"} in state: map[string]string{"%":"4", "bucket":"tf-acc-test-8805275617291579268", "expected_bucket_owner":"", "id":"tf-acc-test-8805275617291579268", "rule.#":"1", "rule.0.%":"9", "rule.0.abort_incomplete_multipart_upload.#":"0", "rule.0.expiration.#":"1", "rule.0.expiration.0.%":"3", "rule.0.expiration.0.date":"2023-04-08T00:00:00Z", "rule.0.expiration.0.days":"0", "rule.0.expiration.0.expired_object_delete_marker":"false", "rule.0.filter.#":"1", "rule.0.filter.0.%":"5", "rule.0.filter.0.and.#":"0", "rule.0.filter.0.object_size_greater_than":"", "rule.0.filter.0.object_size_less_than":"", "rule.0.filter.0.prefix":"", "rule.0.filter.0.tag.#":"0", "rule.0.id":"tf-acc-test-8805275617291579268", "rule.0.noncurrent_version_expiration.#":"0", "rule.0.noncurrent_version_transition.#":"0", "rule.0.prefix":"", "rule.0.status":"Enabled", "rule.0.transition.#":"0"}
--- FAIL: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero (176.44s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/s3 178.432s
FAIL
make: *** [testacc] Error 1
```

#### Run of lifecycle test cases after fix

```
export TF_LOG="ERROR" && export AWS_DEFAULT_REGION="eu-west-1" && export AWS_PROFILE="not-important-for-pr" && make testacc TESTS=TestAccS3BucketLifecycleConfiguration PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketLifecycleConfiguration'  -timeout 180m
=== RUN   TestAccS3BucketLifecycleConfiguration_basic
=== PAUSE TestAccS3BucketLifecycleConfiguration_basic
=== RUN   TestAccS3BucketLifecycleConfiguration_disappears
=== PAUSE TestAccS3BucketLifecycleConfiguration_disappears
=== RUN   TestAccS3BucketLifecycleConfiguration_filterWithPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_filterWithPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_disableRule
=== PAUSE TestAccS3BucketLifecycleConfiguration_disableRule
=== RUN   TestAccS3BucketLifecycleConfiguration_multipleRules
=== PAUSE TestAccS3BucketLifecycleConfiguration_multipleRules
=== RUN   TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration
=== PAUSE TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration
=== RUN   TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition
=== PAUSE TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition
=== RUN   TestAccS3BucketLifecycleConfiguration_prefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_prefix
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_Tag
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_Tag
=== RUN   TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly
=== PAUSE TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly
=== RUN   TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock
=== PAUSE TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock
=== RUN   TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload
=== PAUSE TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions
=== PAUSE TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions
=== RUN   TestAccS3BucketLifecycleConfiguration_migrate_noChange
=== PAUSE TestAccS3BucketLifecycleConfiguration_migrate_noChange
=== RUN   TestAccS3BucketLifecycleConfiguration_migrate_withChange
=== PAUSE TestAccS3BucketLifecycleConfiguration_migrate_withChange
=== RUN   TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix
=== CONT  TestAccS3BucketLifecycleConfiguration_basic
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_Tag
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering
=== CONT  TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering
=== CONT  TestAccS3BucketLifecycleConfiguration_migrate_withChange
=== CONT  TestAccS3BucketLifecycleConfiguration_migrate_noChange
=== CONT  TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering
=== CONT  TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock
=== CONT  TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix
=== CONT  TestAccS3BucketLifecycleConfiguration_prefix
=== CONT  TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan
=== CONT  TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_migrate_noChange (224.80s)
=== CONT  TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_Tag (230.38s)
=== CONT  TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange (236.65s)
=== CONT  TestAccS3BucketLifecycleConfiguration_multipleRules
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering (237.89s)
=== CONT  TestAccS3BucketLifecycleConfiguration_disableRule
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (237.93s)
=== CONT  TestAccS3BucketLifecycleConfiguration_filterWithPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa (238.66s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan (238.77s)
=== CONT  TestAccS3BucketLifecycleConfiguration_disappears
--- PASS: TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions (238.97s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero (239.01s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock (239.88s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix (239.96s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering (240.26s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition (240.90s)
--- PASS: TestAccS3BucketLifecycleConfiguration_prefix (242.06s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering (242.25s)
--- PASS: TestAccS3BucketLifecycleConfiguration_migrate_withChange (243.30s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix (295.87s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disappears (60.90s)
--- PASS: TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload (321.92s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly (323.66s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering (373.02s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration (198.01s)
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix (196.12s)
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules (198.01s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan (210.16s)
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithPrefix (290.85s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disableRule (344.37s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	584.126s
```

