### PR TITLE
Pinpoint Application & OpsWorks Application: Don't return an error on successful Delete

### DIFF
--- a/.changelog/30101.txt
+++ b/.changelog/30101.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_pinpoint_app: Don't return an error like `deleting Pinpoint Application (...): %!s()` after successful Delete
+```
+
+```release-note:bug
+resource/aws_opsworks_application: Don't return an error like `deleting OpsWorks Application (...): %!s()` after successful Delete
+```

--- a/internal/service/opsworks/application.go
+++ b/internal/service/opsworks/application.go
@@ -376,19 +376,20 @@ func resourceApplicationDelete(ctx context.Context, d *schema.ResourceData, meta
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OpsWorksConn()
 
-	req := &opsworks.DeleteAppInput{
+	log.Printf("[DEBUG] Deleting OpsWorks Application: %s", d.Id())
+	_, err := conn.DeleteAppWithContext(ctx, &opsworks.DeleteAppInput{
 		AppId: aws.String(d.Id()),
-	}
-
-	log.Printf("[DEBUG] Deleting OpsWorks application: %s", d.Id())
-
-	_, err := conn.DeleteAppWithContext(ctx, req)
+	})
 
 	if tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
 		return diags
 	}
 
-	return sdkdiag.AppendErrorf(diags, "deleting OpsWorks Application (%s): %s", d.Id(), err)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "deleting OpsWorks Application (%s): %s", d.Id(), err)
+	}
+
+	return diags
 }
 
 func resourceFindEnvironmentVariable(key string, vs []*opsworks.EnvironmentVariable) *opsworks.EnvironmentVariable {

--- a/internal/service/pinpoint/app.go
+++ b/internal/service/pinpoint/app.go
@@ -309,7 +309,7 @@ func resourceAppDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).PinpointConn()
 
-	log.Printf("[DEBUG] Pinpoint Delete App: %s", d.Id())
+	log.Printf("[DEBUG] Deleting Pinpoint Application: %s", d.Id())
 	_, err := conn.DeleteAppWithContext(ctx, &pinpoint.DeleteAppInput{
 		ApplicationId: aws.String(d.Id()),
 	})
@@ -318,7 +318,11 @@ func resourceAppDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diags
 	}
 
-	return sdkdiag.AppendErrorf(diags, "deleting Pinpoint Application (%s): %s", d.Id(), err)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "deleting Pinpoint Application (%s): %s", d.Id(), err)
+	}
+
+	return diags
 }
 
 func expandCampaignHook(configs []interface{}) *pinpoint.CampaignHook {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Don't return a `diags` containing a wrapper `nil` error on successful delete.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/30072.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/29341.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccPinpointApp_basic' PKG=pinpoint ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/pinpoint/... -v -count 1 -parallel 2  -run=TestAccPinpointApp_basic -timeout 180m
=== RUN   TestAccPinpointApp_basic
=== PAUSE TestAccPinpointApp_basic
=== CONT  TestAccPinpointApp_basic
--- PASS: TestAccPinpointApp_basic (21.89s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/pinpoint	31.491s
% make testacc TESTARGS='-run=TestAccOpsWorksApplication_basic' PKG=opsworks ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opsworks/... -v -count 1 -parallel 2  -run=TestAccOpsWorksApplication_basic -timeout 180m
=== RUN   TestAccOpsWorksApplication_basic
=== PAUSE TestAccOpsWorksApplication_basic
=== CONT  TestAccOpsWorksApplication_basic
--- PASS: TestAccOpsWorksApplication_basic (59.71s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opsworks	67.638s
```
