### PR TITLE
add new attributes to secrets manager rotation rules

### DIFF
--- a/.changelog/30425.txt
+++ b/.changelog/30425.txt
@@ -1,7 +1,11 @@
 ```release-note:enhancement
-resource/aws_secretsmanager_secret:  Add `duration` and `schedule_expression` attributes to `rotation_rules` configuration block
+resource/aws_secretsmanager_secret: Add `duration` and `schedule_expression` attributes to `rotation_rules` configuration block
 ```
 
 ```release-note:enhancement
-resource/aws_secretsmanager_secret_rotation:  Add `duration` and `schedule_expression` attributes to `rotation_rules` configuration block
+resource/aws_secretsmanager_secret_rotation: Add `duration` and `schedule_expression` attributes to `rotation_rules` configuration block
+```
+
+```release-note:enhancement
+data-source/aws_secretsmanager_secret: Add `rotation_rules.duration` and `rotation_rules.schedule_expression` attributes
 ```

--- a/.changelog/30425.txt
+++ b/.changelog/30425.txt
@@ -9,3 +9,7 @@ resource/aws_secretsmanager_secret_rotation: Add `duration` and `schedule_expres
 ```release-note:enhancement
 data-source/aws_secretsmanager_secret: Add `rotation_rules.duration` and `rotation_rules.schedule_expression` attributes
 ```
+
+```release-note:enhancement
+data-source/aws_secretsmanager_secret_rotation: Add `rotation_rules.duration` and `rotation_rules.schedule_expression` attributes
+```

--- a/.changelog/30425.txt
+++ b/.changelog/30425.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
-resource/secret_rotation:  Add 'duration' and 'schedule_expression' attributes to rotation_rules block
+resource/aws_secretsmanager_secret:  Add `duration` and `schedule_expression` attributes to `rotation_rules` configuration block
+```
+
+```release-note:enhancement
+resource/aws_secretsmanager_secret_rotation:  Add `duration` and `schedule_expression` attributes to `rotation_rules` configuration block
 ```

--- a/.changelog/30425.txt
+++ b/.changelog/30425.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/secret_rotation:  Add 'duration' and 'schedule_expression' attributes to rotation_rules block
+```

--- a/internal/service/secretsmanager/secret_data_source.go
+++ b/internal/service/secretsmanager/secret_data_source.go
@@ -64,6 +64,14 @@ func DataSourceSecret() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						"duration": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"schedule_expression": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/internal/service/secretsmanager/secret_rotation.go
+++ b/internal/service/secretsmanager/secret_rotation.go
@@ -3,6 +3,7 @@ package secretsmanager
 import (
 	"context"
 	"log"
+	"regexp"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -11,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -48,8 +50,28 @@ func ResourceSecretRotation() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"automatically_after_days": {
-							Type:     schema.TypeInt,
-							Required: true,
+							Type:          schema.TypeInt,
+							Optional:      true,
+							ConflictsWith: []string{"rotation_rules.0.schedule_expression"},
+							ExactlyOneOf:  []string{"rotation_rules.0.automatically_after_days", "rotation_rules.0.schedule_expression"},
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								_, exists := d.GetOk("rotation_rules.0.schedule_expression")
+								return exists
+							},
+							DiffSuppressOnRefresh: true,
+							ValidateFunc:          validation.IntBetween(1, 1000),
+						},
+						"duration": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringMatch(regexp.MustCompile(`[0-9h]+`), ""),
+						},
+						"schedule_expression": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							ConflictsWith: []string{"rotation_rules.0.automatically_after_days"},
+							ExactlyOneOf:  []string{"rotation_rules.0.automatically_after_days", "rotation_rules.0.schedule_expression"},
+							ValidateFunc:  validation.StringMatch(regexp.MustCompile(`[0-9A-Za-z\(\)#\?\*\-\/, ]+`), ""),
 						},
 					},
 				},
@@ -231,11 +253,20 @@ func expandRotationRules(l []interface{}) *secretsmanager.RotationRulesType {
 	if len(l) == 0 {
 		return nil
 	}
+	rules := &secretsmanager.RotationRulesType{}
 
-	m := l[0].(map[string]interface{})
+	tfMap := l[0].(map[string]interface{})
 
-	rules := &secretsmanager.RotationRulesType{
-		AutomaticallyAfterDays: aws.Int64(int64(m["automatically_after_days"].(int))),
+	if v, ok := tfMap["automatically_after_days"].(int); ok && v != 0 {
+		rules.AutomaticallyAfterDays = aws.Int64(int64(v))
+	}
+
+	if v, ok := tfMap["duration"].(string); ok && v != "" {
+		rules.Duration = aws.String(v)
+	}
+
+	if v, ok := tfMap["schedule_expression"].(string); ok && v != "" {
+		rules.ScheduleExpression = aws.String(v)
 	}
 
 	return rules
@@ -243,11 +274,21 @@ func expandRotationRules(l []interface{}) *secretsmanager.RotationRulesType {
 
 func flattenRotationRules(rules *secretsmanager.RotationRulesType) []interface{} {
 	if rules == nil {
-		return []interface{}{}
+		return nil
 	}
 
-	m := map[string]interface{}{
-		"automatically_after_days": int(aws.Int64Value(rules.AutomaticallyAfterDays)),
+	m := map[string]interface{}{}
+
+	if v := rules.AutomaticallyAfterDays; v != nil {
+		m["automatically_after_days"] = int(aws.Int64Value(v))
+	}
+
+	if v := rules.Duration; v != nil {
+		m["duration"] = aws.StringValue(v)
+	}
+
+	if v := rules.ScheduleExpression; v != nil {
+		m["schedule_expression"] = aws.StringValue(v)
 	}
 
 	return []interface{}{m}

--- a/internal/service/secretsmanager/secret_rotation_data_source.go
+++ b/internal/service/secretsmanager/secret_rotation_data_source.go
@@ -41,6 +41,14 @@ func DataSourceSecretRotation() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						"duration": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"schedule_expression": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/internal/service/secretsmanager/secret_rotation_test.go
+++ b/internal/service/secretsmanager/secret_rotation_test.go
@@ -3,6 +3,7 @@ package secretsmanager_test
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -21,7 +22,7 @@ func TestAccSecretsManagerSecretRotation_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_secretsmanager_secret_rotation.test"
 	lambdaFunctionResourceName := "aws_lambda_function.test1"
-
+	days01 := 7
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, secretsmanager.EndpointsID),
@@ -30,13 +31,13 @@ func TestAccSecretsManagerSecretRotation_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test creating secret rotation resource
 			{
-				Config: testAccSecretRotationConfig_basic(rName, 7),
+				Config: testAccSecretRotationConfig_basic(rName, days01),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSecretRotationExists(ctx, resourceName, &secret),
 					resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"),
 					resource.TestCheckResourceAttrPair(resourceName, "rotation_lambda_arn", lambdaFunctionResourceName, "arn"),
 					resource.TestCheckResourceAttr(resourceName, "rotation_rules.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "rotation_rules.0.automatically_after_days", "7"),
+					resource.TestCheckResourceAttr(resourceName, "rotation_rules.0.automatically_after_days", strconv.Itoa(days01)),
 				),
 			},
 			// Test updating rotation
@@ -52,6 +53,88 @@ func TestAccSecretsManagerSecretRotation_basic(t *testing.T) {
 					),
 				},
 			*/
+			// Test importing secret rotation
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSecretsManagerSecretRotation_scheduleExpression(t *testing.T) {
+	ctx := acctest.Context(t)
+	var secret secretsmanager.DescribeSecretOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_secretsmanager_secret_rotation.test"
+	lambdaFunctionResourceName := "aws_lambda_function.test1"
+	scheduleExpression := "rate(10 days)"
+	scheduleExpression02 := "rate(10 days)"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, secretsmanager.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecretRotationDestroy(ctx),
+		Steps: []resource.TestStep{
+			// Test creating secret rotation resource
+			{
+				Config: testAccSecretRotationConfig_scheduleExpression(rName, scheduleExpression),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecretRotationExists(ctx, resourceName, &secret),
+					resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "rotation_lambda_arn", lambdaFunctionResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "rotation_rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rotation_rules.0.schedule_expression", scheduleExpression),
+				),
+			},
+			{
+				Config: testAccSecretRotationConfig_scheduleExpression(rName, scheduleExpression02),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecretRotationExists(ctx, resourceName, &secret),
+					resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "rotation_lambda_arn", lambdaFunctionResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "rotation_rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rotation_rules.0.schedule_expression", scheduleExpression02),
+				),
+			},
+			// Test importing secret rotation
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSecretsManagerSecretRotation_duration(t *testing.T) {
+	ctx := acctest.Context(t)
+	var secret secretsmanager.DescribeSecretOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_secretsmanager_secret_rotation.test"
+	lambdaFunctionResourceName := "aws_lambda_function.test1"
+	days01 := 7
+	duration := "3h"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, secretsmanager.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecretRotationDestroy(ctx),
+		Steps: []resource.TestStep{
+			// Test creating secret rotation resource
+			{
+				Config: testAccSecretRotationConfig_duration(rName, days01, duration),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecretRotationExists(ctx, resourceName, &secret),
+					resource.TestCheckResourceAttr(resourceName, "rotation_enabled", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "rotation_lambda_arn", lambdaFunctionResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "rotation_rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rotation_rules.0.automatically_after_days", strconv.Itoa(days01)),
+					resource.TestCheckResourceAttr(resourceName, "rotation_rules.0.duration", duration),
+				),
+			},
 			// Test importing secret rotation
 			{
 				ResourceName:      resourceName,
@@ -174,4 +257,107 @@ resource "aws_secretsmanager_secret_rotation" "test" {
   depends_on = [aws_lambda_permission.test1]
 }
 `, rName, automaticallyAfterDays)
+}
+
+func testAccSecretRotationConfig_scheduleExpression(rName string, scheduleExpression string) string {
+	return acctest.ConfigLambdaBase(rName, rName, rName) + fmt.Sprintf(`
+# Not a real rotation function
+resource "aws_lambda_function" "test1" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = "%[1]s-1"
+  handler       = "exports.example"
+  role          = aws_iam_role.iam_for_lambda.arn
+  runtime       = "nodejs16.x"
+}
+
+resource "aws_lambda_permission" "test1" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.test1.function_name
+  principal     = "secretsmanager.amazonaws.com"
+  statement_id  = "AllowExecutionFromSecretsManager1"
+}
+
+# Not a real rotation function
+resource "aws_lambda_function" "test2" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = "%[1]s-2"
+  handler       = "exports.example"
+  role          = aws_iam_role.iam_for_lambda.arn
+  runtime       = "nodejs16.x"
+}
+
+resource "aws_lambda_permission" "test2" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.test2.function_name
+  principal     = "secretsmanager.amazonaws.com"
+  statement_id  = "AllowExecutionFromSecretsManager2"
+}
+
+resource "aws_secretsmanager_secret" "test" {
+  name = "%[1]s"
+}
+
+resource "aws_secretsmanager_secret_rotation" "test" {
+  secret_id           = aws_secretsmanager_secret.test.id
+  rotation_lambda_arn = aws_lambda_function.test1.arn
+
+  rotation_rules {
+    schedule_expression = "%[2]s"
+  }
+
+  depends_on = [aws_lambda_permission.test1]
+}
+`, rName, scheduleExpression)
+}
+
+func testAccSecretRotationConfig_duration(rName string, automaticallyAfterDays int, duration string) string {
+	return acctest.ConfigLambdaBase(rName, rName, rName) + fmt.Sprintf(`
+# Not a real rotation function
+resource "aws_lambda_function" "test1" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = "%[1]s-1"
+  handler       = "exports.example"
+  role          = aws_iam_role.iam_for_lambda.arn
+  runtime       = "nodejs16.x"
+}
+
+resource "aws_lambda_permission" "test1" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.test1.function_name
+  principal     = "secretsmanager.amazonaws.com"
+  statement_id  = "AllowExecutionFromSecretsManager1"
+}
+
+# Not a real rotation function
+resource "aws_lambda_function" "test2" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = "%[1]s-2"
+  handler       = "exports.example"
+  role          = aws_iam_role.iam_for_lambda.arn
+  runtime       = "nodejs16.x"
+}
+
+resource "aws_lambda_permission" "test2" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.test2.function_name
+  principal     = "secretsmanager.amazonaws.com"
+  statement_id  = "AllowExecutionFromSecretsManager2"
+}
+
+resource "aws_secretsmanager_secret" "test" {
+  name = "%[1]s"
+}
+
+resource "aws_secretsmanager_secret_rotation" "test" {
+  secret_id           = aws_secretsmanager_secret.test.id
+  rotation_lambda_arn = aws_lambda_function.test1.arn
+
+  rotation_rules {
+    automatically_after_days = %[2]d
+	duration = "%[3]s"
+  }
+
+  depends_on = [aws_lambda_permission.test1]
+}
+`, rName, automaticallyAfterDays, duration)
 }

--- a/internal/service/secretsmanager/secret_rotation_test.go
+++ b/internal/service/secretsmanager/secret_rotation_test.go
@@ -354,7 +354,7 @@ resource "aws_secretsmanager_secret_rotation" "test" {
 
   rotation_rules {
     automatically_after_days = %[2]d
-	duration = "%[3]s"
+    duration                 = "%[3]s"
   }
 
   depends_on = [aws_lambda_permission.test1]

--- a/website/docs/r/secretsmanager_secret_rotation.html.markdown
+++ b/website/docs/r/secretsmanager_secret_rotation.html.markdown
@@ -43,7 +43,9 @@ The following arguments are supported:
 
 ### rotation_rules
 
-* `automatically_after_days` - (Required) Specifies the number of days between automatic scheduled rotations of the secret.
+* `automatically_after_days` - (Optional) Specifies the number of days between automatic scheduled rotations of the secret. Either `automatically_after_days` or `schedule_expression` must be specified.
+* `duration` - (Optional) - The length of the rotation window in hours. For example, `3h` for a three hour window.
+* `schedule_expression` - (Optional) A `cron()` or `rate()` expression that defines the schedule for rotating your secret. Either `automatically_after_days` or `schedule_expression` must be specified.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Description
This adds `duration` and `schedule_expression` attributes to the `rotation_rules` block.


### Relations

Closes #28016

### References
https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_RotationRulesType.html

### Output from Acceptance Testing
##### SecretRotation resource 
```
make testacc TESTS=TestAccSecretsManagerSecretRotation PKG=secretsmanager ACCTEST_PARALLELISM=5                                     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/secretsmanager/... -v -count 1 -parallel 5 -run='TestAccSecretsManagerSecretRotation'  -timeout 180m
=== RUN   TestAccSecretsManagerSecretRotationDataSource_basic
=== PAUSE TestAccSecretsManagerSecretRotationDataSource_basic
=== RUN   TestAccSecretsManagerSecretRotation_basic
=== PAUSE TestAccSecretsManagerSecretRotation_basic
=== RUN   TestAccSecretsManagerSecretRotation_scheduleExpression
=== PAUSE TestAccSecretsManagerSecretRotation_scheduleExpression
=== RUN   TestAccSecretsManagerSecretRotation_duration
=== PAUSE TestAccSecretsManagerSecretRotation_duration
=== CONT  TestAccSecretsManagerSecretRotationDataSource_basic
=== CONT  TestAccSecretsManagerSecretRotation_scheduleExpression
=== CONT  TestAccSecretsManagerSecretRotation_duration
=== CONT  TestAccSecretsManagerSecretRotation_basic
--- PASS: TestAccSecretsManagerSecretRotation_basic (34.19s)
--- PASS: TestAccSecretsManagerSecretRotation_scheduleExpression (51.49s)
--- PASS: TestAccSecretsManagerSecretRotation_duration (55.34s)
--- PASS: TestAccSecretsManagerSecretRotationDataSource_basic (59.88s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	63.074s
```
##### Secret resource 
```
make testacc TESTS=TestAccSecretsManagerSecret PKG=secretsmanager ACCTEST_PARALLELISM=5                                 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/secretsmanager/... -v -count 1 -parallel 5 -run='TestAccSecretsManagerSecret'  -timeout 180m
=== RUN   TestAccSecretsManagerSecretDataSource_basic
=== PAUSE TestAccSecretsManagerSecretDataSource_basic
=== RUN   TestAccSecretsManagerSecretDataSource_arn
=== PAUSE TestAccSecretsManagerSecretDataSource_arn
=== RUN   TestAccSecretsManagerSecretDataSource_name
=== PAUSE TestAccSecretsManagerSecretDataSource_name
=== RUN   TestAccSecretsManagerSecretDataSource_policy
=== PAUSE TestAccSecretsManagerSecretDataSource_policy
=== RUN   TestAccSecretsManagerSecretPolicy_basic
=== PAUSE TestAccSecretsManagerSecretPolicy_basic
=== RUN   TestAccSecretsManagerSecretPolicy_blockPublicPolicy
=== PAUSE TestAccSecretsManagerSecretPolicy_blockPublicPolicy
=== RUN   TestAccSecretsManagerSecretPolicy_disappears
=== PAUSE TestAccSecretsManagerSecretPolicy_disappears
=== RUN   TestAccSecretsManagerSecretRotationDataSource_basic
=== PAUSE TestAccSecretsManagerSecretRotationDataSource_basic
=== RUN   TestAccSecretsManagerSecretRotation_basic
=== PAUSE TestAccSecretsManagerSecretRotation_basic
=== RUN   TestAccSecretsManagerSecretRotation_scheduleExpression
=== PAUSE TestAccSecretsManagerSecretRotation_scheduleExpression
=== RUN   TestAccSecretsManagerSecretRotation_duration
=== PAUSE TestAccSecretsManagerSecretRotation_duration
=== RUN   TestAccSecretsManagerSecret_basic
=== PAUSE TestAccSecretsManagerSecret_basic
=== RUN   TestAccSecretsManagerSecret_withNamePrefix
=== PAUSE TestAccSecretsManagerSecret_withNamePrefix
=== RUN   TestAccSecretsManagerSecret_description
=== PAUSE TestAccSecretsManagerSecret_description
=== RUN   TestAccSecretsManagerSecret_basicReplica
=== PAUSE TestAccSecretsManagerSecret_basicReplica
=== RUN   TestAccSecretsManagerSecret_overwriteReplica
=== PAUSE TestAccSecretsManagerSecret_overwriteReplica
=== RUN   TestAccSecretsManagerSecret_kmsKeyID
=== PAUSE TestAccSecretsManagerSecret_kmsKeyID
=== RUN   TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate
=== PAUSE TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate
=== RUN   TestAccSecretsManagerSecret_rotationLambdaARN
=== PAUSE TestAccSecretsManagerSecret_rotationLambdaARN
=== RUN   TestAccSecretsManagerSecret_rotationRules
=== PAUSE TestAccSecretsManagerSecret_rotationRules
=== RUN   TestAccSecretsManagerSecret_tags
=== PAUSE TestAccSecretsManagerSecret_tags
=== RUN   TestAccSecretsManagerSecret_policy
=== PAUSE TestAccSecretsManagerSecret_policy
=== RUN   TestAccSecretsManagerSecretVersionDataSource_basic
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_basic
=== RUN   TestAccSecretsManagerSecretVersionDataSource_versionID
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_versionID
=== RUN   TestAccSecretsManagerSecretVersionDataSource_versionStage
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_versionStage
=== RUN   TestAccSecretsManagerSecretVersion_basicString
=== PAUSE TestAccSecretsManagerSecretVersion_basicString
=== RUN   TestAccSecretsManagerSecretVersion_base64Binary
=== PAUSE TestAccSecretsManagerSecretVersion_base64Binary
=== RUN   TestAccSecretsManagerSecretVersion_versionStages
=== PAUSE TestAccSecretsManagerSecretVersion_versionStages
=== RUN   TestAccSecretsManagerSecretsDataSource_filter
=== PAUSE TestAccSecretsManagerSecretsDataSource_filter
=== CONT  TestAccSecretsManagerSecretDataSource_basic
=== CONT  TestAccSecretsManagerSecret_overwriteReplica
=== CONT  TestAccSecretsManagerSecretVersionDataSource_basic
=== CONT  TestAccSecretsManagerSecret_rotationRules
=== CONT  TestAccSecretsManagerSecret_policy
=== NAME  TestAccSecretsManagerSecret_overwriteReplica
    acctest.go:806: AWS_ALTERNATE_REGION and AWS_THIRD_REGION must be set to different values for acceptance tests
--- FAIL: TestAccSecretsManagerSecret_overwriteReplica (0.84s)
=== CONT  TestAccSecretsManagerSecret_tags
--- PASS: TestAccSecretsManagerSecretDataSource_basic (3.60s)
=== CONT  TestAccSecretsManagerSecretRotation_basic
--- PASS: TestAccSecretsManagerSecretVersionDataSource_basic (9.28s)
=== CONT  TestAccSecretsManagerSecretVersion_base64Binary
--- PASS: TestAccSecretsManagerSecretVersion_base64Binary (8.14s)
=== CONT  TestAccSecretsManagerSecret_basicReplica
--- PASS: TestAccSecretsManagerSecret_tags (25.63s)
=== CONT  TestAccSecretsManagerSecretsDataSource_filter
--- PASS: TestAccSecretsManagerSecret_basicReplica (13.28s)
=== CONT  TestAccSecretsManagerSecret_description
--- PASS: TestAccSecretsManagerSecret_rotationRules (33.26s)
=== CONT  TestAccSecretsManagerSecretVersion_versionStages
--- PASS: TestAccSecretsManagerSecretRotation_basic (33.70s)
=== CONT  TestAccSecretsManagerSecret_withNamePrefix
--- PASS: TestAccSecretsManagerSecret_policy (37.57s)
=== CONT  TestAccSecretsManagerSecret_basic
--- PASS: TestAccSecretsManagerSecret_description (15.11s)
=== CONT  TestAccSecretsManagerSecretPolicy_basic
--- PASS: TestAccSecretsManagerSecret_withNamePrefix (8.98s)
=== CONT  TestAccSecretsManagerSecretRotation_duration
--- PASS: TestAccSecretsManagerSecret_basic (9.07s)
=== CONT  TestAccSecretsManagerSecretRotation_scheduleExpression
--- PASS: TestAccSecretsManagerSecretVersion_versionStages (20.66s)
=== CONT  TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate
--- PASS: TestAccSecretsManagerSecretPolicy_basic (22.31s)
=== CONT  TestAccSecretsManagerSecret_rotationLambdaARN
--- PASS: TestAccSecretsManagerSecretsDataSource_filter (42.27s)
=== CONT  TestAccSecretsManagerSecret_kmsKeyID
--- PASS: TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate (15.60s)
=== CONT  TestAccSecretsManagerSecretVersion_basicString
--- PASS: TestAccSecretsManagerSecretVersion_basicString (8.45s)
=== CONT  TestAccSecretsManagerSecretVersionDataSource_versionID
--- PASS: TestAccSecretsManagerSecret_kmsKeyID (15.31s)
=== CONT  TestAccSecretsManagerSecretPolicy_disappears
--- PASS: TestAccSecretsManagerSecretRotation_duration (38.17s)
=== CONT  TestAccSecretsManagerSecretDataSource_name
--- PASS: TestAccSecretsManagerSecretVersionDataSource_versionID (7.47s)
=== CONT  TestAccSecretsManagerSecretPolicy_blockPublicPolicy
--- PASS: TestAccSecretsManagerSecretDataSource_name (6.98s)
=== CONT  TestAccSecretsManagerSecretDataSource_policy
=== NAME  TestAccSecretsManagerSecretPolicy_blockPublicPolicy
    secret_policy_test.go:66: Step 1/4 error: After applying this test step, the plan was not empty.
        stdout:


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # aws_secretsmanager_secret_policy.test will be updated in-place
          ~ resource "aws_secretsmanager_secret_policy" "test" {
                id                  = "arn:aws:secretsmanager:us-east-1:590846941288:secret:tf-acc-test-1621540161389076602-SSxhj2"
              ~ policy              = jsonencode(
                  ~ {
                      ~ Statement = [
                          ~ {
                              ~ Principal = {
                                  ~ AWS = "AROAYTEJY3BUO2NLZY6S6" -> "arn:aws:iam::590846941288:role/tf-acc-test-1621540161389076602"
                                }
                                # (4 unchanged attributes hidden)
                            },
                        ]
                        # (1 unchanged attribute hidden)
                    }
                )
                # (2 unchanged attributes hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
--- PASS: TestAccSecretsManagerSecretDataSource_policy (6.86s)
=== CONT  TestAccSecretsManagerSecretDataSource_arn
--- FAIL: TestAccSecretsManagerSecretPolicy_blockPublicPolicy (14.30s)
=== CONT  TestAccSecretsManagerSecretVersionDataSource_versionStage
--- PASS: TestAccSecretsManagerSecretRotation_scheduleExpression (54.31s)
=== CONT  TestAccSecretsManagerSecretRotationDataSource_basic
--- PASS: TestAccSecretsManagerSecretDataSource_arn (7.66s)
--- PASS: TestAccSecretsManagerSecretVersionDataSource_versionStage (7.83s)
--- PASS: TestAccSecretsManagerSecretPolicy_disappears (23.64s)
--- PASS: TestAccSecretsManagerSecret_rotationLambdaARN (43.64s)
--- PASS: TestAccSecretsManagerSecretRotationDataSource_basic (31.92s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	136.226s
FAIL
make: *** [testacc] Error 1
```