### PR TITLE
security_group: Destroying takes forever improvements

### DIFF
--- a/.changelog/30114.txt
+++ b/.changelog/30114.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_security_group: Improve respect for delete timeout set by user and retry of certain errors
+```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -280,7 +280,7 @@ testacc: fmtcheck
 	fi
 	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)
 
-testaccs: fmtcheck
+testacc-short: fmtcheck
 	@echo "Running acceptance tests with -short flag"
 	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -short -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)
 
@@ -311,7 +311,7 @@ tools:
 	cd .ci/tools && $(GO_VER) install github.com/rhysd/actionlint/cmd/actionlint
 	cd .ci/tools && $(GO_VER) install mvdan.cc/gofumpt
 
-ts: testaccs
+ts: testacc-short
 
 website-link-check:
 	@.ci/scripts/markdown-link-check.sh

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -311,9 +311,7 @@ tools:
 	cd .ci/tools && $(GO_VER) install github.com/rhysd/actionlint/cmd/actionlint
 	cd .ci/tools && $(GO_VER) install mvdan.cc/gofumpt
 
-ts: fmtcheck
-	@echo "Running acceptance tests with -short flag"
-	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -short -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)
+ts: testaccs
 
 website-link-check:
 	@.ci/scripts/markdown-link-check.sh

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -280,6 +280,10 @@ testacc: fmtcheck
 	fi
 	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)
 
+testaccs: fmtcheck
+	@echo "Running acceptance tests with -short flag"
+	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -short -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)
+
 testacc-lint:
 	@echo "Checking acceptance tests with terrafmt"
 	find $(SVC_DIR) -type f -name '*_test.go' \
@@ -306,6 +310,10 @@ tools:
 	cd .ci/tools && $(GO_VER) install github.com/hashicorp/go-changelog/cmd/changelog-build
 	cd .ci/tools && $(GO_VER) install github.com/rhysd/actionlint/cmd/actionlint
 	cd .ci/tools && $(GO_VER) install mvdan.cc/gofumpt
+
+ts: fmtcheck
+	@echo "Running acceptance tests with -short flag"
+	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -short -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)
 
 website-link-check:
 	@.ci/scripts/markdown-link-check.sh
@@ -366,10 +374,12 @@ yamllint:
 	test \
 	test-compile \
 	testacc \
+	testaccs \
 	testacc-lint \
 	testacc-lint-fix \
 	tfsdk2fw \
 	tools \
+	ts \
 	website-link-check \
 	website-link-check-ghrc \
 	website-lint \

--- a/internal/service/ec2/vpc_security_group.go
+++ b/internal/service/ec2/vpc_security_group.go
@@ -380,10 +380,16 @@ func resourceSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
+	firstShortRetry := 1 * time.Minute
+	remainingRetry := d.Timeout(schema.TimeoutDelete) - firstShortRetry
+	if d.Timeout(schema.TimeoutDelete) < 1*time.Minute {
+		remainingRetry = 30 * time.Second
+	}
+
 	log.Printf("[DEBUG] Deleting Security Group: %s", d.Id())
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(
 		ctx,
-		2*time.Minute, // short initial attempt followed by full length attempt
+		firstShortRetry, // short initial attempt followed by full length attempt
 		func() (interface{}, error) {
 			return conn.DeleteSecurityGroupWithContext(ctx, &ec2.DeleteSecurityGroupInput{
 				GroupId: aws.String(d.Id()),
@@ -392,7 +398,7 @@ func resourceSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, me
 		errCodeDependencyViolation, errCodeInvalidGroupInUse,
 	)
 
-	if tfawserr.ErrCodeEquals(err, errCodeDependencyViolation) {
+	if tfawserr.ErrCodeEquals(err, errCodeDependencyViolation) || tfawserr.ErrCodeEquals(err, errCodeInvalidGroupInUse) {
 		if v := d.Get("revoke_rules_on_delete").(bool); v {
 			err := forceRevokeSecurityGroupRules(ctx, conn, d.Id(), true)
 
@@ -403,7 +409,7 @@ func resourceSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, me
 
 		_, err = tfresource.RetryWhenAWSErrCodeEquals(
 			ctx,
-			d.Timeout(schema.TimeoutDelete),
+			remainingRetry,
 			func() (interface{}, error) {
 				return conn.DeleteSecurityGroupWithContext(ctx, &ec2.DeleteSecurityGroupInput{
 					GroupId: aws.String(d.Id()),

--- a/internal/service/ec2/vpc_security_group_test.go
+++ b/internal/service/ec2/vpc_security_group_test.go
@@ -1648,6 +1648,10 @@ func TestAccVPCSecurityGroup_forceRevokeRulesTrue(t *testing.T) {
 
 func TestAccVPCSecurityGroup_forceRevokeRulesFalse(t *testing.T) {
 	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var primary ec2.SecurityGroup
 	var secondary ec2.SecurityGroup
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -2807,6 +2811,10 @@ func TestAccVPCSecurityGroup_rulesDropOnError(t *testing.T) {
 // a rule in another SG, it could not previously be deleted.
 func TestAccVPCSecurityGroup_emrDependencyViolation(t *testing.T) {
 	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var group ec2.SecurityGroup
 	resourceName := "aws_security_group.allow_access"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/website/docs/r/codestarconnections_host.markdown
+++ b/website/docs/r/codestarconnections_host.markdown
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 A `vpc_configuration` block supports the following arguments:
 
-* `security_group_ids` - (Required) he ID of the security group or security groups associated with the Amazon VPC connected to the infrastructure where your provider type is installed.
+* `security_group_ids` - (Required) ID of the security group or security groups associated with the Amazon VPC connected to the infrastructure where your provider type is installed.
 * `subnet_ids` - (Required) The ID of the subnet or subnets associated with the Amazon VPC connected to the infrastructure where your provider type is installed.
 * `tls_certificate` - (Optional) The value of the Transport Layer Security (TLS) certificate associated with the infrastructure where your provider type is installed.
 * `vpc_id` - (Required) The ID of the Amazon VPC connected to the infrastructure where your provider type is installed.

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -10,10 +10,7 @@ description: |-
 
 Provides a security group resource.
 
-~> **NOTE on Security Groups and Security Group Rules:** Terraform currently provides a Security Group resource with `ingress` and `egress` rules defined in-line and a [Security Group Rule resource](security_group_rule.html) which manages one or more `ingress` or
-`egress` rules. Both of these resource were added before AWS assigned a [security group rule unique ID](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules.html), and they do not work well in all scenarios using the`description` and `tags` attributes, which rely on the unique ID.
-The [`aws_vpc_security_group_egress_rule`](vpc_security_group_egress_rule.html) and [`aws_vpc_security_group_ingress_rule`](vpc_security_group_ingress_rule.html) resources have been added to address these limitations and should be used for all new security group rules.
-You should not use the `aws_vpc_security_group_egress_rule` and `aws_vpc_security_group_ingress_rule` resources in conjunction with an `aws_security_group` resource with in-line rules or with `aws_security_group_rule` resources defined for the same Security Group, as rule conflicts may occur and rules will be overwritten.
+~> **NOTE on Security Groups and Security Group Rules:** Terraform currently provides a Security Group resource with `ingress` and `egress` rules defined in-line and a [Security Group Rule resource](security_group_rule.html) which manages one or more `ingress` or `egress` rules. Both of these resource were added before AWS assigned a [security group rule unique ID](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules.html), and they do not work well in all scenarios using the`description` and `tags` attributes, which rely on the unique ID. The [`aws_vpc_security_group_egress_rule`](vpc_security_group_egress_rule.html) and [`aws_vpc_security_group_ingress_rule`](vpc_security_group_ingress_rule.html) resources have been added to address these limitations and should be used for all new security group rules. You should not use the `aws_vpc_security_group_egress_rule` and `aws_vpc_security_group_ingress_rule` resources in conjunction with an `aws_security_group` resource with in-line rules or with `aws_security_group_rule` resources defined for the same Security Group, as rule conflicts may occur and rules will be overwritten.
 
 ~> **NOTE:** Referencing Security Groups across VPC peering has certain restrictions. More information is available in the [VPC Peering User Guide](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-security-groups.html).
 
@@ -96,20 +93,120 @@ resource "aws_vpc_endpoint" "my_endpoint" {
 
 You can also find a specific Prefix List using the `aws_prefix_list` data source.
 
-### Change of name or name-prefix value
+### Recreating a Security Group
 
-Security Group's Name [cannot be edited after the resource is created](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/working-with-security-groups.html#creating-security-group). In fact, the `name` and `name-prefix` arguments force the creation of a new Security Group resource when they change value. In that case, Terraform first deletes the existing Security Group resource and then it creates a new one. If the existing Security Group is associated to a Network Interface resource, the deletion cannot complete. The reason is that Network Interface resources cannot be left with no Security Group attached and the new one is not yet available at that point.
+A simple security group `name` change "forces new" the security group--Terraform destroys the security group and creates a new one. (Likewise, `description`, `name_prefix`, or `vpc_id` [cannot be changed](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/working-with-security-groups.html#creating-security-group).) Attempting to recreate the security group leads to a variety of complications depending on how it is used.
 
-You must invert the default behavior of Terraform. That is, first the new Security Group resource must be created, then associated to possible Network Interface resources and finally the old Security Group can be detached and deleted. To force this behavior, you must set the [create_before_destroy](https://www.terraform.io/language/meta-arguments/lifecycle#create_before_destroy) property:
+Security groups are generally associated with other resources--**more than 100** AWS Provider resources reference security groups. Referencing a resource from another resource creates a one-way dependency. For example, if you create an EC2 `aws_instance` that has a `vpc_security_group_ids` argument that refers to an `aws_security_group` resource, the `aws_security_group` is a dependent of the `aws_instance`. Because of this, Terraform will create the security group first so that it can then be associated with the EC2 instance.
+
+However, the dependency relationship actually goes both directions causing the _Security Group Deletion Problem_. AWS does not allow you to delete the security group associated with another resource (_e.g._, the `aws_instance`).
+
+Terraform does [not model bi-directional dependencies](https://developer.hashicorp.com/terraform/internals/graph) like this, but, even if it did, simply knowing the dependency situation would not be enough to solve it. For example, some resources must always have an associated security group while others don't need to. In addition, when the `aws_security_group` resource attempts to recreate, it receives a dependent object error, which does not provide information on whether the dependent object is a security group rule or, for example, an associated EC2 instance. Within Terraform, the associated resource (_e.g._, `aws_instance`) does not receive an error when the `aws_security_group` is trying to recreate even though that is where changes to the associated resource would need to take place (_e.g._, removing the security group association).
+
+Despite these sticky problems, below are some ways to improve your experience when you find it necessary to recreate a security group.
+
+#### `create_before_destroy`
+
+(This example is one approach to [recreating security groups](#recreating-a-security-group). For more information on the challenges and the _Security Group Deletion Problem_, see [the section above](#recreating-a-security-group).)
+
+Normally, Terraform first deletes the existing security group resource and then creates a new one. When a security group is associated with a resource, the delete won't succeed. You can invert the default behavior using the [`create_before_destroy` meta argument](https://www.terraform.io/language/meta-arguments/lifecycle#create_before_destroy):
 
 ```terraform
-resource "aws_security_group" "sg_with_changeable_name" {
+resource "aws_security_group" "example" {
   name = "changeable-name"
   # ... other configuration ...
 
   lifecycle {
-    # Necessary if changing 'name' or 'name_prefix' properties.
     create_before_destroy = true
+  }
+}
+```
+
+#### `replace_triggered_by`
+
+(This example is one approach to [recreating security groups](#recreating-a-security-group). For more information on the challenges and the _Security Group Deletion Problem_, see [the section above](#recreating-a-security-group).)
+
+To replace a resource when a security group changes, use the [`replace_triggered_by` meta argument](https://www.terraform.io/language/meta-arguments/lifecycle#replace_triggered_by). Note that in this example, the `aws_instance` will be destroyed and created again when the `aws_security_group` changes.
+
+```terraform
+resource "aws_security_group" "example" {
+  name = "sg"
+  # ... other configuration ...
+}
+
+resource "aws_instance" "example" {
+  instance_type = "t3.small"
+  # ... other configuration ...
+
+  vpc_security_group_ids = [aws_security_group.test.id]
+
+  lifecycle {
+    # Reference the security group as a whole or individual attributes like `name`
+    replace_triggered_by = [aws_security_group.example]
+  }
+}
+```
+
+#### Shorter timeout
+
+(This example is one approach to [recreating security groups](#recreating-a-security-group). For more information on the challenges and the _Security Group Deletion Problem_, see [the section above](#recreating-a-security-group).)
+
+If destroying a security group takes a long time, it may be because Terraform cannot distinguish between a dependent object (_e.g._, a security group rule or EC2 instance) that is _in the process of being deleted_ and one that is not. In other words, it may be waiting for a train that isn't scheduled to arrive. To fail faster, shorten the `delete` [timeout](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) from the default timeout:
+
+```terraform
+resource "aws_security_group" "example" {
+  name = "izizavle"
+  # ... other configuration ...
+
+  timeouts {
+    delete = "2m"
+  }
+}
+```
+
+#### Provisioners
+
+(This example is one approach to [recreating security groups](#recreating-a-security-group). For more information on the challenges and the _Security Group Deletion Problem_, see [the section above](#recreating-a-security-group).)
+
+**DISCLAIMER:** We **_HIGHLY_** recommend using one of the above approaches and _NOT_ using local provisioners. Provisioners, like the one shown below, should be considered a **last resort** since they are _not readable_, _require skills outside standard Terraform configuration_, are _error prone_ and _difficult to maintain_, are not compatible with cloud environments and upgrade tools, require AWS CLI installation, and are subject to AWS CLI and Terraform changes outside the AWS Provider.
+
+```terraform
+data "aws_security_group" "default" {
+  name   = "default"
+  # ... other configuration ...
+}
+
+resource "aws_security_group" "example" {
+  name = "sg"
+  # ... other configuration ...
+
+  # The downstream resource must have at least one SG attached, therefore we
+  # attach the default SG of the VPC temporarily and remove it later on
+  provisioner "local-exec" {
+    when       = destroy
+    command    = <<DOC
+            ENDPOINT_ID=`aws ec2 describe-vpc-endpoints --filters "Name=tag:Name,Values=${self.tags.workaround1}" --query "VpcEndpoints[0].VpcEndpointId" --output text` &&
+            aws ec2 modify-vpc-endpoint --vpc-endpoint-id $${ENDPOINT_ID} --add-security-group-ids ${self.tags.workaround2} --remove-security-group-ids ${self.id}
+        DOC
+    on_failure = continue
+  }
+
+  tags = {
+    workaround1 = "tagged-name"
+    workaround2 = data.aws_security_group.default.id
+  }
+}
+
+resource "null_resource" "example" {
+  provisioner "local-exec" {
+    command    = <<DOC
+            aws ec2 modify-vpc-endpoint --vpc-endpoint-id ${aws_vpc_endpoint.example.id} --remove-security-group-ids ${data.aws_security_group.default.id}
+        DOC
+    on_failure = continue
+  }
+
+  triggers = {
+    rerun_upon_change_of = join(",", aws_vpc_endpoint.example.security_group_ids)
   }
 }
 ```
@@ -125,8 +222,7 @@ The following arguments are supported:
 * `name` - (Optional, Forces new resource) Name of the security group. If omitted, Terraform will assign a random, unique name.
 * `revoke_rules_on_delete` - (Optional) Instruct Terraform to revoke all of the Security Groups attached ingress and egress rules before deleting the rule itself. This is normally not needed, however certain AWS services such as Elastic Map Reduce may automatically add required rules to security groups used with the service, and those rules may contain a cyclic dependency that prevent the security groups from being destroyed without removing the dependency first. Default `false`.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `vpc_id` - (Optional, Forces new resource) VPC ID.
-  Defaults to the region's default VPC.
+* `vpc_id` - (Optional, Forces new resource) VPC ID. Defaults to the region's default VPC.
 
 ### ingress
 

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -172,7 +172,7 @@ resource "aws_security_group" "example" {
 
 ```terraform
 data "aws_security_group" "default" {
-  name   = "default"
+  name = "default"
   # ... other configuration ...
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #265

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make ts T=TestAccVPCSecurityGroup_ K=vpc               
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -short -count 1 -parallel 20 -run='TestAccVPCSecurityGroup_'  -timeout 180m
=== RUN   TestAccVPCSecurityGroup_basic
=== PAUSE TestAccVPCSecurityGroup_basic
=== RUN   TestAccVPCSecurityGroup_disappears
=== PAUSE TestAccVPCSecurityGroup_disappears
=== RUN   TestAccVPCSecurityGroup_noVPC
=== PAUSE TestAccVPCSecurityGroup_noVPC
=== RUN   TestAccVPCSecurityGroup_nameGenerated
=== PAUSE TestAccVPCSecurityGroup_nameGenerated
=== RUN   TestAccVPCSecurityGroup_nameTerraformPrefix
=== PAUSE TestAccVPCSecurityGroup_nameTerraformPrefix
=== RUN   TestAccVPCSecurityGroup_namePrefix
=== PAUSE TestAccVPCSecurityGroup_namePrefix
=== RUN   TestAccVPCSecurityGroup_namePrefixTerraform
=== PAUSE TestAccVPCSecurityGroup_namePrefixTerraform
=== RUN   TestAccVPCSecurityGroup_tags
=== PAUSE TestAccVPCSecurityGroup_tags
=== RUN   TestAccVPCSecurityGroup_allowAll
=== PAUSE TestAccVPCSecurityGroup_allowAll
=== RUN   TestAccVPCSecurityGroup_sourceSecurityGroup
=== PAUSE TestAccVPCSecurityGroup_sourceSecurityGroup
=== RUN   TestAccVPCSecurityGroup_ipRangeAndSecurityGroupWithSameRules
=== PAUSE TestAccVPCSecurityGroup_ipRangeAndSecurityGroupWithSameRules
=== RUN   TestAccVPCSecurityGroup_ipRangesWithSameRules
=== PAUSE TestAccVPCSecurityGroup_ipRangesWithSameRules
=== RUN   TestAccVPCSecurityGroup_egressMode
=== PAUSE TestAccVPCSecurityGroup_egressMode
=== RUN   TestAccVPCSecurityGroup_ingressMode
=== PAUSE TestAccVPCSecurityGroup_ingressMode
=== RUN   TestAccVPCSecurityGroup_ruleGathering
=== PAUSE TestAccVPCSecurityGroup_ruleGathering
=== RUN   TestAccVPCSecurityGroup_forceRevokeRulesTrue
=== PAUSE TestAccVPCSecurityGroup_forceRevokeRulesTrue
=== RUN   TestAccVPCSecurityGroup_forceRevokeRulesFalse
    vpc_security_group_test.go:1652: skipping long-running test in short mode
--- SKIP: TestAccVPCSecurityGroup_forceRevokeRulesFalse (0.00s)
=== RUN   TestAccVPCSecurityGroup_change
=== PAUSE TestAccVPCSecurityGroup_change
=== RUN   TestAccVPCSecurityGroup_ipv6
=== PAUSE TestAccVPCSecurityGroup_ipv6
=== RUN   TestAccVPCSecurityGroup_self
=== PAUSE TestAccVPCSecurityGroup_self
=== RUN   TestAccVPCSecurityGroup_vpc
=== PAUSE TestAccVPCSecurityGroup_vpc
=== RUN   TestAccVPCSecurityGroup_vpcNegOneIngress
=== PAUSE TestAccVPCSecurityGroup_vpcNegOneIngress
=== RUN   TestAccVPCSecurityGroup_vpcProtoNumIngress
=== PAUSE TestAccVPCSecurityGroup_vpcProtoNumIngress
=== RUN   TestAccVPCSecurityGroup_multiIngress
=== PAUSE TestAccVPCSecurityGroup_multiIngress
=== RUN   TestAccVPCSecurityGroup_vpcAllEgress
=== PAUSE TestAccVPCSecurityGroup_vpcAllEgress
=== RUN   TestAccVPCSecurityGroup_ruleDescription
=== PAUSE TestAccVPCSecurityGroup_ruleDescription
=== RUN   TestAccVPCSecurityGroup_defaultEgressVPC
=== PAUSE TestAccVPCSecurityGroup_defaultEgressVPC
=== RUN   TestAccVPCSecurityGroup_driftComplex
=== PAUSE TestAccVPCSecurityGroup_driftComplex
=== RUN   TestAccVPCSecurityGroup_invalidCIDRBlock
=== PAUSE TestAccVPCSecurityGroup_invalidCIDRBlock
=== RUN   TestAccVPCSecurityGroup_cidrAndGroups
=== PAUSE TestAccVPCSecurityGroup_cidrAndGroups
=== RUN   TestAccVPCSecurityGroup_ingressWithCIDRAndSGsVPC
=== PAUSE TestAccVPCSecurityGroup_ingressWithCIDRAndSGsVPC
=== RUN   TestAccVPCSecurityGroup_egressWithPrefixList
=== PAUSE TestAccVPCSecurityGroup_egressWithPrefixList
=== RUN   TestAccVPCSecurityGroup_ingressWithPrefixList
=== PAUSE TestAccVPCSecurityGroup_ingressWithPrefixList
=== RUN   TestAccVPCSecurityGroup_ipv4AndIPv6Egress
=== PAUSE TestAccVPCSecurityGroup_ipv4AndIPv6Egress
=== RUN   TestAccVPCSecurityGroup_failWithDiffMismatch
=== PAUSE TestAccVPCSecurityGroup_failWithDiffMismatch
=== RUN   TestAccVPCSecurityGroup_RuleLimit_exceededAppend
=== PAUSE TestAccVPCSecurityGroup_RuleLimit_exceededAppend
=== RUN   TestAccVPCSecurityGroup_RuleLimit_cidrBlockExceededAppend
=== PAUSE TestAccVPCSecurityGroup_RuleLimit_cidrBlockExceededAppend
=== RUN   TestAccVPCSecurityGroup_RuleLimit_exceededPrepend
=== PAUSE TestAccVPCSecurityGroup_RuleLimit_exceededPrepend
=== RUN   TestAccVPCSecurityGroup_RuleLimit_exceededAllNew
=== PAUSE TestAccVPCSecurityGroup_RuleLimit_exceededAllNew
=== RUN   TestAccVPCSecurityGroup_rulesDropOnError
=== PAUSE TestAccVPCSecurityGroup_rulesDropOnError
=== RUN   TestAccVPCSecurityGroup_emrDependencyViolation
    vpc_security_group_test.go:2815: skipping long-running test in short mode
--- SKIP: TestAccVPCSecurityGroup_emrDependencyViolation (0.00s)
=== CONT  TestAccVPCSecurityGroup_basic
=== CONT  TestAccVPCSecurityGroup_vpcNegOneIngress
=== CONT  TestAccVPCSecurityGroup_ingressWithPrefixList
=== CONT  TestAccVPCSecurityGroup_ingressWithCIDRAndSGsVPC
=== CONT  TestAccVPCSecurityGroup_egressWithPrefixList
=== CONT  TestAccVPCSecurityGroup_ipRangeAndSecurityGroupWithSameRules
=== CONT  TestAccVPCSecurityGroup_ingressMode
=== CONT  TestAccVPCSecurityGroup_forceRevokeRulesTrue
=== CONT  TestAccVPCSecurityGroup_vpcAllEgress
=== CONT  TestAccVPCSecurityGroup_ruleGathering
=== CONT  TestAccVPCSecurityGroup_invalidCIDRBlock
=== CONT  TestAccVPCSecurityGroup_self
=== CONT  TestAccVPCSecurityGroup_RuleLimit_exceededAllNew
=== CONT  TestAccVPCSecurityGroup_RuleLimit_exceededPrepend
=== CONT  TestAccVPCSecurityGroup_RuleLimit_cidrBlockExceededAppend
=== CONT  TestAccVPCSecurityGroup_RuleLimit_exceededAppend
=== CONT  TestAccVPCSecurityGroup_failWithDiffMismatch
=== CONT  TestAccVPCSecurityGroup_ipv4AndIPv6Egress
=== CONT  TestAccVPCSecurityGroup_defaultEgressVPC
=== CONT  TestAccVPCSecurityGroup_rulesDropOnError
--- PASS: TestAccVPCSecurityGroup_invalidCIDRBlock (10.70s)
=== CONT  TestAccVPCSecurityGroup_namePrefix
--- PASS: TestAccVPCSecurityGroup_failWithDiffMismatch (45.07s)
=== CONT  TestAccVPCSecurityGroup_sourceSecurityGroup
--- PASS: TestAccVPCSecurityGroup_vpcAllEgress (50.04s)
=== CONT  TestAccVPCSecurityGroup_allowAll
--- PASS: TestAccVPCSecurityGroup_self (51.14s)
=== CONT  TestAccVPCSecurityGroup_tags
--- PASS: TestAccVPCSecurityGroup_basic (51.17s)
=== CONT  TestAccVPCSecurityGroup_namePrefixTerraform
--- PASS: TestAccVPCSecurityGroup_defaultEgressVPC (51.23s)
=== CONT  TestAccVPCSecurityGroup_egressMode
--- PASS: TestAccVPCSecurityGroup_vpcNegOneIngress (52.35s)
=== CONT  TestAccVPCSecurityGroup_ipRangesWithSameRules
--- PASS: TestAccVPCSecurityGroup_ingressWithCIDRAndSGsVPC (55.06s)
=== CONT  TestAccVPCSecurityGroup_vpc
=== CONT  TestAccVPCSecurityGroup_multiIngress
--- PASS: TestAccVPCSecurityGroup_ipRangeAndSecurityGroupWithSameRules (61.04s)
--- PASS: TestAccVPCSecurityGroup_namePrefix (52.52s)
=== CONT  TestAccVPCSecurityGroup_cidrAndGroups
--- PASS: TestAccVPCSecurityGroup_ipv4AndIPv6Egress (65.02s)
=== CONT  TestAccVPCSecurityGroup_nameGenerated
--- PASS: TestAccVPCSecurityGroup_egressWithPrefixList (68.46s)
=== CONT  TestAccVPCSecurityGroup_nameTerraformPrefix
--- PASS: TestAccVPCSecurityGroup_ingressWithPrefixList (69.53s)
=== CONT  TestAccVPCSecurityGroup_vpcProtoNumIngress
--- PASS: TestAccVPCSecurityGroup_ruleGathering (74.34s)
=== CONT  TestAccVPCSecurityGroup_ruleDescription
--- PASS: TestAccVPCSecurityGroup_RuleLimit_cidrBlockExceededAppend (85.06s)
=== CONT  TestAccVPCSecurityGroup_driftComplex
--- PASS: TestAccVPCSecurityGroup_rulesDropOnError (85.94s)
=== CONT  TestAccVPCSecurityGroup_ipv6
--- PASS: TestAccVPCSecurityGroup_sourceSecurityGroup (50.17s)
=== CONT  TestAccVPCSecurityGroup_noVPC
--- PASS: TestAccVPCSecurityGroup_namePrefixTerraform (48.85s)
=== CONT  TestAccVPCSecurityGroup_change
--- PASS: TestAccVPCSecurityGroup_allowAll (54.06s)
=== CONT  TestAccVPCSecurityGroup_disappears
--- PASS: TestAccVPCSecurityGroup_vpc (49.34s)
--- PASS: TestAccVPCSecurityGroup_ipRangesWithSameRules (52.31s)
--- PASS: TestAccVPCSecurityGroup_ingressMode (105.09s)
--- PASS: TestAccVPCSecurityGroup_nameGenerated (45.46s)
--- PASS: TestAccVPCSecurityGroup_multiIngress (51.46s)
--- PASS: TestAccVPCSecurityGroup_cidrAndGroups (50.53s)
--- PASS: TestAccVPCSecurityGroup_nameTerraformPrefix (46.30s)
--- PASS: TestAccVPCSecurityGroup_vpcProtoNumIngress (45.64s)
--- PASS: TestAccVPCSecurityGroup_RuleLimit_exceededAppend (129.76s)
--- PASS: TestAccVPCSecurityGroup_RuleLimit_exceededAllNew (117.23s)
--- PASS: TestAccVPCSecurityGroup_RuleLimit_exceededPrepend (119.88s)
--- PASS: TestAccVPCSecurityGroup_ipv6 (45.38s)
--- PASS: TestAccVPCSecurityGroup_driftComplex (48.22s)
--- PASS: TestAccVPCSecurityGroup_disappears (36.96s)
--- PASS: TestAccVPCSecurityGroup_egressMode (92.92s)
--- PASS: TestAccVPCSecurityGroup_tags (96.81s)
--- PASS: TestAccVPCSecurityGroup_change (55.16s)
--- PASS: TestAccVPCSecurityGroup_noVPC (65.25s)
--- PASS: TestAccVPCSecurityGroup_ruleDescription (86.65s)
--- PASS: TestAccVPCSecurityGroup_forceRevokeRulesTrue (240.52s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	256.385s
```
