### PR TITLE
[Tests] aws_medialive_channel: update only channel name

### DIFF
--- a/internal/service/medialive/channel_test.go
+++ b/internal/service/medialive/channel_test.go
@@ -436,7 +436,7 @@ func TestAccMediaLiveChannel_update(t *testing.T) {
 		CheckDestroy:             testAccCheckChannelDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccChannelConfig_update(rName, "AVC", "HD"),
+				Config: testAccChannelConfig_update(rName, rName, "AVC", "HD"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChannelExists(ctx, resourceName, &channel),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -463,7 +463,7 @@ func TestAccMediaLiveChannel_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccChannelConfig_update(rNameUpdated, "AVC", "HD"),
+				Config: testAccChannelConfig_update(rName, rNameUpdated, "AVC", "HD"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckChannelExists(ctx, resourceName, &channel),
 					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
@@ -1354,20 +1354,20 @@ resource "aws_medialive_channel" "test" {
 `, rName, start))
 }
 
-func testAccChannelConfig_update(rName, codec, inputResolution string) string {
+func testAccChannelConfig_update(rName, rNameUpdated, codec, inputResolution string) string {
 	return acctest.ConfigCompose(
 		testAccChannelBaseConfig(rName),
 		testAccChannelBaseS3Config(rName),
 		testAccChannelBaseMultiplexConfig(rName),
 		fmt.Sprintf(`
 resource "aws_medialive_channel" "test" {
-  name          = %[1]q
+  name          = %[2]q
   channel_class = "STANDARD"
   role_arn      = aws_iam_role.test.arn
 
   input_specification {
-    codec            = %[2]q
-    input_resolution = %[3]q
+    codec            = %[3]q
+    input_resolution = %[4]q
     maximum_bitrate  = "MAX_20_MBPS"
   }
 
@@ -1432,7 +1432,7 @@ resource "aws_medialive_channel" "test" {
     }
   }
 }
-`, rName, codec, inputResolution))
+`, rName, rNameUpdated, codec, inputResolution))
 }
 
 func testAccChannelConfig_tags1(rName, key1, value1 string) string {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

update test is intended to only update the name of the `aws_medialive_channel` resource. This fixes current behavior where the names of all resources in the base configs get updated as well.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:
--->

Relates #29373

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccMediaLiveChannel_ PKG=medialive

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/medialive/... -v -count 1 -parallel 20 -run='TestAccMediaLiveChannel_'  -timeout 180m
--- PASS: TestAccMediaLiveChannel_audioDescriptions_codecSettings (75.25s)
--- PASS: TestAccMediaLiveChannel_UDP_outputSettings (90.59s)
--- PASS: TestAccMediaLiveChannel_MsSmooth_outputSettings (92.84s)
--- PASS: TestAccMediaLiveChannel_hls (103.93s)
--- PASS: TestAccMediaLiveChannel_m2ts_settings (108.87s)
--- PASS: TestAccMediaLiveChannel_disappears (162.05s)
--- PASS: TestAccMediaLiveChannel_update (192.00s)
--- PASS: TestAccMediaLiveChannel_updateTags (192.01s)
--- PASS: TestAccMediaLiveChannel_basic (196.45s)
--- PASS: TestAccMediaLiveChannel_status (222.28s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	225.247s
...
```
