### PR TITLE
r/aws_fsx_openzfs_file_system: add validation for `disk_iops_configuration`

### DIFF
--- a/.changelog/30299.txt
+++ b/.changelog/30299.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lakeformation_lf_tag: Fix `iops` validation in `disk_iops_configuration` to allow values for `SINGLE_AZ_1` and `SINGLE_AZ_2`
+```

--- a/internal/service/fsx/openzfs_file_system.go
+++ b/internal/service/fsx/openzfs_file_system.go
@@ -94,7 +94,6 @@ func ResourceOpenzfsFileSystem() *schema.Resource {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
-							// ValidateFunc: validation.IntBetween(0, 160000),
 						},
 						"mode": {
 							Type:         schema.TypeString,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:
--->

Relates #30058

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/performance.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Test failure unrelated to change and is failing in CI. Looks like returned default values

```console
$ make testacc PKG=fsx TESTS="TestAccFSxOpenzfsFileSystem_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/fsx/... -v -count 1 -parallel 20 -run='TestAccFSxOpenzfsFileSystem_'  -timeout 180m
=== NAME  TestAccFSxOpenzfsFileSystem_rootVolume
    openzfs_file_system_test.go:158: Step 1/5 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # aws_fsx_openzfs_file_system.test will be updated in-place
          ~ resource "aws_fsx_openzfs_file_system" "test" {
                id                              = "fs-04bb6f5eef1347cb0"
                tags                            = {
                    "Name" = "tf-acc-test-7501247709983357905"
                }
                # (17 unchanged attributes hidden)

              ~ root_volume_configuration {
                    # (4 unchanged attributes hidden)

                  - user_and_group_quotas {
                      - id                         = 0 -> null
                      - storage_capacity_quota_gib = 0 -> null
                      - type                       = "GROUP" -> null
                    }
                  - user_and_group_quotas {
                      - id                         = 0 -> null
                      - storage_capacity_quota_gib = 0 -> null
                      - type                       = "USER" -> null
                    }

                    # (2 unchanged blocks hidden)
                }

                # (1 unchanged block hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
--- PASS: TestAccFSxOpenzfsFileSystem_kmsKeyID (789.62s)
--- FAIL: TestAccFSxOpenzfsFileSystem_rootVolume (807.35s)
--- PASS: TestAccFSxOpenzfsFileSystem_tags (828.18s)
--- PASS: TestAccFSxOpenzfsFileSystem_storageType (851.35s)
--- PASS: TestAccFSxOpenzfsFileSystem_copyTags (854.03s)
--- PASS: TestAccFSxOpenzfsFileSystem_disappears (859.60s)
--- PASS: TestAccFSxOpenzfsFileSystem_basic (872.99s)
--- PASS: TestAccFSxOpenzfsFileSystem_dailyAutomaticBackupStartTime (894.69s)
--- PASS: TestAccFSxOpenzfsFileSystem_weeklyMaintenanceStartTime (907.20s)
--- PASS: TestAccFSxOpenzfsFileSystem_diskIops (916.09s)
--- PASS: TestAccFSxOpenzfsFileSystem_automaticBackupRetentionDays (993.66s)
--- PASS: TestAccFSxOpenzfsFileSystem_storageCapacity (995.48s)
--- PASS: TestAccFSxOpenzfsFileSystem_throughput (1395.39s)
--- PASS: TestAccFSxOpenzfsFileSystem_throughputCapacity (1431.99s)
--- PASS: TestAccFSxOpenzfsFileSystem_securityGroupIDs (1641.91s)
--- PASS: TestAccFSxOpenzfsFileSystem_deploymentType (1707.85s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/fsx	1710.937s
...
```
