### PR TITLE
Add `event_bridge_config` argument to support AppSync EventBridge data sources

### DIFF
--- a/.changelog/30042.txt
+++ b/.changelog/30042.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_appsync_datasource: Add `event_bridge_config` argument to support AppSync EventBridge data sources
+```

--- a/internal/service/appsync/appsync_test.go
+++ b/internal/service/appsync/appsync_test.go
@@ -30,6 +30,7 @@ func TestAccAppSync_serial(t *testing.T) {
 			"Type_none":                     testAccDataSource_Type_none,
 			"Type_rdbms":                    testAccDataSource_Type_relationalDatabase,
 			"Type_rdbms_options":            testAccDataSource_Type_relationalDatabaseWithOptions,
+			"Type_eventBridge":              testAccDataSource_Type_eventBridge,
 		},
 		"GraphQLAPI": {
 			"basic":                     testAccGraphQLAPI_basic,

--- a/internal/service/appsync/datasource.go
+++ b/internal/service/appsync/datasource.go
@@ -226,6 +226,21 @@ func ResourceDataSource() *schema.Resource {
 				},
 				ConflictsWith: []string{"dynamodb_config", "elasticsearch_config", "http_config", "lambda_config"},
 			},
+			"event_bridge_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"event_bus_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: verify.ValidARN,
+						},
+					},
+				},
+				ConflictsWith: []string{"dynamodb_config", "elasticsearch_config", "http_config", "lambda_config", "relational_database_config"},
+			},
 			"service_role_arn": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -260,6 +275,10 @@ func resourceDataSourceCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	if v, ok := d.GetOk("elasticsearch_config"); ok {
 		input.ElasticsearchConfig = expandElasticsearchDataSourceConfig(v.([]interface{}), region)
+	}
+
+	if v, ok := d.GetOk("event_bridge_config"); ok {
+		input.EventBridgeConfig = expandEventBridgeDataSourceConfig(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("http_config"); ok {
@@ -337,6 +356,10 @@ func resourceDataSourceRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	if err := d.Set("relational_database_config", flattenRelationalDatabaseDataSourceConfig(dataSource.RelationalDatabaseConfig)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting relational_database_config: %s", err)
+	}
+
+	if err := d.Set("event_bridge_config", flattenEventBridgeDataSourceConfig(dataSource.EventBridgeConfig)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting event_bridge_config: %s", err)
 	}
 
 	d.Set("name", dataSource.Name)
@@ -717,6 +740,32 @@ func flattenRelationalDatabaseDataSourceConfig(config *appsync.RelationalDatabas
 	result := map[string]interface{}{
 		"source_type":          aws.StringValue(config.RelationalDatabaseSourceType),
 		"http_endpoint_config": flattenRDSHTTPEndpointConfig(config.RdsHttpEndpointConfig),
+	}
+
+	return []map[string]interface{}{result}
+}
+
+func expandEventBridgeDataSourceConfig(l []interface{}) *appsync.EventBridgeDataSourceConfig {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	configured := l[0].(map[string]interface{})
+
+	result := &appsync.EventBridgeDataSourceConfig{
+		EventBusArn: aws.String(configured["event_bus_arn"].(string)),
+	}
+
+	return result
+}
+
+func flattenEventBridgeDataSourceConfig(config *appsync.EventBridgeDataSourceConfig) []map[string]interface{} {
+	if config == nil {
+		return nil
+	}
+
+	result := map[string]interface{}{
+		"event_bus_arn": aws.StringValue(config.EventBusArn),
 	}
 
 	return []map[string]interface{}{result}

--- a/internal/service/appsync/datasource_test.go
+++ b/internal/service/appsync/datasource_test.go
@@ -39,6 +39,7 @@ func testAccDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "http_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "lambda_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "relational_database_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "event_bridge_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "type", "NONE"),
 				),
@@ -483,6 +484,38 @@ func testAccDataSource_Type_lambda(t *testing.T) {
 	})
 }
 
+func testAccDataSource_Type_eventBridge(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := fmt.Sprintf("tfacctest%d", sdkacctest.RandInt())
+	iamRoleResourceName := "aws_iam_role.test"
+	eventBusResourceName := "aws_cloudwatch_event_bus.test"
+	resourceName := "aws_appsync_datasource.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, appsync.EndpointsID) },
+		ErrorCheck:               acctest.ErrorCheck(t, appsync.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataSourceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceConfig_typeEventBridge(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExistsDataSource(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "event_bridge_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "event_bridge_config.0.event_bus_arn", eventBusResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "type", "AMAZON_EVENTBRIDGE"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccDataSource_Type_none(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := fmt.Sprintf("tfacctest%d", sdkacctest.RandInt())
@@ -748,6 +781,54 @@ resource "aws_iam_role_policy" "test" {
 EOF
 }
 `, rName, rName, rName)
+}
+
+func testAccDatasourceConfig_eventBridgeBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_event_bus" "test" {
+  name = %q
+}
+
+resource "aws_iam_role" "test" {
+  name = %q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "appsync.amazonaws.com"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test" {
+  role = aws_iam_role.test.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "events:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${aws_cloudwatch_event_bus.test.arn}"
+      ]
+    }
+  ]
+}
+EOF
+}
+`, rName, rName)
 }
 
 func testAccDataSourceConfig_description(rName, description string) string {
@@ -1099,6 +1180,26 @@ resource "aws_appsync_datasource" "test" {
 
   lambda_config {
     function_arn = aws_lambda_function.test.arn
+  }
+}
+`, rName, rName)
+}
+
+func testAccDataSourceConfig_typeEventBridge(rName string) string {
+	return testAccDatasourceConfig_eventBridgeBase(rName) + fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "API_KEY"
+  name                = %q
+}
+
+resource "aws_appsync_datasource" "test" {
+  api_id           = aws_appsync_graphql_api.test.id
+  name             = %q
+  service_role_arn = aws_iam_role.test.arn
+  type             = "AMAZON_EVENTBRIDGE"
+
+  event_bridge_config {
+    event_bus_arn = aws_cloudwatch_event_bus.test.arn
   }
 }
 `, rName, rName)

--- a/internal/service/appsync/graphql_api_test.go
+++ b/internal/service/appsync/graphql_api_test.go
@@ -293,7 +293,7 @@ func testAccGraphQLAPI_AuthenticationType_lambda(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 	lambdaAuthorizerResourceName := "aws_lambda_function.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, appsync.EndpointsID) },
 		ErrorCheck:               acctest.ErrorCheck(t, appsync.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -734,7 +734,7 @@ func testAccGraphQLAPI_LambdaAuthorizerConfig_authorizerURI(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 	lambdaAuthorizerResourceName := "aws_lambda_function.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, appsync.EndpointsID) },
 		ErrorCheck:               acctest.ErrorCheck(t, appsync.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -774,7 +774,7 @@ func testAccGraphQLAPI_LambdaAuthorizerConfig_identityValidationExpression(t *te
 	resourceName := "aws_appsync_graphql_api.test"
 	lambdaAuthorizerResourceName := "aws_lambda_function.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, appsync.EndpointsID) },
 		ErrorCheck:               acctest.ErrorCheck(t, appsync.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -815,7 +815,7 @@ func testAccGraphQLAPI_LambdaAuthorizerConfig_authorizerResultTTLInSeconds(t *te
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_appsync_graphql_api.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, appsync.EndpointsID) },
 		ErrorCheck:               acctest.ErrorCheck(t, appsync.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1058,7 +1058,7 @@ func testAccGraphQLAPI_AdditionalAuthentication_lambda(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 	lambdaAuthorizerResourceName := "aws_lambda_function.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, appsync.EndpointsID) },
 		ErrorCheck:               acctest.ErrorCheck(t, appsync.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/website/docs/r/appsync_datasource.html.markdown
+++ b/website/docs/r/appsync_datasource.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 * `api_id` - (Required) API ID for the GraphQL API for the data source.
 * `name` - (Required) User-supplied name for the data source.
-* `type` - (Required) Type of the Data Source. Valid values: `AWS_LAMBDA`, `AMAZON_DYNAMODB`, `AMAZON_ELASTICSEARCH`, `HTTP`, `NONE`, `RELATIONAL_DATABASE`.
+* `type` - (Required) Type of the Data Source. Valid values: `AWS_LAMBDA`, `AMAZON_DYNAMODB`, `AMAZON_ELASTICSEARCH`, `HTTP`, `NONE`, `RELATIONAL_DATABASE`, `AMAZON_EVENTBRIDGE`.
 * `description` - (Optional) Description of the data source.
 * `service_role_arn` - (Optional) IAM service role ARN for the data source.
 * `dynamodb_config` - (Optional) DynamoDB settings. See [below](#dynamodb_config)
@@ -87,6 +87,7 @@ The following arguments are supported:
 * `http_config` - (Optional) HTTP settings. See [below](#http_config)
 * `lambda_config` - (Optional) AWS Lambda settings. See [below](#lambda_config)
 * `relational_database_config` (Optional) AWS RDS settings. See [Relational Database Config](#relational_database_config)
+* `event_bridge_config` - (Optional) AWS EventBridge settings. See [below](#event_bridge_config)
 
 ### dynamodb_config
 
@@ -146,6 +147,12 @@ The following arguments are supported:
 The following arguments are supported:
 
 * `function_arn` - (Required) ARN for the Lambda function.
+
+### event_bridge_config
+
+The following arguments are supported:
+
+* `event_bus_arn` - (Required) ARN for the EventBridge bus.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Hi there,

this pull request adds a new argument, event_bridge_config, to the aws_appsync_datasource resource. 

## Changes

- Added a new event_bridge_config argument to the aws_appsync_datasource resource
- Updated the resource's documentation to include the new event_bridge_config argument
- Added new acceptance tests to cover the event_bridge_config argument and its behavior

Resolves #29625

```
$ make testacc TESTS=TestAccAppSync_serial/DataSource/Type_eventBridge PKG=appsync

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/appsync/... -v -count 1 -parallel 20 -run='TestAccAppSync_serial/DataSource/Type_eventBridge'  -timeout 180m
=== RUN   TestAccAppSync_serial
=== PAUSE TestAccAppSync_serial
=== CONT  TestAccAppSync_serial
=== RUN   TestAccAppSync_serial/DataSource
=== RUN   TestAccAppSync_serial/DataSource/Type_eventBridge
--- PASS: TestAccAppSync_serial (32.93s)
    --- PASS: TestAccAppSync_serial/DataSource (32.93s)
        --- PASS: TestAccAppSync_serial/DataSource/Type_eventBridge (32.93s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appsync    35.627s
```

Please let me know if you have any questions or require any changes to this pull request. 
I look forward to your review and feedback.

