### PR TITLE
Use session.NewSession instead of deprecated session.New

### DIFF
--- a/.ci/.golangci2.yml
+++ b/.ci/.golangci2.yml
@@ -41,10 +41,6 @@ issues:
     - linters:
         - staticcheck
       text: "SA1019: endpoints.\\w+ is deprecated: Use client package's EndpointsID value instead of these ServiceIDs. These IDs are not maintained, and are out of date."
-      # AWS Session creation
-    - linters:
-        - staticcheck
-      text: "SA1019: session.New is deprecated: Use NewSession functions to create sessions instead"
     # Per-Service
     - linters:
         - staticcheck

--- a/internal/service/iam/user_login_profile_test.go
+++ b/internal/service/iam/user_login_profile_test.go
@@ -333,13 +333,17 @@ func testDecryptPasswordAndTest(ctx context.Context, nProfile, nAccessKey, key s
 
 		decryptedPassword, err := pgpkeys.DecryptBytes(password, key)
 		if err != nil {
-			return fmt.Errorf("Error decrypting password: %s", err)
+			return fmt.Errorf("error decrypting password: %s", err)
 		}
 
-		iamAsCreatedUserSession := session.New(&aws.Config{
+		iamAsCreatedUserSession, err := session.NewSession(&aws.Config{
 			Region:      aws.String(acctest.Region()),
 			Credentials: credentials.NewStaticCredentials(accessKeyId, secretAccessKey, ""),
 		})
+
+		if err != nil {
+			return fmt.Errorf("error creating session: %s", err)
+		}
 		_, err = iamAsCreatedUserSession.Config.Credentials.GetWithContext(ctx)
 		if err != nil {
 			return fmt.Errorf("Error getting session credentials: %s", err)

--- a/internal/service/iam/user_login_profile_test.go
+++ b/internal/service/iam/user_login_profile_test.go
@@ -362,6 +362,9 @@ func testDecryptPasswordAndTest(ctx context.Context, nProfile, nAccessKey, key s
 				if tfawserr.ErrCodeEquals(err, "InvalidClientTokenId") {
 					return retry.RetryableError(err)
 				}
+				if tfawserr.ErrMessageContains(err, "AccessDenied", "not authorized to perform: iam:ChangePassword") {
+					return retry.RetryableError(err)
+				}
 
 				return retry.NonRetryableError(fmt.Errorf("changing decrypted password: %s", err))
 			}

--- a/internal/service/iam/user_login_profile_test.go
+++ b/internal/service/iam/user_login_profile_test.go
@@ -333,20 +333,15 @@ func testDecryptPasswordAndTest(ctx context.Context, nProfile, nAccessKey, key s
 
 		decryptedPassword, err := pgpkeys.DecryptBytes(password, key)
 		if err != nil {
-			return fmt.Errorf("error decrypting password: %s", err)
+			return fmt.Errorf("decrypting password: %s", err)
 		}
 
 		iamAsCreatedUserSession, err := session.NewSession(&aws.Config{
 			Region:      aws.String(acctest.Region()),
 			Credentials: credentials.NewStaticCredentials(accessKeyId, secretAccessKey, ""),
 		})
-
 		if err != nil {
-			return fmt.Errorf("error creating session: %s", err)
-		}
-		_, err = iamAsCreatedUserSession.Config.Credentials.GetWithContext(ctx)
-		if err != nil {
-			return fmt.Errorf("Error getting session credentials: %s", err)
+			return fmt.Errorf("creating session: %s", err)
 		}
 
 		return retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
@@ -368,7 +363,7 @@ func testDecryptPasswordAndTest(ctx context.Context, nProfile, nAccessKey, key s
 					return retry.RetryableError(err)
 				}
 
-				return retry.NonRetryableError(fmt.Errorf("Error changing decrypted password: %s", err))
+				return retry.NonRetryableError(fmt.Errorf("changing decrypted password: %s", err))
 			}
 
 			return nil


### PR DESCRIPTION
Replaced use of session.New by session.NewSession and removed the associated golanglint-ci exclusion.

### Relations
Closes #30323 

