### PR TITLE
Fix `aws_cloudwatch_event_target` example

### DIFF
--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -271,14 +271,16 @@ resource "aws_api_gateway_stage" "example" {
 
 ```terraform
 data "aws_iam_policy_document" "assume_role" {
-  effect = "Allow"
+  statement {
+    effect = "Allow"
 
-  principals {
-    type        = "Service"
-    identifiers = ["events.amazonaws.com"]
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
   }
-
-  actions = ["sts:AssumeRole"]
 }
 
 resource "aws_iam_role" "event_bus_invoke_remote_event_bus" {
@@ -491,7 +493,7 @@ The following arguments are optional:
 ### dead_letter_config
 
 * `arn` - (Optional) - ARN of the SQS queue specified as the target for the dead-letter queue.
-  
+
 ### ecs_target
 
 * `task_definition_arn` - (Required) The ARN of the task definition to use if the event target is an Amazon ECS cluster.


### PR DESCRIPTION
### Description

The `aws_iam_policy_document` data source needed the `statement` block. Also removed a little bit of extra whitespace while I was at it.

### Relations

Closes #29969

### References

N/a

### Output from Acceptance Testing

N/a, docs
