### PR TITLE
Update Neptune ServerlessMinNCUs value from 2.5 to 1.0

### DIFF
--- a/internal/service/neptune/cluster.go
+++ b/internal/service/neptune/cluster.go
@@ -31,7 +31,7 @@ const (
 
 	DefaultPort = 8182
 
-	ServerlessMinNCUs = 2.5
+	ServerlessMinNCUs = 1
 	ServerlessMaxNCUs = 128.0
 )
 


### PR DESCRIPTION
It is possible now for Neptune to decrease the minimum NCU value to 1.0 instead of 2.5 before. https://docs.aws.amazon.com/neptune/latest/userguide/neptune-serverless-capacity-scaling.html

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
