### PR TITLE
Add Community Check reusable workflow

### DIFF
--- a/.github/workflows/community-check.yml
+++ b/.github/workflows/community-check.yml
@@ -17,7 +17,7 @@ jobs:
     name: Check community lists for username
     runs-on: ubuntu-latest
     outputs:
-      is_contributor: ${{ steps.determination.outputs.is_contributor }}
+      is_core_contributor: ${{ steps.determination.outputs.is_core_contributor }}
       is_maintainer: ${{ steps.determination.outputs.is_maintainer }}
       is_partner: ${{ steps.determination.outputs.is_partner }}
     steps:

--- a/.github/workflows/community-check.yml
+++ b/.github/workflows/community-check.yml
@@ -1,0 +1,54 @@
+name: Community Check
+
+on:
+  workflow_call:
+    outputs:
+      core_contributor:
+        value: ${{ jobs.community_check.outputs.is_core_contributor }}
+      maintainer:
+        value: ${{ jobs.community_check.outputs.is_maintainer }}
+      partner:
+        value: ${{ jobs.community_check.outputs.is_partner }}
+
+permissions: {}
+
+jobs:
+  community_check:
+    name: Check community lists for username
+    runs-on: ubuntu-latest
+    outputs:
+      is_contributor: ${{ steps.determination.outputs.is_contributor }}
+      is_maintainer: ${{ steps.determination.outputs.is_maintainer }}
+      is_partner: ${{ steps.determination.outputs.is_partner }}
+    steps:
+      - name: Decode user lists from secrets
+        id: decode
+        env:
+          CORE_CONTRIBUTORS: ${{ secrets.CORE_CONTRIBUTORS }}
+          MAINTAINERS: ${{ secrets.MAINTAINERS }}
+          PARTNERS: ${{ secrets.PARTNERS }}
+        run: |
+          # Create shell variables to hold decoded values
+          CORE_CONTRIBUTORS_DECODED=$(echo $CORE_CONTRIBUTORS | base64 -d | jq '. | tojson')
+          MAINTAINERS_DECODED=$(echo $MAINTAINERS | base64 -d | jq '. | tojson')
+          PARTNERS_DECODED=$(echo $PARTNERS | base64 -d | jq '. | tojson')
+
+          # Mask the variables so the values aren't exposed
+          echo "::add-mask::$CORE_CONTRIBUTORS_DECODED"
+          echo "::add-mask::$MAINTAINERS_DECODED"
+          echo "::add-mask::$PARTNERS_DECODED"
+
+          # Set outputs
+          echo "core_contributors_list=$CORE_CONTRIBUTORS_DECODED" >> $GITHUB_OUTPUT
+          echo "maintainers_list=$MAINTAINERS_DECODED" >> $GITHUB_OUTPUT
+          echo "partners_list=$PARTNERS_DECODED" >> $GITHUB_OUTPUT
+      - name: Determine if user is in lists
+        id: determination
+        env:
+          IS_CORE_CONTRIBUTOR: ${{ contains(fromJSON(steps.decode.outputs.core_contributors_list), github.actor) }}
+          IS_MAINTAINER: ${{ contains(fromJSON(steps.decode.outputs.maintainers_list), github.actor) }}
+          IS_PARTNER: ${{ contains(fromJSON(steps.decode.outputs.partners_list), github.actor) }}
+        run: |
+          echo "is_core_contributor=$IS_CORE_CONTRIBUTOR" >> $GITHUB_OUTPUT
+          echo "is_maintainer=$IS_MAINTAINER" >> $GITHUB_OUTPUT
+          echo "is_partner=$IS_PARTNER" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Description

This PR adds a reusable workflow that can be used to determine whether an actor is a Core Contributor, Partner, or Maintainer, for use with other GitHub Actions that depend on these determinations

### Relations

Depends on: #30276
Before: #30279

### References

- [GitHub: Reusing Workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
- [GitHub: Security Hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions) (This has info on the reasoning behind the `permissions` block and why we need to `add-mask`)

### Output from Acceptance Testing

N/a, Actions

### Usage

Once this is (and the PR that this depends on) is merged, the workflow can be used something like this:

```yaml
name: Label if user is on a list
on: [issues]

jobs:
  community_check:
    uses: ./.github/workflows/community-check.yml # Note: We cannot version pin for local workflows.
    secrets: inherit # The reusable workflow needs access to the repository's GitHub Actions Secrets

  label_groups:
    needs: community_check # Mark this job as dependent on the previous
    runs-on: ubuntu-latest
    steps: # these labels are made up for the sake of showing what the workflow can do
      - name: Label Contributors
        if: needs.community_check.outputs.core_contributor
        uses: actions-ecosystem/action-add-labels@v1
        with:
          labels: contributor
      - name: Label Maintainers
        if: needs.community_check.outputs.maintainer
        uses: actions-ecosystem/action-add-labels@v1
        with:
          labels: maintainer
      - name: Label Partners
        if: needs.community_check.outputs.partner
        uses: actions-ecosystem/action-add-labels@v1
        with:
          labels: partner
```