### PR TITLE
Handle pending RDS engine version updates

### DIFF
--- a/.changelog/30247.txt
+++ b/.changelog/30247.txt
@@ -1,0 +1,16 @@
+```release-note:bug
+resource/aws_rds_cluster: Fix inconsistent final plan errors when `engine_version` updates are not applied immediately
+```
+
+```release-note:bug
+resource/aws_rds_cluster_instance: Fix inconsistent final plan errors when `engine_version` updates are not applied immediately
+```
+
+```release-note:bug
+resource/aws_rds_instance: Fix inconsistent final plan errors when `engine_version` updates are not applied immediately
+```
+
+```release-note:bug
+resource/aws_rds_cluster: Send `db_instance_parameter_group_name` on all modify requests when set 
+```
+

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -1464,7 +1464,11 @@ func removeIAMRoleFromCluster(ctx context.Context, conn *rds.RDS, clusterID, rol
 func clusterSetResourceDataEngineVersionFromCluster(d *schema.ResourceData, c *rds.DBCluster) {
 	oldVersion := d.Get("engine_version").(string)
 	newVersion := aws.StringValue(c.EngineVersion)
-	compareActualEngineVersion(d, oldVersion, newVersion)
+	var pendingVersion string
+	if c.PendingModifiedValues != nil && c.PendingModifiedValues.EngineVersion != nil {
+		pendingVersion = aws.StringValue(c.PendingModifiedValues.EngineVersion)
+	}
+	compareActualEngineVersion(d, oldVersion, newVersion, pendingVersion)
 }
 
 func FindDBClusterByID(ctx context.Context, conn *rds.RDS, id string) (*rds.DBCluster, error) {

--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -563,5 +563,9 @@ func resourceClusterInstanceDelete(ctx context.Context, d *schema.ResourceData, 
 func clusterSetResourceDataEngineVersionFromClusterInstance(d *schema.ResourceData, c *rds.DBInstance) {
 	oldVersion := d.Get("engine_version").(string)
 	newVersion := aws.StringValue(c.EngineVersion)
-	compareActualEngineVersion(d, oldVersion, newVersion)
+	var pendingVersion string
+	if c.PendingModifiedValues != nil && c.PendingModifiedValues.EngineVersion != nil {
+		pendingVersion = aws.StringValue(c.PendingModifiedValues.EngineVersion)
+	}
+	compareActualEngineVersion(d, oldVersion, newVersion, pendingVersion)
 }

--- a/internal/service/rds/engine_version_test.go
+++ b/internal/service/rds/engine_version_test.go
@@ -10,10 +10,17 @@ func TestCompareActualEngineVersion(t *testing.T) {
 	type testCase struct {
 		configuredVersion           string
 		actualVersion               string
+		pendingVersion              string
 		expectedEngineVersion       string
 		expectedEngineVersionActual string
 	}
 	tests := map[string]testCase{
+		"import": {
+			configuredVersion:           "", // no "old" value on import
+			actualVersion:               "8.1",
+			expectedEngineVersion:       "8.1",
+			expectedEngineVersionActual: "8.1",
+		},
 		"point version upgrade": {
 			configuredVersion:           "8.0",
 			actualVersion:               "8.0.27",
@@ -31,6 +38,20 @@ func TestCompareActualEngineVersion(t *testing.T) {
 			actualVersion:               "9.0.0",
 			expectedEngineVersion:       "9.0.0",
 			expectedEngineVersionActual: "9.0.0",
+		},
+		"pending minor version upgrade": {
+			configuredVersion:           "8.1.1",
+			actualVersion:               "8.0",
+			pendingVersion:              "8.1.1",
+			expectedEngineVersion:       "8.1.1",
+			expectedEngineVersionActual: "8.0",
+		},
+		"pending major version upgrade": {
+			configuredVersion:           "9.0.0",
+			actualVersion:               "8.1",
+			pendingVersion:              "9.0.0",
+			expectedEngineVersion:       "9.0.0",
+			expectedEngineVersionActual: "8.1",
 		},
 		"aurora upgrade": {
 			configuredVersion:           "5.7.mysql_aurora.2.07",
@@ -66,7 +87,7 @@ func TestCompareActualEngineVersion(t *testing.T) {
 			r := ResourceCluster()
 			d := r.Data(nil)
 			d.Set("engine_version", test.configuredVersion)
-			compareActualEngineVersion(d, test.configuredVersion, test.actualVersion)
+			compareActualEngineVersion(d, test.configuredVersion, test.actualVersion, test.pendingVersion)
 
 			if want, got := test.expectedEngineVersion, d.Get("engine_version"); got != want {
 				t.Errorf("unexpected engine_version; want: %q, got: %q", want, got)

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -2247,7 +2247,11 @@ func isStorageTypeGP3BelowAllocatedStorageThreshold(d *schema.ResourceData) bool
 func dbSetResourceDataEngineVersionFromInstance(d *schema.ResourceData, c *rds.DBInstance) {
 	oldVersion := d.Get("engine_version").(string)
 	newVersion := aws.StringValue(c.EngineVersion)
-	compareActualEngineVersion(d, oldVersion, newVersion)
+	var pendingVersion string
+	if c.PendingModifiedValues != nil && c.PendingModifiedValues.EngineVersion != nil {
+		pendingVersion = aws.StringValue(c.PendingModifiedValues.EngineVersion)
+	}
+	compareActualEngineVersion(d, oldVersion, newVersion, pendingVersion)
 }
 
 type dbInstanceARN struct {

--- a/internal/service/rds/verify.go
+++ b/internal/service/rds/verify.go
@@ -4,16 +4,30 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func compareActualEngineVersion(d *schema.ResourceData, oldVersion string, newVersion string) {
-	newVersionSubstr := newVersion
+// compareActualEngineVersion sets engine version related attributes
+//
+// `engine_version_actual` is always set to newVersion
+//
+// `engine_version` is set to newVersion unless:
+//   - old and pending versions are equal (ie. the update is awaiting a
+//     maintenance window)
+//   - old and new versions are not exactly equal, but match after accounting
+//     for an omitted patch value in the configuration (ie. old="1.3",
+//     new="1.3.27" will not trigger a set)
+func compareActualEngineVersion(d *schema.ResourceData, oldVersion, newVersion, pendingVersion string) {
+	d.Set("engine_version_actual", newVersion)
 
+	if oldVersion != "" && oldVersion == pendingVersion {
+		return
+	}
+
+	newVersionSubstr := newVersion
 	if len(newVersion) > len(oldVersion) {
 		newVersionSubstr = string([]byte(newVersion)[0 : len(oldVersion)+1])
 	}
-
-	if oldVersion != newVersion && string(append([]byte(oldVersion), []byte(".")...)) != newVersionSubstr {
-		d.Set("engine_version", newVersion)
+	if oldVersion != newVersion && oldVersion+"." == newVersionSubstr {
+		return
 	}
 
-	d.Set("engine_version_actual", newVersion)
+	d.Set("engine_version", newVersion)
 }


### PR DESCRIPTION
### Description
This change fixes "inconsistent final plan" errors caused by deferred engine version updates (`apply_immediately = false`) in the RDS cluster, cluster instance, and instance resources. Specifically, read operations will now check the `PendingModifiedValues` for a non-nil `EngineVersion`. If present, and equal to the existing configured value, this will be stored in state to ensure a consistent final plan and avoid persistent diffs until the update takes place during the next maintenance window.

Additionally, this change improves the cluster update workflow when there are pending updates by:
- Setting the `EngineVersion` field if the configured and "actual" engine versions differ.
  - This can occur when multiple applies happen prior to a maintenance window. In this situation the desired engine version is sent again, rather than omitting the field entirely (the current behavior).
- Setting the `DBInstanceParameterGroupName` field any time the value is set.
  - This attribute is not returned from the `DescribeDBClusters` API, so once set there is no way to detect drift and determine when state does not match the remote value. Sending the value whenever configured avoids errors where the desired value _should_ be sent, but isn't because no drift could be detected. Sending a value that matches the existing remote should have no negative impact.

### Relations

Closes #29861
Closes #22022
Closes #28219
Relates #30245

### References
- [ModifyDBCluster](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBCluster.html)
- [CreateDBCluster](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBCluster.html)
- [DescribeDBClusters](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBClusters.html)


### Output from Acceptance Testing

```console
$ make testacc PKG=rds TESTS=TestAccRDSCluster_allowMajorVersionUpgrade
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSCluster_allowMajorVersionUpgrade'  -timeout 180m
=== RUN   TestAccRDSCluster_allowMajorVersionUpgrade
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgrade
=== RUN   TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately
=== RUN   TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm
=== RUN   TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters
=== CONT  TestAccRDSCluster_allowMajorVersionUpgrade
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately (950.64s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgrade (2141.41s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters (2259.32s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm (2409.43s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        2412.582s
```

```console
$ make testacc PKG=rds TESTS=TestAccRDSCluster_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSCluster_'  -timeout 180m
<snip>
--- PASS: TestAccRDSCluster_EngineMode_global (152.24s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_encryptedRestore
--- PASS: TestAccRDSCluster_iamAuth (161.20s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags
--- PASS: TestAccRDSCluster_identifierGenerated (162.58s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs
--- PASS: TestAccRDSCluster_identifierPrefix (162.75s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_tags
--- PASS: TestAccRDSCluster_basic (166.60s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow
--- PASS: TestAccRDSCluster_backupsUpdate (191.74s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow
--- PASS: TestAccRDSCluster_deletionProtection (204.22s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_masterUsername
--- PASS: TestAccRDSCluster_copyTagsToSnapshot (302.90s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_masterPassword
--- PASS: TestAccRDSCluster_Scaling_defaultMinCapacity (306.86s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_kmsKeyID
--- PASS: TestAccRDSCluster_enableHTTPEndpoint (324.78s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal
--- PASS: TestAccRDSCluster_pointInTimeRestore (467.58s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierEngineVersion_different
--- PASS: TestAccRDSCluster_engineMode (498.77s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned
--- PASS: TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow (415.64s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierEngineMode_parallelQuery
    cluster_test.go:1756: Step 1/1 error: Error running apply: exit status 1

        Error: creating RDS Cluster (tf-acc-test-2442697265199590370-source): InvalidParameterCombination: Cannot find version null for aurora
                status code: 400, request id: b8fb3c84-4ec4-4b61-8a45-eda467758d15

          with aws_rds_cluster.source,
          on terraform_plugin_test.tf line 2, in resource "aws_rds_cluster" "source":
           2: resource "aws_rds_cluster" "source" {

=== CONT  TestAccRDSCluster_SnapshotIdentifier_deletionProtection
--- FAIL: TestAccRDSCluster_SnapshotIdentifierEngineMode_parallelQuery (4.26s)
--- PASS: TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs (450.67s)
=== CONT  TestAccRDSCluster_snapshotIdentifier
--- PASS: TestAccRDSCluster_SnapshotIdentifier_encryptedRestore (476.70s)
=== CONT  TestAccRDSCluster_availabilityZones
--- PASS: TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags (470.27s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters
--- PASS: TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow (456.09s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update
--- PASS: TestAccRDSCluster_SnapshotIdentifier_masterUsername (445.91s)
=== CONT  TestAccRDSCluster_tags
--- PASS: TestAccRDSCluster_SnapshotIdentifier_masterPassword (385.53s)
=== CONT  TestAccRDSCluster_serverlessV2ScalingConfiguration
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal (415.03s)
=== CONT  TestAccRDSCluster_scaling
--- PASS: TestAccRDSCluster_SnapshotIdentifier_kmsKeyID (446.47s)
=== CONT  TestAccRDSCluster_port
    cluster_test.go:1529: Step 1/2 error: Error running apply: exit status 1

        Error: creating RDS Cluster (tf-acc-test-4181258938337893371): InvalidParameterCombination: The Parameter Group default.aurora-postgresql13 with DBParameterGroupFamily aurora-postgresql13 cannot be used for this instance. Please use a Parameter Group with DBParameterGroupFamily aurora-postgresql14
                status code: 400, request id: 9ccc5fdd-7e47-4045-80c4-b90d3c3e3fca

          with aws_rds_cluster.test,
          on terraform_plugin_test.tf line 2, in resource "aws_rds_cluster" "test":
           2: resource "aws_rds_cluster" "test" {

--- FAIL: TestAccRDSCluster_port (5.41s)
=== CONT  TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql
--- PASS: TestAccRDSCluster_availabilityZones (176.39s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding
    cluster_test.go:1501: Step 1/1 error: Error running apply: exit status 1

        Error: creating RDS Global Cluster: InvalidParameterValue: The requested engine version was not found or does not support global functionality
                status code: 400, request id: 8841bd8c-c280-4607-bcc8-70909151616b

          with aws_rds_global_cluster.test,
          on terraform_plugin_test.tf line 18, in resource "aws_rds_global_cluster" "test":
          18: resource "aws_rds_global_cluster" "test" {

--- FAIL: TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding (9.44s)
=== CONT  TestAccRDSCluster_encrypted
--- PASS: TestAccRDSCluster_onlyMajorVersion (860.77s)
=== CONT  TestAccRDSCluster_networkType
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update (214.30s)
=== CONT  TestAccRDSCluster_kmsKey
--- PASS: TestAccRDSCluster_tags (213.28s)
=== CONT  TestAccRDSCluster_updateIAMRoles
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineVersion_different (437.60s)
=== CONT  TestAccRDSCluster_engineVersionWithPrimaryInstance
--- PASS: TestAccRDSCluster_serverlessV2ScalingConfiguration (219.72s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove
--- PASS: TestAccRDSCluster_SnapshotIdentifier_tags (780.79s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately (969.24s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned (486.24s)
=== CONT  TestAccRDSCluster_EnabledCloudWatchLogsExports_mySQL
--- PASS: TestAccRDSCluster_encrypted (184.34s)
=== CONT  TestAccRDSCluster_missingUserNameCausesError
--- PASS: TestAccRDSCluster_missingUserNameCausesError (5.16s)
=== CONT  TestAccRDSCluster_takeFinalSnapshot
--- PASS: TestAccRDSCluster_snapshotIdentifier (405.58s)
=== CONT  TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports
--- PASS: TestAccRDSCluster_updateIAMRoles (175.31s)
=== CONT  TestAccRDSCluster_backtrackWindow
--- PASS: TestAccRDSCluster_kmsKey (180.37s)
=== CONT  TestAccRDSCluster_dbSubnetGroupName
--- PASS: TestAccRDSCluster_networkType (208.95s)
=== CONT  TestAccRDSCluster_EngineMode_parallelQuery
    cluster_test.go:1183: Step 1/1 error: Error running apply: exit status 1

        Error: creating RDS Cluster (tf-acc-test-6924192451476223119): InvalidParameterCombination: Cannot find version null for aurora
                status code: 400, request id: 745c2f17-093d-4fa1-822a-2e2b32766a5f

          with aws_rds_cluster.test,
          on terraform_plugin_test.tf line 2, in resource "aws_rds_cluster" "test":
           2: resource "aws_rds_cluster" "test" {

--- FAIL: TestAccRDSCluster_EngineMode_parallelQuery (4.37s)
=== CONT  TestAccRDSCluster_engineVersion
--- PASS: TestAccRDSCluster_scaling (336.55s)
=== CONT  TestAccRDSCluster_dbClusterInstanceClass
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add (162.41s)
=== CONT  TestAccRDSCluster_EngineMode_multiMaster
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove (198.33s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global (137.64s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned
--- PASS: TestAccRDSCluster_SnapshotIdentifier_deletionProtection (567.98s)
=== CONT  TestAccRDSCluster_disappears
--- PASS: TestAccRDSCluster_dbSubnetGroupName (173.48s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier
--- PASS: TestAccRDSCluster_EnabledCloudWatchLogsExports_mySQL (243.87s)
--- PASS: TestAccRDSCluster_backtrackWindow (194.27s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned (148.39s)
--- PASS: TestAccRDSCluster_EngineMode_multiMaster (163.55s)
--- PASS: TestAccRDSCluster_takeFinalSnapshot (276.77s)
--- PASS: TestAccRDSCluster_disappears (142.09s)
--- PASS: TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports (398.87s)
--- PASS: TestAccRDSCluster_engineVersion (465.10s)
--- PASS: TestAccRDSCluster_iops (1904.38s)
--- PASS: TestAccRDSCluster_allocatedStorage (1944.34s)
--- PASS: TestAccRDSCluster_storageType (1964.65s)
--- PASS: TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID (2151.53s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm (2190.92s)
=== NAME  TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql
    cluster_test.go:775: Step 2/2 error: Error running post-apply refresh: exit status 1

        Error: reading RDS Global Cluster for RDS Cluster (tf-acc-test-6347732204348353326): RequestError: send request failed
        caused by: Post "https://rds.us-west-2.amazonaws.com/": read tcp 192.168.0.170:61584->54.240.253.127:443: read: connection reset by peer

          with aws_rds_cluster.test,
          on terraform_plugin_test.tf line 2, in resource "aws_rds_cluster" "test":
           2: resource "aws_rds_cluster" "test" {

--- PASS: TestAccRDSCluster_allowMajorVersionUpgrade (2251.78s)
--- PASS: TestAccRDSCluster_dbClusterInstanceClass (1175.51s)
--- PASS: TestAccRDSCluster_engineVersionWithPrimaryInstance (1349.47s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters (1667.27s)
--- FAIL: TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql (1540.10s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters (1782.34s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier (1895.94s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/rds        3115.569s
FAIL
make: *** [testacc] Error 1
```

Failures are unrelated to this change.