### PR TITLE
Fixes "inconsistent result" errors with empty `Set` values

### DIFF
--- a/internal/flex/framework.go
+++ b/internal/flex/framework.go
@@ -158,6 +158,19 @@ func FlattenFrameworkStringSet(_ context.Context, vs []*string) types.Set {
 	return types.SetValueMust(types.StringType, elems)
 }
 
+// FlattenFrameworkStringSetLegacy converts a slice of string pointers to a framework Set value.
+//
+// A nil slice is converted to an empty (non-null) Set.
+func FlattenFrameworkStringSetLegacy(_ context.Context, vs []*string) types.Set {
+	elems := make([]attr.Value, len(vs))
+
+	for i, v := range vs {
+		elems[i] = types.StringValue(aws.ToString(v))
+	}
+
+	return types.SetValueMust(types.StringType, elems)
+}
+
 // FlattenFrameworkStringValueSet converts a slice of string values to a framework Set value.
 //
 // A nil slice is converted to a null Set.

--- a/internal/framework/flex/flex.go
+++ b/internal/framework/flex/flex.go
@@ -21,12 +21,12 @@ var (
 )
 
 var (
-	BoolToFramework           = flex.BoolToFramework
-	FlattenFrameworkStringSet = flex.FlattenFrameworkStringSet
-	Int64ToFramework          = flex.Int64ToFramework
-	Int64ToFrameworkLegacy    = flex.Int64ToFrameworkLegacy
-	StringToFramework         = flex.StringToFramework
-	StringToFrameworkLegacy   = flex.StringToFrameworkLegacy
+	BoolToFramework                 = flex.BoolToFramework
+	FlattenFrameworkStringSetLegacy = flex.FlattenFrameworkStringSetLegacy
+	Int64ToFramework                = flex.Int64ToFramework
+	Int64ToFrameworkLegacy          = flex.Int64ToFrameworkLegacy
+	StringToFramework               = flex.StringToFramework
+	StringToFrameworkLegacy         = flex.StringToFrameworkLegacy
 )
 
 func ARNStringFromFramework(_ context.Context, v fwtypes.ARN) *string {

--- a/internal/service/cognitoidp/managed_user_pool_client.go
+++ b/internal/service/cognitoidp/managed_user_pool_client.go
@@ -15,7 +15,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -51,6 +54,9 @@ func (r *resourceManagedUserPoolClient) Schema(ctx context.Context, request reso
 				Validators: []validator.Int64{
 					int64validator.Between(1, 86400),
 				},
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 			"allowed_oauth_flows": schema.SetAttribute{
 				ElementType: types.StringType,
@@ -62,10 +68,16 @@ func (r *resourceManagedUserPoolClient) Schema(ctx context.Context, request reso
 						stringvalidator.OneOf(cognitoidentityprovider.OAuthFlowType_Values()...),
 					),
 				},
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"allowed_oauth_flows_user_pool_client": schema.BoolAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"allowed_oauth_scopes": schema.SetAttribute{
 				ElementType: types.StringType,
@@ -74,12 +86,18 @@ func (r *resourceManagedUserPoolClient) Schema(ctx context.Context, request reso
 				Validators: []validator.Set{
 					setvalidator.SizeAtMost(50),
 				},
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"auth_session_validity": schema.Int64Attribute{
 				Optional: true,
 				Computed: true,
 				Validators: []validator.Int64{
 					int64validator.Between(3, 15),
+				},
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
 				},
 			},
 			"callback_urls": schema.SetAttribute{
@@ -92,31 +110,50 @@ func (r *resourceManagedUserPoolClient) Schema(ctx context.Context, request reso
 						userPoolClientURLValidator...,
 					),
 				},
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"client_secret": schema.StringAttribute{
 				Computed:  true,
 				Sensitive: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"default_redirect_uri": schema.StringAttribute{
 				Optional:   true,
 				Computed:   true,
 				Validators: userPoolClientURLValidator,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"enable_propagate_additional_user_context_data": schema.BoolAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"enable_token_revocation": schema.BoolAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"explicit_auth_flows": schema.SetAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
 				Validators: []validator.Set{
 					setvalidator.ValueStringsAre(
 						stringvalidator.OneOf(cognitoidentityprovider.ExplicitAuthFlowsType_Values()...),
 					),
+				},
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"id": framework.IDAttribute(),
@@ -125,6 +162,9 @@ func (r *resourceManagedUserPoolClient) Schema(ctx context.Context, request reso
 				Computed: true,
 				Validators: []validator.Int64{
 					int64validator.Between(1, 86400),
+				},
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
 				},
 			},
 			"logout_urls": schema.SetAttribute{
@@ -137,9 +177,15 @@ func (r *resourceManagedUserPoolClient) Schema(ctx context.Context, request reso
 						userPoolClientURLValidator...,
 					),
 				},
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name_pattern": schema.StringAttribute{
 				CustomType: fwtypes.RegexpType,
@@ -162,16 +208,26 @@ func (r *resourceManagedUserPoolClient) Schema(ctx context.Context, request reso
 				Validators: []validator.String{
 					stringvalidator.OneOf(cognitoidentityprovider.PreventUserExistenceErrorTypes_Values()...),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"read_attributes": schema.SetAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"refresh_token_validity": schema.Int64Attribute{
 				Optional: true,
 				Computed: true,
 				Validators: []validator.Int64{
 					int64validator.Between(0, 315360000),
+				},
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
 				},
 			},
 			"supported_identity_providers": schema.SetAttribute{
@@ -183,6 +239,9 @@ func (r *resourceManagedUserPoolClient) Schema(ctx context.Context, request reso
 						userPoolClientIdentityProviderValidator...,
 					),
 				},
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"user_pool_id": schema.StringAttribute{
 				Required: true,
@@ -193,6 +252,10 @@ func (r *resourceManagedUserPoolClient) Schema(ctx context.Context, request reso
 			"write_attributes": schema.SetAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -288,8 +351,13 @@ func (r *resourceManagedUserPoolClient) Schema(ctx context.Context, request reso
 func (r *resourceManagedUserPoolClient) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
 	conn := r.Meta().CognitoIDPConn()
 
-	var plan resourceManagedUserPoolClientData
+	var config resourceManagedUserPoolClientData
+	response.Diagnostics.Append(request.Config.Get(ctx, &config)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 
+	var plan resourceManagedUserPoolClientData
 	response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)
 	if response.Diagnostics.HasError() {
 		return
@@ -309,7 +377,7 @@ func (r *resourceManagedUserPoolClient) Create(ctx context.Context, request reso
 		}
 	}
 
-	userPoolClient, err := FindCognitoUserPoolClientByName(ctx, conn, userPoolId, nameMatcher)
+	poolClient, err := FindCognitoUserPoolClientByName(ctx, conn, userPoolId, nameMatcher)
 	if err != nil {
 		response.Diagnostics.AddError(
 			"acquiring Cognito User Pool Client",
@@ -318,92 +386,92 @@ func (r *resourceManagedUserPoolClient) Create(ctx context.Context, request reso
 		return
 	}
 
-	data := newManagedUserPoolClientData(ctx, plan, userPoolClient, &response.Diagnostics)
+	config.update(ctx, poolClient, &response.Diagnostics)
 	if response.Diagnostics.HasError() {
 		return
 	}
 
 	needsUpdate := false
 
-	if !plan.AccessTokenValidity.IsUnknown() && !plan.AccessTokenValidity.Equal(data.AccessTokenValidity) {
+	if !plan.AccessTokenValidity.IsUnknown() && !plan.AccessTokenValidity.Equal(config.AccessTokenValidity) {
 		needsUpdate = true
-		data.AccessTokenValidity = plan.AccessTokenValidity
+		config.AccessTokenValidity = plan.AccessTokenValidity
 	}
-	if !plan.AllowedOauthFlows.IsUnknown() && !plan.AllowedOauthFlows.Equal(data.AllowedOauthFlows) {
+	if !plan.AllowedOauthFlows.IsUnknown() && !plan.AllowedOauthFlows.Equal(config.AllowedOauthFlows) {
 		needsUpdate = true
-		data.AllowedOauthFlows = plan.AllowedOauthFlows
+		config.AllowedOauthFlows = plan.AllowedOauthFlows
 	}
-	if !plan.AllowedOauthFlowsUserPoolClient.IsUnknown() && !plan.AllowedOauthFlowsUserPoolClient.Equal(data.AllowedOauthFlowsUserPoolClient) {
+	if !plan.AllowedOauthFlowsUserPoolClient.IsUnknown() && !plan.AllowedOauthFlowsUserPoolClient.Equal(config.AllowedOauthFlowsUserPoolClient) {
 		needsUpdate = true
-		data.AllowedOauthFlowsUserPoolClient = plan.AllowedOauthFlowsUserPoolClient
+		config.AllowedOauthFlowsUserPoolClient = plan.AllowedOauthFlowsUserPoolClient
 	}
-	if !plan.AllowedOauthScopes.IsUnknown() && !plan.AllowedOauthScopes.Equal(data.AllowedOauthScopes) {
+	if !plan.AllowedOauthScopes.IsUnknown() && !plan.AllowedOauthScopes.Equal(config.AllowedOauthScopes) {
 		needsUpdate = true
-		data.AllowedOauthScopes = plan.AllowedOauthScopes
+		config.AllowedOauthScopes = plan.AllowedOauthScopes
 	}
-	if !plan.AnalyticsConfiguration.IsUnknown() && !plan.AnalyticsConfiguration.Equal(data.AnalyticsConfiguration) {
+	if !plan.AnalyticsConfiguration.IsUnknown() && !plan.AnalyticsConfiguration.Equal(config.AnalyticsConfiguration) {
 		needsUpdate = true
-		data.AnalyticsConfiguration = plan.AnalyticsConfiguration
+		config.AnalyticsConfiguration = plan.AnalyticsConfiguration
 	}
-	if !plan.AuthSessionValidity.IsUnknown() && !plan.AuthSessionValidity.Equal(data.AuthSessionValidity) {
+	if !plan.AuthSessionValidity.IsUnknown() && !plan.AuthSessionValidity.Equal(config.AuthSessionValidity) {
 		needsUpdate = true
-		data.AuthSessionValidity = plan.AuthSessionValidity
+		config.AuthSessionValidity = plan.AuthSessionValidity
 	}
-	if !plan.CallbackUrls.IsUnknown() && !plan.CallbackUrls.Equal(data.CallbackUrls) {
+	if !plan.CallbackUrls.IsUnknown() && !plan.CallbackUrls.Equal(config.CallbackUrls) {
 		needsUpdate = true
-		data.CallbackUrls = plan.CallbackUrls
+		config.CallbackUrls = plan.CallbackUrls
 	}
-	if !plan.DefaultRedirectUri.IsUnknown() && !plan.DefaultRedirectUri.Equal(data.DefaultRedirectUri) {
+	if !plan.DefaultRedirectUri.IsUnknown() && !plan.DefaultRedirectUri.Equal(config.DefaultRedirectUri) {
 		needsUpdate = true
-		data.DefaultRedirectUri = plan.DefaultRedirectUri
+		config.DefaultRedirectUri = plan.DefaultRedirectUri
 	}
-	if !plan.EnablePropagateAdditionalUserContextData.IsUnknown() && !plan.EnablePropagateAdditionalUserContextData.Equal(data.EnablePropagateAdditionalUserContextData) {
+	if !plan.EnablePropagateAdditionalUserContextData.IsUnknown() && !plan.EnablePropagateAdditionalUserContextData.Equal(config.EnablePropagateAdditionalUserContextData) {
 		needsUpdate = true
-		data.EnablePropagateAdditionalUserContextData = plan.EnablePropagateAdditionalUserContextData
+		config.EnablePropagateAdditionalUserContextData = plan.EnablePropagateAdditionalUserContextData
 	}
-	if !plan.EnableTokenRevocation.IsUnknown() && !plan.EnableTokenRevocation.Equal(data.EnableTokenRevocation) {
+	if !plan.EnableTokenRevocation.IsUnknown() && !plan.EnableTokenRevocation.Equal(config.EnableTokenRevocation) {
 		needsUpdate = true
-		data.EnableTokenRevocation = plan.EnableTokenRevocation
+		config.EnableTokenRevocation = plan.EnableTokenRevocation
 	}
-	if !plan.ExplicitAuthFlows.IsUnknown() && !plan.ExplicitAuthFlows.Equal(data.ExplicitAuthFlows) {
+	if !plan.ExplicitAuthFlows.IsUnknown() && !plan.ExplicitAuthFlows.Equal(config.ExplicitAuthFlows) {
 		needsUpdate = true
-		data.ExplicitAuthFlows = plan.ExplicitAuthFlows
+		config.ExplicitAuthFlows = plan.ExplicitAuthFlows
 	}
-	if !plan.IdTokenValidity.IsUnknown() && !plan.IdTokenValidity.Equal(data.IdTokenValidity) {
+	if !plan.IdTokenValidity.IsUnknown() && !plan.IdTokenValidity.Equal(config.IdTokenValidity) {
 		needsUpdate = true
-		data.IdTokenValidity = plan.IdTokenValidity
+		config.IdTokenValidity = plan.IdTokenValidity
 	}
-	if !plan.LogoutUrls.IsUnknown() && !plan.LogoutUrls.Equal(data.LogoutUrls) {
+	if !plan.LogoutUrls.IsUnknown() && !plan.LogoutUrls.Equal(config.LogoutUrls) {
 		needsUpdate = true
-		data.LogoutUrls = plan.LogoutUrls
+		config.LogoutUrls = plan.LogoutUrls
 	}
-	if !plan.PreventUserExistenceErrors.IsUnknown() && !plan.PreventUserExistenceErrors.Equal(data.PreventUserExistenceErrors) {
+	if !plan.PreventUserExistenceErrors.IsUnknown() && !plan.PreventUserExistenceErrors.Equal(config.PreventUserExistenceErrors) {
 		needsUpdate = true
-		data.PreventUserExistenceErrors = plan.PreventUserExistenceErrors
+		config.PreventUserExistenceErrors = plan.PreventUserExistenceErrors
 	}
-	if !plan.ReadAttributes.IsUnknown() && !plan.ReadAttributes.Equal(data.ReadAttributes) {
+	if !plan.ReadAttributes.IsUnknown() && !plan.ReadAttributes.Equal(config.ReadAttributes) {
 		needsUpdate = true
-		data.ReadAttributes = plan.ReadAttributes
+		config.ReadAttributes = plan.ReadAttributes
 	}
-	if !plan.RefreshTokenValidity.IsUnknown() && !plan.RefreshTokenValidity.Equal(data.RefreshTokenValidity) {
+	if !plan.RefreshTokenValidity.IsUnknown() && !plan.RefreshTokenValidity.Equal(config.RefreshTokenValidity) {
 		needsUpdate = true
-		data.RefreshTokenValidity = plan.RefreshTokenValidity
+		config.RefreshTokenValidity = plan.RefreshTokenValidity
 	}
-	if !plan.SupportedIdentityProviders.IsUnknown() && !plan.SupportedIdentityProviders.Equal(data.SupportedIdentityProviders) {
+	if !plan.SupportedIdentityProviders.IsUnknown() && !plan.SupportedIdentityProviders.Equal(config.SupportedIdentityProviders) {
 		needsUpdate = true
-		data.SupportedIdentityProviders = plan.SupportedIdentityProviders
+		config.SupportedIdentityProviders = plan.SupportedIdentityProviders
 	}
-	if !plan.TokenValidityUnits.IsUnknown() && !plan.TokenValidityUnits.Equal(data.TokenValidityUnits) {
+	if !plan.TokenValidityUnits.IsUnknown() && !plan.TokenValidityUnits.Equal(config.TokenValidityUnits) {
 		needsUpdate = true
-		data.TokenValidityUnits = plan.TokenValidityUnits
+		config.TokenValidityUnits = plan.TokenValidityUnits
 	}
-	if !plan.WriteAttributes.IsUnknown() && !plan.WriteAttributes.Equal(data.WriteAttributes) {
+	if !plan.WriteAttributes.IsUnknown() && !plan.WriteAttributes.Equal(config.WriteAttributes) {
 		needsUpdate = true
-		data.WriteAttributes = plan.WriteAttributes
+		config.WriteAttributes = plan.WriteAttributes
 	}
 
 	if needsUpdate {
-		params := data.updateInput(ctx, &response.Diagnostics)
+		params := config.updateInput(ctx, &response.Diagnostics)
 		if response.Diagnostics.HasError() {
 			return
 		}
@@ -421,18 +489,17 @@ func (r *resourceManagedUserPoolClient) Create(ctx context.Context, request reso
 
 		poolClient := output.(*cognitoidentityprovider.UpdateUserPoolClientOutput).UserPoolClient
 
-		data = newManagedUserPoolClientData(ctx, data, poolClient, &response.Diagnostics)
+		config.update(ctx, poolClient, &response.Diagnostics)
 		if response.Diagnostics.HasError() {
 			return
 		}
 	}
 
-	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+	response.Diagnostics.Append(response.State.Set(ctx, &config)...)
 }
 
 func (r *resourceManagedUserPoolClient) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
 	var state resourceManagedUserPoolClientData
-
 	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
 	if response.Diagnostics.HasError() {
 		return
@@ -440,7 +507,7 @@ func (r *resourceManagedUserPoolClient) Read(ctx context.Context, request resour
 
 	conn := r.Meta().CognitoIDPConn()
 
-	userPoolClient, err := FindCognitoUserPoolClientByID(ctx, conn, state.UserPoolID.ValueString(), state.ID.ValueString())
+	poolClient, err := FindCognitoUserPoolClientByID(ctx, conn, state.UserPoolID.ValueString(), state.ID.ValueString())
 	if tfresource.NotFound(err) {
 		create.LogNotFoundRemoveState(names.CognitoIDP, create.ErrActionReading, ResNameUserPoolClient, state.ID.ValueString())
 		response.State.RemoveResource(ctx)
@@ -451,8 +518,7 @@ func (r *resourceManagedUserPoolClient) Read(ctx context.Context, request resour
 		return
 	}
 
-	state = newManagedUserPoolClientData(ctx, state, userPoolClient, &response.Diagnostics)
-
+	state.update(ctx, poolClient, &response.Diagnostics)
 	if response.Diagnostics.HasError() {
 		return
 	}
@@ -461,18 +527,13 @@ func (r *resourceManagedUserPoolClient) Read(ctx context.Context, request resour
 }
 
 func (r *resourceManagedUserPoolClient) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
-	var state, config, plan resourceManagedUserPoolClientData
-
-	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
-	if response.Diagnostics.HasError() {
-		return
-	}
-
+	var config resourceManagedUserPoolClientData
 	response.Diagnostics.Append(request.Config.Get(ctx, &config)...)
 	if response.Diagnostics.HasError() {
 		return
 	}
 
+	var plan resourceManagedUserPoolClientData
 	response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)
 	if response.Diagnostics.HasError() {
 		return
@@ -498,18 +559,17 @@ func (r *resourceManagedUserPoolClient) Update(ctx context.Context, request reso
 
 	poolClient := output.(*cognitoidentityprovider.UpdateUserPoolClientOutput).UserPoolClient
 
-	data := newManagedUserPoolClientData(ctx, plan, poolClient, &response.Diagnostics)
+	config.update(ctx, poolClient, &response.Diagnostics)
 	if response.Diagnostics.HasError() {
 		return
 	}
 
-	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+	response.Diagnostics.Append(response.State.Set(ctx, &config)...)
 }
 
 func (r *resourceManagedUserPoolClient) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
-	var data resourceManagedUserPoolClientData
-
-	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	var state resourceManagedUserPoolClientData
+	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
 	if response.Diagnostics.HasError() {
 		return
 	}
@@ -559,34 +619,32 @@ type resourceManagedUserPoolClientData struct {
 	WriteAttributes                          types.Set      `tfsdk:"write_attributes"`
 }
 
-func newManagedUserPoolClientData(ctx context.Context, plan resourceManagedUserPoolClientData, in *cognitoidentityprovider.UserPoolClientType, diags *diag.Diagnostics) resourceManagedUserPoolClientData {
-	return resourceManagedUserPoolClientData{
-		AccessTokenValidity:                      flex.Int64ToFrameworkLegacy(ctx, in.AccessTokenValidity),
-		AllowedOauthFlows:                        flex.FlattenFrameworkStringSet(ctx, in.AllowedOAuthFlows),
-		AllowedOauthFlowsUserPoolClient:          flex.BoolToFramework(ctx, in.AllowedOAuthFlowsUserPoolClient),
-		AllowedOauthScopes:                       flex.FlattenFrameworkStringSet(ctx, in.AllowedOAuthScopes),
-		AnalyticsConfiguration:                   flattenAnaylticsConfiguration(ctx, in.AnalyticsConfiguration, diags),
-		AuthSessionValidity:                      flex.Int64ToFramework(ctx, in.AuthSessionValidity),
-		CallbackUrls:                             flex.FlattenFrameworkStringSet(ctx, in.CallbackURLs),
-		ClientSecret:                             flex.StringToFrameworkLegacy(ctx, in.ClientSecret),
-		DefaultRedirectUri:                       flex.StringToFrameworkLegacy(ctx, in.DefaultRedirectURI),
-		EnablePropagateAdditionalUserContextData: flex.BoolToFramework(ctx, in.EnablePropagateAdditionalUserContextData),
-		EnableTokenRevocation:                    flex.BoolToFramework(ctx, in.EnableTokenRevocation),
-		ExplicitAuthFlows:                        flex.FlattenFrameworkStringSet(ctx, in.ExplicitAuthFlows),
-		ID:                                       flex.StringToFramework(ctx, in.ClientId),
-		IdTokenValidity:                          flex.Int64ToFrameworkLegacy(ctx, in.IdTokenValidity),
-		LogoutUrls:                               flex.FlattenFrameworkStringSet(ctx, in.LogoutURLs),
-		Name:                                     flex.StringToFramework(ctx, in.ClientName),
-		NamePattern:                              plan.NamePattern,
-		NamePrefix:                               plan.NamePrefix,
-		PreventUserExistenceErrors:               flex.StringToFrameworkLegacy(ctx, in.PreventUserExistenceErrors),
-		ReadAttributes:                           flex.FlattenFrameworkStringSet(ctx, in.ReadAttributes),
-		RefreshTokenValidity:                     flex.Int64ToFramework(ctx, in.RefreshTokenValidity),
-		SupportedIdentityProviders:               flex.FlattenFrameworkStringSet(ctx, in.SupportedIdentityProviders),
-		TokenValidityUnits:                       flattenTokenValidityUnits(ctx, in.TokenValidityUnits),
-		UserPoolID:                               flex.StringToFramework(ctx, in.UserPoolId),
-		WriteAttributes:                          flex.FlattenFrameworkStringSet(ctx, in.WriteAttributes),
-	}
+func (data *resourceManagedUserPoolClientData) update(ctx context.Context, in *cognitoidentityprovider.UserPoolClientType, diags *diag.Diagnostics) {
+	data.AccessTokenValidity = flex.Int64ToFrameworkLegacy(ctx, in.AccessTokenValidity)
+	data.AllowedOauthFlows = flex.FlattenFrameworkStringSetLegacy(ctx, in.AllowedOAuthFlows)
+	data.AllowedOauthFlowsUserPoolClient = flex.BoolToFramework(ctx, in.AllowedOAuthFlowsUserPoolClient)
+	data.AllowedOauthScopes = flex.FlattenFrameworkStringSetLegacy(ctx, in.AllowedOAuthScopes)
+	data.AnalyticsConfiguration = flattenAnaylticsConfiguration(ctx, in.AnalyticsConfiguration, diags)
+	data.AuthSessionValidity = flex.Int64ToFramework(ctx, in.AuthSessionValidity)
+	data.CallbackUrls = flex.FlattenFrameworkStringSetLegacy(ctx, in.CallbackURLs)
+	data.ClientSecret = flex.StringToFrameworkLegacy(ctx, in.ClientSecret)
+	data.DefaultRedirectUri = flex.StringToFrameworkLegacy(ctx, in.DefaultRedirectURI)
+	data.EnablePropagateAdditionalUserContextData = flex.BoolToFramework(ctx, in.EnablePropagateAdditionalUserContextData)
+	data.EnableTokenRevocation = flex.BoolToFramework(ctx, in.EnableTokenRevocation)
+	data.ExplicitAuthFlows = flex.FlattenFrameworkStringSetLegacy(ctx, in.ExplicitAuthFlows)
+	data.ID = flex.StringToFramework(ctx, in.ClientId)
+	data.IdTokenValidity = flex.Int64ToFrameworkLegacy(ctx, in.IdTokenValidity)
+	data.LogoutUrls = flex.FlattenFrameworkStringSetLegacy(ctx, in.LogoutURLs)
+	data.Name = flex.StringToFramework(ctx, in.ClientName)
+	// NamePattern:                plan.NamePattern,
+	// NamePrefix:                 plan.NamePrefix,
+	data.PreventUserExistenceErrors = flex.StringToFrameworkLegacy(ctx, in.PreventUserExistenceErrors)
+	data.ReadAttributes = flex.FlattenFrameworkStringSetLegacy(ctx, in.ReadAttributes)
+	data.RefreshTokenValidity = flex.Int64ToFramework(ctx, in.RefreshTokenValidity)
+	data.SupportedIdentityProviders = flex.FlattenFrameworkStringSetLegacy(ctx, in.SupportedIdentityProviders)
+	data.TokenValidityUnits = flattenTokenValidityUnits(ctx, in.TokenValidityUnits)
+	data.UserPoolID = flex.StringToFramework(ctx, in.UserPoolId)
+	data.WriteAttributes = flex.FlattenFrameworkStringSetLegacy(ctx, in.WriteAttributes)
 }
 
 func (data resourceManagedUserPoolClientData) updateInput(ctx context.Context, diags *diag.Diagnostics) *cognitoidentityprovider.UpdateUserPoolClientInput {

--- a/internal/service/cognitoidp/managed_user_pool_client_test.go
+++ b/internal/service/cognitoidp/managed_user_pool_client_test.go
@@ -59,12 +59,12 @@ func TestAccCognitoIDPManagedUserPoolClient_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_redirect_uri", ""),
 					resource.TestCheckResourceAttr(resourceName, "enable_propagate_additional_user_context_data", "false"),
 					resource.TestCheckResourceAttr(resourceName, "enable_token_revocation", "true"),
-					resource.TestCheckNoResourceAttr(resourceName, "explicit_auth_flows"),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "id_token_validity", "0"),
 					resource.TestCheckResourceAttr(resourceName, "logout_urls.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "logout_urls.0", regexp.MustCompile(fmt.Sprintf(`https://search-%s-\w+.%s.es.amazonaws.com/_dashboards/app/home`, rName, acctest.Region()))),
 					resource.TestCheckResourceAttr(resourceName, "prevent_user_existence_errors", ""),
-					resource.TestCheckNoResourceAttr(resourceName, "read_attributes"),
+					resource.TestCheckResourceAttr(resourceName, "read_attributes.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "refresh_token_validity", "30"),
 					resource.TestCheckResourceAttr(resourceName, "supported_identity_providers.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "supported_identity_providers.0", "COGNITO"),
@@ -806,6 +806,104 @@ func TestAccCognitoIDPManagedUserPoolClient_Disappears_OpenSearchDomain(t *testi
 	})
 }
 
+func TestAccCognitoIDPManagedUserPoolClient_emptySets(t *testing.T) {
+	ctx := acctest.Context(t)
+	var client cognitoidentityprovider.UserPoolClientType
+	rName := randomOpenSearchDomainName()
+	resourceName := "aws_cognito_managed_user_pool_client.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolClientDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccManagedUserPoolClientConfig_emptySets(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolClientExists(ctx, resourceName, &client),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_flows.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "callback_urls.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "logout_urls.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "read_attributes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "supported_identity_providers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "write_attributes.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccUserPoolClientImportStateIDFunc(ctx, resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name_prefix",
+				},
+			},
+			{
+				Config:   testAccManagedUserPoolClientConfig_nulls(rName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccCognitoIDPManagedUserPoolClient_nulls(t *testing.T) {
+	ctx := acctest.Context(t)
+	var client cognitoidentityprovider.UserPoolClientType
+	rName := randomOpenSearchDomainName()
+	resourceName := "aws_cognito_managed_user_pool_client.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolClientDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccManagedUserPoolClientConfig_nulls(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolClientExists(ctx, resourceName, &client),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_flows.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "callback_urls.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "logout_urls.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "read_attributes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "supported_identity_providers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "write_attributes.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccUserPoolClientImportStateIDFunc(ctx, resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name_prefix",
+				},
+			},
+			{
+				Config: testAccManagedUserPoolClientConfig_emptySets(rName),
+				// This currently shows a diff of "null -> []"
+				// PlanOnly: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolClientExists(ctx, resourceName, &client),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_flows.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "callback_urls.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "logout_urls.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "read_attributes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "supported_identity_providers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "write_attributes.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccManagedUserPoolClientBaseConfig(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
@@ -1198,7 +1296,7 @@ func testAccManagedUserPoolClientConfig_analyticsARNShareData(rName string, shar
 	return acctest.ConfigCompose(
 		testAccManagedUserPoolClientAnalyticsBaseConfig(rName),
 		fmt.Sprintf(`
-resource "aws_cognito_user_pool_client" "test" {
+resource "aws_cognito_managed_user_pool_client" "test" {
   name_prefix  = "AmazonOpenSearchService-%[1]s"
   user_pool_id = aws_cognito_user_pool.test.id
 
@@ -1229,4 +1327,46 @@ resource "aws_cognito_managed_user_pool_client" "test" {
   auth_session_validity = %[2]d
 }
 `, rName, validity))
+}
+
+func testAccManagedUserPoolClientConfig_emptySets(rName string) string {
+	return acctest.ConfigCompose(
+		testAccManagedUserPoolClientBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_cognito_managed_user_pool_client" "test" {
+  name_prefix  = "AmazonOpenSearchService-%[1]s"
+  user_pool_id = aws_cognito_user_pool.test.id
+
+  depends_on = [
+    aws_opensearch_domain.test,
+  ]
+
+  // allowed_oauth_flows and allowed_oauth_scopes cannot be empty:
+  // > InvalidParameterException: AllowedOAuthFlows and AllowedOAuthScopes are
+  // > required if user pool client is allowed to use OAuth flows.
+  // callback_urls cannot be empty:
+  // > InvalidOAuthFlowException: CallbackUrls can not be empty when code flow
+  // > or implicit flow is selected
+  explicit_auth_flows = []
+  logout_urls = []
+  read_attributes = []
+  supported_identity_providers = []
+  write_attributes = []
+}
+`, rName))
+}
+
+func testAccManagedUserPoolClientConfig_nulls(rName string) string {
+	return acctest.ConfigCompose(
+		testAccManagedUserPoolClientBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_cognito_managed_user_pool_client" "test" {
+  name_prefix  = "AmazonOpenSearchService-%[1]s"
+  user_pool_id = aws_cognito_user_pool.test.id
+
+  depends_on = [
+    aws_opensearch_domain.test,
+  ]
+}
+`, rName))
 }

--- a/internal/service/cognitoidp/managed_user_pool_client_test.go
+++ b/internal/service/cognitoidp/managed_user_pool_client_test.go
@@ -1341,17 +1341,17 @@ resource "aws_cognito_managed_user_pool_client" "test" {
     aws_opensearch_domain.test,
   ]
 
-  // allowed_oauth_flows and allowed_oauth_scopes cannot be empty:
-  // > InvalidParameterException: AllowedOAuthFlows and AllowedOAuthScopes are
-  // > required if user pool client is allowed to use OAuth flows.
-  // callback_urls cannot be empty:
-  // > InvalidOAuthFlowException: CallbackUrls can not be empty when code flow
-  // > or implicit flow is selected
-  explicit_auth_flows = []
-  logout_urls = []
-  read_attributes = []
+  # allowed_oauth_flows and allowed_oauth_scopes cannot be empty:
+  # > InvalidParameterException: AllowedOAuthFlows and AllowedOAuthScopes are
+  # > required if user pool client is allowed to use OAuth flows.
+  # callback_urls cannot be empty:
+  # > InvalidOAuthFlowException: CallbackUrls can not be empty when code flow
+  # > or implicit flow is selected
+  explicit_auth_flows          = []
+  logout_urls                  = []
+  read_attributes              = []
   supported_identity_providers = []
-  write_attributes = []
+  write_attributes             = []
 }
 `, rName))
 }

--- a/internal/service/cognitoidp/user_pool_client.go
+++ b/internal/service/cognitoidp/user_pool_client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -45,8 +46,6 @@ type resourceUserPoolClient struct {
 	framework.ResourceWithConfigure
 }
 
-// Metadata should return the full name of the resource, such as
-// examplecloud_thing.
 func (r *resourceUserPoolClient) Metadata(_ context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
 	response.TypeName = "aws_cognito_user_pool_client"
 }
@@ -68,11 +67,15 @@ func (r *resourceUserPoolClient) Schema(ctx context.Context, request resource.Sc
 			"allowed_oauth_flows": schema.SetAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
 				Validators: []validator.Set{
 					setvalidator.SizeAtMost(3),
 					setvalidator.ValueStringsAre(
 						stringvalidator.OneOf(cognitoidentityprovider.OAuthFlowType_Values()...),
 					),
+				},
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"allowed_oauth_flows_user_pool_client": schema.BoolAttribute{
@@ -85,8 +88,12 @@ func (r *resourceUserPoolClient) Schema(ctx context.Context, request resource.Sc
 			"allowed_oauth_scopes": schema.SetAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
 				Validators: []validator.Set{
 					setvalidator.SizeAtMost(50),
+				},
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"auth_session_validity": schema.Int64Attribute{
@@ -109,10 +116,16 @@ func (r *resourceUserPoolClient) Schema(ctx context.Context, request resource.Sc
 						userPoolClientURLValidator...,
 					),
 				},
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"client_secret": schema.StringAttribute{
 				Computed:  true,
 				Sensitive: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"default_redirect_uri": schema.StringAttribute{
 				Optional:   true,
@@ -139,10 +152,14 @@ func (r *resourceUserPoolClient) Schema(ctx context.Context, request resource.Sc
 			"explicit_auth_flows": schema.SetAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
 				Validators: []validator.Set{
 					setvalidator.ValueStringsAre(
 						stringvalidator.OneOf(cognitoidentityprovider.ExplicitAuthFlowsType_Values()...),
 					),
+				},
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"generate_secret": schema.BoolAttribute{
@@ -172,6 +189,9 @@ func (r *resourceUserPoolClient) Schema(ctx context.Context, request resource.Sc
 						userPoolClientURLValidator...,
 					),
 				},
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				Required:   true,
@@ -190,6 +210,10 @@ func (r *resourceUserPoolClient) Schema(ctx context.Context, request resource.Sc
 			"read_attributes": schema.SetAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"refresh_token_validity": schema.Int64Attribute{
 				Optional: true,
@@ -204,10 +228,14 @@ func (r *resourceUserPoolClient) Schema(ctx context.Context, request resource.Sc
 			"supported_identity_providers": schema.SetAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
 				Validators: []validator.Set{
 					setvalidator.ValueStringsAre(
 						userPoolClientIdentityProviderValidator...,
 					),
+				},
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"user_pool_id": schema.StringAttribute{
@@ -219,6 +247,10 @@ func (r *resourceUserPoolClient) Schema(ctx context.Context, request resource.Sc
 			"write_attributes": schema.SetAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -314,8 +346,13 @@ func (r *resourceUserPoolClient) Schema(ctx context.Context, request resource.Sc
 func (r *resourceUserPoolClient) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
 	conn := r.Meta().CognitoIDPConn()
 
-	var plan resourceUserPoolClientData
+	var config resourceUserPoolClientData
+	response.Diagnostics.Append(request.Config.Get(ctx, &config)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 
+	var plan resourceUserPoolClientData
 	response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)
 	if response.Diagnostics.HasError() {
 		return
@@ -337,45 +374,49 @@ func (r *resourceUserPoolClient) Create(ctx context.Context, request resource.Cr
 
 	poolClient := resp.UserPoolClient
 
-	data := newUserPoolClientData(ctx, plan, poolClient, &response.Diagnostics)
+	config.update(ctx, poolClient, &response.Diagnostics)
 	if response.Diagnostics.HasError() {
 		return
 	}
 
-	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+	response.Diagnostics.Append(response.State.Set(ctx, &config)...)
 }
 
 func (r *resourceUserPoolClient) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
-	var data resourceUserPoolClientData
-
-	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	var state resourceUserPoolClientData
+	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
 	if response.Diagnostics.HasError() {
 		return
 	}
 
 	conn := r.Meta().CognitoIDPConn()
 
-	userPoolClient, err := FindCognitoUserPoolClientByID(ctx, conn, data.UserPoolID.ValueString(), data.ID.ValueString())
+	poolClient, err := FindCognitoUserPoolClientByID(ctx, conn, state.UserPoolID.ValueString(), state.ID.ValueString())
 	if tfresource.NotFound(err) {
-		create.LogNotFoundRemoveState(names.CognitoIDP, create.ErrActionReading, ResNameUserPoolClient, data.ID.ValueString())
+		create.LogNotFoundRemoveState(names.CognitoIDP, create.ErrActionReading, ResNameUserPoolClient, state.ID.ValueString())
 		response.State.RemoveResource(ctx)
 		return
 	}
 	if err != nil {
-		response.Diagnostics.Append(create.DiagErrorFramework(names.CognitoIDP, create.ErrActionReading, ResNameUserPoolClient, data.ID.ValueString(), err))
+		response.Diagnostics.Append(create.DiagErrorFramework(names.CognitoIDP, create.ErrActionReading, ResNameUserPoolClient, state.ID.ValueString(), err))
 		return
 	}
 
-	data = newUserPoolClientData(ctx, data, userPoolClient, &response.Diagnostics)
-
+	state.update(ctx, poolClient, &response.Diagnostics)
 	if response.Diagnostics.HasError() {
 		return
 	}
 
-	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
 
 func (r *resourceUserPoolClient) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	var config resourceUserPoolClientData
+	response.Diagnostics.Append(request.Config.Get(ctx, &config)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
 	var plan resourceUserPoolClientData
 	response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)
 	if response.Diagnostics.HasError() {
@@ -402,12 +443,12 @@ func (r *resourceUserPoolClient) Update(ctx context.Context, request resource.Up
 
 	poolClient := output.(*cognitoidentityprovider.UpdateUserPoolClientOutput).UserPoolClient
 
-	data := newUserPoolClientData(ctx, plan, poolClient, &response.Diagnostics)
+	config.update(ctx, poolClient, &response.Diagnostics)
 	if response.Diagnostics.HasError() {
 		return
 	}
 
-	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+	response.Diagnostics.Append(response.State.Set(ctx, &config)...)
 }
 
 func (r *resourceUserPoolClient) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
@@ -478,38 +519,35 @@ type resourceUserPoolClientData struct {
 	WriteAttributes                          types.Set    `tfsdk:"write_attributes"`
 }
 
-func newUserPoolClientData(ctx context.Context, plan resourceUserPoolClientData, in *cognitoidentityprovider.UserPoolClientType, diags *diag.Diagnostics) resourceUserPoolClientData {
-	return resourceUserPoolClientData{
-		AccessTokenValidity:                      flex.Int64ToFrameworkLegacy(ctx, in.AccessTokenValidity),
-		AllowedOauthFlows:                        flex.FlattenFrameworkStringSet(ctx, in.AllowedOAuthFlows),
-		AllowedOauthFlowsUserPoolClient:          flex.BoolToFramework(ctx, in.AllowedOAuthFlowsUserPoolClient),
-		AllowedOauthScopes:                       flex.FlattenFrameworkStringSet(ctx, in.AllowedOAuthScopes),
-		AnalyticsConfiguration:                   flattenAnaylticsConfiguration(ctx, in.AnalyticsConfiguration, diags),
-		AuthSessionValidity:                      flex.Int64ToFramework(ctx, in.AuthSessionValidity),
-		CallbackUrls:                             flex.FlattenFrameworkStringSet(ctx, in.CallbackURLs),
-		ClientSecret:                             flex.StringToFrameworkLegacy(ctx, in.ClientSecret),
-		DefaultRedirectUri:                       flex.StringToFrameworkLegacy(ctx, in.DefaultRedirectURI),
-		EnablePropagateAdditionalUserContextData: flex.BoolToFramework(ctx, in.EnablePropagateAdditionalUserContextData),
-		EnableTokenRevocation:                    flex.BoolToFramework(ctx, in.EnableTokenRevocation),
-		ExplicitAuthFlows:                        flex.FlattenFrameworkStringSet(ctx, in.ExplicitAuthFlows),
-		ID:                                       flex.StringToFramework(ctx, in.ClientId),
-		IdTokenValidity:                          flex.Int64ToFrameworkLegacy(ctx, in.IdTokenValidity),
-		GenerateSecret:                           plan.GenerateSecret,
-		LogoutUrls:                               flex.FlattenFrameworkStringSet(ctx, in.LogoutURLs),
-		Name:                                     flex.StringToFramework(ctx, in.ClientName),
-		PreventUserExistenceErrors:               flex.StringToFrameworkLegacy(ctx, in.PreventUserExistenceErrors),
-		ReadAttributes:                           flex.FlattenFrameworkStringSet(ctx, in.ReadAttributes),
-		RefreshTokenValidity:                     flex.Int64ToFramework(ctx, in.RefreshTokenValidity),
-		SupportedIdentityProviders:               flex.FlattenFrameworkStringSet(ctx, in.SupportedIdentityProviders),
-		TokenValidityUnits:                       flattenTokenValidityUnits(ctx, in.TokenValidityUnits),
-		UserPoolID:                               flex.StringToFramework(ctx, in.UserPoolId),
-		WriteAttributes:                          flex.FlattenFrameworkStringSet(ctx, in.WriteAttributes),
-	}
+func (data *resourceUserPoolClientData) update(ctx context.Context, in *cognitoidentityprovider.UserPoolClientType, diags *diag.Diagnostics) {
+	data.AccessTokenValidity = flex.Int64ToFrameworkLegacy(ctx, in.AccessTokenValidity)
+	data.AllowedOauthFlows = flex.FlattenFrameworkStringSetLegacy(ctx, in.AllowedOAuthFlows)
+	data.AllowedOauthFlowsUserPoolClient = flex.BoolToFramework(ctx, in.AllowedOAuthFlowsUserPoolClient)
+	data.AllowedOauthScopes = flex.FlattenFrameworkStringSetLegacy(ctx, in.AllowedOAuthScopes)
+	data.AnalyticsConfiguration = flattenAnaylticsConfiguration(ctx, in.AnalyticsConfiguration, diags)
+	data.AuthSessionValidity = flex.Int64ToFramework(ctx, in.AuthSessionValidity)
+	data.CallbackUrls = flex.FlattenFrameworkStringSetLegacy(ctx, in.CallbackURLs)
+	data.ClientSecret = flex.StringToFrameworkLegacy(ctx, in.ClientSecret)
+	data.DefaultRedirectUri = flex.StringToFrameworkLegacy(ctx, in.DefaultRedirectURI)
+	data.EnablePropagateAdditionalUserContextData = flex.BoolToFramework(ctx, in.EnablePropagateAdditionalUserContextData)
+	data.EnableTokenRevocation = flex.BoolToFramework(ctx, in.EnableTokenRevocation)
+	data.ExplicitAuthFlows = flex.FlattenFrameworkStringSetLegacy(ctx, in.ExplicitAuthFlows)
+	data.ID = flex.StringToFramework(ctx, in.ClientId)
+	data.IdTokenValidity = flex.Int64ToFrameworkLegacy(ctx, in.IdTokenValidity)
+	data.LogoutUrls = flex.FlattenFrameworkStringSetLegacy(ctx, in.LogoutURLs)
+	data.Name = flex.StringToFramework(ctx, in.ClientName)
+	data.PreventUserExistenceErrors = flex.StringToFrameworkLegacy(ctx, in.PreventUserExistenceErrors)
+	data.ReadAttributes = flex.FlattenFrameworkStringSetLegacy(ctx, in.ReadAttributes)
+	data.RefreshTokenValidity = flex.Int64ToFramework(ctx, in.RefreshTokenValidity)
+	data.SupportedIdentityProviders = flex.FlattenFrameworkStringSetLegacy(ctx, in.SupportedIdentityProviders)
+	data.TokenValidityUnits = flattenTokenValidityUnits(ctx, in.TokenValidityUnits)
+	data.UserPoolID = flex.StringToFramework(ctx, in.UserPoolId)
+	data.WriteAttributes = flex.FlattenFrameworkStringSetLegacy(ctx, in.WriteAttributes)
 }
 
 func (data resourceUserPoolClientData) createInput(ctx context.Context, diags *diag.Diagnostics) *cognitoidentityprovider.CreateUserPoolClientInput {
 	return &cognitoidentityprovider.CreateUserPoolClientInput{
-		AccessTokenValidity:                      flex.Int64FromFramework(ctx, data.AccessTokenValidity),
+		AccessTokenValidity:                      flex.Int64FromFrameworkLegacy(ctx, data.AccessTokenValidity),
 		AllowedOAuthFlows:                        flex.ExpandFrameworkStringSet(ctx, data.AllowedOauthFlows),
 		AllowedOAuthFlowsUserPoolClient:          flex.BoolFromFramework(ctx, data.AllowedOauthFlowsUserPoolClient),
 		AllowedOAuthScopes:                       flex.ExpandFrameworkStringSet(ctx, data.AllowedOauthScopes),
@@ -517,14 +555,14 @@ func (data resourceUserPoolClientData) createInput(ctx context.Context, diags *d
 		AuthSessionValidity:                      flex.Int64FromFramework(ctx, data.AuthSessionValidity),
 		CallbackURLs:                             flex.ExpandFrameworkStringSet(ctx, data.CallbackUrls),
 		ClientName:                               flex.StringFromFramework(ctx, data.Name),
-		DefaultRedirectURI:                       flex.StringFromFramework(ctx, data.DefaultRedirectUri),
+		DefaultRedirectURI:                       flex.StringFromFrameworkLegacy(ctx, data.DefaultRedirectUri),
 		EnablePropagateAdditionalUserContextData: flex.BoolFromFramework(ctx, data.EnablePropagateAdditionalUserContextData),
 		EnableTokenRevocation:                    flex.BoolFromFramework(ctx, data.EnableTokenRevocation),
 		ExplicitAuthFlows:                        flex.ExpandFrameworkStringSet(ctx, data.ExplicitAuthFlows),
 		GenerateSecret:                           flex.BoolFromFramework(ctx, data.GenerateSecret),
-		IdTokenValidity:                          flex.Int64FromFramework(ctx, data.IdTokenValidity),
+		IdTokenValidity:                          flex.Int64FromFrameworkLegacy(ctx, data.IdTokenValidity),
 		LogoutURLs:                               flex.ExpandFrameworkStringSet(ctx, data.LogoutUrls),
-		PreventUserExistenceErrors:               flex.StringFromFramework(ctx, data.PreventUserExistenceErrors),
+		PreventUserExistenceErrors:               flex.StringFromFrameworkLegacy(ctx, data.PreventUserExistenceErrors),
 		ReadAttributes:                           flex.ExpandFrameworkStringSet(ctx, data.ReadAttributes),
 		RefreshTokenValidity:                     flex.Int64FromFramework(ctx, data.RefreshTokenValidity),
 		SupportedIdentityProviders:               flex.ExpandFrameworkStringSet(ctx, data.SupportedIdentityProviders),
@@ -536,7 +574,7 @@ func (data resourceUserPoolClientData) createInput(ctx context.Context, diags *d
 
 func (data resourceUserPoolClientData) updateInput(ctx context.Context, diags *diag.Diagnostics) *cognitoidentityprovider.UpdateUserPoolClientInput {
 	return &cognitoidentityprovider.UpdateUserPoolClientInput{
-		AccessTokenValidity:                      flex.Int64FromFramework(ctx, data.AccessTokenValidity),
+		AccessTokenValidity:                      flex.Int64FromFrameworkLegacy(ctx, data.AccessTokenValidity),
 		AllowedOAuthFlows:                        flex.ExpandFrameworkStringSet(ctx, data.AllowedOauthFlows),
 		AllowedOAuthFlowsUserPoolClient:          flex.BoolFromFramework(ctx, data.AllowedOauthFlowsUserPoolClient),
 		AllowedOAuthScopes:                       flex.ExpandFrameworkStringSet(ctx, data.AllowedOauthScopes),
@@ -545,13 +583,13 @@ func (data resourceUserPoolClientData) updateInput(ctx context.Context, diags *d
 		CallbackURLs:                             flex.ExpandFrameworkStringSet(ctx, data.CallbackUrls),
 		ClientId:                                 flex.StringFromFramework(ctx, data.ID),
 		ClientName:                               flex.StringFromFramework(ctx, data.Name),
-		DefaultRedirectURI:                       flex.StringFromFramework(ctx, data.DefaultRedirectUri),
+		DefaultRedirectURI:                       flex.StringFromFrameworkLegacy(ctx, data.DefaultRedirectUri),
 		EnablePropagateAdditionalUserContextData: flex.BoolFromFramework(ctx, data.EnablePropagateAdditionalUserContextData),
 		EnableTokenRevocation:                    flex.BoolFromFramework(ctx, data.EnableTokenRevocation),
 		ExplicitAuthFlows:                        flex.ExpandFrameworkStringSet(ctx, data.ExplicitAuthFlows),
-		IdTokenValidity:                          flex.Int64FromFramework(ctx, data.IdTokenValidity),
+		IdTokenValidity:                          flex.Int64FromFrameworkLegacy(ctx, data.IdTokenValidity),
 		LogoutURLs:                               flex.ExpandFrameworkStringSet(ctx, data.LogoutUrls),
-		PreventUserExistenceErrors:               flex.StringFromFramework(ctx, data.PreventUserExistenceErrors),
+		PreventUserExistenceErrors:               flex.StringFromFrameworkLegacy(ctx, data.PreventUserExistenceErrors),
 		ReadAttributes:                           flex.ExpandFrameworkStringSet(ctx, data.ReadAttributes),
 		RefreshTokenValidity:                     flex.Int64FromFramework(ctx, data.RefreshTokenValidity),
 		SupportedIdentityProviders:               flex.ExpandFrameworkStringSet(ctx, data.SupportedIdentityProviders),

--- a/internal/service/cognitoidp/user_pool_client.go
+++ b/internal/service/cognitoidp/user_pool_client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -60,6 +61,9 @@ func (r *resourceUserPoolClient) Schema(ctx context.Context, request resource.Sc
 				Validators: []validator.Int64{
 					int64validator.Between(1, 86400),
 				},
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 			"allowed_oauth_flows": schema.SetAttribute{
 				ElementType: types.StringType,
@@ -74,6 +78,9 @@ func (r *resourceUserPoolClient) Schema(ctx context.Context, request resource.Sc
 			"allowed_oauth_flows_user_pool_client": schema.BoolAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"allowed_oauth_scopes": schema.SetAttribute{
 				ElementType: types.StringType,
@@ -87,6 +94,9 @@ func (r *resourceUserPoolClient) Schema(ctx context.Context, request resource.Sc
 				Computed: true,
 				Validators: []validator.Int64{
 					int64validator.Between(3, 15),
+				},
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
 				},
 			},
 			"callback_urls": schema.SetAttribute{
@@ -108,14 +118,23 @@ func (r *resourceUserPoolClient) Schema(ctx context.Context, request resource.Sc
 				Optional:   true,
 				Computed:   true,
 				Validators: userPoolClientURLValidator,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"enable_propagate_additional_user_context_data": schema.BoolAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"enable_token_revocation": schema.BoolAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"explicit_auth_flows": schema.SetAttribute{
 				ElementType: types.StringType,
@@ -139,6 +158,9 @@ func (r *resourceUserPoolClient) Schema(ctx context.Context, request resource.Sc
 				Validators: []validator.Int64{
 					int64validator.Between(1, 86400),
 				},
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 			"logout_urls": schema.SetAttribute{
 				ElementType: types.StringType,
@@ -161,6 +183,9 @@ func (r *resourceUserPoolClient) Schema(ctx context.Context, request resource.Sc
 				Validators: []validator.String{
 					stringvalidator.OneOf(cognitoidentityprovider.PreventUserExistenceErrorTypes_Values()...),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"read_attributes": schema.SetAttribute{
 				ElementType: types.StringType,
@@ -171,6 +196,9 @@ func (r *resourceUserPoolClient) Schema(ctx context.Context, request resource.Sc
 				Computed: true,
 				Validators: []validator.Int64{
 					int64validator.Between(0, 315360000),
+				},
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
 				},
 			},
 			"supported_identity_providers": schema.SetAttribute{

--- a/internal/service/cognitoidp/user_pool_client_test.go
+++ b/internal/service/cognitoidp/user_pool_client_test.go
@@ -766,6 +766,198 @@ func TestAccCognitoIDPUserPoolClient_Disappears_userPool(t *testing.T) {
 	})
 }
 
+func TestAccCognitoIDPUserPoolClient_emptySets(t *testing.T) {
+	ctx := acctest.Context(t)
+	var client cognitoidentityprovider.UserPoolClientType
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool_client.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolClientDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolClientConfig_emptySets(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolClientExists(ctx, resourceName, &client),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_flows.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "callback_urls.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "logout_urls.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "read_attributes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "supported_identity_providers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "write_attributes.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccUserPoolClientImportStateIDFunc(ctx, resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:   testAccUserPoolClientConfig_nulls(rName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccCognitoIDPUserPoolClient_nulls(t *testing.T) {
+	ctx := acctest.Context(t)
+	var client cognitoidentityprovider.UserPoolClientType
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool_client.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolClientDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolClientConfig_nulls(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolClientExists(ctx, resourceName, &client),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_flows.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "callback_urls.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "logout_urls.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "read_attributes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "supported_identity_providers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "write_attributes.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccUserPoolClientImportStateIDFunc(ctx, resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:   testAccUserPoolClientConfig_emptySets(rName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccCognitoIDPUserPoolClient_frameworkMigration_nulls(t *testing.T) {
+	ctx := acctest.Context(t)
+	var client cognitoidentityprovider.UserPoolClientType
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool_client.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		CheckDestroy: testAccCheckUserPoolClientDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "4.59.0",
+					},
+				},
+				Config: testAccUserPoolClientConfig_nulls(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolClientExists(ctx, resourceName, &client),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_flows.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "callback_urls.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "logout_urls.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "read_attributes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "supported_identity_providers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "write_attributes.#", "0"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccUserPoolClientConfig_nulls(rName),
+				PlanOnly:                 true,
+			},
+		},
+	})
+}
+
+func TestAccCognitoIDPUserPoolClient_frameworkMigration_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var client cognitoidentityprovider.UserPoolClientType
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool_client.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		CheckDestroy: testAccCheckUserPoolClientDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "4.59.0",
+					},
+				},
+				Config: testAccUserPoolClientConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolClientExists(ctx, resourceName, &client),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccUserPoolClientConfig_basic(rName),
+				PlanOnly:                 true,
+			},
+		},
+	})
+}
+
+func TestAccCognitoIDPUserPoolClient_frameworkMigration_emptySet(t *testing.T) {
+	ctx := acctest.Context(t)
+	var client cognitoidentityprovider.UserPoolClientType
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool_client.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		CheckDestroy: testAccCheckUserPoolClientDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "4.59.0",
+					},
+				},
+				Config: testAccUserPoolClientConfig_emptySets(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolClientExists(ctx, resourceName, &client),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_flows.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_oauth_scopes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "callback_urls.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "logout_urls.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "read_attributes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "supported_identity_providers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "write_attributes.#", "0"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccUserPoolClientConfig_emptySets(rName),
+				PlanOnly:                 true,
+			},
+		},
+	})
+}
+
 func testAccUserPoolClientImportStateIDFunc(ctx context.Context, resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -1129,6 +1321,37 @@ resource "aws_cognito_user_pool_client" "test" {
   explicit_auth_flows   = ["ADMIN_NO_SRP_AUTH"]
 }
 `, rName, validity))
+}
+
+func testAccUserPoolClientConfig_emptySets(rName string) string {
+	return acctest.ConfigCompose(
+		testAccUserPoolClientBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_cognito_user_pool_client" "test" {
+  name                = %[1]q
+  user_pool_id        = aws_cognito_user_pool.test.id
+
+  allowed_oauth_flows = []
+  allowed_oauth_scopes = []
+  callback_urls = []
+  explicit_auth_flows = []
+  logout_urls = []
+  read_attributes = []
+  supported_identity_providers = []
+  write_attributes = []
+}
+`, rName))
+}
+
+func testAccUserPoolClientConfig_nulls(rName string) string {
+	return acctest.ConfigCompose(
+		testAccUserPoolClientBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_cognito_user_pool_client" "test" {
+  name         = %[1]q
+  user_pool_id = aws_cognito_user_pool.test.id
+}
+`, rName))
 }
 
 func testAccPreCheckPinpointApp(ctx context.Context, t *testing.T) {

--- a/internal/service/cognitoidp/user_pool_client_test.go
+++ b/internal/service/cognitoidp/user_pool_client_test.go
@@ -1328,17 +1328,17 @@ func testAccUserPoolClientConfig_emptySets(rName string) string {
 		testAccUserPoolClientBaseConfig(rName),
 		fmt.Sprintf(`
 resource "aws_cognito_user_pool_client" "test" {
-  name                = %[1]q
-  user_pool_id        = aws_cognito_user_pool.test.id
+  name         = %[1]q
+  user_pool_id = aws_cognito_user_pool.test.id
 
-  allowed_oauth_flows = []
-  allowed_oauth_scopes = []
-  callback_urls = []
-  explicit_auth_flows = []
-  logout_urls = []
-  read_attributes = []
+  allowed_oauth_flows          = []
+  allowed_oauth_scopes         = []
+  callback_urls                = []
+  explicit_auth_flows          = []
+  logout_urls                  = []
+  read_attributes              = []
   supported_identity_providers = []
-  write_attributes = []
+  write_attributes             = []
 }
 `, rName))
 }


### PR DESCRIPTION
### Description

After the migration of the `aws_cognito_user_pool_client` resource from `terraform-plugin-sdk/v2` to `terraform-plugin-framework`, resources configured with an empty set (e.g. `logout_urls = []`) would return the error

> ... produced an unexpected new value: .logout_urls: was cty.SetValEmpty(cty.String), but now null.

The similar resource `aws_cognito_managed_user_pool_client` also had the same errors.

### Relations

Closes #30268

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=cognitoidp TESTS='TestAccCognitoIDPUserPoolClient_|TestAccCognitoIDPManagedUserPoolClient_'

--- PASS: TestAccCognitoIDPUserPoolClient_Disappears_userPool (35.58s)
--- PASS: TestAccCognitoIDPUserPoolClient_disappears (38.87s)
--- PASS: TestAccCognitoIDPUserPoolClient_allFields (41.49s)
--- PASS: TestAccCognitoIDPUserPoolClient_nulls (59.65s)
--- PASS: TestAccCognitoIDPUserPoolClient_emptySets (60.97s)
--- PASS: TestAccCognitoIDPUserPoolClient_frameworkMigration_emptySet (65.78s)
--- PASS: TestAccCognitoIDPUserPoolClient_frameworkMigration_basic (66.64s)
--- PASS: TestAccCognitoIDPUserPoolClient_allFieldsUpdatingOneField (66.69s)
--- PASS: TestAccCognitoIDPUserPoolClient_frameworkMigration_nulls (68.01s)
--- PASS: TestAccCognitoIDPUserPoolClient_tokenValidityUnits (72.24s)
--- PASS: TestAccCognitoIDPUserPoolClient_idTokenValidity (72.33s)
--- PASS: TestAccCognitoIDPUserPoolClient_tokenValidityUnitsWTokenValidity (72.34s)
--- PASS: TestAccCognitoIDPUserPoolClient_authSessionValidity (72.51s)
--- PASS: TestAccCognitoIDPUserPoolClient_refreshTokenValidity (74.15s)
--- PASS: TestAccCognitoIDPUserPoolClient_name (74.36s)
--- PASS: TestAccCognitoIDPUserPoolClient_tokenValidityUnits_AccessToken (75.18s)
--- PASS: TestAccCognitoIDPUserPoolClient_analyticsWithARN (75.67s)
--- PASS: TestAccCognitoIDPUserPoolClient_basic (17.82s)
--- PASS: TestAccCognitoIDPUserPoolClient_analyticsApplicationID (90.76s)
--- PASS: TestAccCognitoIDPUserPoolClient_accessTokenValidity (30.62s)
--- PASS: TestAccCognitoIDPUserPoolClient_enableRevocation (27.90s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_tokenValidityUnitsWTokenValidity (1680.53s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_analyticsApplicationID (1653.54s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_accessTokenValidity (1673.92s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_basic (1742.67s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_tokenValidityUnits_AccessToken (1683.59s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_tokenValidityUnits (1737.81s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_authSessionValidity (1727.61s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_refreshTokenValidity (1785.57s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_namePattern (1763.40s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_allFields (1857.24s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_emptySets (1836.57s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_Disappears_OpenSearchDomain (1878.36s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_allFieldsUpdatingOneField (2051.19s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_enableRevocation (1995.01s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_nulls (2164.75s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_idTokenValidity (2381.51s)
```
