### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin Framework resources `t*` (Phase 3c)

### DIFF
--- a/internal/service/timestreamwrite/database.go
+++ b/internal/service/timestreamwrite/database.go
@@ -15,9 +15,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_timestreamwrite_database")
+// @SDKResource("aws_timestreamwrite_database", name="Database")
+// @Tags(identifierAttribute="arn")
 func ResourceDatabase() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDatabaseCreate,
@@ -60,10 +62,8 @@ func ResourceDatabase() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-
-			"tags": tftags.TagsSchema(),
-
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -72,21 +72,15 @@ func ResourceDatabase() *schema.Resource {
 
 func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).TimestreamWriteConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	dbName := d.Get("database_name").(string)
-
 	input := &timestreamwrite.CreateDatabaseInput{
 		DatabaseName: aws.String(dbName),
+		Tags:         GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("kms_key_id"); ok {
 		input.KmsKeyId = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	resp, err := conn.CreateDatabaseWithContext(ctx, input)
@@ -106,8 +100,6 @@ func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).TimestreamWriteConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	input := &timestreamwrite.DescribeDatabaseInput{
 		DatabaseName: aws.String(d.Id()),
@@ -137,23 +129,6 @@ func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("kms_key_id", db.KmsKeyId)
 	d.Set("table_count", db.TableCount)
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("error listing tags for Timestream Database (%s): %w", arn, err))
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting tags: %w", err))
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting tags_all: %w", err))
-	}
-
 	return nil
 }
 
@@ -170,14 +145,6 @@ func resourceDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error updating Timestream Database (%s): %w", d.Id(), err))
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.FromErr(fmt.Errorf("error updating Timestream Database (%s) tags: %w", d.Get("arn").(string), err))
 		}
 	}
 

--- a/internal/service/timestreamwrite/service_package_gen.go
+++ b/internal/service/timestreamwrite/service_package_gen.go
@@ -28,10 +28,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDatabase,
 			TypeName: "aws_timestreamwrite_database",
+			Name:     "Database",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceTable,
 			TypeName: "aws_timestreamwrite_table",
+			Name:     "Table",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/timestreamwrite/table.go
+++ b/internal/service/timestreamwrite/table.go
@@ -16,9 +16,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_timestreamwrite_table")
+// @SDKResource("aws_timestreamwrite_table", name="Table")
+// @Tags(identifierAttribute="arn")
 func ResourceTable() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTableCreate,
@@ -128,10 +130,8 @@ func ResourceTable() *schema.Resource {
 					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`), "must only include alphanumeric, underscore, period, or hyphen characters"),
 				),
 			},
-
-			"tags": tftags.TagsSchema(),
-
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -140,13 +140,12 @@ func ResourceTable() *schema.Resource {
 
 func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).TimestreamWriteConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	tableName := d.Get("table_name").(string)
 	input := &timestreamwrite.CreateTableInput{
 		DatabaseName: aws.String(d.Get("database_name").(string)),
 		TableName:    aws.String(tableName),
+		Tags:         GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("retention_properties"); ok && len(v.([]interface{})) > 0 && v.([]interface{}) != nil {
@@ -155,10 +154,6 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	if v, ok := d.GetOk("magnetic_store_write_properties"); ok && len(v.([]interface{})) > 0 && v.([]interface{}) != nil {
 		input.MagneticStoreWriteProperties = expandMagneticStoreWriteProperties(v.([]interface{}))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	output, err := conn.CreateTableWithContext(ctx, input)
@@ -178,8 +173,6 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 func resourceTableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).TimestreamWriteConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	tableName, databaseName, err := TableParseID(d.Id())
 
@@ -220,23 +213,6 @@ func resourceTableRead(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	d.Set("table_name", table.TableName)
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("error listing tags for Timestream Table (%s): %w", arn, err))
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting tags: %w", err))
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting tags_all: %w", err))
-	}
-
 	return nil
 }
 
@@ -267,14 +243,6 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error updating Timestream Table (%s): %w", d.Id(), err))
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.FromErr(fmt.Errorf("error updating Timestream Table (%s) tags: %w", d.Get("arn").(string), err))
 		}
 	}
 

--- a/internal/service/transcribe/medical_vocabulary.go
+++ b/internal/service/transcribe/medical_vocabulary.go
@@ -19,9 +19,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_transcribe_medical_vocabulary")
+// @SDKResource("aws_transcribe_medical_vocabulary", name="Medical Vocabulary")
+// @Tags(identifierAttribute="arn")
 func ResourceMedicalVocabulary() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceMedicalVocabularyCreate,
@@ -65,8 +67,8 @@ func ResourceMedicalVocabulary() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(1, 200),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -81,13 +83,7 @@ func resourceMedicalVocabularyCreate(ctx context.Context, d *schema.ResourceData
 		VocabularyName:    aws.String(vocabularyName),
 		VocabularyFileUri: aws.String(d.Get("vocabulary_file_uri").(string)),
 		LanguageCode:      types.LanguageCode(d.Get("language_code").(string)),
-	}
-
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
-
-	if len(tags) > 0 {
-		in.Tags = Tags(tags.IgnoreAWS())
+		Tags:              GetTagsIn(ctx),
 	}
 
 	out, err := conn.CreateMedicalVocabulary(ctx, in)
@@ -136,24 +132,6 @@ func resourceMedicalVocabularyRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("vocabulary_name", out.VocabularyName)
 	d.Set("language_code", out.LanguageCode)
 
-	tags, err := ListTags(ctx, conn, arn)
-	if err != nil {
-		return diag.Errorf("listing tags for Transcribe MedicalVocabulary (%s): %s", d.Id(), err)
-	}
-
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
-	}
-
 	return nil
 }
 
@@ -178,14 +156,6 @@ func resourceMedicalVocabularyUpdate(ctx context.Context, d *schema.ResourceData
 
 		if _, err := waitMedicalVocabularyUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return diag.Errorf("waiting for Transcribe MedicalVocabulary (%s) update: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.Errorf("error updating Transcribe MedicalVocabulary (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/transcribe/service_package_gen.go
+++ b/internal/service/transcribe/service_package_gen.go
@@ -45,11 +45,17 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			Factory:  ResourceVocabulary,
 			TypeName: "aws_transcribe_vocabulary",
 			Name:     "Vocabulary",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceVocabularyFilter,
 			TypeName: "aws_transcribe_vocabulary_filter",
 			Name:     "Vocabulary Filter",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/transcribe/service_package_gen.go
+++ b/internal/service/transcribe/service_package_gen.go
@@ -28,18 +28,28 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceLanguageModel,
 			TypeName: "aws_transcribe_language_model",
+			Name:     "Language Model",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceMedicalVocabulary,
 			TypeName: "aws_transcribe_medical_vocabulary",
+			Name:     "Medical Vocabulary",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceVocabulary,
 			TypeName: "aws_transcribe_vocabulary",
+			Name:     "Vocabulary",
 		},
 		{
 			Factory:  ResourceVocabularyFilter,
 			TypeName: "aws_transcribe_vocabulary_filter",
+			Name:     "Vocabulary Filter",
 		},
 	}
 }

--- a/internal/service/transcribe/vocabulary.go
+++ b/internal/service/transcribe/vocabulary.go
@@ -24,6 +24,7 @@ import (
 )
 
 // @SDKResource("aws_transcribe_vocabulary", name="Vocabulary")
+// @Tags(identifierAttribute="arn")
 func ResourceVocabulary() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceVocabularyCreate,

--- a/internal/service/transcribe/vocabulary_filter.go
+++ b/internal/service/transcribe/vocabulary_filter.go
@@ -25,6 +25,7 @@ import (
 )
 
 // @SDKResource("aws_transcribe_vocabulary_filter", name="Vocabulary Filter")
+// @Tags(identifierAttribute="arn")
 func ResourceVocabularyFilter() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceVocabularyFilterCreate,

--- a/internal/service/transfer/server.go
+++ b/internal/service/transfer/server.go
@@ -22,9 +22,11 @@ import ( // nosemgrep:ci.aws-sdk-go-multiple-service-imports
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_transfer_server")
+// @SDKResource("aws_transfer_server", name="Server")
+// @Tags(identifierAttribute="arn")
 func ResourceServer() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceServerCreate,
@@ -222,8 +224,8 @@ func ResourceServer() *schema.Resource {
 				Default:      SecurityPolicyName2018_11,
 				ValidateFunc: validation.StringInSlice(SecurityPolicyName_Values(), false),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"url": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -282,10 +284,10 @@ func ResourceServer() *schema.Resource {
 func resourceServerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).TransferConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
-	input := &transfer.CreateServerInput{}
+	input := &transfer.CreateServerInput{
+		Tags: GetTagsIn(ctx),
+	}
 
 	if v, ok := d.GetOk("certificate"); ok {
 		input.Certificate = aws.String(v.(string))
@@ -378,10 +380,6 @@ func resourceServerCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		input.WorkflowDetails = expandWorkflowDetails(v.([]interface{}))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
 	output, err := conn.CreateServerWithContext(ctx, input)
 
 	if err != nil {
@@ -422,8 +420,6 @@ func resourceServerCreate(ctx context.Context, d *schema.ResourceData, meta inte
 func resourceServerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).TransferConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	output, err := FindServerByID(ctx, conn, d.Id())
 
@@ -499,16 +495,7 @@ func resourceServerRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return sdkdiag.AppendErrorf(diags, "setting workflow_details: %s", err)
 	}
 
-	tags := KeyValueTags(ctx, output.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, output.Tags)
 
 	return diags
 }
@@ -720,14 +707,6 @@ func resourceServerUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			if err := startServer(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 				return sdkdiag.AppendFromErr(diags, err)
 			}
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Transfer Server (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/transfer/service_package_gen.go
+++ b/internal/service/transfer/service_package_gen.go
@@ -37,6 +37,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceServer,
 			TypeName: "aws_transfer_server",
+			Name:     "Server",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceSSHKey,
@@ -49,10 +53,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceUser,
 			TypeName: "aws_transfer_user",
+			Name:     "User",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceWorkflow,
 			TypeName: "aws_transfer_workflow",
+			Name:     "Workflow",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/tags/tags.go
+++ b/internal/tags/tags.go
@@ -22,15 +22,6 @@ func TagsSchemaComputed() *schema.Schema {
 	}
 }
 
-func TagsSchemaComputedDeprecated(message string) *schema.Schema {
-	return &schema.Schema{
-		Type:       schema.TypeMap,
-		Computed:   true,
-		Elem:       &schema.Schema{Type: schema.TypeString},
-		Deprecated: message,
-	}
-}
-
 func TagsSchemaForceNew() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeMap,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin Framework.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=timestreamwrite ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/timestreamwrite/... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccTimestreamWriteDatabase_basic
=== PAUSE TestAccTimestreamWriteDatabase_basic
=== RUN   TestAccTimestreamWriteDatabase_tags
=== PAUSE TestAccTimestreamWriteDatabase_tags
=== RUN   TestAccTimestreamWriteTable_basic
=== PAUSE TestAccTimestreamWriteTable_basic
=== RUN   TestAccTimestreamWriteTable_tags
=== PAUSE TestAccTimestreamWriteTable_tags
=== CONT  TestAccTimestreamWriteDatabase_basic
=== CONT  TestAccTimestreamWriteTable_basic
=== CONT  TestAccTimestreamWriteDatabase_tags
--- PASS: TestAccTimestreamWriteDatabase_basic (23.25s)
=== CONT  TestAccTimestreamWriteTable_tags
--- PASS: TestAccTimestreamWriteTable_basic (24.36s)
--- PASS: TestAccTimestreamWriteDatabase_tags (48.66s)
--- PASS: TestAccTimestreamWriteTable_tags (46.02s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/timestreamwrite	74.806s
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=transfer ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/transfer/... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccTransferWorkflow_basic
--- PASS: TestAccTransferWorkflow_basic (18.88s)
=== RUN   TestAccTransferWorkflow_tags
--- PASS: TestAccTransferWorkflow_tags (36.78s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/transfer	64.098s
% make testacc TESTARGS='-run=TestAccTransfer_serial/^User$$\|^Server$$/^basic$$\|^tags$$' PKG=transfer
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/transfer/... -v -count 1 -parallel 20  -run=TestAccTransfer_serial/^User$\|^Server$/^basic$\|^tags$ -timeout 180m
=== RUN   TestAccTransfer_serial
=== PAUSE TestAccTransfer_serial
=== CONT  TestAccTransfer_serial
=== RUN   TestAccTransfer_serial/User
=== RUN   TestAccTransfer_serial/User/disappears
=== RUN   TestAccTransfer_serial/User/tags
=== RUN   TestAccTransfer_serial/User/HomeDirectoryMappings
=== RUN   TestAccTransfer_serial/User/ModifyWithOptions
=== RUN   TestAccTransfer_serial/User/Posix
=== RUN   TestAccTransfer_serial/User/UserNameValidation
=== RUN   TestAccTransfer_serial/User/basic
--- PASS: TestAccTransfer_serial (1149.02s)
    --- PASS: TestAccTransfer_serial/User (1149.02s)
        --- PASS: TestAccTransfer_serial/User/disappears (195.72s)
        --- PASS: TestAccTransfer_serial/User/tags (173.29s)
        --- PASS: TestAccTransfer_serial/User/HomeDirectoryMappings (203.65s)
        --- PASS: TestAccTransfer_serial/User/ModifyWithOptions (215.09s)
        --- PASS: TestAccTransfer_serial/User/Posix (163.18s)
        --- PASS: TestAccTransfer_serial/User/UserNameValidation (16.69s)
        --- PASS: TestAccTransfer_serial/User/basic (181.40s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/transfer	1159.365s
% make testacc TESTARGS='-run=TestAccTransfer_serial/Server/basic\|TestAccTransfer_serial/Server/tags' PKG=transfer
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/transfer/... -v -count 1 -parallel 20  -run=TestAccTransfer_serial/Server/basic\|TestAccTransfer_serial/Server/tags -timeout 180m
=== RUN   TestAccTransfer_serial
=== PAUSE TestAccTransfer_serial
=== CONT  TestAccTransfer_serial
=== RUN   TestAccTransfer_serial/Server
=== RUN   TestAccTransfer_serial/Server/tags
=== RUN   TestAccTransfer_serial/Server/basic
--- PASS: TestAccTransfer_serial (368.29s)
    --- PASS: TestAccTransfer_serial/Server (368.29s)
        --- PASS: TestAccTransfer_serial/Server/tags (173.79s)
        --- PASS: TestAccTransfer_serial/Server/basic (194.50s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/transfer	373.688s
```
