### PR TITLE
r/aws_elastic_beanstalk_configuration_template: Map `InvalidParameterValue: No Platform named ...` to NotFoundError

### DIFF
--- a/.changelog/29863.txt
+++ b/.changelog/29863.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elastic_beanstalk_configuration_template: Map errors like `InvalidParameterValue: No Platform named '...' found.` to `resource.NotFoundError` so `terraform refesh` correctly removes the resource from state
+```

--- a/internal/service/elasticbeanstalk/configuration_template.go
+++ b/internal/service/elasticbeanstalk/configuration_template.go
@@ -63,36 +63,32 @@ func resourceConfigurationTemplateCreate(ctx context.Context, d *schema.Resource
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElasticBeanstalkConn()
 
-	// Get the relevant properties
 	name := d.Get("name").(string)
-	appName := d.Get("application").(string)
-
-	optionSettings := gatherOptionSettings(d)
-
-	opts := elasticbeanstalk.CreateConfigurationTemplateInput{
-		ApplicationName: aws.String(appName),
+	input := &elasticbeanstalk.CreateConfigurationTemplateInput{
+		ApplicationName: aws.String(d.Get("application").(string)),
+		OptionSettings:  gatherOptionSettings(d),
 		TemplateName:    aws.String(name),
-		OptionSettings:  optionSettings,
 	}
 
 	if attr, ok := d.GetOk("description"); ok {
-		opts.Description = aws.String(attr.(string))
+		input.Description = aws.String(attr.(string))
 	}
 
 	if attr, ok := d.GetOk("environment_id"); ok {
-		opts.EnvironmentId = aws.String(attr.(string))
+		input.EnvironmentId = aws.String(attr.(string))
 	}
 
 	if attr, ok := d.GetOk("solution_stack_name"); ok {
-		opts.SolutionStackName = aws.String(attr.(string))
+		input.SolutionStackName = aws.String(attr.(string))
 	}
 
-	log.Printf("[DEBUG] Elastic Beanstalk configuration template create opts: %s", opts)
-	if _, err := conn.CreateConfigurationTemplateWithContext(ctx, &opts); err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating Elastic Beanstalk configuration template: %s", err)
+	output, err := conn.CreateConfigurationTemplateWithContext(ctx, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating Elastic Beanstalk Configuration Template (%s): %s", name, err)
 	}
 
-	d.SetId(name)
+	d.SetId(aws.StringValue(output.TemplateName))
 
 	return append(diags, resourceConfigurationTemplateRead(ctx, d, meta)...)
 }
@@ -125,44 +121,21 @@ func resourceConfigurationTemplateUpdate(ctx context.Context, d *schema.Resource
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElasticBeanstalkConn()
 
-	log.Printf("[DEBUG] Elastic Beanstalk configuration template update: %s", d.Get("name").(string))
-
 	if d.HasChange("description") {
-		if err := resourceConfigurationTemplateDescriptionUpdate(ctx, conn, d); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Elastic Beanstalk Configuration Template (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("setting") {
-		if err := resourceConfigurationTemplateOptionSettingsUpdate(ctx, conn, d); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Elastic Beanstalk Configuration Template (%s): %s", d.Id(), err)
-		}
-	}
-
-	return append(diags, resourceConfigurationTemplateRead(ctx, d, meta)...)
-}
-
-func resourceConfigurationTemplateDescriptionUpdate(ctx context.Context, conn *elasticbeanstalk.ElasticBeanstalk, d *schema.ResourceData) error {
-	_, err := conn.UpdateConfigurationTemplateWithContext(ctx, &elasticbeanstalk.UpdateConfigurationTemplateInput{
-		ApplicationName: aws.String(d.Get("application").(string)),
-		TemplateName:    aws.String(d.Get("name").(string)),
-		Description:     aws.String(d.Get("description").(string)),
-	})
-
-	return err
-}
-
-func resourceConfigurationTemplateOptionSettingsUpdate(ctx context.Context, conn *elasticbeanstalk.ElasticBeanstalk, d *schema.ResourceData) error {
-	if d.HasChange("setting") {
-		_, err := conn.ValidateConfigurationSettingsWithContext(ctx, &elasticbeanstalk.ValidateConfigurationSettingsInput{
+		input := &elasticbeanstalk.UpdateConfigurationTemplateInput{
 			ApplicationName: aws.String(d.Get("application").(string)),
-			TemplateName:    aws.String(d.Get("name").(string)),
-			OptionSettings:  gatherOptionSettings(d),
-		})
-		if err != nil {
-			return err
+			Description:     aws.String(d.Get("description").(string)),
+			TemplateName:    aws.String(d.Id()),
 		}
 
+		_, err := conn.UpdateConfigurationTemplateWithContext(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating Elastic Beanstalk Configuration Template (%s): %s", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("setting") {
 		o, n := d.GetChange("setting")
 		if o == nil {
 			o = new(schema.Set)
@@ -196,41 +169,43 @@ func resourceConfigurationTemplateOptionSettingsUpdate(ctx context.Context, conn
 			}
 		}
 
-		req := &elasticbeanstalk.UpdateConfigurationTemplateInput{
+		input := &elasticbeanstalk.UpdateConfigurationTemplateInput{
 			ApplicationName: aws.String(d.Get("application").(string)),
-			TemplateName:    aws.String(d.Get("name").(string)),
 			OptionSettings:  add,
+			TemplateName:    aws.String(d.Id()),
 		}
 
 		for _, elem := range remove {
-			req.OptionsToRemove = append(req.OptionsToRemove, &elasticbeanstalk.OptionSpecification{
+			input.OptionsToRemove = append(input.OptionsToRemove, &elasticbeanstalk.OptionSpecification{
 				Namespace:  elem.Namespace,
 				OptionName: elem.OptionName,
 			})
 		}
 
-		log.Printf("[DEBUG] Update Configuration Template request: %s", req)
-		if _, err := conn.UpdateConfigurationTemplateWithContext(ctx, req); err != nil {
-			return err
+		_, err := conn.UpdateConfigurationTemplateWithContext(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating Elastic Beanstalk Configuration Template (%s): %s", d.Id(), err)
 		}
 	}
 
-	return nil
+	return append(diags, resourceConfigurationTemplateRead(ctx, d, meta)...)
 }
 
 func resourceConfigurationTemplateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElasticBeanstalkConn()
 
-	application := d.Get("application").(string)
-
+	log.Printf("[INFO] Deleting Elastic Beanstalk Configuration Template: %s", d.Id())
 	_, err := conn.DeleteConfigurationTemplateWithContext(ctx, &elasticbeanstalk.DeleteConfigurationTemplateInput{
-		ApplicationName: aws.String(application),
+		ApplicationName: aws.String(d.Get("application").(string)),
 		TemplateName:    aws.String(d.Id()),
 	})
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting Elastic Beanstalk Configuration Template (%s): %s", d.Id(), err)
 	}
+
 	return diags
 }
 

--- a/internal/service/elasticbeanstalk/configuration_template.go
+++ b/internal/service/elasticbeanstalk/configuration_template.go
@@ -209,6 +209,10 @@ func resourceConfigurationTemplateDelete(ctx context.Context, d *schema.Resource
 	return diags
 }
 
+const (
+	errCodeInvalidParameterValue = "InvalidParameterValue"
+)
+
 func FindConfigurationSettingsByTwoPartKey(ctx context.Context, conn *elasticbeanstalk.ElasticBeanstalk, applicationName, templateName string) (*elasticbeanstalk.ConfigurationSettingsDescription, error) {
 	input := &elasticbeanstalk.DescribeConfigurationSettingsInput{
 		ApplicationName: aws.String(applicationName),
@@ -217,7 +221,7 @@ func FindConfigurationSettingsByTwoPartKey(ctx context.Context, conn *elasticbea
 
 	output, err := conn.DescribeConfigurationSettingsWithContext(ctx, input)
 
-	if tfawserr.ErrMessageContains(err, "InvalidParameterValue", "No Configuration Template named") || tfawserr.ErrMessageContains(err, "InvalidParameterValue", "No Application named") {
+	if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "No Configuration Template named") || tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "No Application named") || tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "No Platform named") {
 		return nil, &resource.NotFoundError{
 			LastError:   err,
 			LastRequest: input,

--- a/internal/service/elasticbeanstalk/configuration_template_test.go
+++ b/internal/service/elasticbeanstalk/configuration_template_test.go
@@ -61,6 +61,30 @@ func TestAccElasticBeanstalkConfigurationTemplate_disappears(t *testing.T) {
 	})
 }
 
+func TestAccElasticBeanstalkConfigurationTemplate_Disappears_application(t *testing.T) {
+	ctx := acctest.Context(t)
+	var config elasticbeanstalk.ConfigurationSettingsDescription
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_elastic_beanstalk_configuration_template.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, elasticbeanstalk.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConfigurationTemplateDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigurationTemplateConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationTemplateExists(ctx, resourceName, &config),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfelasticbeanstalk.ResourceApplication(), "aws_elastic_beanstalk_application.test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccElasticBeanstalkConfigurationTemplate_vpc(t *testing.T) {
 	ctx := acctest.Context(t)
 	var config elasticbeanstalk.ConfigurationSettingsDescription


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Maps errors like `InvalidParameterValue: No Platform named '...' found.` to `resource.NotFoundError` so `terraform refesh` correctly removes the resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/29856.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/1222.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/27991.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccElasticBeanstalkConfigurationTemplate_' PKG=elasticbeanstalk ACCTEST_PARALLELISM=3 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticbeanstalk/... -v -count 1 -parallel 3  -run=TestAccElasticBeanstalkConfigurationTemplate_ -timeout 180m
=== RUN   TestAccElasticBeanstalkConfigurationTemplate_basic
=== PAUSE TestAccElasticBeanstalkConfigurationTemplate_basic
=== RUN   TestAccElasticBeanstalkConfigurationTemplate_disappears
=== PAUSE TestAccElasticBeanstalkConfigurationTemplate_disappears
=== RUN   TestAccElasticBeanstalkConfigurationTemplate_Disappears_application
=== PAUSE TestAccElasticBeanstalkConfigurationTemplate_Disappears_application
=== RUN   TestAccElasticBeanstalkConfigurationTemplate_vpc
=== PAUSE TestAccElasticBeanstalkConfigurationTemplate_vpc
=== RUN   TestAccElasticBeanstalkConfigurationTemplate_settings
=== PAUSE TestAccElasticBeanstalkConfigurationTemplate_settings
=== CONT  TestAccElasticBeanstalkConfigurationTemplate_basic
=== CONT  TestAccElasticBeanstalkConfigurationTemplate_vpc
=== CONT  TestAccElasticBeanstalkConfigurationTemplate_Disappears_application
--- PASS: TestAccElasticBeanstalkConfigurationTemplate_Disappears_application (19.69s)
=== CONT  TestAccElasticBeanstalkConfigurationTemplate_disappears
--- PASS: TestAccElasticBeanstalkConfigurationTemplate_basic (21.55s)
=== CONT  TestAccElasticBeanstalkConfigurationTemplate_settings
--- PASS: TestAccElasticBeanstalkConfigurationTemplate_vpc (28.34s)
--- PASS: TestAccElasticBeanstalkConfigurationTemplate_disappears (21.62s)
--- PASS: TestAccElasticBeanstalkConfigurationTemplate_settings (22.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticbeanstalk	49.141s
```
