### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin Framework resources EC2 (Phase 3b)

### DIFF
--- a/internal/service/ec2/ebs_snapshot_copy.go
+++ b/internal/service/ec2/ebs_snapshot_copy.go
@@ -14,9 +14,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ebs_snapshot_copy")
+// @SDKResource("aws_ebs_snapshot_copy", name="EBS Snapshot")
+// @Tags(identifierAttribute="id")
 func ResourceEBSSnapshotCopy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceEBSSnapshotCopyCreate,
@@ -87,8 +89,8 @@ func ResourceEBSSnapshotCopy() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validation.StringInSlice(append(ec2.TargetStorageTier_Values(), TargetStorageTierStandard), false),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"temporary_restore_days": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -108,13 +110,11 @@ func ResourceEBSSnapshotCopy() *schema.Resource {
 func resourceEBSSnapshotCopyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &ec2.CopySnapshotInput{
 		SourceRegion:      aws.String(d.Get("source_region").(string)),
 		SourceSnapshotId:  aws.String(d.Get("source_snapshot_id").(string)),
-		TagSpecifications: tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeSnapshot),
+		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypeSnapshot),
 	}
 
 	if v, ok := d.GetOk("description"); ok {

--- a/internal/service/ec2/ec2_capacity_reservation.go
+++ b/internal/service/ec2/ec2_capacity_reservation.go
@@ -16,9 +16,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ec2_capacity_reservation")
+// @SDKResource("aws_ec2_capacity_reservation", name="Capacity Reservation")
+// @Tags(identifierAttribute="id")
 func ResourceCapacityReservation() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceCapacityReservationCreate,
@@ -100,8 +102,8 @@ func ResourceCapacityReservation() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: verify.ValidARN,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"tenancy": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -116,8 +118,6 @@ func ResourceCapacityReservation() *schema.Resource {
 func resourceCapacityReservationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &ec2.CreateCapacityReservationInput{
 		AvailabilityZone:  aws.String(d.Get("availability_zone").(string)),
@@ -125,7 +125,7 @@ func resourceCapacityReservationCreate(ctx context.Context, d *schema.ResourceDa
 		InstanceCount:     aws.Int64(int64(d.Get("instance_count").(int))),
 		InstancePlatform:  aws.String(d.Get("instance_platform").(string)),
 		InstanceType:      aws.String(d.Get("instance_type").(string)),
-		TagSpecifications: tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeCapacityReservation),
+		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypeCapacityReservation),
 	}
 
 	if v, ok := d.GetOk("ebs_optimized"); ok {
@@ -177,8 +177,6 @@ func resourceCapacityReservationCreate(ctx context.Context, d *schema.ResourceDa
 func resourceCapacityReservationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	reservation, err := FindCapacityReservationByID(ctx, conn, d.Id())
 
@@ -211,16 +209,7 @@ func resourceCapacityReservationRead(ctx context.Context, d *schema.ResourceData
 	d.Set("placement_group_arn", reservation.PlacementGroupArn)
 	d.Set("tenancy", reservation.Tenancy)
 
-	tags := KeyValueTags(ctx, reservation.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, reservation.Tags)
 
 	return diags
 }
@@ -251,14 +240,6 @@ func resourceCapacityReservationUpdate(ctx context.Context, d *schema.ResourceDa
 
 		if _, err := WaitCapacityReservationActive(ctx, conn, d.Id()); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for EC2 Capacity Reservation (%s) update: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
 		}
 	}
 

--- a/internal/service/ec2/ec2_host.go
+++ b/internal/service/ec2/ec2_host.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ec2_host")
+// @SDKResource("aws_ec2_host", name="Host")
+// @Tags(identifierAttribute="id")
 func ResourceHost() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceHostCreate,
@@ -75,8 +77,8 @@ func ResourceHost() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -84,15 +86,14 @@ func ResourceHost() *schema.Resource {
 func resourceHostCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &ec2.AllocateHostsInput{
-		AutoPlacement:    aws.String(d.Get("auto_placement").(string)),
-		AvailabilityZone: aws.String(d.Get("availability_zone").(string)),
-		ClientToken:      aws.String(id.UniqueId()),
-		HostRecovery:     aws.String(d.Get("host_recovery").(string)),
-		Quantity:         aws.Int64(1),
+		AutoPlacement:     aws.String(d.Get("auto_placement").(string)),
+		AvailabilityZone:  aws.String(d.Get("availability_zone").(string)),
+		ClientToken:       aws.String(id.UniqueId()),
+		HostRecovery:      aws.String(d.Get("host_recovery").(string)),
+		Quantity:          aws.Int64(1),
+		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypeDedicatedHost),
 	}
 
 	if v, ok := d.GetOk("instance_family"); ok {
@@ -105,10 +106,6 @@ func resourceHostCreate(ctx context.Context, d *schema.ResourceData, meta interf
 
 	if v, ok := d.GetOk("outpost_arn"); ok {
 		input.OutpostArn = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		input.TagSpecifications = tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeDedicatedHost)
 	}
 
 	output, err := conn.AllocateHostsWithContext(ctx, input)
@@ -129,8 +126,6 @@ func resourceHostCreate(ctx context.Context, d *schema.ResourceData, meta interf
 func resourceHostRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	host, err := FindHostByID(ctx, conn, d.Id())
 
@@ -160,16 +155,7 @@ func resourceHostRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	d.Set("outpost_arn", host.OutpostArn)
 	d.Set("owner_id", host.OwnerId)
 
-	tags := KeyValueTags(ctx, host.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, host.Tags)
 
 	return diags
 }
@@ -211,13 +197,6 @@ func resourceHostUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 
 		if _, err := WaitHostUpdated(ctx, conn, d.Id()); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for EC2 Host (%s) update: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating EC2 Host (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ec2/ec2_placement_group.go
+++ b/internal/service/ec2/ec2_placement_group.go
@@ -22,7 +22,7 @@ import (
 )
 
 // @SDKResource("aws_placement_group", name="Placement Group")
-// @Tags(identifierAttribute="id")
+// @Tags(identifierAttribute="placement_group_id")
 func ResourcePlacementGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePlacementGroupCreate,

--- a/internal/service/ec2/ec2_placement_group.go
+++ b/internal/service/ec2/ec2_placement_group.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_placement_group")
+// @SDKResource("aws_placement_group", name="Placement Group")
+// @Tags(identifierAttribute="id")
 func ResourcePlacementGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePlacementGroupCreate,
@@ -67,8 +69,8 @@ func ResourcePlacementGroup() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice(ec2.PlacementStrategy_Values(), false),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: customdiff.All(
@@ -81,14 +83,12 @@ func ResourcePlacementGroup() *schema.Resource {
 func resourcePlacementGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &ec2.CreatePlacementGroupInput{
 		GroupName:         aws.String(name),
 		Strategy:          aws.String(d.Get("strategy").(string)),
-		TagSpecifications: tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypePlacementGroup),
+		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypePlacementGroup),
 	}
 
 	if v, ok := d.GetOk("partition_count"); ok {
@@ -119,8 +119,6 @@ func resourcePlacementGroupCreate(ctx context.Context, d *schema.ResourceData, m
 func resourcePlacementGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	pg, err := FindPlacementGroupByName(ctx, conn, d.Id())
 
@@ -148,31 +146,15 @@ func resourcePlacementGroupRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("spread_level", pg.SpreadLevel)
 	d.Set("strategy", pg.Strategy)
 
-	tags := KeyValueTags(ctx, pg.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, pg.Tags)
 
 	return diags
 }
 
 func resourcePlacementGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).EC2Conn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("placement_group_id").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating EC2 Placement Group (%s) tags: %s", d.Id(), err)
-		}
-	}
+	// Tags only.
 
 	return append(diags, resourcePlacementGroupRead(ctx, d, meta)...)
 }

--- a/internal/service/ec2/ec2_spot_fleet_request.go
+++ b/internal/service/ec2/ec2_spot_fleet_request.go
@@ -23,9 +23,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_spot_fleet_request")
+// @SDKResource("aws_spot_fleet_request", name="Spot Fleet Request")
+// @Tags(identifierAttribute="id")
 func ResourceSpotFleetRequest() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{
@@ -804,8 +806,8 @@ func ResourceSpotFleetRequest() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"target_capacity": {
 				Type:     schema.TypeInt,
 				Required: true,
@@ -860,13 +862,8 @@ func ResourceSpotFleetRequest() *schema.Resource {
 }
 
 func resourceSpotFleetRequestCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var
-	// http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotFleet.html
-	diags diag.Diagnostics
-
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	_, launchSpecificationOk := d.GetOk("launch_specification")
 
@@ -876,7 +873,7 @@ func resourceSpotFleetRequestCreate(ctx context.Context, d *schema.ResourceData,
 		IamFleetRole:                     aws.String(d.Get("iam_fleet_role").(string)),
 		InstanceInterruptionBehavior:     aws.String(d.Get("instance_interruption_behaviour").(string)),
 		ReplaceUnhealthyInstances:        aws.Bool(d.Get("replace_unhealthy_instances").(bool)),
-		TagSpecifications:                tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeSpotFleetRequest),
+		TagSpecifications:                getTagSpecificationsIn(ctx, ec2.ResourceTypeSpotFleetRequest),
 		TargetCapacity:                   aws.Int64(int64(d.Get("target_capacity").(int))),
 		TerminateInstancesWithExpiration: aws.Bool(d.Get("terminate_instances_with_expiration").(bool)),
 		Type:                             aws.String(d.Get("fleet_type").(string)),
@@ -1013,13 +1010,8 @@ func resourceSpotFleetRequestCreate(ctx context.Context, d *schema.ResourceData,
 }
 
 func resourceSpotFleetRequestRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var
-	// http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSpotFleetRequests.html
-	diags diag.Diagnostics
-
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	output, err := FindSpotFleetRequestByID(ctx, conn, d.Id())
 
@@ -1065,16 +1057,7 @@ func resourceSpotFleetRequestRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("fleet_type", config.Type)
 	d.Set("launch_specification", launchSpec)
 
-	tags := KeyValueTags(ctx, output.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, output.Tags)
 
 	if err := d.Set("launch_template_config", flattenLaunchTemplateConfigs(config.LaunchTemplateConfigs)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting launch_template_config: %s", err)
@@ -1112,9 +1095,7 @@ func resourceSpotFleetRequestRead(ctx context.Context, d *schema.ResourceData, m
 }
 
 func resourceSpotFleetRequestUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var
-	// http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifySpotFleetRequest.html
-	diags diag.Diagnostics
+	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Conn()
 
@@ -1144,14 +1125,6 @@ func resourceSpotFleetRequestUpdate(ctx context.Context, d *schema.ResourceData,
 
 		if _, err := WaitSpotFleetRequestUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for EC2 Spot Fleet Request (%s) update: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
 		}
 	}
 

--- a/internal/service/ec2/ipam_pool.go
+++ b/internal/service/ec2/ipam_pool.go
@@ -22,6 +22,7 @@ import (
 )
 
 // @SDKResource("aws_vpc_ipam_pool", name="IPAM Pool")
+// @Tags(identifierAttribute="id")
 func ResourceIPAMPool() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceIPAMPoolCreate,

--- a/internal/service/ec2/ipam_pool.go
+++ b/internal/service/ec2/ipam_pool.go
@@ -18,9 +18,10 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_vpc_ipam_pool")
+// @SDKResource("aws_vpc_ipam_pool", name="IPAM Pool")
 func ResourceIPAMPool() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceIPAMPoolCreate,
@@ -129,8 +130,8 @@ func ResourceIPAMPool() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -140,15 +141,13 @@ func ResourceIPAMPool() *schema.Resource {
 func resourceIPAMPoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	addressFamily := d.Get("address_family").(string)
 	input := &ec2.CreateIpamPoolInput{
 		AddressFamily:     aws.String(addressFamily),
 		ClientToken:       aws.String(id.UniqueId()),
 		IpamScopeId:       aws.String(d.Get("ipam_scope_id").(string)),
-		TagSpecifications: tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeIpamPool),
+		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypeIpamPool),
 	}
 
 	if v, ok := d.GetOk("allocation_default_netmask_length"); ok {
@@ -217,8 +216,6 @@ func resourceIPAMPoolCreate(ctx context.Context, d *schema.ResourceData, meta in
 func resourceIPAMPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	pool, err := FindIPAMPoolByID(ctx, conn, d.Id())
 
@@ -248,16 +245,7 @@ func resourceIPAMPoolRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("source_ipam_pool_id", pool.SourceIpamPoolId)
 	d.Set("state", pool.State)
 
-	tags := KeyValueTags(ctx, pool.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, pool.Tags)
 
 	return diags
 }
@@ -313,14 +301,6 @@ func resourceIPAMPoolUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 		if _, err := WaitIPAMPoolUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for IPAM Pool (%s) update: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating IPAM Pool (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ec2/ipam_resource_discovery.go
+++ b/internal/service/ec2/ipam_resource_discovery.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_vpc_ipam_resource_discovery")
+// @SDKResource("aws_vpc_ipam_resource_discovery", name="IPAM Resource Discovery")
+// @Tags(identifierAttribute="id")
 func ResourceIPAMResourceDiscovery() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceIPAMResourceDiscoveryCreate,
@@ -72,8 +74,8 @@ func ResourceIPAMResourceDiscovery() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: customdiff.Sequence(
@@ -99,13 +101,11 @@ func ResourceIPAMResourceDiscovery() *schema.Resource {
 func resourceIPAMResourceDiscoveryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &ec2.CreateIpamResourceDiscoveryInput{
 		ClientToken:       aws.String(id.UniqueId()),
 		OperatingRegions:  expandIPAMOperatingRegions(d.Get("operating_regions").(*schema.Set).List()),
-		TagSpecifications: tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeIpamResourceDiscovery),
+		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypeIpamResourceDiscovery),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -130,8 +130,6 @@ func resourceIPAMResourceDiscoveryCreate(ctx context.Context, d *schema.Resource
 func resourceIPAMResourceDiscoveryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	rd, err := FindIPAMResourceDiscoveryByID(ctx, conn, d.Id())
 
@@ -154,16 +152,7 @@ func resourceIPAMResourceDiscoveryRead(ctx context.Context, d *schema.ResourceDa
 	}
 	d.Set("owner_id", rd.OwnerId)
 
-	tags := KeyValueTags(ctx, rd.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, rd.Tags)
 
 	return diags
 }
@@ -212,14 +201,6 @@ func resourceIPAMResourceDiscoveryUpdate(ctx context.Context, d *schema.Resource
 
 		if _, err := WaitIPAMResourceDiscoveryUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for IPAM Resource Discovery (%s) update: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating IPAM Resource Discovery (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ec2/ipam_resource_discovery_association.go
+++ b/internal/service/ec2/ipam_resource_discovery_association.go
@@ -21,6 +21,7 @@ import (
 )
 
 // @SDKResource("aws_vpc_ipam_resource_discovery_association", name="IPAM Resource Discovery Association")
+// @Tags(identifierAttribute="id")
 func ResourceIPAMResourceDiscoveryAssociation() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceIPAMResourceDiscoveryAssociationCreate,

--- a/internal/service/ec2/ipam_resource_discovery_association.go
+++ b/internal/service/ec2/ipam_resource_discovery_association.go
@@ -17,9 +17,10 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_vpc_ipam_resource_discovery_association")
+// @SDKResource("aws_vpc_ipam_resource_discovery_association", name="IPAM Resource Discovery Association")
 func ResourceIPAMResourceDiscoveryAssociation() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceIPAMResourceDiscoveryAssociationCreate,
@@ -72,8 +73,8 @@ func ResourceIPAMResourceDiscoveryAssociation() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -81,8 +82,6 @@ func ResourceIPAMResourceDiscoveryAssociation() *schema.Resource {
 func resourceIPAMResourceDiscoveryAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	ipamID := d.Get("ipam_id").(string)
 	ipamResourceDiscoveryID := d.Get("ipam_resource_discovery_id").(string)
@@ -90,7 +89,7 @@ func resourceIPAMResourceDiscoveryAssociationCreate(ctx context.Context, d *sche
 		ClientToken:             aws.String(id.UniqueId()),
 		IpamId:                  aws.String(ipamID),
 		IpamResourceDiscoveryId: aws.String(ipamResourceDiscoveryID),
-		TagSpecifications:       tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeIpamResourceDiscoveryAssociation),
+		TagSpecifications:       getTagSpecificationsIn(ctx, ec2.ResourceTypeIpamResourceDiscoveryAssociation),
 	}
 
 	output, err := conn.AssociateIpamResourceDiscoveryWithContext(ctx, input)
@@ -111,8 +110,6 @@ func resourceIPAMResourceDiscoveryAssociationCreate(ctx context.Context, d *sche
 func resourceIPAMResourceDiscoveryAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	rda, err := FindIPAMResourceDiscoveryAssociationByID(ctx, conn, d.Id())
 
@@ -135,33 +132,17 @@ func resourceIPAMResourceDiscoveryAssociationRead(ctx context.Context, d *schema
 	d.Set("owner_id", rda.OwnerId)
 	d.Set("state", rda.State)
 
-	tags := KeyValueTags(ctx, rda.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, rda.Tags)
 
 	return nil
 }
 
 func resourceIPAMResourceDiscoveryAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).EC2Conn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
+	// Tags only.
 
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating IPAM Resource Discovery Association (%s) tags: %s", d.Id(), err)
-		}
-	}
-
-	return nil
+	return append(diags, resourceIPAMResourceDiscoveryAssociationRead(ctx, d, meta)...)
 }
 
 func resourceIPAMResourceDiscoveryAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/ec2/outposts_local_gateway_route_table_vpc_association.go
+++ b/internal/service/ec2/outposts_local_gateway_route_table_vpc_association.go
@@ -14,9 +14,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ec2_local_gateway_route_table_vpc_association")
+// @SDKResource("aws_ec2_local_gateway_route_table_vpc_association", name="Local Gateway Route Table VPC Association")
+// @Tags(identifierAttribute="id")
 func ResourceLocalGatewayRouteTableVPCAssociation() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceLocalGatewayRouteTableVPCAssociationCreate,
@@ -39,8 +41,8 @@ func ResourceLocalGatewayRouteTableVPCAssociation() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -53,12 +55,10 @@ func ResourceLocalGatewayRouteTableVPCAssociation() *schema.Resource {
 func resourceLocalGatewayRouteTableVPCAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	req := &ec2.CreateLocalGatewayRouteTableVpcAssociationInput{
 		LocalGatewayRouteTableId: aws.String(d.Get("local_gateway_route_table_id").(string)),
-		TagSpecifications:        tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeLocalGatewayRouteTableVpcAssociation),
+		TagSpecifications:        getTagSpecificationsIn(ctx, ec2.ResourceTypeLocalGatewayRouteTableVpcAssociation),
 		VpcId:                    aws.String(d.Get("vpc_id").(string)),
 	}
 
@@ -80,8 +80,6 @@ func resourceLocalGatewayRouteTableVPCAssociationCreate(ctx context.Context, d *
 func resourceLocalGatewayRouteTableVPCAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	association, err := GetLocalGatewayRouteTableVPCAssociation(ctx, conn, d.Id())
 
@@ -104,16 +102,7 @@ func resourceLocalGatewayRouteTableVPCAssociationRead(ctx context.Context, d *sc
 	d.Set("local_gateway_id", association.LocalGatewayId)
 	d.Set("local_gateway_route_table_id", association.LocalGatewayRouteTableId)
 
-	tags := KeyValueTags(ctx, association.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, association.Tags)
 
 	d.Set("vpc_id", association.VpcId)
 
@@ -122,15 +111,8 @@ func resourceLocalGatewayRouteTableVPCAssociationRead(ctx context.Context, d *sc
 
 func resourceLocalGatewayRouteTableVPCAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).EC2Conn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating EC2 Local Gateway Route Table VPC Association (%s) tags: %s", d.Id(), err)
-		}
-	}
+	// Tags only.
 
 	return append(diags, resourceLocalGatewayRouteTableVPCAssociationRead(ctx, d, meta)...)
 }

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -695,6 +695,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceLaunchTemplate,
 			TypeName: "aws_launch_template",
+			Name:     "Launch Template",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceMainRouteTableAssociation,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -431,14 +431,26 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceEBSSnapshot,
 			TypeName: "aws_ebs_snapshot",
+			Name:     "EBS Snapshot",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceEBSSnapshotCopy,
 			TypeName: "aws_ebs_snapshot_copy",
+			Name:     "EBS Snapshot",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceEBSSnapshotImport,
 			TypeName: "aws_ebs_snapshot_import",
+			Name:     "EBS Snapshot",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceEBSVolume,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -412,6 +412,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDefaultNetworkACL,
 			TypeName: "aws_default_network_acl",
+			Name:     "Network ACL",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceDefaultRouteTable,
@@ -776,6 +780,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceNetworkACL,
 			TypeName: "aws_network_acl",
+			Name:     "Network ACL",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceNetworkACLAssociation,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -455,6 +455,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceEBSVolume,
 			TypeName: "aws_ebs_volume",
+			Name:     "EBS Volume",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceAvailabilityZoneGroup,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -507,6 +507,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceFleet,
 			TypeName: "aws_ec2_fleet",
+			Name:     "Fleet",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceHost,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -1034,6 +1034,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			Factory:  ResourceIPAMResourceDiscoveryAssociation,
 			TypeName: "aws_vpc_ipam_resource_discovery_association",
 			Name:     "IPAM Resource Discovery Association",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceIPAMScope,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -591,10 +591,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceTransitGatewayConnect,
 			TypeName: "aws_ec2_transit_gateway_connect",
+			Name:     "Transit Gateway Connect",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTransitGatewayConnectPeer,
 			TypeName: "aws_ec2_transit_gateway_connect_peer",
+			Name:     "Transit Gateway Connect Peer",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTransitGatewayMulticastDomain,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -643,6 +643,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceTransitGatewayPolicyTable,
 			TypeName: "aws_ec2_transit_gateway_policy_table",
+			Name:     "Transit Gateway Policy Table",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTransitGatewayPolicyTableAssociation,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -916,6 +916,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceVPCEndpoint,
 			TypeName: "aws_vpc_endpoint",
+			Name:     "VPC Endpoint",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceVPCEndpointConnectionAccepter,
@@ -940,6 +944,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceVPCEndpointService,
 			TypeName: "aws_vpc_endpoint_service",
+			Name:     "VPC Endpoint Service",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceVPCEndpointServiceAllowedPrincipal,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -627,10 +627,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceTransitGatewayPeeringAttachment,
 			TypeName: "aws_ec2_transit_gateway_peering_attachment",
+			Name:     "Transit Gateway Peering Attachment",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTransitGatewayPeeringAttachmentAccepter,
 			TypeName: "aws_ec2_transit_gateway_peering_attachment_accepter",
+			Name:     "Transit Gateway Peering Attachment",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTransitGatewayPolicyTable,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -876,6 +876,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceIPAMResourceDiscovery,
 			TypeName: "aws_vpc_ipam_resource_discovery",
+			Name:     "IPAM Resource Discovery",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceIPAMResourceDiscoveryAssociation,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -552,6 +552,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceManagedPrefixList,
 			TypeName: "aws_ec2_managed_prefix_list",
+			Name:     "Managed Prefix List",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceManagedPrefixListEntry,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -408,6 +408,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			Factory:  ResourceCustomerGateway,
 			TypeName: "aws_customer_gateway",
 			Name:     "Customer Gateway",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceDefaultNetworkACL,
@@ -862,7 +865,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			TypeName: "aws_placement_group",
 			Name:     "Placement Group",
 			Tags: &types.ServicePackageResourceTags{
-				IdentifierAttribute: "id",
+				IdentifierAttribute: "placement_group_id",
 			},
 		},
 		{
@@ -1009,6 +1012,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			Factory:  ResourceIPAMPool,
 			TypeName: "aws_vpc_ipam_pool",
 			Name:     "IPAM Pool",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceIPAMPoolCIDR,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -748,6 +748,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceFlowLog,
 			TypeName: "aws_flow_log",
+			Name:     "Flow Log",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceInstance,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -379,14 +379,26 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceAMI,
 			TypeName: "aws_ami",
+			Name:     "AMI",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceAMICopy,
 			TypeName: "aws_ami_copy",
+			Name:     "AMI",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceAMIFromInstance,
 			TypeName: "aws_ami_from_instance",
+			Name:     "AMI",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceAMILaunchPermission,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -500,6 +500,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceClientVPNEndpoint,
 			TypeName: "aws_ec2_client_vpn_endpoint",
+			Name:     "Client VPN Endpoint",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceClientVPNNetworkAssociation,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -732,6 +732,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceEgressOnlyInternetGateway,
 			TypeName: "aws_egress_only_internet_gateway",
+			Name:     "Egress-only Internet Gateway",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceEIP,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -994,10 +994,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceVPCPeeringConnection,
 			TypeName: "aws_vpc_peering_connection",
+			Name:     "VPC Peering Connection",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceVPCPeeringConnectionAccepter,
 			TypeName: "aws_vpc_peering_connection_accepter",
+			Name:     "VPC Peering Connection",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceVPCPeeringConnectionOptions,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -515,6 +515,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceHost,
 			TypeName: "aws_ec2_host",
+			Name:     "Host",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceInstanceState,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -583,6 +583,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceTransitGateway,
 			TypeName: "aws_ec2_transit_gateway",
+			Name:     "Transit Gateway",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTransitGatewayConnect,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -420,6 +420,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDefaultRouteTable,
 			TypeName: "aws_default_route_table",
+			Name:     "Route Table",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceDefaultSecurityGroup,
@@ -856,6 +860,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceRouteTable,
 			TypeName: "aws_route_table",
+			Name:     "Route Table",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceRouteTableAssociation,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -432,6 +432,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDefaultVPC,
 			TypeName: "aws_default_vpc",
+			Name:     "VPC",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceDefaultVPCDHCPOptions,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -663,6 +663,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceTransitGatewayRouteTable,
 			TypeName: "aws_ec2_transit_gateway_route_table",
+			Name:     "Transit Gateway Route Table",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTransitGatewayRouteTableAssociation,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -428,6 +428,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDefaultSecurityGroup,
 			TypeName: "aws_default_security_group",
+			Name:     "Security Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceDefaultSubnet,
@@ -872,6 +876,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceSecurityGroup,
 			TypeName: "aws_security_group",
+			Name:     "Security Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceSecurityGroupRule,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -735,6 +735,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourcePlacementGroup,
 			TypeName: "aws_placement_group",
+			Name:     "Placement Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceRoute,
@@ -767,6 +771,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceSpotFleetRequest,
 			TypeName: "aws_spot_fleet_request",
+			Name:     "Spot Fleet Request",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceSpotInstanceRequest,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -607,6 +607,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceTransitGatewayMulticastDomain,
 			TypeName: "aws_ec2_transit_gateway_multicast_domain",
+			Name:     "Transit Gateway Multicast Domain",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTransitGatewayMulticastDomainAssociation,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -760,6 +760,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceInternetGateway,
 			TypeName: "aws_internet_gateway",
+			Name:     "Internet Gateway",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceInternetGatewayAttachment,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -407,6 +407,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCustomerGateway,
 			TypeName: "aws_customer_gateway",
+			Name:     "Customer Gateway",
 		},
 		{
 			Factory:  ResourceDefaultNetworkACL,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -531,6 +531,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceLocalGatewayRouteTableVPCAssociation,
 			TypeName: "aws_ec2_local_gateway_route_table_vpc_association",
+			Name:     "Local Gateway Route Table VPC Association",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceManagedPrefixList,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -880,6 +880,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceIPAMResourceDiscoveryAssociation,
 			TypeName: "aws_vpc_ipam_resource_discovery_association",
+			Name:     "IPAM Resource Discovery Association",
 		},
 		{
 			Factory:  ResourceIPAMScope,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -671,6 +671,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceInstance,
 			TypeName: "aws_instance",
+			Name:     "Instance",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceInternetGateway,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -889,6 +889,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceIPAMScope,
 			TypeName: "aws_vpc_ipam_scope",
+			Name:     "IPAM Scope",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceVPCIPv4CIDRBlockAssociation,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -576,6 +576,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceTrafficMirrorFilter,
 			TypeName: "aws_ec2_traffic_mirror_filter",
+			Name:     "Traffic Mirror Filter",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTrafficMirrorFilterRule,
@@ -584,10 +588,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceTrafficMirrorSession,
 			TypeName: "aws_ec2_traffic_mirror_session",
+			Name:     "Traffic Mirror Session",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTrafficMirrorTarget,
 			TypeName: "aws_ec2_traffic_mirror_target",
+			Name:     "Traffic Mirror Target",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTransitGateway,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -487,6 +487,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCarrierGateway,
 			TypeName: "aws_ec2_carrier_gateway",
+			Name:     "Carrier Gateway",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceClientVPNAuthorizationRule,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -779,6 +779,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceSpotInstanceRequest,
 			TypeName: "aws_spot_instance_request",
+			Name:     "Spot Instance Request",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceSubnet,
@@ -843,6 +847,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceIPAM,
 			TypeName: "aws_vpc_ipam",
+			Name:     "IPAM",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceIPAMOrganizationAdminAccount,
@@ -851,6 +859,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceIPAMPool,
 			TypeName: "aws_vpc_ipam_pool",
+			Name:     "IPAM Pool",
 		},
 		{
 			Factory:  ResourceIPAMPoolCIDR,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -808,6 +808,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceNetworkInterface,
 			TypeName: "aws_network_interface",
+			Name:     "Network Interface",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceNetworkInterfaceAttachment,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -479,6 +479,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCapacityReservation,
 			TypeName: "aws_ec2_capacity_reservation",
+			Name:     "Capacity Reservation",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceCarrierGateway,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -969,6 +969,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceVPNConnection,
 			TypeName: "aws_vpn_connection",
+			Name:     "VPN Connection",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceVPNConnectionRoute,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -452,6 +452,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDefaultVPCDHCPOptions,
 			TypeName: "aws_default_vpc_dhcp_options",
+			Name:     "DHCP Options",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceEBSDefaultKMSKey,
@@ -936,6 +940,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceVPCDHCPOptions,
 			TypeName: "aws_vpc_dhcp_options",
+			Name:     "DHCP Options",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceVPCDHCPOptionsAssociation,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -647,6 +647,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceEIP,
 			TypeName: "aws_eip",
+			Name:     "EIP",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceEIPAssociation,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -776,6 +776,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceNATGateway,
 			TypeName: "aws_nat_gateway",
+			Name:     "NAT Gateway",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceNetworkACL,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -679,10 +679,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceTransitGatewayVPCAttachment,
 			TypeName: "aws_ec2_transit_gateway_vpc_attachment",
+			Name:     "Transit Gateway VPC Attachment",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTransitGatewayVPCAttachmentAccepter,
 			TypeName: "aws_ec2_transit_gateway_vpc_attachment_accepter",
+			Name:     "Transit Gateway VPC Attachment",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceEgressOnlyInternetGateway,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -560,10 +560,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceNetworkInsightsAnalysis,
 			TypeName: "aws_ec2_network_insights_analysis",
+			Name:     "Network Insights Analysis",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceNetworkInsightsPath,
 			TypeName: "aws_ec2_network_insights_path",
+			Name:     "Network Insights Path",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceSerialConsoleAccess,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -436,6 +436,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDefaultSubnet,
 			TypeName: "aws_default_subnet",
+			Name:     "Subnet",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceDefaultVPC,
@@ -912,6 +916,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceSubnet,
 			TypeName: "aws_subnet",
+			Name:     "Subnet",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceVolumeAttachment,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -687,6 +687,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceKeyPair,
 			TypeName: "aws_key_pair",
+			Name:     "Key Pair",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "key_pair_id",
+			},
 		},
 		{
 			Factory:  ResourceLaunchTemplate,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -982,6 +982,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceVPNGateway,
 			TypeName: "aws_vpn_gateway",
+			Name:     "VPN Gateway",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceVPNGatewayAttachment,

--- a/internal/service/ec2/tags.go
+++ b/internal/service/ec2/tags.go
@@ -9,20 +9,6 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 )
 
-// tagSpecificationsFromKeyValueTags returns the tag specifications for the given KeyValueTags object and resource type.
-func tagSpecificationsFromKeyValueTags(tags tftags.KeyValueTags, t string) []*ec2.TagSpecification {
-	if len(tags) == 0 {
-		return nil
-	}
-
-	return []*ec2.TagSpecification{
-		{
-			ResourceType: aws.String(t),
-			Tags:         Tags(tags.IgnoreAWS()),
-		},
-	}
-}
-
 // tagSpecificationsFromMap returns the tag specifications for the given tag key/value map and resource type.
 func tagSpecificationsFromMap(ctx context.Context, m map[string]interface{}, t string) []*ec2.TagSpecification {
 	if len(m) == 0 {

--- a/internal/service/ec2/tags.go
+++ b/internal/service/ec2/tags.go
@@ -37,14 +37,18 @@ func tagSpecificationsFromMap(ctx context.Context, m map[string]interface{}, t s
 	}
 }
 
-func tagSpecificationsFromTags(tags []*ec2.Tag, t string) []*ec2.TagSpecification {
+// getTagSpecificationsIn returns EC2 service tags from Context.
+// nil is returned if there are no input tags.
+func getTagSpecificationsIn(ctx context.Context, resourceType string) []*ec2.TagSpecification {
+	tags := GetTagsIn(ctx)
+
 	if len(tags) == 0 {
 		return nil
 	}
 
 	return []*ec2.TagSpecification{
 		{
-			ResourceType: aws.String(t),
+			ResourceType: aws.String(resourceType),
 			Tags:         tags,
 		},
 	}

--- a/internal/service/ec2/transitgateway_.go
+++ b/internal/service/ec2/transitgateway_.go
@@ -19,9 +19,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ec2_transit_gateway")
+// @SDKResource("aws_ec2_transit_gateway", name="Transit Gateway")
+// @Tags(identifierAttribute="id")
 func ResourceTransitGateway() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTransitGatewayCreate,
@@ -108,8 +110,8 @@ func ResourceTransitGateway() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"transit_gateway_cidr_blocks": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -138,8 +140,6 @@ func ResourceTransitGateway() *schema.Resource {
 func resourceTransitGatewayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &ec2.CreateTransitGatewayInput{
 		Options: &ec2.TransitGatewayRequestOptions{
@@ -150,7 +150,7 @@ func resourceTransitGatewayCreate(ctx context.Context, d *schema.ResourceData, m
 			MulticastSupport:             aws.String(d.Get("multicast_support").(string)),
 			VpnEcmpSupport:               aws.String(d.Get("vpn_ecmp_support").(string)),
 		},
-		TagSpecifications: tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeTransitGateway),
+		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypeTransitGateway),
 	}
 
 	if v, ok := d.GetOk("amazon_side_asn"); ok {
@@ -184,8 +184,6 @@ func resourceTransitGatewayCreate(ctx context.Context, d *schema.ResourceData, m
 func resourceTransitGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	transitGateway, err := FindTransitGatewayByID(ctx, conn, d.Id())
 
@@ -213,16 +211,7 @@ func resourceTransitGatewayRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("transit_gateway_cidr_blocks", aws.StringValueSlice(transitGateway.Options.TransitGatewayCidrBlocks))
 	d.Set("vpn_ecmp_support", transitGateway.Options.VpnEcmpSupport)
 
-	tags := KeyValueTags(ctx, transitGateway.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, transitGateway.Tags)
 
 	return diags
 }
@@ -284,14 +273,6 @@ func resourceTransitGatewayUpdate(ctx context.Context, d *schema.ResourceData, m
 
 		if _, err := WaitTransitGatewayUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for EC2 Transit Gateway (%s) update: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating EC2 Transit Gateway (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ec2/transitgateway_connect.go
+++ b/internal/service/ec2/transitgateway_connect.go
@@ -15,9 +15,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ec2_transit_gateway_connect")
+// @SDKResource("aws_ec2_transit_gateway_connect", name="Transit Gateway Connect")
+// @Tags(identifierAttribute="id")
 func ResourceTransitGatewayConnect() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTransitGatewayConnectCreate,
@@ -45,8 +47,8 @@ func ResourceTransitGatewayConnect() *schema.Resource {
 				Default:      ec2.ProtocolValueGre,
 				ValidateFunc: validation.StringInSlice(ec2.ProtocolValue_Values(), false),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"transit_gateway_default_route_table_association": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -75,16 +77,13 @@ func ResourceTransitGatewayConnect() *schema.Resource {
 
 func resourceTransitGatewayConnectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	transportAttachmentID := d.Get("transport_attachment_id").(string)
-
 	input := &ec2.CreateTransitGatewayConnectInput{
 		Options: &ec2.CreateTransitGatewayConnectRequestOptions{
 			Protocol: aws.String(d.Get("protocol").(string)),
 		},
-		TagSpecifications:                   tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeTransitGatewayAttachment),
+		TagSpecifications:                   getTagSpecificationsIn(ctx, ec2.ResourceTypeTransitGatewayAttachment),
 		TransportTransitGatewayAttachmentId: aws.String(transportAttachmentID),
 	}
 
@@ -130,8 +129,6 @@ func resourceTransitGatewayConnectCreate(ctx context.Context, d *schema.Resource
 
 func resourceTransitGatewayConnectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	transitGatewayConnect, err := FindTransitGatewayConnectByID(ctx, conn, d.Id())
 
@@ -194,16 +191,7 @@ func resourceTransitGatewayConnectRead(ctx context.Context, d *schema.ResourceDa
 	d.Set("transit_gateway_id", transitGatewayConnect.TransitGatewayId)
 	d.Set("transport_attachment_id", transitGatewayConnect.TransportTransitGatewayAttachmentId)
 
-	tags := KeyValueTags(ctx, transitGatewayConnect.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, transitGatewayConnect.Tags)
 
 	return nil
 }
@@ -229,14 +217,6 @@ func resourceTransitGatewayConnectUpdate(ctx context.Context, d *schema.Resource
 			if err := transitGatewayRouteTablePropagationUpdate(ctx, conn, aws.StringValue(transitGateway.Options.PropagationDefaultRouteTableId), d.Id(), d.Get("transit_gateway_default_route_table_propagation").(bool)); err != nil {
 				return diag.FromErr(err)
 			}
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return diag.Errorf("updating EC2 Transit Gateway Connect (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ec2/transitgateway_peering_attachment_accepter.go
+++ b/internal/service/ec2/transitgateway_peering_attachment_accepter.go
@@ -14,9 +14,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ec2_transit_gateway_peering_attachment_accepter")
+// @SDKResource("aws_ec2_transit_gateway_peering_attachment_accepter", name="Transit Gateway Peering Attachment")
+// @Tags(identifierAttribute="id")
 func ResourceTransitGatewayPeeringAttachmentAccepter() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTransitGatewayPeeringAttachmentAccepterCreate,
@@ -43,8 +45,8 @@ func ResourceTransitGatewayPeeringAttachmentAccepter() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"transit_gateway_attachment_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -61,8 +63,6 @@ func ResourceTransitGatewayPeeringAttachmentAccepter() *schema.Resource {
 func resourceTransitGatewayPeeringAttachmentAccepterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	transitGatewayAttachmentID := d.Get("transit_gateway_attachment_id").(string)
 	input := &ec2.AcceptTransitGatewayPeeringAttachmentInput{
@@ -82,7 +82,7 @@ func resourceTransitGatewayPeeringAttachmentAccepterCreate(ctx context.Context, 
 		return sdkdiag.AppendErrorf(diags, "waiting for EC2 Transit Gateway Peering Attachment (%s) update: %s", d.Id(), err)
 	}
 
-	if len(tags) > 0 {
+	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
 		if err := CreateTags(ctx, conn, d.Id(), tags); err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating EC2 Transit Gateway Peering Attachment (%s) tags: %s", d.Id(), err)
 		}
@@ -94,8 +94,6 @@ func resourceTransitGatewayPeeringAttachmentAccepterCreate(ctx context.Context, 
 func resourceTransitGatewayPeeringAttachmentAccepterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	transitGatewayPeeringAttachment, err := FindTransitGatewayPeeringAttachmentByID(ctx, conn, d.Id())
 
@@ -122,33 +120,17 @@ func resourceTransitGatewayPeeringAttachmentAccepterRead(ctx context.Context, d 
 	d.Set("transit_gateway_attachment_id", transitGatewayPeeringAttachment.TransitGatewayAttachmentId)
 	d.Set("transit_gateway_id", transitGatewayPeeringAttachment.AccepterTgwInfo.TransitGatewayId)
 
-	tags := KeyValueTags(ctx, transitGatewayPeeringAttachment.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, transitGatewayPeeringAttachment.Tags)
 
 	return diags
 }
 
 func resourceTransitGatewayPeeringAttachmentAccepterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).EC2Conn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
+	// Tags only.
 
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating EC2 Transit Gateway Peering Attachment (%s) tags: %s", d.Id(), err)
-		}
-	}
-
-	return diags
+	return append(diags, resourceTransitGatewayPeeringAttachmentAccepterRead(ctx, d, meta)...)
 }
 
 func resourceTransitGatewayPeeringAttachmentAccepterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/ec2/transitgateway_peering_attachment_accepter_test.go
+++ b/internal/service/ec2/transitgateway_peering_attachment_accepter_test.go
@@ -53,7 +53,7 @@ func testAccTransitGatewayPeeringAttachmentAccepter_basic(t *testing.T) {
 	})
 }
 
-func testAccTransitGatewayPeeringAttachmentAccepter_Tags(t *testing.T) {
+func testAccTransitGatewayPeeringAttachmentAccepter_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var transitGatewayPeeringAttachment ec2.TransitGatewayPeeringAttachment
 	resourceName := "aws_ec2_transit_gateway_peering_attachment_accepter.test"

--- a/internal/service/ec2/transitgateway_peering_attachment_test.go
+++ b/internal/service/ec2/transitgateway_peering_attachment_test.go
@@ -82,7 +82,7 @@ func testAccTransitGatewayPeeringAttachment_disappears(t *testing.T) {
 	})
 }
 
-func testAccTransitGatewayPeeringAttachment_Tags(t *testing.T) {
+func testAccTransitGatewayPeeringAttachment_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var transitGatewayPeeringAttachment ec2.TransitGatewayPeeringAttachment
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/ec2/transitgateway_policy_table_test.go
+++ b/internal/service/ec2/transitgateway_policy_table_test.go
@@ -101,7 +101,7 @@ func testAccTransitGatewayPolicyTable_disappears_TransitGateway(t *testing.T) {
 	})
 }
 
-func testAccTransitGatewayPolicyTable_Tags(t *testing.T) {
+func testAccTransitGatewayPolicyTable_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var transitGatewayPolicyTable1, transitGatewayPolicyTable2, transitGatewayPolicyTable3 ec2.TransitGatewayPolicyTable
 	resourceName := "aws_ec2_transit_gateway_policy_table.test"

--- a/internal/service/ec2/transitgateway_route_table.go
+++ b/internal/service/ec2/transitgateway_route_table.go
@@ -17,9 +17,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ec2_transit_gateway_route_table")
+// @SDKResource("aws_ec2_transit_gateway_route_table", name="Transit Gateway Route Table")
+// @Tags(identifierAttribute="id")
 func ResourceTransitGatewayRouteTable() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTransitGatewayRouteTableCreate,
@@ -46,8 +48,8 @@ func ResourceTransitGatewayRouteTable() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"transit_gateway_id": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -61,12 +63,10 @@ func ResourceTransitGatewayRouteTable() *schema.Resource {
 func resourceTransitGatewayRouteTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &ec2.CreateTransitGatewayRouteTableInput{
 		TransitGatewayId:  aws.String(d.Get("transit_gateway_id").(string)),
-		TagSpecifications: tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeTransitGatewayRouteTable),
+		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypeTransitGatewayRouteTable),
 	}
 
 	log.Printf("[DEBUG] Creating EC2 Transit Gateway Route Table: %s", input)
@@ -88,8 +88,6 @@ func resourceTransitGatewayRouteTableCreate(ctx context.Context, d *schema.Resou
 func resourceTransitGatewayRouteTableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	transitGatewayRouteTable, err := FindTransitGatewayRouteTableByID(ctx, conn, d.Id())
 
@@ -115,33 +113,17 @@ func resourceTransitGatewayRouteTableRead(ctx context.Context, d *schema.Resourc
 	d.Set("default_propagation_route_table", transitGatewayRouteTable.DefaultPropagationRouteTable)
 	d.Set("transit_gateway_id", transitGatewayRouteTable.TransitGatewayId)
 
-	tags := KeyValueTags(ctx, transitGatewayRouteTable.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, transitGatewayRouteTable.Tags)
 
 	return diags
 }
 
 func resourceTransitGatewayRouteTableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).EC2Conn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
+	// Tags only.
 
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating EC2 Transit Gateway Route Table (%s) tags: %s", d.Id(), err)
-		}
-	}
-
-	return diags
+	return append(diags, resourceTransitGatewayRouteTableRead(ctx, d, meta)...)
 }
 
 func resourceTransitGatewayRouteTableDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/ec2/transitgateway_route_table_test.go
+++ b/internal/service/ec2/transitgateway_route_table_test.go
@@ -102,7 +102,7 @@ func testAccTransitGatewayRouteTable_disappears_TransitGateway(t *testing.T) {
 	})
 }
 
-func testAccTransitGatewayRouteTable_Tags(t *testing.T) {
+func testAccTransitGatewayRouteTable_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var transitGatewayRouteTable1, transitGatewayRouteTable2, transitGatewayRouteTable3 ec2.TransitGatewayRouteTable
 	resourceName := "aws_ec2_transit_gateway_route_table.test"

--- a/internal/service/ec2/transitgateway_test.go
+++ b/internal/service/ec2/transitgateway_test.go
@@ -26,7 +26,7 @@ func TestAccTransitGateway_serial(t *testing.T) {
 		"Connect": {
 			"basic":      testAccTransitGatewayConnect_basic,
 			"disappears": testAccTransitGatewayConnect_disappears,
-			"Tags":       testAccTransitGatewayConnect_tags,
+			"tags":       testAccTransitGatewayConnect_tags,
 			"TransitGatewayDefaultRouteTableAssociation":                       testAccTransitGatewayConnect_TransitGatewayDefaultRouteTableAssociation,
 			"TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled": testAccTransitGatewayConnect_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled,
 			"TransitGatewayDefaultRouteTablePropagation":                       testAccTransitGatewayConnect_TransitGatewayDefaultRouteTablePropagation,
@@ -34,14 +34,15 @@ func TestAccTransitGateway_serial(t *testing.T) {
 		"ConnectPeer": {
 			"basic":                 testAccTransitGatewayConnectPeer_basic,
 			"disappears":            testAccTransitGatewayConnectPeer_disappears,
+			"tags":                  testAccTransitGatewayConnectPeer_tags,
 			"BgpAsn":                testAccTransitGatewayConnectPeer_bgpASN,
 			"InsideCidrBlocks":      testAccTransitGatewayConnectPeer_insideCIDRBlocks,
-			"Tags":                  testAccTransitGatewayConnectPeer_tags,
 			"TransitGatewayAddress": testAccTransitGatewayConnectPeer_TransitGatewayAddress,
 		},
 		"Gateway": {
 			"basic":                       testAccTransitGateway_basic,
 			"disappears":                  testAccTransitGateway_disappears,
+			"tags":                        testAccTransitGateway_tags,
 			"AmazonSideASN":               testAccTransitGateway_AmazonSideASN,
 			"AutoAcceptSharedAttachments": testAccTransitGateway_AutoAcceptSharedAttachments,
 			"CidrBlocks":                  testAccTransitGateway_cidrBlocks,
@@ -50,7 +51,6 @@ func TestAccTransitGateway_serial(t *testing.T) {
 			"DefaultRouteTablePropagation":                       testAccTransitGateway_DefaultRouteTablePropagation,
 			"Description":                                        testAccTransitGateway_Description,
 			"DnsSupport":                                         testAccTransitGateway_DNSSupport,
-			"Tags":                                               testAccTransitGateway_Tags,
 			"VpnEcmpSupport":                                     testAccTransitGateway_VPNECMPSupport,
 		},
 		"MulticastDomain": {
@@ -79,19 +79,19 @@ func TestAccTransitGateway_serial(t *testing.T) {
 		"PeeringAttachment": {
 			"basic":            testAccTransitGatewayPeeringAttachment_basic,
 			"disappears":       testAccTransitGatewayPeeringAttachment_disappears,
+			"tags":             testAccTransitGatewayPeeringAttachment_tags,
 			"DifferentAccount": testAccTransitGatewayPeeringAttachment_differentAccount,
-			"Tags":             testAccTransitGatewayPeeringAttachment_Tags,
 		},
 		"PeeringAttachmentAccepter": {
 			"basic":            testAccTransitGatewayPeeringAttachmentAccepter_basic,
+			"tags":             testAccTransitGatewayPeeringAttachmentAccepter_tags,
 			"DifferentAccount": testAccTransitGatewayPeeringAttachmentAccepter_differentAccount,
-			"Tags":             testAccTransitGatewayPeeringAttachmentAccepter_Tags,
 		},
 		"PolicyTable": {
 			"basic":                    testAccTransitGatewayPolicyTable_basic,
 			"disappears":               testAccTransitGatewayPolicyTable_disappears,
 			"disappearsTransitGateway": testAccTransitGatewayPolicyTable_disappears_TransitGateway,
-			"Tags":                     testAccTransitGatewayPolicyTable_Tags,
+			"tags":                     testAccTransitGatewayPolicyTable_tags,
 		},
 		"PolicyTableAssociation": {
 			"basic":      testAccTransitGatewayPolicyTableAssociation_basic,
@@ -114,7 +114,7 @@ func TestAccTransitGateway_serial(t *testing.T) {
 			"basic":                    testAccTransitGatewayRouteTable_basic,
 			"disappears":               testAccTransitGatewayRouteTable_disappears,
 			"disappearsTransitGateway": testAccTransitGatewayRouteTable_disappears_TransitGateway,
-			"Tags":                     testAccTransitGatewayRouteTable_Tags,
+			"tags":                     testAccTransitGatewayRouteTable_tags,
 		},
 		"RouteTableAssociation": {
 			"basic":      testAccTransitGatewayRouteTableAssociation_basic,
@@ -127,19 +127,19 @@ func TestAccTransitGateway_serial(t *testing.T) {
 		"VpcAttachment": {
 			"basic":                testAccTransitGatewayVPCAttachment_basic,
 			"disappears":           testAccTransitGatewayVPCAttachment_disappears,
+			"tags":                 testAccTransitGatewayVPCAttachment_tags,
 			"ApplianceModeSupport": testAccTransitGatewayVPCAttachment_ApplianceModeSupport,
 			"DnsSupport":           testAccTransitGatewayVPCAttachment_DNSSupport,
 			"Ipv6Support":          testAccTransitGatewayVPCAttachment_IPv6Support,
 			"SharedTransitGateway": testAccTransitGatewayVPCAttachment_SharedTransitGateway,
 			"SubnetIds":            testAccTransitGatewayVPCAttachment_SubnetIDs,
-			"Tags":                 testAccTransitGatewayVPCAttachment_Tags,
 			"TransitGatewayDefaultRouteTableAssociation":                       testAccTransitGatewayVPCAttachment_TransitGatewayDefaultRouteTableAssociation,
 			"TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled": testAccTransitGatewayVPCAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled,
 			"TransitGatewayDefaultRouteTablePropagation":                       testAccTransitGatewayVPCAttachment_TransitGatewayDefaultRouteTablePropagation,
 		},
 		"VpcAttachmentAccepter": {
 			"basic": testAccTransitGatewayVPCAttachmentAccepter_basic,
-			"Tags":  testAccTransitGatewayVPCAttachmentAccepter_Tags,
+			"tags":  testAccTransitGatewayVPCAttachmentAccepter_tags,
 			"TransitGatewayDefaultRouteTableAssociationAndPropagation": testAccTransitGatewayVPCAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagation,
 		},
 	}
@@ -555,7 +555,7 @@ func testAccTransitGateway_Description(t *testing.T) {
 	})
 }
 
-func testAccTransitGateway_Tags(t *testing.T) {
+func testAccTransitGateway_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var transitGateway1, transitGateway2, transitGateway3 ec2.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"

--- a/internal/service/ec2/transitgateway_vpc_attachment_accepter_test.go
+++ b/internal/service/ec2/transitgateway_vpc_attachment_accepter_test.go
@@ -57,7 +57,7 @@ func testAccTransitGatewayVPCAttachmentAccepter_basic(t *testing.T) {
 	})
 }
 
-func testAccTransitGatewayVPCAttachmentAccepter_Tags(t *testing.T) {
+func testAccTransitGatewayVPCAttachmentAccepter_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var transitGatewayVpcAttachment ec2.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment_accepter.test"

--- a/internal/service/ec2/transitgateway_vpc_attachment_test.go
+++ b/internal/service/ec2/transitgateway_vpc_attachment_test.go
@@ -263,7 +263,7 @@ func testAccTransitGatewayVPCAttachment_SubnetIDs(t *testing.T) {
 	})
 }
 
-func testAccTransitGatewayVPCAttachment_Tags(t *testing.T) {
+func testAccTransitGatewayVPCAttachment_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var transitGatewayVpcAttachment1, transitGatewayVpcAttachment2, transitGatewayVpcAttachment3 ec2.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"

--- a/internal/service/ec2/vpc_.go
+++ b/internal/service/ec2/vpc_.go
@@ -20,6 +20,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 const (
@@ -172,8 +173,8 @@ func ResourceVPC() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -189,7 +190,7 @@ func resourceVPCCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	input := &ec2.CreateVpcInput{
 		AmazonProvidedIpv6CidrBlock: aws.Bool(d.Get("assign_generated_ipv6_cidr_block").(bool)),
 		InstanceTenancy:             aws.String(d.Get("instance_tenancy").(string)),
-		TagSpecifications:           tagSpecificationsFromTags(GetTagsIn(ctx), ec2.ResourceTypeVpc),
+		TagSpecifications:           getTagSpecificationsIn(ctx, ec2.ResourceTypeVpc),
 	}
 
 	if v, ok := d.GetOk("cidr_block"); ok {

--- a/internal/service/ec2/vpc_default_network_acl.go
+++ b/internal/service/ec2/vpc_default_network_acl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // ACL Network ACLs all contain explicit deny-all rules that cannot be
@@ -21,7 +22,8 @@ const (
 	defaultACLRuleNumberIPv6 = 32768
 )
 
-// @SDKResource("aws_default_network_acl")
+// @SDKResource("aws_default_network_acl", name="Network ACL")
+// @Tags(identifierAttribute="id")
 func ResourceDefaultNetworkACL() *schema.Resource {
 	networkACLRuleSetNestedBlock := &schema.Schema{
 		Type:     schema.TypeSet,
@@ -79,8 +81,8 @@ func ResourceDefaultNetworkACL() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -118,9 +120,8 @@ func resourceDefaultNetworkACLCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	// Configure tags.
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-	newTags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{}))).IgnoreConfig(ignoreTagsConfig)
+	newTags := KeyValueTags(ctx, GetTagsIn(ctx))
 	oldTags := KeyValueTags(ctx, nacl.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	if !oldTags.Equal(newTags) {

--- a/internal/service/ec2/vpc_default_route_table.go
+++ b/internal/service/ec2/vpc_default_route_table.go
@@ -15,9 +15,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_default_route_table")
+// @SDKResource("aws_default_route_table", name="Route Table")
+// @Tags(identifierAttribute="id")
 func ResourceDefaultRouteTable() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDefaultRouteTableCreate,
@@ -132,8 +134,8 @@ func ResourceDefaultRouteTable() *schema.Resource {
 				Set: resourceRouteTableHash,
 			},
 
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 
 			"vpc_id": {
 				Type:     schema.TypeString,
@@ -148,8 +150,6 @@ func ResourceDefaultRouteTable() *schema.Resource {
 func resourceDefaultRouteTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	routeTableID := d.Get("default_route_table_id").(string)
 
@@ -246,7 +246,7 @@ func resourceDefaultRouteTableCreate(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
-	if len(tags) > 0 {
+	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
 		if err := CreateTags(ctx, conn, d.Id(), tags); err != nil {
 			return sdkdiag.AppendErrorf(diags, "adding tags: %s", err)
 		}

--- a/internal/service/ec2/vpc_default_security_group.go
+++ b/internal/service/ec2/vpc_default_security_group.go
@@ -10,9 +10,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_default_security_group")
+// @SDKResource("aws_default_security_group", name="Security Group")
+// @Tags(identifierAttribute="id")
 func ResourceDefaultSecurityGroup() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{
@@ -61,8 +63,8 @@ func ResourceDefaultSecurityGroup() *schema.Resource {
 				Default:  false,
 				Optional: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -77,8 +79,6 @@ func ResourceDefaultSecurityGroup() *schema.Resource {
 
 func resourceDefaultSecurityGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	input := &ec2.DescribeSecurityGroupsInput{
 		Filters: BuildAttributeFilterList(
@@ -110,11 +110,12 @@ func resourceDefaultSecurityGroupCreate(ctx context.Context, d *schema.ResourceD
 
 	d.SetId(aws.StringValue(sg.GroupId))
 
-	oTagsAll := KeyValueTags(ctx, sg.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-	nTagsAll := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+	newTags := KeyValueTags(ctx, GetTagsIn(ctx))
+	oldTags := KeyValueTags(ctx, sg.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-	if !nTagsAll.Equal(oTagsAll) {
-		if err := UpdateTags(ctx, conn, d.Id(), oTagsAll.Map(), nTagsAll.Map()); err != nil {
+	if !newTags.Equal(oldTags) {
+		if err := UpdateTags(ctx, conn, d.Id(), oldTags, newTags); err != nil {
 			return diag.Errorf("updating Default Security Group (%s) tags: %s", d.Id(), err)
 		}
 	}

--- a/internal/service/ec2/vpc_default_subnet.go
+++ b/internal/service/ec2/vpc_default_subnet.go
@@ -15,9 +15,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_default_subnet")
+// @SDKResource("aws_default_subnet", name="Subnet")
+// @Tags(identifierAttribute="id")
 func ResourceDefaultSubnet() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{
@@ -143,8 +145,8 @@ func ResourceDefaultSubnet() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validation.StringInSlice(ec2.HostnameType_Values(), false),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -230,9 +232,8 @@ func resourceDefaultSubnetCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	// Configure tags.
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-	newTags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{}))).IgnoreConfig(ignoreTagsConfig)
+	newTags := KeyValueTags(ctx, GetTagsIn(ctx))
 	oldTags := KeyValueTags(ctx, subnet.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	if !oldTags.Equal(newTags) {

--- a/internal/service/ec2/vpc_default_vpc.go
+++ b/internal/service/ec2/vpc_default_vpc.go
@@ -14,9 +14,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_default_vpc")
+// @SDKResource("aws_default_vpc", name="VPC")
+// @Tags(identifierAttribute="id")
 func ResourceDefaultVPC() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{
@@ -153,8 +155,8 @@ func ResourceDefaultVPC() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -301,9 +303,8 @@ func resourceDefaultVPCCreate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	// Configure tags.
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-	newTags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{}))).IgnoreConfig(ignoreTagsConfig)
+	newTags := KeyValueTags(ctx, GetTagsIn(ctx))
 	oldTags := KeyValueTags(ctx, vpc.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	if !oldTags.Equal(newTags) {

--- a/internal/service/ec2/vpc_default_vpc_dhcp_options.go
+++ b/internal/service/ec2/vpc_default_vpc_dhcp_options.go
@@ -13,9 +13,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_default_vpc_dhcp_options")
+// @SDKResource("aws_default_vpc_dhcp_options", name="DHCP Options")
+// @Tags(identifierAttribute="id")
 func ResourceDefaultVPCDHCPOptions() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{
@@ -67,8 +69,8 @@ func ResourceDefaultVPCDHCPOptions() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }

--- a/internal/service/ec2/vpc_dhcp_options.go
+++ b/internal/service/ec2/vpc_dhcp_options.go
@@ -16,9 +16,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_vpc_dhcp_options")
+// @SDKResource("aws_vpc_dhcp_options", name="DHCP Options")
+// @Tags(identifierAttribute="id")
 func ResourceVPCDHCPOptions() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceVPCDHCPOptionsCreate,
@@ -74,8 +76,8 @@ func ResourceVPCDHCPOptions() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -95,8 +97,6 @@ var (
 func resourceVPCDHCPOptionsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	dhcpConfigurations, err := optionsMap.resourceDataToDHCPConfigurations(d)
 
@@ -106,7 +106,7 @@ func resourceVPCDHCPOptionsCreate(ctx context.Context, d *schema.ResourceData, m
 
 	input := &ec2.CreateDhcpOptionsInput{
 		DhcpConfigurations: dhcpConfigurations,
-		TagSpecifications:  tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeDhcpOptions),
+		TagSpecifications:  getTagSpecificationsIn(ctx, ec2.ResourceTypeDhcpOptions),
 	}
 
 	output, err := conn.CreateDhcpOptionsWithContext(ctx, input)
@@ -123,8 +123,6 @@ func resourceVPCDHCPOptionsCreate(ctx context.Context, d *schema.ResourceData, m
 func resourceVPCDHCPOptionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindDHCPOptionsByID(ctx, conn, d.Id())
@@ -159,31 +157,15 @@ func resourceVPCDHCPOptionsRead(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "reading EC2 DHCP Options (%s): %s", d.Id(), err)
 	}
 
-	tags := KeyValueTags(ctx, opts.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, opts.Tags)
 
 	return diags
 }
 
 func resourceVPCDHCPOptionsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).EC2Conn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating EC2 DHCP Options Set (%s) tags: %s", d.Id(), err)
-		}
-	}
+	// Tags only.
 
 	return append(diags, resourceVPCDHCPOptionsRead(ctx, d, meta)...)
 }

--- a/internal/service/ec2/vpc_internet_gateway.go
+++ b/internal/service/ec2/vpc_internet_gateway.go
@@ -17,9 +17,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_internet_gateway")
+// @SDKResource("aws_internet_gateway", name="Internet Gateway")
+// @Tags(identifierAttribute="id")
 func ResourceInternetGateway() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceInternetGatewayCreate,
@@ -46,8 +48,8 @@ func ResourceInternetGateway() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -62,11 +64,9 @@ func ResourceInternetGateway() *schema.Resource {
 func resourceInternetGatewayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &ec2.CreateInternetGatewayInput{
-		TagSpecifications: tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeInternetGateway),
+		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypeInternetGateway),
 	}
 
 	log.Printf("[DEBUG] Creating EC2 Internet Gateway: %s", input)
@@ -90,8 +90,6 @@ func resourceInternetGatewayCreate(ctx context.Context, d *schema.ResourceData, 
 func resourceInternetGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindInternetGatewayByID(ctx, conn, d.Id())
@@ -126,16 +124,7 @@ func resourceInternetGatewayRead(ctx context.Context, d *schema.ResourceData, me
 		d.Set("vpc_id", ig.Attachments[0].VpcId)
 	}
 
-	tags := KeyValueTags(ctx, ig.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, ig.Tags)
 
 	return diags
 }
@@ -157,14 +146,6 @@ func resourceInternetGatewayUpdate(ctx context.Context, d *schema.ResourceData, 
 			if err := attachInternetGateway(ctx, conn, d.Id(), v, d.Timeout(schema.TimeoutUpdate)); err != nil {
 				return sdkdiag.AppendErrorf(diags, "updating EC2 Internet Gateway (%s): %s", d.Id(), err)
 			}
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating EC2 Internet Gateway (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ec2/vpc_nat_gateway.go
+++ b/internal/service/ec2/vpc_nat_gateway.go
@@ -15,9 +15,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_nat_gateway")
+// @SDKResource("aws_nat_gateway", name="NAT Gateway")
+// @Tags(identifierAttribute="id")
 func ResourceNATGateway() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceNATGatewayCreate,
@@ -62,8 +64,8 @@ func ResourceNATGateway() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -72,12 +74,10 @@ func ResourceNATGateway() *schema.Resource {
 
 func resourceNATGatewayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &ec2.CreateNatGatewayInput{
 		ClientToken:       aws.String(id.UniqueId()),
-		TagSpecifications: tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeNatgateway),
+		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypeNatgateway),
 	}
 
 	if v, ok := d.GetOk("allocation_id"); ok {
@@ -113,8 +113,6 @@ func resourceNATGatewayCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 func resourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	ng, err := FindNATGatewayByID(ctx, conn, d.Id())
 
@@ -136,31 +134,13 @@ func resourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta in
 	d.Set("public_ip", address.PublicIp)
 	d.Set("subnet_id", ng.SubnetId)
 
-	tags := KeyValueTags(ctx, ng.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, ng.Tags)
 
 	return nil
 }
 
 func resourceNATGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).EC2Conn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return diag.Errorf("updating EC2 NAT Gateway (%s) tags: %s", d.Id(), err)
-		}
-	}
-
+	// Tags only.
 	return resourceNATGatewayRead(ctx, d, meta)
 }
 

--- a/internal/service/ec2/vpc_peering_connection_accepter.go
+++ b/internal/service/ec2/vpc_peering_connection_accepter.go
@@ -13,9 +13,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_vpc_peering_connection_accepter")
+// @SDKResource("aws_vpc_peering_connection_accepter", name="VPC Peering Connection")
+// @Tags(identifierAttribute="id")
 func ResourceVPCPeeringConnectionAccepter() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceVPCPeeringAccepterCreate,
@@ -65,9 +67,9 @@ func ResourceVPCPeeringConnectionAccepter() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"requester": vpcPeeringConnectionOptionsSchema,
-			"tags":      tftags.TagsSchema(),
-			"tags_all":  tftags.TagsSchemaComputed(),
+			"requester":       vpcPeeringConnectionOptionsSchema,
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -86,8 +88,6 @@ func ResourceVPCPeeringConnectionAccepter() *schema.Resource {
 func resourceVPCPeeringAccepterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	if peeringConnectionOptionsAllowsClassicLink(d) {
 		return sdkdiag.AppendErrorf(diags, `with the retirement of EC2-Classic no VPC Peering Connections can be accepted with ClassicLink options enabled`)
@@ -114,7 +114,7 @@ func resourceVPCPeeringAccepterCreate(ctx context.Context, d *schema.ResourceDat
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	if len(tags) > 0 {
+	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
 		if err := CreateTags(ctx, conn, d.Id(), tags.Map()); err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating EC2 VPC Peering Connection (%s) tags: %s", d.Id(), err)
 		}

--- a/internal/service/ec2/vpc_traffic_mirror_session.go
+++ b/internal/service/ec2/vpc_traffic_mirror_session.go
@@ -16,9 +16,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ec2_traffic_mirror_session")
+// @SDKResource("aws_ec2_traffic_mirror_session", name="Traffic Mirror Session")
+// @Tags(identifierAttribute="id")
 func ResourceTrafficMirrorSession() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTrafficMirrorSessionCreate,
@@ -58,8 +60,8 @@ func ResourceTrafficMirrorSession() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.IntBetween(1, 32766),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"traffic_mirror_filter_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -81,11 +83,10 @@ func ResourceTrafficMirrorSession() *schema.Resource {
 func resourceTrafficMirrorSessionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &ec2.CreateTrafficMirrorSessionInput{
 		NetworkInterfaceId:    aws.String(d.Get("network_interface_id").(string)),
+		TagSpecifications:     getTagSpecificationsIn(ctx, ec2.ResourceTypeTrafficMirrorSession),
 		TrafficMirrorFilterId: aws.String(d.Get("traffic_mirror_filter_id").(string)),
 		TrafficMirrorTargetId: aws.String(d.Get("traffic_mirror_target_id").(string)),
 	}
@@ -106,10 +107,6 @@ func resourceTrafficMirrorSessionCreate(ctx context.Context, d *schema.ResourceD
 		input.VirtualNetworkId = aws.Int64(int64(v.(int)))
 	}
 
-	if len(tags) > 0 {
-		input.TagSpecifications = tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeTrafficMirrorSession)
-	}
-
 	output, err := conn.CreateTrafficMirrorSessionWithContext(ctx, input)
 
 	if err != nil {
@@ -124,8 +121,6 @@ func resourceTrafficMirrorSessionCreate(ctx context.Context, d *schema.ResourceD
 func resourceTrafficMirrorSessionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	session, err := FindTrafficMirrorSessionByID(ctx, conn, d.Id())
 
@@ -157,16 +152,7 @@ func resourceTrafficMirrorSessionRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("traffic_mirror_target_id", session.TrafficMirrorTargetId)
 	d.Set("virtual_network_id", session.VirtualNetworkId)
 
-	tags := KeyValueTags(ctx, session.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, session.Tags)
 
 	return diags
 }
@@ -226,14 +212,6 @@ func resourceTrafficMirrorSessionUpdate(ctx context.Context, d *schema.ResourceD
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating EC2 Traffic Mirror Session (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating EC2 Traffic Mirror Session (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ec2/vpc_traffic_mirror_target.go
+++ b/internal/service/ec2/vpc_traffic_mirror_target.go
@@ -15,9 +15,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ec2_traffic_mirror_target")
+// @SDKResource("aws_ec2_traffic_mirror_target", name="Traffic Mirror Target")
+// @Tags(identifierAttribute="id")
 func ResourceTrafficMirrorTarget() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTrafficMirrorTargetCreate,
@@ -76,8 +78,8 @@ func ResourceTrafficMirrorTarget() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -85,10 +87,10 @@ func ResourceTrafficMirrorTarget() *schema.Resource {
 func resourceTrafficMirrorTargetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
-	input := &ec2.CreateTrafficMirrorTargetInput{}
+	input := &ec2.CreateTrafficMirrorTargetInput{
+		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypeTrafficMirrorTarget),
+	}
 
 	if v, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(v.(string))
@@ -106,10 +108,6 @@ func resourceTrafficMirrorTargetCreate(ctx context.Context, d *schema.ResourceDa
 		input.NetworkLoadBalancerArn = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		input.TagSpecifications = tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeTrafficMirrorTarget)
-	}
-
 	output, err := conn.CreateTrafficMirrorTargetWithContext(ctx, input)
 
 	if err != nil {
@@ -124,8 +122,6 @@ func resourceTrafficMirrorTargetCreate(ctx context.Context, d *schema.ResourceDa
 func resourceTrafficMirrorTargetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	target, err := FindTrafficMirrorTargetByID(ctx, conn, d.Id())
 
@@ -154,31 +150,15 @@ func resourceTrafficMirrorTargetRead(ctx context.Context, d *schema.ResourceData
 	d.Set("network_load_balancer_arn", target.NetworkLoadBalancerArn)
 	d.Set("owner_id", ownerID)
 
-	tags := KeyValueTags(ctx, target.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, target.Tags)
 
 	return diags
 }
 
 func resourceTrafficMirrorTargetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).EC2Conn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating EC2 Traffic Mirror Target (%s) tags: %s", d.Id(), err)
-		}
-	}
+	// Tags only
 
 	return append(diags, resourceTrafficMirrorTargetRead(ctx, d, meta)...)
 }

--- a/internal/service/ec2/vpnsite_customer_gateway.go
+++ b/internal/service/ec2/vpnsite_customer_gateway.go
@@ -21,6 +21,7 @@ import (
 )
 
 // @SDKResource("aws_customer_gateway", name="Customer Gateway")
+// @Tags(identifierAttribute="id")
 func ResourceCustomerGateway() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceCustomerGatewayCreate,

--- a/internal/service/ec2/vpnsite_customer_gateway.go
+++ b/internal/service/ec2/vpnsite_customer_gateway.go
@@ -17,9 +17,10 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_customer_gateway")
+// @SDKResource("aws_customer_gateway", name="Customer Gateway")
 func ResourceCustomerGateway() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceCustomerGatewayCreate,
@@ -60,8 +61,8 @@ func ResourceCustomerGateway() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.IsIPv4Address,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"type": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -76,11 +77,9 @@ func ResourceCustomerGateway() *schema.Resource {
 
 func resourceCustomerGatewayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &ec2.CreateCustomerGatewayInput{
-		TagSpecifications: tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeCustomerGateway),
+		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypeCustomerGateway),
 		Type:              aws.String(d.Get("type").(string)),
 	}
 
@@ -123,8 +122,6 @@ func resourceCustomerGatewayCreate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceCustomerGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	customerGateway, err := FindCustomerGatewayByID(ctx, conn, d.Id())
 
@@ -152,31 +149,13 @@ func resourceCustomerGatewayRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("ip_address", customerGateway.IpAddress)
 	d.Set("type", customerGateway.Type)
 
-	tags := KeyValueTags(ctx, customerGateway.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, customerGateway.Tags)
 
 	return nil
 }
 
 func resourceCustomerGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).EC2Conn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return diag.Errorf("updating EC2 Customer Gateway (%s) tags: %s", d.Id(), err)
-		}
-	}
-
+	// Tags only.
 	return resourceCustomerGatewayRead(ctx, d, meta)
 }
 

--- a/internal/service/ec2/wavelength_carrier_gateway.go
+++ b/internal/service/ec2/wavelength_carrier_gateway.go
@@ -16,9 +16,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ec2_carrier_gateway")
+// @SDKResource("aws_ec2_carrier_gateway, name="Carrier Gateway")
+// @Tags(identifierAttribute="id")
 func ResourceCarrierGateway() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceCarrierGatewayCreate,
@@ -41,8 +43,8 @@ func ResourceCarrierGateway() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -55,11 +57,9 @@ func ResourceCarrierGateway() *schema.Resource {
 func resourceCarrierGatewayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &ec2.CreateCarrierGatewayInput{
-		TagSpecifications: tagSpecificationsFromKeyValueTags(tags, ec2.ResourceTypeCarrierGateway),
+		TagSpecifications: getTagSpecificationsIn(ctx, ec2.ResourceTypeCarrierGateway),
 		VpcId:             aws.String(d.Get("vpc_id").(string)),
 	}
 
@@ -83,8 +83,6 @@ func resourceCarrierGatewayCreate(ctx context.Context, d *schema.ResourceData, m
 func resourceCarrierGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	carrierGateway, err := FindCarrierGatewayByID(ctx, conn, d.Id())
 
@@ -110,31 +108,15 @@ func resourceCarrierGatewayRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("owner_id", ownerID)
 	d.Set("vpc_id", carrierGateway.VpcId)
 
-	tags := KeyValueTags(ctx, carrierGateway.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, carrierGateway.Tags)
 
 	return diags
 }
 
 func resourceCarrierGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).EC2Conn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating EC2 Carrier Gateway (%s) tags: %s", d.Id(), err)
-		}
-	}
+	// Tags only.
 
 	return append(diags, resourceCarrierGatewayRead(ctx, d, meta)...)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin Framework.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30421.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccTransitGateway_serial/Connect/basic\|TestAccTransitGateway_serial/Connect/tags\|TestAccTransitGateway_serial/Gateway/basic\|TestAccTransitGateway_serial/Gateway/tags\|TestAccTransitGateway_serial/MulticastDomain/basic\|TestAccTransitGateway_serial/MulticastDomain/tags\|TestAccTransitGateway_serial/PeeringAttachment/basic\|TestAccTransitGateway_serial/PeeringAttachment/tags\|TestAccTransitGateway_serial/PolicyTable/basic\|TestAccTransitGateway_serial/PolicyTable/tags\|TestAccTransitGateway_serial/RouteTable/basic\|TestAccTransitGateway_serial/RouteTable/tags\|TestAccTransitGateway_serial/VpcAttachment/tags\|TestAccTransitGateway_serial/VpcAttachment/basic' PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccTransitGateway_serial/Connect/basic\|TestAccTransitGateway_serial/Connect/tags\|TestAccTransitGateway_serial/Gateway/basic\|TestAccTransitGateway_serial/Gateway/tags\|TestAccTransitGateway_serial/MulticastDomain/basic\|TestAccTransitGateway_serial/MulticastDomain/tags\|TestAccTransitGateway_serial/PeeringAttachment/basic\|TestAccTransitGateway_serial/PeeringAttachment/tags\|TestAccTransitGateway_serial/PolicyTable/basic\|TestAccTransitGateway_serial/PolicyTable/tags\|TestAccTransitGateway_serial/RouteTable/basic\|TestAccTransitGateway_serial/RouteTable/tags\|TestAccTransitGateway_serial/VpcAttachment/tags\|TestAccTransitGateway_serial/VpcAttachment/basic -timeout 180m
=== RUN   TestAccTransitGateway_serial
=== PAUSE TestAccTransitGateway_serial
=== CONT  TestAccTransitGateway_serial
=== RUN   TestAccTransitGateway_serial/VpcAttachment
=== RUN   TestAccTransitGateway_serial/VpcAttachment/basic
=== RUN   TestAccTransitGateway_serial/VpcAttachment/tags
=== RUN   TestAccTransitGateway_serial/MulticastDomainAssociation
=== RUN   TestAccTransitGateway_serial/MulticastDomainAssociation/basic
=== RUN   TestAccTransitGateway_serial/PolicyTableAssociation
=== RUN   TestAccTransitGateway_serial/PolicyTableAssociation/basic
=== RUN   TestAccTransitGateway_serial/RouteTableAssociation
=== RUN   TestAccTransitGateway_serial/RouteTableAssociation/basic
=== RUN   TestAccTransitGateway_serial/RouteTablePropagation
=== RUN   TestAccTransitGateway_serial/RouteTablePropagation/basic
=== RUN   TestAccTransitGateway_serial/Gateway
=== RUN   TestAccTransitGateway_serial/Gateway/tags
=== RUN   TestAccTransitGateway_serial/Gateway/basic
=== RUN   TestAccTransitGateway_serial/PolicyTable
=== RUN   TestAccTransitGateway_serial/PolicyTable/basic
=== RUN   TestAccTransitGateway_serial/PolicyTable/tags
=== RUN   TestAccTransitGateway_serial/RouteTable
=== RUN   TestAccTransitGateway_serial/RouteTable/basic
=== RUN   TestAccTransitGateway_serial/RouteTable/tags
=== RUN   TestAccTransitGateway_serial/PeeringAttachment
=== RUN   TestAccTransitGateway_serial/PeeringAttachment/basic
=== RUN   TestAccTransitGateway_serial/PeeringAttachment/tags
=== RUN   TestAccTransitGateway_serial/PeeringAttachmentAccepter
=== RUN   TestAccTransitGateway_serial/PeeringAttachmentAccepter/basic
=== RUN   TestAccTransitGateway_serial/PeeringAttachmentAccepter/tags
=== RUN   TestAccTransitGateway_serial/VpcAttachmentAccepter
=== RUN   TestAccTransitGateway_serial/VpcAttachmentAccepter/basic
    acctest.go:772: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
=== RUN   TestAccTransitGateway_serial/VpcAttachmentAccepter/tags
    acctest.go:772: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
=== RUN   TestAccTransitGateway_serial/Connect
=== RUN   TestAccTransitGateway_serial/Connect/tags
=== RUN   TestAccTransitGateway_serial/Connect/basic
=== RUN   TestAccTransitGateway_serial/ConnectPeer
=== RUN   TestAccTransitGateway_serial/ConnectPeer/basic
=== RUN   TestAccTransitGateway_serial/ConnectPeer/tags
=== RUN   TestAccTransitGateway_serial/MulticastDomain
=== RUN   TestAccTransitGateway_serial/MulticastDomain/basic
=== RUN   TestAccTransitGateway_serial/MulticastDomain/tags
--- PASS: TestAccTransitGateway_serial (8532.57s)
    --- PASS: TestAccTransitGateway_serial/VpcAttachment (714.47s)
        --- PASS: TestAccTransitGateway_serial/VpcAttachment/basic (322.13s)
        --- PASS: TestAccTransitGateway_serial/VpcAttachment/tags (392.34s)
    --- PASS: TestAccTransitGateway_serial/MulticastDomainAssociation (347.32s)
        --- PASS: TestAccTransitGateway_serial/MulticastDomainAssociation/basic (347.32s)
    --- PASS: TestAccTransitGateway_serial/PolicyTableAssociation (1106.92s)
        --- PASS: TestAccTransitGateway_serial/PolicyTableAssociation/basic (1106.92s)
    --- PASS: TestAccTransitGateway_serial/RouteTableAssociation (411.55s)
        --- PASS: TestAccTransitGateway_serial/RouteTableAssociation/basic (411.55s)
    --- PASS: TestAccTransitGateway_serial/RouteTablePropagation (300.75s)
        --- PASS: TestAccTransitGateway_serial/RouteTablePropagation/basic (300.75s)
    --- PASS: TestAccTransitGateway_serial/Gateway (398.80s)
        --- PASS: TestAccTransitGateway_serial/Gateway/tags (214.64s)
        --- PASS: TestAccTransitGateway_serial/Gateway/basic (184.16s)
    --- PASS: TestAccTransitGateway_serial/PolicyTable (452.93s)
        --- PASS: TestAccTransitGateway_serial/PolicyTable/basic (216.18s)
        --- PASS: TestAccTransitGateway_serial/PolicyTable/tags (236.75s)
    --- PASS: TestAccTransitGateway_serial/RouteTable (475.84s)
        --- PASS: TestAccTransitGateway_serial/RouteTable/basic (212.67s)
        --- PASS: TestAccTransitGateway_serial/RouteTable/tags (263.16s)
    --- PASS: TestAccTransitGateway_serial/PeeringAttachment (607.58s)
        --- PASS: TestAccTransitGateway_serial/PeeringAttachment/basic (300.76s)
        --- PASS: TestAccTransitGateway_serial/PeeringAttachment/tags (306.82s)
    --- PASS: TestAccTransitGateway_serial/PeeringAttachmentAccepter (1282.52s)
        --- PASS: TestAccTransitGateway_serial/PeeringAttachmentAccepter/basic (641.86s)
        --- PASS: TestAccTransitGateway_serial/PeeringAttachmentAccepter/tags (640.66s)
    --- PASS: TestAccTransitGateway_serial/VpcAttachmentAccepter (0.00s)
        --- SKIP: TestAccTransitGateway_serial/VpcAttachmentAccepter/basic (0.00s)
        --- SKIP: TestAccTransitGateway_serial/VpcAttachmentAccepter/tags (0.00s)
    --- PASS: TestAccTransitGateway_serial/Connect (704.00s)
        --- PASS: TestAccTransitGateway_serial/Connect/tags (384.39s)
        --- PASS: TestAccTransitGateway_serial/Connect/basic (319.61s)
    --- PASS: TestAccTransitGateway_serial/ConnectPeer (1212.30s)
        --- PASS: TestAccTransitGateway_serial/ConnectPeer/basic (558.98s)
        --- PASS: TestAccTransitGateway_serial/ConnectPeer/tags (653.31s)
    --- PASS: TestAccTransitGateway_serial/MulticastDomain (517.57s)
        --- PASS: TestAccTransitGateway_serial/MulticastDomain/basic (243.47s)
        --- PASS: TestAccTransitGateway_serial/MulticastDomain/tags (274.09s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	8537.963s
```

```console
% AWS_DEFAULT_REGION=eu-west-1 make testacc TESTARGS='-run=TestAccVPCDefaultVPCAndSubnet_serial\|TestAccVPCDefaultVPCDHCPOptions_serial\|TestAccIPAMResourceDiscovery_serial/ResourceDiscovery/basic\|TestAccIPAMResourceDiscovery_serial/ResourceDiscovery/tags\|TestAccClientVPNEndpoint_serial/Endpoint_basic\|TestAccClientVPNEndpoint_serial/Endpoint_tags' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccVPCDefaultVPCAndSubnet_serial\|TestAccVPCDefaultVPCDHCPOptions_serial\|TestAccIPAMResourceDiscovery_serial/ResourceDiscovery/basic\|TestAccIPAMResourceDiscovery_serial/ResourceDiscovery/tags\|TestAccClientVPNEndpoint_serial/Endpoint_basic\|TestAccClientVPNEndpoint_serial/Endpoint_tags -timeout 180m
=== RUN   TestAccIPAMResourceDiscovery_serial
=== PAUSE TestAccIPAMResourceDiscovery_serial
=== RUN   TestAccVPCDefaultVPCDHCPOptions_serial
=== PAUSE TestAccVPCDefaultVPCDHCPOptions_serial
=== RUN   TestAccVPCDefaultVPCAndSubnet_serial
=== PAUSE TestAccVPCDefaultVPCAndSubnet_serial
=== RUN   TestAccClientVPNEndpoint_serial
=== PAUSE TestAccClientVPNEndpoint_serial
=== CONT  TestAccIPAMResourceDiscovery_serial
=== RUN   TestAccIPAMResourceDiscovery_serial/ResourceDiscovery
=== CONT  TestAccVPCDefaultVPCAndSubnet_serial
=== CONT  TestAccVPCDefaultVPCDHCPOptions_serial
=== RUN   TestAccIPAMResourceDiscovery_serial/ResourceDiscovery/basic
=== RUN   TestAccVPCDefaultVPCDHCPOptions_serial/basic
=== RUN   TestAccVPCDefaultVPCAndSubnet_serial/Subnet
=== RUN   TestAccVPCDefaultVPCAndSubnet_serial/Subnet/existing.basic
=== CONT  TestAccVPCDefaultVPCDHCPOptions_serial/basic
    vpc_default_vpc_dhcp_options_test.go:30: Step 1/1 error: Error running apply: exit status 1
        
        Error: reading EC2 Default DHCP Options Set: too many results: wanted 1, got 2
        
          with aws_default_vpc_dhcp_options.test,
          on terraform_plugin_test.tf line 2, in resource "aws_default_vpc_dhcp_options" "test":
           2: resource "aws_default_vpc_dhcp_options" "test" {
        
=== RUN   TestAccVPCDefaultVPCDHCPOptions_serial/owner
    vpc_default_vpc_dhcp_options_test.go:57: Step 1/1 error: Error running apply: exit status 1
        
        Error: reading EC2 Default DHCP Options Set: too many results: wanted 1, got 2
        
          with aws_default_vpc_dhcp_options.test,
          on terraform_plugin_test.tf line 4, in resource "aws_default_vpc_dhcp_options" "test":
           4: resource "aws_default_vpc_dhcp_options" "test" {
        
=== RUN   TestAccVPCDefaultVPCDHCPOptions_serial/v4.20.0_regression
=== RUN   TestAccVPCDefaultVPCAndSubnet_serial/Subnet/existing.forceDestroy
=== RUN   TestAccIPAMResourceDiscovery_serial/ResourceDiscovery/tags
=== CONT  TestAccVPCDefaultVPCDHCPOptions_serial/v4.20.0_regression
    vpc_default_vpc_dhcp_options_test.go:86: Step 1/2 error: Error running apply: exit status 1
        
        Error: Multiple default DHCP Options Sets found
        
          with aws_default_vpc_dhcp_options.test,
          on terraform_plugin_test.tf line 14, in resource "aws_default_vpc_dhcp_options" "test":
          14: resource "aws_default_vpc_dhcp_options" "test" {
        
--- FAIL: TestAccVPCDefaultVPCDHCPOptions_serial (38.97s)
    --- FAIL: TestAccVPCDefaultVPCDHCPOptions_serial/basic (7.20s)
    --- FAIL: TestAccVPCDefaultVPCDHCPOptions_serial/owner (6.78s)
    --- FAIL: TestAccVPCDefaultVPCDHCPOptions_serial/v4.20.0_regression (24.99s)
=== CONT  TestAccClientVPNEndpoint_serial
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_basic
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_basic
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_tags
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_tags
=== RUN   TestAccClientVPNEndpoint_serial/Endpoint_basicDataSource
=== PAUSE TestAccClientVPNEndpoint_serial/Endpoint_basicDataSource
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_basic
=== RUN   TestAccVPCDefaultVPCAndSubnet_serial/Subnet/existing.ipv6
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_basicDataSource
=== RUN   TestAccIPAMResourceDiscovery_serial/ResourceDiscoveryAssociation
=== RUN   TestAccIPAMResourceDiscovery_serial/ResourceDiscoveryAssociation/tags
=== CONT  TestAccClientVPNEndpoint_serial/Endpoint_tags
=== RUN   TestAccVPCDefaultVPCAndSubnet_serial/Subnet/existing.privateDnsNameOptionsOnLaunch
--- PASS: TestAccClientVPNEndpoint_serial (0.82s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_basic (23.04s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_basicDataSource (20.75s)
    --- PASS: TestAccClientVPNEndpoint_serial/Endpoint_tags (50.94s)
=== RUN   TestAccVPCDefaultVPCAndSubnet_serial/Subnet/notFound.basic
    vpc_default_subnet_test.go:63: Deleting existing default subnet: subnet-077522134c11da70d
    vpc_default_subnet_test.go:63: Deleting existing default subnet: subnet-016c2bd9d7c0cd0dc
    vpc_default_subnet_test.go:63: Deleting existing default subnet: subnet-0908db79969574ffa
=== RUN   TestAccIPAMResourceDiscovery_serial/ResourceDiscoveryAssociation/basic
=== RUN   TestAccVPCDefaultVPCAndSubnet_serial/Subnet/notFound.ipv6Native
    vpc_default_subnet_test.go:63: Deleting existing default subnet: subnet-07de0fead9c5bda0f
    vpc_default_subnet_test.go:63: Deleting existing default subnet: subnet-037b29a61e501d62f
    vpc_default_subnet_test.go:63: Deleting existing default subnet: subnet-06d69ed388799a154
--- PASS: TestAccIPAMResourceDiscovery_serial (186.07s)
    --- PASS: TestAccIPAMResourceDiscovery_serial/ResourceDiscovery (82.05s)
        --- PASS: TestAccIPAMResourceDiscovery_serial/ResourceDiscovery/basic (30.13s)
        --- PASS: TestAccIPAMResourceDiscovery_serial/ResourceDiscovery/tags (51.91s)
    --- PASS: TestAccIPAMResourceDiscovery_serial/ResourceDiscoveryAssociation (104.02s)
        --- PASS: TestAccIPAMResourceDiscovery_serial/ResourceDiscoveryAssociation/tags (64.23s)
        --- PASS: TestAccIPAMResourceDiscovery_serial/ResourceDiscoveryAssociation/basic (39.79s)
=== RUN   TestAccVPCDefaultVPCAndSubnet_serial/VPC
=== RUN   TestAccVPCDefaultVPCAndSubnet_serial/VPC/existing.basic
=== RUN   TestAccVPCDefaultVPCAndSubnet_serial/VPC/existing.assignGeneratedIPv6CIDRBlock
=== RUN   TestAccVPCDefaultVPCAndSubnet_serial/VPC/existing.forceDestroy
=== RUN   TestAccVPCDefaultVPCAndSubnet_serial/VPC/notFound.basic
    vpc_default_vpc_test.go:54: Deleting existing default VPC: vpc-0d4b54dee16611f44
=== RUN   TestAccVPCDefaultVPCAndSubnet_serial/VPC/notFound.assignGeneratedIPv6CIDRBlock
    vpc_default_vpc_test.go:54: Deleting existing default VPC: vpc-069450f310bdf10e7
=== RUN   TestAccVPCDefaultVPCAndSubnet_serial/VPC/notFound.forceDestroy
    vpc_default_vpc_test.go:54: Deleting existing default VPC: vpc-0a2c67605f63eb430
--- PASS: TestAccVPCDefaultVPCAndSubnet_serial (405.83s)
    --- PASS: TestAccVPCDefaultVPCAndSubnet_serial/Subnet (222.98s)
        --- PASS: TestAccVPCDefaultVPCAndSubnet_serial/Subnet/existing.basic (21.29s)
        --- PASS: TestAccVPCDefaultVPCAndSubnet_serial/Subnet/existing.forceDestroy (21.34s)
        --- PASS: TestAccVPCDefaultVPCAndSubnet_serial/Subnet/existing.ipv6 (58.60s)
        --- PASS: TestAccVPCDefaultVPCAndSubnet_serial/Subnet/existing.privateDnsNameOptionsOnLaunch (40.84s)
        --- PASS: TestAccVPCDefaultVPCAndSubnet_serial/Subnet/notFound.basic (21.28s)
        --- PASS: TestAccVPCDefaultVPCAndSubnet_serial/Subnet/notFound.ipv6Native (59.63s)
    --- PASS: TestAccVPCDefaultVPCAndSubnet_serial/VPC (182.84s)
        --- PASS: TestAccVPCDefaultVPCAndSubnet_serial/VPC/existing.basic (37.21s)
        --- PASS: TestAccVPCDefaultVPCAndSubnet_serial/VPC/existing.assignGeneratedIPv6CIDRBlock (27.36s)
        --- PASS: TestAccVPCDefaultVPCAndSubnet_serial/VPC/existing.forceDestroy (42.49s)
        --- PASS: TestAccVPCDefaultVPCAndSubnet_serial/VPC/notFound.basic (20.54s)
        --- PASS: TestAccVPCDefaultVPCAndSubnet_serial/VPC/notFound.assignGeneratedIPv6CIDRBlock (30.96s)
        --- PASS: TestAccVPCDefaultVPCAndSubnet_serial/VPC/notFound.forceDestroy (24.28s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	411.077s
FAIL
make: *** [testacc] Error 1
```
Failures are unrelated to this change.

```console
% ACCTEST_TIMEOUT=360m  make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 360m
=== RUN   TestAccEC2EBSDefaultKMSKeyDataSource_basic
=== PAUSE TestAccEC2EBSDefaultKMSKeyDataSource_basic
=== RUN   TestAccEC2EBSDefaultKMSKey_basic
=== PAUSE TestAccEC2EBSDefaultKMSKey_basic
=== RUN   TestAccEC2EBSEncryptionByDefaultDataSource_basic
=== PAUSE TestAccEC2EBSEncryptionByDefaultDataSource_basic
=== RUN   TestAccEC2EBSEncryptionByDefault_basic
=== PAUSE TestAccEC2EBSEncryptionByDefault_basic
=== RUN   TestAccEC2EBSSnapshotCopy_basic
=== PAUSE TestAccEC2EBSSnapshotCopy_basic
=== RUN   TestAccEC2EBSSnapshotCopy_tags
=== PAUSE TestAccEC2EBSSnapshotCopy_tags
=== RUN   TestAccEC2EBSSnapshotCreateVolumePermission_basic
=== PAUSE TestAccEC2EBSSnapshotCreateVolumePermission_basic
=== RUN   TestAccEC2EBSSnapshotDataSource_basic
=== PAUSE TestAccEC2EBSSnapshotDataSource_basic
=== RUN   TestAccEC2EBSSnapshotIDsDataSource_basic
=== PAUSE TestAccEC2EBSSnapshotIDsDataSource_basic
=== RUN   TestAccEC2EBSSnapshotImport_basic
=== PAUSE TestAccEC2EBSSnapshotImport_basic
=== RUN   TestAccEC2EBSSnapshotImport_tags
=== PAUSE TestAccEC2EBSSnapshotImport_tags
=== RUN   TestAccEC2EBSSnapshot_basic
=== PAUSE TestAccEC2EBSSnapshot_basic
=== RUN   TestAccEC2EBSSnapshot_tags
=== PAUSE TestAccEC2EBSSnapshot_tags
=== RUN   TestAccEC2EBSVolumeAttachment_basic
=== PAUSE TestAccEC2EBSVolumeAttachment_basic
=== RUN   TestAccEC2EBSVolumeDataSource_basic
=== PAUSE TestAccEC2EBSVolumeDataSource_basic
=== RUN   TestAccEC2EBSVolume_basic
=== PAUSE TestAccEC2EBSVolume_basic
=== RUN   TestAccEC2EBSVolume_GP3_basic
=== PAUSE TestAccEC2EBSVolume_GP3_basic
=== RUN   TestAccEC2EBSVolumesDataSource_basic
=== PAUSE TestAccEC2EBSVolumesDataSource_basic
=== RUN   TestAccEC2AMICopy_basic
=== PAUSE TestAccEC2AMICopy_basic
=== RUN   TestAccEC2AMICopy_tags
=== PAUSE TestAccEC2AMICopy_tags
=== RUN   TestAccEC2AMIFromInstance_basic
=== PAUSE TestAccEC2AMIFromInstance_basic
=== RUN   TestAccEC2AMIFromInstance_tags
=== PAUSE TestAccEC2AMIFromInstance_tags
=== RUN   TestAccEC2AMIIDsDataSource_basic
=== PAUSE TestAccEC2AMIIDsDataSource_basic
=== RUN   TestAccEC2AMILaunchPermission_basic
=== PAUSE TestAccEC2AMILaunchPermission_basic
=== RUN   TestAccEC2AMI_basic
=== PAUSE TestAccEC2AMI_basic
=== RUN   TestAccEC2AMI_tags
=== PAUSE TestAccEC2AMI_tags
=== RUN   TestAccEC2AvailabilityZonesDataSource_basic
=== PAUSE TestAccEC2AvailabilityZonesDataSource_basic
=== RUN   TestAccEC2CapacityReservation_basic
=== PAUSE TestAccEC2CapacityReservation_basic
=== RUN   TestAccEC2CapacityReservation_tags
=== PAUSE TestAccEC2CapacityReservation_tags
=== RUN   TestAccEC2EIPAssociation_basic
=== PAUSE TestAccEC2EIPAssociation_basic
=== RUN   TestAccEC2EIPDataSource_tags
=== PAUSE TestAccEC2EIPDataSource_tags
=== RUN   TestAccEC2EIP_basic
=== PAUSE TestAccEC2EIP_basic
=== RUN   TestAccEC2EIP_tags
=== PAUSE TestAccEC2EIP_tags
=== RUN   TestAccEC2EIPsDataSource_basic
=== PAUSE TestAccEC2EIPsDataSource_basic
=== RUN   TestAccEC2Fleet_basic
=== PAUSE TestAccEC2Fleet_basic
=== RUN   TestAccEC2Fleet_tags
=== PAUSE TestAccEC2Fleet_tags
=== RUN   TestAccEC2HostDataSource_basic
=== PAUSE TestAccEC2HostDataSource_basic
=== RUN   TestAccEC2Host_basic
=== PAUSE TestAccEC2Host_basic
=== RUN   TestAccEC2Host_tags
=== PAUSE TestAccEC2Host_tags
=== RUN   TestAccEC2InstanceDataSource_basic
=== PAUSE TestAccEC2InstanceDataSource_basic
=== RUN   TestAccEC2InstanceDataSource_tags
=== PAUSE TestAccEC2InstanceDataSource_tags
=== RUN   TestAccEC2InstanceState_basic
=== PAUSE TestAccEC2InstanceState_basic
=== RUN   TestAccEC2Instance_basic
=== PAUSE TestAccEC2Instance_basic
=== RUN   TestAccEC2Instance_tags
=== PAUSE TestAccEC2Instance_tags
=== RUN   TestAccEC2Instance_EBSRootDevice_basic
=== PAUSE TestAccEC2Instance_EBSRootDevice_basic
=== RUN   TestAccEC2Instance_LaunchTemplate_basic
=== PAUSE TestAccEC2Instance_LaunchTemplate_basic
=== RUN   TestAccEC2InstanceTypeDataSource_basic
=== PAUSE TestAccEC2InstanceTypeDataSource_basic
=== RUN   TestAccEC2InstanceTypesDataSource_basic
=== PAUSE TestAccEC2InstanceTypesDataSource_basic
=== RUN   TestAccEC2InstancesDataSource_basic
=== PAUSE TestAccEC2InstancesDataSource_basic
=== RUN   TestAccEC2InstancesDataSource_tags
=== PAUSE TestAccEC2InstancesDataSource_tags
=== RUN   TestAccEC2KeyPairDataSource_basic
=== PAUSE TestAccEC2KeyPairDataSource_basic
=== RUN   TestAccEC2KeyPair_basic
=== PAUSE TestAccEC2KeyPair_basic
=== RUN   TestAccEC2KeyPair_tags
=== PAUSE TestAccEC2KeyPair_tags
=== RUN   TestAccEC2LaunchTemplateDataSource_tags
=== PAUSE TestAccEC2LaunchTemplateDataSource_tags
=== RUN   TestAccEC2LaunchTemplate_basic
=== PAUSE TestAccEC2LaunchTemplate_basic
=== RUN   TestAccEC2LaunchTemplate_tags
=== PAUSE TestAccEC2LaunchTemplate_tags
=== RUN   TestAccEC2PlacementGroup_basic
=== PAUSE TestAccEC2PlacementGroup_basic
=== RUN   TestAccEC2PlacementGroup_tags
=== PAUSE TestAccEC2PlacementGroup_tags
=== RUN   TestAccEC2PublicIPv4PoolDataSource_basic
=== PAUSE TestAccEC2PublicIPv4PoolDataSource_basic
=== RUN   TestAccEC2PublicIPv4PoolsDataSource_basic
=== PAUSE TestAccEC2PublicIPv4PoolsDataSource_basic
=== RUN   TestAccEC2PublicIPv4PoolsDataSource_tags
=== PAUSE TestAccEC2PublicIPv4PoolsDataSource_tags
=== RUN   TestAccEC2SerialConsoleAccessDataSource_basic
=== PAUSE TestAccEC2SerialConsoleAccessDataSource_basic
=== RUN   TestAccEC2SerialConsoleAccess_basic
=== PAUSE TestAccEC2SerialConsoleAccess_basic
=== RUN   TestAccEC2SpotFleetRequest_basic
=== PAUSE TestAccEC2SpotFleetRequest_basic
=== RUN   TestAccEC2SpotFleetRequest_tags
=== PAUSE TestAccEC2SpotFleetRequest_tags
=== RUN   TestAccEC2SpotInstanceRequest_basic
=== PAUSE TestAccEC2SpotInstanceRequest_basic
=== RUN   TestAccEC2SpotInstanceRequest_tags
=== PAUSE TestAccEC2SpotInstanceRequest_tags
=== RUN   TestAccEC2SpotPriceDataSource_basic
=== PAUSE TestAccEC2SpotPriceDataSource_basic
=== RUN   TestAccIPAMOrganizationAdminAccount_basic
    acctest.go:772: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccIPAMOrganizationAdminAccount_basic (0.47s)
=== RUN   TestAccIPAMPoolCIDR_basic
=== PAUSE TestAccIPAMPoolCIDR_basic
=== RUN   TestAccIPAMPoolCIDRsDataSource_basic
=== PAUSE TestAccIPAMPoolCIDRsDataSource_basic
=== RUN   TestAccIPAMPoolDataSource_basic
=== PAUSE TestAccIPAMPoolDataSource_basic
=== RUN   TestAccIPAMPool_basic
=== PAUSE TestAccIPAMPool_basic
=== RUN   TestAccIPAMPool_tags
=== PAUSE TestAccIPAMPool_tags
=== RUN   TestAccIPAMPoolsDataSource_basic
=== PAUSE TestAccIPAMPoolsDataSource_basic
=== RUN   TestAccIPAMScope_basic
=== PAUSE TestAccIPAMScope_basic
=== RUN   TestAccIPAMScope_tags
=== PAUSE TestAccIPAMScope_tags
=== RUN   TestAccIPAM_basic
=== PAUSE TestAccIPAM_basic
=== RUN   TestAccIPAM_tags
=== PAUSE TestAccIPAM_tags
=== RUN   TestAccEC2OutpostsCoIPPoolsDataSource_basic
=== PAUSE TestAccEC2OutpostsCoIPPoolsDataSource_basic
=== RUN   TestAccEC2OutpostsLocalGatewayDataSource_basic
=== PAUSE TestAccEC2OutpostsLocalGatewayDataSource_basic
=== RUN   TestAccEC2OutpostsLocalGatewayRouteTableDataSource_basic
=== PAUSE TestAccEC2OutpostsLocalGatewayRouteTableDataSource_basic
=== RUN   TestAccEC2OutpostsLocalGatewayRouteTableVPCAssociation_basic
=== PAUSE TestAccEC2OutpostsLocalGatewayRouteTableVPCAssociation_basic
=== RUN   TestAccEC2OutpostsLocalGatewayRouteTableVPCAssociation_tags
=== PAUSE TestAccEC2OutpostsLocalGatewayRouteTableVPCAssociation_tags
=== RUN   TestAccEC2OutpostsLocalGatewayRouteTablesDataSource_basic
=== PAUSE TestAccEC2OutpostsLocalGatewayRouteTablesDataSource_basic
=== RUN   TestAccEC2OutpostsLocalGatewayRoute_basic
=== PAUSE TestAccEC2OutpostsLocalGatewayRoute_basic
=== RUN   TestAccEC2OutpostsLocalGatewayVirtualInterfaceDataSource_tags
=== PAUSE TestAccEC2OutpostsLocalGatewayVirtualInterfaceDataSource_tags
=== RUN   TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupDataSource_tags
=== PAUSE TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupDataSource_tags
=== RUN   TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupsDataSource_basic
=== PAUSE TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupsDataSource_basic
=== RUN   TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupsDataSource_tags
=== PAUSE TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupsDataSource_tags
=== RUN   TestAccEC2OutpostsLocalGatewaysDataSource_basic
=== PAUSE TestAccEC2OutpostsLocalGatewaysDataSource_basic
=== RUN   TestAccEC2Tag_basic
=== PAUSE TestAccEC2Tag_basic
=== RUN   TestAccVPCDataSource_basic
=== PAUSE TestAccVPCDataSource_basic
=== RUN   TestAccVPCDefaultNetworkACL_basic
=== PAUSE TestAccVPCDefaultNetworkACL_basic
=== RUN   TestAccVPCDefaultNetworkACL_tags
=== PAUSE TestAccVPCDefaultNetworkACL_tags
=== RUN   TestAccVPCDefaultRouteTable_basic
=== PAUSE TestAccVPCDefaultRouteTable_basic
=== RUN   TestAccVPCDefaultRouteTable_tags
=== PAUSE TestAccVPCDefaultRouteTable_tags
=== RUN   TestAccVPCDefaultSecurityGroup_basic
=== PAUSE TestAccVPCDefaultSecurityGroup_basic
=== RUN   TestAccVPCDHCPOptionsAssociation_basic
=== PAUSE TestAccVPCDHCPOptionsAssociation_basic
=== RUN   TestAccVPCDHCPOptionsDataSource_basic
=== PAUSE TestAccVPCDHCPOptionsDataSource_basic
=== RUN   TestAccVPCDHCPOptions_basic
=== PAUSE TestAccVPCDHCPOptions_basic
=== RUN   TestAccVPCDHCPOptions_tags
=== PAUSE TestAccVPCDHCPOptions_tags
=== RUN   TestAccVPCEgressOnlyInternetGateway_basic
=== PAUSE TestAccVPCEgressOnlyInternetGateway_basic
=== RUN   TestAccVPCEgressOnlyInternetGateway_tags
=== PAUSE TestAccVPCEgressOnlyInternetGateway_tags
=== RUN   TestAccVPCEndpointConnectionNotification_basic
=== PAUSE TestAccVPCEndpointConnectionNotification_basic
=== RUN   TestAccVPCEndpointPolicy_basic
=== PAUSE TestAccVPCEndpointPolicy_basic
=== RUN   TestAccVPCEndpointRouteTableAssociation_basic
=== PAUSE TestAccVPCEndpointRouteTableAssociation_basic
=== RUN   TestAccVPCEndpointSecurityGroupAssociation_basic
=== PAUSE TestAccVPCEndpointSecurityGroupAssociation_basic
=== RUN   TestAccVPCEndpointServiceAllowedPrincipal_basic
=== PAUSE TestAccVPCEndpointServiceAllowedPrincipal_basic
=== RUN   TestAccVPCEndpointServiceDataSource_CustomFilter_tags
=== PAUSE TestAccVPCEndpointServiceDataSource_CustomFilter_tags
=== RUN   TestAccVPCEndpointService_basic
=== PAUSE TestAccVPCEndpointService_basic
=== RUN   TestAccVPCEndpointService_tags
=== PAUSE TestAccVPCEndpointService_tags
=== RUN   TestAccVPCEndpointSubnetAssociation_basic
=== PAUSE TestAccVPCEndpointSubnetAssociation_basic
=== RUN   TestAccVPCEndpoint_tags
=== PAUSE TestAccVPCEndpoint_tags
=== RUN   TestAccVPCFlowLog_basic
=== PAUSE TestAccVPCFlowLog_basic
=== RUN   TestAccVPCFlowLog_tags
=== PAUSE TestAccVPCFlowLog_tags
=== RUN   TestAccVPCInternetGatewayAttachment_basic
=== PAUSE TestAccVPCInternetGatewayAttachment_basic
=== RUN   TestAccVPCInternetGatewayDataSource_basic
=== PAUSE TestAccVPCInternetGatewayDataSource_basic
=== RUN   TestAccVPCInternetGateway_basic
=== PAUSE TestAccVPCInternetGateway_basic
=== RUN   TestAccVPCIPv4CIDRBlockAssociation_basic
=== PAUSE TestAccVPCIPv4CIDRBlockAssociation_basic
=== RUN   TestAccVPCMainRouteTableAssociation_basic
=== PAUSE TestAccVPCMainRouteTableAssociation_basic
=== RUN   TestAccVPCManagedPrefixListDataSource_basic
=== PAUSE TestAccVPCManagedPrefixListDataSource_basic
=== RUN   TestAccVPCManagedPrefixList_basic
=== PAUSE TestAccVPCManagedPrefixList_basic
=== RUN   TestAccVPCManagedPrefixList_tags
=== PAUSE TestAccVPCManagedPrefixList_tags
=== RUN   TestAccVPCManagedPrefixListsDataSource_basic
=== PAUSE TestAccVPCManagedPrefixListsDataSource_basic
=== RUN   TestAccVPCManagedPrefixListsDataSource_tags
=== PAUSE TestAccVPCManagedPrefixListsDataSource_tags
=== RUN   TestAccVPCNATGatewayDataSource_basic
=== PAUSE TestAccVPCNATGatewayDataSource_basic
=== RUN   TestAccVPCNATGateway_basic
=== PAUSE TestAccVPCNATGateway_basic
=== RUN   TestAccVPCNATGateway_tags
=== PAUSE TestAccVPCNATGateway_tags
=== RUN   TestAccVPCNATGatewaysDataSource_basic
=== PAUSE TestAccVPCNATGatewaysDataSource_basic
=== RUN   TestAccVPCNetworkACLAssociation_basic
=== PAUSE TestAccVPCNetworkACLAssociation_basic
=== RUN   TestAccVPCNetworkACLRule_basic
=== PAUSE TestAccVPCNetworkACLRule_basic
=== RUN   TestAccVPCNetworkACL_basic
=== PAUSE TestAccVPCNetworkACL_basic
=== RUN   TestAccVPCNetworkACL_tags
=== PAUSE TestAccVPCNetworkACL_tags
=== RUN   TestAccVPCNetworkACL_OnlyIngressRules_basic
=== PAUSE TestAccVPCNetworkACL_OnlyIngressRules_basic
=== RUN   TestAccVPCNetworkACLsDataSource_basic
=== PAUSE TestAccVPCNetworkACLsDataSource_basic
=== RUN   TestAccVPCNetworkACLsDataSource_tags
=== PAUSE TestAccVPCNetworkACLsDataSource_tags
=== RUN   TestAccVPCNetworkInsightsAnalysisDataSource_basic
=== PAUSE TestAccVPCNetworkInsightsAnalysisDataSource_basic
=== RUN   TestAccVPCNetworkInsightsAnalysis_basic
=== PAUSE TestAccVPCNetworkInsightsAnalysis_basic
=== RUN   TestAccVPCNetworkInsightsAnalysis_tags
=== PAUSE TestAccVPCNetworkInsightsAnalysis_tags
=== RUN   TestAccVPCNetworkInsightsPathDataSource_basic
=== PAUSE TestAccVPCNetworkInsightsPathDataSource_basic
=== RUN   TestAccVPCNetworkInsightsPath_basic
=== PAUSE TestAccVPCNetworkInsightsPath_basic
=== RUN   TestAccVPCNetworkInsightsPath_tags
=== PAUSE TestAccVPCNetworkInsightsPath_tags
=== RUN   TestAccVPCNetworkInterfaceAttachment_basic
=== PAUSE TestAccVPCNetworkInterfaceAttachment_basic
=== RUN   TestAccVPCNetworkInterfaceDataSource_basic
=== PAUSE TestAccVPCNetworkInterfaceDataSource_basic
=== RUN   TestAccVPCNetworkInterfaceSgAttachment_basic
=== PAUSE TestAccVPCNetworkInterfaceSgAttachment_basic
=== RUN   TestAccVPCNetworkInterface_basic
=== PAUSE TestAccVPCNetworkInterface_basic
=== RUN   TestAccVPCNetworkInterface_tags
=== PAUSE TestAccVPCNetworkInterface_tags
=== RUN   TestAccVPCNetworkInterfacesDataSource_tags
=== PAUSE TestAccVPCNetworkInterfacesDataSource_tags
=== RUN   TestAccVPCPeeringConnectionOptions_basic
=== PAUSE TestAccVPCPeeringConnectionOptions_basic
=== RUN   TestAccVPCPeeringConnection_basic
=== PAUSE TestAccVPCPeeringConnection_basic
=== RUN   TestAccVPCPeeringConnection_tags
=== PAUSE TestAccVPCPeeringConnection_tags
=== RUN   TestAccVPCPeeringConnectionsDataSource_basic
=== PAUSE TestAccVPCPeeringConnectionsDataSource_basic
=== RUN   TestAccVPCPrefixListDataSource_basic
=== PAUSE TestAccVPCPrefixListDataSource_basic
=== RUN   TestAccVPCRouteDataSource_basic
=== PAUSE TestAccVPCRouteDataSource_basic
=== RUN   TestAccVPCRouteTableAssociation_Subnet_basic
=== PAUSE TestAccVPCRouteTableAssociation_Subnet_basic
=== RUN   TestAccVPCRouteTableAssociation_Gateway_basic
=== PAUSE TestAccVPCRouteTableAssociation_Gateway_basic
=== RUN   TestAccVPCRouteTableDataSource_basic
=== PAUSE TestAccVPCRouteTableDataSource_basic
=== RUN   TestAccVPCRouteTable_basic
=== PAUSE TestAccVPCRouteTable_basic
=== RUN   TestAccVPCRouteTable_tags
=== PAUSE TestAccVPCRouteTable_tags
=== RUN   TestAccVPCRouteTablesDataSource_basic
=== PAUSE TestAccVPCRouteTablesDataSource_basic
=== RUN   TestAccVPCRoute_basic
=== PAUSE TestAccVPCRoute_basic
=== RUN   TestAccVPCSecurityGroupDataSource_basic
=== PAUSE TestAccVPCSecurityGroupDataSource_basic
=== RUN   TestAccVPCSecurityGroupEgressRule_basic
=== PAUSE TestAccVPCSecurityGroupEgressRule_basic
=== RUN   TestAccVPCSecurityGroupIngressRule_basic
=== PAUSE TestAccVPCSecurityGroupIngressRule_basic
=== RUN   TestAccVPCSecurityGroupIngressRule_tags
=== PAUSE TestAccVPCSecurityGroupIngressRule_tags
=== RUN   TestAccVPCSecurityGroupRuleDataSource_basic
=== PAUSE TestAccVPCSecurityGroupRuleDataSource_basic
=== RUN   TestAccVPCSecurityGroupRule_PartialMatching_basic
=== PAUSE TestAccVPCSecurityGroupRule_PartialMatching_basic
=== RUN   TestAccVPCSecurityGroupRulesDataSource_basic
=== PAUSE TestAccVPCSecurityGroupRulesDataSource_basic
=== RUN   TestAccVPCSecurityGroupRulesDataSource_tags
=== PAUSE TestAccVPCSecurityGroupRulesDataSource_tags
=== RUN   TestAccVPCSecurityGroup_basic
=== PAUSE TestAccVPCSecurityGroup_basic
=== RUN   TestAccVPCSecurityGroup_tags
=== PAUSE TestAccVPCSecurityGroup_tags
=== RUN   TestAccVPCSubnetCIDRReservation_basic
=== PAUSE TestAccVPCSubnetCIDRReservation_basic
=== RUN   TestAccVPCSubnetDataSource_basic
=== PAUSE TestAccVPCSubnetDataSource_basic
=== RUN   TestAccVPCSubnetIDsDataSource_basic
=== PAUSE TestAccVPCSubnetIDsDataSource_basic
=== RUN   TestAccVPCSubnet_basic
=== PAUSE TestAccVPCSubnet_basic
=== RUN   TestAccVPCSubnet_tags
=== PAUSE TestAccVPCSubnet_tags
=== RUN   TestAccVPCSubnetsDataSource_basic
=== PAUSE TestAccVPCSubnetsDataSource_basic
=== RUN   TestAccVPC_basic
=== PAUSE TestAccVPC_basic
=== RUN   TestAccVPC_tags
=== PAUSE TestAccVPC_tags
=== RUN   TestAccVPCTrafficMirrorFilterRule_basic
=== PAUSE TestAccVPCTrafficMirrorFilterRule_basic
=== RUN   TestAccVPCTrafficMirrorFilter_basic
=== PAUSE TestAccVPCTrafficMirrorFilter_basic
=== RUN   TestAccVPCTrafficMirrorFilter_tags
=== PAUSE TestAccVPCTrafficMirrorFilter_tags
=== RUN   TestAccVPCTrafficMirrorSession_basic
=== PAUSE TestAccVPCTrafficMirrorSession_basic
=== RUN   TestAccVPCTrafficMirrorSession_tags
=== PAUSE TestAccVPCTrafficMirrorSession_tags
=== RUN   TestAccVPCTrafficMirrorTarget_tags
=== PAUSE TestAccVPCTrafficMirrorTarget_tags
=== RUN   TestAccVPCsDataSource_basic
=== PAUSE TestAccVPCsDataSource_basic
=== RUN   TestAccVPCsDataSource_tags
=== PAUSE TestAccVPCsDataSource_tags
=== RUN   TestAccSiteVPNConnectionRoute_basic
=== PAUSE TestAccSiteVPNConnectionRoute_basic
=== RUN   TestAccSiteVPNConnection_basic
=== PAUSE TestAccSiteVPNConnection_basic
=== RUN   TestAccSiteVPNConnection_tags
=== PAUSE TestAccSiteVPNConnection_tags
=== RUN   TestAccSiteVPNCustomerGateway_basic
=== PAUSE TestAccSiteVPNCustomerGateway_basic
=== RUN   TestAccSiteVPNCustomerGateway_tags
=== PAUSE TestAccSiteVPNCustomerGateway_tags
=== RUN   TestAccSiteVPNGatewayAttachment_basic
=== PAUSE TestAccSiteVPNGatewayAttachment_basic
=== RUN   TestAccSiteVPNGatewayRoutePropagation_basic
=== PAUSE TestAccSiteVPNGatewayRoutePropagation_basic
=== RUN   TestAccSiteVPNGateway_basic
=== PAUSE TestAccSiteVPNGateway_basic
=== RUN   TestAccSiteVPNGateway_tags
=== PAUSE TestAccSiteVPNGateway_tags
=== RUN   TestAccWavelengthCarrierGateway_basic
=== PAUSE TestAccWavelengthCarrierGateway_basic
=== RUN   TestAccWavelengthCarrierGateway_tags
=== PAUSE TestAccWavelengthCarrierGateway_tags
=== CONT  TestAccSiteVPNConnection_tags
=== CONT  TestAccEC2EBSDefaultKMSKeyDataSource_basic
=== CONT  TestAccVPCDefaultRouteTable_tags
=== CONT  TestAccEC2EBSDefaultKMSKeyDataSource_basic
    ebs_default_kms_key_data_source_test.go:13: Step 1/1 error: Check failed: Check 1/1 error: Default CMK (arn:aws:kms:us-west-2:123456789012:key/039ff87e-a813-4464-829a-603049ac93ee) is the account's AWS-managed default CMK (arn:aws:kms:us-west-2:123456789012:key/039ff87e-a813-4464-829a-603049ac93ee)
--- FAIL: TestAccEC2EBSDefaultKMSKeyDataSource_basic (7.07s)
=== CONT  TestAccEC2InstancesDataSource_basic
--- PASS: TestAccVPCDefaultRouteTable_tags (42.00s)
=== CONT  TestAccVPCDefaultRouteTable_basic
--- PASS: TestAccVPCDefaultRouteTable_basic (26.52s)
=== CONT  TestAccVPCDefaultNetworkACL_tags
--- PASS: TestAccVPCDefaultNetworkACL_tags (44.22s)
=== CONT  TestAccVPCDefaultNetworkACL_basic
--- PASS: TestAccEC2InstancesDataSource_basic (113.15s)
=== CONT  TestAccVPCDataSource_basic
--- PASS: TestAccVPCDefaultNetworkACL_basic (18.64s)
=== CONT  TestAccEC2Tag_basic
--- PASS: TestAccVPCDataSource_basic (29.49s)
=== CONT  TestAccIPAMPoolCIDR_basic
    ipam_pool_cidr_test.go:25: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_vpc_ipam_pool.test will be updated in-place
          ~ resource "aws_vpc_ipam_pool" "test" {
                id                    = "ipam-pool-09a0014262402532d"
              + tags_all              = (known after apply)
                # (9 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccIPAMPoolCIDR_basic (59.73s)
=== CONT  TestAccEC2SpotPriceDataSource_basic
--- PASS: TestAccSiteVPNConnection_tags (217.82s)
=== CONT  TestAccEC2SpotInstanceRequest_tags
--- PASS: TestAccEC2SpotPriceDataSource_basic (11.61s)
=== CONT  TestAccEC2SpotInstanceRequest_basic
--- PASS: TestAccEC2SpotInstanceRequest_basic (108.46s)
=== CONT  TestAccEC2SpotFleetRequest_tags
=== CONT  TestAccEC2Tag_basic
    tag_test.go:19: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_customer_gateway.test will be updated in-place
          ~ resource "aws_customer_gateway" "test" {
                id         = "cgw-06f1111c220e9948a"
              + tags_all   = (known after apply)
                # (4 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- PASS: TestAccEC2SpotInstanceRequest_tags (175.07s)
=== CONT  TestAccEC2SpotFleetRequest_basic
--- PASS: TestAccEC2SpotFleetRequest_tags (190.26s)
=== CONT  TestAccEC2SerialConsoleAccess_basic
--- PASS: TestAccEC2SpotFleetRequest_basic (134.28s)
=== CONT  TestAccIPAMPoolCIDRsDataSource_basic
--- PASS: TestAccEC2SerialConsoleAccess_basic (24.67s)
=== CONT  TestAccEC2OutpostsLocalGatewaysDataSource_basic
    acctest.go:1047: skipping since no Outposts found
--- SKIP: TestAccEC2OutpostsLocalGatewaysDataSource_basic (0.63s)
=== CONT  TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupsDataSource_tags
    acctest.go:1047: skipping since no Outposts found
--- SKIP: TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupsDataSource_tags (0.20s)
=== CONT  TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupsDataSource_basic
    acctest.go:1047: skipping since no Outposts found
--- SKIP: TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupsDataSource_basic (0.18s)
=== CONT  TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupDataSource_tags
    acctest.go:1047: skipping since no Outposts found
--- SKIP: TestAccEC2OutpostsLocalGatewayVirtualInterfaceGroupDataSource_tags (0.23s)
=== CONT  TestAccEC2OutpostsLocalGatewayVirtualInterfaceDataSource_tags
    acctest.go:1047: skipping since no Outposts found
--- SKIP: TestAccEC2OutpostsLocalGatewayVirtualInterfaceDataSource_tags (0.21s)
=== CONT  TestAccEC2OutpostsLocalGatewayRoute_basic
    acctest.go:1047: skipping since no Outposts found
--- SKIP: TestAccEC2OutpostsLocalGatewayRoute_basic (0.20s)
=== CONT  TestAccEC2OutpostsLocalGatewayRouteTablesDataSource_basic
    acctest.go:1047: skipping since no Outposts found
--- SKIP: TestAccEC2OutpostsLocalGatewayRouteTablesDataSource_basic (0.17s)
=== CONT  TestAccEC2OutpostsLocalGatewayRouteTableVPCAssociation_tags
    acctest.go:1047: skipping since no Outposts found
--- SKIP: TestAccEC2OutpostsLocalGatewayRouteTableVPCAssociation_tags (0.22s)
=== CONT  TestAccEC2OutpostsLocalGatewayRouteTableVPCAssociation_basic
    acctest.go:1047: skipping since no Outposts found
--- SKIP: TestAccEC2OutpostsLocalGatewayRouteTableVPCAssociation_basic (0.17s)
=== CONT  TestAccEC2OutpostsLocalGatewayRouteTableDataSource_basic
    acctest.go:1047: skipping since no Outposts found
--- SKIP: TestAccEC2OutpostsLocalGatewayRouteTableDataSource_basic (0.20s)
=== CONT  TestAccEC2OutpostsLocalGatewayDataSource_basic
    acctest.go:1047: skipping since no Outposts found
--- SKIP: TestAccEC2OutpostsLocalGatewayDataSource_basic (0.21s)
=== CONT  TestAccEC2OutpostsCoIPPoolsDataSource_basic
    acctest.go:1047: skipping since no Outposts found
--- SKIP: TestAccEC2OutpostsCoIPPoolsDataSource_basic (0.18s)
=== CONT  TestAccIPAM_tags
--- FAIL: TestAccEC2Tag_basic (427.66s)
=== CONT  TestAccIPAM_basic
=== CONT  TestAccIPAMPoolCIDRsDataSource_basic
    ipam_pool_cidrs_data_source_test.go:15: Step 1/3 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
         <= read (data resources)
        
        Terraform will perform the following actions:
        
          # data.aws_vpc_ipam_pool_cidrs.test will be read during apply
          # (config refers to values not yet known)
         <= data "aws_vpc_ipam_pool_cidrs" "test"  {
              ~ id              = "ipam-pool-0362fccaabab71f60" -> (known after apply)
              ~ ipam_pool_cidrs = [
                  - {
                      - cidr  = "172.2.0.0/16"
                      - state = "provisioned"
                    },
                ] -> (known after apply)
                # (1 unchanged attribute hidden)
        
              + timeouts {
                  + read = (known after apply)
                }
            }
        
          # aws_vpc_ipam_pool.test will be updated in-place
          ~ resource "aws_vpc_ipam_pool" "test" {
                id                    = "ipam-pool-0362fccaabab71f60"
              + tags_all              = (known after apply)
                # (9 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccIPAMPoolCIDRsDataSource_basic (73.46s)
=== CONT  TestAccIPAMScope_tags
--- PASS: TestAccIPAM_tags (53.97s)
=== CONT  TestAccEC2SerialConsoleAccessDataSource_basic
--- PASS: TestAccIPAM_basic (49.28s)
=== CONT  TestAccIPAMScope_basic
--- PASS: TestAccEC2SerialConsoleAccessDataSource_basic (11.96s)
=== CONT  TestAccIPAMPoolsDataSource_basic
    ipam_pools_data_source_test.go:17: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
         <= read (data resources)
        
        Terraform will perform the following actions:
        
          # data.aws_vpc_ipam_pools.test will be read during apply
          # (config refers to values not yet known)
         <= data "aws_vpc_ipam_pools" "test"  {
              ~ id         = "us-west-2" -> (known after apply)
              ~ ipam_pools = [
                  - {
                      - address_family                    = "ipv4"
                      - allocation_default_netmask_length = 32
                      - allocation_max_netmask_length     = 32
                      - allocation_min_netmask_length     = 32
                      - allocation_resource_tags          = {
                          - "test" = "1"
                        }
                      - arn                               = "arn:aws:ec2::123456789012:ipam-pool/ipam-pool-02cc2e9c8c88cf24a"
                      - auto_import                       = true
                      - aws_service                       = ""
                      - description                       = "test"
                      - id                                = ""
                      - ipam_pool_id                      = ""
                      - ipam_scope_id                     = "ipam-scope-034510857718e00d5"
                      - ipam_scope_type                   = "private"
                      - locale                            = "None"
                      - pool_depth                        = 1
                      - publicly_advertisable             = false
                      - source_ipam_pool_id               = ""
                      - state                             = "create-complete"
                      - tags                              = {}
                    },
                ] -> (known after apply)
            }
        
          # aws_vpc_ipam_pool.test will be updated in-place
          ~ resource "aws_vpc_ipam_pool" "test" {
                id                                = "ipam-pool-02cc2e9c8c88cf24a"
              + tags_all                          = (known after apply)
                # (14 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccIPAMPoolsDataSource_basic (49.93s)
=== CONT  TestAccIPAMPool_tags
--- PASS: TestAccIPAMScope_tags (62.68s)
=== CONT  TestAccEC2PublicIPv4PoolsDataSource_tags
--- PASS: TestAccIPAMScope_basic (62.95s)
=== CONT  TestAccIPAMPool_basic
--- PASS: TestAccEC2PublicIPv4PoolsDataSource_tags (11.68s)
=== CONT  TestAccEC2PublicIPv4PoolsDataSource_basic
--- PASS: TestAccEC2PublicIPv4PoolsDataSource_basic (11.49s)
=== CONT  TestAccEC2PublicIPv4PoolDataSource_basic
    ec2_public_ipv4_pool_data_source_test.go:49: skipping since no EC2 Public IPv4 Pools found
--- SKIP: TestAccEC2PublicIPv4PoolDataSource_basic (0.10s)
=== CONT  TestAccEC2PlacementGroup_tags
=== CONT  TestAccIPAMPool_tags
    ipam_pool_test.go:163: Step 2/4 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
        
          map[string]string{
        - 	"tags.%":        "1",
        - 	"tags.key1":     "value1",
        - 	"tags_all.%":    "1",
        - 	"tags_all.key1": "value1",
          }
=== CONT  TestAccIPAMPool_basic
    ipam_pool_test.go:22: Step 1/3 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_vpc_ipam_pool.test will be updated in-place
          ~ resource "aws_vpc_ipam_pool" "test" {
                id                    = "ipam-pool-0caf93bc244d46daa"
              + tags_all              = (known after apply)
                # (9 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
=== CONT  TestAccEC2PlacementGroup_tags
    ec2_placement_group_test.go:79: Step 3/4 error: Error running apply: exit status 1
        
        Error: updating tags for EC2 (Elastic Compute Cloud) Placement Group (tf-acc-test-2618531062826989821): tagging resource (tf-acc-test-2618531062826989821): InvalidID: The ID 'tf-acc-test-2618531062826989821' is not valid
        	status code: 400, request id: 334bfe97-e849-4107-9e85-e21e1cf37910
        
          with aws_placement_group.test,
          on terraform_plugin_test.tf line 2, in resource "aws_placement_group" "test":
           2: resource "aws_placement_group" "test" {
        
--- FAIL: TestAccEC2PlacementGroup_tags (21.50s)
=== CONT  TestAccEC2PlacementGroup_basic
--- FAIL: TestAccIPAMPool_tags (57.71s)
=== CONT  TestAccEC2AMI_basic
--- FAIL: TestAccIPAMPool_basic (50.48s)
=== CONT  TestAccEC2InstanceTypesDataSource_basic
--- PASS: TestAccEC2PlacementGroup_basic (16.40s)
=== CONT  TestAccEC2InstanceTypeDataSource_basic
--- PASS: TestAccEC2InstanceTypeDataSource_basic (11.87s)
=== CONT  TestAccIPAMPoolDataSource_basic
--- PASS: TestAccEC2InstanceTypesDataSource_basic (21.79s)
=== CONT  TestAccEC2Instance_LaunchTemplate_basic
=== CONT  TestAccIPAMPoolDataSource_basic
    ipam_pool_data_source_test.go:16: Step 1/1 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
         <= read (data resources)
        
        Terraform will perform the following actions:
        
          # data.aws_vpc_ipam_pool.test will be read during apply
          # (config refers to values not yet known)
         <= data "aws_vpc_ipam_pool" "test"  {
              ~ address_family                    = "ipv4" -> (known after apply)
              ~ allocation_default_netmask_length = 32 -> (known after apply)
              ~ allocation_max_netmask_length     = 32 -> (known after apply)
              ~ allocation_min_netmask_length     = 32 -> (known after apply)
              ~ allocation_resource_tags          = {
                  - "test" = "1"
                } -> (known after apply)
              ~ arn                               = "arn:aws:ec2::123456789012:ipam-pool/ipam-pool-0eb76d7f3bb4f07be" -> (known after apply)
              ~ auto_import                       = true -> (known after apply)
              + aws_service                       = (known after apply)
              ~ description                       = "test" -> (known after apply)
              - id                                = "ipam-pool-0eb76d7f3bb4f07be" -> null
              ~ ipam_scope_id                     = "ipam-scope-0f1e01075b68de311" -> (known after apply)
              ~ ipam_scope_type                   = "private" -> (known after apply)
              ~ locale                            = "None" -> (known after apply)
              ~ pool_depth                        = 1 -> (known after apply)
              ~ publicly_advertisable             = false -> (known after apply)
              + source_ipam_pool_id               = (known after apply)
              ~ state                             = "create-complete" -> (known after apply)
              ~ tags                              = {} -> (known after apply)
                # (1 unchanged attribute hidden)
        
              + timeouts {
                  + read = (known after apply)
                }
            }
        
          # aws_vpc_ipam_pool.test will be updated in-place
          ~ resource "aws_vpc_ipam_pool" "test" {
                id                                = "ipam-pool-0eb76d7f3bb4f07be"
              + tags_all                          = (known after apply)
                # (14 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccIPAMPoolDataSource_basic (45.95s)
=== CONT  TestAccEC2LaunchTemplate_tags
--- PASS: TestAccEC2AMI_basic (65.63s)
=== CONT  TestAccEC2Instance_EBSRootDevice_basic
--- PASS: TestAccEC2LaunchTemplate_tags (38.15s)
=== CONT  TestAccEC2KeyPair_tags
--- PASS: TestAccEC2KeyPair_tags (37.17s)
=== CONT  TestAccEC2KeyPair_basic
--- PASS: TestAccEC2Instance_LaunchTemplate_basic (117.83s)
=== CONT  TestAccEC2LaunchTemplate_basic
--- PASS: TestAccEC2KeyPair_basic (16.10s)
=== CONT  TestAccEC2KeyPairDataSource_basic
--- PASS: TestAccEC2LaunchTemplate_basic (16.79s)
=== CONT  TestAccEC2LaunchTemplateDataSource_tags
--- PASS: TestAccEC2KeyPairDataSource_basic (14.75s)
=== CONT  TestAccEC2InstancesDataSource_tags
--- PASS: TestAccEC2LaunchTemplateDataSource_tags (15.60s)
=== CONT  TestAccEC2EBSSnapshot_tags
--- PASS: TestAccEC2Instance_EBSRootDevice_basic (114.14s)
=== CONT  TestAccEC2AMILaunchPermission_basic
--- PASS: TestAccEC2EBSSnapshot_tags (77.06s)
=== CONT  TestAccEC2EBSSnapshotCreateVolumePermission_basic
    acctest.go:772: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccEC2EBSSnapshotCreateVolumePermission_basic (0.00s)
=== CONT  TestAccEC2AMIIDsDataSource_basic
--- PASS: TestAccEC2AMIIDsDataSource_basic (18.87s)
=== CONT  TestAccEC2EBSSnapshot_basic
--- PASS: TestAccEC2InstancesDataSource_tags (124.02s)
=== CONT  TestAccEC2AMIFromInstance_tags
--- PASS: TestAccEC2EBSSnapshot_basic (53.73s)
=== CONT  TestAccEC2Instance_tags
--- PASS: TestAccEC2Instance_tags (155.19s)
=== CONT  TestAccEC2Instance_basic
--- PASS: TestAccEC2AMILaunchPermission_basic (346.11s)
=== CONT  TestAccEC2InstanceState_basic
--- PASS: TestAccEC2Instance_basic (95.64s)
=== CONT  TestAccEC2InstanceDataSource_tags
--- PASS: TestAccEC2AMIFromInstance_tags (330.05s)
=== CONT  TestAccEC2InstanceDataSource_basic
--- PASS: TestAccEC2InstanceDataSource_tags (123.12s)
=== CONT  TestAccEC2AMIFromInstance_basic
--- PASS: TestAccEC2InstanceDataSource_basic (94.74s)
=== CONT  TestAccEC2AMICopy_tags
--- PASS: TestAccEC2InstanceState_basic (345.32s)
=== CONT  TestAccEC2AMICopy_basic
--- PASS: TestAccEC2AMIFromInstance_basic (315.30s)
=== CONT  TestAccEC2EBSVolumesDataSource_basic
--- PASS: TestAccEC2EBSVolumesDataSource_basic (36.88s)
=== CONT  TestAccEC2Host_tags
--- PASS: TestAccEC2Host_tags (41.91s)
=== CONT  TestAccEC2Host_basic
--- PASS: TestAccEC2Host_basic (17.77s)
=== CONT  TestAccEC2HostDataSource_basic
--- PASS: TestAccEC2HostDataSource_basic (15.09s)
=== CONT  TestAccEC2Fleet_tags
--- PASS: TestAccEC2AMICopy_tags (413.85s)
=== CONT  TestAccEC2EBSVolume_GP3_basic
--- PASS: TestAccEC2EBSVolume_GP3_basic (37.37s)
=== CONT  TestAccEC2EBSVolume_basic
--- PASS: TestAccEC2EBSVolume_basic (37.01s)
=== CONT  TestAccEC2EBSVolumeDataSource_basic
--- PASS: TestAccEC2Fleet_tags (98.08s)
=== CONT  TestAccEC2EBSVolumeAttachment_basic
--- PASS: TestAccEC2EBSVolumeDataSource_basic (35.28s)
=== CONT  TestAccEC2Fleet_basic
--- PASS: TestAccEC2AMICopy_basic (377.86s)
=== CONT  TestAccEC2EBSSnapshotIDsDataSource_basic
--- PASS: TestAccEC2Fleet_basic (47.46s)
=== CONT  TestAccEC2EIPsDataSource_basic
--- PASS: TestAccEC2EBSSnapshotIDsDataSource_basic (51.56s)
=== CONT  TestAccEC2EIP_tags
--- PASS: TestAccEC2EIPsDataSource_basic (14.36s)
=== CONT  TestAccEC2EIP_basic
--- PASS: TestAccEC2EIP_basic (16.17s)
=== CONT  TestAccEC2EIPDataSource_tags
--- PASS: TestAccEC2EIPDataSource_tags (14.67s)
=== CONT  TestAccEC2EIPAssociation_basic
--- PASS: TestAccEC2EIP_tags (37.16s)
=== CONT  TestAccEC2EBSSnapshotImport_basic
--- PASS: TestAccEC2EBSVolumeAttachment_basic (116.31s)
=== CONT  TestAccEC2CapacityReservation_tags
--- PASS: TestAccEC2CapacityReservation_tags (41.73s)
=== CONT  TestAccEC2CapacityReservation_basic
--- PASS: TestAccEC2CapacityReservation_basic (17.34s)
=== CONT  TestAccVPCMainRouteTableAssociation_basic
--- PASS: TestAccEC2EIPAssociation_basic (98.89s)
=== CONT  TestAccVPCNetworkInsightsPath_tags
--- PASS: TestAccVPCMainRouteTableAssociation_basic (35.68s)
=== CONT  TestAccEC2EBSSnapshotImport_tags
--- PASS: TestAccEC2EBSSnapshotImport_basic (143.44s)
=== CONT  TestAccEC2AvailabilityZonesDataSource_basic
--- PASS: TestAccVPCNetworkInsightsPath_tags (53.17s)
=== CONT  TestAccEC2AMI_tags
--- PASS: TestAccEC2AvailabilityZonesDataSource_basic (11.14s)
=== CONT  TestAccEC2EBSSnapshotDataSource_basic
--- PASS: TestAccEC2EBSSnapshotDataSource_basic (51.16s)
=== CONT  TestAccVPCSecurityGroupRule_PartialMatching_basic
--- PASS: TestAccVPCSecurityGroupRule_PartialMatching_basic (30.81s)
=== CONT  TestAccVPCNetworkACLRule_basic
--- PASS: TestAccEC2AMI_tags (90.82s)
=== CONT  TestAccSiteVPNConnection_basic
--- PASS: TestAccEC2EBSSnapshotImport_tags (163.08s)
=== CONT  TestAccVPCNetworkInsightsPathDataSource_basic
--- PASS: TestAccVPCNetworkACLRule_basic (27.16s)
=== CONT  TestAccSiteVPNConnectionRoute_basic
--- PASS: TestAccVPCNetworkInsightsPathDataSource_basic (21.81s)
=== CONT  TestAccVPCsDataSource_tags
--- PASS: TestAccVPCsDataSource_tags (16.31s)
=== CONT  TestAccVPCsDataSource_basic
--- PASS: TestAccVPCsDataSource_basic (17.03s)
=== CONT  TestAccVPCTrafficMirrorTarget_tags
--- PASS: TestAccSiteVPNConnection_basic (194.20s)
=== CONT  TestAccVPCTrafficMirrorSession_tags
--- PASS: TestAccSiteVPNConnectionRoute_basic (193.44s)
=== CONT  TestAccVPCNetworkInsightsPath_basic
--- PASS: TestAccVPCNetworkInsightsPath_basic (24.62s)
=== CONT  TestAccVPCNetworkInterfaceAttachment_basic
--- PASS: TestAccVPCTrafficMirrorTarget_tags (256.79s)
=== CONT  TestAccVPCNetworkACLAssociation_basic
--- PASS: TestAccVPCNetworkACLAssociation_basic (21.69s)
=== CONT  TestAccVPCSecurityGroupRuleDataSource_basic
--- PASS: TestAccVPCSecurityGroupRuleDataSource_basic (20.92s)
=== CONT  TestAccVPCNATGatewaysDataSource_basic
--- PASS: TestAccVPCTrafficMirrorSession_tags (304.72s)
=== CONT  TestAccVPCSecurityGroupIngressRule_tags
--- PASS: TestAccVPCNetworkInterfaceAttachment_basic (278.64s)
=== CONT  TestAccVPCNATGateway_tags
--- PASS: TestAccVPCSecurityGroupIngressRule_tags (49.25s)
=== CONT  TestAccVPCSecurityGroupIngressRule_basic
--- PASS: TestAccVPCSecurityGroupIngressRule_basic (22.28s)
=== CONT  TestAccVPCTrafficMirrorSession_basic
--- PASS: TestAccVPCNATGatewaysDataSource_basic (217.18s)
=== CONT  TestAccVPCTrafficMirrorFilter_tags
--- PASS: TestAccVPCTrafficMirrorFilter_tags (36.35s)
=== CONT  TestAccVPCTrafficMirrorFilter_basic
--- PASS: TestAccVPCTrafficMirrorFilter_basic (36.75s)
=== CONT  TestAccVPCPrefixListDataSource_basic
--- PASS: TestAccVPCPrefixListDataSource_basic (12.71s)
=== CONT  TestAccVPCSecurityGroupDataSource_basic
--- PASS: TestAccVPCSecurityGroupDataSource_basic (20.18s)
=== CONT  TestAccVPCRoute_basic
--- PASS: TestAccVPCRoute_basic (22.43s)
=== CONT  TestAccVPCRouteTablesDataSource_basic
--- PASS: TestAccVPCRouteTablesDataSource_basic (19.82s)
=== CONT  TestAccVPCRouteTable_tags
--- PASS: TestAccVPCNATGateway_tags (233.69s)
=== CONT  TestAccVPCRouteTable_basic
--- PASS: TestAccVPCRouteTable_basic (20.50s)
=== CONT  TestAccVPCNetworkInsightsAnalysis_tags
--- PASS: TestAccVPCRouteTable_tags (46.69s)
=== CONT  TestAccVPCNetworkInsightsAnalysis_basic
    vpc_network_insights_analysis_test.go:24: Step 1/2 error: Check failed: 1 error occurred:
        	* Check 5/9 error: aws_ec2_network_insights_analysis.test: Attribute 'path_found' expected "true", got "false"
        
--- FAIL: TestAccVPCNetworkInsightsAnalysis_basic (43.10s)
=== CONT  TestAccVPCNetworkInsightsAnalysisDataSource_basic
--- PASS: TestAccVPCTrafficMirrorSession_basic (287.81s)
=== CONT  TestAccVPCNetworkACLsDataSource_tags
--- PASS: TestAccVPCNetworkInsightsAnalysis_tags (85.02s)
=== CONT  TestAccVPCNetworkACLsDataSource_basic
--- PASS: TestAccVPCNetworkACLsDataSource_tags (18.09s)
=== CONT  TestAccVPCSecurityGroupEgressRule_basic
--- PASS: TestAccVPCNetworkInsightsAnalysisDataSource_basic (50.00s)
=== CONT  TestAccVPCNetworkACL_OnlyIngressRules_basic
--- PASS: TestAccVPCNetworkACLsDataSource_basic (18.21s)
=== CONT  TestAccVPCPeeringConnectionsDataSource_basic
--- PASS: TestAccVPCPeeringConnectionsDataSource_basic (19.85s)
=== CONT  TestAccVPCNetworkACL_tags
--- PASS: TestAccVPCSecurityGroupEgressRule_basic (23.98s)
=== CONT  TestAccVPCPeeringConnection_tags
--- PASS: TestAccVPCNetworkACL_OnlyIngressRules_basic (33.40s)
=== CONT  TestAccVPCNetworkACL_basic
--- PASS: TestAccVPCNetworkACL_basic (20.62s)
=== CONT  TestAccVPCPeeringConnection_basic
--- PASS: TestAccVPCNetworkACL_tags (47.75s)
=== CONT  TestAccVPCRouteTableDataSource_basic
--- PASS: TestAccVPCPeeringConnection_tags (49.13s)
=== CONT  TestAccVPCPeeringConnectionOptions_basic
--- PASS: TestAccVPCPeeringConnection_basic (20.86s)
=== CONT  TestAccVPCRouteTableAssociation_Gateway_basic
--- PASS: TestAccVPCRouteTableDataSource_basic (21.27s)
=== CONT  TestAccVPCNetworkInterfacesDataSource_tags
--- PASS: TestAccVPCRouteTableAssociation_Gateway_basic (26.50s)
=== CONT  TestAccVPCRouteTableAssociation_Subnet_basic
--- PASS: TestAccVPCNetworkInterfacesDataSource_tags (21.47s)
=== CONT  TestAccVPCNATGateway_basic
--- PASS: TestAccVPCPeeringConnectionOptions_basic (46.27s)
=== CONT  TestAccVPCRouteDataSource_basic
--- PASS: TestAccVPCRouteTableAssociation_Subnet_basic (24.24s)
=== CONT  TestAccVPCNATGatewayDataSource_basic
--- PASS: TestAccVPCRouteDataSource_basic (74.93s)
=== CONT  TestAccVPCSubnetIDsDataSource_basic
--- PASS: TestAccVPCSubnetIDsDataSource_basic (32.11s)
=== CONT  TestAccVPCTrafficMirrorFilterRule_basic
--- PASS: TestAccVPCTrafficMirrorFilterRule_basic (38.89s)
=== CONT  TestAccVPCSubnetDataSource_basic
--- PASS: TestAccVPCSubnetDataSource_basic (20.77s)
=== CONT  TestAccVPCSubnetCIDRReservation_basic
--- PASS: TestAccVPCNATGatewayDataSource_basic (176.89s)
=== CONT  TestAccEC2EBSEncryptionByDefault_basic
--- PASS: TestAccVPCSubnetCIDRReservation_basic (20.22s)
=== CONT  TestAccVPCNetworkInterface_tags
--- PASS: TestAccVPCNATGateway_basic (208.25s)
=== CONT  TestAccEC2EBSSnapshotCopy_tags
--- PASS: TestAccEC2EBSEncryptionByDefault_basic (25.78s)
=== CONT  TestAccVPCNetworkInterface_basic
--- PASS: TestAccVPCNetworkInterface_basic (34.78s)
=== CONT  TestAccEC2EBSSnapshotCopy_basic
--- PASS: TestAccVPCNetworkInterface_tags (65.20s)
=== CONT  TestAccSiteVPNGateway_basic
=== CONT  TestAccEC2EBSSnapshotCopy_tags
    ebs_snapshot_copy_test.go:69: Step 1/3 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        
        Terraform will perform the following actions:
        
          # aws_ebs_snapshot_copy.test must be replaced
        -/+ resource "aws_ebs_snapshot_copy" "test" {
              ~ arn                    = "arn:aws:ec2:us-west-2::snapshot/snap-0f270050ae4c30190" -> (known after apply)
              + data_encryption_key_id = (known after apply)
              - encrypted              = true -> null # forces replacement
              ~ id                     = "snap-0f270050ae4c30190" -> (known after apply)
              - kms_key_id             = "arn:aws:kms:us-west-2:123456789012:key/039ff87e-a813-4464-829a-603049ac93ee" -> null # forces replacement
              + outpost_arn            = (known after apply)
              + owner_alias            = (known after apply)
              ~ owner_id               = "123456789012" -> (known after apply)
              ~ storage_tier           = "standard" -> (known after apply)
                tags                   = {
                    "key1" = "value1"
                }
              ~ volume_id              = "vol-ffffffff" -> (known after apply)
              ~ volume_size            = 1 -> (known after apply)
                # (3 unchanged attributes hidden)
            }
        
        Plan: 1 to add, 0 to change, 1 to destroy.
--- FAIL: TestAccEC2EBSSnapshotCopy_tags (64.76s)
=== CONT  TestAccVPC_tags
--- PASS: TestAccVPC_tags (46.20s)
=== CONT  TestAccVPC_basic
--- PASS: TestAccEC2EBSSnapshotCopy_basic (68.31s)
=== CONT  TestAccVPCNetworkInterfaceSgAttachment_basic
--- PASS: TestAccVPC_basic (19.61s)
=== CONT  TestAccVPCManagedPrefixListsDataSource_tags
--- PASS: TestAccVPCNetworkInterfaceSgAttachment_basic (24.38s)
=== CONT  TestAccVPCSecurityGroup_tags
--- PASS: TestAccVPCManagedPrefixListsDataSource_tags (21.70s)
=== CONT  TestAccWavelengthCarrierGateway_tags
--- PASS: TestAccVPCSecurityGroup_tags (46.99s)
=== CONT  TestAccVPCSecurityGroup_basic
--- PASS: TestAccWavelengthCarrierGateway_tags (46.33s)
=== CONT  TestAccWavelengthCarrierGateway_basic
--- PASS: TestAccVPCSecurityGroup_basic (21.92s)
=== CONT  TestAccVPCSecurityGroupRulesDataSource_tags
--- PASS: TestAccWavelengthCarrierGateway_basic (21.11s)
=== CONT  TestAccVPCSecurityGroupRulesDataSource_basic
--- PASS: TestAccVPCSecurityGroupRulesDataSource_tags (22.95s)
=== CONT  TestAccVPCNetworkInterfaceDataSource_basic
--- PASS: TestAccVPCSecurityGroupRulesDataSource_basic (21.21s)
=== CONT  TestAccVPCManagedPrefixList_basic
--- PASS: TestAccVPCNetworkInterfaceDataSource_basic (22.53s)
=== CONT  TestAccVPCManagedPrefixList_tags
--- PASS: TestAccSiteVPNGateway_basic (227.37s)
=== CONT  TestAccSiteVPNGatewayAttachment_basic
--- PASS: TestAccVPCManagedPrefixList_basic (42.00s)
=== CONT  TestAccSiteVPNGateway_tags
--- PASS: TestAccVPCManagedPrefixList_tags (46.25s)
=== CONT  TestAccEC2EBSEncryptionByDefaultDataSource_basic
--- PASS: TestAccEC2EBSEncryptionByDefaultDataSource_basic (11.31s)
=== CONT  TestAccVPCManagedPrefixListsDataSource_basic
--- PASS: TestAccVPCManagedPrefixListsDataSource_basic (11.14s)
=== CONT  TestAccVPCEndpointServiceAllowedPrincipal_basic
--- PASS: TestAccSiteVPNGateway_tags (115.77s)
=== CONT  TestAccVPCSubnet_tags
--- PASS: TestAccVPCSubnet_tags (44.15s)
=== CONT  TestAccVPCIPv4CIDRBlockAssociation_basic
--- PASS: TestAccSiteVPNGatewayAttachment_basic (191.53s)
=== CONT  TestAccVPCInternetGateway_basic
--- PASS: TestAccVPCInternetGateway_basic (14.94s)
=== CONT  TestAccVPCInternetGatewayDataSource_basic
--- PASS: TestAccVPCIPv4CIDRBlockAssociation_basic (43.11s)
=== CONT  TestAccVPCInternetGatewayAttachment_basic
--- PASS: TestAccVPCInternetGatewayDataSource_basic (18.32s)
=== CONT  TestAccVPCFlowLog_tags
--- PASS: TestAccVPCInternetGatewayAttachment_basic (19.74s)
=== CONT  TestAccVPCFlowLog_basic
--- PASS: TestAccVPCFlowLog_basic (21.58s)
=== CONT  TestAccVPCEndpoint_tags
--- PASS: TestAccVPCEndpointServiceAllowedPrincipal_basic (213.37s)
=== CONT  TestAccVPCEndpointSubnetAssociation_basic
--- PASS: TestAccVPCFlowLog_tags (50.22s)
=== CONT  TestAccVPCEndpointService_tags
--- PASS: TestAccVPCEndpoint_tags (58.15s)
=== CONT  TestAccVPCEndpointService_basic
--- PASS: TestAccVPCEndpointService_tags (246.19s)
=== CONT  TestAccVPCEndpointServiceDataSource_CustomFilter_tags
--- PASS: TestAccVPCEndpointService_basic (225.17s)
=== CONT  TestAccVPCSubnetsDataSource_basic
--- PASS: TestAccVPCSubnetsDataSource_basic (31.56s)
=== CONT  TestAccEC2EBSDefaultKMSKey_basic
--- PASS: TestAccVPCEndpointSubnetAssociation_basic (317.32s)
=== CONT  TestAccVPCSubnet_basic
--- PASS: TestAccEC2EBSDefaultKMSKey_basic (18.36s)
=== CONT  TestAccSiteVPNCustomerGateway_tags
--- PASS: TestAccVPCSubnet_basic (20.57s)
=== CONT  TestAccSiteVPNCustomerGateway_basic
=== CONT  TestAccSiteVPNCustomerGateway_tags
    vpnsite_customer_gateway_test.go:85: Step 2/4 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
        
          map[string]string{
        - 	"tags.%":        "1",
        - 	"tags.key1":     "value1",
        - 	"tags_all.%":    "1",
        - 	"tags_all.key1": "value1",
          }
--- FAIL: TestAccSiteVPNCustomerGateway_tags (26.07s)
=== CONT  TestAccVPCDHCPOptionsDataSource_basic
=== CONT  TestAccSiteVPNCustomerGateway_basic
    vpnsite_customer_gateway_test.go:27: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_customer_gateway.test will be updated in-place
          ~ resource "aws_customer_gateway" "test" {
                id         = "cgw-0863642ab81b0b84b"
              + tags_all   = (known after apply)
                # (4 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccSiteVPNCustomerGateway_basic (20.87s)
=== CONT  TestAccVPCDHCPOptionsAssociation_basic
--- PASS: TestAccVPCDHCPOptionsDataSource_basic (15.64s)
=== CONT  TestAccVPCManagedPrefixListDataSource_basic
--- PASS: TestAccVPCDHCPOptionsAssociation_basic (19.35s)
=== CONT  TestAccVPCDHCPOptions_basic
--- PASS: TestAccVPCManagedPrefixListDataSource_basic (15.77s)
=== CONT  TestAccVPCDefaultSecurityGroup_basic
--- PASS: TestAccVPCDHCPOptions_basic (15.84s)
=== CONT  TestAccVPCEndpointPolicy_basic
--- PASS: TestAccVPCDefaultSecurityGroup_basic (29.14s)
=== CONT  TestAccVPCEndpointSecurityGroupAssociation_basic
--- PASS: TestAccVPCEndpointPolicy_basic (62.99s)
=== CONT  TestAccVPCEndpointRouteTableAssociation_basic
--- PASS: TestAccVPCEndpointSecurityGroupAssociation_basic (54.32s)
=== CONT  TestAccVPCEgressOnlyInternetGateway_tags
--- PASS: TestAccVPCEndpointRouteTableAssociation_basic (31.90s)
=== CONT  TestAccSiteVPNGatewayRoutePropagation_basic
--- PASS: TestAccVPCEndpointServiceDataSource_CustomFilter_tags (227.89s)
=== CONT  TestAccVPCDHCPOptions_tags
--- PASS: TestAccVPCEgressOnlyInternetGateway_tags (45.12s)
=== CONT  TestAccVPCEndpointConnectionNotification_basic
--- PASS: TestAccVPCDHCPOptions_tags (36.60s)
=== CONT  TestAccVPCEgressOnlyInternetGateway_basic
--- PASS: TestAccVPCEgressOnlyInternetGateway_basic (29.21s)
--- PASS: TestAccSiteVPNGatewayRoutePropagation_basic (118.79s)
=== CONT  TestAccVPCEndpointConnectionNotification_basic
    vpc_endpoint_connection_notification_test.go:23: Step 1/3 error: Error running apply: exit status 1
        
        Error: modifying EC2 VPC Endpoint Service (vpce-svc-0444a3332c43e225e) permissions: InvalidPrincipal: Invalid Principal: 'arn:aws:sts::123456789012:assumed-role/terraform_team1_dev-developer/kewbank@hashicorp.com'
        	status code: 400, request id: bae9be5e-ef15-4134-9712-66c4afa0a281
        
          with aws_vpc_endpoint_service.test,
          on terraform_plugin_test.tf line 47, in resource "aws_vpc_endpoint_service" "test":
          47: resource "aws_vpc_endpoint_service" "test" {
        
--- FAIL: TestAccVPCEndpointConnectionNotification_basic (223.58s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	4770.821s
FAIL
make: *** [testacc] Error 1
```
After fixes:
```console
% make testacc TESTARGS='-run=TestAccEC2EBSSnapshotCopy_tags\|TestAccEC2PlacementGroup_tags\|TestAccEC2PlacementGroup_basic\|TestAccSiteVPNCustomerGateway_basic\|TestAccSiteVPNCustomerGateway_tags\|TestAccIPAMPool_tags\|TestAccIPAMPool_basic' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccEC2EBSSnapshotCopy_tags\|TestAccEC2PlacementGroup_tags\|TestAccEC2PlacementGroup_basic\|TestAccSiteVPNCustomerGateway_basic\|TestAccSiteVPNCustomerGateway_tags\|TestAccIPAMPool_tags\|TestAccIPAMPool_basic -timeout 180m
=== RUN   TestAccEC2EBSSnapshotCopy_tags
=== PAUSE TestAccEC2EBSSnapshotCopy_tags
=== RUN   TestAccEC2PlacementGroup_basic
=== PAUSE TestAccEC2PlacementGroup_basic
=== RUN   TestAccEC2PlacementGroup_tags
=== PAUSE TestAccEC2PlacementGroup_tags
=== RUN   TestAccIPAMPool_basic
=== PAUSE TestAccIPAMPool_basic
=== RUN   TestAccIPAMPool_tags
=== PAUSE TestAccIPAMPool_tags
=== RUN   TestAccSiteVPNCustomerGateway_basic
=== PAUSE TestAccSiteVPNCustomerGateway_basic
=== RUN   TestAccSiteVPNCustomerGateway_tags
=== PAUSE TestAccSiteVPNCustomerGateway_tags
=== CONT  TestAccEC2EBSSnapshotCopy_tags
=== CONT  TestAccIPAMPool_tags
=== CONT  TestAccSiteVPNCustomerGateway_tags
--- PASS: TestAccSiteVPNCustomerGateway_tags (50.67s)
=== CONT  TestAccSiteVPNCustomerGateway_basic
--- PASS: TestAccSiteVPNCustomerGateway_basic (27.03s)
=== CONT  TestAccEC2PlacementGroup_tags
--- PASS: TestAccIPAMPool_tags (84.52s)
=== CONT  TestAccIPAMPool_basic
--- PASS: TestAccEC2EBSSnapshotCopy_tags (95.50s)
=== CONT  TestAccEC2PlacementGroup_basic
--- PASS: TestAccEC2PlacementGroup_basic (17.06s)
--- PASS: TestAccEC2PlacementGroup_tags (40.05s)
--- PASS: TestAccIPAMPool_basic (88.09s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	178.337s
```