### PR TITLE
New DataSources - `aws_oam_link` and `aws_oam_links`

### DIFF
--- a/.changelog/30401.txt
+++ b/.changelog/30401.txt
@@ -1,0 +1,7 @@
+```release-note:new-data-source
+aws_oam_link
+```
+
+```release-note:new-data-source
+aws_oam_links
+```

--- a/internal/service/oam/link_data_source.go
+++ b/internal/service/oam/link_data_source.go
@@ -1,0 +1,93 @@
+package oam
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_oam_link")
+func DataSourceLink() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceLinkRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"link_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"link_identifier": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"label": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"label_template": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_types": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"sink_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+const (
+	DSNameLink = "Link Data Source"
+)
+
+func dataSourceLinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient()
+
+	linkIdentifier := d.Get("link_identifier").(string)
+
+	out, err := findLinkByID(ctx, conn, linkIdentifier)
+	if err != nil {
+		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionReading, DSNameLink, linkIdentifier, err)
+	}
+
+	d.SetId(aws.ToString(out.Arn))
+
+	d.Set("arn", out.Arn)
+	d.Set("link_id", out.Id)
+	d.Set("label", out.Label)
+	d.Set("label_template", out.LabelTemplate)
+	d.Set("resource_types", flex.FlattenStringValueList(out.ResourceTypes))
+	d.Set("sink_arn", out.SinkArn)
+
+	tags, err := ListTags(ctx, conn, d.Id())
+	if err != nil {
+		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionReading, DSNameLink, d.Id(), err)
+	}
+
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
+		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionSetting, DSNameLink, d.Id(), err)
+	}
+
+	return nil
+}

--- a/internal/service/oam/link_data_source_test.go
+++ b/internal/service/oam/link_data_source_test.go
@@ -1,0 +1,113 @@
+package oam_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/oam"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccObservabilityAccessManagerLinkDataSource_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	ctx := acctest.Context(t)
+	var link oam.GetLinkOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_oam_link.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+			acctest.PreCheckPartitionHasService(t, names.ObservabilityAccessManagerEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ObservabilityAccessManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+		CheckDestroy:             testAccCheckLinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLinkDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLinkExists(dataSourceName, &link),
+					acctest.MatchResourceAttrRegionalARN(dataSourceName, "arn", "oam", regexp.MustCompile(`link/+.`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "label"),
+					resource.TestCheckResourceAttr(dataSourceName, "label_template", "$AccountName"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "link_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "resource_types.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "resource_types.0", "AWS::CloudWatch::Metric"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "sink_arn"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.key1", "value1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccLinkDataSourceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAlternateAccountProvider(),
+		fmt.Sprintf(`
+data "aws_caller_identity" "source" {}
+data "aws_partition" "source" {}
+
+data "aws_caller_identity" "monitoring" {
+  provider = "awsalternate"
+}
+data "aws_partition" "monitoring" {
+  provider = "awsalternate"
+}
+
+resource "aws_oam_sink" "test" {
+  provider = "awsalternate"
+
+  name = %[1]q
+}
+
+resource "aws_oam_sink_policy" "test" {
+  provider = "awsalternate"
+
+  sink_identifier = aws_oam_sink.test.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = ["oam:CreateLink", "oam:UpdateLink"]
+        Effect   = "Allow"
+        Resource = "*"
+        Principal = {
+          "AWS" = "arn:${data.aws_partition.source.partition}:iam::${data.aws_caller_identity.source.account_id}:root"
+        }
+        Condition = {
+          "ForAnyValue:StringEquals" = {
+            "oam:ResourceTypes" = ["AWS::CloudWatch::Metric", "AWS::Logs::LogGroup"]
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_oam_link" "test" {
+  label_template  = "$AccountName"
+  resource_types  = ["AWS::CloudWatch::Metric"]
+  sink_identifier = aws_oam_sink.test.id
+
+  tags = {
+    key1 = "value1"
+  }
+}
+
+data aws_oam_link "test" {
+  link_identifier = aws_oam_link.test.id
+}
+`, rName))
+}

--- a/internal/service/oam/links_data_source.go
+++ b/internal/service/oam/links_data_source.go
@@ -1,0 +1,57 @@
+package oam
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/oam"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_oam_links")
+func DataSourceLinks() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceLinksRead,
+
+		Schema: map[string]*schema.Schema{
+			"arns": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+const (
+	DSNameLinks = "Links Data Source"
+)
+
+func dataSourceLinksRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient()
+	listLinksInput := &oam.ListLinksInput{}
+
+	paginator := oam.NewListLinksPaginator(conn, listLinksInput)
+	var arns []string
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+
+		if err != nil {
+			return create.DiagError(names.ObservabilityAccessManager, create.ErrActionReading, DSNameLinks, "", err)
+		}
+
+		for _, listLinksItem := range page.Items {
+			arns = append(arns, aws.StringValue(listLinksItem.Arn))
+		}
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region)
+	d.Set("arns", arns)
+
+	return nil
+}

--- a/internal/service/oam/links_data_source_test.go
+++ b/internal/service/oam/links_data_source_test.go
@@ -1,0 +1,104 @@
+package oam_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccObservabilityAccessManagerLinksDataSource_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_oam_links.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+			acctest.PreCheckPartitionHasService(t, names.ObservabilityAccessManagerEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ObservabilityAccessManagerEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLinksDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "arns.#", "1"),
+					acctest.MatchResourceAttrRegionalARN(dataSourceName, "arns.0", "oam", regexp.MustCompile(`link/+.`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccLinksDataSourceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAlternateAccountProvider(),
+		fmt.Sprintf(`
+data "aws_caller_identity" "source" {}
+data "aws_partition" "source" {}
+
+data "aws_caller_identity" "monitoring" {
+  provider = "awsalternate"
+}
+data "aws_partition" "monitoring" {
+  provider = "awsalternate"
+}
+
+resource "aws_oam_sink" "test" {
+  provider = "awsalternate"
+
+  name = %[1]q
+}
+
+resource "aws_oam_sink_policy" "test" {
+  provider = "awsalternate"
+
+  sink_identifier = aws_oam_sink.test.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = ["oam:CreateLink", "oam:UpdateLink"]
+        Effect   = "Allow"
+        Resource = "*"
+        Principal = {
+          "AWS" = "arn:${data.aws_partition.source.partition}:iam::${data.aws_caller_identity.source.account_id}:root"
+        }
+        Condition = {
+          "ForAnyValue:StringEquals" = {
+            "oam:ResourceTypes" = ["AWS::CloudWatch::Metric", "AWS::Logs::LogGroup"]
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_oam_link" "test" {
+  depends_on = [aws_oam_sink_policy.test]
+
+  label_template  = "$AccountName"
+  resource_types  = ["AWS::CloudWatch::Metric"]
+  sink_identifier = aws_oam_sink.test.id
+
+  tags = {
+    key1 = "value1"
+  }
+}
+
+data aws_oam_links "test" {
+  depends_on = [aws_oam_link.test]
+}
+`, rName))
+}

--- a/internal/service/oam/service_package_gen.go
+++ b/internal/service/oam/service_package_gen.go
@@ -22,6 +22,14 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {
 	return []*types.ServicePackageSDKDataSource{
 		{
+			Factory:  DataSourceLink,
+			TypeName: "aws_oam_link",
+		},
+		{
+			Factory:  DataSourceLinks,
+			TypeName: "aws_oam_links",
+		},
+		{
 			Factory:  DataSourceSink,
 			TypeName: "aws_oam_sink",
 		},

--- a/website/docs/d/oam_link.html.markdown
+++ b/website/docs/d/oam_link.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "CloudWatch Observability Access Manager"
+layout: "aws"
+page_title: "AWS: aws_oam_link"
+description: |-
+  Terraform data source for managing an AWS CloudWatch Observability Access Manager Link.
+---
+
+# Data Source: aws_oam_link
+
+Terraform data source for managing an AWS CloudWatch Observability Access Manager Link.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_oam_link" "example" {
+  link_identifier = "arn:aws:oam:us-west-1:111111111111:link/abcd1234-a123-456a-a12b-a123b456c789"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `link_identifier` - (Required) ARN of the link.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the link.
+* `label` - Label that is assigned to this link.
+* `label_template` - Human-readable name used to identify this source account when you are viewing data from it in the monitoring account.
+* `link_id` - ID string that AWS generated as part of the link ARN.
+* `resource_types` - Types of data that the source account shares with the monitoring account.
+* `sink_arn` - ARN of the sink that is used for this link.

--- a/website/docs/d/oam_links.html.markdown
+++ b/website/docs/d/oam_links.html.markdown
@@ -1,0 +1,26 @@
+---
+subcategory: "CloudWatch Observability Access Manager"
+layout: "aws"
+page_title: "AWS: aws_oam_links"
+description: |-
+  Terraform data source for managing an AWS CloudWatch Observability Access Manager Links.
+---
+
+# Data Source: aws_oam_links
+
+Terraform data source for managing an AWS CloudWatch Observability Access Manager Links.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_oam_links" "example" {
+}
+```
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `arns` - Set of ARN of the Links.


### PR DESCRIPTION
### Description
Adding 2 data sources for [aws_oam_link resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/oam_link):

aws_oam_link
aws_oam_links


### Relations

Closes #28158

### References

* [GetLink API Reference](https://docs.aws.amazon.com/OAM/latest/APIReference/API_GetLink.html)
* [ListLinks API Reference](https://docs.aws.amazon.com/OAM/latest/APIReference/API_ListLinks.html)


### Output from Acceptance Testing

```
➜ make testacc PKG=oam TESTS=TestAccObservabilityAccessManagerLinkDataSource
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/oam/... -v -count 1 -parallel 20 -run='TestAccObservabilityAccessManagerLinkDataSource'  -timeout 180m
=== RUN   TestAccObservabilityAccessManagerLinkDataSource_basic
--- PASS: TestAccObservabilityAccessManagerLinkDataSource_basic (151.29s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/oam        176.019s


➜ make testacc PKG=oam TESTS=TestAccObservabilityAccessManagerLinksDataSource
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/oam/... -v -count 1 -parallel 20 -run='TestAccObservabilityAccessManagerLinksDataSource'  -timeout 180m
=== RUN   TestAccObservabilityAccessManagerLinksDataSource_basic
--- PASS: TestAccObservabilityAccessManagerLinksDataSource_basic (78.82s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/oam        103.288s

```
