### PR TITLE
Correctly return errors from S3 Bucket & Object finders

### DIFF
--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -1425,7 +1425,7 @@ func FindBucket(ctx context.Context, conn *s3.S3, bucket string) error {
 		}
 	}
 
-	return nil
+	return err
 }
 
 // https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region

--- a/internal/service/s3/object.go
+++ b/internal/service/s3/object.go
@@ -802,6 +802,10 @@ func FindObjectByThreePartKey(ctx context.Context, conn *s3.S3, bucket, key, eta
 		}
 	}
 
+	if err != nil {
+		return nil, err
+	}
+
 	if output == nil {
 		return nil, tfresource.NewEmptyResultError(input)
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Return `err` if it's non-`nil`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccS3Bucket_Basic_basic\|TestAccS3Bucket_disappears\|TestAccS3Object_' PKG=s3 ACCTEST_PARALLELISM=3 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 3  -run=TestAccS3Bucket_Basic_basic\|TestAccS3Bucket_disappears\|TestAccS3Object_ -timeout 180m
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_disappears
=== PAUSE TestAccS3Bucket_disappears
=== RUN   TestAccS3Object_noNameNoKey
=== PAUSE TestAccS3Object_noNameNoKey
=== RUN   TestAccS3Object_empty
=== PAUSE TestAccS3Object_empty
=== RUN   TestAccS3Object_source
=== PAUSE TestAccS3Object_source
=== RUN   TestAccS3Object_content
=== PAUSE TestAccS3Object_content
=== RUN   TestAccS3Object_etagEncryption
=== PAUSE TestAccS3Object_etagEncryption
=== RUN   TestAccS3Object_contentBase64
=== PAUSE TestAccS3Object_contentBase64
=== RUN   TestAccS3Object_sourceHashTrigger
=== PAUSE TestAccS3Object_sourceHashTrigger
=== RUN   TestAccS3Object_withContentCharacteristics
=== PAUSE TestAccS3Object_withContentCharacteristics
=== RUN   TestAccS3Object_nonVersioned
=== PAUSE TestAccS3Object_nonVersioned
=== RUN   TestAccS3Object_updates
=== PAUSE TestAccS3Object_updates
=== RUN   TestAccS3Object_updateSameFile
=== PAUSE TestAccS3Object_updateSameFile
=== RUN   TestAccS3Object_updatesWithVersioning
=== PAUSE TestAccS3Object_updatesWithVersioning
=== RUN   TestAccS3Object_updatesWithVersioningViaAccessPoint
=== PAUSE TestAccS3Object_updatesWithVersioningViaAccessPoint
=== RUN   TestAccS3Object_kms
=== PAUSE TestAccS3Object_kms
=== RUN   TestAccS3Object_sse
=== PAUSE TestAccS3Object_sse
=== RUN   TestAccS3Object_acl
=== PAUSE TestAccS3Object_acl
=== RUN   TestAccS3Object_metadata
=== PAUSE TestAccS3Object_metadata
=== RUN   TestAccS3Object_storageClass
=== PAUSE TestAccS3Object_storageClass
=== RUN   TestAccS3Object_tags
=== PAUSE TestAccS3Object_tags
=== RUN   TestAccS3Object_tagsLeadingSingleSlash
=== PAUSE TestAccS3Object_tagsLeadingSingleSlash
=== RUN   TestAccS3Object_tagsLeadingMultipleSlashes
=== PAUSE TestAccS3Object_tagsLeadingMultipleSlashes
=== RUN   TestAccS3Object_tagsMultipleSlashes
=== PAUSE TestAccS3Object_tagsMultipleSlashes
=== RUN   TestAccS3Object_objectLockLegalHoldStartWithNone
=== PAUSE TestAccS3Object_objectLockLegalHoldStartWithNone
=== RUN   TestAccS3Object_objectLockLegalHoldStartWithOn
=== PAUSE TestAccS3Object_objectLockLegalHoldStartWithOn
=== RUN   TestAccS3Object_objectLockRetentionStartWithNone
=== PAUSE TestAccS3Object_objectLockRetentionStartWithNone
=== RUN   TestAccS3Object_objectLockRetentionStartWithSet
=== PAUSE TestAccS3Object_objectLockRetentionStartWithSet
=== RUN   TestAccS3Object_objectBucketKeyEnabled
=== PAUSE TestAccS3Object_objectBucketKeyEnabled
=== RUN   TestAccS3Object_bucketBucketKeyEnabled
=== PAUSE TestAccS3Object_bucketBucketKeyEnabled
=== RUN   TestAccS3Object_defaultBucketSSE
=== PAUSE TestAccS3Object_defaultBucketSSE
=== RUN   TestAccS3Object_ignoreTags
=== PAUSE TestAccS3Object_ignoreTags
=== CONT  TestAccS3Bucket_Basic_basic
=== CONT  TestAccS3Object_sse
=== CONT  TestAccS3Object_sourceHashTrigger
--- PASS: TestAccS3Bucket_Basic_basic (28.70s)
=== CONT  TestAccS3Object_objectLockLegalHoldStartWithNone
--- PASS: TestAccS3Object_sse (28.74s)
=== CONT  TestAccS3Object_ignoreTags
--- PASS: TestAccS3Object_sourceHashTrigger (48.87s)
=== CONT  TestAccS3Object_defaultBucketSSE
--- PASS: TestAccS3Object_defaultBucketSSE (24.31s)
=== CONT  TestAccS3Object_bucketBucketKeyEnabled
--- PASS: TestAccS3Object_ignoreTags (50.96s)
=== CONT  TestAccS3Object_objectBucketKeyEnabled
--- PASS: TestAccS3Object_bucketBucketKeyEnabled (24.13s)
=== CONT  TestAccS3Object_objectLockRetentionStartWithSet
--- PASS: TestAccS3Object_objectLockLegalHoldStartWithNone (71.64s)
=== CONT  TestAccS3Object_objectLockRetentionStartWithNone
--- PASS: TestAccS3Object_objectBucketKeyEnabled (23.81s)
=== CONT  TestAccS3Object_objectLockLegalHoldStartWithOn
--- PASS: TestAccS3Object_objectLockLegalHoldStartWithOn (47.83s)
=== CONT  TestAccS3Object_source
--- PASS: TestAccS3Object_objectLockRetentionStartWithNone (70.03s)
=== CONT  TestAccS3Object_contentBase64
--- PASS: TestAccS3Object_source (27.73s)
=== CONT  TestAccS3Object_etagEncryption
--- PASS: TestAccS3Object_objectLockRetentionStartWithSet (92.07s)
=== CONT  TestAccS3Object_content
--- PASS: TestAccS3Object_contentBase64 (24.12s)
=== CONT  TestAccS3Object_updateSameFile
--- PASS: TestAccS3Object_etagEncryption (27.06s)
=== CONT  TestAccS3Object_kms
--- PASS: TestAccS3Object_content (28.13s)
=== CONT  TestAccS3Object_updatesWithVersioningViaAccessPoint
--- PASS: TestAccS3Object_kms (28.92s)
=== CONT  TestAccS3Object_updatesWithVersioning
--- PASS: TestAccS3Object_updateSameFile (50.08s)
=== CONT  TestAccS3Object_noNameNoKey
--- PASS: TestAccS3Object_noNameNoKey (3.22s)
=== CONT  TestAccS3Object_empty
--- PASS: TestAccS3Object_updatesWithVersioningViaAccessPoint (52.89s)
=== CONT  TestAccS3Object_metadata
--- PASS: TestAccS3Object_empty (27.68s)
=== CONT  TestAccS3Object_storageClass
--- PASS: TestAccS3Object_updatesWithVersioning (53.30s)
=== CONT  TestAccS3Object_acl
--- PASS: TestAccS3Object_metadata (59.45s)
=== CONT  TestAccS3Object_tags
--- PASS: TestAccS3Object_acl (65.73s)
=== CONT  TestAccS3Object_tagsLeadingMultipleSlashes
--- PASS: TestAccS3Object_storageClass (87.79s)
=== CONT  TestAccS3Object_tagsLeadingSingleSlash
--- PASS: TestAccS3Object_tags (77.08s)
=== CONT  TestAccS3Object_tagsMultipleSlashes
--- PASS: TestAccS3Object_tagsLeadingMultipleSlashes (74.37s)
=== CONT  TestAccS3Object_updates
--- PASS: TestAccS3Object_tagsLeadingSingleSlash (76.54s)
=== CONT  TestAccS3Bucket_disappears
--- PASS: TestAccS3Bucket_disappears (14.81s)
=== CONT  TestAccS3Object_withContentCharacteristics
--- PASS: TestAccS3Object_updates (44.80s)
=== CONT  TestAccS3Object_nonVersioned
    acctest.go:1468: skipping test; environment variable TF_ACC_ASSUME_ROLE_ARN must be set. Usage: Amazon Resource Name (ARN) of existing IAM Role to assume for testing restricted permissions
--- SKIP: TestAccS3Object_nonVersioned (0.00s)
--- PASS: TestAccS3Object_withContentCharacteristics (19.26s)
--- PASS: TestAccS3Object_tagsMultipleSlashes (75.46s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	491.508s
```
