### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin SDK resources `b*` (Phase 3c)

### DIFF
--- a/internal/service/backup/service_package_gen.go
+++ b/internal/service/backup/service_package_gen.go
@@ -49,6 +49,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceFramework,
 			TypeName: "aws_backup_framework",
+			Name:     "Framework",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceGlobalSettings,
@@ -57,6 +61,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourcePlan,
 			TypeName: "aws_backup_plan",
+			Name:     "Plan",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRegionSettings,
@@ -65,6 +73,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceReportPlan,
 			TypeName: "aws_backup_report_plan",
+			Name:     "Report Plan",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceSelection,
@@ -73,6 +85,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceVault,
 			TypeName: "aws_backup_vault",
+			Name:     "Vault",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceVaultLockConfiguration,

--- a/internal/service/batch/compute_environment.go
+++ b/internal/service/batch/compute_environment.go
@@ -22,9 +22,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_batch_compute_environment")
+// @SDKResource("aws_batch_compute_environment", name="Compute Environment")
+// @Tags(identifierAttribute="arn")
 func ResourceComputeEnvironment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceComputeEnvironmentCreate,
@@ -248,8 +250,8 @@ func ResourceComputeEnvironment() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:tftags.TagsSchema(),
+names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -266,15 +268,13 @@ func ResourceComputeEnvironment() *schema.Resource {
 func resourceComputeEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	computeEnvironmentName := create.Name(d.Get("compute_environment_name").(string), d.Get("compute_environment_name_prefix").(string))
 	computeEnvironmentType := d.Get("type").(string)
-
 	input := &batch.CreateComputeEnvironmentInput{
 		ComputeEnvironmentName: aws.String(computeEnvironmentName),
 		ServiceRole:            aws.String(d.Get("service_role").(string)),
+		Tags: GetTagsIn(ctx),
 		Type:                   aws.String(computeEnvironmentType),
 	}
 
@@ -290,11 +290,6 @@ func resourceComputeEnvironmentCreate(ctx context.Context, d *schema.ResourceDat
 		input.State = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
-	log.Printf("[DEBUG] Creating Batch Compute Environment: %s", input)
 	output, err := conn.CreateComputeEnvironmentWithContext(ctx, input)
 
 	if err != nil {
@@ -313,8 +308,6 @@ func resourceComputeEnvironmentCreate(ctx context.Context, d *schema.ResourceDat
 func resourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	computeEnvironment, err := FindComputeEnvironmentDetailByName(ctx, conn, d.Id())
 
@@ -356,16 +349,7 @@ func resourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData,
 		d.Set("eks_configuration", nil)
 	}
 
-	tags := KeyValueTags(ctx, computeEnvironment.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, computeEnvironment.Tags)
 
 	return diags
 }
@@ -419,14 +403,6 @@ func resourceComputeEnvironmentUpdate(ctx context.Context, d *schema.ResourceDat
 
 		if _, err := waitComputeEnvironmentUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for Batch Compute Environment (%s) update: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
 		}
 	}
 

--- a/internal/service/batch/compute_environment.go
+++ b/internal/service/batch/compute_environment.go
@@ -250,8 +250,8 @@ func ResourceComputeEnvironment() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			names.AttrTags:tftags.TagsSchema(),
-names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -274,7 +274,7 @@ func resourceComputeEnvironmentCreate(ctx context.Context, d *schema.ResourceDat
 	input := &batch.CreateComputeEnvironmentInput{
 		ComputeEnvironmentName: aws.String(computeEnvironmentName),
 		ServiceRole:            aws.String(d.Get("service_role").(string)),
-		Tags: GetTagsIn(ctx),
+		Tags:                   GetTagsIn(ctx),
 		Type:                   aws.String(computeEnvironmentType),
 	}
 

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -17,9 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_batch_job_queue")
+// @SDKResource("aws_batch_job_queue", name="Job Queue")
+// @Tags(identifierAttribute="arn")
 func ResourceJobQueue() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceJobQueueCreate,
@@ -60,8 +62,8 @@ func ResourceJobQueue() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{batch.JQStateDisabled, batch.JQStateEnabled}, true),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -75,21 +77,17 @@ func ResourceJobQueue() *schema.Resource {
 func resourceJobQueueCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
+
 	input := batch.CreateJobQueueInput{
 		ComputeEnvironmentOrder: createComputeEnvironmentOrder(d.Get("compute_environments").([]interface{})),
 		JobQueueName:            aws.String(d.Get("name").(string)),
 		Priority:                aws.Int64(int64(d.Get("priority").(int))),
 		State:                   aws.String(d.Get("state").(string)),
+		Tags:                    GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("scheduling_policy_arn"); ok {
 		input.SchedulingPolicyArn = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	name := d.Get("name").(string)
@@ -122,8 +120,6 @@ func resourceJobQueueCreate(ctx context.Context, d *schema.ResourceData, meta in
 func resourceJobQueueRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	jq, err := GetJobQueue(ctx, conn, d.Id())
 	if err != nil {
@@ -156,16 +152,7 @@ func resourceJobQueueRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("scheduling_policy_arn", jq.SchedulingPolicyArn)
 	d.Set("state", jq.State)
 
-	tags := KeyValueTags(ctx, jq.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, jq.Tags)
 
 	return diags
 }
@@ -214,14 +201,6 @@ func resourceJobQueueUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		_, err = stateConf.WaitForStateContext(ctx)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Batch Job Queue (%s): waiting for completion: %s", d.Get("name").(string), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
 		}
 	}
 

--- a/internal/service/batch/scheduling_policy.go
+++ b/internal/service/batch/scheduling_policy.go
@@ -16,9 +16,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_batch_scheduling_policy")
+// @SDKResource("aws_batch_scheduling_policy", name="Job Definition")
+// @Tags(identifierAttribute="arn")
 func ResourceSchedulingPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSchedulingPolicyCreate,
@@ -89,25 +91,20 @@ func ResourceSchedulingPolicy() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validName,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
 
 func resourceSchedulingPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).BatchConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &batch.CreateSchedulingPolicyInput{
 		FairsharePolicy: expandFairsharePolicy(d.Get("fair_share_policy").([]interface{})),
 		Name:            aws.String(name),
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
+		Tags:            GetTagsIn(ctx),
 	}
 
 	output, err := conn.CreateSchedulingPolicyWithContext(ctx, input)
@@ -124,8 +121,6 @@ func resourceSchedulingPolicyCreate(ctx context.Context, d *schema.ResourceData,
 func resourceSchedulingPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	sp, err := FindSchedulingPolicyByARN(ctx, conn, d.Id())
 
@@ -145,16 +140,7 @@ func resourceSchedulingPolicyRead(ctx context.Context, d *schema.ResourceData, m
 	}
 	d.Set("name", sp.Name)
 
-	tags := KeyValueTags(ctx, sp.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, sp.Tags)
 
 	return diags
 }
@@ -172,14 +158,6 @@ func resourceSchedulingPolicyUpdate(ctx context.Context, d *schema.ResourceData,
 
 		if err != nil {
 			return diag.Errorf("updating Batch Scheduling Policy (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return diag.Errorf("updating Batch Scheduling Policy (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/batch/service_package_gen.go
+++ b/internal/service/batch/service_package_gen.go
@@ -41,18 +41,34 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceComputeEnvironment,
 			TypeName: "aws_batch_compute_environment",
+			Name:     "Compute Environment",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceJobDefinition,
 			TypeName: "aws_batch_job_definition",
+			Name:     "Job Definition",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceJobQueue,
 			TypeName: "aws_batch_job_queue",
+			Name:     "Job Queue",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceSchedulingPolicy,
 			TypeName: "aws_batch_scheduling_policy",
+			Name:     "Job Definition",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin SDK.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30421.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30430.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30449.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30454.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30461.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=b... ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/b.../... -v -count 1 -parallel 2  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccBackupGlobalSettings_basic
=== PAUSE TestAccBackupGlobalSettings_basic
=== RUN   TestAccBackupPlanDataSource_basic
=== PAUSE TestAccBackupPlanDataSource_basic
=== RUN   TestAccBackupPlan_basic
=== PAUSE TestAccBackupPlan_basic
=== RUN   TestAccBackupRegionSettings_basic
=== PAUSE TestAccBackupRegionSettings_basic
=== RUN   TestAccBackupReportPlanDataSource_basic
=== PAUSE TestAccBackupReportPlanDataSource_basic
=== RUN   TestAccBackupReportPlan_basic
=== PAUSE TestAccBackupReportPlan_basic
=== RUN   TestAccBackupSelectionDataSource_basic
=== PAUSE TestAccBackupSelectionDataSource_basic
=== RUN   TestAccBackupSelection_basic
=== PAUSE TestAccBackupSelection_basic
=== RUN   TestAccBackupVaultDataSource_basic
=== PAUSE TestAccBackupVaultDataSource_basic
=== RUN   TestAccBackupVaultLockConfiguration_basic
=== PAUSE TestAccBackupVaultLockConfiguration_basic
=== RUN   TestAccBackupVaultNotification_basic
=== PAUSE TestAccBackupVaultNotification_basic
=== RUN   TestAccBackupVaultPolicy_basic
=== PAUSE TestAccBackupVaultPolicy_basic
=== RUN   TestAccBackupVault_basic
=== PAUSE TestAccBackupVault_basic
=== RUN   TestAccBackupVault_tags
=== PAUSE TestAccBackupVault_tags
=== CONT  TestAccBackupGlobalSettings_basic
=== CONT  TestAccBackupSelection_basic
=== CONT  TestAccBackupGlobalSettings_basic
    acctest.go:912: this AWS account must be the management account of an AWS Organization
--- SKIP: TestAccBackupGlobalSettings_basic (0.75s)
=== CONT  TestAccBackupReportPlanDataSource_basic
    report_plan_data_source_test.go:21: Step 1/2, expected an error with pattern, no match on: Error running pre-apply refresh: exit status 1
        
        Error: reading Backup Report Plan (tf_acc_test_does_not_exist): couldn't find resource
        
          with data.aws_backup_report_plan.test,
          on terraform_plugin_test.tf line 2, in data "aws_backup_report_plan" "test":
           2: data "aws_backup_report_plan" "test" {
        
--- FAIL: TestAccBackupReportPlanDataSource_basic (4.65s)
=== CONT  TestAccBackupSelectionDataSource_basic
--- PASS: TestAccBackupSelection_basic (40.64s)
=== CONT  TestAccBackupReportPlan_basic
--- PASS: TestAccBackupSelectionDataSource_basic (37.96s)
=== CONT  TestAccBackupPlan_basic
--- PASS: TestAccBackupPlan_basic (43.98s)
=== CONT  TestAccBackupRegionSettings_basic
    region_settings_test.go:20: Step 1/4 error: Check failed: 1 error occurred:
        	* Check 2/17 error: aws_backup_region_settings.test: Attribute 'resource_type_opt_in_preference.%' expected "12", got "15"
        
--- FAIL: TestAccBackupRegionSettings_basic (15.08s)
=== CONT  TestAccBackupPlanDataSource_basic
--- PASS: TestAccBackupReportPlan_basic (73.22s)
=== CONT  TestAccBackupVaultPolicy_basic
--- PASS: TestAccBackupPlanDataSource_basic (30.47s)
=== CONT  TestAccBackupVault_tags
--- PASS: TestAccBackupVaultPolicy_basic (53.68s)
=== CONT  TestAccBackupVault_basic
--- PASS: TestAccBackupVault_basic (33.68s)
=== CONT  TestAccBackupVaultLockConfiguration_basic
--- PASS: TestAccBackupVault_tags (78.65s)
=== CONT  TestAccBackupVaultNotification_basic
--- PASS: TestAccBackupVaultLockConfiguration_basic (39.31s)
=== CONT  TestAccBackupVaultDataSource_basic
--- PASS: TestAccBackupVaultNotification_basic (42.14s)
--- PASS: TestAccBackupVaultDataSource_basic (31.41s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/backup	284.490s
=== RUN   TestAccBatchComputeEnvironmentDataSource_basic
=== PAUSE TestAccBatchComputeEnvironmentDataSource_basic
=== RUN   TestAccBatchComputeEnvironment_basic
=== PAUSE TestAccBatchComputeEnvironment_basic
=== RUN   TestAccBatchComputeEnvironment_tags
=== PAUSE TestAccBatchComputeEnvironment_tags
=== RUN   TestAccBatchJobDefinition_basic
=== PAUSE TestAccBatchJobDefinition_basic
=== RUN   TestAccBatchJobDefinition_tags
=== PAUSE TestAccBatchJobDefinition_tags
=== RUN   TestAccBatchJobQueueDataSource_basic
=== PAUSE TestAccBatchJobQueueDataSource_basic
=== RUN   TestAccBatchJobQueue_basic
=== PAUSE TestAccBatchJobQueue_basic
=== RUN   TestAccBatchJobQueue_tags
=== PAUSE TestAccBatchJobQueue_tags
=== RUN   TestAccBatchSchedulingPolicyDataSource_basic
--- PASS: TestAccBatchSchedulingPolicyDataSource_basic (31.85s)
=== RUN   TestAccBatchSchedulingPolicy_basic
=== PAUSE TestAccBatchSchedulingPolicy_basic
=== CONT  TestAccBatchComputeEnvironmentDataSource_basic
=== CONT  TestAccBatchJobQueueDataSource_basic
--- PASS: TestAccBatchComputeEnvironmentDataSource_basic (61.11s)
=== CONT  TestAccBatchJobQueue_tags
--- PASS: TestAccBatchJobQueueDataSource_basic (123.72s)
=== CONT  TestAccBatchSchedulingPolicy_basic
--- PASS: TestAccBatchSchedulingPolicy_basic (62.29s)
=== CONT  TestAccBatchJobDefinition_basic
--- PASS: TestAccBatchJobDefinition_basic (28.39s)
=== CONT  TestAccBatchJobDefinition_tags
--- PASS: TestAccBatchJobQueue_tags (191.46s)
=== CONT  TestAccBatchJobQueue_basic
--- PASS: TestAccBatchJobDefinition_tags (69.83s)
=== CONT  TestAccBatchComputeEnvironment_tags
--- PASS: TestAccBatchComputeEnvironment_tags (90.98s)
=== CONT  TestAccBatchComputeEnvironment_basic
--- PASS: TestAccBatchJobQueue_basic (132.69s)
--- PASS: TestAccBatchComputeEnvironment_basic (46.56s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/batch	482.105s
=== RUN   TestAccBudgetsBudgetAction_basic
=== PAUSE TestAccBudgetsBudgetAction_basic
=== RUN   TestAccBudgetsBudget_basic
=== PAUSE TestAccBudgetsBudget_basic
=== CONT  TestAccBudgetsBudgetAction_basic
=== CONT  TestAccBudgetsBudget_basic
--- PASS: TestAccBudgetsBudget_basic (43.77s)
--- PASS: TestAccBudgetsBudgetAction_basic (59.29s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/budgets	77.405s
FAIL
make: *** [testacc] Error 1
```
