### PR TITLE
New resource - `aws_oam_link`

### DIFF
--- a/.changelog/30125.txt
+++ b/.changelog/30125.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_oam_link
+```

--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -30,11 +30,14 @@ func ExpandStringList(configured []interface{}) []*string {
 // ExpandStringValueList takes the result of flatmap.Expand for an array of strings
 // and returns a []string
 func ExpandStringValueList(configured []interface{}) []string {
-	vs := make([]string, 0, len(configured))
+	return ExpandStringyValueList[string](configured)
+}
+
+func ExpandStringyValueList[E ~string](configured []any) []E {
+	vs := make([]E, 0, len(configured))
 	for _, v := range configured {
-		val, ok := v.(string)
-		if ok && val != "" {
-			vs = append(vs, v.(string))
+		if val, ok := v.(string); ok && val != "" {
+			vs = append(vs, E(val))
 		}
 	}
 	return vs
@@ -114,6 +117,10 @@ func ExpandStringSet(configured *schema.Set) []*string {
 
 func ExpandStringValueSet(configured *schema.Set) []string {
 	return ExpandStringValueList(configured.List()) // nosemgrep:ci.helper-schema-Set-extraneous-ExpandStringList-with-List
+}
+
+func ExpandStringyValueSet[E ~string](configured *schema.Set) []E {
+	return ExpandStringyValueList[E](configured.List())
 }
 
 func FlattenStringSet(list []*string) *schema.Set {

--- a/internal/flex/flex_test.go
+++ b/internal/flex/flex_test.go
@@ -1,66 +1,57 @@
 package flex
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestExpandStringList(t *testing.T) {
 	t.Parallel()
 
-	expanded := []interface{}{"us-east-1a", "us-east-1b"} //lintignore:AWSAT003
-	stringList := ExpandStringList(expanded)
-	expected := []*string{
-		aws.String("us-east-1a"), //lintignore:AWSAT003
-		aws.String("us-east-1b"), //lintignore:AWSAT003
+	configured := []interface{}{"abc", "xyz123"}
+	got := ExpandStringList(configured)
+	want := []*string{
+		aws.String("abc"),
+		aws.String("xyz123"),
 	}
 
-	if !reflect.DeepEqual(stringList, expected) {
-		t.Fatalf(
-			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			stringList,
-			expected)
+	if !cmp.Equal(got, want) {
+		t.Errorf("expanded = %v, want = %v", got, want)
 	}
 }
 
 func TestExpandStringListEmptyItems(t *testing.T) {
 	t.Parallel()
 
-	expanded := []interface{}{"foo", "bar", "", "baz"}
-	stringList := ExpandStringList(expanded)
-	expected := []*string{
+	configured := []interface{}{"foo", "bar", "", "baz"}
+	got := ExpandStringList(configured)
+	want := []*string{
 		aws.String("foo"),
 		aws.String("bar"),
 		aws.String("baz"),
 	}
 
-	if !reflect.DeepEqual(stringList, expected) {
-		t.Fatalf(
-			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			stringList,
-			expected)
+	if !cmp.Equal(got, want) {
+		t.Errorf("expanded = %v, want = %v", got, want)
 	}
 }
 
 func TestExpandResourceId(t *testing.T) {
 	t.Parallel()
 
-	resourceId := "foo,bar,baz"
-	expandedId, _ := ExpandResourceId(resourceId, 3)
-	expected := []string{
+	id := "foo,bar,baz"
+	got, _ := ExpandResourceId(id, 3)
+	want := []string{
 		"foo",
 		"bar",
 		"baz",
 	}
 
-	if !reflect.DeepEqual(expandedId, expected) {
-		t.Fatalf(
-			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			expandedId,
-			expected)
+	if !cmp.Equal(got, want) {
+		t.Errorf("expanded = %v, want = %v", got, want)
 	}
 }
 
@@ -101,14 +92,11 @@ func TestFlattenResourceId(t *testing.T) {
 	t.Parallel()
 
 	idParts := []string{"foo", "bar", "baz"}
-	flattenedId, _ := FlattenResourceId(idParts, 3)
-	expected := "foo,bar,baz"
+	got, _ := FlattenResourceId(idParts, 3)
+	want := "foo,bar,baz"
 
-	if !reflect.DeepEqual(flattenedId, expected) {
-		t.Fatalf(
-			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
-			flattenedId,
-			expected)
+	if !cmp.Equal(got, want) {
+		t.Errorf("flattened = %v, want = %v", got, want)
 	}
 }
 

--- a/internal/flex/flex_test.go
+++ b/internal/flex/flex_test.go
@@ -39,6 +39,30 @@ func TestExpandStringListEmptyItems(t *testing.T) {
 	}
 }
 
+func TestExpandStringValueList(t *testing.T) {
+	t.Parallel()
+
+	configured := []interface{}{"abc", "xyz123"}
+	got := ExpandStringValueList(configured)
+	want := []string{"abc", "xyz123"}
+
+	if !cmp.Equal(got, want) {
+		t.Errorf("expanded = %v, want = %v", got, want)
+	}
+}
+
+func TestExpandStringValueListEmptyItems(t *testing.T) {
+	t.Parallel()
+
+	configured := []interface{}{"foo", "bar", "", "baz"}
+	got := ExpandStringValueList(configured)
+	want := []string{"foo", "bar", "baz"}
+
+	if !cmp.Equal(got, want) {
+		t.Errorf("expanded = %v, want = %v", got, want)
+	}
+}
+
 func TestExpandResourceId(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/inspector2/enabler.go
+++ b/internal/service/inspector2/enabler.go
@@ -71,7 +71,7 @@ func resourceEnablerCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	in := &inspector2.EnableInput{
 		AccountIds:    flex.ExpandStringValueSet(d.Get("account_ids").(*schema.Set)),
-		ResourceTypes: expandResourceScanTypes(flex.ExpandStringValueSet(d.Get("resource_types").(*schema.Set))),
+		ResourceTypes: flex.ExpandStringyValueSet[types.ResourceScanType](d.Get("resource_types").(*schema.Set)),
 		ClientToken:   aws.String(resource.UniqueId()),
 	}
 
@@ -129,7 +129,7 @@ func resourceEnablerDelete(ctx context.Context, d *schema.ResourceData, meta int
 
 	in := &inspector2.DisableInput{
 		AccountIds:    flex.ExpandStringValueSet(d.Get("account_ids").(*schema.Set)),
-		ResourceTypes: expandResourceScanTypes(flex.ExpandStringValueSet(d.Get("resource_types").(*schema.Set))),
+		ResourceTypes: flex.ExpandStringyValueSet[types.ResourceScanType](d.Get("resource_types").(*schema.Set)),
 	}
 
 	_, err := conn.Disable(ctx, in)
@@ -345,16 +345,6 @@ func compositeStatus(ec2, ecr bool, ec2Status, ecrStatus string) string {
 	}
 
 	return string(types.StatusSuspended)
-}
-
-func expandResourceScanTypes(s []string) []types.ResourceScanType {
-	vs := make([]types.ResourceScanType, 0, len(s))
-	for _, v := range s {
-		if v != "" {
-			vs = append(vs, types.ResourceScanType(v))
-		}
-	}
-	return vs
 }
 
 func EnablerID(accountIDs []string, types []string) string {

--- a/internal/service/oam/link.go
+++ b/internal/service/oam/link.go
@@ -94,7 +94,7 @@ func resourceLinkCreate(ctx context.Context, d *schema.ResourceData, meta interf
 
 	in := &oam.CreateLinkInput{
 		LabelTemplate:  aws.String(d.Get("label_template").(string)),
-		ResourceTypes:  ExpandResourceTypes(d.Get("resource_types").(*schema.Set).List()),
+		ResourceTypes:  flex.ExpandStringyValueSet[types.ResourceType](d.Get("resource_types").(*schema.Set)),
 		SinkIdentifier: aws.String(d.Get("sink_identifier").(string)),
 	}
 
@@ -172,7 +172,7 @@ func resourceLinkUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if d.HasChanges("resource_types") {
-		in.ResourceTypes = ExpandResourceTypes(d.Get("resource_types").(*schema.Set).List())
+		in.ResourceTypes = flex.ExpandStringyValueSet[types.ResourceType](d.Get("resource_types").(*schema.Set))
 		update = true
 	}
 
@@ -238,23 +238,4 @@ func findLinkByID(ctx context.Context, conn *oam.Client, id string) (*oam.GetLin
 	}
 
 	return out, nil
-}
-
-func ExpandResourceTypes(resourceTypeList []interface{}) []types.ResourceType {
-	if len(resourceTypeList) == 0 {
-		return nil
-	}
-
-	var resourceTypes []types.ResourceType
-
-	for _, resourceTypeString := range resourceTypeList {
-		if resourceTypeString == nil {
-			continue
-		}
-
-		resourceType := types.ResourceType(resourceTypeString.(string))
-		resourceTypes = append(resourceTypes, resourceType)
-	}
-
-	return resourceTypes
 }

--- a/internal/service/oam/link.go
+++ b/internal/service/oam/link.go
@@ -1,0 +1,274 @@
+package oam
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/oam"
+	"github.com/aws/aws-sdk-go-v2/service/oam/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKResource("aws_oam_link")
+func ResourceLink() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceLinkCreate,
+		ReadWithoutTimeout:   resourceLinkRead,
+		UpdateWithoutTimeout: resourceLinkUpdate,
+		DeleteWithoutTimeout: resourceLinkDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(1 * time.Minute),
+			Update: schema.DefaultTimeout(1 * time.Minute),
+			Delete: schema.DefaultTimeout(1 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"label": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"label_template": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"link_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_types": {
+				Type:     schema.TypeSet,
+				Required: true,
+				MinItems: 1,
+				MaxItems: 50,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice(ResourceTypeValues(types.ResourceType("").Values()), false),
+				},
+				Set: schema.HashString,
+			},
+			"sink_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sink_identifier": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+const (
+	ResNameLink = "Link"
+)
+
+func resourceLinkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient()
+
+	in := &oam.CreateLinkInput{
+		LabelTemplate:  aws.String(d.Get("label_template").(string)),
+		ResourceTypes:  ExpandResourceTypes(d.Get("resource_types").(*schema.Set).List()),
+		SinkIdentifier: aws.String(d.Get("sink_identifier").(string)),
+	}
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
+
+	if len(tags) > 0 {
+		in.Tags = Tags(tags.IgnoreAWS())
+	}
+
+	out, err := conn.CreateLink(ctx, in)
+	if err != nil {
+		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionCreating, ResNameLink, d.Get("sink_identifier").(string), err)
+	}
+
+	if out == nil || out.Id == nil {
+		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionCreating, ResNameLink, d.Get("sink_identifier").(string), errors.New("empty output"))
+	}
+
+	d.SetId(aws.ToString(out.Arn))
+
+	return resourceLinkRead(ctx, d, meta)
+}
+
+func resourceLinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient()
+
+	out, err := findLinkByID(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] ObservabilityAccessManager Link (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionReading, ResNameLink, d.Id(), err)
+	}
+
+	d.Set("arn", out.Arn)
+	d.Set("label", out.Label)
+	d.Set("label_template", out.LabelTemplate)
+	d.Set("link_id", out.Id)
+	d.Set("resource_types", flex.FlattenStringValueList(out.ResourceTypes))
+	d.Set("sink_arn", out.SinkArn)
+	if _, ok := d.GetOk("sink_identifier"); !ok {
+		d.Set("sink_identifier", out.SinkArn)
+	}
+
+	tags, err := ListTags(ctx, conn, d.Id())
+	if err != nil {
+		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionReading, ResNameLink, d.Id(), err)
+	}
+
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionSetting, ResNameLink, d.Id(), err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionSetting, ResNameLink, d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceLinkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient()
+
+	update := false
+
+	in := &oam.UpdateLinkInput{
+		Identifier: aws.String(d.Id()),
+	}
+
+	if d.HasChanges("resource_types") {
+		in.ResourceTypes = ExpandResourceTypes(d.Get("resource_types").(*schema.Set).List())
+		update = true
+	}
+
+	if d.HasChange("tags_all") {
+		log.Printf("[DEBUG] Updating ObservabilityAccessManager Link Tags (%s): %#v", d.Id(), d.Get("tags_all"))
+		oldTags, newTags := d.GetChange("tags_all")
+		if err := UpdateTags(ctx, conn, d.Get("arn").(string), oldTags, newTags); err != nil {
+			return create.DiagError(names.ObservabilityAccessManager, create.ErrActionUpdating, ResNameSink, d.Id(), err)
+		}
+	}
+
+	if update {
+		log.Printf("[DEBUG] Updating ObservabilityAccessManager Link (%s): %#v", d.Id(), in)
+		_, err := conn.UpdateLink(ctx, in)
+		if err != nil {
+			return create.DiagError(names.ObservabilityAccessManager, create.ErrActionUpdating, ResNameLink, d.Id(), err)
+		}
+	}
+
+	return resourceLinkRead(ctx, d, meta)
+}
+
+func resourceLinkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient()
+
+	log.Printf("[INFO] Deleting ObservabilityAccessManager Link %s", d.Id())
+
+	_, err := conn.DeleteLink(ctx, &oam.DeleteLinkInput{
+		Identifier: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		var nfe *types.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return nil
+		}
+
+		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionDeleting, ResNameLink, d.Id(), err)
+	}
+
+	return nil
+}
+
+func findLinkByID(ctx context.Context, conn *oam.Client, id string) (*oam.GetLinkOutput, error) {
+	in := &oam.GetLinkInput{
+		Identifier: aws.String(id),
+	}
+	out, err := conn.GetLink(ctx, in)
+	if err != nil {
+		var nfe *types.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return nil, &resource.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil || out.Arn == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}
+
+func ExpandResourceTypes(resourceTypeList []interface{}) []types.ResourceType {
+	if len(resourceTypeList) == 0 {
+		return nil
+	}
+
+	var resourceTypes []types.ResourceType
+
+	for _, resourceTypeString := range resourceTypeList {
+		if resourceTypeString == nil {
+			continue
+		}
+
+		resourceType := types.ResourceType(resourceTypeString.(string))
+		resourceTypes = append(resourceTypes, resourceType)
+	}
+
+	return resourceTypes
+}
+
+func ResourceTypeValues(resourceTypes []types.ResourceType) []string {
+	var out []string
+
+	for _, v := range resourceTypes {
+		out = append(out, string(v))
+	}
+
+	return out
+}

--- a/internal/service/oam/link.go
+++ b/internal/service/oam/link.go
@@ -184,7 +184,7 @@ func resourceLinkUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		log.Printf("[DEBUG] Updating ObservabilityAccessManager Link Tags (%s): %#v", d.Id(), d.Get("tags_all"))
 		oldTags, newTags := d.GetChange("tags_all")
 		if err := UpdateTags(ctx, conn, d.Get("arn").(string), oldTags, newTags); err != nil {
-			return create.DiagError(names.ObservabilityAccessManager, create.ErrActionUpdating, ResNameSink, d.Id(), err)
+			return create.DiagError(names.ObservabilityAccessManager, create.ErrActionUpdating, ResNameLink, d.Id(), err)
 		}
 	}
 

--- a/internal/service/oam/link_test.go
+++ b/internal/service/oam/link_test.go
@@ -47,6 +47,8 @@ func TestExpandResourceTypesUnitTest(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.TestName, func(t *testing.T) {
+			t.Parallel()
+
 			got := tfoam.ExpandResourceTypes(testCase.Input)
 
 			if got == nil && testCase.Expected == nil {
@@ -85,6 +87,8 @@ func TestResourceTypeValuesUnitTest(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.TestName, func(t *testing.T) {
+			t.Parallel()
+
 			got := tfoam.ResourceTypeValues(testCase.Input)
 
 			if len(got) == 0 && len(testCase.Expected) == 0 {

--- a/internal/service/oam/link_test.go
+++ b/internal/service/oam/link_test.go
@@ -1,0 +1,614 @@
+package oam_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/oam"
+	"github.com/aws/aws-sdk-go-v2/service/oam/types"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfoam "github.com/hashicorp/terraform-provider-aws/internal/service/oam"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestExpandResourceTypesUnitTest(t *testing.T) {
+	testCases := []struct {
+		TestName string
+		Input    []interface{}
+		Expected []types.ResourceType
+	}{
+		{
+			TestName: "Empty resource types",
+			Input:    []interface{}{},
+			Expected: nil,
+		},
+		{
+			TestName: "Non-empty resource types",
+			Input: []interface{}{
+				"AWS::CloudWatch::Metric",
+				"AWS::Logs::LogGroup",
+			},
+			Expected: []types.ResourceType{
+				types.ResourceTypeAwsCloudwatchMetric,
+				types.ResourceTypeAwsLogsLoggroup,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			got := tfoam.ExpandResourceTypes(testCase.Input)
+
+			if got == nil && testCase.Expected == nil {
+				return
+			}
+			if !awsutil.DeepEqual(got, testCase.Expected) {
+				t.Errorf("got %s, expected %s", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+func TestResourceTypeValuesUnitTest(t *testing.T) {
+	testCases := []struct {
+		TestName string
+		Input    []types.ResourceType
+		Expected []string
+	}{
+		{
+			TestName: "Empty resource types",
+			Input:    []types.ResourceType{},
+			Expected: []string{},
+		},
+		{
+			TestName: "Non-empty resource types",
+			Input: []types.ResourceType{
+				types.ResourceTypeAwsCloudwatchMetric,
+				types.ResourceTypeAwsLogsLoggroup,
+			},
+			Expected: []string{
+				"AWS::CloudWatch::Metric",
+				"AWS::Logs::LogGroup",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			got := tfoam.ResourceTypeValues(testCase.Input)
+
+			if len(got) == 0 && len(testCase.Expected) == 0 {
+				return
+			}
+
+			if !awsutil.DeepEqual(got, testCase.Expected) {
+				t.Errorf("got %s, expected %s", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+func TestAccObservabilityAccessManagerLink_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+	ctx := acctest.Context(t)
+
+	var link oam.GetLinkOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_oam_link.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+			acctest.PreCheckPartitionHasService(t, names.ObservabilityAccessManagerEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ObservabilityAccessManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+		CheckDestroy:             testAccCheckLinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLinkConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinkExists(resourceName, &link),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "oam", regexp.MustCompile(`link/+.`)),
+					resource.TestCheckResourceAttrSet(resourceName, "label"),
+					resource.TestCheckResourceAttr(resourceName, "label_template", "$AccountName"),
+					resource.TestCheckResourceAttrSet(resourceName, "link_id"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.0", "AWS::CloudWatch::Metric"),
+					resource.TestCheckResourceAttrSet(resourceName, "sink_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "sink_identifier"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccObservabilityAccessManagerLink_disappears(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+	ctx := acctest.Context(t)
+
+	var link oam.GetLinkOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_oam_link.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+			acctest.PreCheckPartitionHasService(t, names.ObservabilityAccessManagerEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ObservabilityAccessManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+		CheckDestroy:             testAccCheckLinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLinkConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinkExists(resourceName, &link),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfoam.ResourceLink(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccObservabilityAccessManagerLink_update(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+	ctx := acctest.Context(t)
+
+	var link oam.GetLinkOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_oam_link.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+			acctest.PreCheckPartitionHasService(t, names.ObservabilityAccessManagerEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ObservabilityAccessManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+		CheckDestroy:             testAccCheckLinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLinkConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinkExists(resourceName, &link),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "oam", regexp.MustCompile(`link/+.`)),
+					resource.TestCheckResourceAttrSet(resourceName, "label"),
+					resource.TestCheckResourceAttr(resourceName, "label_template", "$AccountName"),
+					resource.TestCheckResourceAttrSet(resourceName, "link_id"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.0", "AWS::CloudWatch::Metric"),
+					resource.TestCheckResourceAttrSet(resourceName, "sink_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "sink_identifier"),
+				),
+			},
+			{
+				Config: testAccLinkConfig_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinkExists(resourceName, &link),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "oam", regexp.MustCompile(`link/+.`)),
+					resource.TestCheckResourceAttrSet(resourceName, "label"),
+					resource.TestCheckResourceAttr(resourceName, "label_template", "$AccountName"),
+					resource.TestCheckResourceAttrSet(resourceName, "link_id"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.0", "AWS::CloudWatch::Metric"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.1", "AWS::Logs::LogGroup"),
+					resource.TestCheckResourceAttrSet(resourceName, "sink_arn"),
+					resource.TestCheckResourceAttrSet(resourceName, "sink_identifier"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccObservabilityAccessManagerLink_tags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+	ctx := acctest.Context(t)
+
+	var link oam.GetLinkOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_oam_link.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+			acctest.PreCheckPartitionHasService(t, names.ObservabilityAccessManagerEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ObservabilityAccessManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+		CheckDestroy:             testAccCheckLinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLinkConfig_tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinkExists(resourceName, &link),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccLinkConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinkExists(resourceName, &link),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccLinkConfig_tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinkExists(resourceName, &link),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+//func TestAccObservabilityAccessManagerLink_tags(t *testing.T) {
+//	if testing.Short() {
+//		t.Skip("skipping long-running test in short mode")
+//	}
+//	ctx := acctest.Context(t)
+//
+//	var link oam.GetLinkOutput
+//	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+//	resourceName := "aws_oam_link.test"
+//
+//	resource.Test(t, resource.TestCase{
+//		PreCheck: func() {
+//			acctest.PreCheck(ctx, t)
+//			acctest.PreCheckAlternateAccount(t)
+//			acctest.PreCheckPartitionHasService(t, names.ObservabilityAccessManagerEndpointID)
+//			testAccPreCheck(ctx, t)
+//		},
+//		ErrorCheck:               acctest.ErrorCheck(t, names.ObservabilityAccessManagerEndpointID),
+//		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+//		CheckDestroy:             testAccCheckLinkDestroy,
+//		Steps: []resource.TestStep{
+//			{
+//				Config: testAccLinkConfig_tags1(rName, "key1", "value1"),
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheckLinkExists(resourceName, &link),
+//					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+//					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+//				),
+//			},
+//			{
+//				Config: testAccLinkConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheckLinkExists(resourceName, &link),
+//					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+//					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+//					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+//				),
+//			},
+//			{
+//				Config: testAccLinkConfig_tags1(rName, "key2", "value2"),
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheckLinkExists(resourceName, &link),
+//					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+//					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+//				),
+//			},
+//			{
+//				ResourceName:      resourceName,
+//				ImportState:       true,
+//				ImportStateVerify: true,
+//			},
+//		},
+//	}
+
+func testAccCheckLinkDestroy(s *terraform.State) error {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).ObservabilityAccessManagerClient()
+	ctx := context.Background()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_oam_link" {
+			continue
+		}
+
+		input := &oam.GetLinkInput{
+			Identifier: aws.String(rs.Primary.ID),
+		}
+		_, err := conn.GetLink(ctx, input)
+		if err != nil {
+			var nfe *types.ResourceNotFoundException
+			if errors.As(err, &nfe) {
+				return nil
+			}
+			return err
+		}
+
+		return create.Error(names.ObservabilityAccessManager, create.ErrActionCheckingDestroyed, tfoam.ResNameLink, rs.Primary.ID, errors.New("not destroyed"))
+	}
+
+	return nil
+}
+
+func testAccCheckLinkExists(name string, link *oam.GetLinkOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.ObservabilityAccessManager, create.ErrActionCheckingExistence, tfoam.ResNameLink, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.ObservabilityAccessManager, create.ErrActionCheckingExistence, tfoam.ResNameLink, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ObservabilityAccessManagerClient()
+		ctx := context.Background()
+		resp, err := conn.GetLink(ctx, &oam.GetLinkInput{
+			Identifier: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return create.Error(names.ObservabilityAccessManager, create.ErrActionCheckingExistence, tfoam.ResNameLink, rs.Primary.ID, err)
+		}
+
+		*link = *resp
+
+		return nil
+	}
+}
+
+func testAccLinkConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAlternateAccountProvider(),
+		fmt.Sprintf(`
+data "aws_caller_identity" "source" {}
+data "aws_partition" "source" {}
+
+data "aws_caller_identity" "monitoring" {
+  provider = "awsalternate"
+}
+data "aws_partition" "monitoring" {
+  provider = "awsalternate"
+}
+
+resource "aws_oam_sink" "test" {
+  provider = "awsalternate"
+
+  name = %[1]q
+}
+
+resource "aws_oam_sink_policy" "test" {
+  provider = "awsalternate"
+
+  sink_identifier = aws_oam_sink.test.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = ["oam:CreateLink", "oam:UpdateLink"]
+        Effect   = "Allow"
+        Resource = "*"
+        Principal = {
+          "AWS" = "arn:${data.aws_partition.source.partition}:iam::${data.aws_caller_identity.source.account_id}:root"
+        }
+        Condition = {
+          "ForAnyValue:StringEquals" = {
+            "oam:ResourceTypes" = ["AWS::CloudWatch::Metric", "AWS::Logs::LogGroup"]
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_oam_link" "test" {
+  label_template  = "$AccountName"
+  resource_types  = ["AWS::CloudWatch::Metric"]
+  sink_identifier = aws_oam_sink.test.id
+}
+`, rName))
+}
+
+func testAccLinkConfig_update(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAlternateAccountProvider(),
+		fmt.Sprintf(`
+data "aws_caller_identity" "source" {}
+data "aws_partition" "source" {}
+
+data "aws_caller_identity" "monitoring" {
+  provider = "awsalternate"
+}
+data "aws_partition" "monitoring" {
+  provider = "awsalternate"
+}
+
+resource "aws_oam_sink" "test" {
+  provider = "awsalternate"
+
+  name = %[1]q
+}
+
+resource "aws_oam_sink_policy" "test" {
+  provider = "awsalternate"
+
+  sink_identifier = aws_oam_sink.test.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = ["oam:CreateLink", "oam:UpdateLink"]
+        Effect   = "Allow"
+        Resource = "*"
+        Principal = {
+          "AWS" = "arn:${data.aws_partition.source.partition}:iam::${data.aws_caller_identity.source.account_id}:root"
+        }
+        Condition = {
+          "ForAnyValue:StringEquals" = {
+            "oam:ResourceTypes" = ["AWS::CloudWatch::Metric", "AWS::Logs::LogGroup"]
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_oam_link" "test" {
+  label_template  = "$AccountName"
+  resource_types  = ["AWS::CloudWatch::Metric", "AWS::Logs::LogGroup"]
+  sink_identifier = aws_oam_sink.test.id
+}
+`, rName))
+}
+
+func testAccLinkConfig_tags1(rName, tag1Key, tag1Value string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAlternateAccountProvider(),
+		fmt.Sprintf(`
+data "aws_caller_identity" "source" {}
+data "aws_partition" "source" {}
+
+data "aws_caller_identity" "monitoring" {
+  provider = "awsalternate"
+}
+data "aws_partition" "monitoring" {
+  provider = "awsalternate"
+}
+
+resource "aws_oam_sink" "test" {
+  provider = "awsalternate"
+
+  name = %[1]q
+}
+
+resource "aws_oam_sink_policy" "test" {
+  provider = "awsalternate"
+
+  sink_identifier = aws_oam_sink.test.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = ["oam:CreateLink", "oam:UpdateLink"]
+        Effect   = "Allow"
+        Resource = "*"
+        Principal = {
+          "AWS" = "arn:${data.aws_partition.source.partition}:iam::${data.aws_caller_identity.source.account_id}:root"
+        }
+        Condition = {
+          "ForAnyValue:StringEquals" = {
+            "oam:ResourceTypes" = ["AWS::CloudWatch::Metric", "AWS::Logs::LogGroup"]
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_oam_link" "test" {
+  label_template  = "$AccountName"
+  resource_types  = ["AWS::CloudWatch::Metric"]
+  sink_identifier = aws_oam_sink.test.id
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tag1Key, tag1Value))
+}
+
+func testAccLinkConfig_tags2(rName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAlternateAccountProvider(),
+		fmt.Sprintf(`
+data "aws_caller_identity" "source" {}
+data "aws_partition" "source" {}
+
+data "aws_caller_identity" "monitoring" {
+  provider = "awsalternate"
+}
+data "aws_partition" "monitoring" {
+  provider = "awsalternate"
+}
+
+resource "aws_oam_sink" "test" {
+  provider = "awsalternate"
+
+  name = %[1]q
+}
+
+resource "aws_oam_sink_policy" "test" {
+  provider = "awsalternate"
+
+  sink_identifier = aws_oam_sink.test.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = ["oam:CreateLink", "oam:UpdateLink"]
+        Effect   = "Allow"
+        Resource = "*"
+        Principal = {
+          "AWS" = "arn:${data.aws_partition.source.partition}:iam::${data.aws_caller_identity.source.account_id}:root"
+        }
+        Condition = {
+          "ForAnyValue:StringEquals" = {
+            "oam:ResourceTypes" = ["AWS::CloudWatch::Metric", "AWS::Logs::LogGroup"]
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_oam_link" "test" {
+  label_template  = "$AccountName"
+  resource_types  = ["AWS::CloudWatch::Metric"]
+  sink_identifier = aws_oam_sink.test.id
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tag1Key, tag1Value, tag2Key, tag2Value))
+}

--- a/internal/service/oam/link_test.go
+++ b/internal/service/oam/link_test.go
@@ -64,50 +64,6 @@ func TestExpandResourceTypesUnitTest(t *testing.T) {
 	}
 }
 
-func TestResourceTypeValuesUnitTest(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		TestName string
-		Input    []types.ResourceType
-		Expected []string
-	}{
-		{
-			TestName: "Empty resource types",
-			Input:    []types.ResourceType{},
-			Expected: []string{},
-		},
-		{
-			TestName: "Non-empty resource types",
-			Input: []types.ResourceType{
-				types.ResourceTypeAwsCloudwatchMetric,
-				types.ResourceTypeAwsLogsLoggroup,
-			},
-			Expected: []string{
-				"AWS::CloudWatch::Metric",
-				"AWS::Logs::LogGroup",
-			},
-		},
-	}
-
-	for _, testCase := range testCases {
-		testCase := testCase
-		t.Run(testCase.TestName, func(t *testing.T) {
-			t.Parallel()
-
-			got := tfoam.ResourceTypeValues(testCase.Input)
-
-			if len(got) == 0 && len(testCase.Expected) == 0 {
-				return
-			}
-
-			if !awsutil.DeepEqual(got, testCase.Expected) {
-				t.Errorf("got %s, expected %s", got, testCase.Expected)
-			}
-		})
-	}
-}
-
 func TestAccObservabilityAccessManagerLink_basic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")

--- a/internal/service/oam/link_test.go
+++ b/internal/service/oam/link_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/oam"
 	"github.com/aws/aws-sdk-go-v2/service/oam/types"
-	"github.com/aws/aws-sdk-go/aws/awsutil"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -21,54 +20,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestExpandResourceTypesUnitTest(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		TestName string
-		Input    []interface{}
-		Expected []types.ResourceType
-	}{
-		{
-			TestName: "Empty resource types",
-			Input:    []interface{}{},
-			Expected: nil,
-		},
-		{
-			TestName: "Non-empty resource types",
-			Input: []interface{}{
-				"AWS::CloudWatch::Metric",
-				"AWS::Logs::LogGroup",
-			},
-			Expected: []types.ResourceType{
-				types.ResourceTypeAwsCloudwatchMetric,
-				types.ResourceTypeAwsLogsLoggroup,
-			},
-		},
-	}
-
-	for _, testCase := range testCases {
-		testCase := testCase
-		t.Run(testCase.TestName, func(t *testing.T) {
-			t.Parallel()
-
-			got := tfoam.ExpandResourceTypes(testCase.Input)
-
-			if got == nil && testCase.Expected == nil {
-				return
-			}
-			if !awsutil.DeepEqual(got, testCase.Expected) {
-				t.Errorf("got %s, expected %s", got, testCase.Expected)
-			}
-		})
-	}
-}
-
 func TestAccObservabilityAccessManagerLink_basic(t *testing.T) {
+	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
-	ctx := acctest.Context(t)
 
 	var link oam.GetLinkOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -109,10 +65,10 @@ func TestAccObservabilityAccessManagerLink_basic(t *testing.T) {
 }
 
 func TestAccObservabilityAccessManagerLink_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
-	ctx := acctest.Context(t)
 
 	var link oam.GetLinkOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -142,10 +98,10 @@ func TestAccObservabilityAccessManagerLink_disappears(t *testing.T) {
 }
 
 func TestAccObservabilityAccessManagerLink_update(t *testing.T) {
+	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
-	ctx := acctest.Context(t)
 
 	var link oam.GetLinkOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -201,10 +157,10 @@ func TestAccObservabilityAccessManagerLink_update(t *testing.T) {
 }
 
 func TestAccObservabilityAccessManagerLink_tags(t *testing.T) {
+	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
-	ctx := acctest.Context(t)
 
 	var link oam.GetLinkOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/oam/link_test.go
+++ b/internal/service/oam/link_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestExpandResourceTypesUnitTest(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		TestName string
 		Input    []interface{}
@@ -46,6 +48,7 @@ func TestExpandResourceTypesUnitTest(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
 		t.Run(testCase.TestName, func(t *testing.T) {
 			t.Parallel()
 
@@ -62,6 +65,8 @@ func TestExpandResourceTypesUnitTest(t *testing.T) {
 }
 
 func TestResourceTypeValuesUnitTest(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		TestName string
 		Input    []types.ResourceType
@@ -86,6 +91,7 @@ func TestResourceTypeValuesUnitTest(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
 		t.Run(testCase.TestName, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/service/oam/link_test.go
+++ b/internal/service/oam/link_test.go
@@ -299,60 +299,6 @@ func TestAccObservabilityAccessManagerLink_tags(t *testing.T) {
 	})
 }
 
-//func TestAccObservabilityAccessManagerLink_tags(t *testing.T) {
-//	if testing.Short() {
-//		t.Skip("skipping long-running test in short mode")
-//	}
-//	ctx := acctest.Context(t)
-//
-//	var link oam.GetLinkOutput
-//	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-//	resourceName := "aws_oam_link.test"
-//
-//	resource.Test(t, resource.TestCase{
-//		PreCheck: func() {
-//			acctest.PreCheck(ctx, t)
-//			acctest.PreCheckAlternateAccount(t)
-//			acctest.PreCheckPartitionHasService(t, names.ObservabilityAccessManagerEndpointID)
-//			testAccPreCheck(ctx, t)
-//		},
-//		ErrorCheck:               acctest.ErrorCheck(t, names.ObservabilityAccessManagerEndpointID),
-//		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
-//		CheckDestroy:             testAccCheckLinkDestroy,
-//		Steps: []resource.TestStep{
-//			{
-//				Config: testAccLinkConfig_tags1(rName, "key1", "value1"),
-//				Check: resource.ComposeTestCheckFunc(
-//					testAccCheckLinkExists(resourceName, &link),
-//					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-//					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
-//				),
-//			},
-//			{
-//				Config: testAccLinkConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
-//				Check: resource.ComposeTestCheckFunc(
-//					testAccCheckLinkExists(resourceName, &link),
-//					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-//					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
-//					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
-//				),
-//			},
-//			{
-//				Config: testAccLinkConfig_tags1(rName, "key2", "value2"),
-//				Check: resource.ComposeTestCheckFunc(
-//					testAccCheckLinkExists(resourceName, &link),
-//					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-//					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
-//				),
-//			},
-//			{
-//				ResourceName:      resourceName,
-//				ImportState:       true,
-//				ImportStateVerify: true,
-//			},
-//		},
-//	}
-
 func testAccCheckLinkDestroy(s *terraform.State) error {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).ObservabilityAccessManagerClient()
 	ctx := context.Background()

--- a/internal/service/oam/service_package_gen.go
+++ b/internal/service/oam/service_package_gen.go
@@ -26,6 +26,10 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
 		{
+			Factory:  ResourceLink,
+			TypeName: "aws_oam_link",
+		},
+		{
 			Factory:  ResourceSink,
 			TypeName: "aws_oam_sink",
 		},

--- a/website/docs/r/oam_link.html.markdown
+++ b/website/docs/r/oam_link.html.markdown
@@ -1,0 +1,64 @@
+---
+subcategory: "CloudWatch Observability Access Manager"
+layout: "aws"
+page_title: "AWS: aws_oam_link"
+description: |-
+  Terraform resource for managing an AWS CloudWatch Observability Access Manager Link.
+---
+
+# Resource: aws_oam_link
+
+Terraform resource for managing an AWS CloudWatch Observability Access Manager Link.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_oam_link" "example" {
+  label_template  = "$AccountName"
+  resource_types  = ["AWS::CloudWatch::Metric"]
+  sink_identifier = aws_oam_sink.test.id
+  tags = {
+    Env = "prod"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `label_template` - (Required) Human-readable name to use to identify this source account when you are viewing data from it in the monitoring account.
+* `resource_types` - (Required) Types of data that the source account shares with the monitoring account.
+* `sink_identifier` - (Required) Identifier of the sink to use to create this link.
+
+The following arguments are optional:
+
+* `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the link.
+* `label` - Label that is assigned to this link.
+* `link_id` - ID string that AWS generated as part of the link ARN.
+* `sink_arn` - ARN of the sink that is used for this link.
+* 
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `1m`)
+* `update` - (Default `1m`)
+* `delete` - (Default `1m`)
+
+## Import
+
+CloudWatch Observability Access Manager Link can be imported using the `arn`, e.g.,
+
+```
+$ terraform import aws_oam_link.example arn:aws:oam:us-west-2:123456789012:link/link-id
+```

--- a/website/docs/r/oam_link.html.markdown
+++ b/website/docs/r/oam_link.html.markdown
@@ -45,7 +45,6 @@ In addition to all arguments above, the following attributes are exported:
 * `label` - Label that is assigned to this link.
 * `link_id` - ID string that AWS generated as part of the link ARN.
 * `sink_arn` - ARN of the sink that is used for this link.
-* 
 
 ## Timeouts
 


### PR DESCRIPTION
### Description
This pull requests add an `aws_oam_link` resource which provides the ability to create a link to a [aws_oam_sink](https://github.com/hashicorp/terraform-provider-aws/pull/29670).


### Relations
Relates #28158

### References
[CreateLink API documentation](https://docs.aws.amazon.com/OAM/latest/APIReference/API_CreateLink.html)


### Output from Acceptance Testing
```
➜ make testacc PKG=oam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/oam/... -v -count 1 -parallel 20   -timeout 180m
=== RUN   TestExpandResourceTypesUnitTest
=== RUN   TestExpandResourceTypesUnitTest/Empty_resource_types
=== RUN   TestExpandResourceTypesUnitTest/Non-empty_resource_types
--- PASS: TestExpandResourceTypesUnitTest (0.00s)
    --- PASS: TestExpandResourceTypesUnitTest/Empty_resource_types (0.00s)
    --- PASS: TestExpandResourceTypesUnitTest/Non-empty_resource_types (0.00s)
=== RUN   TestResourceTypeValuesUnitTest
=== RUN   TestResourceTypeValuesUnitTest/Empty_resource_types
=== RUN   TestResourceTypeValuesUnitTest/Non-empty_resource_types
--- PASS: TestResourceTypeValuesUnitTest (0.00s)
    --- PASS: TestResourceTypeValuesUnitTest/Empty_resource_types (0.00s)
    --- PASS: TestResourceTypeValuesUnitTest/Non-empty_resource_types (0.00s)
=== RUN   TestAccObservabilityAccessManagerLink_basic
--- PASS: TestAccObservabilityAccessManagerLink_basic (167.57s)
=== RUN   TestAccObservabilityAccessManagerLink_disappears
--- PASS: TestAccObservabilityAccessManagerLink_disappears (128.20s)
=== RUN   TestAccObservabilityAccessManagerLink_update
--- PASS: TestAccObservabilityAccessManagerLink_update (255.12s)
=== RUN   TestAccObservabilityAccessManagerLink_tags
--- PASS: TestAccObservabilityAccessManagerLink_tags (347.29s)
...
```
