### PR TITLE
aws_transcribe_vocabulary_filter - typo

### DIFF
--- a/website/docs/r/transcribe_vocabulary_filter.html.markdown
+++ b/website/docs/r/transcribe_vocabulary_filter.html.markdown
@@ -33,12 +33,12 @@ The following arguments are required:
 
 * `language_code` - (Required) The language code you selected for your vocabulary filter. Refer to the [supported languages](https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html) page for accepted codes.
 * `vocabulary_filter_name` - (Required) The name of the VocabularyFilter.
-* `words` - (Required) - A list of terms to include in the vocabulary. Conflicts with `vocabulary_file_uri`
 
 The following arguments are optional:
 
-* `vocabulary_filter_file_uri` - (Required) The Amazon S3 location (URI) of the text file that contains your custom VocabularyFilter. Conflicts with `words`.
+* `vocabulary_filter_file_uri` - (Required) The Amazon S3 location (URI) of the text file that contains your custom VocabularyFilter. Conflicts with `words` argument.
 * `tags` - (Optional) A map of tags to assign to the VocabularyFilter. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `words` - (Optional) - A list of terms to include in the vocabulary. Conflicts with `vocabulary_filter_file_uri` argument.
 
 ## Attributes Reference
 

--- a/website/docs/r/transcribe_vocabulary_filter.html.markdown
+++ b/website/docs/r/transcribe_vocabulary_filter.html.markdown
@@ -36,7 +36,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `vocabulary_filter_file_uri` - (Required) The Amazon S3 location (URI) of the text file that contains your custom VocabularyFilter. Conflicts with `words` argument.
+* `vocabulary_filter_file_uri` - (Optional) The Amazon S3 location (URI) of the text file that contains your custom VocabularyFilter. Conflicts with `words` argument.
 * `tags` - (Optional) A map of tags to assign to the VocabularyFilter. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `words` - (Optional) - A list of terms to include in the vocabulary. Conflicts with `vocabulary_filter_file_uri` argument.
 


### PR DESCRIPTION
### Description
Fix typo `vocabulary_file_uri` -> `vocabulary_filter_file_uri`

### Relations
Closes #30019

### References
https://docs.aws.amazon.com/transcribe/latest/APIReference/API_CreateVocabularyFilter.html

