### PR TITLE
resource/aws_cloudwatch_metric_alarm: Add `period` to `metric_query` block

### DIFF
--- a/.changelog/29896.txt
+++ b/.changelog/29896.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_cloudwatch_metric_alarm: Add `period` parameter to `metric_query`
+```
+
+```release-note:enhancement
+resource/aws_cloudwatch_metric_alarm: Add validation to `period` parameter of `metric_query.metric`
+```

--- a/internal/service/cloudwatch/metric_alarm.go
+++ b/internal/service/cloudwatch/metric_alarm.go
@@ -113,6 +113,10 @@ func ResourceMetricAlarm() *schema.Resource {
 									"period": {
 										Type:     schema.TypeInt,
 										Required: true,
+										ValidateFunc: validation.Any(
+											validation.IntInSlice([]int{1, 5, 10, 30}),
+											validation.IntDivisibleBy(60),
+										),
 									},
 									"stat": {
 										Type:     schema.TypeString,
@@ -137,6 +141,14 @@ func ResourceMetricAlarm() *schema.Resource {
 						"label": {
 							Type:     schema.TypeString,
 							Optional: true,
+						},
+						"period": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ValidateFunc: validation.Any(
+								validation.IntInSlice([]int{1, 5, 10, 30}),
+								validation.IntDivisibleBy(60),
+							),
 						},
 						"return_data": {
 							Type:     schema.TypeBool,
@@ -611,6 +623,9 @@ func flattenMetricAlarmMetrics(metrics []*cloudwatch.MetricDataQuery) []map[stri
 			metric := flattenMetricAlarmMetricsMetricStat(mq.MetricStat)
 			metricQuery["metric"] = []interface{}{metric}
 		}
+		if mq.Period != nil {
+			metricQuery["period"] = aws.Int64Value(mq.Period)
+		}
 		metricQueries = append(metricQueries, metricQuery)
 	}
 
@@ -654,6 +669,9 @@ func expandMetricAlarmMetrics(v *schema.Set) []*cloudwatch.MetricDataQuery {
 		}
 		if v := metricQueryResource["metric"]; v != nil && len(v.([]interface{})) > 0 {
 			metricQuery.MetricStat = expandMetricAlarmMetricsMetric(v.([]interface{}))
+		}
+		if v, ok := metricQueryResource["period"]; ok && v.(int) != 0 {
+			metricQuery.Period = aws.Int64(int64(v.(int)))
 		}
 		if v, ok := metricQueryResource["account_id"]; ok && v.(string) != "" {
 			metricQuery.AccountId = aws.String(v.(string))

--- a/internal/service/cloudwatch/metric_alarm_test.go
+++ b/internal/service/cloudwatch/metric_alarm_test.go
@@ -30,7 +30,7 @@ func TestAccCloudWatchMetricAlarm_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetricAlarmConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "metric_name", "CPUUtilization"),
 					resource.TestCheckResourceAttr(resourceName, "statistic", "Average"),
@@ -72,7 +72,7 @@ func TestAccCloudWatchMetricAlarm_AlarmActions_ec2Automate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetricAlarmConfig_actionsEC2Automate(rName, "reboot"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "1"),
 				),
@@ -84,21 +84,21 @@ func TestAccCloudWatchMetricAlarm_AlarmActions_ec2Automate(t *testing.T) {
 			},
 			{
 				Config: testAccMetricAlarmConfig_actionsEC2Automate(rName, "recover"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "1"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_actionsEC2Automate(rName, "stop"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "1"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_actionsEC2Automate(rName, "terminate"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "1"),
 				),
@@ -121,7 +121,7 @@ func TestAccCloudWatchMetricAlarm_AlarmActions_snsTopic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetricAlarmConfig_actionsSNSTopic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "1"),
 				),
@@ -149,7 +149,7 @@ func TestAccCloudWatchMetricAlarm_AlarmActions_swfAction(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetricAlarmConfig_actionsSWFAction(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "1"),
 				),
@@ -177,7 +177,7 @@ func TestAccCloudWatchMetricAlarm_dataPointsToAlarm(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetricAlarmConfig_datapointsTo(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "datapoints_to_alarm", "2"),
 				),
@@ -200,21 +200,21 @@ func TestAccCloudWatchMetricAlarm_treatMissingData(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetricAlarmConfig_treatMissingData(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "treat_missing_data", "missing"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_treatMissingDataUpdate(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "treat_missing_data", "breaching"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_treatMissingDataNoAttr(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "treat_missing_data", "missing"),
 				),
@@ -242,14 +242,14 @@ func TestAccCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles(t *testing.T
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetricAlarmConfig_treatEvaluateLowSampleCountPercentiles(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "evaluate_low_sample_count_percentiles", "evaluate"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_treatEvaluateLowSampleCountPercentilesUpdated(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "evaluate_low_sample_count_percentiles", "ignore"),
 				),
@@ -304,105 +304,105 @@ func TestAccCloudWatchMetricAlarm_extendedStatistic(t *testing.T) {
 			},
 			{
 				Config: testAccMetricAlarmConfig_extendedStatistic(rName, "p88.0"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "p88.0"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_extendedStatistic(rName, "p0.0"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "p0.0"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_extendedStatistic(rName, "p100"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "p100"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_extendedStatistic(rName, "p95"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "p95"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_extendedStatistic(rName, "tm90"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "tm90"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_extendedStatistic(rName, "TM(2%:98%)"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "TM(2%:98%)"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_extendedStatistic(rName, "TM(150:1000)"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "TM(150:1000)"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_extendedStatistic(rName, "IQM"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "IQM"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_extendedStatistic(rName, "wm98"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "wm98"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_extendedStatistic(rName, "PR(:300)"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "PR(:300)"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_extendedStatistic(rName, "PR(100:2000)"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "PR(100:2000)"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_extendedStatistic(rName, "tc90"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "tc90"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_extendedStatistic(rName, "TC(0.005:0.030)"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "TC(0.005:0.030)"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_extendedStatistic(rName, "TS(80%:)"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "TS(80%:)"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_extendedStatistic(rName, "TC(:0.5)"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "extended_statistic", "TC(:0.5)"),
 				),
@@ -429,35 +429,35 @@ func TestAccCloudWatchMetricAlarm_metricQuery(t *testing.T) {
 			},
 			{
 				Config: testAccMetricAlarmConfig_metricQueryExpressionReference(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "metric_query.#", "2"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_metricQueryCrossAccount(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttrPair(resourceName, "metric_query.0.account_id", "data.aws_caller_identity.current", "account_id"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_metricQueryExpressionReferenceUpdated(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "metric_query.#", "3"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_metricQueryExpressionReference(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "metric_query.#", "2"),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_anomalyDetectionExpression(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "metric_query.#", "2"),
 				),
@@ -502,7 +502,7 @@ func TestAccCloudWatchMetricAlarm_tags(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetricAlarmConfig_tags1(rName, "key1", "value1"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
@@ -515,7 +515,7 @@ func TestAccCloudWatchMetricAlarm_tags(t *testing.T) {
 			},
 			{
 				Config: testAccMetricAlarmConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
@@ -524,7 +524,7 @@ func TestAccCloudWatchMetricAlarm_tags(t *testing.T) {
 			},
 			{
 				Config: testAccMetricAlarmConfig_tags1(rName, "key2", "value2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -548,7 +548,7 @@ func TestAccCloudWatchMetricAlarm_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetricAlarmConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfcloudwatch.ResourceMetricAlarm(), resourceName),
 				),

--- a/internal/service/cloudwatch/metric_alarm_test.go
+++ b/internal/service/cloudwatch/metric_alarm_test.go
@@ -432,12 +432,31 @@ func TestAccCloudWatchMetricAlarm_metricQuery(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "metric_query.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "metric_query.*", map[string]string{
+						"id":          "e1",
+						"expression":  "m1",
+						"label":       "cat",
+						"return_data": "true",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "metric_query.*", map[string]string{
+						"id":                             "m1",
+						"metric.#":                       "1",
+						"metric.0.metric_name":           "CPUUtilization",
+						"metric.0.namespace":             "AWS/EC2",
+						"metric.0.period":                "120",
+						"metric.0.stat":                  "Average",
+						"metric.0.unit":                  "Count",
+						"metric.0.dimensions.%":          "1",
+						"metric.0.dimensions.InstanceId": "i-abc123",
+					}),
 				),
 			},
 			{
 				Config: testAccMetricAlarmConfig_metricQueryCrossAccount(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "metric_query.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metric_query.0.id", "m1"),
 					resource.TestCheckResourceAttrPair(resourceName, "metric_query.0.account_id", "data.aws_caller_identity.current", "account_id"),
 				),
 			},
@@ -446,6 +465,18 @@ func TestAccCloudWatchMetricAlarm_metricQuery(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "metric_query.#", "3"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "metric_query.*", map[string]string{
+						"id":          "e1",
+						"expression":  "m1",
+						"label":       "cat",
+						"return_data": "",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "metric_query.*", map[string]string{
+						"id":          "e2",
+						"expression":  "e1",
+						"label":       "bug",
+						"return_data": "true",
+					}),
 				),
 			},
 			{
@@ -460,6 +491,12 @@ func TestAccCloudWatchMetricAlarm_metricQuery(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMetricAlarmExists(ctx, resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "metric_query.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "metric_query.*", map[string]string{
+						"id":          "e1",
+						"expression":  "ANOMALY_DETECTION_BAND(m1)",
+						"label":       "CPUUtilization (Expected)",
+						"return_data": "true",
+					}),
 				),
 			},
 			{

--- a/internal/service/cloudwatch/metric_alarm_test.go
+++ b/internal/service/cloudwatch/metric_alarm_test.go
@@ -612,12 +612,12 @@ func testAccMetricAlarmConfig_basic(rName string) string {
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = "%s"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
+  evaluation_periods        = 2
   metric_name               = "CPUUtilization"
   namespace                 = "AWS/EC2"
-  period                    = "120"
+  period                    = 120
   statistic                 = "Average"
-  threshold                 = "80"
+  threshold                 = 80
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
 
@@ -633,13 +633,13 @@ func testAccMetricAlarmConfig_datapointsTo(rName string) string {
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = "%s"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
-  datapoints_to_alarm       = "2"
-  evaluation_periods        = "2"
+  datapoints_to_alarm       = 2
+  evaluation_periods        = 2
   metric_name               = "CPUUtilization"
   namespace                 = "AWS/EC2"
-  period                    = "120"
+  period                    = 120
   statistic                 = "Average"
-  threshold                 = "80"
+  threshold                 = 80
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
 
@@ -655,12 +655,12 @@ func testAccMetricAlarmConfig_treatMissingData(rName string) string {
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = "%s"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
+  evaluation_periods        = 2
   metric_name               = "CPUUtilization"
   namespace                 = "AWS/EC2"
-  period                    = "120"
+  period                    = 120
   statistic                 = "Average"
-  threshold                 = "80"
+  threshold                 = 80
   alarm_description         = "This metric monitors ec2 cpu utilization"
   treat_missing_data        = "missing"
   insufficient_data_actions = []
@@ -677,12 +677,12 @@ func testAccMetricAlarmConfig_treatMissingDataUpdate(rName string) string {
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = "%s"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
+  evaluation_periods        = 2
   metric_name               = "CPUUtilization"
   namespace                 = "AWS/EC2"
-  period                    = "120"
+  period                    = 120
   statistic                 = "Average"
-  threshold                 = "80"
+  threshold                 = 80
   alarm_description         = "This metric monitors ec2 cpu utilization"
   treat_missing_data        = "breaching"
   insufficient_data_actions = []
@@ -699,12 +699,12 @@ func testAccMetricAlarmConfig_treatMissingDataNoAttr(rName string) string {
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = "%s"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
+  evaluation_periods        = 2
   metric_name               = "CPUUtilization"
   namespace                 = "AWS/EC2"
-  period                    = "120"
+  period                    = 120
   statistic                 = "Average"
-  threshold                 = "80"
+  threshold                 = 80
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
 
@@ -720,12 +720,12 @@ func testAccMetricAlarmConfig_treatEvaluateLowSampleCountPercentiles(rName strin
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                            = "%s"
   comparison_operator                   = "GreaterThanOrEqualToThreshold"
-  evaluation_periods                    = "2"
+  evaluation_periods                    = 2
   metric_name                           = "CPUUtilization"
   namespace                             = "AWS/EC2"
-  period                                = "120"
+  period                                = 120
   extended_statistic                    = "p88.0"
-  threshold                             = "80"
+  threshold                             = 80
   alarm_description                     = "This metric monitors ec2 cpu utilization"
   evaluate_low_sample_count_percentiles = "evaluate"
   insufficient_data_actions             = []
@@ -742,12 +742,12 @@ func testAccMetricAlarmConfig_treatEvaluateLowSampleCountPercentilesUpdated(rNam
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                            = "%s"
   comparison_operator                   = "GreaterThanOrEqualToThreshold"
-  evaluation_periods                    = "2"
+  evaluation_periods                    = 2
   metric_name                           = "CPUUtilization"
   namespace                             = "AWS/EC2"
-  period                                = "120"
+  period                                = 120
   extended_statistic                    = "p88.0"
-  threshold                             = "80"
+  threshold                             = 80
   alarm_description                     = "This metric monitors ec2 cpu utilization"
   evaluate_low_sample_count_percentiles = "ignore"
   insufficient_data_actions             = []
@@ -764,12 +764,12 @@ func testAccMetricAlarmConfig_extendedStatistic(rName string, stat string) strin
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = "%s"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
+  evaluation_periods        = 2
   metric_name               = "CPUUtilization"
   namespace                 = "AWS/EC2"
-  period                    = "120"
+  period                    = 120
   extended_statistic        = "%s"
-  threshold                 = "80"
+  threshold                 = 80
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
 
@@ -785,11 +785,11 @@ func testAccMetricAlarmConfig_missingStatistic(rName string) string {
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = "%s"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
+  evaluation_periods        = 2
   metric_name               = "CPUUtilization"
   namespace                 = "AWS/EC2"
-  period                    = "120"
-  threshold                 = "80"
+  period                    = 120
+  threshold                 = 80
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
 
@@ -805,8 +805,8 @@ func testAccMetricAlarmConfig_expression(rName string) string {
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = "%s"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
-  threshold                 = "80"
+  evaluation_periods        = 2
+  threshold                 = 80
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
 
@@ -814,7 +814,7 @@ resource "aws_cloudwatch_metric_alarm" "test" {
     id          = "e1"
     expression  = "m1"
     label       = "cat"
-    return_data = "true"
+    return_data = true
   }
 
   metric_query {
@@ -823,7 +823,7 @@ resource "aws_cloudwatch_metric_alarm" "test" {
     metric {
       metric_name = "CPUUtilization"
       namespace   = "AWS/EC2"
-      period      = "120"
+      period      = 120
       stat        = "Average"
       unit        = "Count"
 
@@ -843,20 +843,20 @@ data "aws_caller_identity" "current" {}
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = "%s"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
-  threshold                 = "80"
+  evaluation_periods        = 2
+  threshold                 = 80
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
 
   metric_query {
     id          = "m1"
     account_id  = data.aws_caller_identity.current.account_id
-    return_data = "true"
+    return_data = true
 
     metric {
       metric_name = "CPUUtilization"
       namespace   = "AWS/EC2"
-      period      = "120"
+      period      = 120
       stat        = "Average"
       unit        = "Count"
 
@@ -874,7 +874,7 @@ func testAccMetricAlarmConfig_anomalyDetectionExpression(rName string) string {
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = "%s"
   comparison_operator       = "GreaterThanUpperThreshold"
-  evaluation_periods        = "2"
+  evaluation_periods        = 2
   threshold_metric_id       = "e1"
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
@@ -883,17 +883,17 @@ resource "aws_cloudwatch_metric_alarm" "test" {
     id          = "e1"
     expression  = "ANOMALY_DETECTION_BAND(m1)"
     label       = "CPUUtilization (Expected)"
-    return_data = "true"
+    return_data = true
   }
 
   metric_query {
     id          = "m1"
-    return_data = "true"
+    return_data = true
 
     metric {
       metric_name = "CPUUtilization"
       namespace   = "AWS/EC2"
-      period      = "120"
+      period      = 120
       stat        = "Average"
       unit        = "Count"
 
@@ -911,8 +911,8 @@ func testAccMetricAlarmConfig_expressionUpdated(rName string) string {
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = "%s"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
-  threshold                 = "80"
+  evaluation_periods        = 2
+  threshold                 = 80
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
 
@@ -926,7 +926,7 @@ resource "aws_cloudwatch_metric_alarm" "test" {
     id          = "e2"
     expression  = "e1"
     label       = "bug"
-    return_data = "true"
+    return_data = true
   }
 
   metric_query {
@@ -935,7 +935,7 @@ resource "aws_cloudwatch_metric_alarm" "test" {
     metric {
       metric_name = "CPUUtilization"
       namespace   = "AWS/EC2"
-      period      = "120"
+      period      = 120
       stat        = "p95.45"
       unit        = "Count"
 
@@ -953,8 +953,8 @@ func testAccMetricAlarmConfig_expressionQueryUpdated(rName string) string {
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = "%s"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
-  threshold                 = "80"
+  evaluation_periods        = 2
+  threshold                 = 80
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
 
@@ -962,7 +962,7 @@ resource "aws_cloudwatch_metric_alarm" "test" {
     id          = "e1"
     expression  = "m1"
     label       = "cat"
-    return_data = "true"
+    return_data = true
   }
 
   metric_query {
@@ -971,7 +971,7 @@ resource "aws_cloudwatch_metric_alarm" "test" {
     metric {
       metric_name = "CPUUtilization"
       namespace   = "AWS/EC2"
-      period      = "120"
+      period      = 120
       stat        = "Maximum"
       unit        = "Count"
 
@@ -989,8 +989,8 @@ func testAccMetricAlarmConfig_badExpression(rName string) string {
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = "%s"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
-  threshold                 = "80"
+  evaluation_periods        = 2
+  threshold                 = 80
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
 
@@ -1002,7 +1002,7 @@ resource "aws_cloudwatch_metric_alarm" "test" {
     metric {
       metric_name = "CPUUtilization"
       namespace   = "AWS/EC2"
-      period      = "120"
+      period      = 120
       stat        = "Average"
       unit        = "Count"
 
@@ -1058,12 +1058,12 @@ resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_description   = "Status checks have failed for system"
   alarm_name          = %[1]q
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "2"
+  evaluation_periods  = 2
   metric_name         = "StatusCheckFailed_System"
   namespace           = "AWS/EC2"
-  period              = "60"
+  period              = 60
   statistic           = "Minimum"
-  threshold           = "0"
+  threshold           = 0
   unit                = "Count"
 
   dimensions = {
@@ -1084,12 +1084,12 @@ resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_description   = "Status checks have failed for system"
   alarm_name          = %q
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "2"
+  evaluation_periods  = 2
   metric_name         = "StatusCheckFailed_System"
   namespace           = "AWS/EC2"
-  period              = "60"
+  period              = 60
   statistic           = "Minimum"
-  threshold           = "0"
+  threshold           = 0
   unit                = "Count"
 
   dimensions = {
@@ -1115,12 +1115,12 @@ resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_description   = "Status checks have failed, rebooting system."
   alarm_name          = %q
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "5"
+  evaluation_periods  = 5
   metric_name         = "StatusCheckFailed_Instance"
   namespace           = "AWS/EC2"
-  period              = "60"
+  period              = 60
   statistic           = "Minimum"
-  threshold           = "0"
+  threshold           = 0
   unit                = "Count"
 
   dimensions = {
@@ -1135,12 +1135,12 @@ func testAccMetricAlarmConfig_tags1(rName, tagKey1, tagValue1 string) string {
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = %[1]q
   comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
+  evaluation_periods        = 2
   metric_name               = "CPUUtilization"
   namespace                 = "AWS/EC2"
-  period                    = "120"
+  period                    = 120
   statistic                 = "Average"
-  threshold                 = "80"
+  threshold                 = 80
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
 
@@ -1160,12 +1160,12 @@ func testAccMetricAlarmConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue
 resource "aws_cloudwatch_metric_alarm" "test" {
   alarm_name                = %[1]q
   comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
+  evaluation_periods        = 2
   metric_name               = "CPUUtilization"
   namespace                 = "AWS/EC2"
-  period                    = "120"
+  period                    = 120
   statistic                 = "Average"
-  threshold                 = "80"
+  threshold                 = 80
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
 

--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -16,12 +16,12 @@ Provides a CloudWatch Metric Alarm resource.
 resource "aws_cloudwatch_metric_alarm" "foobar" {
   alarm_name                = "terraform-test-foobar5"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
+  evaluation_periods        = 2
   metric_name               = "CPUUtilization"
   namespace                 = "AWS/EC2"
-  period                    = "120"
+  period                    = 120
   statistic                 = "Average"
-  threshold                 = "80"
+  threshold                 = 80
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
 }
@@ -41,12 +41,12 @@ resource "aws_autoscaling_policy" "bat" {
 resource "aws_cloudwatch_metric_alarm" "bat" {
   alarm_name          = "terraform-test-foobar5"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "2"
+  evaluation_periods  = 2
   metric_name         = "CPUUtilization"
   namespace           = "AWS/EC2"
-  period              = "120"
+  period              = 120
   statistic           = "Average"
-  threshold           = "80"
+  threshold           = 80
 
   dimensions = {
     AutoScalingGroupName = aws_autoscaling_group.bar.name
@@ -63,8 +63,8 @@ resource "aws_cloudwatch_metric_alarm" "bat" {
 resource "aws_cloudwatch_metric_alarm" "foobar" {
   alarm_name                = "terraform-test-foobar"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
-  threshold                 = "10"
+  evaluation_periods        = 2
+  threshold                 = 10
   alarm_description         = "Request error rate has exceeded 10%"
   insufficient_data_actions = []
 
@@ -81,7 +81,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
     metric {
       metric_name = "RequestCount"
       namespace   = "AWS/ApplicationELB"
-      period      = "120"
+      period      = 120
       stat        = "Sum"
       unit        = "Count"
 
@@ -97,7 +97,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
     metric {
       metric_name = "HTTPCode_ELB_5XX_Count"
       namespace   = "AWS/ApplicationELB"
-      period      = "120"
+      period      = 120
       stat        = "Sum"
       unit        = "Count"
 
@@ -113,7 +113,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
 resource "aws_cloudwatch_metric_alarm" "xx_anomaly_detection" {
   alarm_name                = "terraform-test-foobar"
   comparison_operator       = "GreaterThanUpperThreshold"
-  evaluation_periods        = "2"
+  evaluation_periods        = 2
   threshold_metric_id       = "e1"
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
@@ -131,7 +131,7 @@ resource "aws_cloudwatch_metric_alarm" "xx_anomaly_detection" {
     metric {
       metric_name = "CPUUtilization"
       namespace   = "AWS/EC2"
-      period      = "120"
+      period      = 120
       stat        = "Average"
       unit        = "Count"
 
@@ -149,10 +149,10 @@ resource "aws_cloudwatch_metric_alarm" "xx_anomaly_detection" {
 resource "aws_cloudwatch_metric_alarm" "nlb_healthyhosts" {
   alarm_name          = "alarmname"
   comparison_operator = "LessThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = 1
   metric_name         = "HealthyHostCount"
   namespace           = "AWS/NetworkELB"
-  period              = "60"
+  period              = 60
   statistic           = "Average"
   threshold           = var.logstash_servers_count
   alarm_description   = "Number of healthy nodes in Target Group"

--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -184,6 +184,7 @@ The following arguments are supported:
 * `namespace` - (Optional) The namespace for the alarm's associated metric. See docs for the [list of namespaces](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/aws-namespaces.html).
   See docs for [supported metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html).
 * `period` - (Optional) The period in seconds over which the specified `statistic` is applied.
+  Valid values are `10`, `30`, or any multiple of `60`.
 * `statistic` - (Optional) The statistic to apply to the alarm's associated metric.
    Either of the following is supported: `SampleCount`, `Average`, `Sum`, `Minimum`, `Maximum`
 * `threshold` - (Optional) The value against which the specified statistic is compared. This parameter is required for alarms based on static thresholds, but should not be used for alarms based on anomaly detection models.
@@ -198,11 +199,9 @@ The following arguments are supported:
 * `unit` - (Optional) The unit for the alarm's associated metric.
 * `extended_statistic` - (Optional) The percentile statistic for the metric associated with the alarm. Specify a value between p0.0 and p100.
 * `treat_missing_data` - (Optional) Sets how this alarm is to handle missing data points. The following values are supported: `missing`, `ignore`, `breaching` and `notBreaching`. Defaults to `missing`.
-* `evaluate_low_sample_count_percentiles` - (Optional) Used only for alarms
-based on percentiles. If you specify `ignore`, the alarm state will not
-change during periods with too few data points to be statistically significant.
-If you specify `evaluate` or omit this parameter, the alarm will always be
-evaluated and possibly change state no matter how many data points are available.
+* `evaluate_low_sample_count_percentiles` - (Optional) Used only for alarms based on percentiles.
+  If you specify `ignore`, the alarm state will not change during periods with too few data points to be statistically significant.
+  If you specify `evaluate` or omit this parameter, the alarm will always be evaluated and possibly change state no matter how many data points are available.
 The following values are supported: `ignore`, and `evaluate`.
 * `metric_query` (Optional) Enables you to create an alarm based on a metric math expression. You may specify at most 20.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
@@ -217,8 +216,11 @@ The following values are supported: `ignore`, and `evaluate`.
 * `account_id` - (Optional) The ID of the account where the metrics are located, if this is a cross-account alarm.
 * `expression` - (Optional) The math expression to be performed on the returned data, if this object is performing a math expression. This expression can use the id of the other metrics to refer to those metrics, and can also use the id of other expressions to use the result of those expressions. For more information about metric math expressions, see Metric Math Syntax and Functions in the [Amazon CloudWatch User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html#metric-math-syntax).
 * `label` - (Optional) A human-readable label for this metric or expression. This is especially useful if this is an expression, so that you know what the value represents.
-* `return_data` (Optional) Specify exactly one `metric_query` to be `true` to use that `metric_query` result as the alarm.
-* `metric` (Optional) The metric to be returned, along with statistics, period, and units. Use this parameter only if this object is retrieving a metric and not performing a math expression on returned data.
+* `metric` - (Optional) The metric to be returned, along with statistics, period, and units. Use this parameter only if this object is retrieving a metric and not performing a math expression on returned data.
+* `period` - (Optional) Granularity in seconds of returned data points.
+  For metrics with regular resolution, valid values are any multiple of `60`.
+  For high-resolution metrics, valid values are `1`, `5`, `10`, `30`, or any multiple of `60`.
+* `return_data` - (Optional) Specify exactly one `metric_query` to be `true` to use that `metric_query` result as the alarm.
 
 ~> **NOTE:**  You must specify either `metric` or `expression`. Not both.
 
@@ -229,7 +231,9 @@ The following values are supported: `ignore`, and `evaluate`.
   See docs for [supported metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html).
 * `namespace` - (Required) The namespace for this metric. See docs for the [list of namespaces](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/aws-namespaces.html).
   See docs for [supported metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html).
-* `period` - (Required) The period in seconds over which the specified `stat` is applied.
+* `period` - (Required) Granularity in seconds of returned data points.
+  For metrics with regular resolution, valid values are any multiple of `60`.
+  For high-resolution metrics, valid values are `1`, `5`, `10`, `30`, or any multiple of `60`.
 * `stat` - (Required) The statistic to apply to this metric.
    See docs for [supported statistics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html).
 * `unit` - (Optional) The unit for this metric.


### PR DESCRIPTION
### Description

Adds missing `period` parameter to `metric_query` block.

Also adds validation to `metric_query.metric.period`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29398.
Closes #28617.
Closes https://github.com/hashicorp/terraform-provider-aws/pull/28547.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=cloudwatch TESTS=TestAccCloudWatchMetricAlarm_

--- PASS: TestAccCloudWatchMetricAlarm_missingStatistic (8.67s)
--- PASS: TestAccCloudWatchMetricAlarm_disappears (17.45s)
--- PASS: TestAccCloudWatchMetricAlarm_dataPointsToAlarm (19.02s)
--- PASS: TestAccCloudWatchMetricAlarm_basic (23.23s)
--- PASS: TestAccCloudWatchMetricAlarm_AlarmActions_swfAction (23.46s)
--- PASS: TestAccCloudWatchMetricAlarm_AlarmActions_snsTopic (23.51s)
--- PASS: TestAccCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles (30.60s)
--- PASS: TestAccCloudWatchMetricAlarm_treatMissingData (42.59s)
--- PASS: TestAccCloudWatchMetricAlarm_tags (42.77s)
--- PASS: TestAccCloudWatchMetricAlarm_metricQuery (143.82s)
--- PASS: TestAccCloudWatchMetricAlarm_AlarmActions_ec2Automate (177.82s)
--- PASS: TestAccCloudWatchMetricAlarm_extendedStatistic (270.39s)
```
