### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin SDK resources `r*` (Phase 3c)

### DIFF
--- a/internal/service/ram/service_package_gen.go
+++ b/internal/service/ram/service_package_gen.go
@@ -41,6 +41,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceResourceShare,
 			TypeName: "aws_ram_resource_share",
+			Name:     "Resource Share",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceResourceShareAccepter,

--- a/internal/service/rbin/service_package_gen.go
+++ b/internal/service/rbin/service_package_gen.go
@@ -28,6 +28,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceRule,
 			TypeName: "aws_rbin_rule",
+			Name:     "Rule",
 			Tags: &types.ServicePackageResourceTags{
 				IdentifierAttribute: "arn",
 			},

--- a/internal/service/rds/cluster_snapshot.go
+++ b/internal/service/rds/cluster_snapshot.go
@@ -20,17 +20,19 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 const clusterSnapshotCreateTimeout = 2 * time.Minute
 
-// @SDKResource("aws_db_cluster_snapshot")
+// @SDKResource("aws_db_cluster_snapshot", name="Cluster Snapshot")
+// @Tags(identifierAttribute="db_cluster_snapshot_arn")
 func ResourceClusterSnapshot() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClusterSnapshotCreate,
 		ReadWithoutTimeout:   resourceClusterSnapshotRead,
 		DeleteWithoutTimeout: resourceClusterSnapshotDelete,
-		UpdateWithoutTimeout: resourcedbClusterSnapshotUpdate,
+		UpdateWithoutTimeout: resourceClusterSnapshotUpdate,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -111,8 +113,8 @@ func ResourceClusterSnapshot() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -122,17 +124,15 @@ func ResourceClusterSnapshot() *schema.Resource {
 func resourceClusterSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
-	params := &rds.CreateDBClusterSnapshotInput{
+	input := &rds.CreateDBClusterSnapshotInput{
 		DBClusterIdentifier:         aws.String(d.Get("db_cluster_identifier").(string)),
 		DBClusterSnapshotIdentifier: aws.String(d.Get("db_cluster_snapshot_identifier").(string)),
-		Tags:                        Tags(tags.IgnoreAWS()),
+		Tags:                        GetTagsIn(ctx),
 	}
 
 	err := retry.RetryContext(ctx, clusterSnapshotCreateTimeout, func() *retry.RetryError {
-		_, err := conn.CreateDBClusterSnapshotWithContext(ctx, params)
+		_, err := conn.CreateDBClusterSnapshotWithContext(ctx, input)
 		if err != nil {
 			if tfawserr.ErrCodeEquals(err, rds.ErrCodeInvalidDBClusterStateFault) {
 				return retry.RetryableError(err)
@@ -143,7 +143,7 @@ func resourceClusterSnapshotCreate(ctx context.Context, d *schema.ResourceData, 
 	})
 
 	if tfresource.TimedOut(err) {
-		_, err = conn.CreateDBClusterSnapshotWithContext(ctx, params)
+		_, err = conn.CreateDBClusterSnapshotWithContext(ctx, input)
 	}
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating RDS DB Cluster Snapshot: %s", err)
@@ -171,8 +171,6 @@ func resourceClusterSnapshotCreate(ctx context.Context, d *schema.ResourceData, 
 func resourceClusterSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	params := &rds.DescribeDBClusterSnapshotsInput{
 		DBClusterSnapshotIdentifier: aws.String(d.Id()),
@@ -213,39 +211,15 @@ func resourceClusterSnapshotRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("storage_encrypted", snapshot.StorageEncrypted)
 	d.Set("vpc_id", snapshot.VpcId)
 
-	tags, err := ListTags(ctx, conn, d.Get("db_cluster_snapshot_arn").(string))
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for RDS DB Cluster Snapshot (%s): %s", d.Get("db_cluster_snapshot_arn").(string), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
-func resourcedbClusterSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).RDSConn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
+	// Tags only.
 
-		if err := UpdateTags(ctx, conn, d.Get("db_cluster_snapshot_arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating RDS DB Cluster Snapshot (%s) tags: %s", d.Get("db_cluster_snapshot_arn").(string), err)
-		}
-	}
-
-	return diags
+	return append(diags, resourceClusterSnapshotRead(ctx, d, meta)...)
 }
 
 func resourceClusterSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -2608,10 +2608,13 @@ resource "aws_rds_cluster" "test" {
 func testAccClusterConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_cluster" "test" {
-  cluster_identifier  = %[1]q
-  master_username     = "tfacctest"
-  master_password     = "avoid-plaintext-passwords"
-  skip_final_snapshot = true
+  cluster_identifier              = %[1]q
+  database_name                   = "test"
+  master_username                 = "tfacctest"
+  master_password                 = "avoid-plaintext-passwords"
+  engine                          = "aurora-mysql"
+  db_cluster_parameter_group_name = "default.aurora-mysql5.7"
+  skip_final_snapshot             = true
 
   tags = {
     %[2]q = %[3]q
@@ -2623,10 +2626,13 @@ resource "aws_rds_cluster" "test" {
 func testAccClusterConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_cluster" "test" {
-  cluster_identifier  = %[1]q
-  master_username     = "tfacctest"
-  master_password     = "avoid-plaintext-passwords"
-  skip_final_snapshot = true
+  cluster_identifier              = %[1]q
+  database_name                   = "test"
+  master_username                 = "tfacctest"
+  master_password                 = "avoid-plaintext-passwords"
+  engine                          = "aurora-mysql"
+  db_cluster_parameter_group_name = "default.aurora-mysql5.7"
+  skip_final_snapshot             = true
 
   tags = {
     %[2]q = %[3]q

--- a/internal/service/rds/parameter_group.go
+++ b/internal/service/rds/parameter_group.go
@@ -23,9 +23,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_db_parameter_group")
+// @SDKResource("aws_db_parameter_group", name="DB Parameter Group")
+// @Tags(identifierAttribute="arn")
 func ResourceParameterGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceParameterGroupCreate,
@@ -91,8 +93,8 @@ func ResourceParameterGroup() *schema.Resource {
 				},
 				Set: resourceParameterHash,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -102,15 +104,13 @@ func ResourceParameterGroup() *schema.Resource {
 func resourceParameterGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
 	input := &rds.CreateDBParameterGroupInput{
 		DBParameterGroupFamily: aws.String(d.Get("family").(string)),
 		DBParameterGroupName:   aws.String(name),
 		Description:            aws.String(d.Get("description").(string)),
-		Tags:                   Tags(tags.IgnoreAWS()),
+		Tags:                   GetTagsIn(ctx),
 	}
 
 	output, err := conn.CreateDBParameterGroupWithContext(ctx, input)
@@ -130,8 +130,6 @@ func resourceParameterGroupCreate(ctx context.Context, d *schema.ResourceData, m
 func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	dbParameterGroup, err := FindDBParameterGroupByName(ctx, conn, d.Id())
 
@@ -223,23 +221,6 @@ func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "setting parameter: %s", err)
 	}
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for RDS DB Parameter Group (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
@@ -326,14 +307,6 @@ func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 					return sdkdiag.AppendErrorf(diags, "resetting DB Parameter Group (%s): %s", d.Id(), err)
 				}
 			}
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating RDS DB Parameter Group (%s) tags: %s", d.Get("arn").(string), err)
 		}
 	}
 

--- a/internal/service/rds/proxy_data_source.go
+++ b/internal/service/rds/proxy_data_source.go
@@ -28,6 +28,10 @@ func DataSourceProxy() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"client_password_auth_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"description": {
 							Type:     schema.TypeString,
 							Computed: true,

--- a/internal/service/rds/service_package_gen.go
+++ b/internal/service/rds/service_package_gen.go
@@ -85,14 +85,26 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceClusterSnapshot,
 			TypeName: "aws_db_cluster_snapshot",
+			Name:     "Cluster Snapshot",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "db_cluster_snapshot_arn",
+			},
 		},
 		{
 			Factory:  ResourceEventSubscription,
 			TypeName: "aws_db_event_subscription",
+			Name:     "Event Subscription",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceInstance,
 			TypeName: "aws_db_instance",
+			Name:     "DB Instance",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceInstanceAutomatedBackupsReplication,
@@ -105,14 +117,26 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceOptionGroup,
 			TypeName: "aws_db_option_group",
+			Name:     "DB Option Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceParameterGroup,
 			TypeName: "aws_db_parameter_group",
+			Name:     "DB Parameter Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceProxy,
 			TypeName: "aws_db_proxy",
+			Name:     "DB Proxy",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceProxyDefaultTargetGroup,
@@ -121,6 +145,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceProxyEndpoint,
 			TypeName: "aws_db_proxy_endpoint",
+			Name:     "DB Proxy Endpoint",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceProxyTarget,
@@ -129,22 +157,42 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceSecurityGroup,
 			TypeName: "aws_db_security_group",
+			Name:     "DB Security Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceSnapshot,
 			TypeName: "aws_db_snapshot",
+			Name:     "DB Snapshot",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "db_snapshot_arn",
+			},
 		},
 		{
 			Factory:  ResourceSnapshotCopy,
 			TypeName: "aws_db_snapshot_copy",
+			Name:     "DB Snapshot",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "db_snapshot_arn",
+			},
 		},
 		{
 			Factory:  ResourceSubnetGroup,
 			TypeName: "aws_db_subnet_group",
+			Name:     "DB Subnet Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceCluster,
 			TypeName: "aws_rds_cluster",
+			Name:     "Cluster",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceClusterActivityStream,
@@ -153,14 +201,26 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceClusterEndpoint,
 			TypeName: "aws_rds_cluster_endpoint",
+			Name:     "Cluster Endpoint",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceClusterInstance,
 			TypeName: "aws_rds_cluster_instance",
+			Name:     "Cluster Instance",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceClusterParameterGroup,
 			TypeName: "aws_rds_cluster_parameter_group",
+			Name:     "Cluster Parameter Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceClusterRoleAssociation,
@@ -173,6 +233,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceReservedInstance,
 			TypeName: "aws_rds_reserved_instance",
+			Name:     "Reserved Instance",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/redshift/event_subscription.go
+++ b/internal/service/redshift/event_subscription.go
@@ -19,9 +19,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_redshift_event_subscription")
+// @SDKResource("aws_redshift_event_subscription", name="Event Subscription")
+// @Tags(identifierAttribute="arn")
 func ResourceEventSubscription() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceEventSubscriptionCreate,
@@ -106,8 +108,8 @@ func ResourceEventSubscription() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -117,14 +119,12 @@ func ResourceEventSubscription() *schema.Resource {
 func resourceEventSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	request := &redshift.CreateEventSubscriptionInput{
 		SubscriptionName: aws.String(d.Get("name").(string)),
 		SnsTopicArn:      aws.String(d.Get("sns_topic_arn").(string)),
 		Enabled:          aws.Bool(d.Get("enabled").(bool)),
-		Tags:             Tags(tags.IgnoreAWS()),
+		Tags:             GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("event_categories"); ok && v.(*schema.Set).Len() > 0 {
@@ -158,8 +158,6 @@ func resourceEventSubscriptionCreate(ctx context.Context, d *schema.ResourceData
 func resourceEventSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	sub, err := FindEventSubscriptionByName(ctx, conn, d.Id())
 
@@ -190,16 +188,7 @@ func resourceEventSubscriptionRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("source_type", sub.SourceType)
 	d.Set("status", sub.Status)
 
-	tags := KeyValueTags(ctx, sub.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, sub.Tags)
 
 	return diags
 }
@@ -223,14 +212,6 @@ func resourceEventSubscriptionUpdate(ctx context.Context, d *schema.ResourceData
 		_, err := conn.ModifyEventSubscriptionWithContext(ctx, req)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "Modifying Redshift Event Subscription %s failed: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Redshift Event Subscription (%s) tags: %s", d.Get("arn").(string), err)
 		}
 	}
 

--- a/internal/service/redshift/event_subscription.go
+++ b/internal/service/redshift/event_subscription.go
@@ -215,7 +215,7 @@ func resourceEventSubscriptionUpdate(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
-	return diags
+	return append(diags, resourceEventSubscriptionRead(ctx, d, meta)...)
 }
 
 func resourceEventSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/redshift/hsm_client_certificate.go
+++ b/internal/service/redshift/hsm_client_certificate.go
@@ -16,9 +16,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_redshift_hsm_client_certificate")
+// @SDKResource("aws_redshift_hsm_client_certificate", name="HSM Client Certificate")
+// @Tags(identifierAttribute="arn")
 func ResourceHSMClientCertificate() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceHSMClientCertificateCreate,
@@ -44,8 +46,8 @@ func ResourceHSMClientCertificate() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -55,16 +57,13 @@ func ResourceHSMClientCertificate() *schema.Resource {
 func resourceHSMClientCertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	certIdentifier := d.Get("hsm_client_certificate_identifier").(string)
 
 	input := redshift.CreateHsmClientCertificateInput{
 		HsmClientCertificateIdentifier: aws.String(certIdentifier),
+		Tags:                           GetTagsIn(ctx),
 	}
-
-	input.Tags = Tags(tags.IgnoreAWS())
 
 	out, err := conn.CreateHsmClientCertificateWithContext(ctx, &input)
 	if err != nil {
@@ -79,8 +78,6 @@ func resourceHSMClientCertificateCreate(ctx context.Context, d *schema.ResourceD
 func resourceHSMClientCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	out, err := FindHSMClientCertificateByID(ctx, conn, d.Id())
 	if !d.IsNewResource() && tfresource.NotFound(err) {
@@ -106,31 +103,15 @@ func resourceHSMClientCertificateRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("hsm_client_certificate_identifier", out.HsmClientCertificateIdentifier)
 	d.Set("hsm_client_certificate_public_key", out.HsmClientCertificatePublicKey)
 
-	tags := KeyValueTags(ctx, out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, out.Tags)
 
 	return diags
 }
 
 func resourceHSMClientCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).RedshiftConn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Redshift HSM Client Certificate (%s) tags: %s", d.Get("arn").(string), err)
-		}
-	}
+	// Tags only.
 
 	return append(diags, resourceHSMClientCertificateRead(ctx, d, meta)...)
 }

--- a/internal/service/redshift/service_package_gen.go
+++ b/internal/service/redshift/service_package_gen.go
@@ -53,6 +53,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCluster,
 			TypeName: "aws_redshift_cluster",
+			Name:     "Cluster",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceClusterIAMRoles,
@@ -61,6 +65,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceClusterSnapshot,
 			TypeName: "aws_redshift_cluster_snapshot",
+			Name:     "Cluster Snapshot",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceEndpointAccess,
@@ -73,18 +81,34 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceEventSubscription,
 			TypeName: "aws_redshift_event_subscription",
+			Name:     "Event Subscription",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceHSMClientCertificate,
 			TypeName: "aws_redshift_hsm_client_certificate",
+			Name:     "HSM Client Certificate",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceHSMConfiguration,
 			TypeName: "aws_redshift_hsm_configuration",
+			Name:     "HSM Configuration",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceParameterGroup,
 			TypeName: "aws_redshift_parameter_group",
+			Name:     "Parameter Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourcePartner,
@@ -101,10 +125,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceSnapshotCopyGrant,
 			TypeName: "aws_redshift_snapshot_copy_grant",
+			Name:     "Snapshot Copy Grant",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceSnapshotSchedule,
 			TypeName: "aws_redshift_snapshot_schedule",
+			Name:     "Snapshot Schedule",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceSnapshotScheduleAssociation,
@@ -113,10 +145,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceSubnetGroup,
 			TypeName: "aws_redshift_subnet_group",
+			Name:     "Subnet Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceUsageLimit,
 			TypeName: "aws_redshift_usage_limit",
+			Name:     "Usage Limit",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/redshift/snapshot_schedule.go
+++ b/internal/service/redshift/snapshot_schedule.go
@@ -17,9 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_redshift_snapshot_schedule")
+// @SDKResource("aws_redshift_snapshot_schedule", name="Snapshot Schedule")
+// @Tags(identifierAttribute="arn")
 func ResourceSnapshotSchedule() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSnapshotScheduleCreate,
@@ -64,8 +66,8 @@ func ResourceSnapshotSchedule() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -75,8 +77,6 @@ func ResourceSnapshotSchedule() *schema.Resource {
 func resourceSnapshotScheduleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	var identifier string
 	if v, ok := d.GetOk("identifier"); ok {
@@ -91,7 +91,7 @@ func resourceSnapshotScheduleCreate(ctx context.Context, d *schema.ResourceData,
 	createOpts := &redshift.CreateSnapshotScheduleInput{
 		ScheduleIdentifier:  aws.String(identifier),
 		ScheduleDefinitions: flex.ExpandStringSet(d.Get("definitions").(*schema.Set)),
-		Tags:                Tags(tags.IgnoreAWS()),
+		Tags:                GetTagsIn(ctx),
 	}
 	if attr, ok := d.GetOk("description"); ok {
 		createOpts.ScheduleDescription = aws.String(attr.(string))
@@ -110,8 +110,6 @@ func resourceSnapshotScheduleCreate(ctx context.Context, d *schema.ResourceData,
 func resourceSnapshotScheduleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	descOpts := &redshift.DescribeSnapshotSchedulesInput{
 		ScheduleIdentifier: aws.String(d.Id()),
@@ -135,16 +133,7 @@ func resourceSnapshotScheduleRead(ctx context.Context, d *schema.ResourceData, m
 		return sdkdiag.AppendErrorf(diags, "setting definitions: %s", err)
 	}
 
-	tags := KeyValueTags(ctx, snapshotSchedule.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, snapshotSchedule.Tags)
 
 	arn := arn.ARN{
 		Partition: meta.(*conns.AWSClient).Partition,
@@ -162,14 +151,6 @@ func resourceSnapshotScheduleRead(ctx context.Context, d *schema.ResourceData, m
 func resourceSnapshotScheduleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftConn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Redshift Snapshot Schedule (%s) tags: %s", d.Get("arn").(string), err)
-		}
-	}
 
 	if d.HasChange("definitions") {
 		modifyOpts := &redshift.ModifySnapshotScheduleInput{

--- a/internal/service/redshift/subnet_group.go
+++ b/internal/service/redshift/subnet_group.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_redshift_subnet_group")
+// @SDKResource("aws_redshift_subnet_group", name="Subnet Group")
+// @Tags(identifierAttribute="arn")
 func ResourceSubnetGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSubnetGroupCreate,
@@ -57,8 +59,8 @@ func ResourceSubnetGroup() *schema.Resource {
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -68,8 +70,6 @@ func ResourceSubnetGroup() *schema.Resource {
 func resourceSubnetGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	subnetIdsSet := d.Get("subnet_ids").(*schema.Set)
 	subnetIds := make([]*string, subnetIdsSet.Len())
@@ -82,7 +82,7 @@ func resourceSubnetGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 		ClusterSubnetGroupName: aws.String(name),
 		Description:            aws.String(d.Get("description").(string)),
 		SubnetIds:              subnetIds,
-		Tags:                   Tags(tags.IgnoreAWS()),
+		Tags:                   GetTagsIn(ctx),
 	}
 
 	log.Printf("[DEBUG] Creating Redshift Subnet Group: %s", input)
@@ -100,8 +100,6 @@ func resourceSubnetGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 func resourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	subnetgroup, err := FindSubnetGroupByName(ctx, conn, d.Id())
 
@@ -126,16 +124,8 @@ func resourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("description", subnetgroup.Description)
 	d.Set("name", d.Id())
 	d.Set("subnet_ids", subnetIdsToSlice(subnetgroup.Subnets))
-	tags := KeyValueTags(ctx, subnetgroup.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, subnetgroup.Tags)
 
 	return diags
 }
@@ -143,14 +133,6 @@ func resourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 func resourceSubnetGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftConn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Redshift Subnet Group (%s) tags: %s", d.Get("arn").(string), err)
-		}
-	}
 
 	if d.HasChanges("subnet_ids", "description") {
 		_, n := d.GetChange("subnet_ids")

--- a/internal/service/redshiftserverless/service_package_gen.go
+++ b/internal/service/redshiftserverless/service_package_gen.go
@@ -37,6 +37,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceNamespace,
 			TypeName: "aws_redshiftserverless_namespace",
+			Name:     "Namespace",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceResourcePolicy,
@@ -53,6 +57,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceWorkgroup,
 			TypeName: "aws_redshiftserverless_workgroup",
+			Name:     "Workgroup",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/redshiftserverless/workgroup.go
+++ b/internal/service/redshiftserverless/workgroup.go
@@ -17,9 +17,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_redshiftserverless_workgroup")
+// @SDKResource("aws_redshiftserverless_workgroup", name="Workgroup")
+// @Tags(identifierAttribute="arn")
 func ResourceWorkgroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceWorkgroupCreate,
@@ -153,8 +155,8 @@ func ResourceWorkgroup() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -164,11 +166,10 @@ func ResourceWorkgroup() *schema.Resource {
 func resourceWorkgroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftServerlessConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := redshiftserverless.CreateWorkgroupInput{
 		NamespaceName: aws.String(d.Get("namespace_name").(string)),
+		Tags:          GetTagsIn(ctx),
 		WorkgroupName: aws.String(d.Get("workgroup_name").(string)),
 	}
 
@@ -196,8 +197,6 @@ func resourceWorkgroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 		input.SubnetIds = flex.ExpandStringSet(v.(*schema.Set))
 	}
 
-	input.Tags = Tags(tags.IgnoreAWS())
-
 	out, err := conn.CreateWorkgroupWithContext(ctx, &input)
 
 	if err != nil {
@@ -216,8 +215,6 @@ func resourceWorkgroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 func resourceWorkgroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftServerlessConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	out, err := FindWorkgroupByName(ctx, conn, d.Id())
 	if !d.IsNewResource() && tfresource.NotFound(err) {
@@ -246,27 +243,6 @@ func resourceWorkgroupRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	if err := d.Set("endpoint", []interface{}{flattenEndpoint(out.Endpoint)}); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting endpoint: %s", err)
-	}
-
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		if tfawserr.ErrCodeEquals(err, "UnknownOperationException") {
-			return diags
-		}
-
-		return sdkdiag.AppendErrorf(diags, "listing tags for edshift Serverless Workgroup (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
 	}
 
 	return diags
@@ -312,14 +288,6 @@ func resourceWorkgroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 
 		if _, err := waitWorkgroupAvailable(ctx, conn, d.Id()); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for Redshift Serverless Workgroup (%s) to be updated: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Redshift Serverless Workgroup (%s) tags: %s", d.Get("arn").(string), err)
 		}
 	}
 

--- a/internal/service/resourcegroups/service_package_gen.go
+++ b/internal/service/resourcegroups/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceGroup,
 			TypeName: "aws_resourcegroups_group",
+			Name:     "Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/rolesanywhere/service_package_gen.go
+++ b/internal/service/rolesanywhere/service_package_gen.go
@@ -28,10 +28,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceProfile,
 			TypeName: "aws_rolesanywhere_profile",
+			Name:     "Profile",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceTrustAnchor,
 			TypeName: "aws_rolesanywhere_trust_anchor",
+			Name:     "Trust Anchor",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/route53recoveryreadiness/recovery_group.go
+++ b/internal/service/route53recoveryreadiness/recovery_group.go
@@ -21,7 +21,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_route53recoveryreadiness_recovery_group")
+// @SDKResource("aws_route53recoveryreadiness_recovery_group", name="Recovery Group")
+// @Tags(identifierAttribute="arn")
 func ResourceRecoveryGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRecoveryGroupCreate,

--- a/internal/service/route53recoveryreadiness/recovery_group.go
+++ b/internal/service/route53recoveryreadiness/recovery_group.go
@@ -18,6 +18,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @SDKResource("aws_route53recoveryreadiness_recovery_group")
@@ -52,8 +53,8 @@ func ResourceRecoveryGroup() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -63,8 +64,6 @@ func ResourceRecoveryGroup() *schema.Resource {
 func resourceRecoveryGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53RecoveryReadinessConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &route53recoveryreadiness.CreateRecoveryGroupInput{
 		RecoveryGroupName: aws.String(d.Get("recovery_group_name").(string)),
@@ -78,7 +77,7 @@ func resourceRecoveryGroupCreate(ctx context.Context, d *schema.ResourceData, me
 
 	d.SetId(aws.StringValue(resp.RecoveryGroupName))
 
-	if len(tags) > 0 {
+	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
 		arn := aws.StringValue(resp.RecoveryGroupArn)
 		if err := UpdateTags(ctx, conn, arn, nil, tags); err != nil {
 			return sdkdiag.AppendErrorf(diags, "adding Route53 Recovery Readiness RecoveryGroup (%s) tags: %s", d.Id(), err)
@@ -91,8 +90,6 @@ func resourceRecoveryGroupCreate(ctx context.Context, d *schema.ResourceData, me
 func resourceRecoveryGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53RecoveryReadinessConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	input := &route53recoveryreadiness.GetRecoveryGroupInput{
 		RecoveryGroupName: aws.String(d.Id()),
@@ -113,23 +110,6 @@ func resourceRecoveryGroupRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("recovery_group_name", resp.RecoveryGroupName)
 	d.Set("cells", resp.Cells)
 
-	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Route53 Recovery Readiness RecoveryGroup (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
@@ -146,14 +126,6 @@ func resourceRecoveryGroupUpdate(ctx context.Context, d *schema.ResourceData, me
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating Route53 Recovery Readiness RecoveryGroup: %s", err)
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		arn := d.Get("arn").(string)
-		if err := UpdateTags(ctx, conn, arn, o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Route53 Recovery Readiness RecoveryGroup (%s) tags: %s", d.Id(), err)
-		}
 	}
 
 	return append(diags, resourceRecoveryGroupRead(ctx, d, meta)...)

--- a/internal/service/route53recoveryreadiness/resource_set.go
+++ b/internal/service/route53recoveryreadiness/resource_set.go
@@ -21,7 +21,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_route53recoveryreadiness_resource_set")
+// @SDKResource("aws_route53recoveryreadiness_resource_set", name="Resource Set")
+// @Tags(identifierAttribute="arn")
 func ResourceResourceSet() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceResourceSetCreate,

--- a/internal/service/route53recoveryreadiness/resource_set.go
+++ b/internal/service/route53recoveryreadiness/resource_set.go
@@ -18,6 +18,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @SDKResource("aws_route53recoveryreadiness_resource_set")
@@ -137,8 +138,8 @@ func ResourceResourceSet() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -148,8 +149,6 @@ func ResourceResourceSet() *schema.Resource {
 func resourceResourceSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53RecoveryReadinessConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &route53recoveryreadiness.CreateResourceSetInput{
 		ResourceSetName: aws.String(d.Get("resource_set_name").(string)),
@@ -164,7 +163,7 @@ func resourceResourceSetCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	d.SetId(aws.StringValue(resp.ResourceSetName))
 
-	if len(tags) > 0 {
+	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
 		arn := aws.StringValue(resp.ResourceSetArn)
 		if err := UpdateTags(ctx, conn, arn, nil, tags); err != nil {
 			return sdkdiag.AppendErrorf(diags, "adding Route53 Recovery Readiness Resource Set (%s) tags: %s", d.Id(), err)
@@ -177,8 +176,6 @@ func resourceResourceSetCreate(ctx context.Context, d *schema.ResourceData, meta
 func resourceResourceSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53RecoveryReadinessConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	input := &route53recoveryreadiness.GetResourceSetInput{
 		ResourceSetName: aws.String(d.Id()),
@@ -204,23 +201,6 @@ func resourceResourceSetRead(ctx context.Context, d *schema.ResourceData, meta i
 		return sdkdiag.AppendErrorf(diags, "setting AWS Route53 Recovery Readiness Resource Set resources: %s", err)
 	}
 
-	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Route53 Recovery Readiness Resource Set (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
@@ -237,14 +217,6 @@ func resourceResourceSetUpdate(ctx context.Context, d *schema.ResourceData, meta
 	_, err := conn.UpdateResourceSetWithContext(ctx, input)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating Route53 Recovery Readiness Resource Set: %s", err)
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		arn := d.Get("arn").(string)
-		if err := UpdateTags(ctx, conn, arn, o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Route53 Recovery Readiness Resource Set (%s) tags: %s", d.Id(), err)
-		}
 	}
 
 	return append(diags, resourceResourceSetRead(ctx, d, meta)...)

--- a/internal/service/route53recoveryreadiness/service_package_gen.go
+++ b/internal/service/route53recoveryreadiness/service_package_gen.go
@@ -44,10 +44,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceRecoveryGroup,
 			TypeName: "aws_route53recoveryreadiness_recovery_group",
+			Name:     "Recovery Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceResourceSet,
 			TypeName: "aws_route53recoveryreadiness_resource_set",
+			Name:     "Resource Set",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/route53recoveryreadiness/service_package_gen.go
+++ b/internal/service/route53recoveryreadiness/service_package_gen.go
@@ -28,10 +28,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCell,
 			TypeName: "aws_route53recoveryreadiness_cell",
+			Name:     "Cell",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceReadinessCheck,
 			TypeName: "aws_route53recoveryreadiness_readiness_check",
+			Name:     "Readiness Check",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRecoveryGroup,

--- a/internal/service/route53resolver/firewall_domain_list.go
+++ b/internal/service/route53resolver/firewall_domain_list.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_route53_resolver_firewall_domain_list")
+// @SDKResource("aws_route53_resolver_firewall_domain_list", name="Firewall Domain List")
+// @Tags(identifierAttribute="arn")
 func ResourceFirewallDomainList() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceFirewallDomainListCreate,
@@ -48,8 +50,8 @@ func ResourceFirewallDomainList() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validResolverName,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -58,17 +60,12 @@ func ResourceFirewallDomainList() *schema.Resource {
 
 func resourceFirewallDomainListCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).Route53ResolverConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &route53resolver.CreateFirewallDomainListInput{
 		CreatorRequestId: aws.String(id.PrefixedUniqueId("tf-r53-resolver-firewall-domain-list-")),
 		Name:             aws.String(name),
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
+		Tags:             GetTagsIn(ctx),
 	}
 
 	output, err := conn.CreateFirewallDomainListWithContext(ctx, input)
@@ -100,8 +97,6 @@ func resourceFirewallDomainListCreate(ctx context.Context, d *schema.ResourceDat
 
 func resourceFirewallDomainListRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).Route53ResolverConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	firewallDomainList, err := FindFirewallDomainListByID(ctx, conn, d.Id())
 
@@ -140,23 +135,6 @@ func resourceFirewallDomainListRead(ctx context.Context, d *schema.ResourceData,
 
 	d.Set("domains", aws.StringValueSlice(output))
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return diag.Errorf("listing tags for Route53 Resolver Firewall Domain List (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
-	}
-
 	return nil
 }
 
@@ -194,14 +172,6 @@ func resourceFirewallDomainListUpdate(ctx context.Context, d *schema.ResourceDat
 
 		if _, err = waitFirewallDomainListUpdated(ctx, conn, d.Id()); err != nil {
 			return diag.Errorf("waiting for Route53 Resolver Firewall Domain List (%s) update: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.Errorf("updating Route53 Resolver Firewall Domain List (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/route53resolver/firewall_rule_group.go
+++ b/internal/service/route53resolver/firewall_rule_group.go
@@ -15,9 +15,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_route53_resolver_firewall_rule_group")
+// @SDKResource("aws_route53_resolver_firewall_rule_group", name="Firewall Rule Group")
+// @Tags(identifierAttribute="arn")
 func ResourceFirewallRuleGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceFirewallRuleGroupCreate,
@@ -48,8 +50,8 @@ func ResourceFirewallRuleGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -58,17 +60,12 @@ func ResourceFirewallRuleGroup() *schema.Resource {
 
 func resourceFirewallRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).Route53ResolverConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &route53resolver.CreateFirewallRuleGroupInput{
 		CreatorRequestId: aws.String(id.PrefixedUniqueId("tf-r53-resolver-firewall-rule-group-")),
 		Name:             aws.String(name),
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
+		Tags:             GetTagsIn(ctx),
 	}
 
 	output, err := conn.CreateFirewallRuleGroupWithContext(ctx, input)
@@ -84,8 +81,6 @@ func resourceFirewallRuleGroupCreate(ctx context.Context, d *schema.ResourceData
 
 func resourceFirewallRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).Route53ResolverConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	ruleGroup, err := FindFirewallRuleGroupByID(ctx, conn, d.Id())
 
@@ -105,37 +100,11 @@ func resourceFirewallRuleGroupRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("owner_id", ruleGroup.OwnerId)
 	d.Set("share_status", ruleGroup.ShareStatus)
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return diag.Errorf("listing tags for Route53 Resolver Firewall Rule Group (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
-	}
-
 	return nil
 }
 
 func resourceFirewallRuleGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).Route53ResolverConn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.Errorf("updating Route53 Resolver Firewall Rule Group (%s) tags: %s", d.Id(), err)
-		}
-	}
-
+	// Tags only.
 	return resourceFirewallRuleGroupRead(ctx, d, meta)
 }
 

--- a/internal/service/route53resolver/service_package_gen.go
+++ b/internal/service/route53resolver/service_package_gen.go
@@ -69,6 +69,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceEndpoint,
 			TypeName: "aws_route53_resolver_endpoint",
+			Name:     "Endpoint",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceFirewallConfig,
@@ -77,6 +81,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceFirewallDomainList,
 			TypeName: "aws_route53_resolver_firewall_domain_list",
+			Name:     "Firewall Domain List",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceFirewallRule,
@@ -85,14 +93,26 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceFirewallRuleGroup,
 			TypeName: "aws_route53_resolver_firewall_rule_group",
+			Name:     "Firewall Rule Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceFirewallRuleGroupAssociation,
 			TypeName: "aws_route53_resolver_firewall_rule_group_association",
+			Name:     "Rule Group Association",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceQueryLogConfig,
 			TypeName: "aws_route53_resolver_query_log_config",
+			Name:     "Query Log Config",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceQueryLogConfigAssociation,
@@ -101,6 +121,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceRule,
 			TypeName: "aws_route53_resolver_rule",
+			Name:     "Rule",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRuleAssociation,

--- a/internal/service/rum/service_package_gen.go
+++ b/internal/service/rum/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceAppMonitor,
 			TypeName: "aws_rum_app_monitor",
+			Name:     "App Monitor",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceMetricsDestination,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin SDK.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30421.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30430.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30449.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30454.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=r... ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/r.../... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccRAMPrincipalAssociation_basic
=== PAUSE TestAccRAMPrincipalAssociation_basic
=== RUN   TestAccRAMResourceAssociation_basic
=== PAUSE TestAccRAMResourceAssociation_basic
=== RUN   TestAccRAMResourceShareAccepter_basic
=== PAUSE TestAccRAMResourceShareAccepter_basic
=== RUN   TestAccRAMResourceShareDataSource_basic
=== PAUSE TestAccRAMResourceShareDataSource_basic
=== RUN   TestAccRAMResourceShareDataSource_tags
=== PAUSE TestAccRAMResourceShareDataSource_tags
=== RUN   TestAccRAMResourceShare_basic
=== PAUSE TestAccRAMResourceShare_basic
=== RUN   TestAccRAMResourceShare_tags
=== PAUSE TestAccRAMResourceShare_tags
=== CONT  TestAccRAMPrincipalAssociation_basic
=== CONT  TestAccRAMResourceShareDataSource_tags
=== CONT  TestAccRAMResourceShare_tags
--- PASS: TestAccRAMResourceShareDataSource_tags (66.08s)
=== CONT  TestAccRAMResourceShare_basic
--- PASS: TestAccRAMPrincipalAssociation_basic (68.91s)
=== CONT  TestAccRAMResourceShareAccepter_basic
    acctest.go:772: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRAMResourceShareAccepter_basic (0.00s)
=== CONT  TestAccRAMResourceShareDataSource_basic
--- PASS: TestAccRAMResourceShareDataSource_basic (47.91s)
=== CONT  TestAccRAMResourceAssociation_basic
--- PASS: TestAccRAMResourceShare_basic (54.74s)
--- PASS: TestAccRAMResourceShare_tags (137.24s)
--- PASS: TestAccRAMResourceAssociation_basic (40.37s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ram	167.339s
=== RUN   TestAccRBinRule_basic
=== PAUSE TestAccRBinRule_basic
=== RUN   TestAccRBinRule_tags
=== PAUSE TestAccRBinRule_tags
=== CONT  TestAccRBinRule_basic
=== CONT  TestAccRBinRule_tags
--- PASS: TestAccRBinRule_basic (69.33s)
--- PASS: TestAccRBinRule_tags (122.07s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rbin	141.542s
=== RUN   TestAccRDSClusterActivityStream_basic
=== PAUSE TestAccRDSClusterActivityStream_basic
=== RUN   TestAccRDSClusterDataSource_basic
=== PAUSE TestAccRDSClusterDataSource_basic
=== RUN   TestAccRDSClusterEndpoint_basic
=== PAUSE TestAccRDSClusterEndpoint_basic
=== RUN   TestAccRDSClusterEndpoint_tags
=== PAUSE TestAccRDSClusterEndpoint_tags
=== RUN   TestAccRDSClusterInstance_basic
=== PAUSE TestAccRDSClusterInstance_basic
=== RUN   TestAccRDSClusterInstance_tags
=== PAUSE TestAccRDSClusterInstance_tags
=== RUN   TestAccRDSClusterParameterGroup_basic
=== PAUSE TestAccRDSClusterParameterGroup_basic
=== RUN   TestAccRDSClusterParameterGroup_tags
=== PAUSE TestAccRDSClusterParameterGroup_tags
=== RUN   TestAccRDSClusterRoleAssociation_basic
=== PAUSE TestAccRDSClusterRoleAssociation_basic
=== RUN   TestAccRDSClusterSnapshot_basic
=== PAUSE TestAccRDSClusterSnapshot_basic
=== RUN   TestAccRDSClusterSnapshot_tags
=== PAUSE TestAccRDSClusterSnapshot_tags
=== RUN   TestAccRDSCluster_basic
=== PAUSE TestAccRDSCluster_basic
=== RUN   TestAccRDSCluster_tags
=== PAUSE TestAccRDSCluster_tags
=== RUN   TestAccRDSCluster_SnapshotIdentifier_tags
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_tags
=== RUN   TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags
=== PAUSE TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags
=== RUN   TestAccRDSEngineVersionDataSource_basic
=== PAUSE TestAccRDSEngineVersionDataSource_basic
=== RUN   TestAccRDSEventCategoriesDataSource_basic
=== PAUSE TestAccRDSEventCategoriesDataSource_basic
=== RUN   TestAccRDSEventSubscription_basic
=== PAUSE TestAccRDSEventSubscription_basic
=== RUN   TestAccRDSEventSubscription_tags
=== PAUSE TestAccRDSEventSubscription_tags
=== RUN   TestAccRDSExportTask_basic
=== PAUSE TestAccRDSExportTask_basic
=== RUN   TestAccRDSGlobalCluster_basic
=== PAUSE TestAccRDSGlobalCluster_basic
=== RUN   TestAccRDSInstanceAutomatedBackupsReplication_basic
=== PAUSE TestAccRDSInstanceAutomatedBackupsReplication_basic
=== RUN   TestAccRDSInstanceDataSource_basic
=== PAUSE TestAccRDSInstanceDataSource_basic
=== RUN   TestAccRDSInstanceRoleAssociation_basic
=== PAUSE TestAccRDSInstanceRoleAssociation_basic
=== RUN   TestAccRDSInstance_basic
=== PAUSE TestAccRDSInstance_basic
=== RUN   TestAccRDSInstance_tags
=== PAUSE TestAccRDSInstance_tags
=== RUN   TestAccRDSInstance_ReplicateSourceDB_basic
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_basic
=== RUN   TestAccRDSInstance_S3Import_basic
    acctest.go:76: RestoreDBInstanceFromS3 cannot restore from MySQL version 5.6
--- SKIP: TestAccRDSInstance_S3Import_basic (0.00s)
=== RUN   TestAccRDSInstance_SnapshotIdentifier_basic
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_basic
=== RUN   TestAccRDSInstance_SnapshotIdentifier_tags
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_tags
=== RUN   TestAccRDSInstance_BlueGreenDeployment_tags
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_tags
=== RUN   TestAccRDSOptionGroup_basic
=== PAUSE TestAccRDSOptionGroup_basic
=== RUN   TestAccRDSOptionGroup_tags
=== PAUSE TestAccRDSOptionGroup_tags
=== RUN   TestAccRDSOrderableInstanceDataSource_basic
=== PAUSE TestAccRDSOrderableInstanceDataSource_basic
=== RUN   TestAccRDSParameterGroup_basic
=== PAUSE TestAccRDSParameterGroup_basic
=== RUN   TestAccRDSProxyDataSource_basic
=== PAUSE TestAccRDSProxyDataSource_basic
=== RUN   TestAccRDSProxyDefaultTargetGroup_basic
=== PAUSE TestAccRDSProxyDefaultTargetGroup_basic
=== RUN   TestAccRDSProxyEndpoint_basic
=== PAUSE TestAccRDSProxyEndpoint_basic
=== RUN   TestAccRDSProxyEndpoint_tags
=== PAUSE TestAccRDSProxyEndpoint_tags
=== RUN   TestAccRDSProxy_basic
=== PAUSE TestAccRDSProxy_basic
=== RUN   TestAccRDSProxy_tags
=== PAUSE TestAccRDSProxy_tags
=== RUN   TestAccRDSInstanceOffering_basic
=== PAUSE TestAccRDSInstanceOffering_basic
=== RUN   TestAccRDSReservedInstance_basic
    reserved_instance_test.go:24: Environment variable RUN_RDS_RESERVED_INSTANCE_TESTS is not set to true
--- SKIP: TestAccRDSReservedInstance_basic (0.00s)
=== RUN   TestAccRDSSnapshotCopy_basic
=== PAUSE TestAccRDSSnapshotCopy_basic
=== RUN   TestAccRDSSnapshotCopy_tags
=== PAUSE TestAccRDSSnapshotCopy_tags
=== RUN   TestAccRDSSnapshotDataSource_basic
=== PAUSE TestAccRDSSnapshotDataSource_basic
=== RUN   TestAccRDSSnapshot_basic
=== PAUSE TestAccRDSSnapshot_basic
=== RUN   TestAccRDSSnapshot_tags
=== PAUSE TestAccRDSSnapshot_tags
=== RUN   TestAccRDSSubnetGroupDataSource_basic
=== PAUSE TestAccRDSSubnetGroupDataSource_basic
=== RUN   TestAccRDSSubnetGroup_basic
=== PAUSE TestAccRDSSubnetGroup_basic
=== RUN   TestAccRDSSubnetGroup_tags
=== PAUSE TestAccRDSSubnetGroup_tags
=== CONT  TestAccRDSClusterActivityStream_basic
=== CONT  TestAccRDSInstance_tags
=== CONT  TestAccRDSProxyEndpoint_tags
--- PASS: TestAccRDSInstance_tags (549.81s)
=== CONT  TestAccRDSSnapshotDataSource_basic
--- PASS: TestAccRDSProxyEndpoint_tags (931.26s)
=== CONT  TestAccRDSSubnetGroup_tags
--- PASS: TestAccRDSSubnetGroup_tags (69.32s)
=== CONT  TestAccRDSSubnetGroup_basic
--- PASS: TestAccRDSSubnetGroup_basic (42.83s)
=== CONT  TestAccRDSSubnetGroupDataSource_basic
--- PASS: TestAccRDSSubnetGroupDataSource_basic (37.76s)
=== CONT  TestAccRDSSnapshot_tags
--- PASS: TestAccRDSSnapshotDataSource_basic (871.86s)
=== CONT  TestAccRDSSnapshot_basic
--- PASS: TestAccRDSSnapshot_tags (553.11s)
=== CONT  TestAccRDSOptionGroup_tags
--- PASS: TestAccRDSOptionGroup_tags (45.49s)
=== CONT  TestAccRDSProxyEndpoint_basic
--- PASS: TestAccRDSSnapshot_basic (640.55s)
=== CONT  TestAccRDSProxyDefaultTargetGroup_basic
--- PASS: TestAccRDSClusterActivityStream_basic (2072.89s)
=== CONT  TestAccRDSProxyDataSource_basic
panic: Invalid address to set: []string{"auth", "0", "client_password_auth_type"}

goroutine 113240 [running]:
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*ResourceData).Set(0xc0172a3f80, {0xe3f8e86, 0x4}, {0xb9400c0, 0xc004d78708})
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/resource_data.go:230 +0x291
github.com/hashicorp/terraform-provider-aws/internal/service/rds.dataSourceProxyRead({0xf949240, 0xc00e6ed770}, 0x0?, {0xe3b9620?, 0xc016c75c00?})
	/Users/ewbankkit/src/github.com/terraform-providers/terraform-provider-aws/internal/service/rds/proxy_data_source.go:109 +0x3cc
github.com/hashicorp/terraform-provider-aws/internal/provider.interceptedHandler[...].func1(0x0?, {0xe3b9620?, 0xc016c75c00?})
	/Users/ewbankkit/src/github.com/terraform-providers/terraform-provider-aws/internal/provider/intercept.go:94 +0x175
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xf949240?, {0xf949240?, 0xc00e6eccc0?}, 0xd?, {0xe3b9620?, 0xc016c75c00?})
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/resource.go:719 +0x87
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).ReadDataApply(0xc005e74e00, {0xf949240, 0xc00e6eccc0}, 0xc0172a3e80, {0xe3b9620, 0xc016c75c00})
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/resource.go:943 +0x145
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadDataSource(0xc005fe5ef0, {0xf949240?, 0xc00e6ecc00?}, 0xc016ba32e0)
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/grpc_provider.go:1195 +0x38f
github.com/hashicorp/terraform-plugin-mux/tf5muxserver.muxServer.ReadDataSource({0xc00886fa40, 0xc00886faa0, {0xc016983440, 0x2, 0x2}, {0x0, 0x0, 0x0}, {0x0, 0x0, ...}, ...}, ...)
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-mux@v0.9.0/tf5muxserver/mux_server_ReadDataSource.go:27 +0x102
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadDataSource(0xc014ade780, {0xf949240?, 0xc00e6ec180?}, 0xc017105e50)
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov5/tf5server/server.go:658 +0x403
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadDataSource_Handler({0xe0b1020?, 0xc014ade780}, {0xf949240, 0xc00e6ec180}, 0xc0172b3030, 0x0)
	/Users/ewbankkit/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:421 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc015acba40, {0xf958ec0, 0xc014e2c1a0}, 0xc010594000, 0xc00b7802d0, 0x163dbab0, 0x0)
	/Users/ewbankkit/go/pkg/mod/google.golang.org/grpc@v1.53.0/server.go:1336 +0xd23
google.golang.org/grpc.(*Server).handleStream(0xc015acba40, {0xf958ec0, 0xc014e2c1a0}, 0xc010594000, 0x0)
	/Users/ewbankkit/go/pkg/mod/google.golang.org/grpc@v1.53.0/server.go:1704 +0xa2f
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	/Users/ewbankkit/go/pkg/mod/google.golang.org/grpc@v1.53.0/server.go:965 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/Users/ewbankkit/go/pkg/mod/google.golang.org/grpc@v1.53.0/server.go:963 +0x28a
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/rds	2350.957s
=== RUN   TestAccRedshiftAuthenticationProfile_basic
=== PAUSE TestAccRedshiftAuthenticationProfile_basic
=== RUN   TestAccRedshiftClusterCredentialsDataSource_basic
=== PAUSE TestAccRedshiftClusterCredentialsDataSource_basic
=== RUN   TestAccRedshiftClusterDataSource_basic
=== PAUSE TestAccRedshiftClusterDataSource_basic
=== RUN   TestAccRedshiftClusterIAMRoles_basic
=== PAUSE TestAccRedshiftClusterIAMRoles_basic
=== RUN   TestAccRedshiftClusterSnapshot_basic
=== PAUSE TestAccRedshiftClusterSnapshot_basic
=== RUN   TestAccRedshiftClusterSnapshot_tags
=== PAUSE TestAccRedshiftClusterSnapshot_tags
=== RUN   TestAccRedshiftCluster_basic
=== PAUSE TestAccRedshiftCluster_basic
=== RUN   TestAccRedshiftCluster_tags
=== PAUSE TestAccRedshiftCluster_tags
=== RUN   TestAccRedshiftEndpointAccess_basic
=== PAUSE TestAccRedshiftEndpointAccess_basic
=== RUN   TestAccRedshiftEndpointAuthorization_basic
=== PAUSE TestAccRedshiftEndpointAuthorization_basic
=== RUN   TestAccRedshiftEventSubscription_basic
=== PAUSE TestAccRedshiftEventSubscription_basic
=== RUN   TestAccRedshiftEventSubscription_tags
=== PAUSE TestAccRedshiftEventSubscription_tags
=== RUN   TestAccRedshiftHSMClientCertificate_basic
=== PAUSE TestAccRedshiftHSMClientCertificate_basic
=== RUN   TestAccRedshiftHSMClientCertificate_tags
=== PAUSE TestAccRedshiftHSMClientCertificate_tags
=== RUN   TestAccRedshiftHSMConfiguration_basic
=== PAUSE TestAccRedshiftHSMConfiguration_basic
=== RUN   TestAccRedshiftHSMConfiguration_tags
=== PAUSE TestAccRedshiftHSMConfiguration_tags
=== RUN   TestAccRedshiftParameterGroup_basic
=== PAUSE TestAccRedshiftParameterGroup_basic
=== RUN   TestAccRedshiftParameterGroup_tags
=== PAUSE TestAccRedshiftParameterGroup_tags
=== RUN   TestAccRedshiftPartner_basic
=== PAUSE TestAccRedshiftPartner_basic
=== RUN   TestAccRedshiftServiceAccountDataSource_basic
=== PAUSE TestAccRedshiftServiceAccountDataSource_basic
=== RUN   TestAccRedshiftSnapshotCopyGrant_basic
=== PAUSE TestAccRedshiftSnapshotCopyGrant_basic
=== RUN   TestAccRedshiftSnapshotScheduleAssociation_basic
=== PAUSE TestAccRedshiftSnapshotScheduleAssociation_basic
=== RUN   TestAccRedshiftSnapshotSchedule_basic
=== PAUSE TestAccRedshiftSnapshotSchedule_basic
=== RUN   TestAccRedshiftSubnetGroupDataSource_basic
=== PAUSE TestAccRedshiftSubnetGroupDataSource_basic
=== RUN   TestAccRedshiftSubnetGroup_basic
=== PAUSE TestAccRedshiftSubnetGroup_basic
=== RUN   TestAccRedshiftSubnetGroup_tags
=== PAUSE TestAccRedshiftSubnetGroup_tags
=== RUN   TestAccRedshiftUsageLimit_basic
=== PAUSE TestAccRedshiftUsageLimit_basic
=== RUN   TestAccRedshiftUsageLimit_tags
=== PAUSE TestAccRedshiftUsageLimit_tags
=== CONT  TestAccRedshiftAuthenticationProfile_basic
=== CONT  TestAccRedshiftHSMConfiguration_basic
=== CONT  TestAccRedshiftSnapshotScheduleAssociation_basic
--- PASS: TestAccRedshiftHSMConfiguration_basic (71.65s)
=== CONT  TestAccRedshiftUsageLimit_tags
--- PASS: TestAccRedshiftAuthenticationProfile_basic (100.05s)
=== CONT  TestAccRedshiftUsageLimit_basic
--- PASS: TestAccRedshiftSnapshotScheduleAssociation_basic (349.99s)
=== CONT  TestAccRedshiftSubnetGroup_tags
--- PASS: TestAccRedshiftUsageLimit_basic (292.99s)
=== CONT  TestAccRedshiftSubnetGroup_basic
--- PASS: TestAccRedshiftUsageLimit_tags (348.53s)
=== CONT  TestAccRedshiftSubnetGroupDataSource_basic
--- PASS: TestAccRedshiftSubnetGroup_basic (57.45s)
=== CONT  TestAccRedshiftSnapshotSchedule_basic
--- PASS: TestAccRedshiftSubnetGroupDataSource_basic (47.18s)
=== CONT  TestAccRedshiftPartner_basic
--- PASS: TestAccRedshiftSubnetGroup_tags (123.12s)
=== CONT  TestAccRedshiftSnapshotCopyGrant_basic
--- PASS: TestAccRedshiftSnapshotCopyGrant_basic (34.09s)
=== CONT  TestAccRedshiftServiceAccountDataSource_basic
--- PASS: TestAccRedshiftSnapshotSchedule_basic (57.81s)
=== CONT  TestAccRedshiftCluster_tags
--- PASS: TestAccRedshiftServiceAccountDataSource_basic (12.77s)
=== CONT  TestAccRedshiftClusterSnapshot_basic
--- PASS: TestAccRedshiftPartner_basic (207.68s)
=== CONT  TestAccRedshiftHSMClientCertificate_tags
--- PASS: TestAccRedshiftHSMClientCertificate_tags (56.09s)
=== CONT  TestAccRedshiftCluster_basic
--- PASS: TestAccRedshiftCluster_tags (546.78s)
=== CONT  TestAccRedshiftHSMClientCertificate_basic
--- PASS: TestAccRedshiftHSMClientCertificate_basic (33.59s)
=== CONT  TestAccRedshiftClusterSnapshot_tags
--- PASS: TestAccRedshiftCluster_basic (533.28s)
=== CONT  TestAccRedshiftEventSubscription_tags
--- PASS: TestAccRedshiftClusterSnapshot_basic (745.90s)
=== CONT  TestAccRedshiftClusterDataSource_basic
=== CONT  TestAccRedshiftEventSubscription_tags
    event_subscription_test.go:153: Step 3/4 error: Check failed: Check 2/4 error: aws_redshift_event_subscription.test: Attribute 'tags.%' expected "2", got "0"
--- FAIL: TestAccRedshiftEventSubscription_tags (46.67s)
=== CONT  TestAccRedshiftEventSubscription_basic
--- PASS: TestAccRedshiftEventSubscription_basic (45.67s)
=== CONT  TestAccRedshiftEndpointAuthorization_basic
    acctest.go:772: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRedshiftEndpointAuthorization_basic (0.00s)
=== CONT  TestAccRedshiftEndpointAccess_basic
--- PASS: TestAccRedshiftClusterDataSource_basic (250.35s)
=== CONT  TestAccRedshiftClusterCredentialsDataSource_basic
--- PASS: TestAccRedshiftClusterSnapshot_tags (591.94s)
=== CONT  TestAccRedshiftClusterIAMRoles_basic
--- PASS: TestAccRedshiftClusterCredentialsDataSource_basic (228.62s)
=== CONT  TestAccRedshiftParameterGroup_basic
--- PASS: TestAccRedshiftParameterGroup_basic (17.49s)
=== CONT  TestAccRedshiftParameterGroup_tags
--- PASS: TestAccRedshiftParameterGroup_tags (38.54s)
=== CONT  TestAccRedshiftHSMConfiguration_tags
--- PASS: TestAccRedshiftHSMConfiguration_tags (40.33s)
--- PASS: TestAccRedshiftClusterIAMRoles_basic (300.83s)
--- PASS: TestAccRedshiftEndpointAccess_basic (902.60s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	2285.704s
=== RUN   TestAccRedshiftDataStatement_basic
=== PAUSE TestAccRedshiftDataStatement_basic
=== CONT  TestAccRedshiftDataStatement_basic
--- PASS: TestAccRedshiftDataStatement_basic (283.28s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshiftdata	331.822s
=== RUN   TestAccRedshiftServerlessCredentialsDataSource_basic
=== PAUSE TestAccRedshiftServerlessCredentialsDataSource_basic
=== RUN   TestAccRedshiftServerlessEndpointAccess_basic
=== PAUSE TestAccRedshiftServerlessEndpointAccess_basic
=== RUN   TestAccRedshiftServerlessNamespace_basic
=== PAUSE TestAccRedshiftServerlessNamespace_basic
=== RUN   TestAccRedshiftServerlessNamespace_tags
=== PAUSE TestAccRedshiftServerlessNamespace_tags
=== RUN   TestAccRedshiftServerlessResourcePolicy_basic
=== PAUSE TestAccRedshiftServerlessResourcePolicy_basic
=== RUN   TestAccRedshiftServerlessSnapshot_basic
=== PAUSE TestAccRedshiftServerlessSnapshot_basic
=== RUN   TestAccRedshiftServerlessUsageLimit_basic
=== PAUSE TestAccRedshiftServerlessUsageLimit_basic
=== RUN   TestAccRedshiftServerlessWorkgroup_basic
=== PAUSE TestAccRedshiftServerlessWorkgroup_basic
=== RUN   TestAccRedshiftServerlessWorkgroup_tags
=== PAUSE TestAccRedshiftServerlessWorkgroup_tags
=== CONT  TestAccRedshiftServerlessCredentialsDataSource_basic
=== CONT  TestAccRedshiftServerlessSnapshot_basic
=== CONT  TestAccRedshiftServerlessWorkgroup_basic
--- PASS: TestAccRedshiftServerlessCredentialsDataSource_basic (555.77s)
=== CONT  TestAccRedshiftServerlessWorkgroup_tags
--- PASS: TestAccRedshiftServerlessWorkgroup_basic (694.42s)
=== CONT  TestAccRedshiftServerlessNamespace_tags
--- PASS: TestAccRedshiftServerlessNamespace_tags (62.97s)
=== CONT  TestAccRedshiftServerlessResourcePolicy_basic
    acctest.go:772: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRedshiftServerlessResourcePolicy_basic (0.00s)
=== CONT  TestAccRedshiftServerlessUsageLimit_basic
--- PASS: TestAccRedshiftServerlessSnapshot_basic (894.65s)
=== CONT  TestAccRedshiftServerlessNamespace_basic
--- PASS: TestAccRedshiftServerlessNamespace_basic (39.91s)
=== CONT  TestAccRedshiftServerlessEndpointAccess_basic
--- PASS: TestAccRedshiftServerlessWorkgroup_tags (644.26s)
--- PASS: TestAccRedshiftServerlessUsageLimit_basic (882.08s)
--- PASS: TestAccRedshiftServerlessEndpointAccess_basic (1415.98s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshiftserverless	2387.193s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/resourceexplorer2	44.759s [no tests to run]
=== RUN   TestAccResourceGroupsGroup_basic
=== PAUSE TestAccResourceGroupsGroup_basic
=== RUN   TestAccResourceGroupsGroup_tags
=== PAUSE TestAccResourceGroupsGroup_tags
=== CONT  TestAccResourceGroupsGroup_basic
=== CONT  TestAccResourceGroupsGroup_tags
--- PASS: TestAccResourceGroupsGroup_basic (72.21s)
--- PASS: TestAccResourceGroupsGroup_tags (91.91s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroups	137.157s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroupstaggingapi	10.179s [no tests to run]
=== RUN   TestAccRolesAnywhereProfile_basic
=== PAUSE TestAccRolesAnywhereProfile_basic
=== RUN   TestAccRolesAnywhereProfile_tags
=== PAUSE TestAccRolesAnywhereProfile_tags
=== RUN   TestAccRolesAnywhereTrustAnchor_basic
=== PAUSE TestAccRolesAnywhereTrustAnchor_basic
=== RUN   TestAccRolesAnywhereTrustAnchor_tags
=== PAUSE TestAccRolesAnywhereTrustAnchor_tags
=== CONT  TestAccRolesAnywhereProfile_basic
=== CONT  TestAccRolesAnywhereTrustAnchor_basic
=== CONT  TestAccRolesAnywhereTrustAnchor_tags
=== CONT  TestAccRolesAnywhereTrustAnchor_basic
    trust_anchor_test.go:25: Step 1/2 error: Error running apply: exit status 1
        
        Error: creating RolesAnywhere Trust Anchor (tf-acc-test-6790653190008838439): operation error RolesAnywhere: CreateTrustAnchor, https response error StatusCode: 403, RequestID: 60c08ff0-65c2-4fe9-8d3b-d74a952e5e9a, AccessDeniedException: Unauthorized because no identity-based policy allows for the iam:CreateServiceLinkedRole action
        
          with aws_rolesanywhere_trust_anchor.test,
          on terraform_plugin_test.tf line 35, in resource "aws_rolesanywhere_trust_anchor" "test":
          35: resource "aws_rolesanywhere_trust_anchor" "test" {
        
--- FAIL: TestAccRolesAnywhereTrustAnchor_basic (23.03s)
=== CONT  TestAccRolesAnywhereProfile_tags
--- PASS: TestAccRolesAnywhereProfile_basic (33.55s)
--- PASS: TestAccRolesAnywhereTrustAnchor_tags (101.74s)
--- PASS: TestAccRolesAnywhereProfile_tags (93.84s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/rolesanywhere	128.519s
=== RUN   TestAccRoute53CIDRCollection_basic
=== PAUSE TestAccRoute53CIDRCollection_basic
=== RUN   TestAccRoute53CIDRLocation_basic
=== PAUSE TestAccRoute53CIDRLocation_basic
=== RUN   TestAccRoute53DelegationSetDataSource_basic
--- PASS: TestAccRoute53DelegationSetDataSource_basic (76.26s)
=== RUN   TestAccRoute53DelegationSet_basic
=== PAUSE TestAccRoute53DelegationSet_basic
=== RUN   TestAccRoute53HealthCheck_basic
=== PAUSE TestAccRoute53HealthCheck_basic
=== RUN   TestAccRoute53HealthCheck_tags
=== PAUSE TestAccRoute53HealthCheck_tags
=== RUN   TestAccRoute53HostedZoneDNSSEC_basic
=== PAUSE TestAccRoute53HostedZoneDNSSEC_basic
=== RUN   TestAccRoute53KeySigningKey_basic
=== PAUSE TestAccRoute53KeySigningKey_basic
=== RUN   TestAccRoute53QueryLog_basic
=== PAUSE TestAccRoute53QueryLog_basic
=== RUN   TestAccRoute53Record_basic
=== PAUSE TestAccRoute53Record_basic
=== RUN   TestAccRoute53Record_Weighted_basic
=== PAUSE TestAccRoute53Record_Weighted_basic
=== RUN   TestAccRoute53Record_WeightedToSimple_basic
=== PAUSE TestAccRoute53Record_WeightedToSimple_basic
=== RUN   TestAccRoute53Record_Geolocation_basic
=== PAUSE TestAccRoute53Record_Geolocation_basic
=== RUN   TestAccRoute53Record_Latency_basic
=== PAUSE TestAccRoute53Record_Latency_basic
=== RUN   TestAccRoute53Record_MultiValueAnswer_basic
=== PAUSE TestAccRoute53Record_MultiValueAnswer_basic
=== RUN   TestAccRoute53TrafficPolicyDocumentDataSource_basic
=== PAUSE TestAccRoute53TrafficPolicyDocumentDataSource_basic
=== RUN   TestAccRoute53TrafficPolicyInstance_basic
=== PAUSE TestAccRoute53TrafficPolicyInstance_basic
=== RUN   TestAccRoute53TrafficPolicy_basic
=== PAUSE TestAccRoute53TrafficPolicy_basic
=== RUN   TestAccRoute53VPCAssociationAuthorization_basic
=== PAUSE TestAccRoute53VPCAssociationAuthorization_basic
=== RUN   TestAccRoute53ZoneAssociation_basic
=== PAUSE TestAccRoute53ZoneAssociation_basic
=== RUN   TestAccRoute53ZoneDataSource_tags
=== PAUSE TestAccRoute53ZoneDataSource_tags
=== RUN   TestAccRoute53Zone_basic
=== PAUSE TestAccRoute53Zone_basic
=== RUN   TestAccRoute53Zone_tags
=== PAUSE TestAccRoute53Zone_tags
=== CONT  TestAccRoute53CIDRCollection_basic
=== CONT  TestAccRoute53Record_Geolocation_basic
=== CONT  TestAccRoute53KeySigningKey_basic
    acctest.go:834: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccRoute53KeySigningKey_basic (0.00s)
=== CONT  TestAccRoute53VPCAssociationAuthorization_basic
    acctest.go:772: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRoute53VPCAssociationAuthorization_basic (0.00s)
=== CONT  TestAccRoute53Zone_tags
--- PASS: TestAccRoute53CIDRCollection_basic (38.96s)
=== CONT  TestAccRoute53Zone_basic
--- PASS: TestAccRoute53Zone_basic (78.96s)
=== CONT  TestAccRoute53ZoneDataSource_tags
--- PASS: TestAccRoute53Zone_tags (167.57s)
=== CONT  TestAccRoute53ZoneAssociation_basic
--- PASS: TestAccRoute53Record_Geolocation_basic (169.61s)
=== CONT  TestAccRoute53Record_Weighted_basic
--- PASS: TestAccRoute53ZoneDataSource_tags (95.34s)
=== CONT  TestAccRoute53Record_WeightedToSimple_basic
--- PASS: TestAccRoute53ZoneAssociation_basic (150.74s)
=== CONT  TestAccRoute53TrafficPolicyDocumentDataSource_basic
--- PASS: TestAccRoute53TrafficPolicyDocumentDataSource_basic (13.25s)
=== CONT  TestAccRoute53TrafficPolicy_basic
--- PASS: TestAccRoute53Record_Weighted_basic (177.25s)
=== CONT  TestAccRoute53TrafficPolicyInstance_basic
--- PASS: TestAccRoute53TrafficPolicy_basic (17.64s)
=== CONT  TestAccRoute53HealthCheck_basic
--- PASS: TestAccRoute53HealthCheck_basic (33.22s)
=== CONT  TestAccRoute53HostedZoneDNSSEC_basic
    acctest.go:834: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccRoute53HostedZoneDNSSEC_basic (0.00s)
=== CONT  TestAccRoute53HealthCheck_tags
--- PASS: TestAccRoute53Record_WeightedToSimple_basic (201.60s)
=== CONT  TestAccRoute53DelegationSet_basic
--- PASS: TestAccRoute53HealthCheck_tags (60.05s)
=== CONT  TestAccRoute53QueryLog_basic
    acctest.go:834: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccRoute53QueryLog_basic (0.00s)
=== CONT  TestAccRoute53CIDRLocation_basic
--- PASS: TestAccRoute53DelegationSet_basic (27.71s)
=== CONT  TestAccRoute53Record_MultiValueAnswer_basic
--- PASS: TestAccRoute53CIDRLocation_basic (26.33s)
=== CONT  TestAccRoute53Record_basic
--- PASS: TestAccRoute53TrafficPolicyInstance_basic (156.82s)
=== CONT  TestAccRoute53Record_Latency_basic
--- PASS: TestAccRoute53Record_MultiValueAnswer_basic (118.95s)
--- PASS: TestAccRoute53Record_basic (144.74s)
--- PASS: TestAccRoute53Record_Latency_basic (161.85s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	757.079s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53domains	16.567s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53recoverycontrolconfig	16.883s [no tests to run]
=== RUN   TestAccRoute53RecoveryReadinessCell_basic
=== PAUSE TestAccRoute53RecoveryReadinessCell_basic
=== RUN   TestAccRoute53RecoveryReadinessCell_tags
=== PAUSE TestAccRoute53RecoveryReadinessCell_tags
=== RUN   TestAccRoute53RecoveryReadinessReadinessCheck_basic
=== PAUSE TestAccRoute53RecoveryReadinessReadinessCheck_basic
=== RUN   TestAccRoute53RecoveryReadinessReadinessCheck_tags
=== PAUSE TestAccRoute53RecoveryReadinessReadinessCheck_tags
=== RUN   TestAccRoute53RecoveryReadinessRecoveryGroup_basic
=== PAUSE TestAccRoute53RecoveryReadinessRecoveryGroup_basic
=== RUN   TestAccRoute53RecoveryReadinessRecoveryGroup_tags
=== PAUSE TestAccRoute53RecoveryReadinessRecoveryGroup_tags
=== RUN   TestAccRoute53RecoveryReadinessResourceSet_basic
=== PAUSE TestAccRoute53RecoveryReadinessResourceSet_basic
=== RUN   TestAccRoute53RecoveryReadinessResourceSet_tags
=== PAUSE TestAccRoute53RecoveryReadinessResourceSet_tags
=== CONT  TestAccRoute53RecoveryReadinessCell_basic
=== CONT  TestAccRoute53RecoveryReadinessRecoveryGroup_basic
=== CONT  TestAccRoute53RecoveryReadinessResourceSet_tags
=== CONT  TestAccRoute53RecoveryReadinessRecoveryGroup_basic
    recovery_group_test.go:24: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_route53recoveryreadiness_recovery_group.test will be updated in-place
          ~ resource "aws_route53recoveryreadiness_recovery_group" "test" {
                id                  = "tf-acc-test-4505256912069131627"
              + tags_all            = (known after apply)
                # (2 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccRoute53RecoveryReadinessRecoveryGroup_basic (26.71s)
=== CONT  TestAccRoute53RecoveryReadinessResourceSet_basic
=== CONT  TestAccRoute53RecoveryReadinessResourceSet_tags
    resource_set_test.go:99: Step 2/4 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
        
          map[string]string{
        - 	"tags.%":        "1",
        - 	"tags.key1":     "value1",
        - 	"tags_all.%":    "1",
        - 	"tags_all.key1": "value1",
          }
--- PASS: TestAccRoute53RecoveryReadinessCell_basic (39.88s)
=== CONT  TestAccRoute53RecoveryReadinessRecoveryGroup_tags
--- FAIL: TestAccRoute53RecoveryReadinessResourceSet_tags (40.34s)
=== CONT  TestAccRoute53RecoveryReadinessReadinessCheck_basic
=== CONT  TestAccRoute53RecoveryReadinessResourceSet_basic
    resource_set_test.go:33: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_route53recoveryreadiness_resource_set.test will be updated in-place
          ~ resource "aws_route53recoveryreadiness_resource_set" "test" {
                id                = "tf-acc-test-6696650215917224987"
              + tags_all          = (known after apply)
                # (3 unchanged attributes hidden)
        
              ~ resources {
                  + readiness_scopes = []
                    # (1 unchanged attribute hidden)
                }
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccRoute53RecoveryReadinessResourceSet_basic (26.37s)
=== CONT  TestAccRoute53RecoveryReadinessReadinessCheck_tags
=== CONT  TestAccRoute53RecoveryReadinessReadinessCheck_basic
    readiness_check_test.go:34: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_route53recoveryreadiness_resource_set.test will be updated in-place
          ~ resource "aws_route53recoveryreadiness_resource_set" "test" {
                id                = "tf-acc-test-set-2557407895367482572"
              + tags_all          = (known after apply)
                # (3 unchanged attributes hidden)
        
              ~ resources {
                  + readiness_scopes = []
                    # (1 unchanged attribute hidden)
                }
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccRoute53RecoveryReadinessReadinessCheck_basic (31.43s)
=== CONT  TestAccRoute53RecoveryReadinessCell_tags
=== CONT  TestAccRoute53RecoveryReadinessRecoveryGroup_tags
    recovery_group_test.go:103: Step 2/4 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
        
          map[string]string{
        - 	"tags.%":        "1",
        - 	"tags.key1":     "value1",
        - 	"tags_all.%":    "1",
        - 	"tags_all.key1": "value1",
          }
=== CONT  TestAccRoute53RecoveryReadinessReadinessCheck_tags
    readiness_check_test.go:100: Step 1/4 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_route53recoveryreadiness_resource_set.test will be updated in-place
          ~ resource "aws_route53recoveryreadiness_resource_set" "test" {
                id                = "resource-set-for-testing"
              + tags_all          = (known after apply)
                # (3 unchanged attributes hidden)
        
              ~ resources {
                  + readiness_scopes = []
                    # (1 unchanged attribute hidden)
                }
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccRoute53RecoveryReadinessRecoveryGroup_tags (39.69s)
--- FAIL: TestAccRoute53RecoveryReadinessReadinessCheck_tags (29.97s)
--- PASS: TestAccRoute53RecoveryReadinessCell_tags (103.65s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/route53recoveryreadiness	191.929s
=== RUN   TestAccRoute53ResolverConfig_basic
=== PAUSE TestAccRoute53ResolverConfig_basic
=== RUN   TestAccRoute53ResolverDNSSECConfig_basic
=== PAUSE TestAccRoute53ResolverDNSSECConfig_basic
=== RUN   TestAccRoute53ResolverEndpointDataSource_basic
=== PAUSE TestAccRoute53ResolverEndpointDataSource_basic
=== RUN   TestAccRoute53ResolverEndpoint_basic
=== PAUSE TestAccRoute53ResolverEndpoint_basic
=== RUN   TestAccRoute53ResolverEndpoint_tags
=== PAUSE TestAccRoute53ResolverEndpoint_tags
=== RUN   TestAccRoute53ResolverFirewallConfigDataSource_basic
--- PASS: TestAccRoute53ResolverFirewallConfigDataSource_basic (44.09s)
=== RUN   TestAccRoute53ResolverFirewallConfig_basic
=== PAUSE TestAccRoute53ResolverFirewallConfig_basic
=== RUN   TestAccRoute53ResolverFirewallDomainListDataSource_basic
--- PASS: TestAccRoute53ResolverFirewallDomainListDataSource_basic (120.35s)
=== RUN   TestAccRoute53ResolverFirewallDomainList_basic
=== PAUSE TestAccRoute53ResolverFirewallDomainList_basic
=== RUN   TestAccRoute53ResolverFirewallDomainList_tags
=== PAUSE TestAccRoute53ResolverFirewallDomainList_tags
=== RUN   TestAccRoute53ResolverRuleGroupAssociationDataSource_basic
--- PASS: TestAccRoute53ResolverRuleGroupAssociationDataSource_basic (147.37s)
=== RUN   TestAccRoute53ResolverFirewallRuleGroupAssociation_basic
=== PAUSE TestAccRoute53ResolverFirewallRuleGroupAssociation_basic
=== RUN   TestAccRoute53ResolverFirewallRuleGroupAssociation_tags
=== PAUSE TestAccRoute53ResolverFirewallRuleGroupAssociation_tags
=== RUN   TestAccRoute53ResolverFirewallRuleGroupDataSource_basic
--- PASS: TestAccRoute53ResolverFirewallRuleGroupDataSource_basic (21.59s)
=== RUN   TestAccRoute53ResolverFirewallRuleGroup_basic
=== PAUSE TestAccRoute53ResolverFirewallRuleGroup_basic
=== RUN   TestAccRoute53ResolverFirewallRuleGroup_tags
=== PAUSE TestAccRoute53ResolverFirewallRuleGroup_tags
=== RUN   TestAccRoute53ResolverFirewallRule_basic
=== PAUSE TestAccRoute53ResolverFirewallRule_basic
=== RUN   TestAccRoute53ResolverFirewallRulesDataSource_basic
=== PAUSE TestAccRoute53ResolverFirewallRulesDataSource_basic
=== RUN   TestAccRoute53ResolverQueryLogConfigAssociation_basic
=== PAUSE TestAccRoute53ResolverQueryLogConfigAssociation_basic
=== RUN   TestAccRoute53ResolverQueryLogConfig_basic
=== PAUSE TestAccRoute53ResolverQueryLogConfig_basic
=== RUN   TestAccRoute53ResolverQueryLogConfig_tags
=== PAUSE TestAccRoute53ResolverQueryLogConfig_tags
=== RUN   TestAccRoute53ResolverRuleAssociation_basic
=== PAUSE TestAccRoute53ResolverRuleAssociation_basic
=== RUN   TestAccRoute53ResolverRuleDataSource_basic
=== PAUSE TestAccRoute53ResolverRuleDataSource_basic
=== RUN   TestAccRoute53ResolverRule_basic
=== PAUSE TestAccRoute53ResolverRule_basic
=== RUN   TestAccRoute53ResolverRule_tags
=== PAUSE TestAccRoute53ResolverRule_tags
=== RUN   TestAccRoute53ResolverRulesDataSource_basic
=== PAUSE TestAccRoute53ResolverRulesDataSource_basic
=== CONT  TestAccRoute53ResolverConfig_basic
=== CONT  TestAccRoute53ResolverFirewallRuleGroup_tags
=== CONT  TestAccRoute53ResolverRuleAssociation_basic
--- PASS: TestAccRoute53ResolverFirewallRuleGroup_tags (66.93s)
=== CONT  TestAccRoute53ResolverRule_tags
--- PASS: TestAccRoute53ResolverRule_tags (50.08s)
=== CONT  TestAccRoute53ResolverRulesDataSource_basic
--- PASS: TestAccRoute53ResolverRulesDataSource_basic (14.40s)
=== CONT  TestAccRoute53ResolverFirewallDomainList_basic
--- PASS: TestAccRoute53ResolverRuleAssociation_basic (188.83s)
=== CONT  TestAccRoute53ResolverFirewallRuleGroup_basic
--- PASS: TestAccRoute53ResolverFirewallDomainList_basic (62.31s)
=== CONT  TestAccRoute53ResolverEndpoint_basic
--- PASS: TestAccRoute53ResolverFirewallRuleGroup_basic (22.95s)
=== CONT  TestAccRoute53ResolverFirewallConfig_basic
--- PASS: TestAccRoute53ResolverFirewallConfig_basic (30.77s)
=== CONT  TestAccRoute53ResolverFirewallRuleGroupAssociation_tags
--- PASS: TestAccRoute53ResolverEndpoint_basic (105.46s)
=== CONT  TestAccRoute53ResolverEndpoint_tags
--- PASS: TestAccRoute53ResolverFirewallRuleGroupAssociation_tags (217.99s)
=== CONT  TestAccRoute53ResolverFirewallRuleGroupAssociation_basic
--- PASS: TestAccRoute53ResolverConfig_basic (462.44s)
=== CONT  TestAccRoute53ResolverQueryLogConfigAssociation_basic
--- PASS: TestAccRoute53ResolverEndpoint_tags (187.26s)
=== CONT  TestAccRoute53ResolverQueryLogConfig_tags
--- PASS: TestAccRoute53ResolverQueryLogConfigAssociation_basic (40.32s)
=== CONT  TestAccRoute53ResolverQueryLogConfig_basic
--- PASS: TestAccRoute53ResolverQueryLogConfig_basic (26.59s)
=== CONT  TestAccRoute53ResolverFirewallRulesDataSource_basic
--- PASS: TestAccRoute53ResolverQueryLogConfig_tags (50.13s)
=== CONT  TestAccRoute53ResolverFirewallDomainList_tags
--- PASS: TestAccRoute53ResolverFirewallRuleGroupAssociation_basic (175.60s)
=== CONT  TestAccRoute53ResolverFirewallRule_basic
--- PASS: TestAccRoute53ResolverFirewallDomainList_tags (111.42s)
=== CONT  TestAccRoute53ResolverEndpointDataSource_basic
--- PASS: TestAccRoute53ResolverFirewallRule_basic (67.59s)
=== CONT  TestAccRoute53ResolverRule_basic
--- PASS: TestAccRoute53ResolverFirewallRulesDataSource_basic (179.50s)
=== CONT  TestAccRoute53ResolverRuleDataSource_basic
--- PASS: TestAccRoute53ResolverRule_basic (25.74s)
=== CONT  TestAccRoute53ResolverDNSSECConfig_basic
--- PASS: TestAccRoute53ResolverRuleDataSource_basic (25.06s)
--- PASS: TestAccRoute53ResolverEndpointDataSource_basic (106.06s)
--- PASS: TestAccRoute53ResolverDNSSECConfig_basic (417.17s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53resolver	1495.633s
=== RUN   TestAccRUMAppMonitor_basic
=== PAUSE TestAccRUMAppMonitor_basic
=== RUN   TestAccRUMAppMonitor_tags
=== PAUSE TestAccRUMAppMonitor_tags
=== RUN   TestAccRUMMetricsDestination_basic
=== PAUSE TestAccRUMMetricsDestination_basic
=== CONT  TestAccRUMAppMonitor_basic
=== CONT  TestAccRUMMetricsDestination_basic
=== CONT  TestAccRUMAppMonitor_tags
--- PASS: TestAccRUMMetricsDestination_basic (52.95s)
--- PASS: TestAccRUMAppMonitor_basic (78.36s)
--- PASS: TestAccRUMAppMonitor_tags (99.77s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rum	109.866s
FAIL
make: *** [testacc] Error 1
```
```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=route53recoveryreadiness ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53recoveryreadiness/... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccRoute53RecoveryReadinessCell_basic
=== PAUSE TestAccRoute53RecoveryReadinessCell_basic
=== RUN   TestAccRoute53RecoveryReadinessCell_tags
=== PAUSE TestAccRoute53RecoveryReadinessCell_tags
=== RUN   TestAccRoute53RecoveryReadinessReadinessCheck_basic
=== PAUSE TestAccRoute53RecoveryReadinessReadinessCheck_basic
=== RUN   TestAccRoute53RecoveryReadinessReadinessCheck_tags
=== PAUSE TestAccRoute53RecoveryReadinessReadinessCheck_tags
=== RUN   TestAccRoute53RecoveryReadinessRecoveryGroup_basic
=== PAUSE TestAccRoute53RecoveryReadinessRecoveryGroup_basic
=== RUN   TestAccRoute53RecoveryReadinessRecoveryGroup_tags
=== PAUSE TestAccRoute53RecoveryReadinessRecoveryGroup_tags
=== RUN   TestAccRoute53RecoveryReadinessResourceSet_basic
=== PAUSE TestAccRoute53RecoveryReadinessResourceSet_basic
=== RUN   TestAccRoute53RecoveryReadinessResourceSet_tags
=== PAUSE TestAccRoute53RecoveryReadinessResourceSet_tags
=== CONT  TestAccRoute53RecoveryReadinessCell_basic
=== CONT  TestAccRoute53RecoveryReadinessRecoveryGroup_basic
=== CONT  TestAccRoute53RecoveryReadinessResourceSet_basic
--- PASS: TestAccRoute53RecoveryReadinessResourceSet_basic (29.36s)
=== CONT  TestAccRoute53RecoveryReadinessRecoveryGroup_tags
--- PASS: TestAccRoute53RecoveryReadinessCell_basic (29.47s)
=== CONT  TestAccRoute53RecoveryReadinessReadinessCheck_basic
--- PASS: TestAccRoute53RecoveryReadinessRecoveryGroup_basic (29.65s)
=== CONT  TestAccRoute53RecoveryReadinessReadinessCheck_tags
--- PASS: TestAccRoute53RecoveryReadinessReadinessCheck_basic (34.93s)
=== CONT  TestAccRoute53RecoveryReadinessCell_tags
--- PASS: TestAccRoute53RecoveryReadinessRecoveryGroup_tags (80.46s)
=== CONT  TestAccRoute53RecoveryReadinessResourceSet_tags
--- PASS: TestAccRoute53RecoveryReadinessReadinessCheck_tags (86.12s)
--- PASS: TestAccRoute53RecoveryReadinessCell_tags (72.41s)
--- PASS: TestAccRoute53RecoveryReadinessResourceSet_tags (51.40s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53recoveryreadiness	179.824s
% make testacc TESTARGS='-run=TestAccRedshiftEventSubscription_' PKG=redshift ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/redshift/... -v -count 1 -parallel 3  -run=TestAccRedshiftEventSubscription_ -timeout 180m
=== RUN   TestAccRedshiftEventSubscription_basic
=== PAUSE TestAccRedshiftEventSubscription_basic
=== RUN   TestAccRedshiftEventSubscription_withSourceIDs
=== PAUSE TestAccRedshiftEventSubscription_withSourceIDs
=== RUN   TestAccRedshiftEventSubscription_categoryUpdate
=== PAUSE TestAccRedshiftEventSubscription_categoryUpdate
=== RUN   TestAccRedshiftEventSubscription_tags
=== PAUSE TestAccRedshiftEventSubscription_tags
=== RUN   TestAccRedshiftEventSubscription_disappears
=== PAUSE TestAccRedshiftEventSubscription_disappears
=== CONT  TestAccRedshiftEventSubscription_basic
=== CONT  TestAccRedshiftEventSubscription_tags
=== CONT  TestAccRedshiftEventSubscription_disappears
--- PASS: TestAccRedshiftEventSubscription_disappears (24.35s)
=== CONT  TestAccRedshiftEventSubscription_categoryUpdate
--- PASS: TestAccRedshiftEventSubscription_basic (54.15s)
=== CONT  TestAccRedshiftEventSubscription_withSourceIDs
--- PASS: TestAccRedshiftEventSubscription_tags (67.68s)
--- PASS: TestAccRedshiftEventSubscription_categoryUpdate (52.88s)
--- PASS: TestAccRedshiftEventSubscription_withSourceIDs (44.67s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	105.598s
% make testacc TESTARGS='-run=TestAccRDSCluster_tags' PKG=rds
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20  -run=TestAccRDSCluster_tags -timeout 180m
=== RUN   TestAccRDSCluster_tags
=== PAUSE TestAccRDSCluster_tags
=== CONT  TestAccRDSCluster_tags
--- PASS: TestAccRDSCluster_tags (199.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	204.787s
```
