### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin Framework resources `w*` and `x*` (Phase 3c)

### DIFF
--- a/internal/service/waf/rate_based_rule.go
+++ b/internal/service/waf/rate_based_rule.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_waf_rate_based_rule")
+// @SDKResource("aws_waf_rate_based_rule", name="Rate Based Rule")
+// @Tags(identifierAttribute="arn")
 func ResourceRateBasedRule() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRateBasedRuleCreate,
@@ -79,8 +81,8 @@ func ResourceRateBasedRule() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.IntAtLeast(100),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -90,8 +92,6 @@ func ResourceRateBasedRule() *schema.Resource {
 func resourceRateBasedRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &waf.CreateRateBasedRuleInput{
@@ -99,15 +99,12 @@ func resourceRateBasedRuleCreate(ctx context.Context, d *schema.ResourceData, me
 		Name:       aws.String(name),
 		RateKey:    aws.String(d.Get("rate_key").(string)),
 		RateLimit:  aws.Int64(int64(d.Get("rate_limit").(int))),
+		Tags:       GetTagsIn(ctx),
 	}
 
 	wr := NewRetryer(conn)
 	outputRaw, err := wr.RetryWithToken(ctx, func(token *string) (interface{}, error) {
 		input.ChangeToken = token
-
-		if len(tags) > 0 {
-			input.Tags = Tags(tags.IgnoreAWS())
-		}
 
 		return conn.CreateRateBasedRuleWithContext(ctx, input)
 	})
@@ -135,8 +132,6 @@ func resourceRateBasedRuleCreate(ctx context.Context, d *schema.ResourceData, me
 func resourceRateBasedRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	rule, err := FindRateBasedRuleByID(ctx, conn, d.Id())
 
@@ -177,23 +172,6 @@ func resourceRateBasedRuleRead(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendErrorf(diags, "setting predicates: %s", err)
 	}
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for WAF Rate Based Rule (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
@@ -210,14 +188,6 @@ func resourceRateBasedRuleUpdate(ctx context.Context, d *schema.ResourceData, me
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating WAF Rate Based Rule (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
 		}
 	}
 

--- a/internal/service/waf/rule.go
+++ b/internal/service/waf/rule.go
@@ -20,13 +20,15 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 const (
 	RuleDeleteTimeout = 5 * time.Minute
 )
 
-// @SDKResource("aws_waf_rule")
+// @SDKResource("aws_waf_rule", name="Rule")
+// @Tags(identifierAttribute="arn")
 func ResourceRule() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRuleCreate,
@@ -71,8 +73,8 @@ func ResourceRule() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -86,22 +88,17 @@ func ResourceRule() *schema.Resource {
 func resourceRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	wr := NewRetryer(conn)
 	out, err := wr.RetryWithToken(ctx, func(token *string) (interface{}, error) {
-		params := &waf.CreateRuleInput{
+		input := &waf.CreateRuleInput{
 			ChangeToken: token,
 			MetricName:  aws.String(d.Get("metric_name").(string)),
 			Name:        aws.String(d.Get("name").(string)),
+			Tags:        GetTagsIn(ctx),
 		}
 
-		if len(tags) > 0 {
-			params.Tags = Tags(tags.IgnoreAWS())
-		}
-
-		return conn.CreateRuleWithContext(ctx, params)
+		return conn.CreateRuleWithContext(ctx, input)
 	})
 
 	if err != nil {
@@ -126,8 +123,6 @@ func resourceRuleCreate(ctx context.Context, d *schema.ResourceData, meta interf
 func resourceRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	params := &waf.GetRuleInput{
 		RuleId: aws.String(d.Id()),
@@ -172,24 +167,6 @@ func resourceRuleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 		Resource:  fmt.Sprintf("rule/%s", d.Id()),
 	}.String()
 	d.Set("arn", arn)
-
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for WAF Rule (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	d.Set("predicates", predicates)
 	d.Set("name", resp.Rule.Name)
 	d.Set("metric_name", resp.Rule.MetricName)
@@ -208,14 +185,6 @@ func resourceRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		err := updateRuleResource(ctx, d.Id(), oldP, newP, conn)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating WAF Rule (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating WAF Rule (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/waf/service_package_gen.go
+++ b/internal/service/waf/service_package_gen.go
@@ -61,6 +61,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceRateBasedRule,
 			TypeName: "aws_waf_rate_based_rule",
+			Name:     "Rate Based Rule",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRegexMatchSet,
@@ -73,10 +77,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceRule,
 			TypeName: "aws_waf_rule",
+			Name:     "Rule",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRuleGroup,
 			TypeName: "aws_waf_rule_group",
+			Name:     "Rule Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceSizeConstraintSet,
@@ -89,6 +101,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceWebACL,
 			TypeName: "aws_waf_web_acl",
+			Name:     "Web ACL",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceXSSMatchSet,

--- a/internal/service/waf/web_acl.go
+++ b/internal/service/waf/web_acl.go
@@ -17,9 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_waf_web_acl")
+// @SDKResource("aws_waf_web_acl", name="Web ACL")
+// @Tags(identifierAttribute="arn")
 func ResourceWebACL() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceWebACLCreate,
@@ -145,8 +147,8 @@ func ResourceWebACL() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -156,23 +158,18 @@ func ResourceWebACL() *schema.Resource {
 func resourceWebACLCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	wr := NewRetryer(conn)
 	out, err := wr.RetryWithToken(ctx, func(token *string) (interface{}, error) {
-		params := &waf.CreateWebACLInput{
+		input := &waf.CreateWebACLInput{
 			ChangeToken:   token,
 			DefaultAction: ExpandAction(d.Get("default_action").([]interface{})),
 			MetricName:    aws.String(d.Get("metric_name").(string)),
 			Name:          aws.String(d.Get("name").(string)),
+			Tags:          GetTagsIn(ctx),
 		}
 
-		if len(tags) > 0 {
-			params.Tags = Tags(tags.IgnoreAWS())
-		}
-
-		return conn.CreateWebACLWithContext(ctx, params)
+		return conn.CreateWebACLWithContext(ctx, input)
 	})
 
 	if err != nil {
@@ -224,8 +221,6 @@ func resourceWebACLCreate(ctx context.Context, d *schema.ResourceData, meta inte
 func resourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	params := &waf.GetWebACLInput{
 		WebACLId: aws.String(d.Id()),
@@ -260,23 +255,6 @@ func resourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 	d.Set("name", resp.WebACL.Name)
 	d.Set("metric_name", resp.WebACL.MetricName)
-
-	tags, err := ListTags(ctx, conn, arn)
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for WAF Web ACL (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	if err := d.Set("rules", FlattenWebACLRules(resp.WebACL.Rules)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting rules: %s", err)
 	}
@@ -345,14 +323,6 @@ func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			if _, err := conn.DeleteLoggingConfigurationWithContext(ctx, input); err != nil {
 				return sdkdiag.AppendErrorf(diags, "deleting WAF Web ACL (%s) Logging Configuration: %s", d.Id(), err)
 			}
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating WAF Web ACL (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/wafregional/rate_based_rule.go
+++ b/internal/service/wafregional/rate_based_rule.go
@@ -18,9 +18,11 @@ import (
 	tfwaf "github.com/hashicorp/terraform-provider-aws/internal/service/waf"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_wafregional_rate_based_rule")
+// @SDKResource("aws_wafregional_rate_based_rule", name="Rate Based Rule")
+// @Tags(identifierAttribute="arn")
 func ResourceRateBasedRule() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRateBasedRuleCreate,
@@ -74,8 +76,8 @@ func ResourceRateBasedRule() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.IntAtLeast(100),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -89,25 +91,20 @@ func ResourceRateBasedRule() *schema.Resource {
 func resourceRateBasedRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 	region := meta.(*conns.AWSClient).Region
 
 	wr := NewRetryer(conn, region)
 	out, err := wr.RetryWithToken(ctx, func(token *string) (interface{}, error) {
-		params := &waf.CreateRateBasedRuleInput{
+		input := &waf.CreateRateBasedRuleInput{
 			ChangeToken: token,
 			MetricName:  aws.String(d.Get("metric_name").(string)),
 			Name:        aws.String(d.Get("name").(string)),
 			RateKey:     aws.String(d.Get("rate_key").(string)),
 			RateLimit:   aws.Int64(int64(d.Get("rate_limit").(int))),
+			Tags:        GetTagsIn(ctx),
 		}
 
-		if len(tags) > 0 {
-			params.Tags = Tags(tags.IgnoreAWS())
-		}
-
-		return conn.CreateRateBasedRuleWithContext(ctx, params)
+		return conn.CreateRateBasedRuleWithContext(ctx, input)
 	})
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating WAF Regional Rate Based Rule (%s): %s", d.Get("name").(string), err)
@@ -130,8 +127,6 @@ func resourceRateBasedRuleCreate(ctx context.Context, d *schema.ResourceData, me
 func resourceRateBasedRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	params := &waf.GetRateBasedRuleInput{
 		RuleId: aws.String(d.Id()),
@@ -165,23 +160,6 @@ func resourceRateBasedRuleRead(ctx context.Context, d *schema.ResourceData, meta
 		Service:   "waf-regional",
 	}.String()
 	d.Set("arn", arn)
-
-	tagList, err := ListTags(ctx, conn, arn)
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "to get WAF Regional Rated Based Rule parameter tags for %s: %s", d.Get("name"), err)
-	}
-
-	tags := tagList.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	d.Set("predicate", predicates)
 	d.Set("name", resp.Rule.Name)
 	d.Set("metric_name", resp.Rule.MetricName)
@@ -204,14 +182,6 @@ func resourceRateBasedRuleUpdate(ctx context.Context, d *schema.ResourceData, me
 		err := updateRateBasedRuleResourceWR(ctx, d.Id(), oldP, newP, rateLimit, conn, region)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating WAF Regional Rate Based Rule Predicates (%s): %s", d.Get("name").(string), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
 		}
 	}
 

--- a/internal/service/wafregional/rule.go
+++ b/internal/service/wafregional/rule.go
@@ -18,9 +18,11 @@ import (
 	tfwaf "github.com/hashicorp/terraform-provider-aws/internal/service/waf"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_wafregional_rule")
+// @SDKResource("aws_wafregional_rule", name="Rule")
+// @Tags(identifierAttribute="arn")
 func ResourceRule() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRuleCreate,
@@ -64,8 +66,8 @@ func ResourceRule() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -79,23 +81,18 @@ func ResourceRule() *schema.Resource {
 func resourceRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 	region := meta.(*conns.AWSClient).Region
 
 	wr := NewRetryer(conn, region)
 	out, err := wr.RetryWithToken(ctx, func(token *string) (interface{}, error) {
-		params := &waf.CreateRuleInput{
+		input := &waf.CreateRuleInput{
 			ChangeToken: token,
 			MetricName:  aws.String(d.Get("metric_name").(string)),
 			Name:        aws.String(d.Get("name").(string)),
+			Tags:        GetTagsIn(ctx),
 		}
 
-		if len(tags) > 0 {
-			params.Tags = Tags(tags.IgnoreAWS())
-		}
-
-		return conn.CreateRuleWithContext(ctx, params)
+		return conn.CreateRuleWithContext(ctx, input)
 	})
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating WAF Regional Rule (%s): %s", d.Get("name").(string), err)
@@ -117,8 +114,6 @@ func resourceRuleCreate(ctx context.Context, d *schema.ResourceData, meta interf
 func resourceRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	params := &waf.GetRuleInput{
 		RuleId: aws.String(d.Id()),
@@ -143,24 +138,6 @@ func resourceRuleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 		Service:   "waf-regional",
 	}.String()
 	d.Set("arn", arn)
-
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for WAF Regional Rule (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	d.Set("predicate", flattenPredicates(resp.Rule.Predicates))
 	d.Set("name", resp.Rule.Name)
 	d.Set("metric_name", resp.Rule.MetricName)
@@ -170,7 +147,6 @@ func resourceRuleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 
 func resourceRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).WAFRegionalConn()
 
 	if d.HasChange("predicate") {
 		o, n := d.GetChange("predicate")
@@ -179,14 +155,6 @@ func resourceRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		err := updateRuleResource(ctx, d.Id(), oldP, newP, meta)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating WAF Rule: %s", err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
 		}
 	}
 

--- a/internal/service/wafregional/rule_group.go
+++ b/internal/service/wafregional/rule_group.go
@@ -17,9 +17,11 @@ import (
 	tfwaf "github.com/hashicorp/terraform-provider-aws/internal/service/waf"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_wafregional_rule_group")
+// @SDKResource("aws_wafregional_rule_group", name="Rule Group")
+// @Tags(identifierAttribute="arn")
 func ResourceRuleGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRuleGroupCreate,
@@ -76,8 +78,8 @@ func ResourceRuleGroup() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -91,23 +93,18 @@ func ResourceRuleGroup() *schema.Resource {
 func resourceRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 	region := meta.(*conns.AWSClient).Region
 
 	wr := NewRetryer(conn, region)
 	out, err := wr.RetryWithToken(ctx, func(token *string) (interface{}, error) {
-		params := &waf.CreateRuleGroupInput{
+		input := &waf.CreateRuleGroupInput{
 			ChangeToken: token,
 			MetricName:  aws.String(d.Get("metric_name").(string)),
 			Name:        aws.String(d.Get("name").(string)),
+			Tags:        GetTagsIn(ctx),
 		}
 
-		if len(tags) > 0 {
-			params.Tags = Tags(tags.IgnoreAWS())
-		}
-
-		return conn.CreateRuleGroupWithContext(ctx, params)
+		return conn.CreateRuleGroupWithContext(ctx, input)
 	})
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating WAF Regional Rule Group (%s): %s", d.Get("name").(string), err)
@@ -131,8 +128,6 @@ func resourceRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 func resourceRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	params := &waf.GetRuleGroupInput{
 		RuleGroupId: aws.String(d.Id()),
@@ -164,22 +159,6 @@ func resourceRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 		Service:   "waf-regional",
 	}.String()
 	d.Set("arn", arn)
-
-	tags, err := ListTags(ctx, conn, arn)
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for WAF Regional Rule Group (%s): %s", arn, err)
-	}
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	d.Set("activated_rule", tfwaf.FlattenActivatedRules(rResp.ActivatedRules))
 	d.Set("name", resp.RuleGroup.Name)
 	d.Set("metric_name", resp.RuleGroup.MetricName)
@@ -199,14 +178,6 @@ func resourceRuleGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		err := updateRuleGroupResourceWR(ctx, d.Id(), oldRules, newRules, conn, region)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating WAF Regional Rule Group (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
 		}
 	}
 

--- a/internal/service/wafregional/service_package_gen.go
+++ b/internal/service/wafregional/service_package_gen.go
@@ -61,6 +61,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceRateBasedRule,
 			TypeName: "aws_wafregional_rate_based_rule",
+			Name:     "Rate Based Rule",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRegexMatchSet,
@@ -73,10 +77,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceRule,
 			TypeName: "aws_wafregional_rule",
+			Name:     "Rule",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRuleGroup,
 			TypeName: "aws_wafregional_rule_group",
+			Name:     "Rule Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceSizeConstraintSet,
@@ -89,6 +101,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceWebACL,
 			TypeName: "aws_wafregional_web_acl",
+			Name:     "Web ACL",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceWebACLAssociation,

--- a/internal/service/wafregional/web_acl.go
+++ b/internal/service/wafregional/web_acl.go
@@ -18,9 +18,11 @@ import (
 	tfwaf "github.com/hashicorp/terraform-provider-aws/internal/service/waf"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_wafregional_web_acl")
+// @SDKResource("aws_wafregional_web_acl", name="Web ACL")
+// @Tags(identifierAttribute="arn")
 func ResourceWebACL() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceWebACLCreate,
@@ -165,8 +167,8 @@ func ResourceWebACL() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -176,24 +178,19 @@ func ResourceWebACL() *schema.Resource {
 func resourceWebACLCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 	region := meta.(*conns.AWSClient).Region
 
 	wr := NewRetryer(conn, region)
 	out, err := wr.RetryWithToken(ctx, func(token *string) (interface{}, error) {
-		params := &waf.CreateWebACLInput{
+		input := &waf.CreateWebACLInput{
 			ChangeToken:   token,
 			DefaultAction: tfwaf.ExpandAction(d.Get("default_action").([]interface{})),
 			MetricName:    aws.String(d.Get("metric_name").(string)),
 			Name:          aws.String(d.Get("name").(string)),
+			Tags:          GetTagsIn(ctx),
 		}
 
-		if len(tags) > 0 {
-			params.Tags = Tags(tags.IgnoreAWS())
-		}
-
-		return conn.CreateWebACLWithContext(ctx, params)
+		return conn.CreateWebACLWithContext(ctx, input)
 	})
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating WAF Regional Web ACL (%s): %s", d.Get("name").(string), err)
@@ -249,8 +246,6 @@ func resourceWebACLCreate(ctx context.Context, d *schema.ResourceData, meta inte
 func resourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	params := &waf.GetWebACLInput{
 		WebACLId: aws.String(d.Id()),
@@ -293,22 +288,6 @@ func resourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("metric_name", resp.WebACL.MetricName)
 	if err := d.Set("rule", tfwaf.FlattenWebACLRules(resp.WebACL.Rules)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting rule: %s", err)
-	}
-
-	tags, err := ListTags(ctx, conn, webACLARN)
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for WAF Regional ACL (%s): %s", webACLARN, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
 	}
 
 	getLoggingConfigurationInput := &waf.GetLoggingConfigurationInput{

--- a/internal/service/wafv2/regex_pattern_set.go
+++ b/internal/service/wafv2/regex_pattern_set.go
@@ -18,13 +18,15 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 const (
 	regexPatternSetDeleteTimeout = 5 * time.Minute
 )
 
-// @SDKResource("aws_wafv2_regex_pattern_set")
+// @SDKResource("aws_wafv2_regex_pattern_set", name="Regex Pattern Set")
+// @Tags(identifierAttribute="arn")
 func ResourceRegexPatternSet() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRegexPatternSetCreate,
@@ -91,8 +93,8 @@ func ResourceRegexPatternSet() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice(wafv2.Scope_Values(), false),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -101,14 +103,13 @@ func ResourceRegexPatternSet() *schema.Resource {
 
 func resourceRegexPatternSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).WAFV2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &wafv2.CreateRegexPatternSetInput{
 		Name:                  aws.String(name),
 		RegularExpressionList: []*wafv2.Regex{},
 		Scope:                 aws.String(d.Get("scope").(string)),
+		Tags:                  GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -119,11 +120,6 @@ func resourceRegexPatternSetCreate(ctx context.Context, d *schema.ResourceData, 
 		input.RegularExpressionList = expandRegexPatternSet(v.(*schema.Set).List())
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
-	log.Printf("[INFO] Creating WAFv2 RegexPatternSet: %s", input)
 	output, err := conn.CreateRegexPatternSetWithContext(ctx, input)
 
 	if err != nil {
@@ -137,8 +133,6 @@ func resourceRegexPatternSetCreate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceRegexPatternSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).WAFV2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	output, err := FindRegexPatternSetByThreePartKey(ctx, conn, d.Id(), d.Get("name").(string), d.Get("scope").(string))
 
@@ -160,23 +154,6 @@ func resourceRegexPatternSetRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("name", regexPatternSet.Name)
 	if err := d.Set("regular_expression", flattenRegexPatternSet(regexPatternSet.RegularExpressionList)); err != nil {
 		return diag.Errorf("setting regular_expression: %s", err)
-	}
-
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return diag.Errorf("listing tags for WAFv2 RegexPatternSet (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
 	}
 
 	return nil
@@ -207,15 +184,6 @@ func resourceRegexPatternSetUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		if err != nil {
 			return diag.Errorf("updating WAFv2 RegexPatternSet (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		arn := d.Get("arn").(string)
-
-		if err := UpdateTags(ctx, conn, arn, o, n); err != nil {
-			return diag.Errorf("updating tags for WAFv2 RegexPatternSet (%s): %s", arn, err)
 		}
 	}
 

--- a/internal/service/wafv2/rule_group.go
+++ b/internal/service/wafv2/rule_group.go
@@ -19,6 +19,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 const (
@@ -27,7 +28,8 @@ const (
 	ruleGroupDeleteTimeout = 5 * time.Minute
 )
 
-// @SDKResource("aws_wafv2_rule_group")
+// @SDKResource("aws_wafv2_rule_group", name="Rule Group")
+// @Tags(identifierAttribute="arn")
 func ResourceRuleGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRuleGroupCreate,
@@ -120,8 +122,8 @@ func ResourceRuleGroup() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice(wafv2.Scope_Values(), false),
 			},
-			"tags":              tftags.TagsSchema(),
-			"tags_all":          tftags.TagsSchemaComputed(),
+			names.AttrTags:      tftags.TagsSchema(),
+			names.AttrTagsAll:   tftags.TagsSchemaComputed(),
 			"visibility_config": visibilityConfigSchema(),
 		},
 
@@ -131,8 +133,6 @@ func ResourceRuleGroup() *schema.Resource {
 
 func resourceRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).WAFV2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &wafv2.CreateRuleGroupInput{
@@ -140,6 +140,7 @@ func resourceRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 		Name:             aws.String(name),
 		Rules:            expandRules(d.Get("rule").(*schema.Set).List()),
 		Scope:            aws.String(d.Get("scope").(string)),
+		Tags:             GetTagsIn(ctx),
 		VisibilityConfig: expandVisibilityConfig(d.Get("visibility_config").([]interface{})),
 	}
 
@@ -151,11 +152,6 @@ func resourceRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 		input.Description = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
-	log.Printf("[INFO] Creating WAFv2 RuleGroup: %s", input)
 	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ruleGroupCreateTimeout, func() (interface{}, error) {
 		return conn.CreateRuleGroupWithContext(ctx, input)
 	}, wafv2.ErrCodeWAFUnavailableEntityException)
@@ -173,8 +169,6 @@ func resourceRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 func resourceRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).WAFV2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	output, err := FindRuleGroupByThreePartKey(ctx, conn, d.Id(), d.Get("name").(string), d.Get("scope").(string))
 
@@ -189,7 +183,6 @@ func resourceRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	ruleGroup := output.RuleGroup
-	arn := aws.StringValue(ruleGroup.ARN)
 	d.Set("arn", ruleGroup.ARN)
 	d.Set("capacity", ruleGroup.Capacity)
 	if err := d.Set("custom_response_body", flattenCustomResponseBodies(ruleGroup.CustomResponseBodies)); err != nil {
@@ -203,23 +196,6 @@ func resourceRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 	}
 	if err := d.Set("visibility_config", flattenVisibilityConfig(ruleGroup.VisibilityConfig)); err != nil {
 		return diag.Errorf("setting visibility_config: %s", err)
-	}
-
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return diag.Errorf("listing tags for WAFv2 RuleGroup (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
 	}
 
 	return nil
@@ -253,15 +229,6 @@ func resourceRuleGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 
 		if err != nil {
 			return diag.Errorf("updating WAFv2 RuleGroup (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		arn := d.Get("arn").(string)
-
-		if err := UpdateTags(ctx, conn, arn, o, n); err != nil {
-			return diag.Errorf("updating tags for WAFv2 RuleGroup (%s): %s", arn, err)
 		}
 	}
 

--- a/internal/service/wafv2/service_package_gen.go
+++ b/internal/service/wafv2/service_package_gen.go
@@ -45,18 +45,34 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceIPSet,
 			TypeName: "aws_wafv2_ip_set",
+			Name:     "IP Set",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRegexPatternSet,
 			TypeName: "aws_wafv2_regex_pattern_set",
+			Name:     "Regex Pattern Set",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRuleGroup,
 			TypeName: "aws_wafv2_rule_group",
+			Name:     "Rule Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceWebACL,
 			TypeName: "aws_wafv2_web_acl",
+			Name:     "Web ACL",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceWebACLAssociation,

--- a/internal/service/workspaces/directory.go
+++ b/internal/service/workspaces/directory.go
@@ -16,18 +16,22 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_workspaces_directory")
+// @SDKResource("aws_workspaces_directory", name="Directory")
+// @Tags(identifierAttribute="id")
 func ResourceDirectory() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDirectoryCreate,
 		ReadWithoutTimeout:   resourceDirectoryRead,
 		UpdateWithoutTimeout: resourceDirectoryUpdate,
 		DeleteWithoutTimeout: resourceDirectoryDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+
 		Schema: map[string]*schema.Schema{
 			"alias": {
 				Type:     schema.TypeString,
@@ -111,8 +115,8 @@ func ResourceDirectory() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"workspace_access_properties": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -209,16 +213,14 @@ func ResourceDirectory() *schema.Resource {
 func resourceDirectoryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WorkSpacesConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
-	directoryID := d.Get("directory_id").(string)
 
+	directoryID := d.Get("directory_id").(string)
 	input := &workspaces.RegisterWorkspaceDirectoryInput{
 		DirectoryId:       aws.String(directoryID),
 		EnableSelfService: aws.Bool(false), // this is handled separately below
 		EnableWorkDocs:    aws.Bool(false),
 		Tenancy:           aws.String(workspaces.TenancyShared),
-		Tags:              Tags(tags.IgnoreAWS()),
+		Tags:              GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("subnet_ids"); ok {
@@ -301,8 +303,6 @@ func resourceDirectoryCreate(ctx context.Context, d *schema.ResourceData, meta i
 func resourceDirectoryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WorkSpacesConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	directory, err := FindDirectoryByID(ctx, conn, d.Id())
 
@@ -345,22 +345,6 @@ func resourceDirectoryRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	if err := d.Set("dns_ip_addresses", flex.FlattenStringSet(directory.DnsIpAddresses)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting dns_ip_addresses: %s", err)
-	}
-
-	tags, err := ListTags(ctx, conn, d.Id())
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags: %s", err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
 	}
 
 	return diags
@@ -438,13 +422,6 @@ func resourceDirectoryUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		}
 
 		log.Printf("[INFO] Updated WorkSpaces Directory (%s) IP Groups", d.Id())
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
-		}
 	}
 
 	return append(diags, resourceDirectoryRead(ctx, d, meta)...)

--- a/internal/service/workspaces/ip_group.go
+++ b/internal/service/workspaces/ip_group.go
@@ -13,9 +13,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_workspaces_ip_group")
+// @SDKResource("aws_workspaces_ip_group", name="IP Group")
+// @Tags(identifierAttribute="id")
 func ResourceIPGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceIPGroupCreate,
@@ -54,8 +56,8 @@ func ResourceIPGroup() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -65,17 +67,15 @@ func ResourceIPGroup() *schema.Resource {
 func resourceIPGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WorkSpacesConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	rules := d.Get("rules").(*schema.Set).List()
-
 	resp, err := conn.CreateIpGroupWithContext(ctx, &workspaces.CreateIpGroupInput{
 		GroupName: aws.String(d.Get("name").(string)),
 		GroupDesc: aws.String(d.Get("description").(string)),
 		UserRules: expandIPGroupRules(rules),
-		Tags:      Tags(tags.IgnoreAWS()),
+		Tags:      GetTagsIn(ctx),
 	})
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating WorkSpaces IP Group: %s", err)
 	}
@@ -88,8 +88,6 @@ func resourceIPGroupCreate(ctx context.Context, d *schema.ResourceData, meta int
 func resourceIPGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WorkSpacesConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	resp, err := conn.DescribeIpGroupsWithContext(ctx, &workspaces.DescribeIpGroupsInput{
 		GroupIds: []*string{aws.String(d.Id())},
@@ -118,22 +116,6 @@ func resourceIPGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("description", ipGroup.GroupDesc)
 	d.Set("rules", flattenIPGroupRules(ipGroup.UserRules))
 
-	tags, err := ListTags(ctx, conn, d.Id())
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for WorkSpaces IP Group (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
@@ -150,13 +132,6 @@ func resourceIPGroupUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		})
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating WorkSpaces IP Group (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
 		}
 	}
 

--- a/internal/service/workspaces/service_package_gen.go
+++ b/internal/service/workspaces/service_package_gen.go
@@ -45,14 +45,26 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDirectory,
 			TypeName: "aws_workspaces_directory",
+			Name:     "Directory",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceIPGroup,
 			TypeName: "aws_workspaces_ip_group",
+			Name:     "IP Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceWorkspace,
 			TypeName: "aws_workspaces_workspace",
+			Name:     "Workspace",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }

--- a/internal/service/workspaces/workspace.go
+++ b/internal/service/workspaces/workspace.go
@@ -15,9 +15,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_workspaces_workspace")
+// @SDKResource("aws_workspaces_workspace", name="Workspace")
+// @Tags(identifierAttribute="id")
 func ResourceWorkspace() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceWorkspaceCreate,
@@ -128,8 +130,8 @@ func ResourceWorkspace() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(WorkspaceAvailableTimeout),
@@ -144,8 +146,6 @@ func ResourceWorkspace() *schema.Resource {
 func resourceWorkspaceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WorkSpacesConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &workspaces.WorkspaceRequest{
 		BundleId:                    aws.String(d.Get("bundle_id").(string)),
@@ -153,7 +153,7 @@ func resourceWorkspaceCreate(ctx context.Context, d *schema.ResourceData, meta i
 		UserName:                    aws.String(d.Get("user_name").(string)),
 		RootVolumeEncryptionEnabled: aws.Bool(d.Get("root_volume_encryption_enabled").(bool)),
 		UserVolumeEncryptionEnabled: aws.Bool(d.Get("user_volume_encryption_enabled").(bool)),
-		Tags:                        Tags(tags.IgnoreAWS()),
+		Tags:                        GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("volume_encryption_key"); ok {
@@ -188,8 +188,6 @@ func resourceWorkspaceCreate(ctx context.Context, d *schema.ResourceData, meta i
 func resourceWorkspaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WorkSpacesConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	rawOutput, state, err := StatusWorkspaceState(ctx, conn, d.Id())()
 	if err != nil {
@@ -213,22 +211,6 @@ func resourceWorkspaceRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("volume_encryption_key", workspace.VolumeEncryptionKey)
 	if err := d.Set("workspace_properties", FlattenWorkspaceProperties(workspace.WorkspaceProperties)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting workspace properties: %s", err)
-	}
-
-	tags, err := ListTags(ctx, conn, d.Id())
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags: %s", err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
 	}
 
 	return diags
@@ -269,13 +251,6 @@ func resourceWorkspaceUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	if d.HasChange("workspace_properties.0.user_volume_size_gib") {
 		if err := workspacePropertyUpdate(ctx, "user_volume_size_gib", conn, d); err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating WorkSpaces Workspace (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
 		}
 	}
 

--- a/internal/service/xray/group.go
+++ b/internal/service/xray/group.go
@@ -13,9 +13,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_xray_group")
+// @SDKResource("aws_xray_group", name="Group")
+// @Tags(identifierAttribute="arn")
 func ResourceGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceGroupCreate,
@@ -62,8 +64,8 @@ func ResourceGroup() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -71,14 +73,12 @@ func ResourceGroup() *schema.Resource {
 func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).XRayConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("group_name").(string)
 	input := &xray.CreateGroupInput{
 		GroupName:        aws.String(name),
 		FilterExpression: aws.String(d.Get("filter_expression").(string)),
-		Tags:             Tags(tags.IgnoreAWS()),
+		Tags:             GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("insights_configuration"); ok {
@@ -99,8 +99,6 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).XRayConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	input := &xray.GetGroupInput{
 		GroupARN: aws.String(d.Id()),
@@ -126,23 +124,6 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		return sdkdiag.AppendErrorf(diags, "setting insights_configuration: %s", err)
 	}
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Xray Group (%q): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
@@ -165,14 +146,6 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating XRay Group (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
 		}
 	}
 

--- a/internal/service/xray/sampling_rule.go
+++ b/internal/service/xray/sampling_rule.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/xray"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -14,9 +15,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_xray_sampling_rule")
+// @SDKResource("aws_xray_sampling_rule", name="Sampling Rule")
+// @Tags(identifierAttribute="arn")
 func ResourceSamplingRule() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSamplingRuleCreate,
@@ -98,8 +101,8 @@ func ResourceSamplingRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -107,8 +110,6 @@ func ResourceSamplingRule() *schema.Resource {
 func resourceSamplingRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).XRayConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	samplingRule := &xray.SamplingRule{
 		RuleName:      aws.String(d.Get("rule_name").(string)),
@@ -130,7 +131,7 @@ func resourceSamplingRuleCreate(ctx context.Context, d *schema.ResourceData, met
 
 	params := &xray.CreateSamplingRuleInput{
 		SamplingRule: samplingRule,
-		Tags:         Tags(tags.IgnoreAWS()),
+		Tags:         GetTagsIn(ctx),
 	}
 
 	out, err := conn.CreateSamplingRuleWithContext(ctx, params)
@@ -146,8 +147,6 @@ func resourceSamplingRuleCreate(ctx context.Context, d *schema.ResourceData, met
 func resourceSamplingRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).XRayConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	samplingRule, err := GetSamplingRule(ctx, conn, d.Id())
 
@@ -176,35 +175,12 @@ func resourceSamplingRuleRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("attributes", aws.StringValueMap(samplingRule.Attributes))
 	d.Set("arn", arn)
 
-	tags, err := ListTags(ctx, conn, arn)
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Xray Sampling group (%q): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
 func resourceSamplingRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).XRayConn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
-		}
-	}
 
 	if d.HasChanges("attributes", "priority", "fixed_rate", "reservoir_size", "service_name", "service_type",
 		"host", "http_method", "url_path", "resource_arn") {
@@ -249,11 +225,14 @@ func resourceSamplingRuleDelete(ctx context.Context, d *schema.ResourceData, met
 	conn := meta.(*conns.AWSClient).XRayConn()
 
 	log.Printf("[INFO] Deleting XRay Sampling Rule: %s", d.Id())
-
-	params := &xray.DeleteSamplingRuleInput{
+	_, err := conn.DeleteSamplingRuleWithContext(ctx, &xray.DeleteSamplingRuleInput{
 		RuleName: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrMessageContains(err, xray.ErrCodeInvalidRequestException, "Sampling rule does not exist") {
+		return diags
 	}
-	_, err := conn.DeleteSamplingRuleWithContext(ctx, params)
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting XRay Sampling Rule: %s", d.Id())
 	}

--- a/internal/service/xray/service_package_gen.go
+++ b/internal/service/xray/service_package_gen.go
@@ -32,10 +32,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceGroup,
 			TypeName: "aws_xray_group",
+			Name:     "Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceSamplingRule,
 			TypeName: "aws_xray_sampling_rule",
+			Name:     "Sampling Rule",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin SDK v2.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccXRayGroup_basic\|TestAccXRayGroup_tags\|TestAccXRaySamplingRule_basic\|TestAccXRaySamplingRule_tags' PKG=xray ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/xray/... -v -count 1 -parallel 3  -run=TestAccXRayGroup_basic\|TestAccXRayGroup_tags\|TestAccXRaySamplingRule_basic\|TestAccXRaySamplingRule_tags -timeout 180m
=== RUN   TestAccXRayGroup_basic
=== PAUSE TestAccXRayGroup_basic
=== RUN   TestAccXRayGroup_tags
=== PAUSE TestAccXRayGroup_tags
=== RUN   TestAccXRaySamplingRule_basic
=== PAUSE TestAccXRaySamplingRule_basic
=== RUN   TestAccXRaySamplingRule_tags
=== PAUSE TestAccXRaySamplingRule_tags
=== CONT  TestAccXRayGroup_basic
=== CONT  TestAccXRaySamplingRule_basic
=== CONT  TestAccXRaySamplingRule_tags
--- PASS: TestAccXRaySamplingRule_basic (18.74s)
=== CONT  TestAccXRayGroup_tags
--- PASS: TestAccXRayGroup_basic (30.49s)
--- PASS: TestAccXRaySamplingRule_tags (41.35s)
--- PASS: TestAccXRayGroup_tags (38.95s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/xray	63.223s
```
```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=waf... ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/waf.../... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccWAFByteMatchSet_basic
=== PAUSE TestAccWAFByteMatchSet_basic
=== RUN   TestAccWAFGeoMatchSet_basic
=== PAUSE TestAccWAFGeoMatchSet_basic
=== RUN   TestAccWAFIPSetDataSource_basic
=== PAUSE TestAccWAFIPSetDataSource_basic
=== RUN   TestAccWAFIPSet_basic
=== PAUSE TestAccWAFIPSet_basic
=== RUN   TestAccWAFRuleDataSource_basic
=== PAUSE TestAccWAFRuleDataSource_basic
=== RUN   TestAccWAFRuleGroup_basic
=== PAUSE TestAccWAFRuleGroup_basic
=== RUN   TestAccWAFRuleGroup_tags
=== PAUSE TestAccWAFRuleGroup_tags
=== RUN   TestAccWAFRule_basic
=== PAUSE TestAccWAFRule_basic
=== RUN   TestAccWAFRule_tags
=== PAUSE TestAccWAFRule_tags
=== RUN   TestAccWAFSizeConstraintSet_basic
=== PAUSE TestAccWAFSizeConstraintSet_basic
=== RUN   TestAccWAFSQLInjectionMatchSet_basic
=== PAUSE TestAccWAFSQLInjectionMatchSet_basic
=== RUN   TestAccWAFSubscribedRuleGroupDataSource_basic
    subscribed_rule_group_test.go:17: Environment variable WAF_SUBSCRIBED_RULE_GROUP_NAME is not set
--- SKIP: TestAccWAFSubscribedRuleGroupDataSource_basic (0.00s)
=== RUN   TestAccWAFWebACLDataSource_basic
=== PAUSE TestAccWAFWebACLDataSource_basic
=== RUN   TestAccWAFWebACL_basic
=== PAUSE TestAccWAFWebACL_basic
=== RUN   TestAccWAFWebACL_tags
=== PAUSE TestAccWAFWebACL_tags
=== RUN   TestAccWAFXSSMatchSet_basic
=== PAUSE TestAccWAFXSSMatchSet_basic
=== CONT  TestAccWAFByteMatchSet_basic
=== CONT  TestAccWAFRule_tags
=== CONT  TestAccWAFXSSMatchSet_basic
--- PASS: TestAccWAFByteMatchSet_basic (32.43s)
=== CONT  TestAccWAFWebACL_tags
--- PASS: TestAccWAFXSSMatchSet_basic (33.67s)
=== CONT  TestAccWAFWebACL_basic
--- PASS: TestAccWAFWebACL_basic (28.82s)
=== CONT  TestAccWAFWebACLDataSource_basic
--- PASS: TestAccWAFRule_tags (74.78s)
=== CONT  TestAccWAFSQLInjectionMatchSet_basic
--- PASS: TestAccWAFWebACLDataSource_basic (27.79s)
=== CONT  TestAccWAFSizeConstraintSet_basic
--- PASS: TestAccWAFWebACL_tags (68.05s)
=== CONT  TestAccWAFRuleDataSource_basic
--- PASS: TestAccWAFSQLInjectionMatchSet_basic (28.77s)
=== CONT  TestAccWAFRule_basic
--- PASS: TestAccWAFSizeConstraintSet_basic (28.91s)
=== CONT  TestAccWAFRuleGroup_tags
--- PASS: TestAccWAFRuleDataSource_basic (24.11s)
=== CONT  TestAccWAFRuleGroup_basic
--- PASS: TestAccWAFRule_basic (31.75s)
=== CONT  TestAccWAFIPSetDataSource_basic
--- PASS: TestAccWAFRuleGroup_basic (31.59s)
=== CONT  TestAccWAFIPSet_basic
--- PASS: TestAccWAFIPSetDataSource_basic (24.12s)
=== CONT  TestAccWAFGeoMatchSet_basic
--- PASS: TestAccWAFRuleGroup_tags (61.34s)
--- PASS: TestAccWAFIPSet_basic (29.03s)
--- PASS: TestAccWAFGeoMatchSet_basic (26.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/waf	194.419s
=== RUN   TestAccWAFRegionalByteMatchSet_basic
=== PAUSE TestAccWAFRegionalByteMatchSet_basic
=== RUN   TestAccWAFRegionalGeoMatchSet_basic
=== PAUSE TestAccWAFRegionalGeoMatchSet_basic
=== RUN   TestAccWAFRegionalIPSetDataSource_basic
=== PAUSE TestAccWAFRegionalIPSetDataSource_basic
=== RUN   TestAccWAFRegionalIPSet_basic
=== PAUSE TestAccWAFRegionalIPSet_basic
=== RUN   TestAccWAFRegionalRateBasedRuleDataSource_basic
=== PAUSE TestAccWAFRegionalRateBasedRuleDataSource_basic
=== RUN   TestAccWAFRegionalRateBasedRule_basic
=== PAUSE TestAccWAFRegionalRateBasedRule_basic
=== RUN   TestAccWAFRegionalRateBasedRule_tags
=== PAUSE TestAccWAFRegionalRateBasedRule_tags
=== RUN   TestAccWAFRegionalRuleDataSource_basic
=== PAUSE TestAccWAFRegionalRuleDataSource_basic
=== RUN   TestAccWAFRegionalRuleGroup_basic
=== PAUSE TestAccWAFRegionalRuleGroup_basic
=== RUN   TestAccWAFRegionalRuleGroup_tags
=== PAUSE TestAccWAFRegionalRuleGroup_tags
=== RUN   TestAccWAFRegionalRule_basic
=== PAUSE TestAccWAFRegionalRule_basic
=== RUN   TestAccWAFRegionalRule_tags
=== PAUSE TestAccWAFRegionalRule_tags
=== RUN   TestAccWAFRegionalSizeConstraintSet_basic
=== PAUSE TestAccWAFRegionalSizeConstraintSet_basic
=== RUN   TestAccWAFRegionalSQLInjectionMatchSet_basic
=== PAUSE TestAccWAFRegionalSQLInjectionMatchSet_basic
=== RUN   TestAccWAFRegionalSubscribedRuleGroupDataSource_basic
    subscribed_rule_group_test.go:17: Environment variable WAF_SUBSCRIBED_RULE_GROUP_NAME is not set
--- SKIP: TestAccWAFRegionalSubscribedRuleGroupDataSource_basic (0.00s)
=== RUN   TestAccWAFRegionalWebACLAssociation_basic
=== PAUSE TestAccWAFRegionalWebACLAssociation_basic
=== RUN   TestAccWAFRegionalWebACLDataSource_basic
=== PAUSE TestAccWAFRegionalWebACLDataSource_basic
=== RUN   TestAccWAFRegionalWebACL_basic
=== PAUSE TestAccWAFRegionalWebACL_basic
=== RUN   TestAccWAFRegionalWebACL_tags
=== PAUSE TestAccWAFRegionalWebACL_tags
=== RUN   TestAccWAFRegionalXSSMatchSet_basic
=== PAUSE TestAccWAFRegionalXSSMatchSet_basic
=== CONT  TestAccWAFRegionalByteMatchSet_basic
=== CONT  TestAccWAFRegionalWebACLDataSource_basic
=== CONT  TestAccWAFRegionalXSSMatchSet_basic
--- PASS: TestAccWAFRegionalWebACLDataSource_basic (30.41s)
=== CONT  TestAccWAFRegionalWebACL_tags
--- PASS: TestAccWAFRegionalXSSMatchSet_basic (32.76s)
=== CONT  TestAccWAFRegionalWebACL_basic
--- PASS: TestAccWAFRegionalByteMatchSet_basic (34.37s)
=== CONT  TestAccWAFRegionalSQLInjectionMatchSet_basic
--- PASS: TestAccWAFRegionalSQLInjectionMatchSet_basic (33.50s)
=== CONT  TestAccWAFRegionalWebACLAssociation_basic
--- PASS: TestAccWAFRegionalWebACL_basic (37.98s)
=== CONT  TestAccWAFRegionalIPSet_basic
--- PASS: TestAccWAFRegionalIPSet_basic (31.39s)
=== CONT  TestAccWAFRegionalRateBasedRuleDataSource_basic
--- PASS: TestAccWAFRegionalWebACL_tags (76.26s)
=== CONT  TestAccWAFRegionalIPSetDataSource_basic
--- PASS: TestAccWAFRegionalRateBasedRuleDataSource_basic (27.31s)
=== CONT  TestAccWAFRegionalGeoMatchSet_basic
--- PASS: TestAccWAFRegionalIPSetDataSource_basic (26.35s)
=== CONT  TestAccWAFRegionalSizeConstraintSet_basic
--- PASS: TestAccWAFRegionalGeoMatchSet_basic (29.04s)
=== CONT  TestAccWAFRegionalRuleGroup_basic
--- PASS: TestAccWAFRegionalSizeConstraintSet_basic (28.98s)
=== CONT  TestAccWAFRegionalRuleGroup_tags
--- PASS: TestAccWAFRegionalRuleGroup_basic (30.39s)
=== CONT  TestAccWAFRegionalRuleDataSource_basic
--- PASS: TestAccWAFRegionalRuleDataSource_basic (21.44s)
=== CONT  TestAccWAFRegionalRule_tags
--- PASS: TestAccWAFRegionalRuleGroup_tags (59.66s)
=== CONT  TestAccWAFRegionalRateBasedRule_basic
--- PASS: TestAccWAFRegionalWebACLAssociation_basic (168.66s)
=== CONT  TestAccWAFRegionalRateBasedRule_tags
--- PASS: TestAccWAFRegionalRateBasedRule_basic (28.69s)
=== CONT  TestAccWAFRegionalRule_basic
--- PASS: TestAccWAFRegionalRule_tags (54.86s)
--- PASS: TestAccWAFRegionalRule_basic (24.70s)
--- PASS: TestAccWAFRegionalRateBasedRule_tags (55.14s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafregional	303.865s
=== RUN   TestAccWAFV2IPSetDataSource_basic
=== PAUSE TestAccWAFV2IPSetDataSource_basic
=== RUN   TestAccWAFV2IPSet_basic
=== PAUSE TestAccWAFV2IPSet_basic
=== RUN   TestAccWAFV2IPSet_tags
=== PAUSE TestAccWAFV2IPSet_tags
=== RUN   TestAccWAFV2RegexPatternSetDataSource_basic
=== PAUSE TestAccWAFV2RegexPatternSetDataSource_basic
=== RUN   TestAccWAFV2RegexPatternSet_basic
=== PAUSE TestAccWAFV2RegexPatternSet_basic
=== RUN   TestAccWAFV2RegexPatternSet_tags
=== PAUSE TestAccWAFV2RegexPatternSet_tags
=== RUN   TestAccWAFV2RuleGroupDataSource_basic
=== PAUSE TestAccWAFV2RuleGroupDataSource_basic
=== RUN   TestAccWAFV2RuleGroup_basic
=== PAUSE TestAccWAFV2RuleGroup_basic
=== RUN   TestAccWAFV2RuleGroup_tags
=== PAUSE TestAccWAFV2RuleGroup_tags
=== RUN   TestAccWAFV2WebACLAssociation_basic
=== PAUSE TestAccWAFV2WebACLAssociation_basic
=== RUN   TestAccWAFV2WebACLDataSource_basic
=== PAUSE TestAccWAFV2WebACLDataSource_basic
=== RUN   TestAccWAFV2WebACLLoggingConfiguration_basic
=== PAUSE TestAccWAFV2WebACLLoggingConfiguration_basic
=== RUN   TestAccWAFV2WebACL_basic
=== PAUSE TestAccWAFV2WebACL_basic
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== RUN   TestAccWAFV2WebACL_RateBased_basic
=== PAUSE TestAccWAFV2WebACL_RateBased_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_basic
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_basic
=== RUN   TestAccWAFV2WebACL_GeoMatch_basic
=== PAUSE TestAccWAFV2WebACL_GeoMatch_basic
=== RUN   TestAccWAFV2WebACL_IPSetReference_basic
=== PAUSE TestAccWAFV2WebACL_IPSetReference_basic
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_basic
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_basic
=== RUN   TestAccWAFV2WebACL_tags
=== PAUSE TestAccWAFV2WebACL_tags
=== CONT  TestAccWAFV2IPSetDataSource_basic
=== CONT  TestAccWAFV2WebACLDataSource_basic
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_basic
--- PASS: TestAccWAFV2IPSetDataSource_basic (28.70s)
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_basic
--- PASS: TestAccWAFV2WebACLDataSource_basic (52.89s)
=== CONT  TestAccWAFV2WebACL_tags
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_basic (105.84s)
=== CONT  TestAccWAFV2WebACL_IPSetReference_basic
--- PASS: TestAccWAFV2WebACL_IPSetReference_basic (53.13s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_basic
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_basic (157.84s)
=== CONT  TestAccWAFV2WebACL_RateBased_basic
--- PASS: TestAccWAFV2WebACL_tags (133.94s)
=== CONT  TestAccWAFV2RegexPatternSet_tags
--- PASS: TestAccWAFV2RegexPatternSet_tags (49.83s)
=== CONT  TestAccWAFV2WebACLAssociation_basic
--- PASS: TestAccWAFV2WebACL_RateBased_basic (65.55s)
=== CONT  TestAccWAFV2RuleGroup_tags
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_basic (127.32s)
=== CONT  TestAccWAFV2RuleGroup_basic
--- PASS: TestAccWAFV2RuleGroup_basic (25.74s)
=== CONT  TestAccWAFV2RuleGroupDataSource_basic
--- PASS: TestAccWAFV2RuleGroup_tags (67.54s)
=== CONT  TestAccWAFV2RegexPatternSetDataSource_basic
--- PASS: TestAccWAFV2RegexPatternSetDataSource_basic (18.05s)
=== CONT  TestAccWAFV2RegexPatternSet_basic
--- PASS: TestAccWAFV2RuleGroupDataSource_basic (26.94s)
=== CONT  TestAccWAFV2WebACL_basic
--- PASS: TestAccWAFV2RegexPatternSet_basic (28.91s)
=== CONT  TestAccWAFV2WebACL_GeoMatch_basic
--- PASS: TestAccWAFV2WebACL_basic (27.69s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_basic
--- PASS: TestAccWAFV2WebACL_GeoMatch_basic (46.57s)
=== CONT  TestAccWAFV2IPSet_basic
--- PASS: TestAccWAFV2IPSet_basic (26.87s)
=== CONT  TestAccWAFV2IPSet_tags
--- PASS: TestAccWAFV2IPSet_tags (38.35s)
=== CONT  TestAccWAFV2WebACLLoggingConfiguration_basic
    web_acl_logging_configuration_test.go:26: Step 1/2 error: Error running apply: exit status 1
        
        Error: error creating S3 bucket ACL for tf-acc-test-8893173864125490027: AccessControlListNotSupported: The bucket does not allow ACLs
        	status code: 400, request id: 72M4095S2NMKJV6C, host id: 2JfiXEZ44G8JBPkFRyBva2wRIOBAncA0VmNM0naskmGpXc/2RukOA+CJKoefnr+uP39Z0//90Wc=
        
          with aws_s3_bucket_acl.test,
          on terraform_plugin_test.tf line 36, in resource "aws_s3_bucket_acl" "test":
          36: resource "aws_s3_bucket_acl" "test" {
        
=== CONT  TestAccWAFV2WebACLAssociation_basic
    web_acl_association_test.go:25: Step 1/2 error: Error running apply: exit status 1
        
        Error: creating WAFv2 WebACL Association (arn:aws:wafv2:us-west-2:187416307283:regional/webacl/tf-acc-test-3204428642727575776/9ab7d102-deab-4f3d-9442-7519d7935feb,arn:aws:apigateway:us-west-2::/restapis/gktm0x2nnk/stages/tf-acc-test-3204428642727575776): WAFUnavailableEntityException: AWS WAF couldn’t retrieve the resource that you requested. Retry your request.
        
          with aws_wafv2_web_acl_association.test,
          on terraform_plugin_test.tf line 52, in resource "aws_wafv2_web_acl_association" "test":
          52: resource "aws_wafv2_web_acl_association" "test" {
        
--- FAIL: TestAccWAFV2WebACLAssociation_basic (316.94s)
--- FAIL: TestAccWAFV2WebACLLoggingConfiguration_basic (197.40s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/wafv2	569.061s
FAIL
make: *** [testacc] Error 1
```
Failures are unrelated to this change.