### PR TITLE
EventBridge `event_bus_name` parameter validation

### DIFF
--- a/internal/service/events/bus_policy.go
+++ b/internal/service/events/bus_policy.go
@@ -38,7 +38,7 @@ func ResourceBusPolicy() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validBusNameOrARN,
+				ValidateFunc: validBusName,
 				Default:      DefaultEventBusName,
 			},
 			"policy": {

--- a/internal/service/events/permission.go
+++ b/internal/service/events/permission.go
@@ -67,7 +67,7 @@ func ResourcePermission() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validBusNameOrARN,
+				ValidateFunc: validBusName,
 				Default:      DefaultEventBusName,
 			},
 			"principal": {

--- a/internal/service/events/validate.go
+++ b/internal/service/events/validate.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/eventbridge"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -81,24 +83,53 @@ func mapMaxItems(max int) schema.SchemaValidateFunc {
 
 var validArchiveName = validation.All(
 	validation.StringLenBetween(1, 48),
-	validation.StringMatch(regexp.MustCompile(`^[\.\-_A-Za-z0-9]+`), ""),
+	validation.StringMatch(regexp.MustCompile(`^`+validNameCharClass+`$`), ""),
 )
 
-var validBusNameOrARN = validation.Any(
-	verify.ValidARN,
-	validation.All(
-		validation.StringLenBetween(1, 256),
-		validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9._\-/]+$`), ""),
+var validBusName = validation.All(
+	validation.StringLenBetween(1, 256),
+	validBusNameFormat,
+)
+
+var validBusNameOrARN = validation.All(
+	validation.StringLenBetween(1, 1600),
+	validation.Any(
+		verify.ValidARNCheck(eventBusARNCheck),
+		validBusNameFormat,
 	),
 )
 
+var validBusNameFormat = validation.StringMatch(regexp.MustCompile(`^`+validBusNameCharClass+`$`), "")
+
+func eventBusARNCheck(v any, k string, arn arn.ARN) (ws []string, errors []error) {
+	if !isEventBusARN(arn) {
+		errors = append(errors, fmt.Errorf("%q (%s) is not a valid Event Bus ARN", k, v))
+	}
+	return
+}
+
 var validSourceName = validation.All(
 	validation.StringLenBetween(1, 256),
-	validation.StringMatch(regexp.MustCompile(`^aws\.partner(/[\.\-_A-Za-z0-9]+){2,}$`), ""),
+	validation.StringMatch(regexp.MustCompile(`^aws\.partner(/`+validNameCharClass+`){2,}$`), ""),
 )
 
 var validCustomEventBusName = validation.All(
 	validation.StringLenBetween(1, 256),
-	validation.StringMatch(regexp.MustCompile(`^[/\.\-_A-Za-z0-9]+$`), ""),
 	validation.StringDoesNotMatch(regexp.MustCompile(`^default$`), "cannot be 'default'"),
 )
+
+func isEventBusARN(arn arn.ARN) bool {
+	if arn.Service != eventbridge.EndpointsID {
+		return false
+	}
+
+	re := regexp.MustCompile(`^event-bus/(` + validBusNameCharClass + `)$`)
+
+	return re.MatchString(arn.Resource)
+}
+
+var validNameChars = `\.\-_A-Za-z0-9`
+var validNameCharClass = `[` + validNameChars + `]+`
+
+var validBusNameCharPattern = `/` + validNameChars
+var validBusNameCharClass = `[` + validBusNameCharPattern + `]+`

--- a/internal/service/events/validate_test.go
+++ b/internal/service/events/validate_test.go
@@ -113,7 +113,7 @@ func TestValidBusNameOrARN(t *testing.T) {
 	for _, v := range validNames {
 		_, errors := validBusNameOrARN(v, "name")
 		if len(errors) != 0 {
-			t.Fatalf("%q should be a valid CW event rule name: %q", v, errors)
+			t.Fatalf("%q should be a valid CW event bus name: %q", v, errors)
 		}
 	}
 
@@ -124,7 +124,7 @@ func TestValidBusNameOrARN(t *testing.T) {
 	for _, v := range invalidNames {
 		_, errors := validBusNameOrARN(v, "name")
 		if len(errors) == 0 {
-			t.Fatalf("%q should be an invalid CW event rule name", v)
+			t.Fatalf("%q should be an invalid CW event bus name", v)
 		}
 	}
 }

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -35,39 +35,64 @@ func Valid4ByteASN(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
-func ValidARN(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
+// ValidARN validates that a string value matches a generic ARN format
+var ValidARN = ValidARNCheck()
 
-	if value == "" {
+type ARNCheckFunc func(any, string, arn.ARN) ([]string, []error)
+
+// ValidARNCheck validates that a string value matches an ARN format with additional validation on the parsed ARN value
+// It must:
+// * Be parseable as an ARN
+// * Have a valid partition
+// * Have a valid region
+// * Have either an empty or valid account ID
+// * Have a non-empty resource part
+// * Pass the supplied checks
+func ValidARNCheck(f ...ARNCheckFunc) schema.SchemaValidateFunc {
+	return func(v any, k string) (ws []string, errors []error) {
+		value, ok := v.(string)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+			return ws, errors
+		}
+
+		if value == "" {
+			return ws, errors
+		}
+
+		parsedARN, err := arn.Parse(value)
+
+		if err != nil {
+			errors = append(errors, fmt.Errorf("%q (%s) is an invalid ARN: %s", k, value, err))
+			return ws, errors
+		}
+
+		if parsedARN.Partition == "" {
+			errors = append(errors, fmt.Errorf("%q (%s) is an invalid ARN: missing partition value", k, value))
+		} else if !partitionRegexp.MatchString(parsedARN.Partition) {
+			errors = append(errors, fmt.Errorf("%q (%s) is an invalid ARN: invalid partition value (expecting to match regular expression: %s)", k, value, partitionRegexp))
+		}
+
+		if parsedARN.Region != "" && !regionRegexp.MatchString(parsedARN.Region) {
+			errors = append(errors, fmt.Errorf("%q (%s) is an invalid ARN: invalid region value (expecting to match regular expression: %s)", k, value, regionRegexp))
+		}
+
+		if parsedARN.AccountID != "" && !accountIDRegexp.MatchString(parsedARN.AccountID) {
+			errors = append(errors, fmt.Errorf("%q (%s) is an invalid ARN: invalid account ID value (expecting to match regular expression: %s)", k, value, accountIDRegexp))
+		}
+
+		if parsedARN.Resource == "" {
+			errors = append(errors, fmt.Errorf("%q (%s) is an invalid ARN: missing resource value", k, value))
+		}
+
+		for _, f := range f {
+			w, e := f(v, k, parsedARN)
+			ws = append(ws, w...)
+			errors = append(errors, e...)
+		}
+
 		return ws, errors
 	}
-
-	parsedARN, err := arn.Parse(value)
-
-	if err != nil {
-		errors = append(errors, fmt.Errorf("%q (%s) is an invalid ARN: %s", k, value, err))
-		return ws, errors
-	}
-
-	if parsedARN.Partition == "" {
-		errors = append(errors, fmt.Errorf("%q (%s) is an invalid ARN: missing partition value", k, value))
-	} else if !partitionRegexp.MatchString(parsedARN.Partition) {
-		errors = append(errors, fmt.Errorf("%q (%s) is an invalid ARN: invalid partition value (expecting to match regular expression: %s)", k, value, partitionRegexp))
-	}
-
-	if parsedARN.Region != "" && !regionRegexp.MatchString(parsedARN.Region) {
-		errors = append(errors, fmt.Errorf("%q (%s) is an invalid ARN: invalid region value (expecting to match regular expression: %s)", k, value, regionRegexp))
-	}
-
-	if parsedARN.AccountID != "" && !accountIDRegexp.MatchString(parsedARN.AccountID) {
-		errors = append(errors, fmt.Errorf("%q (%s) is an invalid ARN: invalid account ID value (expecting to match regular expression: %s)", k, value, accountIDRegexp))
-	}
-
-	if parsedARN.Resource == "" {
-		errors = append(errors, fmt.Errorf("%q (%s) is an invalid ARN: missing resource value", k, value))
-	}
-
-	return ws, errors
 }
 
 func ValidAccountID(v interface{}, k string) (ws []string, errors []error) {

--- a/website/docs/r/cloudwatch_event_bus_policy.html.markdown
+++ b/website/docs/r/cloudwatch_event_bus_policy.html.markdown
@@ -139,7 +139,8 @@ resource "aws_cloudwatch_event_bus_policy" "test" {
 The following arguments are supported:
 
 * `policy` - (Required) The text of the policy. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).
-* `event_bus_name` - (Optional) The event bus to set the permissions on. If you omit this, the permissions are set on the `default` event bus.
+* `event_bus_name` - (Optional) The name of the event bus to set the permissions on.
+  If you omit this, the permissions are set on the `default` event bus.
 
 ## Attributes Reference
 

--- a/website/docs/r/cloudwatch_event_permission.html.markdown
+++ b/website/docs/r/cloudwatch_event_permission.html.markdown
@@ -48,7 +48,8 @@ The following arguments are supported:
 * `statement_id` - (Required) An identifier string for the external account that you are granting permissions to.
 * `action` - (Optional) The action that you are enabling the other account to perform. Defaults to `events:PutEvents`.
 * `condition` - (Optional) Configuration block to limit the event bus permissions you are granting to only accounts that fulfill the condition. Specified below.
-* `event_bus_name` - (Optional) The event bus to set the permissions on. If you omit this, the permissions are set on the `default` event bus.
+* `event_bus_name` - (Optional) The name of the event bus to set the permissions on.
+  If you omit this, the permissions are set on the `default` event bus.
 
 ### condition
 

--- a/website/docs/r/cloudwatch_event_rule.html.markdown
+++ b/website/docs/r/cloudwatch_event_rule.html.markdown
@@ -63,7 +63,8 @@ The following arguments are supported:
 * `name` - (Optional) The name of the rule. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `schedule_expression` - (Optional) The scheduling expression. For example, `cron(0 20 * * ? *)` or `rate(5 minutes)`. At least one of `schedule_expression` or `event_pattern` is required. Can only be used on the default event bus. For more information, refer to the AWS documentation [Schedule Expressions for Rules](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html).
-* `event_bus_name` - (Optional) The event bus to associate with this rule. If you omit this, the `default` event bus is used.
+* `event_bus_name` - (Optional) The name or ARN of the event bus to associate with this rule.
+  If you omit this, the `default` event bus is used.
 * `event_pattern` - (Optional) The event pattern described a JSON object. At least one of `schedule_expression` or `event_pattern` is required. See full documentation of [Events and Event Patterns in EventBridge](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html) for details.
 * `description` - (Optional) The description of the rule.
 * `role_arn` - (Optional) The Amazon Resource Name (ARN) associated with the role that is used for target invocation.

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -464,7 +464,8 @@ The following arguments are optional:
 * `batch_target` - (Optional) Parameters used when you are using the rule to invoke an Amazon Batch Job. Documented below. A maximum of 1 are allowed.
 * `dead_letter_config` - (Optional)  Parameters used when you are providing a dead letter config. Documented below. A maximum of 1 are allowed.
 * `ecs_target` - (Optional) Parameters used when you are using the rule to invoke Amazon ECS Task. Documented below. A maximum of 1 are allowed.
-* `event_bus_name` - (Optional) The event bus to associate with the rule. If you omit this, the `default` event bus is used.
+* `event_bus_name` - (Optional) The name or ARN of the event bus to associate with the rule.
+  If you omit this, the `default` event bus is used.
 * `http_target` - (Optional) Parameters used when you are using the rule to invoke an API Gateway REST endpoint. Documented below. A maximum of 1 is allowed.
 * `input` - (Optional) Valid JSON text passed to the target. Conflicts with `input_path` and `input_transformer`.
 * `input_path` - (Optional) The value of the [JSONPath](http://goessner.net/articles/JsonPath/) that is used for extracting part of the matched event when passing it to the target. Conflicts with `input` and `input_transformer`.


### PR DESCRIPTION
### Description

For the `event_bus_name` parameter, the EventBridge resources `aws_cloudwatch_event_rule` and  `aws_cloudwatch_event_target` accept a name or ARN, while `aws_cloudwatch_event_bus_policy` and `aws_cloudwatch_event_permission` only accept a name. This PR updates the validation for the four resources.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #18182

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=events TESTS='TestAccEventsTarget_|TestAccEventsPermission_|TestAccEventsBusPolicy_|TestAccEventsRule_'

--- SKIP: TestAccEventsRule_partnerEventBus (0.00s)
--- SKIP: TestAccEventsTarget_partnerEventBus (0.00s)
--- PASS: TestAccEventsTarget_disappears (95.21s)
--- PASS: TestAccEventsRule_namePrefix (101.97s)
--- PASS: TestAccEventsRule_Name_generated (102.16s)
--- PASS: TestAccEventsRule_scheduleAndPattern (104.38s)
--- PASS: TestAccEventsTarget_inputTransformerJSONString (130.28s)
--- PASS: TestAccEventsTarget_ecsFull (139.85s)
--- PASS: TestAccEventsRule_role (141.80s)
--- PASS: TestAccEventsTarget_ecsWithBlankTaskCount (147.87s)
--- PASS: TestAccEventsTarget_Input_transformer (159.48s)
--- PASS: TestAccEventsTarget_sqs (161.80s)
--- PASS: TestAccEventsTarget_kinesis (169.14s)
--- PASS: TestAccEventsRule_description (178.60s)
--- PASS: TestAccEventsRule_pattern (180.28s)
--- PASS: TestAccEventsBusPolicy_basic (182.06s)
--- PASS: TestAccEventsTarget_ecsCapacityProvider (184.91s)
--- PASS: TestAccEventsPermission_condition (186.41s)
--- PASS: TestAccEventsTarget_batch (197.20s)
--- PASS: TestAccEventsTarget_ssmDocument (124.43s)
--- PASS: TestAccEventsRule_eventBusName (254.11s)
--- PASS: TestAccEventsTarget_http (119.94s)
--- PASS: TestAccEventsTarget_generatedTargetID (113.25s)
--- PASS: TestAccEventsTarget_ecs (134.51s)
--- PASS: TestAccEventsPermission_multiple (174.19s)
--- PASS: TestAccEventsRule_eventBusARN (119.68s)
--- PASS: TestAccEventsTarget_full (138.01s)
--- PASS: TestAccEventsPermission_eventBusName (118.01s)
--- PASS: TestAccEventsPermission_disappears (204.67s)
--- PASS: TestAccEventsTarget_ecsWithoutLaunchType (312.95s)
--- PASS: TestAccEventsTarget_ecsWithBlankLaunchType (314.93s)
--- PASS: TestAccEventsPermission_action (131.11s)
--- PASS: TestAccEventsTarget_RetryPolicy_deadLetter (148.67s)
--- PASS: TestAccEventsTarget_http_params (179.96s)
--- PASS: TestAccEventsTarget_basic (149.52s)
--- PASS: TestAccEventsBusPolicy_ignoreEquivalent (101.57s)
--- PASS: TestAccEventsRule_basic (240.69s)
--- PASS: TestAccEventsTarget_eventBusARN (71.08s)
--- PASS: TestAccEventsTarget_eventBusName (67.10s)
--- PASS: TestAccEventsPermission_basic (174.06s)
--- PASS: TestAccEventsRule_isEnabled (111.42s)
--- PASS: TestAccEventsRule_tags (107.67s)
--- PASS: TestAccEventsBusPolicy_disappears (194.34s)
--- PASS: TestAccEventsTarget_redshift (387.47s)
```
