### PR TITLE
Change httptokens to optional for ec2 launch template

### DIFF
--- a/.changelog/30393.txt
+++ b/.changelog/30393.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_launch_template: Make default value of `http_tokens` under `metadata_options` as optional
+```

--- a/.changelog/30393.txt
+++ b/.changelog/30393.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/aws_launch_template: Make http_tokens optional under metadata_options
-```

--- a/.changelog/30393.txt
+++ b/.changelog/30393.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_launch_template: Make `http_tokens` optional under `metadata_options`
+resource/aws_launch_template: Make http_tokens optional under metadata_options
 ```

--- a/.changelog/30393.txt
+++ b/.changelog/30393.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_launch_template: Change default value of `http_tokens` under `metadata_options` as optional
+resource/aws_launch_template: Make `http_tokens` optional under `metadata_options`
 ```

--- a/.changelog/30393.txt
+++ b/.changelog/30393.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_launch_template: Make default value of `http_tokens` under `metadata_options` as optional
+resource/aws_launch_template: Change default value of `http_tokens` under `metadata_options` as optional
 ```

--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -677,7 +677,7 @@ func ResourceLaunchTemplate() *schema.Resource {
 						"http_tokens": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							Computed:     true,
+							Default:      ec2.LaunchTemplateHttpTokensStateOptional,
 							ValidateFunc: validation.StringInSlice(ec2.LaunchTemplateHttpTokensState_Values(), false),
 						},
 						"instance_metadata_tags": {

--- a/internal/service/ec2/ec2_launch_template_test.go
+++ b/internal/service/ec2/ec2_launch_template_test.go
@@ -4098,7 +4098,7 @@ resource "aws_launch_template" "test" {
 
   metadata_options {
     http_endpoint               = "enabled"
-	http_tokens                 = "optional"
+    http_tokens                 = "optional"
   }
 }
 `, rName)

--- a/internal/service/ec2/ec2_launch_template_test.go
+++ b/internal/service/ec2/ec2_launch_template_test.go
@@ -2917,6 +2917,23 @@ func TestAccEC2LaunchTemplate_metadataOptions(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
+				Config: testAccLaunchTemplateConfig_metadataOptionsWithOptionalHttpTokens(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchTemplateExists(ctx, resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_endpoint", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_tokens", "optional"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_put_response_hop_limit", "2"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.http_protocol_ipv6", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_options.0.instance_metadata_tags", "disabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccLaunchTemplateConfig_metadataOptionsIPv6(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(ctx, resourceName, &template),
@@ -4069,6 +4086,19 @@ resource "aws_launch_template" "test" {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
     http_put_response_hop_limit = 2
+  }
+}
+`, rName)
+}
+
+func testAccLaunchTemplateConfig_metadataOptionsWithOptionalHttpTokens(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = %[1]q
+
+  metadata_options {
+    http_endpoint               = "enabled"
+	http_tokens                 = "optional"
   }
 }
 `, rName)

--- a/internal/service/ec2/ec2_launch_template_test.go
+++ b/internal/service/ec2/ec2_launch_template_test.go
@@ -4097,8 +4097,8 @@ resource "aws_launch_template" "test" {
   name = %[1]q
 
   metadata_options {
-    http_endpoint               = "enabled"
-    http_tokens                 = "optional"
+    http_endpoint = "enabled"
+    http_tokens   = "optional"
   }
 }
 `, rName)

--- a/internal/service/ec2/ec2_launch_template_test.go
+++ b/internal/service/ec2/ec2_launch_template_test.go
@@ -2917,7 +2917,7 @@ func TestAccEC2LaunchTemplate_metadataOptions(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccLaunchTemplateConfig_metadataOptionsWithOptionalHttpTokens(rName),
+				Config: testAccLaunchTemplateConfig_metadataOptionsWithOptionalHTTPTokens(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(ctx, resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "metadata_options.#", "1"),

--- a/internal/service/ec2/ec2_launch_template_test.go
+++ b/internal/service/ec2/ec2_launch_template_test.go
@@ -4091,7 +4091,7 @@ resource "aws_launch_template" "test" {
 `, rName)
 }
 
-func testAccLaunchTemplateConfig_metadataOptionsWithOptionalHttpTokens(rName string) string {
+func testAccLaunchTemplateConfig_metadataOptionsWithOptionalHTTPTokens(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
   name = %[1]q


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Make default value for http_tokens as optional

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/30382

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$  make testacc TESTS=TestAccEC2LaunchTemplate_metadataOptions PKG=ec2

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2LaunchTemplate_metadataOptions'  -timeout 180m
=== RUN   TestAccEC2LaunchTemplate_metadataOptions
=== PAUSE TestAccEC2LaunchTemplate_metadataOptions
=== CONT  TestAccEC2LaunchTemplate_metadataOptions
--- PASS: TestAccEC2LaunchTemplate_metadataOptions (67.87s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	72.534s


...
```

