### PR TITLE
[Docs]: aws_cloudfront_origin_access_control arguments reference updates

### DIFF
--- a/website/docs/r/cloudfront_origin_access_control.html.markdown
+++ b/website/docs/r/cloudfront_origin_access_control.html.markdown
@@ -31,10 +31,10 @@ resource "aws_cloudfront_origin_access_control" "example" {
 The following arguments are required:
 
 * `name` - (Required) A name that identifies the Origin Access Control.
-* `description` - (Required) The description of the Origin Access Control. It may be empty.
-* `origin_access_control_origin_type` - (Required) The type of origin that this Origin Access Control is for. The only valid value is `s3`.
-* `signing_behavior` - (Required) Specifies which requests CloudFront signs. Specify `always` for the most common use case. Allowed values: `always`, `never`, `no-override`.
-* `signing_protocol` - (Required) Determines how CloudFront signs (authenticates) requests. Valid values: `sigv4`.
+* `description` - (Optional) The description of the Origin Access Control. Defaults to "Managed by Terraform" if omitted.
+* `origin_access_control_origin_type` - (Required) The type of origin that this Origin Access Control is for. Valid values are `s3`, and `mediastore`.
+* `signing_behavior` - (Required) Specifies which requests CloudFront signs. Specify `always` for the most common use case. Allowed values: `always`, `never`, and `no-override`.
+* `signing_protocol` - (Required) Determines how CloudFront signs (authenticates) requests. The only valid value is `sigv4`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This pull request implements changes to the documentation of the CloudFront Origin Access Control resource. The changes are:

- the `description` field is now optional and will default to `Managed by Terraform` if omitted. 
- the `origin_access_control_origin_type` field now allows for both `s3` and `mediastore` values. 
- semantic enhancements for `signing_behavior` and `signing_protocol` fields.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000 
--->

Closes #30334 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateOriginAccessControl.html#API_CreateOriginAccessControl_RequestSyntax
