### PR TITLE
Move existing workflows over to reusable workflow

### DIFF
--- a/.github/workflows/autoremove_labels.yml
+++ b/.github/workflows/autoremove_labels.yml
@@ -6,16 +6,17 @@ on:
   pull_request_target:
     types: [closed]
 
-env:
-  IN_MAINTAINER_LIST: ${{ contains(secrets.MAINTAINER_LIST, github.actor) }}
-
 jobs:
+  community_check:
+    uses: ./.github/workflows/community-check.yml
+    secrets: inherit
+
   RemoveNeedsTriageFromMaintainers:
-    if: github.event.action == 'opened'
+    needs: community_check
+    if: github.event.action == 'opened' && needs.community_check.outputs.maintainer
     runs-on: ubuntu-latest
     steps:
       - name: Remove needs-triage label from member's Issues
-        if: fromJSON(env.IN_MAINTAINER_LIST)
         uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0
         with:
           labels: |

--- a/.github/workflows/autoremove_labels.yml
+++ b/.github/workflows/autoremove_labels.yml
@@ -13,7 +13,7 @@ jobs:
 
   RemoveNeedsTriageFromMaintainers:
     needs: community_check
-    if: github.event.action == 'opened' && needs.community_check.outputs.maintainer
+    if: (github.event.action == 'opened' && needs.community_check.outputs.maintainer)
     runs-on: ubuntu-latest
     steps:
       - name: Remove needs-triage label from member's Issues

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,26 +11,29 @@ on:
       - CHANGELOG.md
   pull_request_target:
 
-env:
-  IN_MAINTAINER_LIST: ${{ contains(secrets.MAINTAINER_LIST, github.actor) }}
-
 jobs:
+  community_check:
+    uses: ./.github/workflows/community-check.yml
+    secrets: inherit
+
   changes:
+    needs: community_check
     name: Filter Changes
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50
-        if: github.event_name == 'pull_request_target' && env.IN_MAINTAINER_LIST == 'false'
+        if: github.event_name == 'pull_request_target' && !needs.community_check.outputs.maintainer
         id: filter
         with:
           filters: |
             changed:
               - CHANGELOG.md
+
   comment:
     needs: changes
-    if: ${{ needs.changes.outputs.changed == 'true' }}
+    if: needs.changes.outputs.changed
     name: Comment
     runs-on: ubuntu-latest
     steps:
@@ -43,7 +46,7 @@ jobs:
           body-includes: "Please note that the `CHANGELOG.md` file contents are handled by the maintainers during merge"
       - run: echo ${{ steps.prc.outputs.comment-id }}
       - name: PR Comment
-        if: ${{ steps.prc.outputs.comment-id == '' }}
+        if: steps.prc.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,6 +58,7 @@ jobs:
             Please note that the `CHANGELOG.md` file contents are handled by the maintainers during merge. This is to prevent pull request merge conflicts, especially for contributions which may not be merged immediately. Please see the [Contributing Guide](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing) for additional pull request review items.
 
             Remove any changes to the `CHANGELOG.md` file and commit them in this pull request to prevent delays with reviewing and potentially merging this pull request.
+
   misspell:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,7 +24,7 @@ jobs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50
-        if: github.event_name == 'pull_request_target' && !needs.community_check.outputs.maintainer
+        if: (github.event_name == 'pull_request_target' && !needs.community_check.outputs.maintainer)
         id: filter
         with:
           filters: |

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -7,18 +7,20 @@ on:
       - 'release/**'
   pull_request_target:
 
-env:
-  IN_MAINTAINER_LIST: ${{ contains(secrets.MAINTAINER_LIST, github.actor) }}
-
 jobs:
+  community_check:
+    uses: ./.github/workflows/community-check.yml
+    secrets: inherit
+
   changes:
+    needs: community_check
     name: Filter Changes
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50
-        if: github.event_name == 'pull_request_target' && env.IN_MAINTAINER_LIST == 'false'
+        if: github.event_name == 'pull_request_target' && !needs.community_check.outputs.maintainer
         id: filter
         with:
           filters: |
@@ -26,9 +28,10 @@ jobs:
               - .ci/providerlint/**
               - go.mod
               - go.sum
+
   comment:
     needs: changes
-    if: ${{ needs.changes.outputs.changed == 'true' }}
+    if: needs.changes.outputs.changed
     name: Comment
     runs-on: ubuntu-latest
     steps:
@@ -41,7 +44,7 @@ jobs:
           body-includes: "Please note that typically Go dependency changes"
       - run: echo ${{ steps.prc.outputs.comment-id }}
       - name: PR Comment
-        if: ${{ steps.prc.outputs.comment-id == '' }}
+        if: steps.prc.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -59,6 +62,7 @@ jobs:
             * If this pull request is for supporting a new AWS service:
               * Ensure the new AWS service changes are following the [Contributing Guide section on new services](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing/contribution-checklists.md#new-service), in particular that the dependency addition and initial provider support are in a separate pull request from other changes (e.g. new resources). Contributions not following this item will not be reviewed until the changes are split.
               * If this pull request is already a separate pull request from the above item, you can ignore this message.
+
   go_mod:
     name: go mod
     runs-on: ubuntu-latest

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -20,7 +20,7 @@ jobs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50
-        if: github.event_name == 'pull_request_target' && !needs.community_check.outputs.maintainer
+        if: (github.event_name == 'pull_request_target' && !needs.community_check.outputs.maintainer)
         id: filter
         with:
           filters: |

--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -4,15 +4,17 @@ on:
   issue_comment:
     types: [created]
 
-env:
-  IN_MAINTAINER_LIST: ${{ contains(secrets.MAINTAINER_LIST, github.actor) }}
-
 jobs:
+  community_check:
+    uses: ./.github/workflows/community-check.yml
+    secrets: inherit
+
   issue_comment_triage:
+    needs: community_check
     runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0
-        if: github.event_name == 'issue_comment' && env.IN_MAINTAINER_LIST == 'false'
+        if: github.event_name == 'issue_comment' && !needs.community_check.outputs.maintainer
         with:
           labels: |
             stale

--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0
-        if: github.event_name == 'issue_comment' && !needs.community_check.outputs.maintainer
+        if: (github.event_name == 'issue_comment' && !needs.community_check.outputs.maintainer)
         with:
           labels: |
             stale

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -4,9 +4,6 @@ on:
   issues:
     types: [opened]
 
-env:
-  IN_MAINTAINER_LIST: ${{ contains(secrets.MAINTAINER_LIST, github.actor) }}
-
 jobs:
   AddLabelsForIssueTriage:
     runs-on: ubuntu-latest

--- a/.github/workflows/maintainer-edit.yml
+++ b/.github/workflows/maintainer-edit.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment if maintainers cannot edit
-        if: !needs.community_check.outputs.maintainer && !github.event.pull_request.maintainer_can_modify
+        if: (!needs.community_check.outputs.maintainer && !github.event.pull_request.maintainer_can_modify)
         uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/maintainer-edit.yml
+++ b/.github/workflows/maintainer-edit.yml
@@ -4,14 +4,16 @@ on:
     types:
       - opened
 jobs:
+  community_check:
+    uses: ./.github/workflows/community-check.yml
+    secrets: inherit
+
   PermissionsCheck:
-    env:
-      MAINTAINER_CAN_MODIFY: ${{ github.event.pull_request.maintainer_can_modify }}
-      IN_MAINTAINER_LIST: ${{ contains( secrets.MAINTAINER_LIST, github.actor) }}
+    needs: community_check
     runs-on: ubuntu-latest
     steps:
       - name: Comment if maintainers cannot edit
-        if: ${{ ( env.IN_MAINTAINER_LIST == 'false' ) && ( env.MAINTAINER_CAN_MODIFY == 'false' ) }}
+        if: !needs.community_check.outputs.maintainer && !github.event.pull_request.maintainer_can_modify
         uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -4,16 +4,18 @@ on:
   pull_request_target:
     types: [opened, ready_for_review]
 
-env:
-  IN_MAINTAINER_LIST: ${{ contains(secrets.MAINTAINER_LIST, github.actor) }}
-
 jobs:
+  community_check:
+    uses: ./.github/workflows/community-check.yml
+    secrets: inherit
+
   WorkingBoardReview:
+    needs: community_check
     runs-on: ubuntu-latest
     steps:
       - name: Move team PRs to Review column
         uses: alex-page/github-project-automation-plus@v0.8.3
-        if: env.IN_MAINTAINER_LIST == 'true' && github.event.pull_request.draft == false
+        if: needs.community_check.outputs.maintainer && github.event.pull_request.draft == false
         with:
           project: AWS Provider Working Board
           column: Open Maintainer PR

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Move team PRs to Review column
         uses: alex-page/github-project-automation-plus@v0.8.3
-        if: needs.community_check.outputs.maintainer && github.event.pull_request.draft == false
+        if: (needs.community_check.outputs.maintainer && github.event.pull_request.draft == false)
         with:
           project: AWS Provider Working Board
           column: Open Maintainer PR

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - name: Apply needs-triage Label
         uses: actions/labeler@v4
-        if: github.event.action == 'opened' && !needs.community_check.outputs.maintainer
+        if: (github.event.action == 'opened' && !needs.community_check.outputs.maintainer)
         with:
           configuration-path: .github/labeler-pr-needs-triage.yml
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -3,10 +3,11 @@ on:
 
 name: Pull Request Target (All types)
 
-env:
-  IN_MAINTAINER_LIST: ${{ contains(secrets.MAINTAINER_LIST, github.actor) }}
-
 jobs:
+  community_check:
+    uses: ./.github/workflows/community-check.yml
+    secrets: inherit
+
   Labeler:
     runs-on: ubuntu-latest
     steps:
@@ -16,16 +17,19 @@ jobs:
         with:
           configuration-path: .github/labeler-pr-triage.yml
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
   NeedsTriageLabeler:
+    needs: community_check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - name: Apply needs-triage Label
         uses: actions/labeler@v4
-        if: github.event.action == 'opened' && env.IN_MAINTAINER_LIST == 'false'
+        if: github.event.action == 'opened' && !needs.community_check.outputs.maintainer
         with:
           configuration-path: .github/labeler-pr-needs-triage.yml
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
   SizeLabeler:
     runs-on: ubuntu-latest
     steps:
@@ -43,6 +47,7 @@ jobs:
           l_max_size: '300'
           xl_label: 'size/XL'
           message_if_xl: ''
+
   PullRequestComments:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Description

This PR moves our existing GitHub Actions workflows that previously used the `MAINTAINER_LIST` secret over to the new method outlined in the linked PRs.

### Relations

Depends on: #30277
Depends on: #30276

### References

- [GitHub Actions Workflow Syntax: `if`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif)
- [GitHub Actions: Reusing Workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)

### Output from Acceptance Testing

N/a, Actions
