### PR TITLE
Serializes WAF rate-based rule tests

### DIFF
--- a/.ci/.semgrep-service-name3.yml
+++ b/.ci/.semgrep-service-name3.yml
@@ -2898,6 +2898,7 @@ rules:
           metavariable: $NAME
           patterns:
             - pattern-regex: "(?i)WAF"
+            - pattern-not-regex: ^testAccWAFRateBasedRule.+
             - pattern-not-regex: ^TestAcc.*
     severity: WARNING
   - id: waf-in-test-name

--- a/internal/generate/servicesemgrep/service.tmpl
+++ b/internal/generate/servicesemgrep/service.tmpl
@@ -33,6 +33,9 @@
             - pattern-not-regex: ^testAccSSMDefaultPatchBaseline_.+
             - pattern-not-regex: ^testAccSSMPatchBaseline_.+
             {{- end }}
+            {{- if eq .ServiceAlias "WAF" }}
+            - pattern-not-regex: ^testAccWAFRateBasedRule.+
+            {{- end }}
             - pattern-not-regex: ^TestAcc.*
     severity: WARNING
 {{- end }}

--- a/internal/service/waf/rate_based_rule_data_source_test.go
+++ b/internal/service/waf/rate_based_rule_data_source_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
-func TestAccWAFRateBasedRuleDataSource_basic(t *testing.T) {
+func testAccWAFRateBasedRuleDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_waf_rate_based_rule.wafrule"
 	datasourceName := "data.aws_waf_rate_based_rule.wafrule"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, waf.EndpointsID) },
 		ErrorCheck:               acctest.ErrorCheck(t, waf.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/waf/rate_based_rule_test.go
+++ b/internal/service/waf/rate_based_rule_test.go
@@ -16,13 +16,33 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func TestAccWAFRateBasedRule_basic(t *testing.T) {
+// Serialize to avoid resource limits
+func TestAccWAFRateBasedRule_serial(t *testing.T) {
+	testCases := map[string]map[string]func(t *testing.T){
+		"resource": {
+			"basic":              testAccWAFRateBasedRule_basic,
+			"changeNameForceNew": testAccWAFRateBasedRule_changeNameForceNew,
+			"disappears":         testAccWAFRateBasedRule_disappears,
+			"changePredicates":   testAccWAFRateBasedRule_changePredicates,
+			"changeRateLimit":    testAccWAFRateBasedRule_changeRateLimit,
+			"noPredicates":       testAccWAFRateBasedRule_noPredicates,
+			"Tags":               testAccWAFRateBasedRule_tags,
+		},
+		"data_source": {
+			"basic": testAccWAFRateBasedRuleDataSource_basic,
+		},
+	}
+
+	acctest.RunSerialTests2Levels(t, testCases, 0)
+}
+
+func testAccWAFRateBasedRule_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v waf.RateBasedRule
 	wafRuleName := fmt.Sprintf("wafrule%s", sdkacctest.RandString(5))
 	resourceName := "aws_waf_rate_based_rule.wafrule"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, waf.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -47,14 +67,14 @@ func TestAccWAFRateBasedRule_basic(t *testing.T) {
 	})
 }
 
-func TestAccWAFRateBasedRule_changeNameForceNew(t *testing.T) {
+func testAccWAFRateBasedRule_changeNameForceNew(t *testing.T) {
 	ctx := acctest.Context(t)
 	var before, after waf.RateBasedRule
 	wafRuleName := fmt.Sprintf("wafrule%s", sdkacctest.RandString(5))
 	wafRuleNewName := fmt.Sprintf("wafrulenew%s", sdkacctest.RandString(5))
 	resourceName := "aws_waf_rate_based_rule.wafrule"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, waf.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -87,13 +107,13 @@ func TestAccWAFRateBasedRule_changeNameForceNew(t *testing.T) {
 	})
 }
 
-func TestAccWAFRateBasedRule_disappears(t *testing.T) {
+func testAccWAFRateBasedRule_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v waf.RateBasedRule
 	wafRuleName := fmt.Sprintf("wafrule%s", sdkacctest.RandString(5))
 	resourceName := "aws_waf_rate_based_rule.wafrule"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, waf.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -111,7 +131,7 @@ func TestAccWAFRateBasedRule_disappears(t *testing.T) {
 	})
 }
 
-func TestAccWAFRateBasedRule_changePredicates(t *testing.T) {
+func testAccWAFRateBasedRule_changePredicates(t *testing.T) {
 	ctx := acctest.Context(t)
 	var ipset waf.IPSet
 	var byteMatchSet waf.ByteMatchSet
@@ -120,7 +140,7 @@ func TestAccWAFRateBasedRule_changePredicates(t *testing.T) {
 	ruleName := fmt.Sprintf("wafrule%s", sdkacctest.RandString(5))
 	resourceName := "aws_waf_rate_based_rule.wafrule"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, waf.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -162,14 +182,14 @@ func TestAccWAFRateBasedRule_changePredicates(t *testing.T) {
 }
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/9659
-func TestAccWAFRateBasedRule_changeRateLimit(t *testing.T) {
+func testAccWAFRateBasedRule_changeRateLimit(t *testing.T) {
 	ctx := acctest.Context(t)
 	var ipset waf.IPSet
 	var before, after waf.RateBasedRule
 	ruleName := fmt.Sprintf("wafrule%s", sdkacctest.RandString(5))
 	resourceName := "aws_waf_rate_based_rule.wafrule"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, waf.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -212,13 +232,13 @@ func TestAccWAFRateBasedRule_changeRateLimit(t *testing.T) {
 	})
 }
 
-func TestAccWAFRateBasedRule_noPredicates(t *testing.T) {
+func testAccWAFRateBasedRule_noPredicates(t *testing.T) {
 	ctx := acctest.Context(t)
 	var rule waf.RateBasedRule
 	ruleName := fmt.Sprintf("wafrule%s", sdkacctest.RandString(5))
 	resourceName := "aws_waf_rate_based_rule.wafrule"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, waf.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -241,13 +261,13 @@ func TestAccWAFRateBasedRule_noPredicates(t *testing.T) {
 	})
 }
 
-func TestAccWAFRateBasedRule_tags(t *testing.T) {
+func testAccWAFRateBasedRule_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var rule waf.RateBasedRule
 	ruleName := fmt.Sprintf("wafrule%s", sdkacctest.RandString(5))
 	resourceName := "aws_waf_rate_based_rule.wafrule"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, waf.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,


### PR DESCRIPTION
### Description

Serializes WAF Rate-Based Rule acceptance tests to avoid hitting resource limits

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=waf TESTS=TestAccWAFRateBasedRule

--- PASS: TestAccWAFRateBasedRule_serial (190.65s)
    --- PASS: TestAccWAFRateBasedRule_serial/resource (177.08s)
        --- PASS: TestAccWAFRateBasedRule_serial/resource/basic (19.85s)
        --- PASS: TestAccWAFRateBasedRule_serial/resource/changeNameForceNew (36.38s)
        --- PASS: TestAccWAFRateBasedRule_serial/resource/disappears (17.62s)
        --- PASS: TestAccWAFRateBasedRule_serial/resource/changePredicates (31.44s)
        --- PASS: TestAccWAFRateBasedRule_serial/resource/changeRateLimit (28.15s)
        --- PASS: TestAccWAFRateBasedRule_serial/resource/noPredicates (13.99s)
        --- PASS: TestAccWAFRateBasedRule_serial/resource/Tags (29.66s)
    --- PASS: TestAccWAFRateBasedRule_serial/data_source (13.56s)
        --- PASS: TestAccWAFRateBasedRule_serial/data_source/basic (13.56s)
```
