### PR TITLE
Emrserverless add image configuration

### DIFF
--- a/.changelog/30398.txt
+++ b/.changelog/30398.txt
@@ -1,4 +1,7 @@
 ```release-note:enhancement
 resource/aws_imagebuilder_container_recipe: Add `platform_override` field
+```
+
+```release-note:enhancement
 resource/aws_emrserverless_application: Add `image_configuration` field
 ```

--- a/.changelog/30398.txt
+++ b/.changelog/30398.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+resource/aws_imagebuilder_container_recipe: Add `platform_override` field
+resource/aws_emrserverless_application: Add `image_configuration` field
+```

--- a/internal/service/emrserverless/application.go
+++ b/internal/service/emrserverless/application.go
@@ -309,7 +309,7 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 		return sdkdiag.AppendErrorf(diags, "setting auto_stop_configuration: %s", err)
 	}
 
-	if err := d.Set("image_configuration", []interface{}{flattenImageConfiguration(application.ImageConfiguration)}); err != nil {
+	if err := d.Set("image_configuration", flattenImageConfiguration(application.ImageConfiguration)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting image_configuration: %s", err)
 	}
 
@@ -578,18 +578,20 @@ func expandImageConfiguration(tfMap map[string]interface{}) *emrserverless.Image
 	return apiObject
 }
 
-func flattenImageConfiguration(apiObject *emrserverless.ImageConfiguration) map[string]interface{} {
-	if apiObject == nil {
+func flattenImageConfiguration(apiObject *emrserverless.ImageConfiguration) []interface{} {
+	if apiObject == nil || apiObject.ImageUri == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	var tfList []interface{}
 
 	if v := apiObject.ImageUri; v != nil {
-		tfMap["image_uri"] = aws.StringValue(v)
+		tfList = append(tfList, map[string]interface{}{
+			"image_uri": aws.StringValue(v),
+		})
 	}
 
-	return tfMap
+	return tfList
 }
 
 func expandInitialCapacity(tfMap *schema.Set) map[string]*emrserverless.InitialCapacityConfig {

--- a/internal/service/emrserverless/application_test.go
+++ b/internal/service/emrserverless/application_test.go
@@ -2,7 +2,6 @@ package emrserverless_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"regexp"
 	"testing"
@@ -148,15 +147,8 @@ func TestAccEMRServerlessApplication_imageConfiguration(t *testing.T) {
 	resourceName := "aws_emrserverless_application.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
-	firstVersionRegex, err := regexp.Compile("1\\.0\\.0")
-	if err != nil {
-		t.Error(err)
-	}
-
-	secondVersionRegex, err := regexp.Compile("1\\.0\\.1")
-	if err != nil {
-		t.Error(err)
-	}
+	firstVersionRegex := regexp.MustCompile(`1\.0\.0`)
+	secondVersionRegex := regexp.MustCompile(`1\.0\.1`)
 
 	firstImageConfig, err := testAccApplicationConfig_imageConfiguration(rName, "1.0.0", "1.0.1", "1.0.0")
 	if err != nil {
@@ -513,11 +505,11 @@ resource "aws_emrserverless_application" "test" {
 // repo in order to run the test
 func testAccApplicationConfig_imageConfiguration(rName, firstImageVersion, secondImageVersion, selectedImageVersion string) (string, error) {
 	if firstImageVersion == secondImageVersion {
-		return "", errors.New(fmt.Sprintf("firstImageVersion and secondImageVersion cannot be equal. Was given %[1]q for both", firstImageVersion))
+		return "", fmt.Errorf("firstImageVersion and secondImageVersion cannot be equal. Was given %[1]q for both", firstImageVersion)
 	}
 
 	if selectedImageVersion != firstImageVersion && selectedImageVersion != secondImageVersion {
-		return "", errors.New(fmt.Sprintf("selectedImageVersion must be equal to firstImageVersion or secondImageVersion (%[1]q or %[2]q). Was given %[3]q", firstImageVersion, secondImageVersion, selectedImageVersion))
+		return "", fmt.Errorf("selectedImageVersion must be equal to firstImageVersion or secondImageVersion (%[1]q or %[2]q). Was given %[3]q", firstImageVersion, secondImageVersion, selectedImageVersion)
 	}
 
 	selectedVersionResourceName := "test_version1"

--- a/internal/service/emrserverless/application_test.go
+++ b/internal/service/emrserverless/application_test.go
@@ -531,150 +531,150 @@ data "aws_region" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_ecr_repository" "test" {
-	name = %[1]q
-	force_delete = true
+  name         = %[1]q
+  force_delete = true
 }
 
 resource "aws_vpc" "test" {
-	cidr_block = "10.0.0.0/16"
+  cidr_block = "10.0.0.0/16"
 }
 
 resource "aws_default_route_table" "test" {
-	default_route_table_id = aws_vpc.test.default_route_table_id
+  default_route_table_id = aws_vpc.test.default_route_table_id
 
-	route {
-		cidr_block = "0.0.0.0/0"
-		gateway_id = aws_internet_gateway.test.id
-	}
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.test.id
+  }
 }
 
 resource "aws_internet_gateway" "test" {
-	vpc_id = aws_vpc.test.id
+  vpc_id = aws_vpc.test.id
 }
 
 resource "aws_subnet" "test" {
-	cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
-	map_public_ip_on_launch = true
-	vpc_id                  = aws_vpc.test.id
+  cidr_block              = cidrsubnet(aws_vpc.test.cidr_block, 8, 0)
+  map_public_ip_on_launch = true
+  vpc_id                  = aws_vpc.test.id
 }
 
 resource "aws_default_security_group" "test" {
-	vpc_id = aws_vpc.test.id
+  vpc_id = aws_vpc.test.id
 
-	egress {
-		cidr_blocks = ["0.0.0.0/0"]
-		from_port   = 0
-		protocol    = "-1"
-		to_port     = 0
-	}
+  egress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 0
+    protocol    = "-1"
+    to_port     = 0
+  }
 
-	ingress {
-		from_port = 0
-		protocol  = -1
-		self      = true
-		to_port   = 0
-	}
+  ingress {
+    from_port = 0
+    protocol  = -1
+    self      = true
+    to_port   = 0
+  }
 }
 
 resource "aws_iam_role" "test" {
-	assume_role_policy = jsonencode({
-		Version = "2012-10-17"
-		Statement = [{
-			Action = "sts:AssumeRole"
-			Effect = "Allow"
-			Principal = {
-				Service = "ec2.${data.aws_partition.current.dns_suffix}"
-			}
-			Sid = ""
-		}]
-	})
-	name = %[1]q
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.${data.aws_partition.current.dns_suffix}"
+      }
+      Sid = ""
+    }]
+  })
+  name = %[1]q
 }
 
 resource "aws_iam_role_policy_attachment" "AmazonSSMManagedInstanceCore" {
-	policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
-	role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  role       = aws_iam_role.test.name
 }
 
 resource "aws_iam_role_policy_attachment" "EC2InstanceProfileForImageBuilder" {
-	policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder"
-	role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder"
+  role       = aws_iam_role.test.name
 }
 
 resource "aws_iam_role_policy_attachment" "EC2InstanceProfileForImageBuilderECRContainerBuilds" {
-	policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/EC2InstanceProfileForImageBuilderECRContainerBuilds"
-	role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/EC2InstanceProfileForImageBuilderECRContainerBuilds"
+  role       = aws_iam_role.test.name
 }
 
 resource "aws_iam_instance_profile" "test" {
-	name = aws_iam_role.test.name
-	role = aws_iam_role.test.name
+  name = aws_iam_role.test.name
+  role = aws_iam_role.test.name
 
-	depends_on = [
-		aws_iam_role_policy_attachment.AmazonSSMManagedInstanceCore,
-		aws_iam_role_policy_attachment.EC2InstanceProfileForImageBuilderECRContainerBuilds
-	]
+  depends_on = [
+    aws_iam_role_policy_attachment.AmazonSSMManagedInstanceCore,
+    aws_iam_role_policy_attachment.EC2InstanceProfileForImageBuilderECRContainerBuilds
+  ]
 }
 
 resource "aws_imagebuilder_container_recipe" "test_version1" {
-	name              = "%[1]s_version1"
-	container_type    = "DOCKER"
-	parent_image      = "public.ecr.aws/emr-serverless/hive/emr-6.9.0"
-	version           = %[3]q
-	platform_override = "Linux"
+  name              = "%[1]s_version1"
+  container_type    = "DOCKER"
+  parent_image      = "public.ecr.aws/emr-serverless/hive/emr-6.9.0"
+  version           = %[3]q
+  platform_override = "Linux"
 
-	component {
-		component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/hello-world-linux/x.x.x"
-	}
+  component {
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/hello-world-linux/x.x.x"
+  }
 
-	dockerfile_template_data = <<EOF
+  dockerfile_template_data = <<EOF
 FROM {{{ imagebuilder:parentImage }}}
 EOF
 
-	target_repository {
-		repository_name = aws_ecr_repository.test.name
-		service         = "ECR"
-	}
+  target_repository {
+    repository_name = aws_ecr_repository.test.name
+    service         = "ECR"
+  }
 }
 
 resource "aws_imagebuilder_container_recipe" "test_version2" {
-	name              = "%[1]s_version2"
-	container_type    = "DOCKER"
-	parent_image      = "public.ecr.aws/emr-serverless/hive/emr-6.9.0"
-	version           = %[4]q
-	platform_override = "Linux"
+  name              = "%[1]s_version2"
+  container_type    = "DOCKER"
+  parent_image      = "public.ecr.aws/emr-serverless/hive/emr-6.9.0"
+  version           = %[4]q
+  platform_override = "Linux"
 
-	component {
-		component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/hello-world-linux/x.x.x"
-	}
+  component {
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/hello-world-linux/x.x.x"
+  }
 
-	dockerfile_template_data = <<EOF
+  dockerfile_template_data = <<EOF
 FROM {{{ imagebuilder:parentImage }}}
 EOF
 
-	target_repository {
-		repository_name = aws_ecr_repository.test.name
-		service         = "ECR"
-	}
+  target_repository {
+    repository_name = aws_ecr_repository.test.name
+    service         = "ECR"
+  }
 }
 
 resource "aws_imagebuilder_infrastructure_configuration" "test" {
-	instance_profile_name = aws_iam_instance_profile.test.name
-	name                  = %[1]q
-	security_group_ids    = [aws_default_security_group.test.id]
-	subnet_id             = aws_subnet.test.id
+  instance_profile_name = aws_iam_instance_profile.test.name
+  name                  = %[1]q
+  security_group_ids    = [aws_default_security_group.test.id]
+  subnet_id             = aws_subnet.test.id
 
-	depends_on = [aws_default_route_table.test]
+  depends_on = [aws_default_route_table.test]
 }
 
 resource "aws_imagebuilder_image" "test_version1" {
-	container_recipe_arn             = aws_imagebuilder_container_recipe.test_version1.arn
-	infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.test.arn
+  container_recipe_arn             = aws_imagebuilder_container_recipe.test_version1.arn
+  infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.test.arn
 }
 
 resource "aws_imagebuilder_image" "test_version2" {
-	container_recipe_arn             = aws_imagebuilder_container_recipe.test_version2.arn
-	infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.test.arn
+  container_recipe_arn             = aws_imagebuilder_container_recipe.test_version2.arn
+  infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.test.arn
 }
 
 resource "aws_emrserverless_application" "test" {
@@ -683,7 +683,7 @@ resource "aws_emrserverless_application" "test" {
   type          = "hive"
 
   image_configuration {
-		image_uri    = "${aws_ecr_repository.test.repository_url}:${replace(aws_imagebuilder_image.%[2]s.version, "/", "-")}"
+    image_uri = "${aws_ecr_repository.test.repository_url}:${replace(aws_imagebuilder_image.%[2]s.version, "/", "-")}"
   }
 }
 `, rName, selectedVersionResourceName, firstImageVersion, secondImageVersion), nil

--- a/internal/service/imagebuilder/container_recipe.go
+++ b/internal/service/imagebuilder/container_recipe.go
@@ -234,6 +234,12 @@ func ResourceContainerRecipe() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"platform_override": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"Linux", "Windows"}, false),
+			},
 			"tags":     tftags.TagsSchema(),
 			"tags_all": tftags.TagsSchemaComputed(),
 			"target_repository": {
@@ -316,6 +322,10 @@ func resourceContainerRecipeCreate(ctx context.Context, d *schema.ResourceData, 
 
 	if v, ok := d.GetOk("parent_image"); ok {
 		input.ParentImage = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("platform_override"); ok {
+		input.PlatformOverride = aws.String(v.(string))
 	}
 
 	if len(tags) > 0 {

--- a/internal/service/imagebuilder/container_recipe_test.go
+++ b/internal/service/imagebuilder/container_recipe_test.go
@@ -661,6 +661,35 @@ func TestAccImageBuilderContainerRecipe_workingDirectory(t *testing.T) {
 	})
 }
 
+func TestAccImageBuilderContainerRecipe_platformOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_imagebuilder_container_recipe.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, imagebuilder.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckContainerRecipeDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				// A public ecr image can only be used if platform override is set, so this test will only pass if it is set correctly
+				Config: testAccContainerRecipeConfig_platformOverride(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerRecipeExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "platform", "Linux"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"platform_override"},
+			},
+		},
+	})
+}
+
 func testAccCheckContainerRecipeDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ImageBuilderConn()
@@ -1514,6 +1543,35 @@ EOF
   }
 
   working_directory = "/tmp"
+}
+`, rName))
+}
+
+func testAccContainerRecipeConfig_platformOverride(rName string) string {
+	return acctest.ConfigCompose(
+		testAccContainerRecipeBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_imagebuilder_container_recipe" "test" {
+  name           		= %[1]q
+  container_type 		= "DOCKER"
+  parent_image   		= "public.ecr.aws/amazonlinux/amazonlinux:latest"
+  version        		= "1.0.0"
+	platform_override = "Linux"
+
+  component {
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+  }
+
+  dockerfile_template_data = <<EOF
+FROM {{{ imagebuilder:parentImage }}}
+{{{ imagebuilder:environments }}}
+{{{ imagebuilder:components }}}
+EOF
+
+  target_repository {
+    repository_name = aws_ecr_repository.test.name
+    service         = "ECR"
+  }
 }
 `, rName))
 }

--- a/internal/service/imagebuilder/container_recipe_test.go
+++ b/internal/service/imagebuilder/container_recipe_test.go
@@ -1552,11 +1552,11 @@ func testAccContainerRecipeConfig_platformOverride(rName string) string {
 		testAccContainerRecipeBaseConfig(rName),
 		fmt.Sprintf(`
 resource "aws_imagebuilder_container_recipe" "test" {
-  name           		= %[1]q
-  container_type 		= "DOCKER"
-  parent_image   		= "public.ecr.aws/amazonlinux/amazonlinux:latest"
-  version        		= "1.0.0"
-	platform_override = "Linux"
+  name              = %[1]q
+  container_type    = "DOCKER"
+  parent_image      = "public.ecr.aws/amazonlinux/amazonlinux:latest"
+  version           = "1.0.0"
+  platform_override = "Linux"
 
   component {
     component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"

--- a/website/docs/r/emrserverless_application.markdown
+++ b/website/docs/r/emrserverless_application.markdown
@@ -66,6 +66,7 @@ The following arguments are required:
 * `architecture` – (Optional) The CPU architecture of an application. Valid values are `ARM64` or `X86_64`. Default value is `X86_64`.
 * `auto_start_configuration` – (Optional) The configuration for an application to automatically start on job submission.
 * `auto_stop_configuration` – (Optional) The configuration for an application to automatically stop after a certain amount of time being idle.
+* `image_configuration` – (Optional) The image configuration applied to all worker types.
 * `initial_capacity` – (Optional) The capacity to initialize when the application is created.
 * `maximum_capacity` – (Optional) The maximum capacity to allocate when the application is created. This is cumulative across all workers at any given point in time, not just when an application is created. No new resources will be created once any one of the defined limits is hit.
 * `name` – (Required) The name of the application.
@@ -98,6 +99,10 @@ The following arguments are required:
 
 * `security_group_ids` - (Optional) The array of security group Ids for customer VPC connectivity.
 * `subnet_ids` - (Optional) The array of subnet Ids for customer VPC connectivity.
+
+#### image_configuration Arguments
+
+* `image_uri` - (Required) The image URI.
 
 #### initial_capacity_config Arguments
 

--- a/website/docs/r/imagebuilder_container_recipe.html.markdown
+++ b/website/docs/r/imagebuilder_container_recipe.html.markdown
@@ -65,6 +65,7 @@ The following attributes are optional:
 * `dockerfile_template_uri` - (Optional) The Amazon S3 URI for the Dockerfile that will be used to build the container image.
 * `instance_configuration` - (Optional) Configuration block used to configure an instance for building and testing container images. Detailed below.
 * `kms_key_id` - (Optional) The KMS key used to encrypt the container image.
+* `platform_override` - (Optional) Specifies the operating system platform when you use a custom base image.
 * `tags` - (Optional) Key-value map of resource tags for the container recipe. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `working_directory` - (Optional) The working directory to be used during build and test workflows.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds the ability to define a custom image for an EMR Serverless application. Also added `platform_override` option support for AWS ImageBuilder.

When I tried to use a public ecr image (for example `public.ecr.aws/emr-serverless/hive/emr-6.9.0`) for the imageUri option, I received a 500 error (also occurred when using the aws-cli as well). To get around this, I had to build a custom image off that base and put it in a temporary ECR repo. Unfortunately, this make the new acceptance test a lot more complicated and long running.

Also, sorry if my Go isn't particularly idiomatic - I'm a relative newbie with it! Happy to take on any feedback :).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #24711
Closes #30230

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make testacc TESTS=TestAccEMRServerlessApplication_basic PKG=emrserverless
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/emrserverless/... -v -count 1 -parallel 20 -run='TestAccEMRServerlessApplication_basic'  -timeout 180m
=== RUN   TestAccEMRServerlessApplication_basic
=== PAUSE TestAccEMRServerlessApplication_basic
=== CONT  TestAccEMRServerlessApplication_basic
--- PASS: TestAccEMRServerlessApplication_basic (81.53s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/emrserverless      100.781s

$ make testacc TESTS=TestAccEMRServerlessApplication_imageCon PKG=emrserverless
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/emrserverless/... -v -count 1 -parallel 20 -run='TestAccEMRServerlessApplication_imageCon'  -timeout 180m
=== RUN   TestAccEMRServerlessApplication_imageConfiguration
=== PAUSE TestAccEMRServerlessApplication_imageConfiguration
=== CONT  TestAccEMRServerlessApplication_imageConfiguration
--- PASS: TestAccEMRServerlessApplication_imageConfiguration (585.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/emrserverless      605.158s
...
```
