### PR TITLE
chore: fix medialive channel test names and parameters

### DIFF
--- a/internal/service/medialive/channel_test.go
+++ b/internal/service/medialive/channel_test.go
@@ -76,7 +76,7 @@ func TestAccMediaLiveChannel_basic(t *testing.T) {
 	})
 }
 
-func TestAccMediaLiveChannel_m2ts_settings(t *testing.T) {
+func TestAccMediaLiveChannel_M2TS_settings(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -268,7 +268,7 @@ func TestAccMediaLiveChannel_MsSmooth_outputSettings(t *testing.T) {
 	})
 }
 
-func TestAccMediaLiveChannel_audioDescriptions_codecSettings(t *testing.T) {
+func TestAccMediaLiveChannel_AudioDescriptions_codecSettings(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -327,7 +327,7 @@ func TestAccMediaLiveChannel_audioDescriptions_codecSettings(t *testing.T) {
 	})
 }
 
-func TestAccMediaLiveChannel_videoDescriptions_codecSettings_h264Settings(t *testing.T) {
+func TestAccMediaLiveChannel_VideoDescriptions_CodecSettings_h264Settings(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -1182,14 +1182,14 @@ resource "aws_medialive_channel" "test" {
                 audio_buffer_model        = "ATSC"
                 buffer_model              = "MULTIPLEX"
                 rate_mode                 = "CBR"
-                audio_pids                = "200"
-                dvb_sub_pids              = "300"
-                arib_captions_pid         = "100"
+                audio_pids                = 200
+                dvb_sub_pids              = 300
+                arib_captions_pid         = 100
                 arib_captions_pid_control = "AUTO"
-                video_pid                 = "101"
-                fragment_time             = "1.92"
-                program_num               = "1"
-                segmentation_time         = "1.92"
+                video_pid                 = 101
+                fragment_time             = 1.92
+                program_num               = 1
+                segmentation_time         = 1.92
               }
             }
           }
@@ -1363,29 +1363,29 @@ resource "aws_medialive_channel" "test" {
           adaptive_quantization   = "LOW"
           bitrate                 = "5400000"
           buf_size                = "10800000"
-          buf_fill_pct            = "90"
+          buf_fill_pct            = 90
           entropy_encoding        = "CABAC"
           flicker_aq              = "ENABLED"
           force_field_pictures    = "DISABLED"
           framerate_control       = "SPECIFIED"
-          framerate_numerator     = "50"
-          framerate_denominator   = "1"
+          framerate_numerator     = 50
+          framerate_denominator   = 1
           gop_b_reference         = "DISABLED"
-          gop_closed_cadence      = "1"
-          gop_num_b_frames        = "1"
-          gop_size                = "1.92"
+          gop_closed_cadence      = 1
+          gop_num_b_frames        = 1
+          gop_size                = 1.92
           gop_size_units          = "SECONDS"
           subgop_length           = "FIXED"
           scan_type               = "PROGRESSIVE"
           level                   = "H264_LEVEL_AUTO"
           look_ahead_rate_control = "HIGH"
-          num_ref_frames          = "3"
+          num_ref_frames          = 3
           par_control             = "INITIALIZE_FROM_SOURCE"
           profile                 = "HIGH"
           rate_control_mode       = "CBR"
           syntax                  = "DEFAULT"
           scene_change_detect     = "ENABLED"
-          slices                  = "1"
+          slices                  = 1
           spatial_aq              = "ENABLED"
           temporal_aq             = "ENABLED"
           timecode_insertion      = "PIC_TIMING_SEI"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

cleanup test names for `aws_medialive_channel`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccMediaLiveChannel_ PKG=medialive

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/medialive/... -v -count 1 -parallel 20 -run='TestAccMediaLiveChannel_'  -timeout 180m
--- PASS: TestAccMediaLiveChannel_AudioDescriptions_codecSettings (74.19s)
--- PASS: TestAccMediaLiveChannel_M2TS_settings (86.47s)
--- PASS: TestAccMediaLiveChannel_disappears (91.49s)
--- PASS: TestAccMediaLiveChannel_basic (97.57s)
--- PASS: TestAccMediaLiveChannel_updateTags (114.05s)
--- PASS: TestAccMediaLiveChannel_UDP_outputSettings (137.55s)
--- PASS: TestAccMediaLiveChannel_MsSmooth_outputSettings (150.22s)
--- PASS: TestAccMediaLiveChannel_update (169.05s)
--- PASS: TestAccMediaLiveChannel_hls (174.20s)
--- PASS: TestAccMediaLiveChannel_VideoDescriptions_CodecSettings_h264Settings (224.53s)
--- PASS: TestAccMediaLiveChannel_status (283.95s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	287.170s

...
```
