### PR TITLE
docs: Fixed link to AWS doc based on API type

### DIFF
--- a/website/docs/r/apigatewayv2_api_mapping.html.markdown
+++ b/website/docs/r/apigatewayv2_api_mapping.html.markdown
@@ -30,7 +30,7 @@ The following arguments are supported:
 * `api_id` - (Required) API identifier.
 * `domain_name` - (Required) Domain name. Use the [`aws_apigatewayv2_domain_name`](/docs/providers/aws/r/apigatewayv2_domain_name.html) resource to configure a domain name.
 * `stage` - (Required) API stage. Use the [`aws_apigatewayv2_stage`](/docs/providers/aws/r/apigatewayv2_stage.html) resource to configure an API stage.
-* `api_mapping_key` - (Optional) The API mapping key. Refer to [REST/HTTP API](https://docs.aws.amazon.com/apigateway/latest/developerguide/rest-api-mappings.html) or [WebSocket API](https://docs.aws.amazon.com/apigateway/latest/developerguide/websocket-api-mappings.html).
+* `api_mapping_key` - (Optional) The API mapping key. Refer to [REST API](https://docs.aws.amazon.com/apigateway/latest/developerguide/rest-api-mappings.html), [HTTP API](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-mappings.html) or [WebSocket API](https://docs.aws.amazon.com/apigateway/latest/developerguide/websocket-api-mappings.html).
 
 ## Attributes Reference
 

--- a/website/docs/r/apigatewayv2_api_mapping.html.markdown
+++ b/website/docs/r/apigatewayv2_api_mapping.html.markdown
@@ -30,7 +30,7 @@ The following arguments are supported:
 * `api_id` - (Required) API identifier.
 * `domain_name` - (Required) Domain name. Use the [`aws_apigatewayv2_domain_name`](/docs/providers/aws/r/apigatewayv2_domain_name.html) resource to configure a domain name.
 * `stage` - (Required) API stage. Use the [`aws_apigatewayv2_stage`](/docs/providers/aws/r/apigatewayv2_stage.html) resource to configure an API stage.
-* `api_mapping_key` - (Optional) The [API mapping key](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-mapping-template-reference.html).
+* `api_mapping_key` - (Optional) The API mapping key. Refer to [REST/HTTP API](https://docs.aws.amazon.com/apigateway/latest/developerguide/rest-api-mappings.html) or [WebSocket API](https://docs.aws.amazon.com/apigateway/latest/developerguide/websocket-api-mappings.html).
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Description
The API Mapping Key has a link to WebSocket API mapping templates which is irrelevant to the resource `aws_apigatewayv2_api_mapping`.

The fix includes 3 links. The first for REST APIs, the second for HTTP APIs (they share the same principals with slight changes) and the third to the correct WebSocket API documenation.


### Relations

### References
https://docs.aws.amazon.com/apigateway/latest/developerguide/websocket-api-mappings.html

https://docs.aws.amazon.com/apigateway/latest/developerguide/rest-api-mappings.html

https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-mappings.html

https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-mapping-template-reference.html

### Output from Acceptance Testing

