### PR TITLE
AWS_CE_COST_CATEGORY: fix effective start being changed on update despite no current change

### DIFF
--- a/.changelog/30369.txt
+++ b/.changelog/30369.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ce_cost_explorer: Fixed `effective_start` being reset on any changes despite `effective_start` having the same value
+```

--- a/.changelog/30369.txt
+++ b/.changelog/30369.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_ce_cost_explorer: Fixed `effective_start` being reset on any changes despite `effective_start` having the same value
+resource/aws_ce_cost_category: Fixed `effective_start` being reset on any changes despite `effective_start` having the same value
 ```

--- a/internal/service/ce/cost_category.go
+++ b/internal/service/ce/cost_category.go
@@ -468,6 +468,7 @@ func resourceCostCategoryUpdate(ctx context.Context, d *schema.ResourceData, met
 	if d.HasChangesExcept("tags", "tags_all") {
 		input := &costexplorer.UpdateCostCategoryDefinitionInput{
 			CostCategoryArn: aws.String(d.Id()),
+			EffectiveStart:  aws.String(d.Get("effective_start").(string)),
 			Rules:           expandCostCategoryRules(d.Get("rule").(*schema.Set).List()),
 			RuleVersion:     aws.String(d.Get("rule_version").(string)),
 		}
@@ -478,10 +479,6 @@ func resourceCostCategoryUpdate(ctx context.Context, d *schema.ResourceData, met
 
 		if d.HasChange("split_charge_rule") {
 			input.SplitChargeRules = expandCostCategorySplitChargeRules(d.Get("split_charge_rule").(*schema.Set).List())
-		}
-
-		if d.HasChange("effective_start") {
-			input.EffectiveStart = aws.String(d.Get("effective_start").(string))
 		}
 
 		_, err := conn.UpdateCostCategoryDefinitionWithContext(ctx, input)


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Fixed effective_start date being reset to the start of the current month. Effective_start date is required (see API documentation in the references). If the effective_start has not been changed by the current change, terraform passes nil which results on AWS side to use the default value (first day of current month).

### Relations

Closes #29044 

### References

[AWS API Reference](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_CostCategoryReference.html)

The [aws sdk](https://pkg.go.dev/github.com/aws/aws-sdk-go@v1.44.232/service/costexplorer#UpdateCostCategoryDefinitionInput) states:
> 	The Cost Category's effective start date. It can only be a billing start
	 date (first day of the month). If the date isn't provided, it's the first
	day of the current month. Dates can't be before the previous twelve months,
	or in the future.


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
