### PR TITLE
:bug: AWS Route now Support IPv6 Destinations with VPC Endpoints as Targets

### DIFF
--- a/.changelog/29994.txt
+++ b/.changelog/29994.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/vpc-route: Remove conflict for IPv6 Destinations
+resource/aws_route: Allow `destination_ipv6_cidr_block` to be specified for a `vpc_endpoint_id` target
 ```

--- a/.changelog/29994.txt
+++ b/.changelog/29994.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/vpc-route: Remove conflict for IPv6 Destinations
+```

--- a/internal/service/ec2/vpc_route.go
+++ b/internal/service/ec2/vpc_route.go
@@ -151,8 +151,7 @@ func ResourceRoute() *schema.Resource {
 				Optional:     true,
 				ExactlyOneOf: routeValidTargets,
 				ConflictsWith: []string{
-					routeDestinationIPv6CIDRBlock, // IPv4 destinations only.
-					routeDestinationPrefixListID,  // "Cannot create or replace a prefix list route targeting a VPC Endpoint."
+					routeDestinationPrefixListID, // "Cannot create or replace a prefix list route targeting a VPC Endpoint."
 				},
 			},
 			"vpc_peering_connection_id": {


### PR DESCRIPTION
### Description

:bug: AWS Route now Support IPv6 Destinations with VPC Endpoints as Targets

Specifically, AWS Network Firewall now supports IPv6 traffic, and in order to route IPv6 traffic there, you need to point the IPv6 destination at the VPC endpoint ID of the network firewall. 

Currently this conflict prevents you from doing so in Terraform.


### Relations

Closes [#29873 ](https://github.com/hashicorp/terraform-provider-aws/issues/29837)



### Output from Acceptance Testing

Added new acceptance test, however I cannot run myself, can someone please run for me?

```
$ make testacc TESTS= TestAccVPCRoute_ipv6ToVPCEndpoint PKG=ec2

...
```
