### PR TITLE
Documentation correction for aws_iam_role_policy_attachment-fix

### DIFF
--- a/website/docs/r/iam_role_policy_attachment.markdown
+++ b/website/docs/r/iam_role_policy_attachment.markdown
@@ -18,14 +18,16 @@ Attaches a Managed IAM Policy to an IAM role
 
 ```terraform
 data "aws_iam_policy_document" "assume_role" {
-  effect = "Allow"
+  statement {
+    effect = "Allow"
 
-  principals {
-    type        = "Service"
-    identifiers = ["ec2.amazonaws.com"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
   }
-
-  actions = ["sts:AssumeRole"]
 }
 
 resource "aws_iam_role" "role" {


### PR DESCRIPTION
Contains changes for the issue : https://github.com/hashicorp/terraform-provider-aws/issues/29987

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description : Resolves issue mentioned in https://github.com/hashicorp/terraform-provider-aws/pull/30150

### Relations : https://github.com/hashicorp/terraform-provider-aws/issues/29987
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #29987

--->

Closes #29987

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description: 

The example usage of the Resource: aws_iam_role_policy_attachment is missing a statement block. The data block in the example usage is missing a statement block.

Added: Added statement block inside the data block for data "aws_iam_policy_document" "assume_role" section.

### References: 
documentation containing issue: 
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment

Linked issue: https://github.com/hashicorp/terraform-provider-aws/issues/29987 
<!---

--->
