### PR TITLE
Fix typos related to policy rewrite

### DIFF
--- a/website/docs/r/appsync_datasource.html.markdown
+++ b/website/docs/r/appsync_datasource.html.markdown
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "example" {
 resource "aws_iam_role_policy" "example" {
   name   = "example"
   role   = aws_iam_role.example.id
-  policy = data.aws_iam_role_policy.example.json
+  policy = data.aws_iam_policy_document.example.json
 }
 
 resource "aws_appsync_graphql_api" "example" {

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -103,7 +103,7 @@ data "aws_iam_policy_document" "example" {
 
 resource "aws_iam_role_policy" "example" {
   role   = aws_iam_role.example.name
-  policy = data.aws_iam_role_policy.example.json
+  policy = data.aws_iam_policy_document.example.json
 }
 
 resource "aws_codebuild_project" "example" {

--- a/website/docs/r/iam_policy_attachment.html.markdown
+++ b/website/docs/r/iam_policy_attachment.html.markdown
@@ -56,7 +56,7 @@ data "aws_iam_policy_document" "policy" {
 resource "aws_iam_policy" "policy" {
   name        = "test-policy"
   description = "A test policy"
-  policy      = data.aws_iam_policy.policy.json
+  policy      = data.aws_iam_policy_document.policy.json
 }
 
 resource "aws_iam_policy_attachment" "test-attach" {


### PR DESCRIPTION
### Description

This PR fixes a few more typos that were introduced in the recent large rewriting of IAM policies switching away from heredoc format.


### Relations

Closes #29872
Closes #29858
Closes #29855

### References

#29360
#29354
#29356

### Output from Acceptance Testing

N/a, docs
