### PR TITLE
Update account_alias_data_source to retun nil if no alias defined.

### DIFF
--- a/internal/service/iam/account_alias_data_source.go
+++ b/internal/service/iam/account_alias_data_source.go
@@ -38,11 +38,6 @@ func dataSourceAccountAliasRead(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "reading IAM Account Alias: %s", err)
 	}
 
-	// 'AccountAliases': [] if there is no alias.
-	if resp == nil || len(resp.AccountAliases) == 0 {
-		return sdkdiag.AppendErrorf(diags, "reading IAM Account Alias: empty result")
-	}
-
 	alias := aws.StringValue(resp.AccountAliases[0])
 	d.SetId(alias)
 	d.Set("account_alias", alias)


### PR DESCRIPTION
Not a GoLang developer but looks like this PR should resolve issue #10076 by allowing `aws_iam_account_alias` to return `nil` when no Account alias exists instead of erroring out.

Sorry if incorrect, but at least this should bring attention to the issue.