### PR TITLE
resource/aws_cognito_risk_configuration: validation for `risk_exception_configuration`

### DIFF
--- a/.changelog/30074.txt
+++ b/.changelog/30074.txt
@@ -1,0 +1,3 @@
+```release-note:bug    
+resource/aws_cognito_risk_configuration: Adds validation to `risk_exception_configuration` and requires at least one of `account_takeover_risk_configuration`, `compromised_credentials_risk_configuration`, or `risk_exception_configuration`.
+```

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -2294,5 +2294,9 @@ func modulePrimaryInstanceState(ms *terraform.ModuleState, name string) (*terraf
 }
 
 func ExpectErrorAttrAtLeastOneOf(attrs ...string) *regexp.Regexp {
-	return regexp.MustCompile(fmt.Sprintf("one of[ \\n]`%s`[ \\n]must be specified", strings.Join(attrs, ",")))
+	return regexp.MustCompile(fmt.Sprintf("one of\\s+`%s`\\s+must be specified", strings.Join(attrs, ",")))
+}
+
+func ExpectErrorAttrMinItems(attr string, expected, actual int) *regexp.Regexp {
+	return regexp.MustCompile(fmt.Sprintf(`Attribute %s requires %d\s+item minimum, but config has only %d declared`, attr, expected, actual))
 }

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -2292,3 +2292,7 @@ func modulePrimaryInstanceState(ms *terraform.ModuleState, name string) (*terraf
 
 	return is, nil
 }
+
+func ExpectErrorAttrAtLeastOneOf(attrs ...string) *regexp.Regexp {
+	return regexp.MustCompile(fmt.Sprintf("one of[ \\n]`%s`[ \\n]must be specified", strings.Join(attrs, ",")))
+}

--- a/internal/service/cognitoidp/risk_configuration.go
+++ b/internal/service/cognitoidp/risk_configuration.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -15,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -323,7 +323,7 @@ func resourceRiskConfigurationRead(ctx context.Context, d *schema.ResourceData, 
 
 	riskConfig, err := FindRiskConfigurationById(ctx, conn, d.Id())
 
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, cognitoidentityprovider.ErrCodeResourceNotFoundException) {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		create.LogNotFoundRemoveState(names.CognitoIDP, create.ErrActionReading, ResNameRiskConfiguration, d.Id())
 		d.SetId("")
 		return diags

--- a/internal/service/cognitoidp/risk_configuration.go
+++ b/internal/service/cognitoidp/risk_configuration.go
@@ -249,10 +249,10 @@ func ResourceRiskConfiguration() *schema.Resource {
 						"blocked_ip_range_list": {
 							Type:     schema.TypeSet,
 							Optional: true,
+							MaxItems: 200,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 								ValidateFunc: validation.All(
-									validation.StringLenBetween(0, 200),
 									validation.IsCIDR,
 								),
 							},
@@ -260,10 +260,10 @@ func ResourceRiskConfiguration() *schema.Resource {
 						"skipped_ip_range_list": {
 							Type:     schema.TypeSet,
 							Optional: true,
+							MaxItems: 200,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 								ValidateFunc: validation.All(
-									validation.StringLenBetween(0, 200),
 									validation.IsCIDR,
 								)},
 						},

--- a/internal/service/cognitoidp/risk_configuration.go
+++ b/internal/service/cognitoidp/risk_configuration.go
@@ -46,6 +46,11 @@ func ResourceRiskConfiguration() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
+				AtLeastOneOf: []string{
+					"account_takeover_risk_configuration",
+					"compromised_credentials_risk_configuration",
+					"risk_exception_configuration",
+				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"actions": {

--- a/internal/service/cognitoidp/risk_configuration.go
+++ b/internal/service/cognitoidp/risk_configuration.go
@@ -254,7 +254,12 @@ func ResourceRiskConfiguration() *schema.Resource {
 						"blocked_ip_range_list": {
 							Type:     schema.TypeSet,
 							Optional: true,
+							MinItems: 1,
 							MaxItems: 200,
+							AtLeastOneOf: []string{
+								"risk_exception_configuration.0.blocked_ip_range_list",
+								"risk_exception_configuration.0.skipped_ip_range_list",
+							},
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 								ValidateFunc: validation.All(
@@ -265,6 +270,7 @@ func ResourceRiskConfiguration() *schema.Resource {
 						"skipped_ip_range_list": {
 							Type:     schema.TypeSet,
 							Optional: true,
+							MinItems: 1,
 							MaxItems: 200,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
@@ -387,6 +393,10 @@ func resourceRiskConfigurationDelete(ctx context.Context, d *schema.ResourceData
 }
 
 func expandRiskExceptionConfiguration(riskConfig []interface{}) *cognitoidentityprovider.RiskExceptionConfigurationType {
+	if len(riskConfig) == 0 || riskConfig[0] == nil {
+		return nil
+	}
+
 	config := riskConfig[0].(map[string]interface{})
 
 	riskExceptionConfigurationType := &cognitoidentityprovider.RiskExceptionConfigurationType{}
@@ -421,6 +431,10 @@ func flattenRiskExceptionConfiguration(apiObject *cognitoidentityprovider.RiskEx
 }
 
 func expandCompromisedCredentialsRiskConfiguration(riskConfig []interface{}) *cognitoidentityprovider.CompromisedCredentialsRiskConfigurationType {
+	if len(riskConfig) == 0 || riskConfig[0] == nil {
+		return nil
+	}
+
 	config := riskConfig[0].(map[string]interface{})
 
 	riskExceptionConfigurationType := &cognitoidentityprovider.CompromisedCredentialsRiskConfigurationType{}
@@ -455,6 +469,10 @@ func flattenCompromisedCredentialsRiskConfiguration(apiObject *cognitoidentitypr
 }
 
 func expandCompromisedCredentialsActions(riskConfig []interface{}) *cognitoidentityprovider.CompromisedCredentialsActionsType {
+	if len(riskConfig) == 0 || riskConfig[0] == nil {
+		return nil
+	}
+
 	config := riskConfig[0].(map[string]interface{})
 
 	compromisedCredentialsAction := &cognitoidentityprovider.CompromisedCredentialsActionsType{}
@@ -481,6 +499,10 @@ func flattenCompromisedCredentialsActions(apiObject *cognitoidentityprovider.Com
 }
 
 func expandAccountTakeoverRiskConfiguration(riskConfig []interface{}) *cognitoidentityprovider.AccountTakeoverRiskConfigurationType {
+	if len(riskConfig) == 0 || riskConfig[0] == nil {
+		return nil
+	}
+
 	config := riskConfig[0].(map[string]interface{})
 
 	accountTakeoverRiskConfiguration := &cognitoidentityprovider.AccountTakeoverRiskConfigurationType{}
@@ -515,6 +537,10 @@ func flattenAccountTakeoverRiskConfiguration(apiObject *cognitoidentityprovider.
 }
 
 func expandAccountTakeoverActions(riskConfig []interface{}) *cognitoidentityprovider.AccountTakeoverActionsType {
+	if len(riskConfig) == 0 || riskConfig[0] == nil {
+		return nil
+	}
+
 	config := riskConfig[0].(map[string]interface{})
 
 	actions := &cognitoidentityprovider.AccountTakeoverActionsType{}
@@ -557,6 +583,10 @@ func flattenAccountTakeoverActions(apiObject *cognitoidentityprovider.AccountTak
 }
 
 func expandAccountTakeoverAction(riskConfig []interface{}) *cognitoidentityprovider.AccountTakeoverActionType {
+	if len(riskConfig) == 0 || riskConfig[0] == nil {
+		return nil
+	}
+
 	config := riskConfig[0].(map[string]interface{})
 
 	action := &cognitoidentityprovider.AccountTakeoverActionType{}
@@ -591,6 +621,10 @@ func flattenAccountTakeoverAction(apiObject *cognitoidentityprovider.AccountTake
 }
 
 func expandNotifyConfiguration(riskConfig []interface{}) *cognitoidentityprovider.NotifyConfigurationType {
+	if len(riskConfig) == 0 || riskConfig[0] == nil {
+		return nil
+	}
+
 	config := riskConfig[0].(map[string]interface{})
 
 	notifConfig := &cognitoidentityprovider.NotifyConfigurationType{}
@@ -657,6 +691,10 @@ func flattenNotifyConfiguration(apiObject *cognitoidentityprovider.NotifyConfigu
 }
 
 func expandNotifyEmail(riskConfig []interface{}) *cognitoidentityprovider.NotifyEmailType {
+	if len(riskConfig) == 0 || riskConfig[0] == nil {
+		return nil
+	}
+
 	config := riskConfig[0].(map[string]interface{})
 
 	notifyEmail := &cognitoidentityprovider.NotifyEmailType{}

--- a/internal/service/cognitoidp/risk_configuration_test.go
+++ b/internal/service/cognitoidp/risk_configuration_test.go
@@ -180,6 +180,28 @@ func TestAccCognitoIDPRiskConfiguration_disappears_userPool(t *testing.T) {
 	})
 }
 
+func TestAccCognitoIDPRiskConfiguration_empty(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRiskConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRiskConfigurationConfig_empty(rName),
+				ExpectError: acctest.ExpectErrorAttrAtLeastOneOf(
+					"account_takeover_risk_configuration",
+					"compromised_credentials_risk_configuration",
+					"risk_exception_configuration",
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRiskConfigurationDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).CognitoIDPConn()
@@ -294,6 +316,18 @@ resource "aws_cognito_user_pool_client" "test" {
   name                = %[1]q
   user_pool_id        = aws_cognito_user_pool.test.id
   explicit_auth_flows = ["ADMIN_NO_SRP_AUTH"]
+}
+`, rName)
+}
+
+func testAccRiskConfigurationConfig_empty(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_risk_configuration" "test" {
+  user_pool_id = aws_cognito_user_pool.test.id
+}
+
+resource "aws_cognito_user_pool" "test" {
+  name = %[1]q
 }
 `, rName)
 }

--- a/internal/service/cognitoidp/risk_configuration_test.go
+++ b/internal/service/cognitoidp/risk_configuration_test.go
@@ -134,6 +134,29 @@ func TestAccCognitoIDPRiskConfiguration_compromised(t *testing.T) {
 	})
 }
 
+func TestAccCognitoIDPRiskConfiguration_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cognito_risk_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRiskConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRiskConfigurationConfig_riskException(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRiskConfigurationExists(ctx, resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfcognitoidp.ResourceRiskConfiguration(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccCognitoIDPRiskConfiguration_disappears_userPool(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/website/docs/r/cognito_risk_configuration.html.markdown
+++ b/website/docs/r/cognito_risk_configuration.html.markdown
@@ -74,8 +74,12 @@ The following arguments are supported:
 
 ### risk_exception_configuration
 
-* `blocked_ip_range_list` - (Optional) Overrides the risk decision to always block the pre-authentication requests. The IP range is in CIDR notation, a compact representation of an IP address and its routing prefix.
-* `skipped_ip_range_list` - (Optional) Risk detection isn't performed on the IP addresses in this range list. The IP range is in CIDR notation.
+* `blocked_ip_range_list` - (Optional) Overrides the risk decision to always block the pre-authentication requests.
+  The IP range is in CIDR notation, a compact representation of an IP address and its routing prefix.
+  Can contain a maximum of 200 items.
+* `skipped_ip_range_list` - (Optional) Risk detection isn't performed on the IP addresses in this range list.
+  The IP range is in CIDR notation.
+  Can contain a maximum of 200 items.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Adds validation to the `risk_exception_configuration` parameter

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29508

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=cognitoidp TESTS=TestAccCognitoIDPRiskConfiguration_

--- PASS: TestAccCognitoIDPRiskConfiguration_nullRiskException (2.70s)
--- PASS: TestAccCognitoIDPRiskConfiguration_emptyRiskException (2.84s)
--- PASS: TestAccCognitoIDPRiskConfiguration_empty (2.88s)
--- PASS: TestAccCognitoIDPRiskConfiguration_disappears_userPool (11.73s)
--- PASS: TestAccCognitoIDPRiskConfiguration_disappears (13.28s)
--- PASS: TestAccCognitoIDPRiskConfiguration_compromised (14.71s)
--- PASS: TestAccCognitoIDPRiskConfiguration_client (15.09s)
--- PASS: TestAccCognitoIDPRiskConfiguration_exception (22.43s)
```
