### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin SDK resources `s*` (Phase 3c)

### DIFF
--- a/internal/service/s3control/service_package_gen.go
+++ b/internal/service/s3control/service_package_gen.go
@@ -49,6 +49,8 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceBucket,
 			TypeName: "aws_s3control_bucket",
+			Name:     "Bucket",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
 			Factory:  resourceBucketLifecycleConfiguration,
@@ -77,6 +79,8 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceStorageLensConfiguration,
 			TypeName: "aws_s3control_storage_lens_configuration",
+			Name:     "Storage Lens Configuration",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 	}
 }

--- a/internal/service/s3control/storage_lens_configuration.go
+++ b/internal/service/s3control/storage_lens_configuration.go
@@ -22,9 +22,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_s3control_storage_lens_configuration")
+// @SDKResource("aws_s3control_storage_lens_configuration", name="Storage Lens Configuration")
+// @Tags
 func resourceStorageLensConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceStorageLensConfigurationCreate,
@@ -381,8 +383,8 @@ func resourceStorageLensConfiguration() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -391,8 +393,6 @@ func resourceStorageLensConfiguration() *schema.Resource {
 
 func resourceStorageLensConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).S3ControlClient()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	accountID := meta.(*conns.AWSClient).AccountID
 	if v, ok := d.GetOk("account_id"); ok {
@@ -404,15 +404,12 @@ func resourceStorageLensConfigurationCreate(ctx context.Context, d *schema.Resou
 	input := &s3control.PutStorageLensConfigurationInput{
 		AccountId: aws.String(accountID),
 		ConfigId:  aws.String(configID),
+		Tags:      StorageLensTags(KeyValueTags(ctx, GetTagsIn(ctx))),
 	}
 
 	if v, ok := d.GetOk("storage_lens_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		input.StorageLensConfiguration = expandStorageLensConfiguration(v.([]interface{})[0].(map[string]interface{}))
 		input.StorageLensConfiguration.Id = aws.String(configID)
-	}
-
-	if len(tags) > 0 {
-		input.Tags = StorageLensTags(tags.IgnoreAWS())
 	}
 
 	_, err := conn.PutStorageLensConfiguration(ctx, input)
@@ -428,8 +425,6 @@ func resourceStorageLensConfigurationCreate(ctx context.Context, d *schema.Resou
 
 func resourceStorageLensConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).S3ControlClient()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	accountID, configID, err := StorageLensConfigurationParseResourceID(d.Id())
 
@@ -462,16 +457,7 @@ func resourceStorageLensConfigurationRead(ctx context.Context, d *schema.Resourc
 		return diag.Errorf("listing tags for S3 Storage Lens Configuration (%s): %s", d.Id(), err)
 	}
 
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, Tags(tags))
 
 	return nil
 }
@@ -623,7 +609,7 @@ func storageLensConfigurationListTags(ctx context.Context, conn *s3control.Clien
 	return KeyValueTagsFromStorageLensTags(ctx, output.Tags), nil
 }
 
-func storageLensConfigurationUpdateTags(ctx context.Context, conn *s3control.Client, accountID, configID string, oldTagsMap interface{}, newTagsMap interface{}) error {
+func storageLensConfigurationUpdateTags(ctx context.Context, conn *s3control.Client, accountID, configID string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 

--- a/internal/service/sagemaker/app.go
+++ b/internal/service/sagemaker/app.go
@@ -19,9 +19,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_sagemaker_app")
+// @SDKResource("aws_sagemaker_app", name="App")
+// @Tags(identifierAttribute="arn")
 func ResourceApp() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAppCreate,
@@ -95,8 +97,8 @@ func ResourceApp() *schema.Resource {
 				Optional:     true,
 				ExactlyOneOf: []string{"space_name", "user_profile_name"},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"user_profile_name": {
 				Type:         schema.TypeString,
 				ForceNew:     true,
@@ -112,13 +114,12 @@ func ResourceApp() *schema.Resource {
 func resourceAppCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &sagemaker.CreateAppInput{
 		AppName:  aws.String(d.Get("app_name").(string)),
 		AppType:  aws.String(d.Get("app_type").(string)),
 		DomainId: aws.String(d.Get("domain_id").(string)),
+		Tags:     GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("user_profile_name"); ok {
@@ -127,10 +128,6 @@ func resourceAppCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	if v, ok := d.GetOk("space_name"); ok {
 		input.SpaceName = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	if v, ok := d.GetOk("resource_spec"); ok {
@@ -161,8 +158,6 @@ func resourceAppCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 func resourceAppRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	domainID, userProfileOrSpaceName, appType, appName, err := decodeAppID(d.Id())
 	if err != nil {
@@ -191,37 +186,13 @@ func resourceAppRead(ctx context.Context, d *schema.ResourceData, meta interface
 		return sdkdiag.AppendErrorf(diags, "setting resource_spec for SageMaker App (%s): %s", d.Id(), err)
 	}
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for SageMaker App (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
 func resourceAppUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).SageMakerConn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating SageMaker App (%s) tags: %s", d.Id(), err)
-		}
-	}
+	// Tags only.
 
 	return append(diags, resourceAppRead(ctx, d, meta)...)
 }

--- a/internal/service/sagemaker/app_image_config.go
+++ b/internal/service/sagemaker/app_image_config.go
@@ -15,9 +15,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_sagemaker_app_image_config")
+// @SDKResource("aws_sagemaker_app_image_config", name="App Image Config")
+// @Tags(identifierAttribute="arn")
 func ResourceAppImageConfig() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAppImageConfigCreate,
@@ -100,8 +102,8 @@ func ResourceAppImageConfig() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 		CustomizeDiff: verify.SetTagsDiff,
 	}
@@ -110,16 +112,11 @@ func ResourceAppImageConfig() *schema.Resource {
 func resourceAppImageConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("app_image_config_name").(string)
 	input := &sagemaker.CreateAppImageConfigInput{
 		AppImageConfigName: aws.String(name),
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
+		Tags:               GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("kernel_gateway_image_config"); ok && len(v.([]interface{})) > 0 {
@@ -139,8 +136,6 @@ func resourceAppImageConfigCreate(ctx context.Context, d *schema.ResourceData, m
 func resourceAppImageConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	image, err := FindAppImageConfigByName(ctx, conn, d.Id())
 	if err != nil {
@@ -160,37 +155,12 @@ func resourceAppImageConfigRead(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "setting kernel_gateway_image_config: %s", err)
 	}
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for SageMaker App Image Config (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
 func resourceAppImageConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating SageMaker App Image Config (%s) tags: %s", d.Id(), err)
-		}
-	}
 
 	if d.HasChange("kernel_gateway_image_config") {
 		input := &sagemaker.UpdateAppImageConfigInput{

--- a/internal/service/sagemaker/endpoint_configuration.go
+++ b/internal/service/sagemaker/endpoint_configuration.go
@@ -19,9 +19,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_sagemaker_endpoint_configuration")
+// @SDKResource("aws_sagemaker_endpoint_configuration", name="Endpoint Configuration")
+// @Tags(identifierAttribute="arn")
 func ResourceEndpointConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceEndpointConfigurationCreate,
@@ -456,8 +458,8 @@ func ResourceEndpointConfiguration() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -467,22 +469,17 @@ func ResourceEndpointConfiguration() *schema.Resource {
 func resourceEndpointConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
 
 	createOpts := &sagemaker.CreateEndpointConfigInput{
 		EndpointConfigName: aws.String(name),
 		ProductionVariants: expandProductionVariants(d.Get("production_variants").([]interface{})),
+		Tags:               GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("kms_key_arn"); ok {
 		createOpts.KmsKeyId = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		createOpts.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	if v, ok := d.GetOk("shadow_production_variants"); ok && len(v.([]interface{})) > 0 {
@@ -510,8 +507,6 @@ func resourceEndpointConfigurationCreate(ctx context.Context, d *schema.Resource
 func resourceEndpointConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	endpointConfig, err := FindEndpointConfigByName(ctx, conn, d.Id())
 
@@ -546,36 +541,14 @@ func resourceEndpointConfigurationRead(ctx context.Context, d *schema.ResourceDa
 		return sdkdiag.AppendErrorf(diags, "setting async_inference_config for SageMaker Endpoint Configuration (%s): %s", d.Id(), err)
 	}
 
-	tags, err := ListTags(ctx, conn, aws.StringValue(endpointConfig.EndpointConfigArn))
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for SageMaker Endpoint Configuration (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
 func resourceEndpointConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).SageMakerConn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
+	// Tags only.
 
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating SageMaker Endpoint Configuration (%s) tags: %s", d.Id(), err)
-		}
-	}
 	return append(diags, resourceEndpointConfigurationRead(ctx, d, meta)...)
 }
 

--- a/internal/service/sagemaker/feature_group.go
+++ b/internal/service/sagemaker/feature_group.go
@@ -17,9 +17,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_sagemaker_feature_group")
+// @SDKResource("aws_sagemaker_feature_group", name="Feature Group")
+// @Tags(identifierAttribute="arn")
 func ResourceFeatureGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceFeatureGroupCreate,
@@ -197,8 +199,8 @@ func ResourceFeatureGroup() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: verify.ValidARN,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -208,25 +210,19 @@ func ResourceFeatureGroup() *schema.Resource {
 func resourceFeatureGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("feature_group_name").(string)
-
 	input := &sagemaker.CreateFeatureGroupInput{
 		FeatureGroupName:            aws.String(name),
 		EventTimeFeatureName:        aws.String(d.Get("event_time_feature_name").(string)),
 		RecordIdentifierFeatureName: aws.String(d.Get("record_identifier_feature_name").(string)),
 		RoleArn:                     aws.String(d.Get("role_arn").(string)),
 		FeatureDefinitions:          expandFeatureGroupFeatureDefinition(d.Get("feature_definition").([]interface{})),
+		Tags:                        GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	if v, ok := d.GetOk("offline_store_config"); ok {
@@ -272,8 +268,6 @@ func resourceFeatureGroupCreate(ctx context.Context, d *schema.ResourceData, met
 func resourceFeatureGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	output, err := FindFeatureGroupByName(ctx, conn, d.Id())
 
@@ -307,36 +301,13 @@ func resourceFeatureGroupRead(ctx context.Context, d *schema.ResourceData, meta 
 		return sdkdiag.AppendErrorf(diags, "setting offline_store_config for SageMaker Feature Group (%s): %s", d.Id(), err)
 	}
 
-	tags, err := ListTags(ctx, conn, arn)
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for SageMaker Feature Group (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
 func resourceFeatureGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).SageMakerConn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating SageMaker Feature Group (%s) tags: %s", d.Id(), err)
-		}
-	}
+	// Tags only.
 
 	return append(diags, resourceFeatureGroupRead(ctx, d, meta)...)
 }

--- a/internal/service/sagemaker/flow_definition.go
+++ b/internal/service/sagemaker/flow_definition.go
@@ -19,9 +19,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_sagemaker_flow_definition")
+// @SDKResource("aws_sagemaker_flow_definition", name="Flow Definition")
+// @Tags(identifierAttribute="arn")
 func ResourceFlowDefinition() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceFlowDefinitionCreate,
@@ -234,8 +236,8 @@ func ResourceFlowDefinition() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: verify.ValidARN,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -245,8 +247,6 @@ func ResourceFlowDefinition() *schema.Resource {
 func resourceFlowDefinitionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("flow_definition_name").(string)
 	input := &sagemaker.CreateFlowDefinitionInput{
@@ -254,6 +254,7 @@ func resourceFlowDefinitionCreate(ctx context.Context, d *schema.ResourceData, m
 		HumanLoopConfig:    expandFlowDefinitionHumanLoopConfig(d.Get("human_loop_config").([]interface{})),
 		RoleArn:            aws.String(d.Get("role_arn").(string)),
 		OutputConfig:       expandFlowDefinitionOutputConfig(d.Get("output_config").([]interface{})),
+		Tags:               GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("human_loop_activation_config"); ok && (len(v.([]interface{})) > 0) {
@@ -266,10 +267,6 @@ func resourceFlowDefinitionCreate(ctx context.Context, d *schema.ResourceData, m
 
 	if v, ok := d.GetOk("human_loop_request_source"); ok && (len(v.([]interface{})) > 0) {
 		input.HumanLoopRequestSource = expandFlowDefinitionHumanLoopRequestSource(v.([]interface{}))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	log.Printf("[DEBUG] Creating SageMaker Flow Definition: %s", input)
@@ -293,8 +290,6 @@ func resourceFlowDefinitionCreate(ctx context.Context, d *schema.ResourceData, m
 func resourceFlowDefinitionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	flowDefinition, err := FindFlowDefinitionByName(ctx, conn, d.Id())
 
@@ -329,37 +324,13 @@ func resourceFlowDefinitionRead(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "setting output_config: %s", err)
 	}
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for SageMaker Flow Definition (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
 func resourceFlowDefinitionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).SageMakerConn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating SageMaker Flow Definition (%s) tags: %s", d.Id(), err)
-		}
-	}
+	// Tags only.
 
 	return append(diags, resourceFlowDefinitionRead(ctx, d, meta)...)
 }

--- a/internal/service/sagemaker/flow_definition_test.go
+++ b/internal/service/sagemaker/flow_definition_test.go
@@ -261,11 +261,6 @@ resource "aws_s3_bucket" "test" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_iam_role" "test" {
   name               = %[1]q
   path               = "/"

--- a/internal/service/sagemaker/image.go
+++ b/internal/service/sagemaker/image.go
@@ -16,9 +16,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_sagemaker_image")
+// @SDKResource("aws_sagemaker_image", name="Image")
+// @Tags(identifierAttribute="arn")
 func ResourceImage() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceImageCreate,
@@ -60,8 +62,8 @@ func ResourceImage() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(1, 512),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -71,13 +73,12 @@ func ResourceImage() *schema.Resource {
 func resourceImageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("image_name").(string)
 	input := &sagemaker.CreateImageInput{
 		ImageName: aws.String(name),
 		RoleArn:   aws.String(d.Get("role_arn").(string)),
+		Tags:      GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("display_name"); ok {
@@ -86,10 +87,6 @@ func resourceImageCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	if v, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	// for some reason even if the operation is retried the same error response is given even though the role is valid. a short sleep before creation solves it.
@@ -111,8 +108,6 @@ func resourceImageCreate(ctx context.Context, d *schema.ResourceData, meta inter
 func resourceImageRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	image, err := FindImageByName(ctx, conn, d.Id())
 	if err != nil {
@@ -130,23 +125,6 @@ func resourceImageRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	d.Set("role_arn", image.RoleArn)
 	d.Set("display_name", image.DisplayName)
 	d.Set("description", image.Description)
-
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for SageMaker Image (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
 
 	return diags
 }
@@ -191,14 +169,6 @@ func resourceImageUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 		if _, err := WaitImageCreated(ctx, conn, d.Id()); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for SageMaker Image (%s) to update: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating SageMaker Image (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/sagemaker/model_package_group.go
+++ b/internal/service/sagemaker/model_package_group.go
@@ -15,9 +15,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_sagemaker_model_package_group")
+// @SDKResource("aws_sagemaker_model_package_group", name="Model Package Group")
+// @Tags(identifierAttribute="arn")
 func ResourceModelPackageGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceModelPackageGroupCreate,
@@ -49,8 +51,8 @@ func ResourceModelPackageGroup() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(1, 1024),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -60,20 +62,15 @@ func ResourceModelPackageGroup() *schema.Resource {
 func resourceModelPackageGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("model_package_group_name").(string)
 	input := &sagemaker.CreateModelPackageGroupInput{
 		ModelPackageGroupName: aws.String(name),
+		Tags:                  GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("model_package_group_description"); ok {
 		input.ModelPackageGroupDescription = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	_, err := conn.CreateModelPackageGroupWithContext(ctx, input)
@@ -93,8 +90,6 @@ func resourceModelPackageGroupCreate(ctx context.Context, d *schema.ResourceData
 func resourceModelPackageGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	mpg, err := FindModelPackageGroupByName(ctx, conn, d.Id())
 	if err != nil {
@@ -111,37 +106,13 @@ func resourceModelPackageGroupRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("arn", arn)
 	d.Set("model_package_group_description", mpg.ModelPackageGroupDescription)
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for SageMaker Model Package Group (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
 func resourceModelPackageGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).SageMakerConn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating SageMaker Model Package Group (%s) tags: %s", d.Id(), err)
-		}
-	}
+	// Tags only.
 
 	return append(diags, resourceModelPackageGroupRead(ctx, d, meta)...)
 }

--- a/internal/service/sagemaker/notebook_instance.go
+++ b/internal/service/sagemaker/notebook_instance.go
@@ -20,9 +20,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_sagemaker_notebook_instance")
+// @SDKResource("aws_sagemaker_notebook_instance", name="Notebook Instance")
+// @Tags(identifierAttribute="arn")
 func ResourceNotebookInstance() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceNotebookInstanceCreate,
@@ -140,8 +142,8 @@ func ResourceNotebookInstance() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"url": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -158,8 +160,6 @@ func ResourceNotebookInstance() *schema.Resource {
 func resourceNotebookInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &sagemaker.CreateNotebookInstanceInput{
@@ -168,6 +168,7 @@ func resourceNotebookInstanceCreate(ctx context.Context, d *schema.ResourceData,
 		NotebookInstanceName:                 aws.String(name),
 		RoleArn:                              aws.String(d.Get("role_arn").(string)),
 		SecurityGroupIds:                     flex.ExpandStringSet(d.Get("security_groups").(*schema.Set)),
+		Tags:                                 GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("accelerator_types"); ok && v.(*schema.Set).Len() > 0 {
@@ -210,10 +211,6 @@ func resourceNotebookInstanceCreate(ctx context.Context, d *schema.ResourceData,
 		input.VolumeSizeInGB = aws.Int64(int64(v.(int)))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
 	log.Printf("[DEBUG] Creating SageMaker Notebook Instance: %s", input)
 	_, err := conn.CreateNotebookInstanceWithContext(ctx, input)
 
@@ -233,8 +230,6 @@ func resourceNotebookInstanceCreate(ctx context.Context, d *schema.ResourceData,
 func resourceNotebookInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	notebookInstance, err := FindNotebookInstanceByName(ctx, conn, d.Id())
 
@@ -270,37 +265,12 @@ func resourceNotebookInstanceRead(ctx context.Context, d *schema.ResourceData, m
 		return sdkdiag.AppendErrorf(diags, "setting instance_metadata_service_configuration: %s", err)
 	}
 
-	tags, err := ListTags(ctx, conn, aws.StringValue(notebookInstance.NotebookInstanceArn))
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for SageMaker Notebook Instance (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
 func resourceNotebookInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating SageMaker Notebook Instance (%s) tags: %s", d.Id(), err)
-		}
-	}
 
 	if d.HasChangesExcept("tags", "tags_all") {
 		input := &sagemaker.UpdateNotebookInstanceInput{

--- a/internal/service/sagemaker/project.go
+++ b/internal/service/sagemaker/project.go
@@ -17,9 +17,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_sagemaker_project")
+// @SDKResource("aws_sagemaker_project", name="Project")
+// @Tags(identifierAttribute="arn")
 func ResourceProject() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceProjectCreate,
@@ -94,8 +96,8 @@ func ResourceProject() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -105,21 +107,16 @@ func ResourceProject() *schema.Resource {
 func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("project_name").(string)
 	input := &sagemaker.CreateProjectInput{
 		ProjectName:                       aws.String(name),
 		ServiceCatalogProvisioningDetails: expandProjectServiceCatalogProvisioningDetails(d.Get("service_catalog_provisioning_details").([]interface{})),
+		Tags:                              GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("project_description"); ok {
 		input.ProjectDescription = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 2*time.Minute, func() (interface{}, error) {
@@ -141,8 +138,6 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta int
 func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	project, err := FindProjectByName(ctx, conn, d.Id())
 	if err != nil {
@@ -162,23 +157,6 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	if err := d.Set("service_catalog_provisioning_details", flattenProjectServiceCatalogProvisioningDetails(project.ServiceCatalogProvisioningDetails)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting service_catalog_provisioning_details: %s", err)
-	}
-
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for SageMaker Project (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
 	}
 
 	return diags
@@ -209,14 +187,6 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		if _, err := WaitProjectUpdated(ctx, conn, d.Id()); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for SageMaker Project (%s) to be updated: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating SageMaker Project (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/sagemaker/sagemaker_test.go
+++ b/internal/service/sagemaker/sagemaker_test.go
@@ -58,9 +58,9 @@ func TestAccSageMaker_serial(t *testing.T) {
 		"FlowDefinition": {
 			"basic":                          testAccFlowDefinition_basic,
 			"disappears":                     testAccFlowDefinition_disappears,
+			"tags":                           testAccFlowDefinition_tags,
 			"HumanLoopConfigPublicWorkforce": testAccFlowDefinition_humanLoopConfig_publicWorkforce,
 			"HumanLoopRequestSource":         testAccFlowDefinition_humanLoopRequestSource,
-			"Tags":                           testAccFlowDefinition_tags,
 		},
 		"Space": {
 			"basic":                    testAccSpace_basic,
@@ -91,10 +91,10 @@ func TestAccSageMaker_serial(t *testing.T) {
 		},
 		"Workteam": {
 			"disappears":         testAccWorkteam_disappears,
+			"tags":               testAccWorkteam_tags,
 			"CognitoConfig":      testAccWorkteam_cognitoConfig,
 			"NotificationConfig": testAccWorkteam_notificationConfig,
 			"OidcConfig":         testAccWorkteam_oidcConfig,
-			"Tags":               testAccWorkteam_tags,
 		},
 		"Servicecatalog": {
 			"basic": testAccServicecatalogPortfolioStatus_basic,

--- a/internal/service/sagemaker/service_package_gen.go
+++ b/internal/service/sagemaker/service_package_gen.go
@@ -33,14 +33,26 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceApp,
 			TypeName: "aws_sagemaker_app",
+			Name:     "App",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceAppImageConfig,
 			TypeName: "aws_sagemaker_app_image_config",
+			Name:     "App Image Config",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceCodeRepository,
 			TypeName: "aws_sagemaker_code_repository",
+			Name:     "Code Repository",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceDevice,
@@ -49,34 +61,66 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDeviceFleet,
 			TypeName: "aws_sagemaker_device_fleet",
+			Name:     "Device Fleet",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceDomain,
 			TypeName: "aws_sagemaker_domain",
+			Name:     "Domain",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceEndpoint,
 			TypeName: "aws_sagemaker_endpoint",
+			Name:     "Endpoint",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceEndpointConfiguration,
 			TypeName: "aws_sagemaker_endpoint_configuration",
+			Name:     "Endpoint Configuration",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceFeatureGroup,
 			TypeName: "aws_sagemaker_feature_group",
+			Name:     "Feature Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceFlowDefinition,
 			TypeName: "aws_sagemaker_flow_definition",
+			Name:     "Flow Definition",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceHumanTaskUI,
 			TypeName: "aws_sagemaker_human_task_ui",
+			Name:     "Human Task UI",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceImage,
 			TypeName: "aws_sagemaker_image",
+			Name:     "Image",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceImageVersion,
@@ -85,10 +129,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceModel,
 			TypeName: "aws_sagemaker_model",
+			Name:     "Model",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceModelPackageGroup,
 			TypeName: "aws_sagemaker_model_package_group",
+			Name:     "Model Package Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceModelPackageGroupPolicy,
@@ -97,6 +149,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceNotebookInstance,
 			TypeName: "aws_sagemaker_notebook_instance",
+			Name:     "Notebook Instance",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceNotebookInstanceLifeCycleConfiguration,
@@ -105,6 +161,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceProject,
 			TypeName: "aws_sagemaker_project",
+			Name:     "Project",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceServicecatalogPortfolioStatus,
@@ -113,14 +173,26 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceSpace,
 			TypeName: "aws_sagemaker_space",
+			Name:     "Space",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceStudioLifecycleConfig,
 			TypeName: "aws_sagemaker_studio_lifecycle_config",
+			Name:     "Studio Lifecycle Config",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceUserProfile,
 			TypeName: "aws_sagemaker_user_profile",
+			Name:     "User Profile",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceWorkforce,
@@ -129,6 +201,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceWorkteam,
 			TypeName: "aws_sagemaker_workteam",
+			Name:     "Workteam",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/sagemaker/workteam.go
+++ b/internal/service/sagemaker/workteam.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_sagemaker_workteam")
+// @SDKResource("aws_sagemaker_workteam", name="Workteam")
+// @Tags(identifierAttribute="arn")
 func ResourceWorkteam() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceWorkteamCreate,
@@ -110,8 +112,8 @@ func ResourceWorkteam() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"workforce_name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -135,8 +137,6 @@ func ResourceWorkteam() *schema.Resource {
 func resourceWorkteamCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("workteam_name").(string)
 	input := &sagemaker.CreateWorkteamInput{
@@ -144,14 +144,11 @@ func resourceWorkteamCreate(ctx context.Context, d *schema.ResourceData, meta in
 		WorkforceName:     aws.String(d.Get("workforce_name").(string)),
 		Description:       aws.String(d.Get("description").(string)),
 		MemberDefinitions: expandWorkteamMemberDefinition(d.Get("member_definition").([]interface{})),
+		Tags:              GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("notification_configuration"); ok {
 		input.NotificationConfiguration = expandWorkteamNotificationConfiguration(v.([]interface{}))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	log.Printf("[DEBUG] Updating SageMaker Workteam: %s", input)
@@ -171,8 +168,6 @@ func resourceWorkteamCreate(ctx context.Context, d *schema.ResourceData, meta in
 func resourceWorkteamRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	workteam, err := FindWorkteamByName(ctx, conn, d.Id())
 
@@ -198,23 +193,6 @@ func resourceWorkteamRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	if err := d.Set("notification_configuration", flattenWorkteamNotificationConfiguration(workteam.NotificationConfiguration)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting notification_configuration: %s", err)
-	}
-
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for SageMaker Workteam (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
 	}
 
 	return diags
@@ -243,14 +221,6 @@ func resourceWorkteamUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating SageMaker Workteam (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating SageMaker Workteam (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/scheduler/service_package_gen.go
+++ b/internal/service/scheduler/service_package_gen.go
@@ -32,6 +32,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceScheduleGroup,
 			TypeName: "aws_scheduler_schedule_group",
+			Name:     "Schedule Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/schemas/service_package_gen.go
+++ b/internal/service/schemas/service_package_gen.go
@@ -28,10 +28,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDiscoverer,
 			TypeName: "aws_schemas_discoverer",
+			Name:     "Discoverer",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRegistry,
 			TypeName: "aws_schemas_registry",
+			Name:     "Registry",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRegistryPolicy,
@@ -40,6 +48,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceSchema,
 			TypeName: "aws_schemas_schema",
+			Name:     "Schema",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/secretsmanager/service_package_gen.go
+++ b/internal/service/secretsmanager/service_package_gen.go
@@ -49,6 +49,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceSecret,
 			TypeName: "aws_secretsmanager_secret",
+			Name:     "Secret",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceSecretPolicy,

--- a/internal/service/servicediscovery/http_namespace.go
+++ b/internal/service/servicediscovery/http_namespace.go
@@ -15,9 +15,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_service_discovery_http_namespace")
+// @SDKResource("aws_service_discovery_http_namespace", name="HTTP Namespace")
+// @Tags(identifierAttribute="arn")
 func ResourceHTTPNamespace() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceHTTPNamespaceCreate,
@@ -49,8 +51,8 @@ func ResourceHTTPNamespace() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validNamespaceName,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -59,21 +61,16 @@ func ResourceHTTPNamespace() *schema.Resource {
 
 func resourceHTTPNamespaceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &servicediscovery.CreateHttpNamespaceInput{
 		CreatorRequestId: aws.String(id.UniqueId()),
 		Name:             aws.String(name),
+		Tags:             GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	log.Printf("[DEBUG] Creating Service Discovery HTTP Namespace: %s", input)
@@ -102,8 +99,6 @@ func resourceHTTPNamespaceCreate(ctx context.Context, d *schema.ResourceData, me
 
 func resourceHTTPNamespaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	ns, err := FindNamespaceByID(ctx, conn, d.Id())
 
@@ -127,37 +122,11 @@ func resourceHTTPNamespaceRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 	d.Set("name", ns.Name)
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return diag.Errorf("listing tags for Service Discovery HTTP Namespace (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
-	}
-
 	return nil
 }
 
 func resourceHTTPNamespaceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.Errorf("updating Service Discovery HTTP Namespace (%s) tags: %s", d.Id(), err)
-		}
-	}
-
+	// Tags only.
 	return resourceHTTPNamespaceRead(ctx, d, meta)
 }
 

--- a/internal/service/servicediscovery/private_dns_namespace.go
+++ b/internal/service/servicediscovery/private_dns_namespace.go
@@ -15,9 +15,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_service_discovery_private_dns_namespace")
+// @SDKResource("aws_service_discovery_private_dns_namespace", name="Private DNS Namespace")
+// @Tags(identifierAttribute="arn")
 func ResourcePrivateDNSNamespace() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePrivateDNSNamespaceCreate,
@@ -57,8 +59,8 @@ func ResourcePrivateDNSNamespace() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validNamespaceName,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vpc": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -72,22 +74,17 @@ func ResourcePrivateDNSNamespace() *schema.Resource {
 
 func resourcePrivateDNSNamespaceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &servicediscovery.CreatePrivateDnsNamespaceInput{
 		CreatorRequestId: aws.String(id.UniqueId()),
 		Name:             aws.String(name),
+		Tags:             GetTagsIn(ctx),
 		Vpc:              aws.String(d.Get("vpc").(string)),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	log.Printf("[DEBUG] Creating Service Discovery Private DNS Namespace: %s", input)
@@ -116,8 +113,6 @@ func resourcePrivateDNSNamespaceCreate(ctx context.Context, d *schema.ResourceDa
 
 func resourcePrivateDNSNamespaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	ns, err := FindNamespaceByID(ctx, conn, d.Id())
 
@@ -141,37 +136,11 @@ func resourcePrivateDNSNamespaceRead(ctx context.Context, d *schema.ResourceData
 	}
 	d.Set("name", ns.Name)
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return diag.Errorf("listing tags for Service Discovery Private DNS Namespace (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
-	}
-
 	return nil
 }
 
 func resourcePrivateDNSNamespaceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.Errorf("updating Service Discovery Private DNS Namespace (%s) tags: %s", d.Id(), err)
-		}
-	}
-
+	// Tags only.
 	return resourcePrivateDNSNamespaceRead(ctx, d, meta)
 }
 

--- a/internal/service/servicediscovery/service_package_gen.go
+++ b/internal/service/servicediscovery/service_package_gen.go
@@ -41,6 +41,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceHTTPNamespace,
 			TypeName: "aws_service_discovery_http_namespace",
+			Name:     "HTTP Namespace",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceInstance,
@@ -49,14 +53,26 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourcePrivateDNSNamespace,
 			TypeName: "aws_service_discovery_private_dns_namespace",
+			Name:     "Private DNS Namespace",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourcePublicDNSNamespace,
 			TypeName: "aws_service_discovery_public_dns_namespace",
+			Name:     "Public DNS Namespace",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceService,
 			TypeName: "aws_service_discovery_service",
+			Name:     "Service",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/sesv2/configuration_set.go
+++ b/internal/service/sesv2/configuration_set.go
@@ -24,7 +24,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_sesv2_configuration_set")
+// @SDKResource("aws_sesv2_configuration_set", name="Configuration Set")
+// @Tags(identifierAttribute="arn")
 func ResourceConfigurationSet() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceConfigurationSetCreate,
@@ -117,8 +118,8 @@ func ResourceConfigurationSet() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"tracking_options": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -184,6 +185,7 @@ func resourceConfigurationSetCreate(ctx context.Context, d *schema.ResourceData,
 
 	in := &sesv2.CreateConfigurationSetInput{
 		ConfigurationSetName: aws.String(d.Get("configuration_set_name").(string)),
+		Tags:                 GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("delivery_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
@@ -208,13 +210,6 @@ func resourceConfigurationSetCreate(ctx context.Context, d *schema.ResourceData,
 
 	if v, ok := d.GetOk("vdm_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		in.VdmOptions = expandVDMOptions(v.([]interface{})[0].(map[string]interface{}))
-	}
-
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
-
-	if len(tags) > 0 {
-		in.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	out, err := conn.CreateConfigurationSet(ctx, in)
@@ -303,23 +298,6 @@ func resourceConfigurationSetRead(ctx context.Context, d *schema.ResourceData, m
 		}
 	} else {
 		d.Set("vdm_options", nil)
-	}
-
-	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
-	if err != nil {
-		return create.DiagError(names.SESV2, create.ErrActionReading, ResNameConfigurationSet, d.Id(), err)
-	}
-
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return create.DiagError(names.SESV2, create.ErrActionSetting, ResNameConfigurationSet, d.Id(), err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return create.DiagError(names.SESV2, create.ErrActionSetting, ResNameConfigurationSet, d.Id(), err)
 	}
 
 	return nil
@@ -444,14 +422,6 @@ func resourceConfigurationSetUpdate(ctx context.Context, d *schema.ResourceData,
 		log.Printf("[DEBUG] Updating SESV2 ConfigurationSet VdmOptions (%s): %#v", d.Id(), in)
 		_, err := conn.PutConfigurationSetVdmOptions(ctx, in)
 		if err != nil {
-			return create.DiagError(names.SESV2, create.ErrActionUpdating, ResNameConfigurationSet, d.Id(), err)
-		}
-	}
-
-	if d.HasChanges("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
 			return create.DiagError(names.SESV2, create.ErrActionUpdating, ResNameConfigurationSet, d.Id(), err)
 		}
 	}

--- a/internal/service/sesv2/service_package_gen.go
+++ b/internal/service/sesv2/service_package_gen.go
@@ -33,6 +33,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceConfigurationSet,
 			TypeName: "aws_sesv2_configuration_set",
+			Name:     "Configuration Set",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceConfigurationSetEventDestination,
@@ -41,6 +45,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceContactList,
 			TypeName: "aws_sesv2_contact_list",
+			Name:     "Contact List",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceDedicatedIPAssignment,
@@ -49,10 +57,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDedicatedIPPool,
 			TypeName: "aws_sesv2_dedicated_ip_pool",
+			Name:     "Dedicated IP Pool",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceEmailIdentity,
 			TypeName: "aws_sesv2_email_identity",
+			Name:     "Email Identity",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceEmailIdentityFeedbackAttributes,

--- a/internal/service/sfn/service_package_gen.go
+++ b/internal/service/sfn/service_package_gen.go
@@ -37,10 +37,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceActivity,
 			TypeName: "aws_sfn_activity",
+			Name:     "Activity",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceStateMachine,
 			TypeName: "aws_sfn_state_machine",
+			Name:     "State Machine",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }

--- a/internal/service/shield/protection.go
+++ b/internal/service/shield/protection.go
@@ -13,9 +13,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_shield_protection")
+// @SDKResource("aws_shield_protection", name="Protection")
+// @Tags(identifierAttribute="arn")
 func ResourceProtection() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceProtectionCreate,
@@ -42,38 +44,21 @@ func ResourceProtection() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: verify.ValidARN,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 		CustomizeDiff: verify.SetTagsDiff,
 	}
-}
-
-func resourceProtectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).ShieldConn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
-		}
-	}
-
-	return append(diags, resourceProtectionRead(ctx, d, meta)...)
 }
 
 func resourceProtectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ShieldConn()
 
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
-
 	input := &shield.CreateProtectionInput{
 		Name:        aws.String(d.Get("name").(string)),
 		ResourceArn: aws.String(d.Get("resource_arn").(string)),
-		Tags:        Tags(tags.IgnoreAWS()),
+		Tags:        GetTagsIn(ctx),
 	}
 
 	resp, err := conn.CreateProtectionWithContext(ctx, input)
@@ -87,8 +72,6 @@ func resourceProtectionCreate(ctx context.Context, d *schema.ResourceData, meta 
 func resourceProtectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ShieldConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	input := &shield.DescribeProtectionInput{
 		ProtectionId: aws.String(d.Id()),
@@ -111,24 +94,15 @@ func resourceProtectionRead(ctx context.Context, d *schema.ResourceData, meta in
 	d.Set("name", resp.Protection.Name)
 	d.Set("resource_arn", resp.Protection.ResourceArn)
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Shield Protection (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
+}
+
+func resourceProtectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// Tags only.
+
+	return append(diags, resourceProtectionRead(ctx, d, meta)...)
 }
 
 func resourceProtectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/shield/service_package_gen.go
+++ b/internal/service/shield/service_package_gen.go
@@ -28,10 +28,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceProtection,
 			TypeName: "aws_shield_protection",
+			Name:     "Protection",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceProtectionGroup,
 			TypeName: "aws_shield_protection_group",
+			Name:     "Protection Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "protection_group_arn",
+			},
 		},
 		{
 			Factory:  ResourceProtectionHealthCheckAssociation,

--- a/internal/service/signer/service_package_gen.go
+++ b/internal/service/signer/service_package_gen.go
@@ -41,6 +41,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceSigningProfile,
 			TypeName: "aws_signer_signing_profile",
+			Name:     "Signing Profile",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceSigningProfilePermission,

--- a/internal/service/signer/signing_profile.go
+++ b/internal/service/signer/signing_profile.go
@@ -18,9 +18,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_signer_signing_profile")
+// @SDKResource("aws_signer_signing_profile", name="Signing Profile")
+// @Tags(identifierAttribute="arn")
 func ResourceSigningProfile() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSigningProfileCreate,
@@ -78,8 +80,8 @@ func ResourceSigningProfile() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -129,8 +131,6 @@ func ResourceSigningProfile() *schema.Resource {
 func resourceSigningProfileCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SignerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	log.Printf("[DEBUG] Creating Signer signing profile")
 
@@ -140,6 +140,7 @@ func resourceSigningProfileCreate(ctx context.Context, d *schema.ResourceData, m
 	signingProfileInput := &signer.PutSigningProfileInput{
 		ProfileName: aws.String(profileName),
 		PlatformId:  aws.String(d.Get("platform_id").(string)),
+		Tags:        GetTagsIn(ctx),
 	}
 
 	if v, exists := d.GetOk("signature_validity_period"); exists {
@@ -148,10 +149,6 @@ func resourceSigningProfileCreate(ctx context.Context, d *schema.ResourceData, m
 			Value: aws.Int64(int64(signatureValidityPeriod["value"].(int))),
 			Type:  aws.String(signatureValidityPeriod["type"].(string)),
 		}
-	}
-
-	if len(tags) > 0 {
-		signingProfileInput.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	_, err := conn.PutSigningProfileWithContext(ctx, signingProfileInput)
@@ -167,8 +164,6 @@ func resourceSigningProfileCreate(ctx context.Context, d *schema.ResourceData, m
 func resourceSigningProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SignerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	signingProfileOutput, err := conn.GetSigningProfileWithContext(ctx, &signer.GetSigningProfileInput{
 		ProfileName: aws.String(d.Id()),
@@ -221,16 +216,7 @@ func resourceSigningProfileRead(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "setting signer signing profile status: %s", err)
 	}
 
-	tags := KeyValueTags(ctx, signingProfileOutput.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, signingProfileOutput.Tags)
 
 	if err := d.Set("revocation_record", flattenSigningProfileRevocationRecord(signingProfileOutput.RevocationRecord)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting signer signing profile revocation record: %s", err)
@@ -241,16 +227,8 @@ func resourceSigningProfileRead(ctx context.Context, d *schema.ResourceData, met
 
 func resourceSigningProfileUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).SignerConn()
 
-	arn := d.Get("arn").(string)
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, arn, o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Signer signing profile (%s) tags: %s", arn, err)
-		}
-	}
+	// Tags only.
 
 	return append(diags, resourceSigningProfileRead(ctx, d, meta)...)
 }

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -23,6 +23,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 var (
@@ -171,8 +172,8 @@ var (
 			Optional:     true,
 			ValidateFunc: validation.IntBetween(0, 100),
 		},
-		"tags":     tftags.TagsSchema(),
-		"tags_all": tftags.TagsSchemaComputed(),
+		names.AttrTags:    tftags.TagsSchema(),
+		names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		"tracing_config": {
 			Type:         schema.TypeString,
 			Optional:     true,

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -20,6 +20,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 var (
@@ -137,8 +138,8 @@ var (
 			Computed:      true,
 			ConflictsWith: []string{"kms_master_key_id"},
 		},
-		"tags":     tftags.TagsSchema(),
-		"tags_all": tftags.TagsSchemaComputed(),
+		names.AttrTags:    tftags.TagsSchema(),
+		names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		"url": {
 			Type:     schema.TypeString,
 			Computed: true,
@@ -171,7 +172,8 @@ var (
 	}, queueSchema).WithIAMPolicyAttribute("policy").WithMissingSetToNil("*").WithAlwaysSendConfiguredBooleanValueOnCreate("sqs_managed_sse_enabled")
 )
 
-// @SDKResource("aws_sqs_queue")
+// @SDKResource("aws_sqs_queue", name="Queue")
+// @Tags(identifierAttribute="id")
 func ResourceQueue() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceQueueCreate,
@@ -194,8 +196,6 @@ func ResourceQueue() *schema.Resource {
 
 func resourceQueueCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).SQSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	var name string
 	fifoQueue := d.Get("fifo_queue").(bool)
@@ -207,6 +207,7 @@ func resourceQueueCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	input := &sqs.CreateQueueInput{
 		QueueName: aws.String(name),
+		Tags:      GetTagsIn(ctx),
 	}
 
 	attributes, err := queueAttributeMap.ResourceDataToAPIAttributesCreate(d)
@@ -216,10 +217,6 @@ func resourceQueueCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	input.Attributes = aws.StringMap(attributes)
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
 
 	log.Printf("[DEBUG] Creating SQS Queue: %s", input)
 	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, queueCreatedTimeout, func() (interface{}, error) {
@@ -249,7 +246,7 @@ func resourceQueueCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	// Only post-create tagging supported in some partitions
-	if input.Tags == nil && len(tags) > 0 {
+	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(ctx, conn, d.Id(), nil, tags)
 
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
@@ -268,8 +265,6 @@ func resourceQueueCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 func resourceQueueRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).SQSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	outputRaw, err := tfresource.RetryWhenNotFound(ctx, queueReadTimeout, func() (interface{}, error) {
 		return FindQueueAttributesByURL(ctx, conn, d.Id())
@@ -312,31 +307,6 @@ func resourceQueueRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 	d.Set("url", d.Id())
 
-	outputRaw, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, queueTagsTimeout, func() (interface{}, error) {
-		return ListTags(ctx, conn, d.Id())
-	}, sqs.ErrCodeQueueDoesNotExist)
-
-	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
-		// Some partitions may not support tagging, giving error
-		log.Printf("[WARN] failed listing tags for SQS Queue (%s): %s", d.Id(), err)
-		return nil
-	}
-
-	if err != nil {
-		return diag.Errorf("listing tags for SQS Queue (%s): %s", d.Id(), err)
-	}
-
-	tags := outputRaw.(tftags.KeyValueTags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
-	}
-
 	return nil
 }
 
@@ -366,21 +336,6 @@ func resourceQueueUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 		if err != nil {
 			return diag.Errorf("waiting for SQS Queue (%s) attributes update: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		err := UpdateTags(ctx, conn, d.Id(), o, n)
-
-		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
-			// Some partitions may not support tagging, giving error
-			log.Printf("[WARN] failed updating tags for SQS Queue (%s): %s", d.Id(), err)
-			return resourceQueueRead(ctx, d, meta)
-		}
-
-		if err != nil {
-			return diag.Errorf("updating tags for SQS Queue (%s): %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/sqs/service_package_gen.go
+++ b/internal/service/sqs/service_package_gen.go
@@ -37,6 +37,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceQueue,
 			TypeName: "aws_sqs_queue",
+			Name:     "Queue",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceQueuePolicy,

--- a/internal/service/storagegateway/file_system_association.go
+++ b/internal/service/storagegateway/file_system_association.go
@@ -17,9 +17,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_storagegateway_file_system_association")
+// @SDKResource("aws_storagegateway_file_system_association", name="File System Association")
+// @Tags(identifierAttribute="arn")
 func ResourceFileSystemAssociation() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceFileSystemAssociationCreate,
@@ -81,8 +83,8 @@ func ResourceFileSystemAssociation() *schema.Resource {
 					validation.StringLenBetween(1, 1024),
 				),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"username": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -98,8 +100,6 @@ func ResourceFileSystemAssociation() *schema.Resource {
 func resourceFileSystemAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).StorageGatewayConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	gatewayARN := d.Get("gateway_arn").(string)
 	input := &storagegateway.AssociateFileSystemInput{
@@ -107,7 +107,7 @@ func resourceFileSystemAssociationCreate(ctx context.Context, d *schema.Resource
 		GatewayARN:  aws.String(gatewayARN),
 		LocationARN: aws.String(d.Get("location_arn").(string)),
 		Password:    aws.String(d.Get("password").(string)),
-		Tags:        Tags(tags.IgnoreAWS()),
+		Tags:        GetTagsIn(ctx),
 		UserName:    aws.String(d.Get("username").(string)),
 	}
 
@@ -137,8 +137,6 @@ func resourceFileSystemAssociationCreate(ctx context.Context, d *schema.Resource
 func resourceFileSystemAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).StorageGatewayConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	filesystem, err := FindFileSystemAssociationByARN(ctx, conn, d.Id())
 
@@ -161,16 +159,7 @@ func resourceFileSystemAssociationRead(ctx context.Context, d *schema.ResourceDa
 		return sdkdiag.AppendErrorf(diags, "setting cache_attributes: %s", err)
 	}
 
-	tags := KeyValueTags(ctx, filesystem.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, filesystem.Tags)
 
 	return diags
 }
@@ -178,13 +167,6 @@ func resourceFileSystemAssociationRead(ctx context.Context, d *schema.ResourceDa
 func resourceFileSystemAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).StorageGatewayConn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
-		}
-	}
 
 	if d.HasChangesExcept("tags_all") {
 		input := &storagegateway.UpdateFileSystemAssociationInput{

--- a/internal/service/storagegateway/gateway.go
+++ b/internal/service/storagegateway/gateway.go
@@ -26,9 +26,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_storagegateway_gateway")
+// @SDKResource("aws_storagegateway_gateway", name="Gateway")
+// @Tags(identifierAttribute="arn")
 func ResourceGateway() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceGatewayCreate,
@@ -250,8 +252,8 @@ func ResourceGateway() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validation.StringInSlice(storagegateway.SMBSecurityStrategy_Values(), false),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"tape_drive_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -272,10 +274,8 @@ func ResourceGateway() *schema.Resource {
 func resourceGatewayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).StorageGatewayConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
-	region := meta.(*conns.AWSClient).Region
 
+	region := meta.(*conns.AWSClient).Region
 	activationKey := d.Get("activation_key").(string)
 
 	// Perform one time fetch of activation key from gateway IP address.
@@ -353,7 +353,7 @@ func resourceGatewayCreate(ctx context.Context, d *schema.ResourceData, meta int
 		GatewayName:     aws.String(d.Get("gateway_name").(string)),
 		GatewayTimezone: aws.String(d.Get("gateway_timezone").(string)),
 		GatewayType:     aws.String(d.Get("gateway_type").(string)),
-		Tags:            Tags(tags.IgnoreAWS()),
+		Tags:            GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("medium_changer_type"); ok {
@@ -485,8 +485,6 @@ func resourceGatewayCreate(ctx context.Context, d *schema.ResourceData, meta int
 func resourceGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).StorageGatewayConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	output, err := FindGatewayByARN(ctx, conn, d.Id())
 
@@ -500,16 +498,7 @@ func resourceGatewayRead(ctx context.Context, d *schema.ResourceData, meta inter
 		return sdkdiag.AppendErrorf(diags, "reading Storage Gateway Gateway (%s): %s", d.Id(), err)
 	}
 
-	tags := KeyValueTags(ctx, output.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, output.Tags)
 
 	smbSettingsInput := &storagegateway.DescribeSMBSettingsInput{
 		GatewayARN: aws.String(d.Id()),
@@ -788,14 +777,6 @@ func resourceGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "deleting Storage Gateway Gateway (%s) bandwidth rate limit: %s", d.Id(), err)
 			}
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
 		}
 	}
 

--- a/internal/service/storagegateway/service_package_gen.go
+++ b/internal/service/storagegateway/service_package_gen.go
@@ -37,30 +37,58 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCachediSCSIVolume,
 			TypeName: "aws_storagegateway_cached_iscsi_volume",
+			Name:     "Cached iSCSI Volume",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceFileSystemAssociation,
 			TypeName: "aws_storagegateway_file_system_association",
+			Name:     "File System Association",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceGateway,
 			TypeName: "aws_storagegateway_gateway",
+			Name:     "Gateway",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceNFSFileShare,
 			TypeName: "aws_storagegateway_nfs_file_share",
+			Name:     "NFS File Share",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceSMBFileShare,
 			TypeName: "aws_storagegateway_smb_file_share",
+			Name:     "SMB File Share",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceStorediSCSIVolume,
 			TypeName: "aws_storagegateway_stored_iscsi_volume",
+			Name:     "Stored iSCSI Volume",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceTapePool,
 			TypeName: "aws_storagegateway_tape_pool",
+			Name:     "Tape Pool",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceUploadBuffer,

--- a/internal/service/storagegateway/smb_file_share.go
+++ b/internal/service/storagegateway/smb_file_share.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_storagegateway_smb_file_share")
+// @SDKResource("aws_storagegateway_smb_file_share", name="SMB File Share")
+// @Tags(identifierAttribute="arn")
 func ResourceSMBFileShare() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSMBFileShareCreate,
@@ -184,8 +186,8 @@ func ResourceSMBFileShare() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"valid_user_list": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -206,8 +208,6 @@ func ResourceSMBFileShare() *schema.Resource {
 func resourceSMBFileShareCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).StorageGatewayConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &storagegateway.CreateSMBFileShareInput{
 		AccessBasedEnumeration: aws.Bool(d.Get("access_based_enumeration").(bool)),
@@ -220,6 +220,7 @@ func resourceSMBFileShareCreate(ctx context.Context, d *schema.ResourceData, met
 		RequesterPays:          aws.Bool(d.Get("requester_pays").(bool)),
 		Role:                   aws.String(d.Get("role_arn").(string)),
 		SMBACLEnabled:          aws.Bool(d.Get("smb_acl_enabled").(bool)),
+		Tags:                   GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("admin_user_list"); ok && v.(*schema.Set).Len() > 0 {
@@ -282,10 +283,6 @@ func resourceSMBFileShareCreate(ctx context.Context, d *schema.ResourceData, met
 		input.VPCEndpointDNSName = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
 	log.Printf("[DEBUG] Creating Storage Gateway SMB File Share: %s", input)
 	output, err := conn.CreateSMBFileShareWithContext(ctx, input)
 
@@ -305,8 +302,6 @@ func resourceSMBFileShareCreate(ctx context.Context, d *schema.ResourceData, met
 func resourceSMBFileShareRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).StorageGatewayConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	fileshare, err := FindSMBFileShareByARN(ctx, conn, d.Id())
 
@@ -356,16 +351,7 @@ func resourceSMBFileShareRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("valid_user_list", aws.StringValueSlice(fileshare.ValidUserList))
 	d.Set("vpc_endpoint_dns_name", fileshare.VPCEndpointDNSName)
 
-	tags := KeyValueTags(ctx, fileshare.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, fileshare.Tags)
 
 	return diags
 }
@@ -443,13 +429,6 @@ func resourceSMBFileShareUpdate(ctx context.Context, d *schema.ResourceData, met
 
 		if _, err = waitSMBFileShareUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for Storage Gateway SMB File Share (%s) to update: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
 		}
 	}
 

--- a/internal/service/storagegateway/tape_pool.go
+++ b/internal/service/storagegateway/tape_pool.go
@@ -13,9 +13,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_storagegateway_tape_pool")
+// @SDKResource("aws_storagegateway_tape_pool", name="Tape Pool")
+// @Tags(identifierAttribute="arn")
 func ResourceTapePool() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTapePoolCreate,
@@ -57,8 +59,8 @@ func ResourceTapePool() *schema.Resource {
 				Default:      0,
 				ValidateFunc: validation.IntBetween(0, 36500),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -68,15 +70,13 @@ func ResourceTapePool() *schema.Resource {
 func resourceTapePoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).StorageGatewayConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &storagegateway.CreateTapePoolInput{
 		PoolName:                aws.String(d.Get("pool_name").(string)),
 		StorageClass:            aws.String(d.Get("storage_class").(string)),
 		RetentionLockType:       aws.String(d.Get("retention_lock_type").(string)),
 		RetentionLockTimeInDays: aws.Int64(int64(d.Get("retention_lock_time_in_days").(int))),
-		Tags:                    Tags(tags.IgnoreAWS()),
+		Tags:                    GetTagsIn(ctx),
 	}
 
 	log.Printf("[DEBUG] Creating Storage Gateway Tape Pool: %s", input)
@@ -90,25 +90,9 @@ func resourceTapePoolCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceTapePoolRead(ctx, d, meta)...)
 }
 
-func resourceTapePoolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).StorageGatewayConn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
-		}
-	}
-
-	return append(diags, resourceTapePoolRead(ctx, d, meta)...)
-}
-
 func resourceTapePoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).StorageGatewayConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	input := &storagegateway.ListTapePoolsInput{
 		PoolARNs: []*string{aws.String(d.Id())},
@@ -136,22 +120,15 @@ func resourceTapePoolRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("retention_lock_type", pool.RetentionLockType)
 	d.Set("storage_class", pool.StorageClass)
 
-	tags, err := ListTags(ctx, conn, poolArn)
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for resource (%s): %s", poolArn, err)
-	}
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
+}
+
+func resourceTapePoolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// Tags only.
+
+	return append(diags, resourceTapePoolRead(ctx, d, meta)...)
 }
 
 func resourceTapePoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/swf/service_package_gen.go
+++ b/internal/service/swf/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDomain,
 			TypeName: "aws_swf_domain",
+			Name:     "Domain",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -34,7 +34,7 @@ func TestAccSyntheticsCanary_basic(t *testing.T) {
 					testAccCheckCanaryExists(ctx, resourceName, &conf1),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", synthetics.ServiceName, regexp.MustCompile(`canary:.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-puppeteer-3.2"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-puppeteer-3.9"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.memory_in_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.timeout_in_seconds", "840"),
@@ -66,7 +66,7 @@ func TestAccSyntheticsCanary_basic(t *testing.T) {
 					testAccCheckCanaryExists(ctx, resourceName, &conf2),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", synthetics.ServiceName, regexp.MustCompile(`canary:.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-puppeteer-3.2"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-puppeteer-3.9"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.memory_in_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.timeout_in_seconds", "840"),
@@ -145,10 +145,10 @@ func TestAccSyntheticsCanary_runtimeVersion(t *testing.T) {
 		CheckDestroy:             testAccCheckCanaryDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCanaryConfig_runtimeVersion(rName, "syn-nodejs-puppeteer-3.1"),
+				Config: testAccCanaryConfig_runtimeVersion(rName, "syn-nodejs-puppeteer-3.7"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCanaryExists(ctx, resourceName, &conf1),
-					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-puppeteer-3.1"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-puppeteer-3.7"),
 				),
 			},
 			{
@@ -158,10 +158,10 @@ func TestAccSyntheticsCanary_runtimeVersion(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"zip_file", "start_canary", "delete_lambda"},
 			},
 			{
-				Config: testAccCanaryConfig_runtimeVersion(rName, "syn-nodejs-puppeteer-3.2"),
+				Config: testAccCanaryConfig_runtimeVersion(rName, "syn-nodejs-puppeteer-3.9"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCanaryExists(ctx, resourceName, &conf1),
-					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-puppeteer-3.2"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-puppeteer-3.9"),
 				),
 			},
 		},
@@ -277,7 +277,7 @@ func TestAccSyntheticsCanary_s3(t *testing.T) {
 					testAccCheckCanaryExists(ctx, resourceName, &conf),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", synthetics.ServiceName, regexp.MustCompile(`canary:.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-puppeteer-3.2"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_version", "syn-nodejs-puppeteer-3.9"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.memory_in_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.timeout_in_seconds", "840"),
@@ -749,7 +749,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-nodejs-puppeteer-3.2"
+  runtime_version      = "syn-nodejs-puppeteer-3.9"
   delete_lambda        = true
 
   schedule {
@@ -773,7 +773,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-nodejs-puppeteer-3.2"
+  runtime_version      = "syn-nodejs-puppeteer-3.9"
   delete_lambda        = true
 
   schedule {
@@ -798,7 +798,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-nodejs-puppeteer-3.2"
+  runtime_version      = "syn-nodejs-puppeteer-3.9"
   delete_lambda        = true
 
   schedule {
@@ -823,7 +823,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-nodejs-puppeteer-3.2"
+  runtime_version      = "syn-nodejs-puppeteer-3.9"
   delete_lambda        = true
 
   schedule {
@@ -849,7 +849,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-nodejs-puppeteer-3.2"
+  runtime_version      = "syn-nodejs-puppeteer-3.9"
   delete_lambda        = true
 
   schedule {
@@ -879,7 +879,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-nodejs-puppeteer-3.2"
+  runtime_version      = "syn-nodejs-puppeteer-3.9"
   delete_lambda        = true
 
   schedule {
@@ -975,7 +975,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest_modified.zip"
-  runtime_version      = "syn-nodejs-puppeteer-3.2"
+  runtime_version      = "syn-nodejs-puppeteer-3.9"
   delete_lambda        = true
 
   schedule {
@@ -996,7 +996,7 @@ resource "aws_synthetics_canary" "test" {
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
   start_canary         = %[2]t
-  runtime_version      = "syn-nodejs-puppeteer-3.2"
+  runtime_version      = "syn-nodejs-puppeteer-3.9"
   delete_lambda        = true
 
   schedule {
@@ -1017,7 +1017,7 @@ resource "aws_synthetics_canary" "test" {
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest_modified.zip"
   start_canary         = %[2]t
-  runtime_version      = "syn-nodejs-puppeteer-3.2"
+  runtime_version      = "syn-nodejs-puppeteer-3.9"
   delete_lambda        = true
 
   schedule {
@@ -1039,7 +1039,7 @@ resource "aws_synthetics_canary" "test" {
   s3_bucket            = aws_s3_object.test.bucket
   s3_key               = aws_s3_object.test.key
   s3_version           = aws_s3_object.test.version_id
-  runtime_version      = "syn-nodejs-puppeteer-3.2"
+  runtime_version      = "syn-nodejs-puppeteer-3.9"
   delete_lambda        = true
 
   schedule {
@@ -1126,7 +1126,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-nodejs-puppeteer-3.2"
+  runtime_version      = "syn-nodejs-puppeteer-3.9"
   delete_lambda        = true
 
   schedule {
@@ -1154,7 +1154,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-nodejs-puppeteer-3.2"
+  runtime_version      = "syn-nodejs-puppeteer-3.9"
   delete_lambda        = true
 
   schedule {
@@ -1182,7 +1182,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-nodejs-puppeteer-3.2"
+  runtime_version      = "syn-nodejs-puppeteer-3.9"
   delete_lambda        = true
 
   schedule {
@@ -1207,7 +1207,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-nodejs-puppeteer-3.2"
+  runtime_version      = "syn-nodejs-puppeteer-3.9"
   delete_lambda        = true
 
   schedule {
@@ -1229,7 +1229,7 @@ resource "aws_synthetics_canary" "test" {
   execution_role_arn   = aws_iam_role.test.arn
   handler              = "exports.handler"
   zip_file             = "test-fixtures/lambdatest.zip"
-  runtime_version      = "syn-nodejs-puppeteer-3.2"
+  runtime_version      = "syn-nodejs-puppeteer-3.9"
   delete_lambda        = true
 
   schedule {

--- a/internal/service/synthetics/service_package_gen.go
+++ b/internal/service/synthetics/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCanary,
 			TypeName: "aws_synthetics_canary",
+			Name:     "Canary",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin SDK.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30421.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30430.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccSageMakerFeatureGroup_serial/tags\|TestAccSageMakerFeatureGroup_serial/basic\|TestAccSageMaker_serial/App/basic\|TestAccSageMaker_serial/App/tags\|TestAccSageMaker_serial/Domain/basic\|TestAccSageMaker_serial/Domain/tags\|TestAccSageMaker_serial/FlowDefinition/basic\|TestAccSageMaker_serial/FlowDefinition/tags\|TestAccSageMaker_serial/Space/basic\|TestAccSageMaker_serial/Space/tags\|TestAccSageMaker_serial/UserProfile/basic\|TestAccSageMaker_serial/UserProfile/tags\|TestAccSageMaker_serial/Workforce/SourceIpConfig\|TestAccSageMaker_serial/Workforce/tags' PKG=sagemaker ACCTEST_PARALELLISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sagemaker/... -v -count 1 -parallel 20  -run=TestAccSageMakerFeatureGroup_serial/tags\|TestAccSageMakerFeatureGroup_serial/basic\|TestAccSageMaker_serial/App/basic\|TestAccSageMaker_serial/App/tags\|TestAccSageMaker_serial/Domain/basic\|TestAccSageMaker_serial/Domain/tags\|TestAccSageMaker_serial/FlowDefinition/basic\|TestAccSageMaker_serial/FlowDefinition/tags\|TestAccSageMaker_serial/Space/basic\|TestAccSageMaker_serial/Space/tags\|TestAccSageMaker_serial/UserProfile/basic\|TestAccSageMaker_serial/UserProfile/tags\|TestAccSageMaker_serial/Workforce/SourceIpConfig\|TestAccSageMaker_serial/Workforce/tags -timeout 180m
=== RUN   TestAccSageMakerFeatureGroup_serial
=== PAUSE TestAccSageMakerFeatureGroup_serial
=== RUN   TestAccSageMaker_serial
=== PAUSE TestAccSageMaker_serial
=== CONT  TestAccSageMakerFeatureGroup_serial
=== CONT  TestAccSageMaker_serial
=== RUN   TestAccSageMakerFeatureGroup_serial/basic
=== RUN   TestAccSageMaker_serial/App
=== RUN   TestAccSageMaker_serial/App/basic
=== RUN   TestAccSageMakerFeatureGroup_serial/offlineConfig_basic
=== RUN   TestAccSageMakerFeatureGroup_serial/tags
--- PASS: TestAccSageMakerFeatureGroup_serial (166.62s)
    --- PASS: TestAccSageMakerFeatureGroup_serial/basic (35.26s)
    --- PASS: TestAccSageMakerFeatureGroup_serial/offlineConfig_basic (63.31s)
    --- PASS: TestAccSageMakerFeatureGroup_serial/tags (68.04s)
=== RUN   TestAccSageMaker_serial/App/tags
=== RUN   TestAccSageMaker_serial/Domain
=== RUN   TestAccSageMaker_serial/Domain/basic
=== RUN   TestAccSageMaker_serial/Domain/tags
=== RUN   TestAccSageMaker_serial/FlowDefinition
=== RUN   TestAccSageMaker_serial/FlowDefinition/basic
    flow_definition_test.go:24: Step 1/2 error: Error running apply: exit status 1
        
        Error: error creating S3 bucket ACL for tf-acc-test-6475717513380588389: AccessControlListNotSupported: The bucket does not allow ACLs
        	status code: 400, request id: HNMWDSFVGTDENFXD, host id: h9hmzWmW+S+T20kb+3NbR+LIPeTrDzl8isSUR85MmIObdTQT1Mg5ScC6SGikZz3ciQH2BKWRnTk=
        
          with aws_s3_bucket_acl.test,
          on terraform_plugin_test.tf line 15, in resource "aws_s3_bucket_acl" "test":
          15: resource "aws_s3_bucket_acl" "test" {
        
=== RUN   TestAccSageMaker_serial/FlowDefinition/tags
    flow_definition_test.go:133: Step 1/4 error: Error running apply: exit status 1
        
        Error: error creating S3 bucket ACL for tf-acc-test-6484606734673996827: AccessControlListNotSupported: The bucket does not allow ACLs
        	status code: 400, request id: J54PSY9KE2BH8XGF, host id: rh1R0wY1I08Vy6z9bi0tWjDdlnR4oKnqFuKIQHOGyqAspEkK5aClqZFHmGsUW6z8Wnh6fKTpre0=
        
          with aws_s3_bucket_acl.test,
          on terraform_plugin_test.tf line 15, in resource "aws_s3_bucket_acl" "test":
          15: resource "aws_s3_bucket_acl" "test" {
        
=== RUN   TestAccSageMaker_serial/Space
=== RUN   TestAccSageMaker_serial/Space/basic
=== RUN   TestAccSageMaker_serial/Space/tags
=== RUN   TestAccSageMaker_serial/UserProfile
=== RUN   TestAccSageMaker_serial/UserProfile/basic
=== RUN   TestAccSageMaker_serial/UserProfile/tags
=== RUN   TestAccSageMaker_serial/Workforce
=== RUN   TestAccSageMaker_serial/Workforce/SourceIpConfig
--- FAIL: TestAccSageMaker_serial (2746.84s)
    --- PASS: TestAccSageMaker_serial/App (903.66s)
        --- PASS: TestAccSageMaker_serial/App/basic (485.56s)
        --- PASS: TestAccSageMaker_serial/App/tags (418.09s)
    --- PASS: TestAccSageMaker_serial/Domain (501.89s)
        --- PASS: TestAccSageMaker_serial/Domain/basic (252.73s)
        --- PASS: TestAccSageMaker_serial/Domain/tags (249.16s)
    --- FAIL: TestAccSageMaker_serial/FlowDefinition (168.87s)
        --- FAIL: TestAccSageMaker_serial/FlowDefinition/basic (83.59s)
        --- FAIL: TestAccSageMaker_serial/FlowDefinition/tags (85.28s)
    --- PASS: TestAccSageMaker_serial/Space (514.07s)
        --- PASS: TestAccSageMaker_serial/Space/basic (257.47s)
        --- PASS: TestAccSageMaker_serial/Space/tags (256.59s)
    --- PASS: TestAccSageMaker_serial/UserProfile (607.47s)
        --- PASS: TestAccSageMaker_serial/UserProfile/basic (261.23s)
        --- PASS: TestAccSageMaker_serial/UserProfile/tags (346.24s)
    --- PASS: TestAccSageMaker_serial/Workforce (50.88s)
        --- PASS: TestAccSageMaker_serial/Workforce/SourceIpConfig (50.88s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker	2752.283s
FAIL
make: *** [testacc] Error 1
% make testacc TESTARGS='-run=TestAccSageMaker_serial/FlowDefinition/basic\|TestAccSageMaker_serial/FlowDefinition/tags' PKG=sagemaker
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sagemaker/... -v -count 1 -parallel 20  -run=TestAccSageMaker_serial/FlowDefinition/basic\|TestAccSageMaker_serial/FlowDefinition/tags -timeout 180m
=== RUN   TestAccSageMaker_serial
=== PAUSE TestAccSageMaker_serial
=== CONT  TestAccSageMaker_serial
=== RUN   TestAccSageMaker_serial/FlowDefinition
=== RUN   TestAccSageMaker_serial/FlowDefinition/tags
=== RUN   TestAccSageMaker_serial/FlowDefinition/basic
--- PASS: TestAccSageMaker_serial (216.80s)
    --- PASS: TestAccSageMaker_serial/FlowDefinition (216.80s)
        --- PASS: TestAccSageMaker_serial/FlowDefinition/tags (123.14s)
        --- PASS: TestAccSageMaker_serial/FlowDefinition/basic (93.66s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker	222.428s
```
```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=s... ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s.../... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccS3BucketAccelerateConfiguration_basic
=== PAUSE TestAccS3BucketAccelerateConfiguration_basic
=== RUN   TestAccS3BucketACL_basic
=== PAUSE TestAccS3BucketACL_basic
=== RUN   TestAccS3BucketAnalyticsConfiguration_basic
=== PAUSE TestAccS3BucketAnalyticsConfiguration_basic
=== RUN   TestAccS3BucketCorsConfiguration_basic
=== PAUSE TestAccS3BucketCorsConfiguration_basic
=== RUN   TestAccS3BucketDataSource_basic
=== PAUSE TestAccS3BucketDataSource_basic
=== RUN   TestAccS3BucketIntelligentTieringConfiguration_basic
=== PAUSE TestAccS3BucketIntelligentTieringConfiguration_basic
=== RUN   TestAccS3BucketInventory_basic
=== PAUSE TestAccS3BucketInventory_basic
=== RUN   TestAccS3BucketLifecycleConfiguration_basic
=== PAUSE TestAccS3BucketLifecycleConfiguration_basic
=== RUN   TestAccS3BucketLogging_basic
=== PAUSE TestAccS3BucketLogging_basic
=== RUN   TestAccS3BucketMetric_basic
=== PAUSE TestAccS3BucketMetric_basic
=== RUN   TestAccS3BucketObjectDataSource_basic
=== PAUSE TestAccS3BucketObjectDataSource_basic
=== RUN   TestAccS3BucketObjectLockConfiguration_basic
=== PAUSE TestAccS3BucketObjectLockConfiguration_basic
=== RUN   TestAccS3BucketObject_tags
=== PAUSE TestAccS3BucketObject_tags
=== RUN   TestAccS3BucketObjectsDataSource_basic
=== PAUSE TestAccS3BucketObjectsDataSource_basic
=== RUN   TestAccS3BucketOwnershipControls_basic
=== PAUSE TestAccS3BucketOwnershipControls_basic
=== RUN   TestAccS3BucketPolicyDataSource_basic
=== PAUSE TestAccS3BucketPolicyDataSource_basic
=== RUN   TestAccS3BucketPolicy_basic
=== PAUSE TestAccS3BucketPolicy_basic
=== RUN   TestAccS3BucketPublicAccessBlock_basic
=== PAUSE TestAccS3BucketPublicAccessBlock_basic
=== RUN   TestAccS3BucketReplicationConfiguration_basic
=== PAUSE TestAccS3BucketReplicationConfiguration_basic
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_basic
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_basic
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Duplicate_basic
=== PAUSE TestAccS3Bucket_Duplicate_basic
=== RUN   TestAccS3Bucket_Tags_basic
=== PAUSE TestAccS3Bucket_Tags_basic
=== RUN   TestAccS3Bucket_Replication_basic
=== PAUSE TestAccS3Bucket_Replication_basic
=== RUN   TestAccS3BucketVersioning_basic
=== PAUSE TestAccS3BucketVersioning_basic
=== RUN   TestAccS3BucketWebsiteConfiguration_basic
=== PAUSE TestAccS3BucketWebsiteConfiguration_basic
=== RUN   TestAccS3CanonicalUserIDDataSource_basic
=== PAUSE TestAccS3CanonicalUserIDDataSource_basic
=== RUN   TestAccS3ObjectCopy_basic
=== PAUSE TestAccS3ObjectCopy_basic
=== RUN   TestAccS3ObjectDataSource_basic
=== PAUSE TestAccS3ObjectDataSource_basic
=== RUN   TestAccS3Object_tags
=== PAUSE TestAccS3Object_tags
=== RUN   TestAccS3ObjectsDataSource_basic
=== PAUSE TestAccS3ObjectsDataSource_basic
=== CONT  TestAccS3BucketAccelerateConfiguration_basic
=== CONT  TestAccS3BucketPolicy_basic
=== CONT  TestAccS3BucketLogging_basic
--- PASS: TestAccS3BucketLogging_basic (103.40s)
=== CONT  TestAccS3BucketPolicyDataSource_basic
--- PASS: TestAccS3BucketPolicy_basic (104.86s)
=== CONT  TestAccS3BucketOwnershipControls_basic
=== CONT  TestAccS3BucketObjectsDataSource_basic
--- PASS: TestAccS3BucketAccelerateConfiguration_basic (115.64s)
--- PASS: TestAccS3BucketPolicyDataSource_basic (72.21s)
=== CONT  TestAccS3BucketObject_tags
--- PASS: TestAccS3BucketOwnershipControls_basic (84.51s)
=== CONT  TestAccS3BucketObjectLockConfiguration_basic
--- PASS: TestAccS3BucketObjectsDataSource_basic (115.81s)
=== CONT  TestAccS3BucketObjectDataSource_basic
--- PASS: TestAccS3BucketObjectLockConfiguration_basic (69.32s)
=== CONT  TestAccS3BucketMetric_basic
--- PASS: TestAccS3BucketObjectDataSource_basic (55.76s)
=== CONT  TestAccS3BucketVersioning_basic
--- PASS: TestAccS3BucketMetric_basic (70.79s)
=== CONT  TestAccS3ObjectsDataSource_basic
=== CONT  TestAccS3Object_tags
--- PASS: TestAccS3BucketVersioning_basic (72.57s)
--- PASS: TestAccS3BucketObject_tags (223.61s)
=== CONT  TestAccS3ObjectDataSource_basic
--- PASS: TestAccS3ObjectsDataSource_basic (101.01s)
=== CONT  TestAccS3ObjectCopy_basic
=== CONT  TestAccS3CanonicalUserIDDataSource_basic
--- PASS: TestAccS3ObjectDataSource_basic (51.15s)
--- PASS: TestAccS3ObjectCopy_basic (46.27s)
=== CONT  TestAccS3BucketWebsiteConfiguration_basic
--- PASS: TestAccS3CanonicalUserIDDataSource_basic (43.16s)
=== CONT  TestAccS3Bucket_Basic_basic
--- PASS: TestAccS3BucketWebsiteConfiguration_basic (86.03s)
=== CONT  TestAccS3Bucket_Replication_basic
--- PASS: TestAccS3Bucket_Basic_basic (92.32s)
=== CONT  TestAccS3Bucket_Tags_basic
=== CONT  TestAccS3Bucket_Duplicate_basic
--- PASS: TestAccS3Object_tags (232.21s)
--- PASS: TestAccS3Bucket_Duplicate_basic (33.84s)
=== CONT  TestAccS3BucketDataSource_basic
=== CONT  TestAccS3BucketLifecycleConfiguration_basic
--- PASS: TestAccS3Bucket_Tags_basic (72.98s)
--- PASS: TestAccS3BucketDataSource_basic (54.68s)
=== CONT  TestAccS3BucketInventory_basic
    bucket_inventory_test.go:32: Step 1/2 error: Check failed: Check 3/15 error: aws_s3_bucket_inventory.test: list or set attribute 'filter' must be checked by element count key (filter.#) or element value keys (e.g. filter.0). Set element value checks should use TestCheckTypeSet functions instead.
--- PASS: TestAccS3Bucket_Replication_basic (152.06s)
=== CONT  TestAccS3BucketIntelligentTieringConfiguration_basic
--- FAIL: TestAccS3BucketInventory_basic (37.23s)
=== CONT  TestAccS3BucketReplicationConfiguration_basic
--- PASS: TestAccS3BucketIntelligentTieringConfiguration_basic (82.31s)
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_basic
    bucket_server_side_encryption_configuration_test.go:24: Step 1/2 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
        stdout
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_s3_bucket_server_side_encryption_configuration.test will be updated in-place
          ~ resource "aws_s3_bucket_server_side_encryption_configuration" "test" {
                id     = "tf-acc-test-8161621615253536664"
                # (1 unchanged attribute hidden)
        
              - rule {
                  - bucket_key_enabled = false -> null
        
                  - apply_server_side_encryption_by_default {
                      - sse_algorithm = "AES256" -> null
                    }
                }
              + rule {
                }
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccS3BucketServerSideEncryptionConfiguration_basic (84.82s)
=== CONT  TestAccS3BucketPublicAccessBlock_basic
=== CONT  TestAccS3BucketAnalyticsConfiguration_basic
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (258.28s)
--- PASS: TestAccS3BucketPublicAccessBlock_basic (107.66s)
=== CONT  TestAccS3BucketCorsConfiguration_basic
--- PASS: TestAccS3BucketAnalyticsConfiguration_basic (100.63s)
=== CONT  TestAccS3BucketACL_basic
--- PASS: TestAccS3BucketCorsConfiguration_basic (72.96s)
--- PASS: TestAccS3BucketACL_basic (55.83s)
--- PASS: TestAccS3BucketReplicationConfiguration_basic (455.58s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/s3	1214.348s
=== RUN   TestAccS3ControlAccessPointPolicy_basic
=== PAUSE TestAccS3ControlAccessPointPolicy_basic
=== RUN   TestAccS3ControlAccessPoint_basic
=== PAUSE TestAccS3ControlAccessPoint_basic
=== RUN   TestAccS3ControlBucketLifecycleConfiguration_basic
=== PAUSE TestAccS3ControlBucketLifecycleConfiguration_basic
=== RUN   TestAccS3ControlBucketLifecycleConfiguration_RuleFilter_tags
=== PAUSE TestAccS3ControlBucketLifecycleConfiguration_RuleFilter_tags
=== RUN   TestAccS3ControlBucketPolicy_basic
=== PAUSE TestAccS3ControlBucketPolicy_basic
=== RUN   TestAccS3ControlBucket_basic
=== PAUSE TestAccS3ControlBucket_basic
=== RUN   TestAccS3ControlBucket_tags
    acctest.go:76: S3 Control Bucket resource tagging requires additional eventual consistency handling, see also: https://github.com/hashicorp/terraform-provider-aws/issues/15572
--- SKIP: TestAccS3ControlBucket_tags (0.00s)
=== RUN   TestAccS3ControlMultiRegionAccessPointDataSource_basic
=== PAUSE TestAccS3ControlMultiRegionAccessPointDataSource_basic
=== RUN   TestAccS3ControlMultiRegionAccessPointPolicy_basic
=== PAUSE TestAccS3ControlMultiRegionAccessPointPolicy_basic
=== RUN   TestAccS3ControlMultiRegionAccessPoint_basic
=== PAUSE TestAccS3ControlMultiRegionAccessPoint_basic
=== RUN   TestAccS3ControlObjectLambdaAccessPointPolicy_basic
=== PAUSE TestAccS3ControlObjectLambdaAccessPointPolicy_basic
=== RUN   TestAccS3ControlObjectLambdaAccessPoint_basic
=== PAUSE TestAccS3ControlObjectLambdaAccessPoint_basic
=== RUN   TestAccS3ControlStorageLensConfiguration_basic
=== PAUSE TestAccS3ControlStorageLensConfiguration_basic
=== RUN   TestAccS3ControlStorageLensConfiguration_tags
=== PAUSE TestAccS3ControlStorageLensConfiguration_tags
=== CONT  TestAccS3ControlAccessPointPolicy_basic
=== CONT  TestAccS3ControlMultiRegionAccessPointPolicy_basic
=== CONT  TestAccS3ControlBucketPolicy_basic
    acctest.go:1047: skipping since no Outposts found
--- SKIP: TestAccS3ControlBucketPolicy_basic (0.91s)
=== CONT  TestAccS3ControlMultiRegionAccessPointDataSource_basic
--- PASS: TestAccS3ControlAccessPointPolicy_basic (83.85s)
=== CONT  TestAccS3ControlBucket_basic
    acctest.go:1047: skipping since no Outposts found
--- SKIP: TestAccS3ControlBucket_basic (0.24s)
=== CONT  TestAccS3ControlBucketLifecycleConfiguration_basic
    acctest.go:1047: skipping since no Outposts found
--- SKIP: TestAccS3ControlBucketLifecycleConfiguration_basic (0.27s)
=== CONT  TestAccS3ControlBucketLifecycleConfiguration_RuleFilter_tags
    acctest.go:1047: skipping since no Outposts found
--- SKIP: TestAccS3ControlBucketLifecycleConfiguration_RuleFilter_tags (0.25s)
=== CONT  TestAccS3ControlObjectLambdaAccessPoint_basic
--- PASS: TestAccS3ControlObjectLambdaAccessPoint_basic (116.85s)
=== CONT  TestAccS3ControlStorageLensConfiguration_tags
--- PASS: TestAccS3ControlStorageLensConfiguration_tags (149.20s)
=== CONT  TestAccS3ControlStorageLensConfiguration_basic
--- PASS: TestAccS3ControlMultiRegionAccessPointPolicy_basic (359.46s)
=== CONT  TestAccS3ControlObjectLambdaAccessPointPolicy_basic
--- PASS: TestAccS3ControlMultiRegionAccessPointDataSource_basic (404.90s)
=== CONT  TestAccS3ControlMultiRegionAccessPoint_basic
--- PASS: TestAccS3ControlStorageLensConfiguration_basic (58.20s)
=== CONT  TestAccS3ControlAccessPoint_basic
--- PASS: TestAccS3ControlObjectLambdaAccessPointPolicy_basic (83.64s)
--- PASS: TestAccS3ControlAccessPoint_basic (60.92s)
--- PASS: TestAccS3ControlMultiRegionAccessPoint_basic (284.54s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3control	708.887s
=== RUN   TestAccS3OutpostsEndpoint_basic
=== PAUSE TestAccS3OutpostsEndpoint_basic
=== CONT  TestAccS3OutpostsEndpoint_basic
    acctest.go:1047: skipping since no Outposts found
--- SKIP: TestAccS3OutpostsEndpoint_basic (0.92s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3outposts	18.833s
=== RUN   TestAccSageMakerAppImageConfig_basic
=== PAUSE TestAccSageMakerAppImageConfig_basic
=== RUN   TestAccSageMakerAppImageConfig_tags
--- PASS: TestAccSageMakerAppImageConfig_tags (137.54s)
=== RUN   TestAccSageMakerCodeRepository_basic
=== PAUSE TestAccSageMakerCodeRepository_basic
=== RUN   TestAccSageMakerCodeRepository_tags
=== PAUSE TestAccSageMakerCodeRepository_tags
=== RUN   TestAccSageMakerDeviceFleet_basic
=== PAUSE TestAccSageMakerDeviceFleet_basic
=== RUN   TestAccSageMakerDeviceFleet_tags
=== PAUSE TestAccSageMakerDeviceFleet_tags
=== RUN   TestAccSageMakerDevice_basic
=== PAUSE TestAccSageMakerDevice_basic
=== RUN   TestAccSageMakerEndpointConfiguration_basic
=== PAUSE TestAccSageMakerEndpointConfiguration_basic
=== RUN   TestAccSageMakerEndpointConfiguration_tags
=== PAUSE TestAccSageMakerEndpointConfiguration_tags
=== RUN   TestAccSageMakerEndpoint_basic
=== PAUSE TestAccSageMakerEndpoint_basic
=== RUN   TestAccSageMakerEndpoint_tags
=== PAUSE TestAccSageMakerEndpoint_tags
=== RUN   TestAccSageMakerHumanTaskUI_basic
--- PASS: TestAccSageMakerHumanTaskUI_basic (80.01s)
=== RUN   TestAccSageMakerHumanTaskUI_tags
--- PASS: TestAccSageMakerHumanTaskUI_tags (143.62s)
=== RUN   TestAccSageMakerImage_basic
=== PAUSE TestAccSageMakerImage_basic
=== RUN   TestAccSageMakerImage_tags
=== PAUSE TestAccSageMakerImage_tags
=== RUN   TestAccSageMakerImageVersion_basic
    image_version_test.go:23: Environment variable SAGEMAKER_IMAGE_VERSION_BASE_IMAGE is not set
--- SKIP: TestAccSageMakerImageVersion_basic (0.00s)
=== RUN   TestAccSageMakerModelPackageGroupPolicy_basic
=== PAUSE TestAccSageMakerModelPackageGroupPolicy_basic
=== RUN   TestAccSageMakerModelPackageGroup_basic
=== PAUSE TestAccSageMakerModelPackageGroup_basic
=== RUN   TestAccSageMakerModelPackageGroup_tags
=== PAUSE TestAccSageMakerModelPackageGroup_tags
=== RUN   TestAccSageMakerModel_basic
=== PAUSE TestAccSageMakerModel_basic
=== RUN   TestAccSageMakerModel_tags
=== PAUSE TestAccSageMakerModel_tags
=== RUN   TestAccSageMakerNotebookInstanceLifecycleConfiguration_basic
=== PAUSE TestAccSageMakerNotebookInstanceLifecycleConfiguration_basic
=== RUN   TestAccSageMakerNotebookInstance_basic
=== PAUSE TestAccSageMakerNotebookInstance_basic
=== RUN   TestAccSageMakerNotebookInstance_tags
=== PAUSE TestAccSageMakerNotebookInstance_tags
=== RUN   TestAccSageMakerPrebuiltECRImageDataSource_basic
=== PAUSE TestAccSageMakerPrebuiltECRImageDataSource_basic
=== RUN   TestAccSageMakerProject_basic
=== PAUSE TestAccSageMakerProject_basic
=== RUN   TestAccSageMakerProject_tags
=== PAUSE TestAccSageMakerProject_tags
=== RUN   TestAccSageMakerStudioLifecycleConfig_basic
--- PASS: TestAccSageMakerStudioLifecycleConfig_basic (58.28s)
=== RUN   TestAccSageMakerStudioLifecycleConfig_tags
--- PASS: TestAccSageMakerStudioLifecycleConfig_tags (120.03s)
=== CONT  TestAccSageMakerAppImageConfig_basic
=== CONT  TestAccSageMakerModelPackageGroupPolicy_basic
=== CONT  TestAccSageMakerEndpointConfiguration_basic
--- PASS: TestAccSageMakerAppImageConfig_basic (66.56s)
=== CONT  TestAccSageMakerNotebookInstance_basic
--- PASS: TestAccSageMakerModelPackageGroupPolicy_basic (78.89s)
=== CONT  TestAccSageMakerProject_tags
--- PASS: TestAccSageMakerEndpointConfiguration_basic (98.72s)
=== CONT  TestAccSageMakerProject_basic
--- PASS: TestAccSageMakerProject_basic (270.27s)
=== CONT  TestAccSageMakerPrebuiltECRImageDataSource_basic
=== CONT  TestAccSageMakerNotebookInstance_basic
    notebook_instance_test.go:31: Step 1/2 error: Check failed: 2 errors occurred:
        	* Check 7/16 error: aws_sagemaker_notebook_instance.test: Attribute 'instance_metadata_service_configuration.0.minimum_instance_metadata_service_version' expected "1", got "2"
        	* Check 10/16 error: aws_sagemaker_notebook_instance.test: Attribute 'platform_identifier' expected "notebook-al1-v1", got "notebook-al2-v2"
        
--- PASS: TestAccSageMakerPrebuiltECRImageDataSource_basic (67.85s)
=== CONT  TestAccSageMakerNotebookInstance_tags
--- PASS: TestAccSageMakerProject_tags (413.63s)
=== CONT  TestAccSageMakerEndpoint_tags
--- FAIL: TestAccSageMakerNotebookInstance_basic (465.97s)
=== CONT  TestAccSageMakerImage_tags
--- PASS: TestAccSageMakerImage_tags (153.15s)
=== CONT  TestAccSageMakerImage_basic
--- PASS: TestAccSageMakerImage_basic (115.70s)
=== CONT  TestAccSageMakerEndpoint_basic
--- PASS: TestAccSageMakerEndpoint_tags (465.70s)
=== CONT  TestAccSageMakerDeviceFleet_basic
--- PASS: TestAccSageMakerDeviceFleet_basic (59.18s)
=== CONT  TestAccSageMakerDevice_basic
--- PASS: TestAccSageMakerDevice_basic (57.88s)
=== CONT  TestAccSageMakerDeviceFleet_tags
--- PASS: TestAccSageMakerEndpoint_basic (332.32s)
=== CONT  TestAccSageMakerModel_basic
--- PASS: TestAccSageMakerNotebookInstance_tags (730.35s)
=== CONT  TestAccSageMakerNotebookInstanceLifecycleConfiguration_basic
--- PASS: TestAccSageMakerModel_basic (57.80s)
=== CONT  TestAccSageMakerModel_tags
--- PASS: TestAccSageMakerDeviceFleet_tags (119.14s)
=== CONT  TestAccSageMakerModelPackageGroup_tags
--- PASS: TestAccSageMakerNotebookInstanceLifecycleConfiguration_basic (43.86s)
=== CONT  TestAccSageMakerCodeRepository_basic
--- PASS: TestAccSageMakerCodeRepository_basic (41.95s)
=== CONT  TestAccSageMakerEndpointConfiguration_tags
--- PASS: TestAccSageMakerModelPackageGroup_tags (101.01s)
=== CONT  TestAccSageMakerCodeRepository_tags
--- PASS: TestAccSageMakerModel_tags (114.40s)
=== CONT  TestAccSageMakerModelPackageGroup_basic
--- PASS: TestAccSageMakerModelPackageGroup_basic (44.31s)
--- PASS: TestAccSageMakerEndpointConfiguration_tags (114.56s)
--- PASS: TestAccSageMakerCodeRepository_tags (83.76s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker	1936.574s
=== RUN   TestAccSchedulerScheduleGroup_basic
=== PAUSE TestAccSchedulerScheduleGroup_basic
=== RUN   TestAccSchedulerScheduleGroup_tags
=== PAUSE TestAccSchedulerScheduleGroup_tags
=== RUN   TestAccSchedulerSchedule_basic
=== PAUSE TestAccSchedulerSchedule_basic
=== CONT  TestAccSchedulerScheduleGroup_basic
=== CONT  TestAccSchedulerSchedule_basic
=== CONT  TestAccSchedulerScheduleGroup_tags
--- PASS: TestAccSchedulerScheduleGroup_basic (113.82s)
--- PASS: TestAccSchedulerSchedule_basic (135.67s)
--- PASS: TestAccSchedulerScheduleGroup_tags (235.66s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/scheduler	263.358s
=== RUN   TestAccSchemasDiscoverer_basic
=== PAUSE TestAccSchemasDiscoverer_basic
=== RUN   TestAccSchemasDiscoverer_tags
=== PAUSE TestAccSchemasDiscoverer_tags
=== RUN   TestAccSchemasRegistryPolicy_basic
=== PAUSE TestAccSchemasRegistryPolicy_basic
=== RUN   TestAccSchemasRegistry_basic
=== PAUSE TestAccSchemasRegistry_basic
=== RUN   TestAccSchemasRegistry_tags
=== PAUSE TestAccSchemasRegistry_tags
=== RUN   TestAccSchemasSchema_basic
=== PAUSE TestAccSchemasSchema_basic
=== RUN   TestAccSchemasSchema_tags
=== PAUSE TestAccSchemasSchema_tags
=== CONT  TestAccSchemasDiscoverer_basic
=== CONT  TestAccSchemasRegistry_tags
=== CONT  TestAccSchemasSchema_tags
--- PASS: TestAccSchemasDiscoverer_basic (110.30s)
=== CONT  TestAccSchemasSchema_basic
--- PASS: TestAccSchemasSchema_basic (84.62s)
=== CONT  TestAccSchemasRegistry_basic
--- PASS: TestAccSchemasSchema_tags (208.83s)
=== CONT  TestAccSchemasDiscoverer_tags
--- PASS: TestAccSchemasRegistry_tags (210.60s)
=== CONT  TestAccSchemasRegistryPolicy_basic
--- PASS: TestAccSchemasRegistry_basic (70.62s)
--- PASS: TestAccSchemasRegistryPolicy_basic (66.98s)
--- PASS: TestAccSchemasDiscoverer_tags (151.62s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/schemas	376.193s
=== RUN   TestAccSecretsManagerRandomPasswordDataSource_basic
=== PAUSE TestAccSecretsManagerRandomPasswordDataSource_basic
=== RUN   TestAccSecretsManagerSecretDataSource_basic
=== PAUSE TestAccSecretsManagerSecretDataSource_basic
=== RUN   TestAccSecretsManagerSecretPolicy_basic
=== PAUSE TestAccSecretsManagerSecretPolicy_basic
=== RUN   TestAccSecretsManagerSecretRotationDataSource_basic
=== PAUSE TestAccSecretsManagerSecretRotationDataSource_basic
=== RUN   TestAccSecretsManagerSecretRotation_basic
=== PAUSE TestAccSecretsManagerSecretRotation_basic
=== RUN   TestAccSecretsManagerSecret_basic
=== PAUSE TestAccSecretsManagerSecret_basic
=== RUN   TestAccSecretsManagerSecret_tags
=== PAUSE TestAccSecretsManagerSecret_tags
=== RUN   TestAccSecretsManagerSecretVersionDataSource_basic
=== PAUSE TestAccSecretsManagerSecretVersionDataSource_basic
=== CONT  TestAccSecretsManagerRandomPasswordDataSource_basic
=== CONT  TestAccSecretsManagerSecretRotation_basic
=== CONT  TestAccSecretsManagerSecretPolicy_basic
--- PASS: TestAccSecretsManagerRandomPasswordDataSource_basic (62.18s)
=== CONT  TestAccSecretsManagerSecretRotationDataSource_basic
=== CONT  TestAccSecretsManagerSecretPolicy_basic
    secret_policy_test.go:28: Step 1/3 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_secretsmanager_secret_policy.test will be updated in-place
          ~ resource "aws_secretsmanager_secret_policy" "test" {
                id         = "arn:aws:secretsmanager:us-west-2:123456789012:secret:tf-acc-test-7651376627850530371-xwSdDm"
              ~ policy     = jsonencode(
                  ~ {
                      ~ Statement = [
                          ~ {
                              ~ Principal = {
                                  ~ AWS = "AROAWH4AAR7YI6IXMRVVF" -> "arn:aws:iam::123456789012:role/tf-acc-test-7651376627850530371"
                                }
                                # (4 unchanged elements hidden)
                            },
                        ]
                        # (1 unchanged element hidden)
                    }
                )
                # (1 unchanged attribute hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccSecretsManagerSecretPolicy_basic (84.08s)
=== CONT  TestAccSecretsManagerSecretDataSource_basic
--- PASS: TestAccSecretsManagerSecretDataSource_basic (24.70s)
=== CONT  TestAccSecretsManagerSecret_tags
=== CONT  TestAccSecretsManagerSecretVersionDataSource_basic
--- PASS: TestAccSecretsManagerSecretRotation_basic (113.56s)
--- PASS: TestAccSecretsManagerSecretRotationDataSource_basic (103.74s)
=== CONT  TestAccSecretsManagerSecret_basic
--- PASS: TestAccSecretsManagerSecretVersionDataSource_basic (71.51s)
--- PASS: TestAccSecretsManagerSecret_basic (65.15s)
--- PASS: TestAccSecretsManagerSecret_tags (191.88s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	328.268s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/securityhub	30.294s [no tests to run]
?   	github.com/hashicorp/terraform-provider-aws/internal/service/securitylake	[no test files]
=== RUN   TestAccServerlessRepoApplicationDataSource_basic
=== PAUSE TestAccServerlessRepoApplicationDataSource_basic
=== RUN   TestAccServerlessRepoCloudFormationStack_basic
=== PAUSE TestAccServerlessRepoCloudFormationStack_basic
=== RUN   TestAccServerlessRepoCloudFormationStack_tags
=== PAUSE TestAccServerlessRepoCloudFormationStack_tags
=== CONT  TestAccServerlessRepoApplicationDataSource_basic
=== CONT  TestAccServerlessRepoCloudFormationStack_tags
=== CONT  TestAccServerlessRepoCloudFormationStack_basic
=== CONT  TestAccServerlessRepoApplicationDataSource_basic
    application_data_source_test.go:19: Step 2/2, expected an error with pattern, no match on: Error running pre-apply refresh: exit status 1
        
        Error: getting Serverless Application Repository application (arn:aws:serverlessrepo:us-west-2:123456789012:applications/ThisFunctionDoesNotExist): couldn't find resource
        
          with data.aws_serverlessapplicationrepository_application.no_such_function,
          on terraform_plugin_test.tf line 8, in data "aws_serverlessapplicationrepository_application" "no_such_function":
           8: data "aws_serverlessapplicationrepository_application" "no_such_function" {
        
--- FAIL: TestAccServerlessRepoApplicationDataSource_basic (73.12s)
--- PASS: TestAccServerlessRepoCloudFormationStack_basic (190.79s)
--- PASS: TestAccServerlessRepoCloudFormationStack_tags (353.95s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/serverlessrepo	374.509s
=== RUN   TestAccServiceCatalogBudgetResourceAssociation_basic
=== PAUSE TestAccServiceCatalogBudgetResourceAssociation_basic
=== RUN   TestAccServiceCatalogConstraintDataSource_basic
=== PAUSE TestAccServiceCatalogConstraintDataSource_basic
=== RUN   TestAccServiceCatalogConstraint_basic
=== PAUSE TestAccServiceCatalogConstraint_basic
=== RUN   TestAccServiceCatalogLaunchPathsDataSource_basic
=== PAUSE TestAccServiceCatalogLaunchPathsDataSource_basic
=== RUN   TestAccServiceCatalogPortfolioConstraintsDataSource_Constraint_basic
=== PAUSE TestAccServiceCatalogPortfolioConstraintsDataSource_Constraint_basic
=== RUN   TestAccServiceCatalogPortfolioDataSource_basic
=== PAUSE TestAccServiceCatalogPortfolioDataSource_basic
=== RUN   TestAccServiceCatalogPortfolio_basic
=== PAUSE TestAccServiceCatalogPortfolio_basic
=== RUN   TestAccServiceCatalogPortfolio_tags
=== PAUSE TestAccServiceCatalogPortfolio_tags
=== RUN   TestAccServiceCatalogPrincipalPortfolioAssociation_basic
=== PAUSE TestAccServiceCatalogPrincipalPortfolioAssociation_basic
=== RUN   TestAccServiceCatalogProductDataSource_basic
=== PAUSE TestAccServiceCatalogProductDataSource_basic
=== RUN   TestAccServiceCatalogProductPortfolioAssociation_basic
=== PAUSE TestAccServiceCatalogProductPortfolioAssociation_basic
=== RUN   TestAccServiceCatalogProduct_basic
=== PAUSE TestAccServiceCatalogProduct_basic
=== RUN   TestAccServiceCatalogProvisionedProduct_basic
=== PAUSE TestAccServiceCatalogProvisionedProduct_basic
=== RUN   TestAccServiceCatalogProvisionedProduct_tags
=== PAUSE TestAccServiceCatalogProvisionedProduct_tags
=== RUN   TestAccServiceCatalogProvisioningArtifact_basic
=== PAUSE TestAccServiceCatalogProvisioningArtifact_basic
=== RUN   TestAccServiceCatalogProvisioningArtifactsDataSource_basic
=== PAUSE TestAccServiceCatalogProvisioningArtifactsDataSource_basic
=== RUN   TestAccServiceCatalogServiceAction_basic
=== PAUSE TestAccServiceCatalogServiceAction_basic
=== RUN   TestAccServiceCatalogTagOptionResourceAssociation_basic
=== PAUSE TestAccServiceCatalogTagOptionResourceAssociation_basic
=== RUN   TestAccServiceCatalogTagOption_basic
=== PAUSE TestAccServiceCatalogTagOption_basic
=== CONT  TestAccServiceCatalogBudgetResourceAssociation_basic
=== CONT  TestAccServiceCatalogProductPortfolioAssociation_basic
=== CONT  TestAccServiceCatalogProvisioningArtifactsDataSource_basic
--- PASS: TestAccServiceCatalogBudgetResourceAssociation_basic (59.82s)
=== CONT  TestAccServiceCatalogProvisionedProduct_tags
--- PASS: TestAccServiceCatalogProvisioningArtifactsDataSource_basic (76.15s)
=== CONT  TestAccServiceCatalogProvisioningArtifact_basic
--- PASS: TestAccServiceCatalogProductPortfolioAssociation_basic (114.48s)
=== CONT  TestAccServiceCatalogProvisionedProduct_basic
--- PASS: TestAccServiceCatalogProvisioningArtifact_basic (80.47s)
=== CONT  TestAccServiceCatalogTagOptionResourceAssociation_basic
--- PASS: TestAccServiceCatalogTagOptionResourceAssociation_basic (68.29s)
=== CONT  TestAccServiceCatalogTagOption_basic
--- PASS: TestAccServiceCatalogTagOption_basic (73.88s)
=== CONT  TestAccServiceCatalogServiceAction_basic
--- PASS: TestAccServiceCatalogProvisionedProduct_basic (199.16s)
=== CONT  TestAccServiceCatalogProduct_basic
--- PASS: TestAccServiceCatalogServiceAction_basic (60.14s)
=== CONT  TestAccServiceCatalogPortfolioDataSource_basic
--- PASS: TestAccServiceCatalogProvisionedProduct_tags (301.97s)
=== CONT  TestAccServiceCatalogProductDataSource_basic
--- PASS: TestAccServiceCatalogProduct_basic (78.70s)
=== CONT  TestAccServiceCatalogPrincipalPortfolioAssociation_basic
--- PASS: TestAccServiceCatalogPortfolioDataSource_basic (56.95s)
=== CONT  TestAccServiceCatalogPortfolio_tags
--- PASS: TestAccServiceCatalogProductDataSource_basic (77.91s)
=== CONT  TestAccServiceCatalogPortfolio_basic
--- PASS: TestAccServiceCatalogPrincipalPortfolioAssociation_basic (99.37s)
=== CONT  TestAccServiceCatalogLaunchPathsDataSource_basic
--- PASS: TestAccServiceCatalogPortfolio_basic (88.09s)
=== CONT  TestAccServiceCatalogPortfolioConstraintsDataSource_Constraint_basic
--- PASS: TestAccServiceCatalogPortfolio_tags (197.18s)
=== CONT  TestAccServiceCatalogConstraint_basic
--- PASS: TestAccServiceCatalogLaunchPathsDataSource_basic (131.62s)
=== CONT  TestAccServiceCatalogConstraintDataSource_basic
--- PASS: TestAccServiceCatalogPortfolioConstraintsDataSource_Constraint_basic (112.49s)
--- PASS: TestAccServiceCatalogConstraintDataSource_basic (107.09s)
--- PASS: TestAccServiceCatalogConstraint_basic (119.53s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog	753.302s
=== RUN   TestAccServiceDiscoveryHTTPNamespaceDataSource_basic
=== PAUSE TestAccServiceDiscoveryHTTPNamespaceDataSource_basic
=== RUN   TestAccServiceDiscoveryHTTPNamespace_basic
=== PAUSE TestAccServiceDiscoveryHTTPNamespace_basic
=== RUN   TestAccServiceDiscoveryHTTPNamespace_tags
=== PAUSE TestAccServiceDiscoveryHTTPNamespace_tags
=== RUN   TestAccServiceDiscoveryPrivateDNSNamespace_basic
=== PAUSE TestAccServiceDiscoveryPrivateDNSNamespace_basic
=== RUN   TestAccServiceDiscoveryPrivateDNSNamespace_tags
=== PAUSE TestAccServiceDiscoveryPrivateDNSNamespace_tags
=== RUN   TestAccServiceDiscoveryPublicDNSNamespace_basic
=== PAUSE TestAccServiceDiscoveryPublicDNSNamespace_basic
=== RUN   TestAccServiceDiscoveryPublicDNSNamespace_tags
=== PAUSE TestAccServiceDiscoveryPublicDNSNamespace_tags
=== RUN   TestAccServiceDiscoveryServiceDataSource_basic
=== PAUSE TestAccServiceDiscoveryServiceDataSource_basic
=== RUN   TestAccServiceDiscoveryService_tags
=== PAUSE TestAccServiceDiscoveryService_tags
=== CONT  TestAccServiceDiscoveryPublicDNSNamespace_basic
=== CONT  TestAccServiceDiscoveryHTTPNamespaceDataSource_basic
=== CONT  TestAccServiceDiscoveryHTTPNamespace_tags
--- PASS: TestAccServiceDiscoveryHTTPNamespaceDataSource_basic (151.11s)
=== CONT  TestAccServiceDiscoveryHTTPNamespace_basic
--- PASS: TestAccServiceDiscoveryPublicDNSNamespace_basic (162.06s)
=== CONT  TestAccServiceDiscoveryServiceDataSource_basic
--- PASS: TestAccServiceDiscoveryHTTPNamespace_tags (240.46s)
=== CONT  TestAccServiceDiscoveryService_tags
--- PASS: TestAccServiceDiscoveryHTTPNamespace_basic (166.52s)
=== CONT  TestAccServiceDiscoveryPublicDNSNamespace_tags
--- PASS: TestAccServiceDiscoveryServiceDataSource_basic (162.72s)
=== CONT  TestAccServiceDiscoveryPrivateDNSNamespace_basic
--- PASS: TestAccServiceDiscoveryPrivateDNSNamespace_basic (196.14s)
=== CONT  TestAccServiceDiscoveryPrivateDNSNamespace_tags
--- PASS: TestAccServiceDiscoveryService_tags (308.53s)
--- PASS: TestAccServiceDiscoveryPublicDNSNamespace_tags (274.81s)
--- PASS: TestAccServiceDiscoveryPrivateDNSNamespace_tags (194.91s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicediscovery	733.604s
=== RUN   TestAccServiceQuotasServiceQuota_basic
=== PAUSE TestAccServiceQuotasServiceQuota_basic
=== CONT  TestAccServiceQuotasServiceQuota_basic
--- PASS: TestAccServiceQuotasServiceQuota_basic (72.50s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicequotas	93.389s
=== RUN   TestAccSESConfigurationSet_basic
=== PAUSE TestAccSESConfigurationSet_basic
=== RUN   TestAccSESDomainDKIM_basic
=== PAUSE TestAccSESDomainDKIM_basic
=== RUN   TestAccSESDomainIdentityDataSource_basic
=== PAUSE TestAccSESDomainIdentityDataSource_basic
=== RUN   TestAccSESDomainIdentity_basic
=== PAUSE TestAccSESDomainIdentity_basic
=== RUN   TestAccSESDomainIdentityVerification_basic
    domain_identity_verification_test.go:23: Environment variable SES_DOMAIN_IDENTITY_ROOT_DOMAIN is not set. For DNS verification requests, this domain must be publicly accessible and configurable via Route53 during the testing. 
--- SKIP: TestAccSESDomainIdentityVerification_basic (0.00s)
=== RUN   TestAccSESDomainMailFrom_basic
=== PAUSE TestAccSESDomainMailFrom_basic
=== RUN   TestAccSESEmailIdentityDataSource_basic
=== PAUSE TestAccSESEmailIdentityDataSource_basic
=== RUN   TestAccSESEmailIdentity_basic
=== PAUSE TestAccSESEmailIdentity_basic
=== RUN   TestAccSESEventDestination_basic
=== PAUSE TestAccSESEventDestination_basic
=== RUN   TestAccSESIdentityNotificationTopic_basic
=== PAUSE TestAccSESIdentityNotificationTopic_basic
=== RUN   TestAccSESIdentityPolicy_basic
=== PAUSE TestAccSESIdentityPolicy_basic
=== RUN   TestAccSESReceiptFilter_basic
=== PAUSE TestAccSESReceiptFilter_basic
=== RUN   TestAccSESReceiptRuleSet_basic
=== PAUSE TestAccSESReceiptRuleSet_basic
=== RUN   TestAccSESReceiptRule_basic
=== PAUSE TestAccSESReceiptRule_basic
=== RUN   TestAccSESTemplate_basic
=== PAUSE TestAccSESTemplate_basic
=== CONT  TestAccSESConfigurationSet_basic
=== CONT  TestAccSESEventDestination_basic
=== CONT  TestAccSESReceiptRuleSet_basic
--- PASS: TestAccSESConfigurationSet_basic (68.81s)
=== CONT  TestAccSESReceiptFilter_basic
--- PASS: TestAccSESReceiptRuleSet_basic (69.89s)
=== CONT  TestAccSESIdentityPolicy_basic
--- PASS: TestAccSESReceiptFilter_basic (58.40s)
=== CONT  TestAccSESIdentityNotificationTopic_basic
--- PASS: TestAccSESIdentityPolicy_basic (59.52s)
=== CONT  TestAccSESTemplate_basic
--- PASS: TestAccSESTemplate_basic (62.69s)
=== CONT  TestAccSESDomainMailFrom_basic
--- PASS: TestAccSESIdentityNotificationTopic_basic (166.37s)
=== CONT  TestAccSESEmailIdentity_basic
--- PASS: TestAccSESDomainMailFrom_basic (138.64s)
=== CONT  TestAccSESEmailIdentityDataSource_basic
--- PASS: TestAccSESEmailIdentity_basic (94.75s)
=== CONT  TestAccSESReceiptRule_basic
=== CONT  TestAccSESEmailIdentityDataSource_basic
    email_identity_data_dource_test.go:18: Step 1/1 error: Error running second post-apply plan: exit status 1
        
        Error: [WARN] Email not listed in response when fetching verification attributes for no-reply@hashicorp.com
        
          with data.aws_ses_email_identity.test,
          on terraform_plugin_test.tf line 5, in data "aws_ses_email_identity" "test":
           5: data "aws_ses_email_identity" "test" {
        
--- FAIL: TestAccSESEmailIdentityDataSource_basic (79.01s)
=== CONT  TestAccSESDomainIdentityDataSource_basic
--- PASS: TestAccSESEventDestination_basic (423.11s)
=== CONT  TestAccSESDomainIdentity_basic
--- PASS: TestAccSESDomainIdentityDataSource_basic (74.50s)
=== CONT  TestAccSESDomainDKIM_basic
--- PASS: TestAccSESReceiptRule_basic (96.25s)
--- PASS: TestAccSESDomainIdentity_basic (70.26s)
--- PASS: TestAccSESDomainDKIM_basic (47.83s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ses	555.895s
=== RUN   TestAccSESV2ConfigurationSetEventDestination_basic
=== PAUSE TestAccSESV2ConfigurationSetEventDestination_basic
=== RUN   TestAccSESV2ConfigurationSet_basic
=== PAUSE TestAccSESV2ConfigurationSet_basic
=== RUN   TestAccSESV2ConfigurationSet_tags
=== PAUSE TestAccSESV2ConfigurationSet_tags
=== RUN   TestAccSESV2ContactList_basic
--- PASS: TestAccSESV2ContactList_basic (56.48s)
=== RUN   TestAccSESV2ContactList_tags
--- PASS: TestAccSESV2ContactList_tags (90.18s)
=== RUN   TestAccSESV2DedicatedIPPoolDataSource_basic
=== PAUSE TestAccSESV2DedicatedIPPoolDataSource_basic
=== RUN   TestAccSESV2DedicatedIPPool_basic
=== PAUSE TestAccSESV2DedicatedIPPool_basic
=== RUN   TestAccSESV2DedicatedIPPool_tags
=== PAUSE TestAccSESV2DedicatedIPPool_tags
=== RUN   TestAccSESV2EmailIdentityFeedbackAttributes_basic
=== PAUSE TestAccSESV2EmailIdentityFeedbackAttributes_basic
=== RUN   TestAccSESV2EmailIdentityMailFromAttributes_basic
=== PAUSE TestAccSESV2EmailIdentityMailFromAttributes_basic
=== RUN   TestAccSESV2EmailIdentity_tags
=== PAUSE TestAccSESV2EmailIdentity_tags
=== CONT  TestAccSESV2ConfigurationSetEventDestination_basic
=== CONT  TestAccSESV2EmailIdentity_tags
=== CONT  TestAccSESV2DedicatedIPPool_basic
--- PASS: TestAccSESV2DedicatedIPPool_basic (76.56s)
=== CONT  TestAccSESV2ConfigurationSet_tags
--- PASS: TestAccSESV2ConfigurationSetEventDestination_basic (131.12s)
=== CONT  TestAccSESV2DedicatedIPPoolDataSource_basic
--- PASS: TestAccSESV2EmailIdentity_tags (197.53s)
=== CONT  TestAccSESV2EmailIdentityFeedbackAttributes_basic
--- PASS: TestAccSESV2DedicatedIPPoolDataSource_basic (83.98s)
=== CONT  TestAccSESV2EmailIdentityMailFromAttributes_basic
--- PASS: TestAccSESV2EmailIdentityFeedbackAttributes_basic (98.26s)
=== CONT  TestAccSESV2DedicatedIPPool_tags
--- PASS: TestAccSESV2ConfigurationSet_tags (219.24s)
=== CONT  TestAccSESV2ConfigurationSet_basic
--- PASS: TestAccSESV2EmailIdentityMailFromAttributes_basic (95.30s)
--- PASS: TestAccSESV2ConfigurationSet_basic (57.67s)
--- PASS: TestAccSESV2DedicatedIPPool_tags (92.61s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sesv2	557.314s
=== RUN   TestAccSFNActivityDataSource_basic
=== PAUSE TestAccSFNActivityDataSource_basic
=== RUN   TestAccSFNActivity_basic
=== PAUSE TestAccSFNActivity_basic
=== RUN   TestAccSFNActivity_tags
=== PAUSE TestAccSFNActivity_tags
=== RUN   TestAccSFNStateMachineDataSource_basic
=== PAUSE TestAccSFNStateMachineDataSource_basic
=== RUN   TestAccSFNStateMachine_tags
=== PAUSE TestAccSFNStateMachine_tags
=== CONT  TestAccSFNActivityDataSource_basic
=== CONT  TestAccSFNStateMachineDataSource_basic
=== CONT  TestAccSFNActivity_tags
--- PASS: TestAccSFNActivityDataSource_basic (75.16s)
=== CONT  TestAccSFNStateMachine_tags
--- PASS: TestAccSFNStateMachineDataSource_basic (129.48s)
=== CONT  TestAccSFNActivity_basic
--- PASS: TestAccSFNActivity_basic (103.39s)
--- PASS: TestAccSFNActivity_tags (237.34s)
--- PASS: TestAccSFNStateMachine_tags (245.75s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sfn	342.590s
=== RUN   TestAccShieldProtectionGroup_basic
=== PAUSE TestAccShieldProtectionGroup_basic
=== RUN   TestAccShieldProtectionGroup_tags
=== PAUSE TestAccShieldProtectionGroup_tags
=== RUN   TestAccShieldProtectionHealthCheckAssociation_basic
=== PAUSE TestAccShieldProtectionHealthCheckAssociation_basic
=== RUN   TestAccShieldProtection_CloudFront_tags
=== PAUSE TestAccShieldProtection_CloudFront_tags
=== CONT  TestAccShieldProtectionGroup_basic
=== CONT  TestAccShieldProtectionHealthCheckAssociation_basic
=== CONT  TestAccShieldProtectionGroup_tags
=== CONT  TestAccShieldProtectionGroup_basic
    protection_group_test.go:25: Step 1/2 error: Check failed: Check 5/7 error: aws_shield_protection_group.test: Attribute 'resource_type' found when not expected
--- FAIL: TestAccShieldProtectionGroup_basic (43.95s)
=== CONT  TestAccShieldProtection_CloudFront_tags
--- PASS: TestAccShieldProtectionHealthCheckAssociation_basic (97.79s)
--- PASS: TestAccShieldProtectionGroup_tags (188.89s)
--- PASS: TestAccShieldProtection_CloudFront_tags (380.18s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/shield	447.298s
=== RUN   TestAccSignerSigningJobDataSource_basic
=== PAUSE TestAccSignerSigningJobDataSource_basic
=== RUN   TestAccSignerSigningJob_basic
=== PAUSE TestAccSignerSigningJob_basic
=== RUN   TestAccSignerSigningProfileDataSource_basic
=== PAUSE TestAccSignerSigningProfileDataSource_basic
=== RUN   TestAccSignerSigningProfilePermission_basic
=== PAUSE TestAccSignerSigningProfilePermission_basic
=== RUN   TestAccSignerSigningProfile_basic
=== PAUSE TestAccSignerSigningProfile_basic
=== RUN   TestAccSignerSigningProfile_tags
=== PAUSE TestAccSignerSigningProfile_tags
=== CONT  TestAccSignerSigningJobDataSource_basic
=== CONT  TestAccSignerSigningProfile_tags
=== CONT  TestAccSignerSigningProfile_basic
=== CONT  TestAccSignerSigningJobDataSource_basic
    signing_profile_test.go:208: skipping acceptance testing: Signing Platform (AWSLambda-SHA384-ECDSA) not found
--- SKIP: TestAccSignerSigningJobDataSource_basic (1.24s)
=== CONT  TestAccSignerSigningProfileDataSource_basic
=== CONT  TestAccSignerSigningProfile_tags
    signing_profile_test.go:208: skipping acceptance testing: Signing Platform (AWSLambda-SHA384-ECDSA) not found
--- SKIP: TestAccSignerSigningProfile_tags (1.25s)
=== CONT  TestAccSignerSigningJob_basic
=== CONT  TestAccSignerSigningProfile_basic
    signing_profile_test.go:208: skipping acceptance testing: Signing Platform (AWSLambda-SHA384-ECDSA) not found
--- SKIP: TestAccSignerSigningProfile_basic (1.26s)
=== CONT  TestAccSignerSigningProfilePermission_basic
=== CONT  TestAccSignerSigningProfileDataSource_basic
    signing_profile_test.go:208: skipping acceptance testing: Signing Platform (AWSLambda-SHA384-ECDSA) not found
--- SKIP: TestAccSignerSigningProfileDataSource_basic (0.13s)
=== CONT  TestAccSignerSigningJob_basic
    signing_profile_test.go:208: skipping acceptance testing: Signing Platform (AWSLambda-SHA384-ECDSA) not found
--- SKIP: TestAccSignerSigningJob_basic (0.12s)
=== CONT  TestAccSignerSigningProfilePermission_basic
    signing_profile_test.go:208: skipping acceptance testing: Signing Platform (AWSLambda-SHA384-ECDSA) not found
--- SKIP: TestAccSignerSigningProfilePermission_basic (0.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/signer	20.335s
=== RUN   TestAccSimpleDBDomain_basic
=== PAUSE TestAccSimpleDBDomain_basic
=== CONT  TestAccSimpleDBDomain_basic
--- PASS: TestAccSimpleDBDomain_basic (71.19s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/simpledb	103.829s
=== RUN   TestAccSNSPlatformApplication_GCM_basic
    platform_application_test.go:178: Environment variable GCM_API_KEY is not set
--- SKIP: TestAccSNSPlatformApplication_GCM_basic (0.00s)
=== RUN   TestAccSNSPlatformApplication_basic
    platform_application_test.go:94: no SNS Platform Application environment variables found
--- SKIP: TestAccSNSPlatformApplication_basic (0.00s)
=== RUN   TestAccSNSTopicDataProtectionPolicy_basic
=== PAUSE TestAccSNSTopicDataProtectionPolicy_basic
=== RUN   TestAccSNSTopicDataSource_basic
=== PAUSE TestAccSNSTopicDataSource_basic
=== RUN   TestAccSNSTopicPolicy_basic
=== PAUSE TestAccSNSTopicPolicy_basic
=== RUN   TestAccSNSTopicSubscription_basic
=== PAUSE TestAccSNSTopicSubscription_basic
=== RUN   TestAccSNSTopic_basic
=== PAUSE TestAccSNSTopic_basic
=== RUN   TestAccSNSTopic_tags
=== PAUSE TestAccSNSTopic_tags
=== CONT  TestAccSNSTopicDataProtectionPolicy_basic
=== CONT  TestAccSNSTopicSubscription_basic
=== CONT  TestAccSNSTopicPolicy_basic
--- PASS: TestAccSNSTopicDataProtectionPolicy_basic (40.25s)
=== CONT  TestAccSNSTopicDataSource_basic
--- PASS: TestAccSNSTopicPolicy_basic (40.52s)
=== CONT  TestAccSNSTopic_tags
--- PASS: TestAccSNSTopicDataSource_basic (32.49s)
=== CONT  TestAccSNSTopic_basic
--- PASS: TestAccSNSTopicSubscription_basic (102.62s)
--- PASS: TestAccSNSTopic_basic (47.20s)
--- PASS: TestAccSNSTopic_tags (111.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sns	168.586s
=== RUN   TestAccSQSQueueDataSource_basic
=== PAUSE TestAccSQSQueueDataSource_basic
=== RUN   TestAccSQSQueueDataSource_tags
=== PAUSE TestAccSQSQueueDataSource_tags
=== RUN   TestAccSQSQueuePolicy_basic
=== PAUSE TestAccSQSQueuePolicy_basic
=== RUN   TestAccSQSQueueRedriveAllowPolicy_basic
=== PAUSE TestAccSQSQueueRedriveAllowPolicy_basic
=== RUN   TestAccSQSQueueRedrivePolicy_basic
=== PAUSE TestAccSQSQueueRedrivePolicy_basic
=== RUN   TestAccSQSQueue_basic
=== PAUSE TestAccSQSQueue_basic
=== RUN   TestAccSQSQueue_tags
=== PAUSE TestAccSQSQueue_tags
=== RUN   TestAccSQSQueue_Policy_basic
=== PAUSE TestAccSQSQueue_Policy_basic
=== CONT  TestAccSQSQueueDataSource_basic
=== CONT  TestAccSQSQueueRedrivePolicy_basic
=== CONT  TestAccSQSQueue_tags
--- PASS: TestAccSQSQueueDataSource_basic (82.54s)
=== CONT  TestAccSQSQueue_Policy_basic
--- PASS: TestAccSQSQueue_tags (156.97s)
=== CONT  TestAccSQSQueue_basic
--- PASS: TestAccSQSQueue_Policy_basic (103.07s)
=== CONT  TestAccSQSQueuePolicy_basic
--- PASS: TestAccSQSQueueRedrivePolicy_basic (193.37s)
=== CONT  TestAccSQSQueueRedriveAllowPolicy_basic
--- PASS: TestAccSQSQueue_basic (60.96s)
=== CONT  TestAccSQSQueueDataSource_tags
--- PASS: TestAccSQSQueueDataSource_tags (60.99s)
--- PASS: TestAccSQSQueuePolicy_basic (133.49s)
--- PASS: TestAccSQSQueueRedriveAllowPolicy_basic (166.84s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	391.307s
=== RUN   TestAccSSMActivation_basic
=== PAUSE TestAccSSMActivation_basic
=== RUN   TestAccSSMActivation_tags
=== PAUSE TestAccSSMActivation_tags
=== RUN   TestAccSSMAssociation_basic
=== PAUSE TestAccSSMAssociation_basic
=== RUN   TestAccSSMDocumentDataSource_basic
=== PAUSE TestAccSSMDocumentDataSource_basic
=== RUN   TestAccSSMDocument_basic
=== PAUSE TestAccSSMDocument_basic
=== RUN   TestAccSSMDocument_tags
=== PAUSE TestAccSSMDocument_tags
=== RUN   TestAccSSMMaintenanceWindowTarget_basic
=== PAUSE TestAccSSMMaintenanceWindowTarget_basic
=== RUN   TestAccSSMMaintenanceWindowTask_basic
=== PAUSE TestAccSSMMaintenanceWindowTask_basic
=== RUN   TestAccSSMMaintenanceWindow_basic
=== PAUSE TestAccSSMMaintenanceWindow_basic
=== RUN   TestAccSSMMaintenanceWindow_tags
=== PAUSE TestAccSSMMaintenanceWindow_tags
=== RUN   TestAccSSMParameterDataSource_basic
=== PAUSE TestAccSSMParameterDataSource_basic
=== RUN   TestAccSSMParameter_basic
=== PAUSE TestAccSSMParameter_basic
=== RUN   TestAccSSMParameter_Overwrite_basic
=== PAUSE TestAccSSMParameter_Overwrite_basic
=== RUN   TestAccSSMParameter_Overwrite_tags
=== PAUSE TestAccSSMParameter_Overwrite_tags
=== RUN   TestAccSSMParameter_tags
=== PAUSE TestAccSSMParameter_tags
=== RUN   TestAccSSMParameter_Secure_basic
=== PAUSE TestAccSSMParameter_Secure_basic
=== RUN   TestAccSSMParametersByPathDataSource_basic
=== PAUSE TestAccSSMParametersByPathDataSource_basic
=== RUN   TestAccSSMPatchBaseline_basic
=== PAUSE TestAccSSMPatchBaseline_basic
=== RUN   TestAccSSMPatchBaseline_tags
=== PAUSE TestAccSSMPatchBaseline_tags
=== RUN   TestAccSSMPatchGroup_basic
=== PAUSE TestAccSSMPatchGroup_basic
=== RUN   TestAccSSMResourceDataSync_basic
=== PAUSE TestAccSSMResourceDataSync_basic
=== RUN   TestAccSSMServiceSetting_basic
=== PAUSE TestAccSSMServiceSetting_basic
=== CONT  TestAccSSMActivation_basic
=== CONT  TestAccSSMParameter_basic
=== CONT  TestAccSSMMaintenanceWindowTarget_basic
--- PASS: TestAccSSMMaintenanceWindowTarget_basic (80.92s)
=== CONT  TestAccSSMDocumentDataSource_basic
--- PASS: TestAccSSMParameter_basic (81.04s)
=== CONT  TestAccSSMDocument_tags
--- PASS: TestAccSSMActivation_basic (85.16s)
=== CONT  TestAccSSMDocument_basic
--- PASS: TestAccSSMDocument_basic (55.47s)
=== CONT  TestAccSSMAssociation_basic
--- PASS: TestAccSSMDocumentDataSource_basic (78.35s)
=== CONT  TestAccSSMMaintenanceWindow_tags
--- PASS: TestAccSSMDocument_tags (118.32s)
=== CONT  TestAccSSMParameterDataSource_basic
--- PASS: TestAccSSMMaintenanceWindow_tags (94.42s)
=== CONT  TestAccSSMActivation_tags
--- PASS: TestAccSSMParameterDataSource_basic (55.28s)
=== CONT  TestAccSSMPatchBaseline_basic
--- PASS: TestAccSSMAssociation_basic (119.61s)
=== CONT  TestAccSSMServiceSetting_basic
--- PASS: TestAccSSMActivation_tags (43.87s)
=== CONT  TestAccSSMResourceDataSync_basic
--- PASS: TestAccSSMPatchBaseline_basic (56.47s)
=== CONT  TestAccSSMPatchGroup_basic
--- PASS: TestAccSSMServiceSetting_basic (57.61s)
=== CONT  TestAccSSMPatchBaseline_tags
--- PASS: TestAccSSMResourceDataSync_basic (43.82s)
=== CONT  TestAccSSMParameter_tags
--- PASS: TestAccSSMPatchGroup_basic (35.43s)
=== CONT  TestAccSSMParametersByPathDataSource_basic
--- PASS: TestAccSSMParametersByPathDataSource_basic (36.92s)
=== CONT  TestAccSSMParameter_Secure_basic
--- PASS: TestAccSSMPatchBaseline_tags (99.10s)
=== CONT  TestAccSSMParameter_Overwrite_tags
--- PASS: TestAccSSMParameter_Secure_basic (43.21s)
=== CONT  TestAccSSMParameter_Overwrite_basic
--- PASS: TestAccSSMParameter_tags (105.97s)
=== CONT  TestAccSSMMaintenanceWindow_basic
--- PASS: TestAccSSMParameter_Overwrite_tags (43.25s)
=== CONT  TestAccSSMMaintenanceWindowTask_basic
--- PASS: TestAccSSMMaintenanceWindow_basic (42.16s)
--- PASS: TestAccSSMParameter_Overwrite_basic (100.62s)
--- PASS: TestAccSSMMaintenanceWindowTask_basic (71.12s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	553.661s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssmincidents	20.490s [no tests to run]
=== RUN   TestAccSSOAdminCustomerManagedPolicyAttachment_basic
=== PAUSE TestAccSSOAdminCustomerManagedPolicyAttachment_basic
=== RUN   TestAccSSOAdminInstancesDataSource_basic
=== PAUSE TestAccSSOAdminInstancesDataSource_basic
=== RUN   TestAccSSOAdminManagedPolicyAttachment_basic
=== PAUSE TestAccSSOAdminManagedPolicyAttachment_basic
=== RUN   TestAccSSOAdminPermissionSetInlinePolicy_basic
=== PAUSE TestAccSSOAdminPermissionSetInlinePolicy_basic
=== RUN   TestAccSSOAdminPermissionSet_basic
=== PAUSE TestAccSSOAdminPermissionSet_basic
=== RUN   TestAccSSOAdminPermissionSet_tags
    instances_data_source_test.go:29: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::123456789012:assumed-role/tf_aws_provider2_test-admin/kewbank@hashicorp.com is not authorized to perform: sso:ListInstances
--- SKIP: TestAccSSOAdminPermissionSet_tags (1.11s)
=== RUN   TestAccSSOAdminPermissionsBoundaryAttachment_basic
=== PAUSE TestAccSSOAdminPermissionsBoundaryAttachment_basic
=== CONT  TestAccSSOAdminCustomerManagedPolicyAttachment_basic
=== CONT  TestAccSSOAdminPermissionSetInlinePolicy_basic
=== CONT  TestAccSSOAdminPermissionsBoundaryAttachment_basic
    instances_data_source_test.go:29: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::123456789012:assumed-role/tf_aws_provider2_test-admin/kewbank@hashicorp.com is not authorized to perform: sso:ListInstances
--- SKIP: TestAccSSOAdminPermissionsBoundaryAttachment_basic (0.10s)
=== CONT  TestAccSSOAdminManagedPolicyAttachment_basic
=== CONT  TestAccSSOAdminCustomerManagedPolicyAttachment_basic
    instances_data_source_test.go:29: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::123456789012:assumed-role/tf_aws_provider2_test-admin/kewbank@hashicorp.com is not authorized to perform: sso:ListInstances
--- SKIP: TestAccSSOAdminCustomerManagedPolicyAttachment_basic (0.11s)
=== CONT  TestAccSSOAdminPermissionSet_basic
=== CONT  TestAccSSOAdminPermissionSetInlinePolicy_basic
    instances_data_source_test.go:29: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::123456789012:assumed-role/tf_aws_provider2_test-admin/kewbank@hashicorp.com is not authorized to perform: sso:ListInstances
--- SKIP: TestAccSSOAdminPermissionSetInlinePolicy_basic (0.11s)
=== CONT  TestAccSSOAdminInstancesDataSource_basic
=== CONT  TestAccSSOAdminManagedPolicyAttachment_basic
    instances_data_source_test.go:29: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::123456789012:assumed-role/tf_aws_provider2_test-admin/kewbank@hashicorp.com is not authorized to perform: sso:ListInstances
--- SKIP: TestAccSSOAdminManagedPolicyAttachment_basic (0.10s)
=== CONT  TestAccSSOAdminPermissionSet_basic
    instances_data_source_test.go:29: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::123456789012:assumed-role/tf_aws_provider2_test-admin/kewbank@hashicorp.com is not authorized to perform: sso:ListInstances
--- SKIP: TestAccSSOAdminPermissionSet_basic (0.10s)
=== CONT  TestAccSSOAdminInstancesDataSource_basic
    instances_data_source_test.go:29: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::123456789012:assumed-role/tf_aws_provider2_test-admin/kewbank@hashicorp.com is not authorized to perform: sso:ListInstances
--- SKIP: TestAccSSOAdminInstancesDataSource_basic (0.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssoadmin	19.997s
=== RUN   TestAccStorageGatewayCachediSCSIVolume_basic
=== PAUSE TestAccStorageGatewayCachediSCSIVolume_basic
=== RUN   TestAccStorageGatewayCachediSCSIVolume_tags
=== PAUSE TestAccStorageGatewayCachediSCSIVolume_tags
=== RUN   TestAccStorageGatewayFileSystemAssociation_basic
=== PAUSE TestAccStorageGatewayFileSystemAssociation_basic
=== RUN   TestAccStorageGatewayFileSystemAssociation_tags
=== PAUSE TestAccStorageGatewayFileSystemAssociation_tags
=== RUN   TestAccStorageGatewayGateway_tags
=== PAUSE TestAccStorageGatewayGateway_tags
=== RUN   TestAccStorageGatewayNFSFileShare_basic
=== PAUSE TestAccStorageGatewayNFSFileShare_basic
=== RUN   TestAccStorageGatewayNFSFileShare_tags
=== PAUSE TestAccStorageGatewayNFSFileShare_tags
=== RUN   TestAccStorageGatewaySMBFileShare_tags
=== PAUSE TestAccStorageGatewaySMBFileShare_tags
=== RUN   TestAccStorageGatewayStorediSCSIVolume_basic
=== PAUSE TestAccStorageGatewayStorediSCSIVolume_basic
=== RUN   TestAccStorageGatewayStorediSCSIVolume_tags
=== PAUSE TestAccStorageGatewayStorediSCSIVolume_tags
=== RUN   TestAccStorageGatewayTapePool_basic
=== PAUSE TestAccStorageGatewayTapePool_basic
=== RUN   TestAccStorageGatewayTapePool_tags
=== PAUSE TestAccStorageGatewayTapePool_tags
=== RUN   TestAccStorageGatewayUploadBuffer_basic
=== PAUSE TestAccStorageGatewayUploadBuffer_basic
=== RUN   TestAccStorageGatewayWorkingStorage_basic
=== PAUSE TestAccStorageGatewayWorkingStorage_basic
=== CONT  TestAccStorageGatewayCachediSCSIVolume_basic
=== CONT  TestAccStorageGatewaySMBFileShare_tags
=== CONT  TestAccStorageGatewayTapePool_tags
--- PASS: TestAccStorageGatewayTapePool_tags (79.84s)
=== CONT  TestAccStorageGatewayUploadBuffer_basic
--- PASS: TestAccStorageGatewayCachediSCSIVolume_basic (263.19s)
=== CONT  TestAccStorageGatewayStorediSCSIVolume_tags
--- PASS: TestAccStorageGatewaySMBFileShare_tags (391.11s)
=== CONT  TestAccStorageGatewayTapePool_basic
--- PASS: TestAccStorageGatewayTapePool_basic (23.01s)
=== CONT  TestAccStorageGatewayGateway_tags
--- PASS: TestAccStorageGatewayUploadBuffer_basic (445.58s)
=== CONT  TestAccStorageGatewayNFSFileShare_tags
--- PASS: TestAccStorageGatewayGateway_tags (278.61s)
=== CONT  TestAccStorageGatewayNFSFileShare_basic
--- PASS: TestAccStorageGatewayStorediSCSIVolume_tags (576.81s)
=== CONT  TestAccStorageGatewayWorkingStorage_basic
--- PASS: TestAccStorageGatewayNFSFileShare_tags (328.62s)
=== CONT  TestAccStorageGatewayFileSystemAssociation_basic
--- PASS: TestAccStorageGatewayNFSFileShare_basic (277.23s)
=== CONT  TestAccStorageGatewayFileSystemAssociation_tags
--- PASS: TestAccStorageGatewayWorkingStorage_basic (431.89s)
=== CONT  TestAccStorageGatewayCachediSCSIVolume_tags
=== CONT  TestAccStorageGatewayFileSystemAssociation_basic
    file_system_association_test.go:30: Step 1/2 error: Error running apply: exit status 1
        
        Error: waiting for Directory Service Directory (d-92675fd093) create: unexpected state 'Failed', wanted target 'Active'. last error: An internal service error has been encountered during directory creation. Please retry the operation.
        
          with aws_directory_service_directory.test,
          on terraform_plugin_test.tf line 117, in resource "aws_directory_service_directory" "test":
         117: resource "aws_directory_service_directory" "test" {
        
--- PASS: TestAccStorageGatewayCachediSCSIVolume_tags (276.14s)
=== CONT  TestAccStorageGatewayStorediSCSIVolume_basic
--- PASS: TestAccStorageGatewayStorediSCSIVolume_basic (433.44s)
--- FAIL: TestAccStorageGatewayFileSystemAssociation_basic (1558.61s)
--- PASS: TestAccStorageGatewayFileSystemAssociation_tags (3716.82s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway	4701.363s
=== RUN   TestAccSTSCallerIdentityDataSource_basic
=== PAUSE TestAccSTSCallerIdentityDataSource_basic
=== CONT  TestAccSTSCallerIdentityDataSource_basic
--- PASS: TestAccSTSCallerIdentityDataSource_basic (28.87s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sts	49.873s
=== RUN   TestAccSWFDomain_basic
=== PAUSE TestAccSWFDomain_basic
=== RUN   TestAccSWFDomain_tags
=== PAUSE TestAccSWFDomain_tags
=== CONT  TestAccSWFDomain_basic
=== CONT  TestAccSWFDomain_tags
=== CONT  TestAccSWFDomain_basic
    domain_test.go:25: Environment variable SWF_DOMAIN_TESTING_ENABLED is not set. SWF limits domains per region and the API does not support deletions. Set the environment variable to any value to enable.
--- SKIP: TestAccSWFDomain_basic (0.43s)
=== CONT  TestAccSWFDomain_tags
    domain_test.go:25: Environment variable SWF_DOMAIN_TESTING_ENABLED is not set. SWF limits domains per region and the API does not support deletions. Set the environment variable to any value to enable.
--- SKIP: TestAccSWFDomain_tags (0.43s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/swf	21.657s
=== RUN   TestAccSyntheticsCanary_basic
=== PAUSE TestAccSyntheticsCanary_basic
=== RUN   TestAccSyntheticsCanary_tags
=== PAUSE TestAccSyntheticsCanary_tags
=== CONT  TestAccSyntheticsCanary_basic
=== CONT  TestAccSyntheticsCanary_tags
=== CONT  TestAccSyntheticsCanary_basic
    canary_test.go:25: Step 1/3 error: Error running apply: exit status 1
        
        Error: creating Synthetics Canary (tf-acc-test-gnrvahxl): ValidationException: Deprecated runtime version specified.
        
          with aws_synthetics_canary.test,
          on terraform_plugin_test.tf line 110, in resource "aws_synthetics_canary" "test":
         110: resource "aws_synthetics_canary" "test" {
        
=== CONT  TestAccSyntheticsCanary_tags
    canary_test.go:495: Step 1/4 error: Error running apply: exit status 1
        
        Error: creating Synthetics Canary (tf-acc-test-cvn8g3kv): ValidationException: Deprecated runtime version specified.
        
          with aws_synthetics_canary.test,
          on terraform_plugin_test.tf line 110, in resource "aws_synthetics_canary" "test":
         110: resource "aws_synthetics_canary" "test" {
        
--- FAIL: TestAccSyntheticsCanary_basic (22.32s)
--- FAIL: TestAccSyntheticsCanary_tags (22.96s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/synthetics	39.080s
FAIL
make: *** [testacc] Error 1
```
```console
% SWF_DOMAIN_TESTING_ENABLED=true make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=swf ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/swf/... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccSWFDomain_basic
=== PAUSE TestAccSWFDomain_basic
=== RUN   TestAccSWFDomain_tags
=== PAUSE TestAccSWFDomain_tags
=== CONT  TestAccSWFDomain_basic
=== CONT  TestAccSWFDomain_tags
--- PASS: TestAccSWFDomain_basic (18.38s)
=== CONT  TestAccSWFDomain_tags
    testing_new.go:82: Error running post-test destroy, there may be dangling resources: SWF Domain still exists: tf-acc-test-789443083236518301
--- FAIL: TestAccSWFDomain_tags (158.84s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/swf	164.344s
FAIL
make: *** [testacc] Error 1
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=synthetics ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/synthetics/... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccSyntheticsCanary_basic
=== PAUSE TestAccSyntheticsCanary_basic
=== RUN   TestAccSyntheticsCanary_tags
=== PAUSE TestAccSyntheticsCanary_tags
=== CONT  TestAccSyntheticsCanary_basic
=== CONT  TestAccSyntheticsCanary_tags
--- PASS: TestAccSyntheticsCanary_tags (89.36s)
--- PASS: TestAccSyntheticsCanary_basic (91.43s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/synthetics	97.109s
```