### PR TITLE
r/aws_rds_cluster: Fix crash when attempting to update `master_password`

### DIFF
--- a/.changelog/30379.txt
+++ b/.changelog/30379.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_cluster: Fix crash when updating `master_password`
+```

--- a/.changelog/30379.txt
+++ b/.changelog/30379.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_rds_cluster: Fix crash when updating `master_password`
 ```
+
+```release-note:bug
+resource/aws_db_instance: Fix crash when updating `password`
+```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -1279,12 +1279,12 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			input.ManageMasterUserPassword = aws.Bool(d.Get("manage_master_user_password").(bool))
 		}
 		if d.HasChange("master_password") {
-			if v, ok := d.GetOk("master_password"); ok && len(v.([]interface{})) > 0 && v.([]interface{}) != nil {
+			if v, ok := d.GetOk("master_password"); ok {
 				input.MasterUserPassword = aws.String(v.(string))
 			}
 		}
 		if d.HasChange("master_user_secret_kms_key_id") {
-			if v, ok := d.GetOk("master_user_secret_kms_key_id"); ok && len(v.([]interface{})) > 0 && v.([]interface{}) != nil {
+			if v, ok := d.GetOk("master_user_secret_kms_key_id"); ok {
 				input.MasterUserSecretKmsKeyId = aws.String(v.(string))
 			}
 		}

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -2500,7 +2500,8 @@ resource "aws_rds_cluster" "test" {
   database_name                   = "test"
   manage_master_user_password     = true
   master_username                 = "tfacctest"
-  db_cluster_parameter_group_name = "default.aurora5.6"
+  engine                          = "aurora-mysql"
+  db_cluster_parameter_group_name = "default.aurora-mysql5.7"
   skip_final_snapshot             = true
 }
 `, rName)
@@ -4397,7 +4398,8 @@ resource "aws_rds_cluster" "test" {
   database_name                   = "test"
   master_username                 = "tfacctest"
   master_password                 = %[2]q
-  db_cluster_parameter_group_name = "default.aurora5.6"
+  engine                          = "aurora-mysql"
+  db_cluster_parameter_group_name = "default.aurora-mysql5.7"
   skip_final_snapshot             = true
 }
 `, rName, password)

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -2338,6 +2338,36 @@ func TestAccRDSCluster_enableHTTPEndpoint(t *testing.T) {
 	})
 }
 
+func TestAccRDSCluster_password(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dbCluster rds.DBCluster
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_rds_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, rds.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_password(rName, "valid-password-1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(resourceName, "master_password", "valid-password-1"),
+				),
+			},
+			{
+				Config: testAccClusterConfig_password(rName, "valid-password-2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(resourceName, "master_password", "valid-password-2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckClusterDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		return testAccCheckClusterDestroyWithProvider(ctx)(s, acctest.Provider)
@@ -4358,4 +4388,17 @@ resource "aws_rds_cluster" "test" {
   }
 }
 `, rName, enableHttpEndpoint)
+}
+
+func testAccClusterConfig_password(rName, password string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster" "test" {
+  cluster_identifier              = %[1]q
+  database_name                   = "test"
+  master_username                 = "tfacctest"
+  master_password                 = %[2]q
+  db_cluster_parameter_group_name = "default.aurora5.6"
+  skip_final_snapshot             = true
+}
+`, rName, password)
 }

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -1520,12 +1520,16 @@ func TestAccRDSCluster_ManagedMasterPassword_managedSpecificKMSKey(t *testing.T)
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_managedMasterPasswordKMSKey(rName, 0),
+				Config: testAccClusterConfig_managedMasterPasswordKMSKey(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "rds", fmt.Sprintf("cluster:%s", rName)),
+					resource.TestCheckResourceAttrSet(resourceName, "cluster_resource_id"),
+					resource.TestCheckResourceAttr(resourceName, "db_cluster_parameter_group_name", "default.aurora5.6"),
+					resource.TestCheckResourceAttr(resourceName, "engine", "aurora"),
+					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
 					resource.TestCheckResourceAttr(resourceName, "manage_master_user_password", "true"),
 					resource.TestCheckResourceAttr(resourceName, "master_user_secret.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "master_user_secret_kms_key_id", "aws_kms_key.test.0", "arn"),
 					resource.TestCheckResourceAttrSet(resourceName, "master_user_secret.0.kms_key_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "master_user_secret.0.secret_arn"),
 					resource.TestCheckResourceAttrSet(resourceName, "master_user_secret.0.secret_status"),
@@ -1545,18 +1549,6 @@ func TestAccRDSCluster_ManagedMasterPassword_managedSpecificKMSKey(t *testing.T)
 					"master_user_secret_kms_key_id",
 					"skip_final_snapshot",
 				},
-			},
-			{
-				Config: testAccClusterConfig_managedMasterPasswordKMSKey(rName, 1),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
-					resource.TestCheckResourceAttr(resourceName, "manage_master_user_password", "true"),
-					resource.TestCheckResourceAttr(resourceName, "master_user_secret.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "master_user_secret_kms_key_id", "aws_kms_key.test.1", "arn"),
-					resource.TestCheckResourceAttrSet(resourceName, "master_user_secret.0.kms_key_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "master_user_secret.0.secret_arn"),
-					resource.TestCheckResourceAttrSet(resourceName, "master_user_secret.0.secret_status"),
-				),
 			},
 		},
 	})
@@ -2346,41 +2338,6 @@ func TestAccRDSCluster_enableHTTPEndpoint(t *testing.T) {
 	})
 }
 
-func TestAccRDSCluster_password(t *testing.T) {
-	ctx := acctest.Context(t)
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
-	var dbCluster rds.DBCluster
-
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_rds_cluster.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, rds.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccClusterConfig_password(rName, "avoid-plaintext-passwords"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
-					resource.TestCheckResourceAttr(resourceName, "master_password", "avoid-plaintext-passwords"),
-				),
-			},
-			{
-				Config: testAccClusterConfig_password(rName, "barbarbar"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
-					resource.TestCheckResourceAttr(resourceName, "master_password", "barbarbar"),
-				),
-			},
-		},
-	})
-}
-
 func testAccCheckClusterDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		return testAccCheckClusterDestroyWithProvider(ctx)(s, acctest.Provider)
@@ -2519,15 +2476,13 @@ resource "aws_rds_cluster" "test" {
 `, rName)
 }
 
-func testAccClusterConfig_managedMasterPasswordKMSKey(rName string, idx int) string {
+func testAccClusterConfig_managedMasterPasswordKMSKey(rName string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
-resource "aws_kms_key" "test" {
-  count = 2
-
-  description = "%[1]s-${count.index}"
+resource "aws_kms_key" "example" {
+  description = "Terraform acc test %[1]s"
 
   policy = <<POLICY
 {
@@ -2554,11 +2509,11 @@ resource "aws_rds_cluster" "test" {
   database_name                   = "test"
   manage_master_user_password     = true
   master_username                 = "tfacctest"
-  master_user_secret_kms_key_id   = aws_kms_key.test[%[2]d].arn
+  master_user_secret_kms_key_id   = aws_kms_key.example.arn
   db_cluster_parameter_group_name = "default.aurora5.6"
   skip_final_snapshot             = true
 }
-`, rName, idx)
+`, rName)
 }
 
 func testAccClusterConfig_tags1(rName, tagKey1, tagValue1 string) string {
@@ -4403,17 +4358,4 @@ resource "aws_rds_cluster" "test" {
   }
 }
 `, rName, enableHttpEndpoint)
-}
-
-func testAccClusterConfig_password(rName, password string) string {
-	return fmt.Sprintf(`
-resource "aws_rds_cluster" "test" {
-  cluster_identifier              = %[1]q
-  database_name                   = "test"
-  master_username                 = "tfacctest"
-  master_password                 = %[2]q
-  db_cluster_parameter_group_name = "default.aurora5.6"
-  skip_final_snapshot             = true
-}
-`, rName, password)
 }

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -2092,7 +2092,8 @@ func dbInstancePopulateModify(input *rds_sdkv2.ModifyDBInstanceInput, d *schema.
 	}
 
 	if d.HasChange("master_user_secret_kms_key_id") {
-		if v, ok := d.GetOk("master_user_secret_kms_key_id"); ok && len(v.([]interface{})) > 0 && v.([]interface{}) != nil {
+		needsModify = true
+		if v, ok := d.GetOk("master_user_secret_kms_key_id"); ok {
 			input.MasterUserSecretKmsKeyId = aws.String(v.(string))
 		}
 	}
@@ -2139,7 +2140,7 @@ func dbInstancePopulateModify(input *rds_sdkv2.ModifyDBInstanceInput, d *schema.
 	if d.HasChange("password") {
 		needsModify = true
 		// With ManageMasterUserPassword set to true, the password is no longer needed, so we omit it from the API call.
-		if v, ok := d.GetOk("password"); ok && len(v.([]interface{})) > 0 && v.([]interface{}) != nil {
+		if v, ok := d.GetOk("password"); ok {
 			input.MasterUserPassword = aws.String(v.(string))
 		}
 	}

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -2095,6 +2095,8 @@ func dbInstancePopulateModify(input *rds_sdkv2.ModifyDBInstanceInput, d *schema.
 		needsModify = true
 		if v, ok := d.GetOk("master_user_secret_kms_key_id"); ok {
 			input.MasterUserSecretKmsKeyId = aws.String(v.(string))
+			// InvalidParameterValue: A ManageMasterUserPassword value is required when MasterUserSecretKmsKeyId is specified.
+			input.ManageMasterUserPassword = aws.Bool(d.Get("manage_master_user_password").(bool))
 		}
 	}
 

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -971,10 +971,10 @@ func TestAccRDSInstance_password(t *testing.T) {
 				ExpectError: regexp.MustCompile(`MasterUserPassword is not a valid password because it is shorter than 8 characters`),
 			},
 			{
-				Config: testAccInstanceConfig_password(rName, "valid-password"),
+				Config: testAccInstanceConfig_password(rName, "valid-password-1"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "password", "valid-password"),
+					resource.TestCheckResourceAttr(resourceName, "password", "valid-password-1"),
 				),
 			},
 			{
@@ -987,6 +987,13 @@ func TestAccRDSInstance_password(t *testing.T) {
 					"password",
 					"skip_final_snapshot",
 				},
+			},
+			{
+				Config: testAccInstanceConfig_password(rName, "valid-password-2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "password", "valid-password-2"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/30372.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/30383.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/28848.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccRDSInstance_password\|TestAccRDSInstance_basic' PKG=rds ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 3  -run=TestAccRDSInstance_password\|TestAccRDSInstance_basic -timeout 180m
=== RUN   TestAccRDSInstance_basic
=== PAUSE TestAccRDSInstance_basic
=== RUN   TestAccRDSInstance_password
=== PAUSE TestAccRDSInstance_password
=== CONT  TestAccRDSInstance_basic
=== CONT  TestAccRDSInstance_password
--- PASS: TestAccRDSInstance_basic (533.28s)
--- PASS: TestAccRDSInstance_password (693.91s)
PASS
```
```console
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	700.100s
% make testacc TESTARGS='-run=TestAccRDSCluster_password\|TestAccRDSCluster_basic' PKG=rds ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 3  -run=TestAccRDSCluster_password\|TestAccRDSCluster_basic -timeout 180m
=== RUN   TestAccRDSCluster_basic
=== PAUSE TestAccRDSCluster_basic
=== RUN   TestAccRDSCluster_password
=== PAUSE TestAccRDSCluster_password
=== CONT  TestAccRDSCluster_basic
=== CONT  TestAccRDSCluster_password
=== CONT  TestAccRDSCluster_basic
    cluster_test.go:43: Step 1/2 error: Check failed: 3 errors occurred:
        	* Check 13/16 error: aws_rds_cluster.test: Attribute 'reader_endpoint' expected to be set
        	* Check 14/16 error: aws_rds_cluster.test: Attribute 'scaling_configuration.#' expected "0", got "1"
        	* Check 15/16 error: aws_rds_cluster.test: Attribute 'storage_encrypted' expected "false", got "true"
        
--- PASS: TestAccRDSCluster_password (189.34s)
--- FAIL: TestAccRDSCluster_basic (315.91s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/rds	321.166s
FAIL
make: *** [testacc] Error 1
```
Failure is related to #30355.