### PR TITLE
skaff: Add missing context to the CheckDestroy function

### DIFF
--- a/skaff/resource/resourcetest.tmpl
+++ b/skaff/resource/resourcetest.tmpl
@@ -240,7 +240,7 @@ func TestAcc{{ .Service }}{{ .Resource }}_disappears(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t, {{ .ServicePackage }}.EndpointsID),
 		{{- end }}
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheck{{ .Resource }}Destroy,
+		CheckDestroy:             testAccCheck{{ .Resource }}Destroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAcc{{ .Resource }}Config_basic(rName, testAcc{{ .Resource }}VersionNewer),


### PR DESCRIPTION
### Description
One of the `CheckDestroy` functions is missing the `ctx` argument.

### Relations
N/A

### References
N/A


### Output from Acceptance Testing
N/A