### PR TITLE
aws_launch_template: Show safer example for `device_name`, and mark it as required

### DIFF
--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -17,7 +17,7 @@ resource "aws_launch_template" "foo" {
   name = "foo"
 
   block_device_mappings {
-    device_name = "/dev/sda1"
+    device_name = "/dev/sdf"
 
     ebs {
       volume_size = 20
@@ -168,7 +168,7 @@ To find out more information for an existing AMI to override the configuration, 
 
 Each `block_device_mappings` supports the following:
 
-* `device_name` - (Optional) The name of the device to mount.
+* `device_name` - (Required) The name of the device to mount.
 * `ebs` - (Optional) Configure EBS volume properties.
 * `no_device` - (Optional) Suppresses the specified device included in the AMI's block device mapping.
 * `virtual_name` - (Optional) The [Instance Store Device


### PR DESCRIPTION
### Description

`device_name` is apparently required in a `block_device_mappings` entry of a `aws_launch_template`.

`terraform validate` doesn't fail when it's missing but `apply` will come back with a HTTP 400 error. The [AWS documentation on Block Device Mappings](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html) also mentions it being required:

> When you create a block device mapping, you specify the following information for each block device that you need to attach to the instance:
> 
> * The device name used within Amazon EC2. The block device driver for the instance assigns the actual volume name when mounting the volume. The name assigned can be different from the name that Amazon EC2 recommends. For more information, see Device names on Linux instances.

The examples on the page all include `DeviceName`, also when `VirtualName` or `NoDevice` is used.

Secondly, the example in the Terraform document page shows `/dev/sda1` being used for the additional volume. Doing this can cause you to end up with unbootable instances, even if the root volume of the AMI is /dev/xvda (don't ask me how I know). Moreover, the web management console won't allow you to select `/dev/sda` when setting up a launch template.

According to
[Device names on Linux instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html), `/dev/sdf` is a safe choice for both HVM and Paravirtual instances.

### References

* https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
* https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html

### And then?

A next step I guess would be to fix the discrepancy between `validate` (no `device_name` is ok) and `apply` (API error when `device_name` is missing), by removing the `Optional: true` parameter at `device_name` in `ec2_launch_template.go`

At least, unless I'm missing something here. Are there legacy situations when no device name was allowed?
