### PR TITLE
docs(api-gateway-usage-plan-key): correct example

### DIFF
--- a/website/docs/r/api_gateway_stage.html.markdown
+++ b/website/docs/r/api_gateway_stage.html.markdown
@@ -142,7 +142,6 @@ In addition to all arguments above, the following attributes are exported:
   e.g., `arn:aws:execute-api:eu-west-2:123456789012:z4675bid1j/prod`
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `web_acl_arn` - ARN of the WebAcl associated with the Stage.
-* `stage_name` - Name of the stage
 
 ## Import
 

--- a/website/docs/r/api_gateway_stage.html.markdown
+++ b/website/docs/r/api_gateway_stage.html.markdown
@@ -142,6 +142,7 @@ In addition to all arguments above, the following attributes are exported:
   e.g., `arn:aws:execute-api:eu-west-2:123456789012:z4675bid1j/prod`
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `web_acl_arn` - ARN of the WebAcl associated with the Stage.
+* `stage_name` - Name of the stage
 
 ## Import
 

--- a/website/docs/r/api_gateway_usage_plan_key.html.markdown
+++ b/website/docs/r/api_gateway_usage_plan_key.html.markdown
@@ -24,7 +24,7 @@ resource "aws_api_gateway_usage_plan" "myusageplan" {
 
   api_stages {
     api_id = aws_api_gateway_rest_api.test.id
-    stage  = aws_api_gateway_deployment.foo.stage_name
+    stage  = aws_api_gateway_stage.foo.stage_name
   }
 }
 


### PR DESCRIPTION
### Description

The current documentation provides example usage which includes: 

```terraform
resource "aws_api_gateway_usage_plan" "myusageplan" {
  name = "my_usage_plan"

  api_stages {
    api_id = aws_api_gateway_rest_api.test.id
    stage  = aws_api_gateway_deployment.foo.stage_name
  }
}
```

The `stage` field here references `aws_api_gateway_deployment`. If you look at the attributes available for that resource [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_deployment#attributes-reference) you can see it does not have `stage_name`. 

Instead, this should be referencing `aws_api_gateway_stage`. 

### Relations

Closes #29913 

### References

- [StackOverflow](https://stackoverflow.com/a/72824794/2558542)
- [`api_gateway_usage_plan_key` Documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_usage_plan_key#example-usage)
- [`aws_api_gateway_stage`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_stage#attributes-reference) Documentation


### Output from Acceptance Testing

NA