### PR TITLE
Updated missing outputs for `vpc_ipam` resource

### DIFF
--- a/website/docs/r/vpc_ipam.html.markdown
+++ b/website/docs/r/vpc_ipam.html.markdown
@@ -74,6 +74,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - Amazon Resource Name (ARN) of IPAM
 * `id` - The ID of the IPAM
+* `default_resource_discovery_id` - The IPAM's default resource discovery ID.
+* `default_resource_discovery_association_id` - The IPAM's default resource discovery association ID.
 * `private_default_scope_id` - The ID of the IPAM's private scope. A scope is a top-level container in IPAM. Each scope represents an IP-independent network. Scopes enable you to represent networks where you have overlapping IP space. When you create an IPAM, IPAM automatically creates two scopes: public and private. The private scope is intended for private IP space. The public scope is intended for all internet-routable IP space.
 * `public_default_scope_id` - The ID of the IPAM's public scope. A scope is a top-level container in IPAM. Each scope represents an IP-independent network. Scopes enable you to represent networks where you have overlapping IP space. When you create an IPAM, IPAM automatically creates two scopes: public and private. The private scope is intended for private
 IP space. The public scope is intended for all internet-routable IP space.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add missing outputs for `aws_vpc_ipam` resource.
  - `default_resource_discovery_id`
  - `default_resource_discovery_association_id`

Terraform actually prints that output.

```bash
  + resource "aws_vpc_ipam" "this" {
      + arn                                       = (known after apply)
      + default_resource_discovery_association_id = (known after apply)
      + default_resource_discovery_id             = (known after apply)
      + description                               = "Test IPAM"
      + id                                        = (known after apply)
      + private_default_scope_id                  = (known after apply)
      + public_default_scope_id                   = (known after apply)
      + scope_count                               = (known after apply)
      + tags                                      = {
...
        }
      + tags_all                                  = {
...
        }

      + operating_regions {
          + region_name = "ap-northeast-2"
        }
    }

```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
