### PR TITLE
Fix OpenSearch dashboard endpoint 

### DIFF
--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -449,7 +449,7 @@ func ResourceDomain() *schema.Resource {
 				Optional: true,
 				Default:  "OpenSearch_1.1",
 			},
-			"kibana_endpoint": {
+			"dashboard_endpoint": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -848,14 +848,14 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 		endpoints := flex.PointersMapToStringList(ds.Endpoints)
 		d.Set("endpoint", endpoints["vpc"])
-		d.Set("kibana_endpoint", getKibanaEndpoint(d))
+		d.Set("dashboard_endpoint", getDashboardEndpoint(d))
 		if ds.Endpoint != nil {
 			return sdkdiag.AppendErrorf(diags, "%q: OpenSearch domain in VPC expected to have null Endpoint value", d.Id())
 		}
 	} else {
 		if ds.Endpoint != nil {
 			d.Set("endpoint", ds.Endpoint)
-			d.Set("kibana_endpoint", getKibanaEndpoint(d))
+			d.Set("dashboard_endpoint", getDashboardEndpoint(d))
 		}
 		if ds.Endpoints != nil {
 			return sdkdiag.AppendErrorf(diags, "%q: OpenSearch domain not in VPC expected to have null Endpoints value", d.Id())
@@ -1097,8 +1097,8 @@ func suppressEquivalentKMSKeyIDs(k, old, new string, d *schema.ResourceData) boo
 	return strings.Contains(old, new)
 }
 
-func getKibanaEndpoint(d *schema.ResourceData) string {
-	return d.Get("endpoint").(string) + "/_plugin/kibana/"
+func getDashboardEndpoint(d *schema.ResourceData) string {
+	return d.Get("endpoint").(string) + "/_dashboards"
 }
 
 func isDedicatedMasterDisabled(k, old, new string, d *schema.ResourceData) bool {

--- a/internal/service/opensearch/domain_data_source.go
+++ b/internal/service/opensearch/domain_data_source.go
@@ -109,7 +109,7 @@ func DataSourceDomain() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"kibana_endpoint": {
+			"dashboard_endpoint": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -386,7 +386,7 @@ func dataSourceDomainRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("arn", ds.ARN)
 	d.Set("domain_id", ds.DomainId)
 	d.Set("endpoint", ds.Endpoint)
-	d.Set("kibana_endpoint", getKibanaEndpoint(d))
+	d.Set("dashboard_endpoint", getDashboardEndpoint(d))
 
 	if err := d.Set("advanced_security_options", flattenAdvancedSecurityOptions(ds.AdvancedSecurityOptions)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting advanced_security_options: %s", err)
@@ -427,14 +427,14 @@ func dataSourceDomainRead(ctx context.Context, d *schema.ResourceData, meta inte
 		if err := d.Set("endpoint", endpoints["vpc"]); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting endpoint: %s", err)
 		}
-		d.Set("kibana_endpoint", getKibanaEndpoint(d))
+		d.Set("dashboard_endpoint", getDashboardEndpoint(d))
 		if ds.Endpoint != nil {
 			return sdkdiag.AppendErrorf(diags, "%q: OpenSearch domain in VPC expected to have null Endpoint value", d.Id())
 		}
 	} else {
 		if ds.Endpoint != nil {
 			d.Set("endpoint", ds.Endpoint)
-			d.Set("kibana_endpoint", getKibanaEndpoint(d))
+			d.Set("dashboard_endpoint", getDashboardEndpoint(d))
 		}
 		if ds.Endpoints != nil {
 			return sdkdiag.AppendErrorf(diags, "%q: OpenSearch domain not in VPC expected to have null Endpoints value", d.Id())

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -150,7 +150,7 @@ func TestAccOpenSearchDomain_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(ctx, resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "OpenSearch_1.1"),
-					resource.TestMatchResourceAttr(resourceName, "dashboard_endpoint", regexp.MustCompile(`.*(opensearch|es)\..*/_dashboards/`)),
+					resource.TestMatchResourceAttr(resourceName, "dashboard_endpoint", regexp.MustCompile(`.*(opensearch|es)\..*/_dashboards`)),
 					resource.TestCheckResourceAttr(resourceName, "vpc_options.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -150,7 +150,7 @@ func TestAccOpenSearchDomain_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(ctx, resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "OpenSearch_1.1"),
-					resource.TestMatchResourceAttr(resourceName, "kibana_endpoint", regexp.MustCompile(`.*(opensearch|es)\..*/_plugin/kibana/`)),
+					resource.TestMatchResourceAttr(resourceName, "dashboard_endpoint", regexp.MustCompile(`.*(opensearch|es)\..*/_dashboards/`)),
 					resource.TestCheckResourceAttr(resourceName, "vpc_options.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),

--- a/website/docs/d/opensearch_domain.html.markdown
+++ b/website/docs/d/opensearch_domain.html.markdown
@@ -57,7 +57,7 @@ The following attributes are exported:
     * `warm_enabled` - Warm storage is enabled.
     * `warm_count` - Number of warm nodes in the cluster.
     * `warm_type` - Instance type for the OpenSearch cluster's warm nodes.
-* `cognito_options` - Domain Amazon Cognito Authentication options for Kibana.
+* `cognito_options` - Domain Amazon Cognito Authentication options for Dashboard.
     * `enabled` - Whether Amazon Cognito Authentication is enabled.
     * `user_pool_id` - Cognito User pool used by the domain.
     * `identity_pool_id` - Cognito Identity pool used by the domain.
@@ -76,7 +76,7 @@ The following attributes are exported:
     * `enabled` - Whether encryption at rest is enabled in the domain.
     * `kms_key_id` - KMS key id used to encrypt data at rest.
 * `endpoint` – Domain-specific endpoint used to submit index, search, and data upload requests.
-* `kibana_endpoint` - Domain-specific endpoint used to access the Kibana application.
+* `dashboard_endpoint` - Domain-specific endpoint used to access the Dashboard application.
 * `log_publishing_options` - Domain log publishing related options.
     * `log_type` - Type of OpenSearch log being published.
     * `cloudwatch_log_group_arn` - CloudWatch Log Group where the logs are published.

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -322,7 +322,7 @@ The following arguments are optional:
 * `advanced_security_options` - (Optional) Configuration block for [fine-grained access control](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/fgac.html). Detailed below.
 * `auto_tune_options` - (Optional) Configuration block for the Auto-Tune options of the domain. Detailed below.
 * `cluster_config` - (Optional) Configuration block for the cluster of the domain. Detailed below.
-* `cognito_options` - (Optional) Configuration block for authenticating Kibana with Cognito. Detailed below.
+* `cognito_options` - (Optional) Configuration block for authenticating dashboard with Cognito. Detailed below.
 * `domain_endpoint_options` - (Optional) Configuration block for domain endpoint HTTP(S) related options. Detailed below.
 * `ebs_options` - (Optional) Configuration block for EBS related options, may be required based on chosen [instance size](https://aws.amazon.com/opensearch-service/pricing/). Detailed below.
 * `engine_version` - (Optional) Either `Elasticsearch_X.Y` or `OpenSearch_X.Y` to specify the engine version for the Amazon OpenSearch Service domain. For example, `OpenSearch_1.0` or `Elasticsearch_7.9`. See [Creating and managing Amazon OpenSearch Service domains](http://docs.aws.amazon.com/opensearch-service/latest/developerguide/createupdatedomains.html#createdomains). Defaults to `OpenSearch_1.1`.
@@ -387,9 +387,9 @@ The following arguments are optional:
 
 ### cognito_options
 
-AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/es-cognito-auth.html)
+AWS documentation: [Amazon Cognito Authentication for Dashboard](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/es-cognito-auth.html)
 
-* `enabled` - (Optional) Whether Amazon Cognito authentication with Kibana is enabled or not. Default is `false`.
+* `enabled` - (Optional) Whether Amazon Cognito authentication with Dashboard is enabled or not. Default is `false`.
 * `identity_pool_id` - (Required) ID of the Cognito Identity Pool to use.
 * `role_arn` - (Required) ARN of the IAM role that has the AmazonOpenSearchServiceCognitoAccess policy attached.
 * `user_pool_id` - (Required) ID of the Cognito User Pool to use.
@@ -452,7 +452,7 @@ In addition to all arguments above, the following attributes are exported:
 * `domain_id` - Unique identifier for the domain.
 * `domain_name` - Name of the OpenSearch domain.
 * `endpoint` - Domain-specific endpoint used to submit index, search, and data upload requests.
-* `kibana_endpoint` - Domain-specific endpoint for kibana without https scheme.
+* `dashboard_endpoint` - Domain-specific endpoint for Dashboard without https scheme.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `vpc_options.0.availability_zones` - If the domain was created inside a VPC, the names of the availability zones the configured `subnet_ids` were created inside.
 * `vpc_options.0.vpc_id` - If the domain was created inside a VPC, the ID of the VPC.


### PR DESCRIPTION
### Description
OpenSearch" does not use kibana endpoints `_plugin/kibana`.  
The URL is `domain-endpoint/_dashboards/`

### Relations

### References
https://docs.aws.amazon.com/opensearch-service/latest/developerguide/dashboards.html


### Output from Acceptance Testing
```
$ make testacc TESTS='TestAccOpenSearchDomain_basic' PKG=opensearch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchDomain_basic'  -timeout 180m
=== RUN   TestAccOpenSearchDomain_basic
=== PAUSE TestAccOpenSearchDomain_basic
=== CONT  TestAccOpenSearchDomain_basic
--- PASS: TestAccOpenSearchDomain_basic (1658.22s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 1660.304s

...
```
