### PR TITLE
Replaces deprecated `session.New` with `session.NewSession`

### DIFF
--- a/.ci/.golangci2.yml
+++ b/.ci/.golangci2.yml
@@ -37,10 +37,6 @@ issues:
     - linters:
         - staticcheck
       text: "SA1019: endpoints.\\w+ is deprecated: Use client package's EndpointsID value instead of these ServiceIDs. These IDs are not maintained, and are out of date."
-      # AWS Session creation
-    - linters:
-        - staticcheck
-      text: "SA1019: session.New is deprecated: Use NewSession functions to create sessions instead"
     # Per-Service
     - linters:
         - staticcheck

--- a/internal/service/iam/user_login_profile_test.go
+++ b/internal/service/iam/user_login_profile_test.go
@@ -333,16 +333,15 @@ func testDecryptPasswordAndTest(ctx context.Context, nProfile, nAccessKey, key s
 
 		decryptedPassword, err := pgpkeys.DecryptBytes(password, key)
 		if err != nil {
-			return fmt.Errorf("Error decrypting password: %s", err)
+			return fmt.Errorf("decrypting password: %s", err)
 		}
 
-		iamAsCreatedUserSession := session.New(&aws.Config{
+		iamAsCreatedUserSession, err := session.NewSession(&aws.Config{
 			Region:      aws.String(acctest.Region()),
 			Credentials: credentials.NewStaticCredentials(accessKeyId, secretAccessKey, ""),
 		})
-		_, err = iamAsCreatedUserSession.Config.Credentials.GetWithContext(ctx)
 		if err != nil {
-			return fmt.Errorf("Error getting session credentials: %s", err)
+			return fmt.Errorf("getting session credentials: %s", err)
 		}
 
 		return retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
@@ -364,7 +363,7 @@ func testDecryptPasswordAndTest(ctx context.Context, nProfile, nAccessKey, key s
 					return retry.RetryableError(err)
 				}
 
-				return retry.NonRetryableError(fmt.Errorf("Error changing decrypted password: %s", err))
+				return retry.NonRetryableError(fmt.Errorf("changing decrypted password: %s", err))
 			}
 
 			return nil


### PR DESCRIPTION
### Description

Replaces deprecated `session.New` with `session.NewSession`

### Relations

Closes #30323

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=iam TESTS=TestAccIAMUserLoginProfile_basic

--- PASS: TestAccIAMUserLoginProfile_basic (51.00s)
```
