### PR TITLE
d/aws_ecs_cluster - add tags attribute

### DIFF
--- a/.changelog/30073.txt
+++ b/.changelog/30073.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-data/aws_ecs_cluster: Add support for `tags` attribute.
+data-source/aws_ecs_cluster: Add `tags` attribute
 ```

--- a/.changelog/30073.txt
+++ b/.changelog/30073.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data/aws_ecs_cluster: Add support for `tags` attribute.
+```

--- a/internal/service/ecs/cluster_data_source.go
+++ b/internal/service/ecs/cluster_data_source.go
@@ -2,12 +2,12 @@ package ecs
 
 import (
 	"context"
-	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
 // @SDKDataSource("aws_ecs_cluster")

--- a/internal/service/ecs/cluster_data_source_test.go
+++ b/internal/service/ecs/cluster_data_source_test.go
@@ -30,6 +30,7 @@ func TestAccECSClusterDataSource_ecsCluster(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "running_tasks_count", "0"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "service_connect_defaults.#", resourceName, "service_connect_defaults.#"),
 					resource.TestCheckResourceAttr(dataSourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 		},
@@ -56,6 +57,34 @@ func TestAccECSClusterDataSource_ecsClusterContainerInsights(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "running_tasks_count", "0"),
 					resource.TestCheckResourceAttr(dataSourceName, "status", "ACTIVE"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "setting.#", resourceName, "setting.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccECSClusterDataSource_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ecs_cluster.test"
+	resourceName := "aws_ecs_cluster.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ecs.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterDataSourceConfig_tags(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttr(dataSourceName, "pending_tasks_count", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "registered_container_instances_count", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "running_tasks_count", "0"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "service_connect_defaults.#", resourceName, "service_connect_defaults.#"),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
 		},
@@ -89,4 +118,20 @@ data "aws_ecs_cluster" "test" {
   cluster_name = aws_ecs_cluster.test.name
 }
 `, rName)
+}
+
+func testAccClusterDataSourceConfig_tags(rName, tagKey, tagValue string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+  name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+
+data "aws_ecs_cluster" "test" {
+  cluster_name = aws_ecs_cluster.test.name
+}
+`, rName, tagKey, tagValue)
 }

--- a/website/docs/d/ecs_cluster.html.markdown
+++ b/website/docs/d/ecs_cluster.html.markdown
@@ -36,3 +36,4 @@ In addition to all arguments above, the following attributes are exported:
 * `registered_container_instances_count` - The number of registered container instances for the ECS Cluster
 * `service_connect_defaults` - The default Service Connect namespace
 * `setting` - Settings associated with the ECS Cluster
+* `tags` - Key-value map of resource tags


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds `tags` to the `aws_ecs_cluster` data source.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29420

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make testacc TESTS=TestAccECSClusterDataSource PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSClusterDataSource'  -timeout 180m
=== RUN   TestAccECSClusterDataSource_ecsCluster
=== PAUSE TestAccECSClusterDataSource_ecsCluster
=== RUN   TestAccECSClusterDataSource_ecsClusterContainerInsights
=== PAUSE TestAccECSClusterDataSource_ecsClusterContainerInsights
=== RUN   TestAccECSClusterDataSource_tags
=== PAUSE TestAccECSClusterDataSource_tags
=== CONT  TestAccECSClusterDataSource_ecsCluster
=== CONT  TestAccECSClusterDataSource_tags
=== CONT  TestAccECSClusterDataSource_ecsClusterContainerInsights
--- PASS: TestAccECSClusterDataSource_tags (30.33s)
--- PASS: TestAccECSClusterDataSource_ecsCluster (30.35s)
--- PASS: TestAccECSClusterDataSource_ecsClusterContainerInsights (30.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        30.534s

...
```
