### PR TITLE
r/aws_wafv2_ip_set: unknown `addresses` produce error

### DIFF
--- a/.changelog/30352.txt
+++ b/.changelog/30352.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_wafv2_ip_set: Fix `DiffSuppress` on `addresses` to detect changes for unknown values
+```

--- a/internal/service/wafv2/ip_set.go
+++ b/internal/service/wafv2/ip_set.go
@@ -56,23 +56,25 @@ func ResourceIPSet() *schema.Resource {
 				MaxItems: 10000,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					o, n := d.GetChange("addresses")
-					oldAddresses := o.(*schema.Set).List()
-					newAddresses := n.(*schema.Set).List()
-					if len(oldAddresses) == len(newAddresses) {
-						for _, ov := range oldAddresses {
-							hasAddress := false
-							for _, nv := range newAddresses {
-								if verify.CIDRBlocksEqual(ov.(string), nv.(string)) {
-									hasAddress = true
-									break
+					if d.GetRawPlan().GetAttr("addresses").IsWhollyKnown() {
+						o, n := d.GetChange("addresses")
+						oldAddresses := o.(*schema.Set).List()
+						newAddresses := n.(*schema.Set).List()
+						if len(oldAddresses) == len(newAddresses) {
+							for _, ov := range oldAddresses {
+								hasAddress := false
+								for _, nv := range newAddresses {
+									if verify.CIDRBlocksEqual(ov.(string), nv.(string)) {
+										hasAddress = true
+										break
+									}
+								}
+								if !hasAddress {
+									return false
 								}
 							}
-							if !hasAddress {
-								return false
-							}
+							return true
 						}
-						return true
 					}
 					return false
 				},

--- a/internal/service/wafv2/ip_set_test.go
+++ b/internal/service/wafv2/ip_set_test.go
@@ -201,6 +201,29 @@ func TestAccWAFV2IPSet_changeNameForceNew(t *testing.T) {
 	})
 }
 
+func TestAccWAFV2IPSet_addresses(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v wafv2.IPSet
+	ipSetName := fmt.Sprintf("ip-set-%s", sdkacctest.RandString(5))
+	resourceName := "aws_wafv2_ip_set.ip_set"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckScopeRegional(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, wafv2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIPSetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIPSetConfig_addresses(ipSetName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIPSetExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "addresses.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccWAFV2IPSet_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v wafv2.IPSet
@@ -344,6 +367,27 @@ resource "aws_wafv2_ip_set" "ip_set" {
   scope              = "REGIONAL"
   ip_address_version = "IPV4"
   addresses          = ["1.2.3.4/32", "5.6.7.8/32"]
+
+  tags = {
+    Tag1 = "Value1"
+    Tag2 = "Value2"
+  }
+}
+`, name)
+}
+
+func testAccIPSetConfig_addresses(name string) string {
+	return fmt.Sprintf(`
+resource "aws_eip" "test" {
+  vpc = true
+}
+
+resource "aws_wafv2_ip_set" "ip_set" {
+  name               = %[1]q
+  description        = %[1]q
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+  addresses          = ["1.2.3.4/32", "${aws_eip.test.public_ip}/32"]
 
   tags = {
     Tag1 = "Value1"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Diff suppression causes error when all values in `addresses` are not known during plan.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:
--->

Closes #30351

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=wafv2 TESTS="TestAccWAFV2IPSet_"

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2IPSet_'  -timeout 180m
--- PASS: TestAccWAFV2IPSet_disappears (11.70s)
--- PASS: TestAccWAFV2IPSet_ipv6 (16.13s)
--- PASS: TestAccWAFV2IPSet_minimal (21.74s)
--- PASS: TestAccWAFV2IPSet_large (22.03s)
--- PASS: TestAccWAFV2IPSet_basic (25.49s)
--- PASS: TestAccWAFV2IPSet_changeNameForceNew (29.61s)
--- PASS: TestAccWAFV2IPSet_addresses (30.94s)
--- PASS: TestAccWAFV2IPSet_tags (34.71s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafv2	38.483s
...
```
