### PR TITLE
Update missing outputs for vpc_iapm_scope resource

### DIFF
--- a/website/docs/r/vpc_ipam_scope.html.markdown
+++ b/website/docs/r/vpc_ipam_scope.html.markdown
@@ -41,10 +41,12 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The Amazon Resource Name (ARN) of the scope.
 * `id` - The ID of the IPAM Scope.
 * `ipam_arn` - The ARN of the IPAM for which you're creating this scope.
 * `is_default` - Defines if the scope is the default scope or not.
-* `pool_count` - Count of pools under this scope
+* `pool_count` - The number of pools in the scope.
+* `type` - The type of the scope.
 
 ## Import
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Add missing outputs for `aws_vpc_ipam_scope` resource.

- `arn`
- `type`

Update description of `pool_count` output for `aws_vpc_ipam_scope` resource.

Terraform actually prints that output.

```sh
{
              + arn             = (known after apply)
              + description     = "Managed by Terraform."
              + id              = (known after apply)
              + ipam_arn        = (known after apply)
              + ipam_id         = "ipam-00cd75f95fd04902b"
              + ipam_scope_type = (known after apply)
              + is_default      = (known after apply)
              + pool_count      = (known after apply)
```



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
