### PR TITLE
Use `xl` custom runner for main `golangci-lint` job

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,3 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of string
-  labels: [custom, small, medium, large]
+  labels: [custom, small, medium, large, xl]

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -41,7 +41,7 @@ jobs:
   golangci-lintb:
     name: 2 of 2
     needs: [golangci-linta]
-    runs-on: [custom, linux, large]
+    runs-on: [custom, linux, xl]
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

We have started [seeing](https://github.com/hashicorp/terraform-provider-aws/actions/runs/4542741939/jobs/8006580833?pr=29769)

```
Running [/home/runner/golangci-lint-1.52.2-linux-amd64/golangci-lint run --out-format=github-actions --config .ci/.golangci2.yml] in [] ...
  Killed
  
  Error: golangci-lint exit with code 137
```

Try the `xl` custom runner.