### PR TITLE
Fix aws_lightsail_instance name validation

### DIFF
--- a/.changelog/29903.txt
+++ b/.changelog/29903.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lightsail_instance: Fix `name` validation to allow instances to start with a numeric character
+```

--- a/internal/service/lightsail/instance.go
+++ b/internal/service/lightsail/instance.go
@@ -62,7 +62,7 @@ func ResourceInstance() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(2, 255),
-					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]`), "must begin with an alphabetic character"),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9]`), "must begin with an alphanumeric character"),
 					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]+[^._\-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
 				),
 			},

--- a/internal/service/lightsail/instance_test.go
+++ b/internal/service/lightsail/instance_test.go
@@ -58,6 +58,7 @@ func TestAccLightsailInstance_name(t *testing.T) {
 	resourceName := "aws_lightsail_instance.test"
 	rNameWithSpaces := fmt.Sprint(rName, "string with spaces")
 	rNameWithStartingDigit := fmt.Sprintf("01-%s", rName)
+	rNameWithStartingHyphen := fmt.Sprintf("-%s", rName)
 	rNameWithUnderscore := fmt.Sprintf("%s_123456", rName)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -75,8 +76,18 @@ func TestAccLightsailInstance_name(t *testing.T) {
 				ExpectError: regexp.MustCompile(`must contain only alphanumeric characters, underscores, hyphens, and dots`),
 			},
 			{
-				Config:      testAccInstanceConfig_basic(rNameWithStartingDigit),
-				ExpectError: regexp.MustCompile(`must begin with an alphabetic character`),
+				Config:      testAccInstanceConfig_basic(rNameWithStartingHyphen),
+				ExpectError: regexp.MustCompile(`must begin with an alphanumeric character`),
+			},
+			{
+				Config: testAccInstanceConfig_basic(rNameWithStartingDigit),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "availability_zone"),
+					resource.TestCheckResourceAttrSet(resourceName, "blueprint_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "bundle_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "key_pair_name"),
+				),
 			},
 			{
 				Config: testAccInstanceConfig_basic(rName),
@@ -367,7 +378,7 @@ func testAccInstanceConfig_basic(rName string) string {
 resource "aws_lightsail_instance" "test" {
   name              = "%s"
   availability_zone = data.aws_availability_zones.available.names[0]
-  blueprint_id      = "amazon_linux"
+  blueprint_id      = "amazon_linux_2"
   bundle_id         = "nano_1_0"
 }
 `, rName))
@@ -380,7 +391,7 @@ func testAccInstanceConfig_tags1(rName string) string {
 resource "aws_lightsail_instance" "test" {
   name              = "%s"
   availability_zone = data.aws_availability_zones.available.names[0]
-  blueprint_id      = "amazon_linux"
+  blueprint_id      = "amazon_linux_2"
   bundle_id         = "nano_1_0"
 
   tags = {
@@ -398,7 +409,7 @@ func testAccInstanceConfig_tags2(rName string) string {
 resource "aws_lightsail_instance" "test" {
   name              = "%s"
   availability_zone = data.aws_availability_zones.available.names[0]
-  blueprint_id      = "amazon_linux"
+  blueprint_id      = "amazon_linux_2"
   bundle_id         = "nano_1_0"
 
   tags = {
@@ -417,7 +428,7 @@ func testAccInstanceConfig_IPAddressType(rName string, rIPAddressType string) st
 resource "aws_lightsail_instance" "test" {
   name              = %[1]q
   availability_zone = data.aws_availability_zones.available.names[0]
-  blueprint_id      = "amazon_linux"
+  blueprint_id      = "amazon_linux_2"
   bundle_id         = "nano_1_0"
   ip_address_type   = %[2]q
 }
@@ -431,7 +442,7 @@ func testAccInstanceConfig_addOn(rName string, snapshotTime string, status strin
 resource "aws_lightsail_instance" "test" {
   name              = %[1]q
   availability_zone = data.aws_availability_zones.available.names[0]
-  blueprint_id      = "amazon_linux"
+  blueprint_id      = "amazon_linux_2"
   bundle_id         = "nano_1_0"
   add_on {
     type          = "AutoSnapshot"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR corrects the overzealous instance name validation in `aws_lightsail_instance`. Previously the first character of an instance name had to be alphabetic; but can now be alphanumeric. I've added a positive test case for an instance with a numeric first character, and a negative test case for an instance with a symbol first character.
Due to the removal of the `amazon_linux` Lightsail blueprint, I have also updated all `aws_lightsail_instance` acceptance tests to use the `amazon_linux_2` blueprint.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29899

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/lightsail/2016-11-28/api-reference/API_CreateInstances.html - Note there is no requirement mentioned for instances to start with an alphabetic character


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccLightsailInstance_name PKG=lightsail
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lightsail/... -v -count 1 -parallel 20 -run='TestAccLightsailInstance_name'  -timeout 180m
=== RUN   TestAccLightsailInstance_name
=== PAUSE TestAccLightsailInstance_name
=== CONT  TestAccLightsailInstance_name
--- PASS: TestAccLightsailInstance_name (246.28s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lightsail	249.652s
...
```