### PR TITLE
`r/aws_sagemaker_endpoint_configuration`: Fix `variant_name` generation when unset

### DIFF
--- a/.changelog/29915.txt
+++ b/.changelog/29915.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sagemaker_endpoint_configuration: Fix `variant_name` generation when unset
+```

--- a/internal/service/sagemaker/endpoint_configuration.go
+++ b/internal/service/sagemaker/endpoint_configuration.go
@@ -619,8 +619,8 @@ func expandProductionVariants(configured []interface{}) []*sagemaker.ProductionV
 			l.InstanceType = aws.String(v)
 		}
 
-		if v, ok := data["variant_name"]; ok {
-			l.VariantName = aws.String(v.(string))
+		if v, ok := data["variant_name"].(string); ok && v != "" {
+			l.VariantName = aws.String(v)
 		} else {
 			l.VariantName = aws.String(resource.UniqueId())
 		}

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -179,6 +179,33 @@ func TestAccSageMakerEndpointConfiguration_ProductionVariants_acceleratorType(t 
 	})
 }
 
+func TestAccSageMakerEndpointConfiguration_ProductionVariants_variantNameGenerated(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_endpoint_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, sagemaker.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointConfigurationConfig_productionVariantVariantNameGenerated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointConfigurationExists(ctx, resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "production_variants.0.variant_name"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccSageMakerEndpointConfiguration_kmsKeyID(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -593,6 +620,21 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     initial_instance_count = 2
     instance_type          = "ml.t2.medium"
     accelerator_type       = "ml.eia1.medium"
+    initial_variant_weight = 1
+  }
+}
+`, rName))
+}
+
+func testAccEndpointConfigurationConfig_productionVariantVariantNameGenerated(rName string) string {
+	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
+resource "aws_sagemaker_endpoint_configuration" "test" {
+  name = %[1]q
+
+  production_variants {
+    model_name             = aws_sagemaker_model.test.name
+    initial_instance_count = 2
+    instance_type          = "ml.t2.medium"
     initial_variant_weight = 1
   }
 }


### PR DESCRIPTION
### Description
Fix to properly generate `variant_name` when the value is unset in configuration.


### Relations
Closes #20966


### Output from Acceptance Testing
```
$ make testacc PKG=sagemaker TESTS=TestAccSageMakerEndpointConfiguration_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerEndpointConfiguration_'  -timeout 180m

--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_serverless (33.27s)
--- PASS: TestAccSageMakerEndpointConfiguration_kmsKeyID (35.24s)
--- PASS: TestAccSageMakerEndpointConfiguration_Async_notif (35.63s)
--- PASS: TestAccSageMakerEndpointConfiguration_shadowProductionVariants (37.68s)
--- PASS: TestAccSageMakerEndpointConfiguration_Async_client (38.32s)
--- PASS: TestAccSageMakerEndpointConfiguration_disappears (39.01s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_initialVariantWeight (48.70s)
--- PASS: TestAccSageMakerEndpointConfiguration_dataCapture (50.53s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_variantNameGenerated (52.95s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_acceleratorType (54.01s)
--- PASS: TestAccSageMakerEndpointConfiguration_async (54.47s)
--- PASS: TestAccSageMakerEndpointConfiguration_basic (56.97s)
--- PASS: TestAccSageMakerEndpointConfiguration_tags (57.35s)
--- PASS: TestAccSageMakerEndpointConfiguration_async_kms (72.50s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  75.657s
```
