### PR TITLE
[Tests] aws_rds_global_cluster: destroy fails when `force_destroy = true`

### DIFF
--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -1257,7 +1257,7 @@ func TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add(t *testing.T)
 			},
 			{
 				Config:      testAccClusterConfig_GlobalClusterID_EngineMode_global(rName),
-				ExpectError: regexp.MustCompile(`Existing RDS Clusters cannot be added to an existing RDS Global Cluster`),
+				ExpectError: regexp.MustCompile(`(?i)Existing RDS Clusters cannot be added to an existing RDS Global Cluster`),
 			},
 		},
 	})
@@ -1319,7 +1319,7 @@ func TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update(t *testing
 			},
 			{
 				Config:      testAccClusterConfig_GlobalClusterID_EngineMode_globalUpdate(rName, globalClusterResourceName2),
-				ExpectError: regexp.MustCompile(`Existing RDS Clusters cannot be migrated between existing RDS Global Clusters`),
+				ExpectError: regexp.MustCompile(`(?i)Existing RDS Clusters cannot be migrated between existing RDS Global Clusters`),
 			},
 		},
 	})

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -285,8 +285,8 @@ func resourceGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, me
 		log.Printf("[DEBUG] Removing cluster members from  RDS Global Cluster: %s", d.Id())
 
 		// The writer cluster must be removed last
-		globalClusterMembers := d.Get("global_cluster_members").(*schema.Set)
 		var writerARN string
+		globalClusterMembers := d.Get("global_cluster_members").(*schema.Set)
 		if globalClusterMembers.Len() > 0 {
 			for _, globalClusterMemberRaw := range globalClusterMembers.List() {
 				globalClusterMember, ok := globalClusterMemberRaw.(map[string]interface{})

--- a/internal/service/rds/global_cluster_test.go
+++ b/internal/service/rds/global_cluster_test.go
@@ -489,6 +489,29 @@ func TestAccRDSGlobalCluster_EngineVersion_auroraPostgreSQL(t *testing.T) {
 	})
 }
 
+func TestAccRDSGlobalCluster_forceDestroy(t *testing.T) {
+	ctx := acctest.Context(t)
+	var globalCluster1 rds.GlobalCluster
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_rds_global_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalCluster(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, rds.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGlobalClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalClusterConfig_forceDestroy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlobalClusterExists(ctx, resourceName, &globalCluster1),
+					resource.TestCheckResourceAttr(resourceName, "force_destroy", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRDSGlobalCluster_sourceDBClusterIdentifier(t *testing.T) {
 	ctx := acctest.Context(t)
 	var globalCluster1 rds.GlobalCluster
@@ -749,6 +772,15 @@ resource "aws_rds_global_cluster" "test" {
   global_cluster_identifier = %[2]q
 }
 `, engine, rName)
+}
+
+func testAccGlobalClusterConfig_forceDestroy(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_global_cluster" "test" {
+  global_cluster_identifier = %[1]q
+  force_destroy             = true
+}
+`, rName)
 }
 
 func testAccGlobalClusterConfig_primaryEngineVersion(rName, engine, engineVersion string) string {

--- a/internal/service/rds/global_cluster_test.go
+++ b/internal/service/rds/global_cluster_test.go
@@ -345,11 +345,11 @@ func TestAccRDSGlobalCluster_EngineVersion_updateMajor(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccGlobalClusterConfig_primaryEngineVersion(rName, "aurora-mysql", "5.7.mysql_aurora.2.10.2"),
+				Config: testAccGlobalClusterConfig_primaryEngineVersion(rName, "aurora-mysql", "5.7.mysql_aurora.2.11.1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, resourceName, &globalCluster2),
 					testAccCheckGlobalClusterNotRecreated(&globalCluster1, &globalCluster2),
-					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.7.mysql_aurora.2.10.2"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.7.mysql_aurora.2.11.1"),
 				),
 			},
 			{
@@ -422,11 +422,11 @@ func TestAccRDSGlobalCluster_EngineVersion_updateMajorMultiRegion(t *testing.T) 
 				),
 			},
 			{
-				Config: testAccGlobalClusterConfig_engineVersionUpgradeMultiRegion(rNameGlobal, rNamePrimary, rNameSecondary, "aurora-mysql", "5.7.mysql_aurora.2.10.2"),
+				Config: testAccGlobalClusterConfig_engineVersionUpgradeMultiRegion(rNameGlobal, rNamePrimary, rNameSecondary, "aurora-mysql", "5.7.mysql_aurora.2.11.1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, resourceName, &globalCluster2),
 					testAccCheckGlobalClusterNotRecreated(&globalCluster1, &globalCluster2),
-					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.7.mysql_aurora.2.10.2"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "5.7.mysql_aurora.2.11.1"),
 				),
 			},
 		},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When `force_destroy` is `true` the destroy fails if there is no cluster attached.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #30027

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccRDSGlobalCluster_' PKG=rds

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20  -run=TestAccRDSGlobalCluster_ -timeout 180m
--- PASS: TestAccRDSGlobalCluster_disappears (18.51s)
--- PASS: TestAccRDSGlobalCluster_basic (21.48s)
--- PASS: TestAccRDSGlobalCluster_Engine_aurora (22.86s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_aurora (23.48s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_auroraPostgreSQL (24.65s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_auroraMySQL (24.74s)
--- PASS: TestAccRDSGlobalCluster_databaseName (32.93s)
--- PASS: TestAccRDSGlobalCluster_storageEncrypted (34.65s)
--- PASS: TestAccRDSGlobalCluster_deletionProtection (59.85s)
--- PASS: TestAccRDSGlobalCluster_sourceDBClusterIdentifier (133.81s)
--- PASS: TestAccRDSGlobalCluster_SourceDBClusterIdentifier_storageEncrypted (157.50s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_updateMinor (1429.28s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_updateMajor (2005.72s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_updateMinorMultiRegion (3374.43s)
--- PASS: TestAccRDSGlobalCluster_EngineVersion_updateMajorMultiRegion (5296.80s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	5299.981s
...
```

```console
$ make testacc TESTARGS='-run=TestAccRDSGlobalCluster_forceDestroy' PKG=rds

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20  -run=TestAccRDSGlobalCluster_forceDestroy -timeout 180m
--- PASS: TestAccRDSGlobalCluster_forceDestroy (13.54s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	16.564s
```

`rds_cluster` test was previously failing on post destroy

```console
$ make testacc TESTARGS='-run=TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add' PKG=rds

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20  -run=TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add -timeout 180m
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add (120.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	123.673s
```