### PR TITLE
Fix typo in r/aws_eks_cluster

### DIFF
--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -46,7 +46,7 @@ output "kubeconfig-certificate-authority-data" {
 
 ```terraform
 data "aws_iam_policy_document" "assume_role" {
-  satement {
+  statement {
     effect = "Allow"
 
     principals {


### PR DESCRIPTION
### Description

`satement` != `statement` 🙂  

### Relations

Closes #29886

### References

N/a, typo

### Output from Acceptance Testing

N/a, docs
