### PR TITLE
Fix golangci-lint `nolintlint` errors

### DIFF
--- a/internal/service/cognitoidp/managed_user_pool_client_test.go
+++ b/internal/service/cognitoidp/managed_user_pool_client_test.go
@@ -1175,7 +1175,7 @@ resource "aws_cognito_managed_user_pool_client" "test" {
 `, rName))
 }
 
-func testAccManagedUserPoolClientConfig_analyticsARN(rName string) string { //nolint: unused // used in a skipped test
+func testAccManagedUserPoolClientConfig_analyticsARN(rName string) string {
 	return acctest.ConfigCompose(
 		testAccManagedUserPoolClientAnalyticsBaseConfig(rName),
 		fmt.Sprintf(`
@@ -1194,7 +1194,7 @@ resource "aws_cognito_managed_user_pool_client" "test" {
 `, rName))
 }
 
-func testAccManagedUserPoolClientConfig_analyticsARNShareData(rName string, share bool) string { //nolint: unused // used in a skipped test
+func testAccManagedUserPoolClientConfig_analyticsARNShareData(rName string, share bool) string {
 	return acctest.ConfigCompose(
 		testAccManagedUserPoolClientAnalyticsBaseConfig(rName),
 		fmt.Sprintf(`


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes `golangci-lint` [errors like](https://github.com/hashicorp/terraform-provider-aws/actions/runs/4514384870/jobs/7950417807?pr=30250):

```
  Error: directive `//nolint: unused // used in a skipped test` is unused for linter "unused" (nolintlint)
  Error: directive `//nolint: unused // used in a skipped test` is unused for linter "unused" (nolintlint)
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30140.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30219.