### PR TITLE
fix: correct key in tfMap for AS2 transports

### DIFF
--- a/.changelog/30115.txt
+++ b/.changelog/30115.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_transfer_server: Fix error refreshing `protocol_details.as2_transports` value
+```

--- a/internal/service/transfer/server.go
+++ b/internal/service/transfer/server.go
@@ -895,7 +895,7 @@ func flattenProtocolDetails(apiObject *transfer.ProtocolDetails) []interface{} {
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.As2Transports; v != nil {
-		tfMap["as2_transport"] = aws.StringValueSlice(v)
+		tfMap["as2_transports"] = aws.StringValueSlice(v)
 	}
 
 	if v := apiObject.PassiveIp; v != nil {


### PR DESCRIPTION
Changed the key in tfMap to "as2_transports" to resolve an error caused by an incorrect key.

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
key should be "as2_transports":
```go
"as2_transports": {
	Type:     schema.TypeSet,
	Optional: true,
	Computed: true,
	Elem: &schema.Schema{
		Type:         schema.TypeString,
		ValidateFunc: validation.StringInSlice(transfer.As2Transport_Values(), false),
	},
},
```
