### PR TITLE
aws_batch_job_definition - fix  example

### DIFF
--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -99,8 +99,9 @@ resource "aws_batch_job_definition" "test" {
   ]
 
   container_properties = jsonencode({
-    command = ["echo", "test"]
-    image   = "busybox"
+    command    = ["echo", "test"]
+    image      = "busybox"
+    jobRoleArn = "arn:aws:iam::123456789012:role/AWSBatchS3ReadOnly"
 
     fargatePlatformConfiguration = {
       platformVersion = "LATEST"


### PR DESCRIPTION
### Description
Add `jobRoleArn` to Fargate example following AWS example docs

### Relations
Closes #27919

### References
https://docs.aws.amazon.com/batch/latest/userguide/example-job-definitions.html
https://docs.aws.amazon.com/batch/latest/APIReference/API_ContainerProperties.html