### PR TITLE
`d/aws_ecs_task_execution`: Fix interface conversion panics

### DIFF
--- a/.changelog/30214.txt
+++ b/.changelog/30214.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+datasource/aws_ecs_task_execution: Fix type assertion panic on `overrides.0.inference_accelerator_overrides` attribute
+```
+
+```release-note:bug
+datasource/aws_ecs_task_execution: Fix type assertion panic on `overrides.0.container_overrides.*.environment` attribute
+```
+
+```release-note:bug
+datasource/aws_ecs_task_execution: Fix type assertion panic on `overrides.0.container_overrides.*.resource_requirements` attribute
+```

--- a/internal/service/ecs/task_execution_data_source.go
+++ b/internal/service/ecs/task_execution_data_source.go
@@ -450,7 +450,7 @@ func expandTaskEnvironment(tfSet *schema.Set) []*ecs.KeyValuePair {
 	for _, item := range tfSet.List() {
 		tfMap := item.(map[string]interface{})
 		te := &ecs.KeyValuePair{
-			Name:  aws.String(tfMap["name"].(string)),
+			Name:  aws.String(tfMap["key"].(string)),
 			Value: aws.String(tfMap["value"].(string)),
 		}
 		apiObject = append(apiObject, te)

--- a/internal/service/ecs/task_execution_data_source.go
+++ b/internal/service/ecs/task_execution_data_source.go
@@ -2,7 +2,6 @@ package ecs
 
 import (
 	"context"
-	"log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -363,10 +362,8 @@ func expandTaskOverride(tfList []interface{}) *ecs.TaskOverride {
 		return nil
 	}
 
-	log.Printf("[DEBUG] Task Override: %+v", tfList)
 	apiObject := &ecs.TaskOverride{}
 	tfMap := tfList[0].(map[string]interface{})
-	log.Printf("[DEBUG] tfMap: %+v", tfMap)
 
 	if v, ok := tfMap["cpu"]; ok {
 		apiObject.Cpu = aws.String(v.(string))
@@ -381,11 +378,9 @@ func expandTaskOverride(tfList []interface{}) *ecs.TaskOverride {
 		apiObject.TaskRoleArn = aws.String(v.(string))
 	}
 	if v, ok := tfMap["inference_accelerator_overrides"]; ok {
-		log.Printf("[DEBUG] Inference accelerator: %+v", v)
 		apiObject.InferenceAcceleratorOverrides = expandInferenceAcceleratorOverrides(v.(*schema.Set))
 	}
 	if v, ok := tfMap["container_overrides"]; ok {
-		log.Printf("[DEBUG] Container overrides: %+v", v)
 		apiObject.ContainerOverrides = expandContainerOverride(v.([]interface{}))
 	}
 

--- a/internal/service/ecs/task_execution_data_source.go
+++ b/internal/service/ecs/task_execution_data_source.go
@@ -2,6 +2,7 @@ package ecs
 
 import (
 	"context"
+	"log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -361,8 +362,11 @@ func expandTaskOverride(tfList []interface{}) *ecs.TaskOverride {
 	if len(tfList) == 0 {
 		return nil
 	}
+
+	log.Printf("[DEBUG] Task Override: %+v", tfList)
 	apiObject := &ecs.TaskOverride{}
 	tfMap := tfList[0].(map[string]interface{})
+	log.Printf("[DEBUG] tfMap: %+v", tfMap)
 
 	if v, ok := tfMap["cpu"]; ok {
 		apiObject.Cpu = aws.String(v.(string))
@@ -377,22 +381,24 @@ func expandTaskOverride(tfList []interface{}) *ecs.TaskOverride {
 		apiObject.TaskRoleArn = aws.String(v.(string))
 	}
 	if v, ok := tfMap["inference_accelerator_overrides"]; ok {
-		apiObject.InferenceAcceleratorOverrides = expandInferenceAcceleratorOverrides(v.([]interface{}))
+		log.Printf("[DEBUG] Inference accelerator: %+v", v)
+		apiObject.InferenceAcceleratorOverrides = expandInferenceAcceleratorOverrides(v.(*schema.Set))
 	}
 	if v, ok := tfMap["container_overrides"]; ok {
+		log.Printf("[DEBUG] Container overrides: %+v", v)
 		apiObject.ContainerOverrides = expandContainerOverride(v.([]interface{}))
 	}
 
 	return apiObject
 }
 
-func expandInferenceAcceleratorOverrides(tfList []interface{}) []*ecs.InferenceAcceleratorOverride {
-	if len(tfList) == 0 {
+func expandInferenceAcceleratorOverrides(tfSet *schema.Set) []*ecs.InferenceAcceleratorOverride {
+	if tfSet.Len() == 0 {
 		return nil
 	}
 	apiObject := make([]*ecs.InferenceAcceleratorOverride, 0)
 
-	for _, item := range tfList {
+	for _, item := range tfSet.List() {
 		tfMap := item.(map[string]interface{})
 		iao := &ecs.InferenceAcceleratorOverride{
 			DeviceName: aws.String(tfMap["device_name"].(string)),
@@ -420,19 +426,19 @@ func expandContainerOverride(tfList []interface{}) []*ecs.ContainerOverride {
 			co.Command = flex.ExpandStringList(commandStrings)
 		}
 		if v, ok := tfMap["cpu"]; ok {
-			co.Cpu = aws.Int64(v.(int64))
+			co.Cpu = aws.Int64(int64(v.(int)))
 		}
 		if v, ok := tfMap["environment"]; ok {
-			co.Environment = expandTaskEnvironment(v.([]interface{}))
+			co.Environment = expandTaskEnvironment(v.(*schema.Set))
 		}
 		if v, ok := tfMap["memory"]; ok {
-			co.Memory = aws.Int64(v.(int64))
+			co.Memory = aws.Int64(int64(v.(int)))
 		}
 		if v, ok := tfMap["memory_reservation"]; ok {
-			co.Memory = aws.Int64(v.(int64))
+			co.Memory = aws.Int64(int64(v.(int)))
 		}
 		if v, ok := tfMap["resource_requirements"]; ok {
-			co.ResourceRequirements = expandResourceRequirements(v.([]interface{}))
+			co.ResourceRequirements = expandResourceRequirements(v.(*schema.Set))
 		}
 		apiObject = append(apiObject, co)
 	}
@@ -440,13 +446,13 @@ func expandContainerOverride(tfList []interface{}) []*ecs.ContainerOverride {
 	return apiObject
 }
 
-func expandTaskEnvironment(tfList []interface{}) []*ecs.KeyValuePair {
-	if len(tfList) == 0 {
+func expandTaskEnvironment(tfSet *schema.Set) []*ecs.KeyValuePair {
+	if tfSet.Len() == 0 {
 		return nil
 	}
 	apiObject := make([]*ecs.KeyValuePair, 0)
 
-	for _, item := range tfList {
+	for _, item := range tfSet.List() {
 		tfMap := item.(map[string]interface{})
 		te := &ecs.KeyValuePair{
 			Name:  aws.String(tfMap["name"].(string)),
@@ -458,13 +464,13 @@ func expandTaskEnvironment(tfList []interface{}) []*ecs.KeyValuePair {
 	return apiObject
 }
 
-func expandResourceRequirements(tfList []interface{}) []*ecs.ResourceRequirement {
-	if len(tfList) == 0 {
+func expandResourceRequirements(tfSet *schema.Set) []*ecs.ResourceRequirement {
+	if tfSet.Len() == 0 {
 		return nil
 	}
 
 	apiObject := make([]*ecs.ResourceRequirement, 0)
-	for _, item := range tfList {
+	for _, item := range tfSet.List() {
 		tfMap := item.(map[string]interface{})
 		rr := &ecs.ResourceRequirement{
 			Type:  aws.String(tfMap["type"].(string)),

--- a/internal/service/ecs/task_execution_data_source_test.go
+++ b/internal/service/ecs/task_execution_data_source_test.go
@@ -44,6 +44,45 @@ func TestAccECSTaskExecutionDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccECSTaskExecutionDataSource_overrides(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_ecs_task_execution.test"
+	clusterName := "aws_ecs_cluster.test"
+	taskDefinitionName := "aws_ecs_task_definition.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, ecs.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, ecs.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaskExecutionDataSourceConfig_overrides(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "cluster", clusterName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "task_definition", taskDefinitionName, "arn"),
+					resource.TestCheckResourceAttr(dataSourceName, "desired_count", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "launch_type", "FARGATE"),
+					resource.TestCheckResourceAttr(dataSourceName, "network_configuration.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "task_arns.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "overrides.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "overrides.0.container_overrides.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "overrides.0.container_overrides.0.environment.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "overrides.0.container_overrides.0.environment.0.key", "key1"),
+					resource.TestCheckResourceAttr(dataSourceName, "overrides.0.container_overrides.0.environment.0.value", "value1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccECSTaskExecutionDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -180,4 +219,39 @@ data "aws_ecs_task_execution" "test" {
   }
 }
 `, tagKey1, tagValue1))
+}
+
+func testAccTaskExecutionDataSourceConfig_overrides(rName, envKey1, envValue1 string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigVPCWithSubnets(rName, 2),
+		testAccTaskExecutionDataSourceConfig_base(rName),
+		fmt.Sprintf(`
+data "aws_ecs_task_execution" "test" {
+  depends_on = [aws_ecs_cluster_capacity_providers.test]
+
+  cluster         = aws_ecs_cluster.test.id
+  task_definition = aws_ecs_task_definition.test.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = aws_subnet.test[*].id
+    security_groups  = [aws_security_group.test.id]
+    assign_public_ip = false
+  }
+
+  overrides {
+    container_overrides {
+      name = "sleep"
+
+      environment {
+        key   = %[1]q
+        value = %[2]q
+      }
+    }
+    cpu    = "256"
+    memory = "512"
+  }
+}
+`, envKey1, envValue1))
 }


### PR DESCRIPTION
### Description

It seems like many of these type assertions are incorrect, running locally I found terraform would panic with things like:

    panic: interface conversion: interface {} is *schema.Set, not []interface {}

These changes correct many of them however it's far from complete because the overrides end up with the zero values in places like cpu, memory etc.

Someone who knows more about terraform internal types could use this as a starting point. I can take it forward if I have the time.


### Relations

Relates #29783

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
