### PR TITLE
r/aws_dynamodb_table_export - support DynamoDB ExportTableToPointInTime API.

### DIFF
--- a/.changelog/30399.txt
+++ b/.changelog/30399.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_dynamodb_table_export
+```

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -14,7 +14,7 @@ on:
 env:
   SEMGREP_SEND_METRICS: "off"
   SEMGREP_ENABLE_VERSION_CHECK: false
-  SEMGREP_TIMEOUT: 60
+  SEMGREP_TIMEOUT: 300
   COMMON_PARAMS: --error --quiet
 
 jobs:

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -14,6 +14,7 @@ on:
 env:
   SEMGREP_SEND_METRICS: "off"
   SEMGREP_ENABLE_VERSION_CHECK: false
+  SEMGREP_TIMEOUT: 60
   COMMON_PARAMS: --error --quiet
 
 jobs:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -115,7 +115,7 @@ cleantidy: prereq-go ## Clean up tidy
 	@echo "make: Go mods tidied"
 
 clean: cleango cleantidy build tools ## Clean up Go cache, tidy and re-install tools
-	@echo "make: clean complete"	
+	@echo "make: clean complete"
 
 copyright: ## Run copywrite (generate source code headers)
 	@copywrite headers
@@ -334,6 +334,27 @@ semall: semgrep-validate ## Run semgrep on all files
 		--config 'r/dgryski.semgrep-go.oddifsequence' \
 		--config 'r/dgryski.semgrep-go.oserrors'
 
+semfix: semgrep-validate ## Run semgrep on all files
+	@echo "make: running Semgrep checks locally (must have semgrep installed)..."
+	@echo "make: applying fixes with --autofix"
+	@echo "make: WARNING: This will not fix rules that don't have autofixes"
+	@semgrep --error --metrics=off --autofix \
+		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
+		--config .ci/.semgrep.yml \
+		--config .ci/.semgrep-caps-aws-ec2.yml \
+		--config .ci/.semgrep-configs.yml \
+		--config .ci/.semgrep-service-name0.yml \
+		--config .ci/.semgrep-service-name1.yml \
+		--config .ci/.semgrep-service-name2.yml \
+		--config .ci/.semgrep-service-name3.yml \
+		--config .ci/semgrep/ \
+		--config 'r/dgryski.semgrep-go.badnilguard' \
+		--config 'r/dgryski.semgrep-go.errnilcheck' \
+		--config 'r/dgryski.semgrep-go.marshaljson' \
+		--config 'r/dgryski.semgrep-go.nilerr' \
+		--config 'r/dgryski.semgrep-go.oddifsequence' \
+		--config 'r/dgryski.semgrep-go.oserrors'
+
 semgrep-validate: ## Validate semgrep configuration files
 	@semgrep --error --validate \
 		--config .ci/.semgrep.yml \
@@ -485,6 +506,7 @@ yamllint: ## Lint YAML files (via yamllint)
 	sane \
 	sanity \
 	semall \
+	semfix \
 	semgrep \
 	semgrep-validate \
 	skaff \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -317,7 +317,7 @@ sanity: prereq-go ## Run sanity checks with failures allowed
 
 semall: semgrep-validate ## Run semgrep on all files
 	@echo "make: running Semgrep checks locally (must have semgrep installed)..."
-	@semgrep --error --metrics=off \
+	@SEMGREP_TIMEOUT=60 semgrep --error --metrics=off \
 		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
 		--config .ci/.semgrep.yml \
 		--config .ci/.semgrep-caps-aws-ec2.yml \
@@ -338,7 +338,7 @@ semfix: semgrep-validate ## Run semgrep on all files
 	@echo "make: running Semgrep checks locally (must have semgrep installed)..."
 	@echo "make: applying fixes with --autofix"
 	@echo "make: WARNING: This will not fix rules that don't have autofixes"
-	@semgrep --error --metrics=off --autofix \
+	@SEMGREP_TIMEOUT=60 semgrep --error --metrics=off --autofix \
 		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
 		--config .ci/.semgrep.yml \
 		--config .ci/.semgrep-caps-aws-ec2.yml \
@@ -356,7 +356,7 @@ semfix: semgrep-validate ## Run semgrep on all files
 		--config 'r/dgryski.semgrep-go.oserrors'
 
 semgrep-validate: ## Validate semgrep configuration files
-	@semgrep --error --validate \
+	@SEMGREP_TIMEOUT=60 semgrep --error --validate \
 		--config .ci/.semgrep.yml \
 		--config .ci/.semgrep-caps-aws-ec2.yml \
 		--config .ci/.semgrep-configs.yml \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -317,7 +317,7 @@ sanity: prereq-go ## Run sanity checks with failures allowed
 
 semall: semgrep-validate ## Run semgrep on all files
 	@echo "make: running Semgrep checks locally (must have semgrep installed)..."
-	@SEMGREP_TIMEOUT=60 semgrep --error --metrics=off \
+	@SEMGREP_TIMEOUT=300 semgrep --error --metrics=off \
 		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
 		--config .ci/.semgrep.yml \
 		--config .ci/.semgrep-caps-aws-ec2.yml \
@@ -338,7 +338,7 @@ semfix: semgrep-validate ## Run semgrep on all files
 	@echo "make: running Semgrep checks locally (must have semgrep installed)..."
 	@echo "make: applying fixes with --autofix"
 	@echo "make: WARNING: This will not fix rules that don't have autofixes"
-	@SEMGREP_TIMEOUT=60 semgrep --error --metrics=off --autofix \
+	@SEMGREP_TIMEOUT=300 semgrep --error --metrics=off --autofix \
 		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
 		--config .ci/.semgrep.yml \
 		--config .ci/.semgrep-caps-aws-ec2.yml \
@@ -356,7 +356,7 @@ semfix: semgrep-validate ## Run semgrep on all files
 		--config 'r/dgryski.semgrep-go.oserrors'
 
 semgrep-validate: ## Validate semgrep configuration files
-	@SEMGREP_TIMEOUT=60 semgrep --error --validate \
+	@SEMGREP_TIMEOUT=300 semgrep --error --validate \
 		--config .ci/.semgrep.yml \
 		--config .ci/.semgrep-caps-aws-ec2.yml \
 		--config .ci/.semgrep-configs.yml \

--- a/internal/service/dynamodb/find.go
+++ b/internal/service/dynamodb/find.go
@@ -133,3 +133,24 @@ func FindContributorInsights(ctx context.Context, conn *dynamodb.DynamoDB, table
 
 	return output, nil
 }
+
+func FindTableExportByID(ctx context.Context, conn *dynamodb.DynamoDB, id string) (*dynamodb.DescribeExportOutput, error) {
+	input := &dynamodb.DescribeExportInput{
+		ExportArn: aws.String(id),
+	}
+
+	out, err := conn.DescribeExportWithContext(ctx, input)
+
+	if tfawserr.ErrCodeEquals(err, dynamodb.ErrCodeResourceNotFoundException) {
+		return nil, &resource.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if out == nil || out.ExportDescription == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return out, nil
+}

--- a/internal/service/dynamodb/find.go
+++ b/internal/service/dynamodb/find.go
@@ -142,7 +142,7 @@ func FindTableExportByID(ctx context.Context, conn *dynamodb.DynamoDB, id string
 	out, err := conn.DescribeExportWithContext(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, dynamodb.ErrCodeResourceNotFoundException) {
-		return nil, &resource.NotFoundError{
+		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
 		}

--- a/internal/service/dynamodb/service_package_gen.go
+++ b/internal/service/dynamodb/service_package_gen.go
@@ -62,6 +62,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
+			Factory:  ResourceTableExport,
+			TypeName: "aws_dynamodb_table_export",
+		},
+		{
 			Factory:  ResourceTableItem,
 			TypeName: "aws_dynamodb_table_item",
 		},

--- a/internal/service/dynamodb/status.go
+++ b/internal/service/dynamodb/status.go
@@ -206,3 +206,22 @@ func statusContributorInsights(ctx context.Context, conn *dynamodb.DynamoDB, tab
 		return insight, aws.StringValue(insight.ContributorInsightsStatus), nil
 	}
 }
+
+func statusTableExport(ctx context.Context, conn *dynamodb.DynamoDB, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		out, err := FindTableExportByID(ctx, conn, id)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		if out.ExportDescription == nil {
+			return nil, "", nil
+		}
+
+		return out, aws.StringValue(out.ExportDescription.ExportStatus), nil
+	}
+}

--- a/internal/service/dynamodb/status.go
+++ b/internal/service/dynamodb/status.go
@@ -207,7 +207,7 @@ func statusContributorInsights(ctx context.Context, conn *dynamodb.DynamoDB, tab
 	}
 }
 
-func statusTableExport(ctx context.Context, conn *dynamodb.DynamoDB, id string) resource.StateRefreshFunc {
+func statusTableExport(ctx context.Context, conn *dynamodb.DynamoDB, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		out, err := FindTableExportByID(ctx, conn, id)
 		if tfresource.NotFound(err) {

--- a/internal/service/dynamodb/table_export.go
+++ b/internal/service/dynamodb/table_export.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package dynamodb
 
 import (

--- a/internal/service/dynamodb/table_export.go
+++ b/internal/service/dynamodb/table_export.go
@@ -34,7 +34,6 @@ func ResourceTableExport() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(60 * time.Minute),
-			Update: schema.DefaultTimeout(120 * time.Minute),
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 

--- a/internal/service/dynamodb/table_export.go
+++ b/internal/service/dynamodb/table_export.go
@@ -30,7 +30,9 @@ func ResourceTableExport() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(120 * time.Minute),
+			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -122,7 +124,7 @@ const (
 )
 
 func resourceTableExportCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).DynamoDBConn()
+	conn := meta.(*conns.AWSClient).DynamoDBConn(ctx)
 
 	s3Bucket := d.Get("s3_bucket").(string)
 	tableArn := d.Get("table_arn").(string)
@@ -177,7 +179,7 @@ func resourceTableExportCreate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceTableExportRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).DynamoDBConn()
+	conn := meta.(*conns.AWSClient).DynamoDBConn(ctx)
 
 	out, err := FindTableExportByID(ctx, conn, d.Id())
 

--- a/internal/service/dynamodb/table_export.go
+++ b/internal/service/dynamodb/table_export.go
@@ -1,0 +1,218 @@
+package dynamodb
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKResource("aws_dynamodb_table_export")
+func ResourceTableExport() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceTableExportCreate,
+		ReadWithoutTimeout:   resourceTableExportRead,
+		DeleteWithoutTimeout: schema.NoopContext,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"billed_size_in_bytes": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"export_format": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(dynamodb.ExportFormat_Values(), false),
+				ForceNew:     true,
+				Default:      dynamodb.ExportFormatDynamodbJson,
+			},
+			"export_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"export_time": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: verify.ValidUTCTimestamp,
+				ForceNew:     true,
+			},
+			"item_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"manifest_files_s3_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"s3_bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"s3_bucket_owner": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: verify.ValidAccountID,
+				ForceNew:     true,
+			},
+			"s3_prefix": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringLenBetween(0, 1024),
+				ForceNew:     true,
+			},
+			"s3_sse_algorithm": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(dynamodb.S3SseAlgorithm_Values(), false),
+				ForceNew:     true,
+			},
+			"s3_sse_kms_key_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 2048),
+				ForceNew:     true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"table_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+const (
+	ResNameTableExport = "Table Export"
+)
+
+func resourceTableExportCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).DynamoDBConn()
+
+	s3Bucket := d.Get("s3_bucket").(string)
+	tableArn := d.Get("table_arn").(string)
+
+	in := &dynamodb.ExportTableToPointInTimeInput{
+		S3Bucket: aws.String(s3Bucket),
+		TableArn: aws.String(tableArn),
+	}
+
+	if v, ok := d.GetOk("export_format"); ok {
+		in.ExportFormat = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("export_time"); ok {
+		v, _ := time.Parse(time.RFC3339, v.(string))
+		in.ExportTime = aws.Time(v)
+	}
+
+	if v, ok := d.GetOk("s3_bucket_owner"); ok {
+		in.S3BucketOwner = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("s3_sse_algorithm"); ok {
+		in.S3SseAlgorithm = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("s3_prefix"); ok {
+		in.S3Prefix = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("s3_sse_kms_key_id"); ok {
+		in.S3SseKmsKeyId = aws.String(v.(string))
+	}
+
+	log.Printf("Creating export table: %s", in)
+
+	out, err := conn.ExportTableToPointInTime(in)
+	if err != nil {
+		return create.DiagError(names.DynamoDB, create.ErrActionCreating, ResNameTableExport, d.Get("table_arn").(string), err)
+	}
+
+	if out == nil || out.ExportDescription == nil {
+		return create.DiagError(names.DynamoDB, create.ErrActionCreating, ResNameTableExport, d.Get("table_arn").(string), errors.New("empty output"))
+	}
+
+	d.SetId(aws.StringValue(out.ExportDescription.ExportArn))
+
+	if _, err := waitTableExportCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return create.DiagError(names.DynamoDB, create.ErrActionWaitingForCreation, ResNameTableExport, d.Id(), err)
+	}
+
+	return resourceTableExportRead(ctx, d, meta)
+}
+
+func resourceTableExportRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).DynamoDBConn()
+
+	out, err := FindTableExportByID(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] DynamoDB TableExport (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.DynamoDB, create.ErrActionReading, ResNameTableExport, d.Id(), err)
+	}
+	desc := out.ExportDescription
+
+	d.Set("arn", desc.ExportArn)
+	d.Set("billed_size_in_bytes", desc.BilledSizeBytes)
+	d.Set("item_count", desc.ItemCount)
+	d.Set("manifest_files_s3_key", desc.ExportManifest)
+	d.Set("table_arn", desc.TableArn)
+	d.Set("s3_bucket", desc.S3Bucket)
+	d.Set("s3_bucket_owner", desc.S3BucketOwner)
+	d.Set("export_format", desc.ExportFormat)
+	d.Set("s3_prefix", desc.S3Prefix)
+	d.Set("s3_sse_algorithm", desc.S3SseAlgorithm)
+	d.Set("s3_sse_kms_key_id", desc.S3SseKmsKeyId)
+	d.Set("export_status", desc.ExportStatus)
+	if desc.EndTime != nil {
+		d.Set("end_time", aws.TimeValue(desc.EndTime).Format(time.RFC3339))
+	}
+	if desc.StartTime != nil {
+		d.Set("start_time", aws.TimeValue(desc.StartTime).Format(time.RFC3339))
+	}
+	if desc.ExportTime != nil {
+		d.Set("export_time", aws.TimeValue(desc.ExportTime).Format(time.RFC3339))
+	}
+
+	return nil
+}

--- a/internal/service/dynamodb/table_export.go
+++ b/internal/service/dynamodb/table_export.go
@@ -158,7 +158,7 @@ func resourceTableExportCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	log.Printf("Creating export table: %s", in)
 
-	out, err := conn.ExportTableToPointInTime(in)
+	out, err := conn.ExportTableToPointInTimeWithContext(ctx, in)
 	if err != nil {
 		return create.DiagError(names.DynamoDB, create.ErrActionCreating, ResNameTableExport, d.Get("table_arn").(string), err)
 	}

--- a/internal/service/dynamodb/table_export_test.go
+++ b/internal/service/dynamodb/table_export_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package dynamodb_test
 
 import (

--- a/internal/service/dynamodb/table_export_test.go
+++ b/internal/service/dynamodb/table_export_test.go
@@ -1,0 +1,279 @@
+package dynamodb_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfdynamodb "github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccDynamoDBTableExport_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var tableexport dynamodb.DescribeExportOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_dynamodb_table_export.test"
+	s3BucketResourceName := "aws_s3_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.DynamoDB)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableExportConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTableExportExists(ctx, resourceName, &tableexport),
+					resource.TestCheckResourceAttr(resourceName, "export_format", "DYNAMODB_JSON"),
+					resource.TestCheckResourceAttr(resourceName, "export_status", "COMPLETED"),
+					resource.TestCheckResourceAttr(resourceName, "item_count", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, "s3_bucket", s3BucketResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "s3_bucket_owner", ""),
+					resource.TestCheckResourceAttr(resourceName, "s3_prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "s3_sse_algorithm", "AES256"),
+					resource.TestCheckResourceAttr(resourceName, "s3_sse_kms_key_id", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "manifest_files_s3_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "export_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "start_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "end_time"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "dynamodb", regexp.MustCompile(
+						fmt.Sprintf("table\\/%s\\/export\\/+.", rName),
+					)),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "table_arn", "dynamodb", fmt.Sprintf("table/%s", rName)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTableExport_kms(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var tableexport dynamodb.DescribeExportOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_dynamodb_table_export.test"
+	s3BucketResourceName := "aws_s3_bucket.test"
+	kmsKeyResourceName := "aws_kms_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.DynamoDB)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableExportConfig_kms(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTableExportExists(ctx, resourceName, &tableexport),
+					resource.TestCheckResourceAttr(resourceName, "export_format", "DYNAMODB_JSON"),
+					resource.TestCheckResourceAttr(resourceName, "export_status", "COMPLETED"),
+					resource.TestCheckResourceAttr(resourceName, "item_count", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, "s3_bucket", s3BucketResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "s3_bucket_owner", ""),
+					resource.TestCheckResourceAttr(resourceName, "s3_prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "s3_sse_algorithm", "KMS"),
+					resource.TestCheckResourceAttrPair(resourceName, "s3_sse_kms_key_id", kmsKeyResourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "manifest_files_s3_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "export_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "start_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "end_time"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "dynamodb", regexp.MustCompile(
+						fmt.Sprintf("table\\/%s\\/export\\/+.", rName),
+					)),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "table_arn", "dynamodb", fmt.Sprintf("table/%s", rName)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccDynamoDBTableExport_s3Prefix(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var tableexport dynamodb.DescribeExportOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_dynamodb_table_export.test"
+	s3BucketResourceName := "aws_s3_bucket.test"
+	s3BucketPrefix := "test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.DynamoDB)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableExportConfig_s3Prefix(rName, s3BucketPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTableExportExists(ctx, resourceName, &tableexport),
+					resource.TestCheckResourceAttr(resourceName, "export_format", "DYNAMODB_JSON"),
+					resource.TestCheckResourceAttr(resourceName, "export_status", "COMPLETED"),
+					resource.TestCheckResourceAttr(resourceName, "item_count", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, "s3_bucket", s3BucketResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "s3_bucket_owner", ""),
+					resource.TestCheckResourceAttr(resourceName, "s3_prefix", "test"),
+					resource.TestCheckResourceAttr(resourceName, "s3_sse_algorithm", "AES256"),
+					resource.TestCheckResourceAttr(resourceName, "s3_sse_kms_key_id", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "manifest_files_s3_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "export_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "start_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "end_time"),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "dynamodb", regexp.MustCompile(
+						fmt.Sprintf("table\\/%s\\/export\\/+.", rName),
+					)),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "table_arn", "dynamodb", fmt.Sprintf("table/%s", rName)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckTableExportExists(ctx context.Context, name string, tableexport *dynamodb.DescribeExportOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.DynamoDB, create.ErrActionCheckingExistence, tfdynamodb.ResNameTableExport, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.DynamoDB, create.ErrActionCheckingExistence, tfdynamodb.ResNameTableExport, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DynamoDBConn()
+		resp, err := tfdynamodb.FindTableExportByID(ctx, conn, rs.Primary.ID)
+
+		if err != nil {
+			return create.Error(names.DynamoDB, create.ErrActionCheckingExistence, tfdynamodb.ResNameTableExport, rs.Primary.ID, err)
+		}
+
+		*tableexport = *resp
+
+		return nil
+	}
+}
+
+func testAccPreCheck(ctx context.Context, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).DynamoDBConn()
+
+	input := &dynamodb.ListExportsInput{}
+	_, err := conn.ListExportsWithContext(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccTableExportConfig_baseConfig(tableName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  bucket = aws_s3_bucket.test.id
+  acl    = "private"
+}
+
+resource "aws_dynamodb_table" "test" {
+  name           = %[1]q
+  read_capacity  = 2
+  write_capacity = 2
+  hash_key       = "TestTableHashKey"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+}
+`, tableName)
+}
+
+func testAccTableExportConfig_basic(tableName string) string {
+	return acctest.ConfigCompose(testAccTableExportConfig_baseConfig(tableName), ` 
+resource "aws_dynamodb_table_export" "test" {
+  s3_bucket = aws_s3_bucket.test.id
+  table_arn = aws_dynamodb_table.test.arn
+}
+`)
+}
+
+func testAccTableExportConfig_kms(tableName string) string {
+	return acctest.ConfigCompose(testAccTableExportConfig_baseConfig(tableName), `
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+}
+
+resource "aws_dynamodb_table_export" "test" {
+  s3_bucket         = aws_s3_bucket.test.id
+  s3_sse_kms_key_id = aws_kms_key.test.id
+  s3_sse_algorithm  = "KMS"
+  table_arn         = aws_dynamodb_table.test.arn
+}`)
+}
+
+func testAccTableExportConfig_s3Prefix(tableName, s3BucketPrefix string) string {
+	return acctest.ConfigCompose(testAccTableExportConfig_baseConfig(tableName), fmt.Sprintf(`
+resource "aws_dynamodb_table_export" "test" {
+  s3_bucket        = aws_s3_bucket.test.id
+  s3_prefix        = %[1]q
+  s3_sse_algorithm = "AES256"
+  table_arn        = aws_dynamodb_table.test.arn
+}`, s3BucketPrefix))
+}

--- a/internal/service/dynamodb/table_export_test.go
+++ b/internal/service/dynamodb/table_export_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/YakDriver/regexache"
@@ -88,7 +87,7 @@ func TestAccDynamoDBTableExport_kms(t *testing.T) {
 			acctest.PreCheckPartitionHasService(t, names.DynamoDB)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
@@ -108,7 +107,7 @@ func TestAccDynamoDBTableExport_kms(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "export_time"),
 					resource.TestCheckResourceAttrSet(resourceName, "start_time"),
 					resource.TestCheckResourceAttrSet(resourceName, "end_time"),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "dynamodb", regexp.MustCompile(
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "dynamodb", regexache.MustCompile(
 						fmt.Sprintf("table\\/%s\\/export\\/+.", rName),
 					)),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "table_arn", "dynamodb", fmt.Sprintf("table/%s", rName)),
@@ -141,7 +140,7 @@ func TestAccDynamoDBTableExport_s3Prefix(t *testing.T) {
 			acctest.PreCheckPartitionHasService(t, names.DynamoDB)
 			testAccPreCheck(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, dynamodb.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
@@ -161,7 +160,7 @@ func TestAccDynamoDBTableExport_s3Prefix(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "export_time"),
 					resource.TestCheckResourceAttrSet(resourceName, "start_time"),
 					resource.TestCheckResourceAttrSet(resourceName, "end_time"),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "dynamodb", regexp.MustCompile(
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "dynamodb", regexache.MustCompile(
 						fmt.Sprintf("table\\/%s\\/export\\/+.", rName),
 					)),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "table_arn", "dynamodb", fmt.Sprintf("table/%s", rName)),

--- a/internal/service/dynamodb/wait.go
+++ b/internal/service/dynamodb/wait.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
 
@@ -279,7 +278,7 @@ func waitContributorInsightsDeleted(ctx context.Context, conn *dynamodb.DynamoDB
 }
 
 func waitTableExportCreated(ctx context.Context, conn *dynamodb.DynamoDB, id string, timeout time.Duration) (*dynamodb.ExportDescription, error) {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{dynamodb.ExportStatusInProgress},
 		Target:  []string{dynamodb.ExportStatusCompleted, dynamodb.ExportStatusFailed},
 		Refresh: statusTableExport(ctx, conn, id),

--- a/website/docs/r/codebuild_source_credential.html.markdown
+++ b/website/docs/r/codebuild_source_credential.html.markdown
@@ -10,8 +10,7 @@ description: |-
 
 Provides a CodeBuild Source Credentials Resource.
 
-~> **NOTE:**
-[Codebuild only allows a single credential per given server type in a given region](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_codebuild.GitHubSourceCredentials.html). Therefore, when you define `aws_codebuild_source_credential`, [`aws_codebuild_project` resource](/docs/providers/aws/r/codebuild_project.html) defined in the same module will use it.
+~> **NOTE:** [Codebuild only allows a single credential per given server type in a given region](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_codebuild.GitHubSourceCredentials.html). Therefore, when you define `aws_codebuild_source_credential`, [`aws_codebuild_project` resource](/docs/providers/aws/r/codebuild_project.html) defined in the same module will use it.
 
 ## Example Usage
 

--- a/website/docs/r/dynamodb_table_export.html.markdown
+++ b/website/docs/r/dynamodb_table_export.html.markdown
@@ -92,7 +92,6 @@ This resource exports the following attributes in addition to the arguments abov
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
 * `create` - (Default `60m`)
-* `update` - (Default `120m`)
 * `delete` - (Default `60m`)
 
 ## Import

--- a/website/docs/r/dynamodb_table_export.html.markdown
+++ b/website/docs/r/dynamodb_table_export.html.markdown
@@ -3,25 +3,20 @@ subcategory: "DynamoDB"
 layout: "aws"
 page_title: "AWS: aws_dynamodb_table_export"
 description: |-
-Terraform resource for managing an AWS DynamoDB Table Export.
+  Terraform resource for managing an AWS DynamoDB Table Export.
 ---
 
 # Resource: aws_dynamodb_table_export
 
-Terraform resource for managing an AWS DynamoDB Table Export. Terraform will wait until the Table export reaches a
-status of
-`COMPLETED` or `FAILED`.
+Terraform resource for managing an AWS DynamoDB Table Export. Terraform will wait until the Table export reaches a status of `COMPLETED` or `FAILED`.
 
-See
-the [AWS Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport.HowItWorks.html)
-for more information on how this process works.
+See the [AWS Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport.HowItWorks.html) for more information on how this process works.
 
 ~> **TIP:**
 Point-in-time Recovery must be enabled on the target DynamoDB Table.
 
 ~> **NOTE:**
-Once a AWS DynamoDB Table Export has been created it is immutable. The AWS API does not delete this resource.
-When you run destroy the provider will remove the resource from the Terraform state, no exported data will be deleted.
+Once a AWS DynamoDB Table Export has been created it is immutable. The AWS API does not delete this resource. When you run destroy the provider will remove the resource from the Terraform state, no exported data will be deleted.
 
 ## Example Usage
 
@@ -32,12 +27,6 @@ When you run destroy the provider will remove the resource from the Terraform st
 resource "aws_s3_bucket" "example" {
   bucket_prefix = "example"
   force_destroy = true
-}
-
-
-resource "aws_s3_bucket_acl" "example" {
-  bucket = aws_s3_bucket.example.id
-  acl    = "private"
 }
 
 resource "aws_dynamodb_table" "example" {
@@ -74,43 +63,28 @@ resource "aws_dynamodb_table_export" "example" {
 
 The following arguments are required:
 
-* `table_arn` - (Required, Forces new resource) Amazon Resource Name (ARN) associated with the table to export.
-* `s3_bucket` - (Required, Forces new resource) name of the Amazon S3 bucket to export the snapshot to. See
-  the [AWS Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport_Requesting.html#S3DataExport_Requesting_Permissions)
-  for information on how configure this S3 bucket.
+* `s3_bucket` - (Required, Forces new resource) Name of the Amazon S3 bucket to export the snapshot to. See the [AWS Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport_Requesting.html#S3DataExport_Requesting_Permissions) for information on how configure this S3 bucket.
+* `table_arn` - (Required, Forces new resource) ARN associated with the table to export.
 
 The following arguments are optional:
 
-* `export_format` - (Optional, Forces new resource) - Format for the exported data. Valid values are `DYNAMODB_JSON` or `ION`. See
-  the [AWS Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport.Output.html#S3DataExport.Output_Data)
-  for more information on these export formats. Default is `DYNAMODB_JSON`.
-* `export_time` - (Optional, Forces new resource) - Time in RFC3339 format from which to export table data. The table
-  export will be a snapshot of the table's state at this point in time. Omitting this value will result in a snapshot
-  from the current time.
-* `s3_bucket_owner` - (Optional, Forces new resource) ID of the AWS account that owns the bucket the export will be
-  stored in.
-* `s3_prefix` - (Optional, Forces new resource) Amazon S3 bucket prefix to use as the file name and path of the exported
-  snapshot.
-* `s3_sse_algorithm` - (Optional, Forces new resource) Type of encryption used on the bucket where export data will be
-  stored. Valid values are: `AES256`, `KMS`.
-* `s3_sse_kms_key_id` - (Optional, Forces new resource) ID of the AWS KMS managed key used to encrypt the S3 bucket
-  where export data will be stored (if applicable).
+* `export_format` - (Optional, Forces new resource) Format for the exported data. Valid values are `DYNAMODB_JSON` or `ION`. See the [AWS Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport.Output.html#S3DataExport.Output_Data) for more information on these export formats. Default is `DYNAMODB_JSON`.
+* `export_time` - (Optional, Forces new resource) Time in RFC3339 format from which to export table data. The table export will be a snapshot of the table's state at this point in time. Omitting this value will result in a snapshot from the current time.
+* `s3_bucket_owner` - (Optional, Forces new resource) ID of the AWS account that owns the bucket the export will be stored in.
+* `s3_prefix` - (Optional, Forces new resource) Amazon S3 bucket prefix to use as the file name and path of the exported snapshot.
+* `s3_sse_algorithm` - (Optional, Forces new resource) Type of encryption used on the bucket where export data will be stored. Valid values are: `AES256`, `KMS`.
+* `s3_sse_kms_key_id` - (Optional, Forces new resource) ID of the AWS KMS managed key used to encrypt the S3 bucket where export data will be stored (if applicable).
 
 ## Attributes Reference
 
-In addition to all arguments above, the following attributes are exported:
+This resource exports the following attributes in addition to the arguments above:
 
-* `arn` - ARN of the Table Export. Do not begin the description with "An", "The", "Defines", "Indicates", or "
-  Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of
-  storage," without losing any information.
-* `billed_size_in_bytes` - Billable size of the table export
+* `arn` - ARN of the Table Export.
+* `billed_size_in_bytes` - Billable size of the table export.
 * `end_time` - Time at which the export task completed.
-* `export_status` - Status of the export - export can be in one of the following states `IN_PROGRESS`, `COMPLETED`,
-  or `FAILED`.
+* `export_status` - Status of the export - export can be in one of the following states `IN_PROGRESS`, `COMPLETED`, or `FAILED`.
 * `item_count` - Number of items exported.
-* `manifest_files_s3_key` - Name of the manifest file for the export task. See
-  the [AWS Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport.Output.html#S3DataExport.Output_Manifest)
-  for more information on this manifest file.
+* `manifest_files_s3_key` - Name of the manifest file for the export task. See the [AWS Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport.Output.html#S3DataExport.Output_Manifest) for more information on this manifest file.
 * `start_time` - Time at which the export task began.
 
 ## Timeouts
@@ -118,16 +92,22 @@ In addition to all arguments above, the following attributes are exported:
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
 * `create` - (Default `60m`)
-* `update` - (Default `180m`)
-* `delete` - (Default `90m`)
+* `update` - (Default `120m`)
+* `delete` - (Default `60m`)
 
 ## Import
 
-DynamoDB Table Export can be imported using the `arn`, e.g.,
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import DynamoDB table exports using the `arn`. For example:
 
+```terraform
+import {
+  to = aws_dynamodb_table_export.example
+  id = "arn:aws:dynamodb:us-west-2:12345678911:table/my-table-1/export/01580735656614-2c2f422e"
+}
 ```
 
-$ terraform import aws_dynamodb_table_export.example arn:aws:dynamodb:us-west-2:12345678911:
-table/my-table-1/export/01580735656614-2c2f422e
+Using `terraform import`, import DynamoDB table exports using the `arn`. For example:
 
+```console
+% terraform import aws_dynamodb_table_export.example arn:aws:dynamodb:us-west-2:12345678911:table/my-table-1/export/01580735656614-2c2f422e
 ```

--- a/website/docs/r/dynamodb_table_export.html.markdown
+++ b/website/docs/r/dynamodb_table_export.html.markdown
@@ -75,7 +75,7 @@ The following arguments are optional:
 * `s3_sse_algorithm` - (Optional, Forces new resource) Type of encryption used on the bucket where export data will be stored. Valid values are: `AES256`, `KMS`.
 * `s3_sse_kms_key_id` - (Optional, Forces new resource) ID of the AWS KMS managed key used to encrypt the S3 bucket where export data will be stored (if applicable).
 
-## Attributes Reference
+## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 

--- a/website/docs/r/dynamodb_table_export.html.markdown
+++ b/website/docs/r/dynamodb_table_export.html.markdown
@@ -1,0 +1,133 @@
+---
+subcategory: "DynamoDB"
+layout: "aws"
+page_title: "AWS: aws_dynamodb_table_export"
+description: |-
+Terraform resource for managing an AWS DynamoDB Table Export.
+---
+
+# Resource: aws_dynamodb_table_export
+
+Terraform resource for managing an AWS DynamoDB Table Export. Terraform will wait until the Table export reaches a
+status of
+`COMPLETED` or `FAILED`.
+
+See
+the [AWS Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport.HowItWorks.html)
+for more information on how this process works.
+
+~> **TIP:**
+Point-in-time Recovery must be enabled on the target DynamoDB Table.
+
+~> **NOTE:**
+Once a AWS DynamoDB Table Export has been created it is immutable. The AWS API does not delete this resource.
+When you run destroy the provider will remove the resource from the Terraform state, no exported data will be deleted.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+
+resource "aws_s3_bucket" "example" {
+  bucket_prefix = "example"
+  force_destroy = true
+}
+
+
+resource "aws_s3_bucket_acl" "example" {
+  bucket = aws_s3_bucket.example.id
+  acl    = "private"
+}
+
+resource "aws_dynamodb_table" "example" {
+  name         = "example-table-1"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "user_id"
+  attribute {
+    name = "user_id"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+}
+
+resource "aws_dynamodb_table_export" "example" {
+  table_arn = aws_dynamodb_table.example.arn
+  s3_bucket = aws_s3_bucket.example.id
+}
+```
+
+### Example with export time
+
+```terraform
+resource "aws_dynamodb_table_export" "example" {
+  export_time = "2023-04-02T11:30:13+01:00"
+  s3_bucket   = aws_s3_bucket.example.id
+  table_arn   = aws_dynamodb_table.example.arn
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `table_arn` - (Required, Forces new resource) Amazon Resource Name (ARN) associated with the table to export.
+* `s3_bucket` - (Required, Forces new resource) name of the Amazon S3 bucket to export the snapshot to. See
+  the [AWS Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport_Requesting.html#S3DataExport_Requesting_Permissions)
+  for information on how configure this S3 bucket.
+
+The following arguments are optional:
+
+* `export_format` - (Optional, Forces new resource) - Format for the exported data. Valid values are `DYNAMODB_JSON` or `ION`. See
+  the [AWS Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport.Output.html#S3DataExport.Output_Data)
+  for more information on these export formats. Default is `DYNAMODB_JSON`.
+* `export_time` - (Optional, Forces new resource) - Time in RFC3339 format from which to export table data. The table
+  export will be a snapshot of the table's state at this point in time. Omitting this value will result in a snapshot
+  from the current time.
+* `s3_bucket_owner` - (Optional, Forces new resource) ID of the AWS account that owns the bucket the export will be
+  stored in.
+* `s3_prefix` - (Optional, Forces new resource) Amazon S3 bucket prefix to use as the file name and path of the exported
+  snapshot.
+* `s3_sse_algorithm` - (Optional, Forces new resource) Type of encryption used on the bucket where export data will be
+  stored. Valid values are: `AES256`, `KMS`.
+* `s3_sse_kms_key_id` - (Optional, Forces new resource) ID of the AWS KMS managed key used to encrypt the S3 bucket
+  where export data will be stored (if applicable).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the Table Export. Do not begin the description with "An", "The", "Defines", "Indicates", or "
+  Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of
+  storage," without losing any information.
+* `billed_size_in_bytes` - Billable size of the table export
+* `end_time` - Time at which the export task completed.
+* `export_status` - Status of the export - export can be in one of the following states `IN_PROGRESS`, `COMPLETED`,
+  or `FAILED`.
+* `item_count` - Number of items exported.
+* `manifest_files_s3_key` - Name of the manifest file for the export task. See
+  the [AWS Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport.Output.html#S3DataExport.Output_Manifest)
+  for more information on this manifest file.
+* `start_time` - Time at which the export task began.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `60m`)
+* `update` - (Default `180m`)
+* `delete` - (Default `90m`)
+
+## Import
+
+DynamoDB Table Export can be imported using the `arn`, e.g.,
+
+```
+
+$ terraform import aws_dynamodb_table_export.example arn:aws:dynamodb:us-west-2:12345678911:
+table/my-table-1/export/01580735656614-2c2f422e
+
+```

--- a/website/docs/r/dynamodb_table_export.html.markdown
+++ b/website/docs/r/dynamodb_table_export.html.markdown
@@ -12,11 +12,9 @@ Terraform resource for managing an AWS DynamoDB Table Export. Terraform will wai
 
 See the [AWS Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport.HowItWorks.html) for more information on how this process works.
 
-~> **TIP:**
-Point-in-time Recovery must be enabled on the target DynamoDB Table.
+~> **TIP:** Point-in-time Recovery must be enabled on the target DynamoDB Table.
 
-~> **NOTE:**
-Once a AWS DynamoDB Table Export has been created it is immutable. The AWS API does not delete this resource. When you run destroy the provider will remove the resource from the Terraform state, no exported data will be deleted.
+~> **NOTE:** Once a AWS DynamoDB Table Export has been created it is immutable. The AWS API does not delete this resource. When you run destroy the provider will remove the resource from the Terraform state, no exported data will be deleted.
 
 ## Example Usage
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add `aws_dynamodb_table_export` resource.

This change introduces support for the DynamoDB [ExportTableToPointInTime](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExportTableToPointInTime.html) API. 

As issue #28917 describes, that this is not a conventional CRUD resources/API but will prove useful for ops tasks. Here are some observations and notes relating to this implementation:

* AWS provides no mechanism for deleting export table tasks. Even after deleting the table and S3 bucket used in an export, it's still visible in the AWS API - see the [AWS Docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport_Requesting.html#S3DataExport_Requesting_CLI_Details)
> You can find information about export tasks you've run in the past by using the list-exports command. This command returns a list of all exports you've created in the past 90 days. Note that although export task metadata expires after 90 days and jobs older than that are no longer returned by the list-exports command, the objects in your S3 bucket remain as long as their bucket policies allow. DynamoDB never deletes any of the objects it creates in your S3 bucket during an export.
even once we delete a DynamoDB table or the S3 bucket that we export to, the export will still be returned by this API.

* I was having difficulty writing a specific test for the `export_time` attribute as this needs to be greater than or equal to the time Point-in-time recovery was enabled. This value is returned from the https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PointInTimeRecoveryDescription.html API but it's not currently accessible from any Terraform datasource/resource. It might be useful to add this?

* The provider has been configured to wait for either a `COMPLETED` or a `FAILED` status when creating the resource. This means that we will wait for the task to finish - AWS suggests that this will usually be less than 30minutes. I have only tested on empty or small DynamoDB tables. It would be good to understand how long these tasks may take on a large table - the default create timeout may need to be reviewed accordingly.

* I have not tested 'cross account' export (using the `s3_bucket_owner` attribute). Any help testing this would be useful. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28917

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make testacc TESTS=TestAccDynamoDBTableExport PKG=dynamodb
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTableExport'  -timeout 180m
=== RUN   TestAccDynamoDBTableExport_basic
=== PAUSE TestAccDynamoDBTableExport_basic
=== RUN   TestAccDynamoDBTableExport_kms
=== PAUSE TestAccDynamoDBTableExport_kms
=== RUN   TestAccDynamoDBTableExport_s3Prefix
=== PAUSE TestAccDynamoDBTableExport_s3Prefix
=== CONT  TestAccDynamoDBTableExport_basic
=== CONT  TestAccDynamoDBTableExport_s3Prefix
=== CONT  TestAccDynamoDBTableExport_kms
--- PASS: TestAccDynamoDBTableExport_kms (946.40s)
--- PASS: TestAccDynamoDBTableExport_s3Prefix (951.34s)
--- PASS: TestAccDynamoDBTableExport_basic (954.40s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   954.470s

...
```
