### PR TITLE
b/aws_wafv2_ip_set: Don't suppress addresses diff when resource is new

### DIFF
--- a/.changelog/30143.txt
+++ b/.changelog/30143.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_wafv2_ip_set: Fix inconsistent final plan when the addresses attribute contains unknown values
+```

--- a/internal/service/wafv2/ip_set.go
+++ b/internal/service/wafv2/ip_set.go
@@ -56,6 +56,10 @@ func ResourceIPSet() *schema.Resource {
 				MaxItems: 10000,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if d.Id() == "" {
+						return false
+					}
+
 					o, n := d.GetChange("addresses")
 					oldAddresses := o.(*schema.Set).List()
 					newAddresses := n.(*schema.Set).List()


### PR DESCRIPTION
### Description
`DiffSuppressFunc` for `addresses` will suppress when the list contains values unknown at plan time as the old and new lists will be the same length. Skip the check if the resource is new.

### Relations
Closes #20843

### References
None

### Output from Acceptance Testing
```
🍔  →  terraform-provider-aws git:(b-wafv2_ip_set-inconsistent-plan) make testacc TESTS=TestAccWAFV2IPSet PKG=wafv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2IPSet'  -timeout 180m
=== RUN   TestAccWAFV2IPSetDataSource_basic
=== PAUSE TestAccWAFV2IPSetDataSource_basic
=== RUN   TestAccWAFV2IPSet_basic
=== PAUSE TestAccWAFV2IPSet_basic
=== RUN   TestAccWAFV2IPSet_disappears
=== PAUSE TestAccWAFV2IPSet_disappears
=== RUN   TestAccWAFV2IPSet_ipv6
=== PAUSE TestAccWAFV2IPSet_ipv6
=== RUN   TestAccWAFV2IPSet_minimal
=== PAUSE TestAccWAFV2IPSet_minimal
=== RUN   TestAccWAFV2IPSet_changeNameForceNew
=== PAUSE TestAccWAFV2IPSet_changeNameForceNew
=== RUN   TestAccWAFV2IPSet_tags
=== PAUSE TestAccWAFV2IPSet_tags
=== RUN   TestAccWAFV2IPSet_large
=== PAUSE TestAccWAFV2IPSet_large
=== RUN   TestAccWAFV2IPSet_reference
=== PAUSE TestAccWAFV2IPSet_reference
=== CONT  TestAccWAFV2IPSetDataSource_basic
=== CONT  TestAccWAFV2IPSet_changeNameForceNew
=== CONT  TestAccWAFV2IPSet_large
=== CONT  TestAccWAFV2IPSet_reference
=== CONT  TestAccWAFV2IPSet_tags
=== CONT  TestAccWAFV2IPSet_disappears
=== CONT  TestAccWAFV2IPSet_minimal
=== CONT  TestAccWAFV2IPSet_basic
=== CONT  TestAccWAFV2IPSet_ipv6
--- PASS: TestAccWAFV2IPSet_disappears (9.91s)
--- PASS: TestAccWAFV2IPSet_reference (16.37s)
--- PASS: TestAccWAFV2IPSet_minimal (17.92s)
--- PASS: TestAccWAFV2IPSet_ipv6 (18.21s)
--- PASS: TestAccWAFV2IPSet_changeNameForceNew (19.79s)
--- PASS: TestAccWAFV2IPSet_basic (22.45s)
--- PASS: TestAccWAFV2IPSet_large (23.98s)
--- PASS: TestAccWAFV2IPSetDataSource_basic (24.78s)
--- PASS: TestAccWAFV2IPSet_tags (26.15s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafv2	28.919s
```