### PR TITLE
r/aws_ecr_repository: handle err, nil output on read

### DIFF
--- a/.changelog/30067.txt
+++ b/.changelog/30067.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecr_repository: Fix unhandled errors and nil output on read
+```

--- a/internal/service/ecr/repository.go
+++ b/internal/service/ecr/repository.go
@@ -2,6 +2,7 @@ package ecr
 
 import (
 	"context"
+	"errors"
 	"log"
 	"time"
 
@@ -14,10 +15,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @SDKResource("aws_ecr_repository")
@@ -109,6 +112,10 @@ func ResourceRepository() *schema.Resource {
 	}
 }
 
+const (
+	ResNameRepository = "Repository"
+)
+
 func resourceRepositoryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECRConn()
@@ -181,6 +188,12 @@ func resourceRepositoryRead(ctx context.Context, d *schema.ResourceData, meta in
 		log.Printf("[WARN] ECR Repository (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
+	}
+	if err != nil {
+		return create.DiagError(names.ECR, create.ErrActionReading, ResNameRepository, d.Id(), err)
+	}
+	if outputRaw == nil {
+		return create.DiagError(names.ECR, create.ErrActionReading, ResNameRepository, d.Id(), errors.New("empty output"))
 	}
 
 	repository := outputRaw.(*ecr.Repository)


### PR DESCRIPTION
### Description
Fix to properly handle errors that aren't `ResourceNotFound` and nil output values.

### Relations

Closes #30068


### Output from Acceptance Testing

```
$ make testacc PKG=ecr TESTS=TestAccECRRepository_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRRepository_'  -timeout 180m
=== RUN   TestAccECRRepository_basic
=== PAUSE TestAccECRRepository_basic
=== RUN   TestAccECRRepository_disappears
=== PAUSE TestAccECRRepository_disappears
=== RUN   TestAccECRRepository_tags
=== PAUSE TestAccECRRepository_tags
=== RUN   TestAccECRRepository_immutability
=== PAUSE TestAccECRRepository_immutability
=== RUN   TestAccECRRepository_Image_scanning
=== PAUSE TestAccECRRepository_Image_scanning
=== RUN   TestAccECRRepository_Encryption_kms
=== PAUSE TestAccECRRepository_Encryption_kms
=== RUN   TestAccECRRepository_Encryption_aes256
=== PAUSE TestAccECRRepository_Encryption_aes256
=== CONT  TestAccECRRepository_basic
=== CONT  TestAccECRRepository_Image_scanning
=== CONT  TestAccECRRepository_Encryption_aes256
=== CONT  TestAccECRRepository_Encryption_kms
=== CONT  TestAccECRRepository_tags
=== CONT  TestAccECRRepository_disappears
=== CONT  TestAccECRRepository_immutability
--- PASS: TestAccECRRepository_disappears (26.36s)
--- PASS: TestAccECRRepository_basic (34.35s)
--- PASS: TestAccECRRepository_immutability (34.42s)
--- PASS: TestAccECRRepository_Encryption_kms (48.77s)
--- PASS: TestAccECRRepository_Encryption_aes256 (49.34s)
--- PASS: TestAccECRRepository_tags (53.78s)
--- PASS: TestAccECRRepository_Image_scanning (56.39s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        59.599s
```
