### PR TITLE
aws_ssoadmin_account_assignment - update example

### DIFF
--- a/website/docs/r/ssoadmin_account_assignment.html.markdown
+++ b/website/docs/r/ssoadmin_account_assignment.html.markdown
@@ -23,9 +23,11 @@ data "aws_ssoadmin_permission_set" "example" {
 data "aws_identitystore_group" "example" {
   identity_store_id = tolist(data.aws_ssoadmin_instances.example.identity_store_ids)[0]
 
-  filter {
-    attribute_path  = "DisplayName"
-    attribute_value = "ExampleGroup"
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = "ExampleGroup"
+    }
   }
 }
 


### PR DESCRIPTION
### Description
[filter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/identitystore_group#filter) is deprecated

Update example to use `alternate_identifier` per docs for `aws_identitystore_group`

### Relations
Closes #29162

### References
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/identitystore_group