### PR TITLE
Fix typo in `aws_codepipeline`

### DIFF
--- a/website/docs/r/codepipeline.markdown
+++ b/website/docs/r/codepipeline.markdown
@@ -137,9 +137,9 @@ data "aws_iam_policy_document" "codepipeline_policy" {
   }
 
   statement {
-    effect   = "Allow"
-    actions  = ["codestar-connections:UseConnection"]
-    resource = [aws_codestarconnections_connection.example.arn]
+    effect    = "Allow"
+    actions   = ["codestar-connections:UseConnection"]
+    resources = [aws_codestarconnections_connection.example.arn]
   }
 
   statement {


### PR DESCRIPTION
### Description

`resource` != `resources`


### Relations

Closes #30087

### References

- [`aws_iam_policy_document.statement.resources`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#resources)

### Output from Acceptance Testing

N/a, docs
