### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin SDK resources `c*` (Phase 3c)

### DIFF
--- a/internal/service/ce/anomaly_subscription.go
+++ b/internal/service/ce/anomaly_subscription.go
@@ -18,7 +18,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ce_anomaly_subscription")
+// @SDKResource("aws_ce_anomaly_subscription", name="Anomaly Subscription")
+// @Tags(identifierAttribute="id")
 func ResourceAnomalySubscription() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAnomalySubscriptionCreate,
@@ -91,8 +92,8 @@ func ResourceAnomalySubscription() *schema.Resource {
 				Optional: true,
 				Elem:     schemaCostCategoryRule(),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -101,8 +102,6 @@ func ResourceAnomalySubscription() *schema.Resource {
 
 func resourceAnomalySubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).CEConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &costexplorer.CreateAnomalySubscriptionInput{
 		AnomalySubscription: &costexplorer.AnomalySubscription{
@@ -111,6 +110,7 @@ func resourceAnomalySubscriptionCreate(ctx context.Context, d *schema.ResourceDa
 			MonitorArnList:   aws.StringSlice(expandAnomalySubscriptionMonitorARNList(d.Get("monitor_arn_list").([]interface{}))),
 			Subscribers:      expandAnomalySubscriptionSubscribers(d.Get("subscriber").(*schema.Set).List()),
 		},
+		ResourceTags: GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("account_id"); ok {
@@ -123,10 +123,6 @@ func resourceAnomalySubscriptionCreate(ctx context.Context, d *schema.ResourceDa
 
 	if v, ok := d.GetOk("threshold_expression"); ok {
 		input.AnomalySubscription.ThresholdExpression = expandCostExpression(v.([]interface{})[0].(map[string]interface{}))
-	}
-
-	if len(tags) > 0 {
-		input.ResourceTags = Tags(tags.IgnoreAWS())
 	}
 
 	resp, err := conn.CreateAnomalySubscriptionWithContext(ctx, input)
@@ -146,8 +142,6 @@ func resourceAnomalySubscriptionCreate(ctx context.Context, d *schema.ResourceDa
 
 func resourceAnomalySubscriptionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).CEConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	subscription, err := FindAnomalySubscriptionByARN(ctx, conn, d.Id())
 
@@ -171,22 +165,6 @@ func resourceAnomalySubscriptionRead(ctx context.Context, d *schema.ResourceData
 
 	if err = d.Set("threshold_expression", []interface{}{flattenCostCategoryRuleExpression(subscription.ThresholdExpression)}); err != nil {
 		return create.DiagError(names.CE, "setting threshold_expression", ResNameAnomalySubscription, d.Id(), err)
-	}
-
-	tags, err := ListTags(ctx, conn, aws.StringValue(subscription.SubscriptionArn))
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	if err != nil {
-		return create.DiagError(names.CE, create.ErrActionReading, ResNameAnomalySubscription, d.Id(), err)
-	}
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return create.DiagError(names.CE, create.ErrActionUpdating, ResNameAnomalySubscription, d.Id(), err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return create.DiagError(names.CE, create.ErrActionUpdating, ResNameAnomalySubscription, d.Id(), err)
 	}
 
 	return nil
@@ -223,22 +201,6 @@ func resourceAnomalySubscriptionUpdate(ctx context.Context, d *schema.ResourceDa
 		_, err := conn.UpdateAnomalySubscriptionWithContext(ctx, input)
 
 		if err != nil {
-			return create.DiagError(names.CE, create.ErrActionUpdating, ResNameAnomalySubscription, d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags") {
-		o, n := d.GetChange("tags")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return create.DiagError(names.CE, create.ErrActionUpdating, ResNameAnomalySubscription, d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
 			return create.DiagError(names.CE, create.ErrActionUpdating, ResNameAnomalySubscription, d.Id(), err)
 		}
 	}

--- a/internal/service/ce/cost_category.go
+++ b/internal/service/ce/cost_category.go
@@ -19,7 +19,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ce_cost_category")
+// @SDKResource("aws_ce_cost_category", name="Cost Category")
+// @Tags(identifierAttribute="id")
 func ResourceCostCategory() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceCostCategoryCreate,
@@ -158,8 +159,8 @@ func ResourceCostCategory() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -374,13 +375,12 @@ func schemaCostCategoryRuleExpression() *schema.Resource {
 
 func resourceCostCategoryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).CEConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &costexplorer.CreateCostCategoryDefinitionInput{
-		Name:        aws.String(d.Get("name").(string)),
-		Rules:       expandCostCategoryRules(d.Get("rule").(*schema.Set).List()),
-		RuleVersion: aws.String(d.Get("rule_version").(string)),
+		Name:         aws.String(d.Get("name").(string)),
+		ResourceTags: GetTagsIn(ctx),
+		Rules:        expandCostCategoryRules(d.Get("rule").(*schema.Set).List()),
+		RuleVersion:  aws.String(d.Get("rule_version").(string)),
 	}
 
 	if v, ok := d.GetOk("default_value"); ok {
@@ -393,10 +393,6 @@ func resourceCostCategoryCreate(ctx context.Context, d *schema.ResourceData, met
 
 	if v, ok := d.GetOk("effective_start"); ok {
 		input.EffectiveStart = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		input.ResourceTags = Tags(tags.IgnoreAWS())
 	}
 
 	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate),
@@ -416,8 +412,6 @@ func resourceCostCategoryCreate(ctx context.Context, d *schema.ResourceData, met
 
 func resourceCostCategoryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).CEConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	costCategory, err := FindCostCategoryByARN(ctx, conn, d.Id())
 
@@ -441,22 +435,6 @@ func resourceCostCategoryRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("rule_version", costCategory.RuleVersion)
 	if err = d.Set("split_charge_rule", flattenCostCategorySplitChargeRules(costCategory.SplitChargeRules)); err != nil {
 		return create.DiagError(names.CE, "setting split_charge_rule", ResNameCostCategory, d.Id(), err)
-	}
-
-	tags, err := ListTags(ctx, conn, d.Id())
-
-	if err != nil {
-		return create.DiagError(names.CE, "listing tags", ResNameCostCategory, d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return create.DiagError(names.CE, "setting tags", ResNameCostCategory, d.Id(), err)
-	}
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return create.DiagError(names.CE, "setting tags_all", ResNameCostCategory, d.Id(), err)
 	}
 
 	return nil
@@ -484,13 +462,6 @@ func resourceCostCategoryUpdate(ctx context.Context, d *schema.ResourceData, met
 		_, err := conn.UpdateCostCategoryDefinitionWithContext(ctx, input)
 
 		if err != nil {
-			return create.DiagError(names.CE, create.ErrActionUpdating, ResNameCostCategory, d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
 			return create.DiagError(names.CE, create.ErrActionUpdating, ResNameCostCategory, d.Id(), err)
 		}
 	}

--- a/internal/service/ce/service_package_gen.go
+++ b/internal/service/ce/service_package_gen.go
@@ -37,10 +37,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceAnomalyMonitor,
 			TypeName: "aws_ce_anomaly_monitor",
+			Name:     "Anomaly Monitor",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceAnomalySubscription,
 			TypeName: "aws_ce_anomaly_subscription",
+			Name:     "Anomaly Subscription",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceCostAllocationTag,
@@ -49,6 +57,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCostCategory,
 			TypeName: "aws_ce_cost_category",
+			Name:     "Cost Category",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }

--- a/internal/service/cloud9/service_package_gen.go
+++ b/internal/service/cloud9/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceEnvironmentEC2,
 			TypeName: "aws_cloud9_environment_ec2",
+			Name:     "Environment EC2",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceEnvironmentMembership,

--- a/internal/service/cloudformation/service_package_gen.go
+++ b/internal/service/cloudformation/service_package_gen.go
@@ -41,10 +41,14 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceStack,
 			TypeName: "aws_cloudformation_stack",
+			Name:     "Stack",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
 			Factory:  ResourceStackSet,
 			TypeName: "aws_cloudformation_stack_set",
+			Name:     "Stack Set",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
 			Factory:  ResourceStackSetInstance,

--- a/internal/service/cloudformation/stack_set.go
+++ b/internal/service/cloudformation/stack_set.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_cloudformation_stack_set")
+// @SDKResource("aws_cloudformation_stack_set", name="Stack Set")
+// @Tags
 func ResourceStackSet() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceStackSetCreate,
@@ -167,8 +169,8 @@ func ResourceStackSet() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"template_body": {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -191,13 +193,12 @@ func ResourceStackSet() *schema.Resource {
 func resourceStackSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFormationConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &cloudformation.CreateStackSetInput{
 		ClientRequestToken: aws.String(id.UniqueId()),
 		StackSetName:       aws.String(name),
+		Tags:               GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("administration_role_arn"); ok {
@@ -232,10 +233,6 @@ func resourceStackSetCreate(ctx context.Context, d *schema.ResourceData, meta in
 		input.CallAs = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
 	if v, ok := d.GetOk("template_body"); ok {
 		input.TemplateBody = aws.String(v.(string))
 	}
@@ -259,10 +256,8 @@ func resourceStackSetCreate(ctx context.Context, d *schema.ResourceData, meta in
 func resourceStackSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFormationConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-	callAs := d.Get("call_as").(string)
 
+	callAs := d.Get("call_as").(string)
 	stackSet, err := FindStackSetByName(ctx, conn, d.Id(), callAs)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
@@ -297,16 +292,7 @@ func resourceStackSetRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	d.Set("stack_set_id", stackSet.StackSetId)
 
-	tags := KeyValueTags(ctx, stackSet.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, stackSet.Tags)
 
 	d.Set("template_body", stackSet.TemplateBody)
 
@@ -316,8 +302,6 @@ func resourceStackSetRead(ctx context.Context, d *schema.ResourceData, meta inte
 func resourceStackSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFormationConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &cloudformation.UpdateStackSetInput{
 		OperationId:  aws.String(id.UniqueId()),
@@ -359,8 +343,8 @@ func resourceStackSetUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		input.CallAs = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
+	if tags := GetTagsIn(ctx); len(tags) > 0 {
+		input.Tags = tags
 	}
 
 	if v, ok := d.GetOk("template_url"); ok {

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -21,7 +21,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_cloudfront_distribution")
+// @SDKResource("aws_cloudfront_distribution", name="Distribution")
+// @Tags(identifierAttribute="arn")
 func ResourceDistribution() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{
@@ -819,8 +820,8 @@ func ResourceDistribution() *schema.Resource {
 				Default:  false,
 			},
 
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -830,21 +831,22 @@ func ResourceDistribution() *schema.Resource {
 func resourceDistributionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
-	params := &cloudfront.CreateDistributionWithTagsInput{
+	input := &cloudfront.CreateDistributionWithTagsInput{
 		DistributionConfigWithTags: &cloudfront.DistributionConfigWithTags{
 			DistributionConfig: expandDistributionConfig(d),
-			Tags:               &cloudfront.Tags{Items: Tags(tags.IgnoreAWS())},
 		},
+	}
+
+	if tags := GetTagsIn(ctx); len(tags) > 0 {
+		input.DistributionConfigWithTags.Tags = &cloudfront.Tags{Items: tags}
 	}
 
 	var resp *cloudfront.CreateDistributionWithTagsOutput
 	// Handle eventual consistency issues
 	err := retry.RetryContext(ctx, 1*time.Minute, func() *retry.RetryError {
 		var err error
-		resp, err = conn.CreateDistributionWithTagsWithContext(ctx, params)
+		resp, err = conn.CreateDistributionWithTagsWithContext(ctx, input)
 
 		// ACM and IAM certificate eventual consistency
 		// InvalidViewerCertificate: The specified SSL certificate doesn't exist, isn't in us-east-1 region, isn't valid, or doesn't include a valid certificate chain.
@@ -861,7 +863,7 @@ func resourceDistributionCreate(ctx context.Context, d *schema.ResourceData, met
 
 	// Propagate AWS Go SDK retried error, if any
 	if tfresource.TimedOut(err) {
-		resp, err = conn.CreateDistributionWithTagsWithContext(ctx, params)
+		resp, err = conn.CreateDistributionWithTagsWithContext(ctx, input)
 	}
 
 	if err != nil {
@@ -883,8 +885,6 @@ func resourceDistributionCreate(ctx context.Context, d *schema.ResourceData, met
 func resourceDistributionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	output, err := FindDistributionByID(ctx, conn, d.Id())
 
@@ -918,21 +918,6 @@ func resourceDistributionRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("etag", output.ETag)
 	d.Set("arn", output.Distribution.ARN)
 	d.Set("hosted_zone_id", meta.(*conns.AWSClient).CloudFrontDistributionHostedZoneID())
-
-	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for CloudFront Distribution (%s): %s", d.Id(), err)
-	}
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
 
 	return diags
 }
@@ -999,13 +984,6 @@ func resourceDistributionUpdate(ctx context.Context, d *schema.ResourceData, met
 		log.Printf("[DEBUG] Waiting until CloudFront Distribution (%s) is deployed", d.Id())
 		if err := DistributionWaitUntilDeployed(ctx, d.Id(), meta); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting until CloudFront Distribution (%s) is deployed: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags for CloudFront Distribution (%s): %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -835,11 +835,12 @@ func resourceDistributionCreate(ctx context.Context, d *schema.ResourceData, met
 	input := &cloudfront.CreateDistributionWithTagsInput{
 		DistributionConfigWithTags: &cloudfront.DistributionConfigWithTags{
 			DistributionConfig: expandDistributionConfig(d),
+			Tags:               &cloudfront.Tags{Items: []*cloudfront.Tag{}},
 		},
 	}
 
 	if tags := GetTagsIn(ctx); len(tags) > 0 {
-		input.DistributionConfigWithTags.Tags = &cloudfront.Tags{Items: tags}
+		input.DistributionConfigWithTags.Tags.Items = tags
 	}
 
 	var resp *cloudfront.CreateDistributionWithTagsOutput

--- a/internal/service/cloudfront/distribution_data_source_test.go
+++ b/internal/service/cloudfront/distribution_data_source_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/cloudfront"
-	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
@@ -12,8 +11,7 @@ import (
 func TestAccCloudFrontDistributionDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_cloudfront_distribution.test"
-	resourceName := "aws_cloudfront_distribution.s3_distribution"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cloudfront_distribution.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, cloudfront.EndpointsID) },
@@ -21,7 +19,7 @@ func TestAccCloudFrontDistributionDataSource_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDistributionDataSourceConfig_basic(rName),
+				Config: testAccDistributionDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "domain_name", resourceName, "domain_name"),
@@ -37,10 +35,8 @@ func TestAccCloudFrontDistributionDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccDistributionDataSourceConfig_basic(rName string) string {
-	return acctest.ConfigCompose(testAccDistributionConfig_s3Tags(rName), `
+var testAccDistributionDataSourceConfig_basic = acctest.ConfigCompose(testAccDistributionConfig_enabled(false, false), `
 data "aws_cloudfront_distribution" "test" {
-  id = aws_cloudfront_distribution.s3_distribution.id
+  id = aws_cloudfront_distribution.test.id
 }
 `)
-}

--- a/internal/service/cloudfront/service_package_gen.go
+++ b/internal/service/cloudfront/service_package_gen.go
@@ -69,6 +69,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDistribution,
 			TypeName: "aws_cloudfront_distribution",
+			Name:     "Distribution",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceFieldLevelEncryptionConfig,

--- a/internal/service/cloudhsmv2/cluster.go
+++ b/internal/service/cloudhsmv2/cluster.go
@@ -17,9 +17,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_cloudhsm_v2_cluster")
+// @SDKResource("aws_cloudhsm_v2_cluster", name="Cluster")
+// @Tags(identifierAttribute="id")
 func ResourceCluster() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClusterCreate,
@@ -95,8 +97,8 @@ func ResourceCluster() *schema.Resource {
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -110,20 +112,15 @@ func ResourceCluster() *schema.Resource {
 func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudHSMV2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &cloudhsmv2.CreateClusterInput{
 		HsmType:   aws.String(d.Get("hsm_type").(string)),
 		SubnetIds: flex.ExpandStringSet(d.Get("subnet_ids").(*schema.Set)),
+		TagList:   GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("source_backup_identifier"); ok {
 		input.SourceBackupId = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		input.TagList = Tags(tags.IgnoreAWS())
 	}
 
 	output, err := conn.CreateClusterWithContext(ctx, input)
@@ -149,8 +146,6 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudHSMV2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	cluster, err := FindClusterByID(ctx, conn, d.Id())
 
@@ -179,31 +174,15 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("subnet_ids", subnetIDs)
 	d.Set("vpc_id", cluster.VpcId)
 
-	tags := KeyValueTags(ctx, cluster.TagList).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, cluster.TagList)
 
 	return diags
 }
 
 func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).CloudHSMV2Conn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating CloudHSMv2 Cluster (%s) tags: %s", d.Id(), err)
-		}
-	}
+	// Tags only.
 
 	return append(diags, resourceClusterRead(ctx, d, meta)...)
 }

--- a/internal/service/cloudhsmv2/service_package_gen.go
+++ b/internal/service/cloudhsmv2/service_package_gen.go
@@ -33,6 +33,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCluster,
 			TypeName: "aws_cloudhsm_v2_cluster",
+			Name:     "Cluster",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceHSM,

--- a/internal/service/cloudtrail/cloudtrail.go
+++ b/internal/service/cloudtrail/cloudtrail.go
@@ -23,7 +23,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_cloudtrail")
+// @SDKResource("aws_cloudtrail", name="Trail")
+// @Tags(identifierAttribute="arn")
 func ResourceCloudTrail() *schema.Resource { // nosemgrep:ci.cloudtrail-in-func-name
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceCloudTrailCreate,
@@ -243,8 +244,8 @@ func ResourceCloudTrail() *schema.Resource { // nosemgrep:ci.cloudtrail-in-func-
 				Optional: true,
 			},
 
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -254,16 +255,11 @@ func ResourceCloudTrail() *schema.Resource { // nosemgrep:ci.cloudtrail-in-func-
 func resourceCloudTrailCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics { // nosemgrep:ci.cloudtrail-in-func-name
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudTrailConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := cloudtrail.CreateTrailInput{
 		Name:         aws.String(d.Get("name").(string)),
 		S3BucketName: aws.String(d.Get("s3_bucket_name").(string)),
-	}
-
-	if len(tags) > 0 {
-		input.TagsList = Tags(tags.IgnoreAWS())
+		TagsList:     GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("cloud_watch_logs_group_arn"); ok {
@@ -353,8 +349,6 @@ func resourceCloudTrailCreate(ctx context.Context, d *schema.ResourceData, meta 
 func resourceCloudTrailRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics { // nosemgrep:ci.cloudtrail-in-func-name
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudTrailConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	input := cloudtrail.DescribeTrailsInput{
 		TrailNameList: []*string{
@@ -406,23 +400,6 @@ func resourceCloudTrailRead(ctx context.Context, d *schema.ResourceData, meta in
 	arn := aws.StringValue(trail.TrailARN)
 	d.Set("arn", arn)
 	d.Set("home_region", trail.HomeRegion)
-
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Cloudtrail (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
 
 	logstatus, err := getLoggingStatus(ctx, conn, trail.Name)
 	if err != nil {
@@ -528,14 +505,6 @@ func resourceCloudTrailUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		}
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating CloudTrail Trail (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating ECR Repository (%s) tags: %s", d.Get("arn").(string), err)
 		}
 	}
 

--- a/internal/service/cloudtrail/service_package_gen.go
+++ b/internal/service/cloudtrail/service_package_gen.go
@@ -33,10 +33,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCloudTrail,
 			TypeName: "aws_cloudtrail",
+			Name:     "Trail",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceEventDataStore,
 			TypeName: "aws_cloudtrail_event_data_store",
+			Name:     "Event Data Store",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }

--- a/internal/service/cloudwatch/service_package_gen.go
+++ b/internal/service/cloudwatch/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCompositeAlarm,
 			TypeName: "aws_cloudwatch_composite_alarm",
+			Name:     "Composite Alarm",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceDashboard,
@@ -36,10 +40,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceMetricAlarm,
 			TypeName: "aws_cloudwatch_metric_alarm",
+			Name:     "Metric Alarm",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceMetricStream,
 			TypeName: "aws_cloudwatch_metric_stream",
+			Name:     "Metric Alarm",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/codeartifact/domain.go
+++ b/internal/service/codeartifact/domain.go
@@ -20,7 +20,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_codeartifact_domain")
+// @SDKResource("aws_codeartifact_domain", name="Domain")
+// @Tags(identifierAttribute="arn")
 func ResourceDomain() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDomainCreate,
@@ -64,8 +65,8 @@ func ResourceDomain() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -75,20 +76,17 @@ func ResourceDomain() *schema.Resource {
 func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CodeArtifactConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
-	log.Print("[DEBUG] Creating CodeArtifact Domain")
 
-	params := &codeartifact.CreateDomainInput{
+	input := &codeartifact.CreateDomainInput{
 		Domain: aws.String(d.Get("domain").(string)),
-		Tags:   Tags(tags.IgnoreAWS()),
+		Tags:   GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("encryption_key"); ok {
-		params.EncryptionKey = aws.String(v.(string))
+		input.EncryptionKey = aws.String(v.(string))
 	}
 
-	domain, err := conn.CreateDomainWithContext(ctx, params)
+	domain, err := conn.CreateDomainWithContext(ctx, input)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating CodeArtifact Domain: %s", err)
 	}
@@ -101,10 +99,6 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CodeArtifactConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-
-	log.Printf("[DEBUG] Reading CodeArtifact Domain: %s", d.Id())
 
 	domainOwner, domainName, err := DecodeDomainID(d.Id())
 	if err != nil {
@@ -134,36 +128,13 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("repository_count", sm.Domain.RepositoryCount)
 	d.Set("created_time", sm.Domain.CreatedTime.Format(time.RFC3339))
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for CodeArtifact Domain (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
 func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).CodeArtifactConn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating CodeArtifact Domain (%s) tags: %s", d.Id(), err)
-		}
-	}
+	// Tags only.
 
 	return append(diags, resourceDomainRead(ctx, d, meta)...)
 }

--- a/internal/service/codeartifact/repository.go
+++ b/internal/service/codeartifact/repository.go
@@ -20,7 +20,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_codeartifact_repository")
+// @SDKResource("aws_codeartifact_repository", name="Repository")
+// @Tags(identifierAttribute="arn")
 func ResourceRepository() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRepositoryCreate,
@@ -95,8 +96,8 @@ func ResourceRepository() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -106,29 +107,26 @@ func ResourceRepository() *schema.Resource {
 func resourceRepositoryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CodeArtifactConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
-	log.Print("[DEBUG] Creating CodeArtifact Repository")
 
-	params := &codeartifact.CreateRepositoryInput{
+	input := &codeartifact.CreateRepositoryInput{
 		Repository: aws.String(d.Get("repository").(string)),
 		Domain:     aws.String(d.Get("domain").(string)),
-		Tags:       Tags(tags.IgnoreAWS()),
+		Tags:       GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
-		params.Description = aws.String(v.(string))
+		input.Description = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("domain_owner"); ok {
-		params.DomainOwner = aws.String(v.(string))
+		input.DomainOwner = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("upstream"); ok {
-		params.Upstreams = expandUpstreams(v.([]interface{}))
+		input.Upstreams = expandUpstreams(v.([]interface{}))
 	}
 
-	res, err := conn.CreateRepositoryWithContext(ctx, params)
+	res, err := conn.CreateRepositoryWithContext(ctx, input)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating CodeArtifact Repository: %s", err)
 	}
@@ -152,6 +150,52 @@ func resourceRepositoryCreate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	return append(diags, resourceRepositoryRead(ctx, d, meta)...)
+}
+
+func resourceRepositoryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).CodeArtifactConn()
+
+	owner, domain, repo, err := DecodeRepositoryID(d.Id())
+	if err != nil {
+		return create.DiagError(names.CodeArtifact, create.ErrActionReading, ResNameRepository, d.Id(), err)
+	}
+	sm, err := conn.DescribeRepositoryWithContext(ctx, &codeartifact.DescribeRepositoryInput{
+		Repository:  aws.String(repo),
+		Domain:      aws.String(domain),
+		DomainOwner: aws.String(owner),
+	})
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, codeartifact.ErrCodeResourceNotFoundException) {
+		create.LogNotFoundRemoveState(names.CodeArtifact, create.ErrActionReading, ResNameRepository, d.Id())
+		d.SetId("")
+		return diags
+	}
+
+	if err != nil {
+		return create.DiagError(names.CodeArtifact, create.ErrActionReading, ResNameRepository, d.Id(), err)
+	}
+
+	arn := aws.StringValue(sm.Repository.Arn)
+	d.Set("repository", sm.Repository.Name)
+	d.Set("arn", arn)
+	d.Set("domain_owner", sm.Repository.DomainOwner)
+	d.Set("domain", sm.Repository.DomainName)
+	d.Set("administrator_account", sm.Repository.AdministratorAccount)
+	d.Set("description", sm.Repository.Description)
+
+	if sm.Repository.Upstreams != nil {
+		if err := d.Set("upstream", flattenUpstreams(sm.Repository.Upstreams)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "[WARN] Error setting upstream: %s", err)
+		}
+	}
+
+	if sm.Repository.ExternalConnections != nil {
+		if err := d.Set("external_connections", flattenExternalConnections(sm.Repository.ExternalConnections)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "[WARN] Error setting external_connections: %s", err)
+		}
+	}
+
+	return diags
 }
 
 func resourceRepositoryUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -218,81 +262,7 @@ func resourceRepositoryUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		}
 	}
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating CodeArtifact Repository (%s) tags: %s", d.Id(), err)
-		}
-	}
-
 	return append(diags, resourceRepositoryRead(ctx, d, meta)...)
-}
-
-func resourceRepositoryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).CodeArtifactConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-
-	log.Printf("[DEBUG] Reading CodeArtifact Repository: %s", d.Id())
-
-	owner, domain, repo, err := DecodeRepositoryID(d.Id())
-	if err != nil {
-		return create.DiagError(names.CodeArtifact, create.ErrActionReading, ResNameRepository, d.Id(), err)
-	}
-	sm, err := conn.DescribeRepositoryWithContext(ctx, &codeartifact.DescribeRepositoryInput{
-		Repository:  aws.String(repo),
-		Domain:      aws.String(domain),
-		DomainOwner: aws.String(owner),
-	})
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, codeartifact.ErrCodeResourceNotFoundException) {
-		create.LogNotFoundRemoveState(names.CodeArtifact, create.ErrActionReading, ResNameRepository, d.Id())
-		d.SetId("")
-		return diags
-	}
-
-	if err != nil {
-		return create.DiagError(names.CodeArtifact, create.ErrActionReading, ResNameRepository, d.Id(), err)
-	}
-
-	arn := aws.StringValue(sm.Repository.Arn)
-	d.Set("repository", sm.Repository.Name)
-	d.Set("arn", arn)
-	d.Set("domain_owner", sm.Repository.DomainOwner)
-	d.Set("domain", sm.Repository.DomainName)
-	d.Set("administrator_account", sm.Repository.AdministratorAccount)
-	d.Set("description", sm.Repository.Description)
-
-	if sm.Repository.Upstreams != nil {
-		if err := d.Set("upstream", flattenUpstreams(sm.Repository.Upstreams)); err != nil {
-			return sdkdiag.AppendErrorf(diags, "[WARN] Error setting upstream: %s", err)
-		}
-	}
-
-	if sm.Repository.ExternalConnections != nil {
-		if err := d.Set("external_connections", flattenExternalConnections(sm.Repository.ExternalConnections)); err != nil {
-			return sdkdiag.AppendErrorf(diags, "[WARN] Error setting external_connections: %s", err)
-		}
-	}
-
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for CodeArtifact Repository (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
-	return diags
 }
 
 func resourceRepositoryDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/codeartifact/service_package_gen.go
+++ b/internal/service/codeartifact/service_package_gen.go
@@ -37,6 +37,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDomain,
 			TypeName: "aws_codeartifact_domain",
+			Name:     "Domain",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceDomainPermissionsPolicy,
@@ -45,6 +49,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceRepository,
 			TypeName: "aws_codeartifact_repository",
+			Name:     "Repository",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRepositoryPermissionsPolicy,

--- a/internal/service/codebuild/project.go
+++ b/internal/service/codebuild/project.go
@@ -23,9 +23,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_codebuild_project")
+// @SDKResource("aws_codebuild_project", name="Project")
+// @Tags
 func ResourceProject() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceProjectCreate,
@@ -684,8 +686,8 @@ func ResourceProject() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vpc_config": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -737,8 +739,6 @@ func ResourceProject() *schema.Resource {
 func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CodeBuildConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	projectEnv := expandProjectEnvironment(d)
 	projectSource := expandProjectSource(d)
@@ -759,7 +759,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 	}
 
-	params := &codebuild.CreateProjectInput{
+	input := &codebuild.CreateProjectInput{
 		Environment:         projectEnv,
 		Name:                aws.String(d.Get("name").(string)),
 		Source:              &projectSource,
@@ -769,51 +769,51 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta int
 		LogsConfig:          projectLogsConfig,
 		BuildBatchConfig:    projectBatchConfig,
 		FileSystemLocations: projectFileSystemLocations,
-		Tags:                Tags(tags.IgnoreAWS()),
+		Tags:                GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("cache"); ok {
-		params.Cache = expandProjectCache(v.([]interface{}))
+		input.Cache = expandProjectCache(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("concurrent_build_limit"); ok {
-		params.ConcurrentBuildLimit = aws.Int64(int64(v.(int)))
+		input.ConcurrentBuildLimit = aws.Int64(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("description"); ok {
-		params.Description = aws.String(v.(string))
+		input.Description = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("encryption_key"); ok {
-		params.EncryptionKey = aws.String(v.(string))
+		input.EncryptionKey = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("service_role"); ok {
-		params.ServiceRole = aws.String(v.(string))
+		input.ServiceRole = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("source_version"); ok {
-		params.SourceVersion = aws.String(v.(string))
+		input.SourceVersion = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("build_timeout"); ok {
-		params.TimeoutInMinutes = aws.Int64(int64(v.(int)))
+		input.TimeoutInMinutes = aws.Int64(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("queued_timeout"); ok {
-		params.QueuedTimeoutInMinutes = aws.Int64(int64(v.(int)))
+		input.QueuedTimeoutInMinutes = aws.Int64(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("vpc_config"); ok {
-		params.VpcConfig = expandVPCConfig(v.([]interface{}))
+		input.VpcConfig = expandVPCConfig(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("badge_enabled"); ok {
-		params.BadgeEnabled = aws.Bool(v.(bool))
+		input.BadgeEnabled = aws.Bool(v.(bool))
 	}
 
 	if v, ok := d.GetOk("secondary_source_version"); ok && v.(*schema.Set).Len() > 0 {
-		params.SecondarySourceVersions = expandProjectSecondarySourceVersions(v.(*schema.Set))
+		input.SecondarySourceVersions = expandProjectSecondarySourceVersions(v.(*schema.Set))
 	}
 
 	var resp *codebuild.CreateProjectOutput
@@ -821,7 +821,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta int
 	err := retry.RetryContext(ctx, 5*time.Minute, func() *retry.RetryError {
 		var err error
 
-		resp, err = conn.CreateProjectWithContext(ctx, params)
+		resp, err = conn.CreateProjectWithContext(ctx, input)
 		if err != nil {
 			// InvalidInputException: CodeBuild is not authorized to perform
 			// InvalidInputException: Not authorized to perform DescribeSecurityGroups
@@ -836,7 +836,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta int
 	})
 
 	if tfresource.TimedOut(err) {
-		resp, err = conn.CreateProjectWithContext(ctx, params)
+		resp, err = conn.CreateProjectWithContext(ctx, input)
 	}
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "Error creating CodeBuild project: %s", err)
@@ -1342,8 +1342,6 @@ func expandProjectSourceData(data map[string]interface{}) codebuild.ProjectSourc
 func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CodeBuildConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	project, err := FindProjectByARN(ctx, conn, d.Id())
 
@@ -1421,16 +1419,7 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta inter
 		d.Set("badge_url", "")
 	}
 
-	tags := KeyValueTags(ctx, project.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, project.Tags)
 
 	return diags
 }
@@ -1438,8 +1427,6 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta inter
 func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CodeBuildConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	if d.HasChanges("project_visibility", "resource_access_role") {
 		visInput := &codebuild.UpdateProjectVisibilityInput{
@@ -1458,28 +1445,28 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if d.HasChangesExcept("project_visibility", "resource_access_role") {
-		params := &codebuild.UpdateProjectInput{
+		input := &codebuild.UpdateProjectInput{
 			Name: aws.String(d.Get("name").(string)),
 		}
 
 		if d.HasChange("environment") {
 			projectEnv := expandProjectEnvironment(d)
-			params.Environment = projectEnv
+			input.Environment = projectEnv
 		}
 
 		if d.HasChange("file_system_locations") {
 			projectFileSystemLocations := expandProjectFileSystemLocations(d)
-			params.FileSystemLocations = projectFileSystemLocations
+			input.FileSystemLocations = projectFileSystemLocations
 		}
 
 		if d.HasChange("source") {
 			projectSource := expandProjectSource(d)
-			params.Source = &projectSource
+			input.Source = &projectSource
 		}
 
 		if d.HasChange("artifacts") {
 			projectArtifacts := expandProjectArtifacts(d)
-			params.Artifacts = &projectArtifacts
+			input.Artifacts = &projectArtifacts
 		}
 
 		if d.HasChange("secondary_sources") {
@@ -1487,9 +1474,9 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 			if n.(*schema.Set).Len() > 0 {
 				projectSecondarySources := expandProjectSecondarySources(d)
-				params.SecondarySources = projectSecondarySources
+				input.SecondarySources = projectSecondarySources
 			} else {
-				params.SecondarySources = []*codebuild.ProjectSource{}
+				input.SecondarySources = []*codebuild.ProjectSource{}
 			}
 		}
 
@@ -1499,9 +1486,9 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			psv := d.Get("secondary_source_version").(*schema.Set)
 
 			if n.(*schema.Set).Len() > 0 {
-				params.SecondarySourceVersions = expandProjectSecondarySourceVersions(psv)
+				input.SecondarySourceVersions = expandProjectSecondarySourceVersions(psv)
 			} else {
-				params.SecondarySourceVersions = []*codebuild.ProjectSourceVersion{}
+				input.SecondarySourceVersions = []*codebuild.ProjectSourceVersion{}
 			}
 		}
 
@@ -1510,74 +1497,74 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 			if n.(*schema.Set).Len() > 0 {
 				projectSecondaryArtifacts := expandProjectSecondaryArtifacts(d)
-				params.SecondaryArtifacts = projectSecondaryArtifacts
+				input.SecondaryArtifacts = projectSecondaryArtifacts
 			} else {
-				params.SecondaryArtifacts = []*codebuild.ProjectArtifacts{}
+				input.SecondaryArtifacts = []*codebuild.ProjectArtifacts{}
 			}
 		}
 
 		if d.HasChange("vpc_config") {
-			params.VpcConfig = expandVPCConfig(d.Get("vpc_config").([]interface{}))
+			input.VpcConfig = expandVPCConfig(d.Get("vpc_config").([]interface{}))
 		}
 
 		if d.HasChange("logs_config") {
 			logsConfig := expandProjectLogsConfig(d)
-			params.LogsConfig = logsConfig
+			input.LogsConfig = logsConfig
 		}
 
 		if d.HasChange("build_batch_config") {
-			params.BuildBatchConfig = expandBuildBatchConfig(d)
+			input.BuildBatchConfig = expandBuildBatchConfig(d)
 		}
 
 		if d.HasChange("cache") {
 			if v, ok := d.GetOk("cache"); ok {
-				params.Cache = expandProjectCache(v.([]interface{}))
+				input.Cache = expandProjectCache(v.([]interface{}))
 			} else {
-				params.Cache = &codebuild.ProjectCache{
+				input.Cache = &codebuild.ProjectCache{
 					Type: aws.String("NO_CACHE"),
 				}
 			}
 		}
 
 		if d.HasChange("concurrent_build_limit") {
-			params.ConcurrentBuildLimit = aws.Int64(int64(d.Get("concurrent_build_limit").(int)))
+			input.ConcurrentBuildLimit = aws.Int64(int64(d.Get("concurrent_build_limit").(int)))
 		}
 
 		if d.HasChange("description") {
-			params.Description = aws.String(d.Get("description").(string))
+			input.Description = aws.String(d.Get("description").(string))
 		}
 
 		if d.HasChange("encryption_key") {
-			params.EncryptionKey = aws.String(d.Get("encryption_key").(string))
+			input.EncryptionKey = aws.String(d.Get("encryption_key").(string))
 		}
 
 		if d.HasChange("service_role") {
-			params.ServiceRole = aws.String(d.Get("service_role").(string))
+			input.ServiceRole = aws.String(d.Get("service_role").(string))
 		}
 
 		if d.HasChange("source_version") {
-			params.SourceVersion = aws.String(d.Get("source_version").(string))
+			input.SourceVersion = aws.String(d.Get("source_version").(string))
 		}
 
 		if d.HasChange("build_timeout") {
-			params.TimeoutInMinutes = aws.Int64(int64(d.Get("build_timeout").(int)))
+			input.TimeoutInMinutes = aws.Int64(int64(d.Get("build_timeout").(int)))
 		}
 
 		if d.HasChange("queued_timeout") {
-			params.QueuedTimeoutInMinutes = aws.Int64(int64(d.Get("queued_timeout").(int)))
+			input.QueuedTimeoutInMinutes = aws.Int64(int64(d.Get("queued_timeout").(int)))
 		}
 
 		if d.HasChange("badge_enabled") {
-			params.BadgeEnabled = aws.Bool(d.Get("badge_enabled").(bool))
+			input.BadgeEnabled = aws.Bool(d.Get("badge_enabled").(bool))
 		}
 
 		// The documentation clearly says "The replacement set of tags for this build project."
 		// But its a slice of pointers so if not set for every update, they get removed.
-		params.Tags = Tags(tags.IgnoreAWS())
+		input.Tags = GetTagsIn(ctx)
 
 		// Handle IAM eventual consistency
 		err := retry.RetryContext(ctx, propagationTimeout, func() *retry.RetryError {
-			_, err := conn.UpdateProjectWithContext(ctx, params)
+			_, err := conn.UpdateProjectWithContext(ctx, input)
 			if err != nil {
 				// InvalidInputException: CodeBuild is not authorized to perform
 				// InvalidInputException: Not authorized to perform DescribeSecurityGroups
@@ -1592,7 +1579,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		})
 
 		if tfresource.TimedOut(err) {
-			_, err = conn.UpdateProjectWithContext(ctx, params)
+			_, err = conn.UpdateProjectWithContext(ctx, input)
 		}
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating CodeBuild project (%s): %s", d.Id(), err)

--- a/internal/service/codebuild/report_group.go
+++ b/internal/service/codebuild/report_group.go
@@ -19,7 +19,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_codebuild_report_group")
+// @SDKResource("aws_codebuild_report_group", name="Report Group")
+// @Tags
 func ResourceReportGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceReportGroupCreate,
@@ -103,8 +104,8 @@ func ResourceReportGroup() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -114,16 +115,15 @@ func ResourceReportGroup() *schema.Resource {
 func resourceReportGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CodeBuildConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
-	createOpts := &codebuild.CreateReportGroupInput{
+
+	input := &codebuild.CreateReportGroupInput{
 		Name:         aws.String(d.Get("name").(string)),
 		Type:         aws.String(d.Get("type").(string)),
 		ExportConfig: expandReportGroupExportConfig(d.Get("export_config").([]interface{})),
-		Tags:         Tags(tags.IgnoreAWS()),
+		Tags:         GetTagsIn(ctx),
 	}
 
-	resp, err := conn.CreateReportGroupWithContext(ctx, createOpts)
+	resp, err := conn.CreateReportGroupWithContext(ctx, input)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating CodeBuild Report Group: %s", err)
 	}
@@ -136,8 +136,6 @@ func resourceReportGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 func resourceReportGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CodeBuildConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	reportGroup, err := FindReportGroupByARN(ctx, conn, d.Id())
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, codebuild.ErrCodeResourceNotFoundException) {
@@ -172,16 +170,7 @@ func resourceReportGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 		return sdkdiag.AppendErrorf(diags, "setting export config: %s", err)
 	}
 
-	tags := KeyValueTags(ctx, reportGroup.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, reportGroup.Tags)
 
 	return diags
 }
@@ -189,8 +178,6 @@ func resourceReportGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 func resourceReportGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CodeBuildConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &codebuild.UpdateReportGroupInput{
 		Arn: aws.String(d.Id()),
@@ -201,7 +188,7 @@ func resourceReportGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if d.HasChange("tags_all") {
-		input.Tags = Tags(tags.IgnoreAWS())
+		input.Tags = GetTagsIn(ctx)
 	}
 
 	_, err := conn.UpdateReportGroupWithContext(ctx, input)

--- a/internal/service/codebuild/service_package_gen.go
+++ b/internal/service/codebuild/service_package_gen.go
@@ -28,10 +28,14 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceProject,
 			TypeName: "aws_codebuild_project",
+			Name:     "Project",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
 			Factory:  ResourceReportGroup,
 			TypeName: "aws_codebuild_report_group",
+			Name:     "Report Group",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
 			Factory:  ResourceResourcePolicy,

--- a/internal/service/codecommit/service_package_gen.go
+++ b/internal/service/codecommit/service_package_gen.go
@@ -45,6 +45,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceRepository,
 			TypeName: "aws_codecommit_repository",
+			Name:     "Repository",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceTrigger,

--- a/internal/service/codegurureviewer/service_package_gen.go
+++ b/internal/service/codegurureviewer/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceRepositoryAssociation,
 			TypeName: "aws_codegurureviewer_repository_association",
+			Name:     "Repository Association",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }

--- a/internal/service/codepipeline/service_package_gen.go
+++ b/internal/service/codepipeline/service_package_gen.go
@@ -28,14 +28,26 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourcePipeline,
 			TypeName: "aws_codepipeline",
+			Name:     "Pipeline",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceCustomActionType,
 			TypeName: "aws_codepipeline_custom_action_type",
+			Name:     "Custom Action Type",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceWebhook,
 			TypeName: "aws_codepipeline_webhook",
+			Name:     "Webhook",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }

--- a/internal/service/codepipeline/webhook.go
+++ b/internal/service/codepipeline/webhook.go
@@ -20,7 +20,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_codepipeline_webhook")
+// @SDKResource("aws_codepipeline_webhook", name="Webhook")
+// @Tags(identifierAttribute="id")
 func ResourceWebhook() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceWebhookCreate,
@@ -110,8 +111,8 @@ func ResourceWebhook() *schema.Resource {
 				ForceNew: true,
 				Required: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -121,10 +122,8 @@ func ResourceWebhook() *schema.Resource {
 func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CodePipelineConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
-	authType := d.Get("authentication").(string)
 
+	authType := d.Get("authentication").(string)
 	var authConfig map[string]interface{}
 	if v, ok := d.GetOk("authentication_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		authConfig = v.([]interface{})[0].(map[string]interface{})
@@ -139,7 +138,7 @@ func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, meta int
 			TargetPipeline:              aws.String(d.Get("target_pipeline").(string)),
 			AuthenticationConfiguration: extractWebhookAuthConfig(authType, authConfig),
 		},
-		Tags: Tags(tags.IgnoreAWS()),
+		Tags: GetTagsIn(ctx),
 	}
 
 	webhook, err := conn.PutWebhookWithContext(ctx, request)
@@ -155,8 +154,6 @@ func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, meta int
 func resourceWebhookRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CodePipelineConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	arn := d.Id()
 	webhook, err := GetWebhook(ctx, conn, arn)
@@ -193,16 +190,7 @@ func resourceWebhookRead(ctx context.Context, d *schema.ResourceData, meta inter
 		return sdkdiag.AppendErrorf(diags, "setting filter: %s", err)
 	}
 
-	tags := KeyValueTags(ctx, webhook.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, webhook.Tags)
 
 	return diags
 }
@@ -233,14 +221,6 @@ func resourceWebhookUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		_, err := conn.PutWebhookWithContext(ctx, request)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "Error updating webhook: %s", err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating CodePipeline Webhook (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/codestarconnections/service_package_gen.go
+++ b/internal/service/codestarconnections/service_package_gen.go
@@ -33,6 +33,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceConnection,
 			TypeName: "aws_codestarconnections_connection",
+			Name:     "Connection",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceHost,

--- a/internal/service/codestarnotifications/service_package_gen.go
+++ b/internal/service/codestarnotifications/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceNotificationRule,
 			TypeName: "aws_codestarnotifications_notification_rule",
+			Name:     "Notification Rule",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }

--- a/internal/service/cognitoidentity/service_package_gen.go
+++ b/internal/service/cognitoidentity/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourcePool,
 			TypeName: "aws_cognito_identity_pool",
+			Name:     "Pool",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourcePoolProviderPrincipalTag,

--- a/internal/service/cognitoidp/service_package_gen.go
+++ b/internal/service/cognitoidp/service_package_gen.go
@@ -76,6 +76,8 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceUserPool,
 			TypeName: "aws_cognito_user_pool",
+			Name:     "User Pool",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
 			Factory:  ResourceUserPoolDomain,

--- a/internal/service/comprehend/service_package_gen.go
+++ b/internal/service/comprehend/service_package_gen.go
@@ -28,10 +28,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDocumentClassifier,
 			TypeName: "aws_comprehend_document_classifier",
+			Name:     "Document Classifier",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceEntityRecognizer,
 			TypeName: "aws_comprehend_entity_recognizer",
+			Name:     "Entity Recognizer",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }

--- a/internal/service/configservice/config_rule.go
+++ b/internal/service/configservice/config_rule.go
@@ -21,9 +21,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_config_config_rule")
+// @SDKResource("aws_config_config_rule", name="Config Rule")
+// @Tags(identifierAttribute="arn")
 func ResourceConfigRule() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRulePutConfig,
@@ -176,8 +178,8 @@ func ResourceConfigRule() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -187,8 +189,6 @@ func ResourceConfigRule() *schema.Resource {
 func resourceRulePutConfig(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ConfigServiceConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	ruleInput := configservice.ConfigRule{
@@ -209,7 +209,7 @@ func resourceRulePutConfig(ctx context.Context, d *schema.ResourceData, meta int
 
 	input := configservice.PutConfigRuleInput{
 		ConfigRule: &ruleInput,
-		Tags:       Tags(tags.IgnoreAWS()),
+		Tags:       GetTagsIn(ctx),
 	}
 	log.Printf("[DEBUG] Creating AWSConfig config rule: %s", input)
 	err := retry.RetryContext(ctx, propagationTimeout, func() *retry.RetryError {
@@ -234,25 +234,12 @@ func resourceRulePutConfig(ctx context.Context, d *schema.ResourceData, meta int
 
 	d.SetId(name)
 
-	log.Printf("[DEBUG] AWSConfig config rule %q created", name)
-
-	if !d.IsNewResource() && d.HasChange("tags_all") {
-		arn := d.Get("arn").(string)
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, arn, o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Config Config Rule (%s) tags: %s", arn, err)
-		}
-	}
-
 	return append(diags, resourceConfigRuleRead(ctx, d, meta)...)
 }
 
 func resourceConfigRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ConfigServiceConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	rule, err := FindConfigRule(ctx, conn, d.Id())
 
@@ -275,23 +262,6 @@ func resourceConfigRuleRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	d.Set("source", flattenRuleSource(rule.Source))
-
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Config Config Rule (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
 
 	return diags
 }

--- a/internal/service/configservice/service_package_gen.go
+++ b/internal/service/configservice/service_package_gen.go
@@ -28,14 +28,26 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceAggregateAuthorization,
 			TypeName: "aws_config_aggregate_authorization",
+			Name:     "Aggregate Authorization",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceConfigRule,
 			TypeName: "aws_config_config_rule",
+			Name:     "Config Rule",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceConfigurationAggregator,
 			TypeName: "aws_config_configuration_aggregator",
+			Name:     "Configuration Aggregator",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceConfigurationRecorder,

--- a/internal/service/connect/contact_flow_module.go
+++ b/internal/service/connect/contact_flow_module.go
@@ -17,12 +17,14 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 	"github.com/mitchellh/go-homedir"
 )
 
 const contactFlowModuleMutexKey = `aws_connect_contact_flow_module`
 
-// @SDKResource("aws_connect_contact_flow_module")
+// @SDKResource("aws_connect_contact_flow_module", name="Contact Flow Module")
+// @Tags(identifierAttribute="arn")
 func ResourceContactFlowModule() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceContactFlowModuleCreate,
@@ -77,16 +79,14 @@ func ResourceContactFlowModule() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringLenBetween(1, 127),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:tftags.TagsSchema(),
+names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
 
 func resourceContactFlowModuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).ConnectConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	instanceID := d.Get("instance_id").(string)
 	name := d.Get("name").(string)
@@ -94,6 +94,7 @@ func resourceContactFlowModuleCreate(ctx context.Context, d *schema.ResourceData
 	input := &connect.CreateContactFlowModuleInput{
 		Name:       aws.String(name),
 		InstanceId: aws.String(instanceID),
+		Tags: GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -116,10 +117,6 @@ func resourceContactFlowModuleCreate(ctx context.Context, d *schema.ResourceData
 		input.Content = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
 	output, err := conn.CreateContactFlowModuleWithContext(ctx, input)
 
 	if err != nil {
@@ -137,8 +134,6 @@ func resourceContactFlowModuleCreate(ctx context.Context, d *schema.ResourceData
 
 func resourceContactFlowModuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).ConnectConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	instanceID, contactFlowModuleID, err := ContactFlowModuleParseID(d.Id())
 
@@ -172,16 +167,7 @@ func resourceContactFlowModuleRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("description", resp.ContactFlowModule.Description)
 	d.Set("content", resp.ContactFlowModule.Content)
 
-	tags := KeyValueTags(ctx, resp.ContactFlowModule.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting tags: %w", err))
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting tags_all: %w", err))
-	}
+	SetTagsOut(ctx, resp.ContactFlowModule.Tags)
 
 	return nil
 }
@@ -236,13 +222,6 @@ func resourceContactFlowModuleUpdate(ctx context.Context, d *schema.ResourceData
 
 		if updateContentInputErr != nil {
 			return diag.FromErr(fmt.Errorf("error updating Connect Contact Flow Module content (%s): %w", d.Id(), updateContentInputErr))
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.FromErr(fmt.Errorf("error updating tags: %w", err))
 		}
 	}
 

--- a/internal/service/connect/contact_flow_module.go
+++ b/internal/service/connect/contact_flow_module.go
@@ -79,8 +79,8 @@ func ResourceContactFlowModule() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringLenBetween(1, 127),
 			},
-			names.AttrTags:tftags.TagsSchema(),
-names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -94,7 +94,7 @@ func resourceContactFlowModuleCreate(ctx context.Context, d *schema.ResourceData
 	input := &connect.CreateContactFlowModuleInput{
 		Name:       aws.String(name),
 		InstanceId: aws.String(instanceID),
-		Tags: GetTagsIn(ctx),
+		Tags:       GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("description"); ok {

--- a/internal/service/connect/service_package_gen.go
+++ b/internal/service/connect/service_package_gen.go
@@ -89,14 +89,26 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceContactFlow,
 			TypeName: "aws_connect_contact_flow",
+			Name:     "Contact Flow",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceContactFlowModule,
 			TypeName: "aws_connect_contact_flow_module",
+			Name:     "Contact Flow Module",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceHoursOfOperation,
 			TypeName: "aws_connect_hours_of_operation",
+			Name:     "Hours Of Operation",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceInstance,
@@ -113,30 +125,58 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourcePhoneNumber,
 			TypeName: "aws_connect_phone_number",
+			Name:     "Phone Number",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceQueue,
 			TypeName: "aws_connect_queue",
+			Name:     "Queue",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceQuickConnect,
 			TypeName: "aws_connect_quick_connect",
+			Name:     "Quick Connect",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRoutingProfile,
 			TypeName: "aws_connect_routing_profile",
+			Name:     "Routing Profile",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceSecurityProfile,
 			TypeName: "aws_connect_security_profile",
+			Name:     "Security Profile",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceUser,
 			TypeName: "aws_connect_user",
+			Name:     "User",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceUserHierarchyGroup,
 			TypeName: "aws_connect_user_hierarchy_group",
+			Name:     "User Hierarchy Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceUserHierarchyStructure,
@@ -145,6 +185,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceVocabulary,
 			TypeName: "aws_connect_vocabulary",
+			Name:     "Vocabulary",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/connect/user_hierarchy_group.go
+++ b/internal/service/connect/user_hierarchy_group.go
@@ -15,9 +15,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_connect_user_hierarchy_group")
+// @SDKResource("aws_connect_user_hierarchy_group", name="User Hierarchy Group")
+// @Tags(identifierAttribute="arn")
 func ResourceUserHierarchyGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceUserHierarchyGroupCreate,
@@ -84,8 +86,8 @@ func ResourceUserHierarchyGroup() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -116,23 +118,17 @@ func userHierarchyPathLevelSchema() *schema.Schema {
 
 func resourceUserHierarchyGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).ConnectConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	instanceID := d.Get("instance_id").(string)
 	userHierarchyGroupName := d.Get("name").(string)
-
 	input := &connect.CreateUserHierarchyGroupInput{
 		InstanceId: aws.String(instanceID),
 		Name:       aws.String(userHierarchyGroupName),
+		Tags:       GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("parent_group_id"); ok {
 		input.ParentGroupId = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	log.Printf("[DEBUG] Creating Connect User Hierarchy Group %s", input)
@@ -153,8 +149,6 @@ func resourceUserHierarchyGroupCreate(ctx context.Context, d *schema.ResourceDat
 
 func resourceUserHierarchyGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).ConnectConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	instanceID, userHierarchyGroupID, err := UserHierarchyGroupParseID(d.Id())
 
@@ -191,16 +185,7 @@ func resourceUserHierarchyGroupRead(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(fmt.Errorf("error setting Connect User Hierarchy Group hierarchy_path (%s): %w", d.Id(), err))
 	}
 
-	tags := KeyValueTags(ctx, resp.HierarchyGroup.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting tags: %w", err))
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting tags_all: %w", err))
-	}
+	SetTagsOut(ctx, resp.HierarchyGroup.Tags)
 
 	return nil
 }
@@ -222,13 +207,6 @@ func resourceUserHierarchyGroupUpdate(ctx context.Context, d *schema.ResourceDat
 		})
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("updating User Hierarchy Group (%s): %w", d.Id(), err))
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.FromErr(fmt.Errorf("error updating tags: %w", err))
 		}
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin SDK.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30421.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30430.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30449.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30454.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30461.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30463.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30476.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30477.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30478.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=c... ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/c.../... -v -count 1 -parallel 2  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccCEAnomalyMonitor_basic
=== PAUSE TestAccCEAnomalyMonitor_basic
=== RUN   TestAccCEAnomalyMonitor_tags
=== PAUSE TestAccCEAnomalyMonitor_tags
=== RUN   TestAccCEAnomalySubscription_basic
=== PAUSE TestAccCEAnomalySubscription_basic
=== RUN   TestAccCECostAllocationTag_basic
=== PAUSE TestAccCECostAllocationTag_basic
=== RUN   TestAccCECostCategoryDataSource_basic
=== PAUSE TestAccCECostCategoryDataSource_basic
=== RUN   TestAccCECostCategory_basic
=== PAUSE TestAccCECostCategory_basic
=== RUN   TestAccCECostCategory_tags
=== PAUSE TestAccCECostCategory_tags
=== RUN   TestAccCETagsDataSource_basic
=== PAUSE TestAccCETagsDataSource_basic
=== CONT  TestAccCEAnomalyMonitor_basic
=== CONT  TestAccCECostCategoryDataSource_basic
    cost_category_data_source_test.go:19: Step 1/1 error: Error running apply: exit status 1
        
        Error: creating AWS CE (Cost Explorer) Cost Category (): AccessDeniedException: Failed to create Cost Category: Linked account doesn't have access to cost category.
        	status code: 400, request id: ffe8f9bd-76c6-40ae-a237-091aa52b7cfc
        
          with aws_ce_cost_category.test,
          on terraform_plugin_test.tf line 2, in resource "aws_ce_cost_category" "test":
           2: resource "aws_ce_cost_category" "test" {
        
=== CONT  TestAccCEAnomalyMonitor_basic
    anomaly_monitor_test.go:28: Step 1/2 error: Error running apply: exit status 1
        
        Error: Error creating Anomaly Monitor: ValidationException: Linked accounts can only create AWS Services monitor
        	status code: 400, request id: 62505c05-0dd1-43ca-b0dd-c3c63a786e1a
        
          with aws_ce_anomaly_monitor.test,
          on terraform_plugin_test.tf line 2, in resource "aws_ce_anomaly_monitor" "test":
           2: resource "aws_ce_anomaly_monitor" "test" {
        
--- FAIL: TestAccCECostCategoryDataSource_basic (39.10s)
=== CONT  TestAccCECostCategory_tags
--- FAIL: TestAccCEAnomalyMonitor_basic (40.46s)
=== CONT  TestAccCETagsDataSource_basic
=== CONT  TestAccCECostCategory_tags
    cost_category_test.go:186: Step 1/4 error: Error running apply: exit status 1
        
        Error: creating AWS CE (Cost Explorer) Cost Category (): AccessDeniedException: Failed to create Cost Category: Linked account doesn't have access to cost category.
        	status code: 400, request id: 12f4252e-1c8f-4588-8441-15305c019b90
        
          with aws_ce_cost_category.test,
          on terraform_plugin_test.tf line 2, in resource "aws_ce_cost_category" "test":
           2: resource "aws_ce_cost_category" "test" {
        
=== CONT  TestAccCETagsDataSource_basic
    tags_data_source_test.go:27: Step 1/1 error: Error running apply: exit status 1
        
        Error: creating AWS CE (Cost Explorer) Cost Category (): AccessDeniedException: Failed to create Cost Category: Linked account doesn't have access to cost category.
        	status code: 400, request id: 9e1a3222-2b8e-480b-9e46-f9302e5d014a
        
          with aws_ce_cost_category.test,
          on terraform_plugin_test.tf line 2, in resource "aws_ce_cost_category" "test":
           2: resource "aws_ce_cost_category" "test" {
        
--- FAIL: TestAccCECostCategory_tags (36.61s)
=== CONT  TestAccCECostCategory_basic
--- FAIL: TestAccCETagsDataSource_basic (45.09s)
=== CONT  TestAccCEAnomalySubscription_basic
=== CONT  TestAccCECostCategory_basic
    cost_category_test.go:25: Step 1/2 error: Error running apply: exit status 1
        
        Error: creating AWS CE (Cost Explorer) Cost Category (): AccessDeniedException: Failed to create Cost Category: Linked account doesn't have access to cost category.
        	status code: 400, request id: 1f53d18b-4e28-44cf-a36e-a175f059a350
        
          with aws_ce_cost_category.test,
          on terraform_plugin_test.tf line 2, in resource "aws_ce_cost_category" "test":
           2: resource "aws_ce_cost_category" "test" {
        
--- FAIL: TestAccCECostCategory_basic (32.84s)
=== CONT  TestAccCECostAllocationTag_basic
=== CONT  TestAccCEAnomalySubscription_basic
    anomaly_subscription_test.go:30: Step 1/2 error: Error running apply: exit status 1
        
        Error: Error creating Anomaly Monitor: ValidationException: Linked accounts can only create AWS Services monitor
        	status code: 400, request id: 927d0993-2ea4-43f4-ae5a-412954768324
        
          with aws_ce_anomaly_monitor.test,
          on terraform_plugin_test.tf line 2, in resource "aws_ce_anomaly_monitor" "test":
           2: resource "aws_ce_anomaly_monitor" "test" {
        
--- FAIL: TestAccCEAnomalySubscription_basic (34.50s)
=== CONT  TestAccCEAnomalyMonitor_tags
=== CONT  TestAccCECostAllocationTag_basic
    cost_allocation_tag_test.go:25: Step 1/4 error: Error running apply: exit status 1
        
        Error: reading AWS CE (Cost Explorer) Cost Allocation Tags (Tag01): AccessDeniedException: Failed to list Cost Allocation Tags: Linked account doesn't have access to cost allocation tags.
        	status code: 400, request id: 98cb71f0-f167-4e89-943c-703ec49a203a
        
          with aws_ce_cost_allocation_tag.test,
          on terraform_plugin_test.tf line 2, in resource "aws_ce_cost_allocation_tag" "test":
           2: resource "aws_ce_cost_allocation_tag" "test" {
        
=== CONT  TestAccCEAnomalyMonitor_tags
    anomaly_monitor_test.go:119: Step 1/4 error: Error running apply: exit status 1
        
        Error: Error creating Anomaly Monitor: ValidationException: Linked accounts can only create AWS Services monitor
        	status code: 400, request id: 15ad202d-e610-42de-8be8-4ab7d988fc25
        
          with aws_ce_anomaly_monitor.test,
          on terraform_plugin_test.tf line 2, in resource "aws_ce_anomaly_monitor" "test":
           2: resource "aws_ce_anomaly_monitor" "test" {
        
=== CONT  TestAccCECostAllocationTag_basic
    testing_new.go:82: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: updating AWS CE (Cost Explorer) Cost Allocation Tags (Tag01): AccessDeniedException: Failed to update Cost Allocation Tag: Linked account doesn't have access to cost allocation tags.
        	status code: 400, request id: 87fdae34-a854-4f0d-a971-36867590d9b5
        
--- FAIL: TestAccCECostAllocationTag_basic (39.42s)
--- FAIL: TestAccCEAnomalyMonitor_tags (28.99s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ce	233.567s
=== RUN   TestAccChimeVoiceConnectorGroup_basic
=== PAUSE TestAccChimeVoiceConnectorGroup_basic
=== RUN   TestAccChimeVoiceConnectorLogging_basic
=== PAUSE TestAccChimeVoiceConnectorLogging_basic
=== RUN   TestAccChimeVoiceConnectorOrigination_basic
=== PAUSE TestAccChimeVoiceConnectorOrigination_basic
=== RUN   TestAccChimeVoiceConnectorStreaming_basic
=== PAUSE TestAccChimeVoiceConnectorStreaming_basic
=== RUN   TestAccChimeVoiceConnectorTerminationCredentials_basic
=== PAUSE TestAccChimeVoiceConnectorTerminationCredentials_basic
=== RUN   TestAccChimeVoiceConnectorTermination_basic
=== PAUSE TestAccChimeVoiceConnectorTermination_basic
=== RUN   TestAccChimeVoiceConnector_basic
=== PAUSE TestAccChimeVoiceConnector_basic
=== CONT  TestAccChimeVoiceConnectorGroup_basic
=== CONT  TestAccChimeVoiceConnectorTerminationCredentials_basic
--- PASS: TestAccChimeVoiceConnectorTerminationCredentials_basic (100.14s)
=== CONT  TestAccChimeVoiceConnector_basic
--- PASS: TestAccChimeVoiceConnectorGroup_basic (104.55s)
=== CONT  TestAccChimeVoiceConnectorOrigination_basic
--- PASS: TestAccChimeVoiceConnector_basic (95.93s)
=== CONT  TestAccChimeVoiceConnectorStreaming_basic
--- PASS: TestAccChimeVoiceConnectorOrigination_basic (94.21s)
=== CONT  TestAccChimeVoiceConnectorTermination_basic
--- PASS: TestAccChimeVoiceConnectorStreaming_basic (71.33s)
=== CONT  TestAccChimeVoiceConnectorLogging_basic
--- PASS: TestAccChimeVoiceConnectorTermination_basic (72.76s)
--- PASS: TestAccChimeVoiceConnectorLogging_basic (71.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/chime	382.054s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/chimesdkmediapipelines	[no test files]
=== RUN   TestAccCloud9EnvironmentEC2_basic
=== PAUSE TestAccCloud9EnvironmentEC2_basic
=== RUN   TestAccCloud9EnvironmentEC2_tags
=== PAUSE TestAccCloud9EnvironmentEC2_tags
=== RUN   TestAccCloud9EnvironmentMembership_basic
=== PAUSE TestAccCloud9EnvironmentMembership_basic
=== CONT  TestAccCloud9EnvironmentEC2_basic
=== CONT  TestAccCloud9EnvironmentEC2_tags
--- PASS: TestAccCloud9EnvironmentEC2_basic (247.95s)
=== CONT  TestAccCloud9EnvironmentMembership_basic
--- PASS: TestAccCloud9EnvironmentEC2_tags (316.52s)
--- PASS: TestAccCloud9EnvironmentMembership_basic (286.70s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloud9	591.219s
=== RUN   TestAccCloudControlResourceDataSource_basic
=== PAUSE TestAccCloudControlResourceDataSource_basic
=== RUN   TestAccCloudControlResource_basic
=== PAUSE TestAccCloudControlResource_basic
=== CONT  TestAccCloudControlResourceDataSource_basic
=== CONT  TestAccCloudControlResource_basic
--- PASS: TestAccCloudControlResourceDataSource_basic (92.06s)
--- PASS: TestAccCloudControlResource_basic (94.92s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudcontrol	166.859s
=== RUN   TestAccCloudFormationExportDataSource_basic
=== PAUSE TestAccCloudFormationExportDataSource_basic
=== RUN   TestAccCloudFormationStackDataSource_DataSource_basic
=== PAUSE TestAccCloudFormationStackDataSource_DataSource_basic
=== RUN   TestAccCloudFormationStackSetInstance_basic
=== PAUSE TestAccCloudFormationStackSetInstance_basic
=== RUN   TestAccCloudFormationStackSet_basic
=== PAUSE TestAccCloudFormationStackSet_basic
=== RUN   TestAccCloudFormationStackSet_tags
=== PAUSE TestAccCloudFormationStackSet_tags
=== RUN   TestAccCloudFormationStack_basic
=== PAUSE TestAccCloudFormationStack_basic
=== RUN   TestAccCloudFormationType_basic
    type_test.go:30: /Users/ewbankkit/altsrc.2/github.com/terraform-providers/terraform-provider-aws/internal/service/cloudformation/testdata/examplecompany-exampleservice-exampleresource/bin/handler does not exist. To generate locally: cd /Users/ewbankkit/altsrc.2/github.com/terraform-providers/terraform-provider-aws/internal/service/cloudformation/testdata/examplecompany-exampleservice-exampleresource && make build
--- SKIP: TestAccCloudFormationType_basic (0.01s)
=== CONT  TestAccCloudFormationExportDataSource_basic
=== CONT  TestAccCloudFormationStackSet_basic
--- PASS: TestAccCloudFormationExportDataSource_basic (108.24s)
=== CONT  TestAccCloudFormationStack_basic
--- PASS: TestAccCloudFormationStackSet_basic (114.85s)
=== CONT  TestAccCloudFormationStackSetInstance_basic
    stack_set_instance_test.go:26: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_iam_role.Execution will be updated in-place
          ~ resource "aws_iam_role" "Execution" {
              ~ assume_role_policy    = jsonencode(
                  ~ {
                      ~ Statement = [
                          ~ {
                              ~ Action    = "sts:AssumeRole" -> [
                                  + "sts:AssumeRole",
                                ]
                              ~ Principal = {
                                  ~ AWS = "AROAWH4AAR7YMS5BHSBYY" -> [
                                      + "arn:aws:iam::123456789012:role/tf-acc-test-1522448231151117510-Administration",
                                    ]
                                }
                                # (1 unchanged element hidden)
                            },
                        ]
                        # (1 unchanged element hidden)
                    }
                )
                id                    = "tf-acc-test-1522448231151117510-Execution"
                name                  = "tf-acc-test-1522448231151117510-Execution"
                # (8 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccCloudFormationStackSetInstance_basic (114.44s)
=== CONT  TestAccCloudFormationStackDataSource_DataSource_basic
--- PASS: TestAccCloudFormationStack_basic (127.72s)
=== CONT  TestAccCloudFormationStackSet_tags
--- PASS: TestAccCloudFormationStackDataSource_DataSource_basic (94.48s)
--- PASS: TestAccCloudFormationStackSet_tags (249.77s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation	515.811s
=== RUN   TestAccCloudFrontCachePolicyDataSource_basic
=== PAUSE TestAccCloudFrontCachePolicyDataSource_basic
=== RUN   TestAccCloudFrontCachePolicy_basic
=== PAUSE TestAccCloudFrontCachePolicy_basic
=== RUN   TestAccCloudFrontDistributionDataSource_basic
=== PAUSE TestAccCloudFrontDistributionDataSource_basic
=== RUN   TestAccCloudFrontFieldLevelEncryptionConfig_basic
=== PAUSE TestAccCloudFrontFieldLevelEncryptionConfig_basic
=== RUN   TestAccCloudFrontFieldLevelEncryptionProfile_basic
=== PAUSE TestAccCloudFrontFieldLevelEncryptionProfile_basic
=== RUN   TestAccCloudFrontFunctionDataSource_basic
=== PAUSE TestAccCloudFrontFunctionDataSource_basic
=== RUN   TestAccCloudFrontFunction_basic
=== PAUSE TestAccCloudFrontFunction_basic
=== RUN   TestAccCloudFrontKeyGroup_basic
=== PAUSE TestAccCloudFrontKeyGroup_basic
=== RUN   TestAccCloudFrontLogDeliveryCanonicalUserIDDataSource_basic
=== PAUSE TestAccCloudFrontLogDeliveryCanonicalUserIDDataSource_basic
=== RUN   TestAccCloudFrontMonitoringSubscription_basic
=== PAUSE TestAccCloudFrontMonitoringSubscription_basic
=== RUN   TestAccCloudFrontOriginAccessControl_basic
=== PAUSE TestAccCloudFrontOriginAccessControl_basic
=== RUN   TestAccCloudFrontOriginAccessIdentityDataSource_basic
=== PAUSE TestAccCloudFrontOriginAccessIdentityDataSource_basic
=== RUN   TestAccCloudFrontOriginAccessIdentity_basic
=== PAUSE TestAccCloudFrontOriginAccessIdentity_basic
=== RUN   TestAccCloudFrontOriginRequestPolicyDataSource_basic
=== PAUSE TestAccCloudFrontOriginRequestPolicyDataSource_basic
=== RUN   TestAccCloudFrontOriginRequestPolicy_basic
=== PAUSE TestAccCloudFrontOriginRequestPolicy_basic
=== RUN   TestAccCloudFrontPublicKey_basic
=== PAUSE TestAccCloudFrontPublicKey_basic
=== RUN   TestAccCloudFrontRealtimeLogConfigDataSource_basic
=== PAUSE TestAccCloudFrontRealtimeLogConfigDataSource_basic
=== RUN   TestAccCloudFrontRealtimeLogConfig_basic
=== PAUSE TestAccCloudFrontRealtimeLogConfig_basic
=== RUN   TestAccCloudFrontResponseHeadersPolicyDataSource_basic
=== PAUSE TestAccCloudFrontResponseHeadersPolicyDataSource_basic
=== CONT  TestAccCloudFrontCachePolicyDataSource_basic
=== CONT  TestAccCloudFrontOriginAccessControl_basic
--- PASS: TestAccCloudFrontCachePolicyDataSource_basic (84.93s)
=== CONT  TestAccCloudFrontFunctionDataSource_basic
--- PASS: TestAccCloudFrontOriginAccessControl_basic (109.88s)
=== CONT  TestAccCloudFrontMonitoringSubscription_basic
    monitoring_subscription_test.go:22: Step 1/2 error: Error running apply: exit status 1
        
        Error: creating CloudFront Distribution: InvalidParameter: 1 validation error(s) found.
        - missing required field, CreateDistributionWithTagsInput.DistributionConfigWithTags.Tags.
        
        
          with aws_cloudfront_distribution.test,
          on terraform_plugin_test.tf line 2, in resource "aws_cloudfront_distribution" "test":
           2: resource "aws_cloudfront_distribution" "test" {
        
--- FAIL: TestAccCloudFrontMonitoringSubscription_basic (35.55s)
=== CONT  TestAccCloudFrontLogDeliveryCanonicalUserIDDataSource_basic
--- PASS: TestAccCloudFrontFunctionDataSource_basic (86.66s)
=== CONT  TestAccCloudFrontKeyGroup_basic
--- PASS: TestAccCloudFrontLogDeliveryCanonicalUserIDDataSource_basic (64.34s)
=== CONT  TestAccCloudFrontFunction_basic
--- PASS: TestAccCloudFrontKeyGroup_basic (80.74s)
=== CONT  TestAccCloudFrontFieldLevelEncryptionConfig_basic
--- PASS: TestAccCloudFrontFunction_basic (76.09s)
=== CONT  TestAccCloudFrontFieldLevelEncryptionProfile_basic
--- PASS: TestAccCloudFrontFieldLevelEncryptionConfig_basic (122.12s)
=== CONT  TestAccCloudFrontPublicKey_basic
--- PASS: TestAccCloudFrontFieldLevelEncryptionProfile_basic (121.72s)
=== CONT  TestAccCloudFrontResponseHeadersPolicyDataSource_basic
--- PASS: TestAccCloudFrontPublicKey_basic (78.42s)
=== CONT  TestAccCloudFrontRealtimeLogConfig_basic
--- PASS: TestAccCloudFrontResponseHeadersPolicyDataSource_basic (66.58s)
=== CONT  TestAccCloudFrontRealtimeLogConfigDataSource_basic
--- PASS: TestAccCloudFrontRealtimeLogConfig_basic (112.26s)
=== CONT  TestAccCloudFrontDistributionDataSource_basic
--- PASS: TestAccCloudFrontRealtimeLogConfigDataSource_basic (99.00s)
=== CONT  TestAccCloudFrontCachePolicy_basic
--- PASS: TestAccCloudFrontCachePolicy_basic (80.73s)
=== CONT  TestAccCloudFrontOriginRequestPolicyDataSource_basic
--- PASS: TestAccCloudFrontOriginRequestPolicyDataSource_basic (68.54s)
=== CONT  TestAccCloudFrontOriginRequestPolicy_basic
--- PASS: TestAccCloudFrontOriginRequestPolicy_basic (87.11s)
=== CONT  TestAccCloudFrontOriginAccessIdentity_basic
--- PASS: TestAccCloudFrontOriginAccessIdentity_basic (76.80s)
=== CONT  TestAccCloudFrontOriginAccessIdentityDataSource_basic
--- PASS: TestAccCloudFrontOriginAccessIdentityDataSource_basic (56.62s)
--- PASS: TestAccCloudFrontDistributionDataSource_basic (536.75s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	1120.259s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudhsmv2	11.298s [no tests to run]
=== RUN   TestAccCloudSearchDomainServiceAccessPolicy_basic
=== PAUSE TestAccCloudSearchDomainServiceAccessPolicy_basic
=== RUN   TestAccCloudSearchDomain_basic
=== PAUSE TestAccCloudSearchDomain_basic
=== CONT  TestAccCloudSearchDomainServiceAccessPolicy_basic
=== CONT  TestAccCloudSearchDomain_basic
--- PASS: TestAccCloudSearchDomain_basic (923.77s)
--- PASS: TestAccCloudSearchDomainServiceAccessPolicy_basic (1766.86s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudsearch	1867.083s
=== RUN   TestAccCloudTrailEventDataStore_basic
=== PAUSE TestAccCloudTrailEventDataStore_basic
=== RUN   TestAccCloudTrailEventDataStore_tags
=== PAUSE TestAccCloudTrailEventDataStore_tags
=== RUN   TestAccCloudTrailServiceAccountDataSource_basic
=== PAUSE TestAccCloudTrailServiceAccountDataSource_basic
=== CONT  TestAccCloudTrailEventDataStore_basic
=== CONT  TestAccCloudTrailServiceAccountDataSource_basic
--- PASS: TestAccCloudTrailServiceAccountDataSource_basic (69.17s)
=== CONT  TestAccCloudTrailEventDataStore_tags
--- PASS: TestAccCloudTrailEventDataStore_basic (96.05s)
--- PASS: TestAccCloudTrailEventDataStore_tags (162.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudtrail	255.201s
=== RUN   TestAccCloudWatchCompositeAlarm_basic
=== PAUSE TestAccCloudWatchCompositeAlarm_basic
=== RUN   TestAccCloudWatchDashboard_basic
=== PAUSE TestAccCloudWatchDashboard_basic
=== RUN   TestAccCloudWatchMetricAlarm_basic
=== PAUSE TestAccCloudWatchMetricAlarm_basic
=== RUN   TestAccCloudWatchMetricAlarm_tags
=== PAUSE TestAccCloudWatchMetricAlarm_tags
=== RUN   TestAccCloudWatchMetricStream_basic
=== PAUSE TestAccCloudWatchMetricStream_basic
=== RUN   TestAccCloudWatchMetricStream_tags
=== PAUSE TestAccCloudWatchMetricStream_tags
=== CONT  TestAccCloudWatchCompositeAlarm_basic
=== CONT  TestAccCloudWatchMetricAlarm_tags
--- PASS: TestAccCloudWatchCompositeAlarm_basic (82.13s)
=== CONT  TestAccCloudWatchMetricStream_tags
--- PASS: TestAccCloudWatchMetricAlarm_tags (181.02s)
=== CONT  TestAccCloudWatchMetricAlarm_basic
--- PASS: TestAccCloudWatchMetricAlarm_basic (85.05s)
=== CONT  TestAccCloudWatchMetricStream_basic
--- PASS: TestAccCloudWatchMetricStream_tags (396.33s)
=== CONT  TestAccCloudWatchDashboard_basic
--- PASS: TestAccCloudWatchMetricStream_basic (217.67s)
--- PASS: TestAccCloudWatchDashboard_basic (68.43s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch	569.185s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codeartifact	22.483s [no tests to run]
=== RUN   TestAccCodeBuildProject_basic
=== PAUSE TestAccCodeBuildProject_basic
=== RUN   TestAccCodeBuildProject_tags
=== PAUSE TestAccCodeBuildProject_tags
=== RUN   TestAccCodeBuildReportGroup_basic
=== PAUSE TestAccCodeBuildReportGroup_basic
=== RUN   TestAccCodeBuildReportGroup_tags
=== PAUSE TestAccCodeBuildReportGroup_tags
=== RUN   TestAccCodeBuildResourcePolicy_basic
=== PAUSE TestAccCodeBuildResourcePolicy_basic
=== RUN   TestAccCodeBuildSourceCredential_basic
=== PAUSE TestAccCodeBuildSourceCredential_basic
=== CONT  TestAccCodeBuildProject_basic
=== CONT  TestAccCodeBuildSourceCredential_basic
--- PASS: TestAccCodeBuildProject_basic (107.89s)
=== CONT  TestAccCodeBuildResourcePolicy_basic
--- PASS: TestAccCodeBuildSourceCredential_basic (138.73s)
=== CONT  TestAccCodeBuildReportGroup_basic
--- PASS: TestAccCodeBuildResourcePolicy_basic (79.82s)
=== CONT  TestAccCodeBuildProject_tags
--- PASS: TestAccCodeBuildReportGroup_basic (84.81s)
=== CONT  TestAccCodeBuildReportGroup_tags
--- PASS: TestAccCodeBuildProject_tags (148.42s)
--- PASS: TestAccCodeBuildReportGroup_tags (173.38s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codebuild	419.398s
=== RUN   TestAccCodeCommitApprovalRuleTemplateAssociation_basic
=== PAUSE TestAccCodeCommitApprovalRuleTemplateAssociation_basic
=== RUN   TestAccCodeCommitApprovalRuleTemplateDataSource_basic
=== PAUSE TestAccCodeCommitApprovalRuleTemplateDataSource_basic
=== RUN   TestAccCodeCommitApprovalRuleTemplate_basic
=== PAUSE TestAccCodeCommitApprovalRuleTemplate_basic
=== RUN   TestAccCodeCommitRepositoryDataSource_basic
=== PAUSE TestAccCodeCommitRepositoryDataSource_basic
=== RUN   TestAccCodeCommitRepository_basic
=== PAUSE TestAccCodeCommitRepository_basic
=== RUN   TestAccCodeCommitRepository_tags
=== PAUSE TestAccCodeCommitRepository_tags
=== RUN   TestAccCodeCommitTrigger_basic
=== PAUSE TestAccCodeCommitTrigger_basic
=== CONT  TestAccCodeCommitApprovalRuleTemplateAssociation_basic
=== CONT  TestAccCodeCommitRepository_basic
--- PASS: TestAccCodeCommitRepository_basic (94.21s)
=== CONT  TestAccCodeCommitApprovalRuleTemplate_basic
--- PASS: TestAccCodeCommitApprovalRuleTemplateAssociation_basic (95.44s)
=== CONT  TestAccCodeCommitRepositoryDataSource_basic
--- PASS: TestAccCodeCommitRepositoryDataSource_basic (65.03s)
=== CONT  TestAccCodeCommitTrigger_basic
--- PASS: TestAccCodeCommitApprovalRuleTemplate_basic (79.49s)
=== CONT  TestAccCodeCommitApprovalRuleTemplateDataSource_basic
--- PASS: TestAccCodeCommitTrigger_basic (72.12s)
=== CONT  TestAccCodeCommitRepository_tags
--- PASS: TestAccCodeCommitApprovalRuleTemplateDataSource_basic (74.88s)
--- PASS: TestAccCodeCommitRepository_tags (163.51s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codecommit	420.021s
=== RUN   TestAccCodeGuruReviewerRepositoryAssociation_basic
=== PAUSE TestAccCodeGuruReviewerRepositoryAssociation_basic
=== RUN   TestAccCodeGuruReviewerRepositoryAssociation_tags
=== PAUSE TestAccCodeGuruReviewerRepositoryAssociation_tags
=== CONT  TestAccCodeGuruReviewerRepositoryAssociation_basic
=== CONT  TestAccCodeGuruReviewerRepositoryAssociation_tags
--- PASS: TestAccCodeGuruReviewerRepositoryAssociation_basic (144.58s)
--- PASS: TestAccCodeGuruReviewerRepositoryAssociation_tags (251.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codegurureviewer	277.516s
=== RUN   TestAccCodePipeline_basic
=== PAUSE TestAccCodePipeline_basic
=== RUN   TestAccCodePipeline_tags
=== PAUSE TestAccCodePipeline_tags
=== RUN   TestAccCodePipeline_MultiRegion_basic
=== PAUSE TestAccCodePipeline_MultiRegion_basic
=== RUN   TestAccCodePipelineCustomActionType_basic
=== PAUSE TestAccCodePipelineCustomActionType_basic
=== RUN   TestAccCodePipelineCustomActionType_tags
=== PAUSE TestAccCodePipelineCustomActionType_tags
=== RUN   TestAccCodePipelineWebhook_basic
    webhook_test.go:24: skipping test; environment variable GITHUB_TOKEN must be set. Usage: token with GitHub permissions to repository for CodePipeline webhook creation
--- SKIP: TestAccCodePipelineWebhook_basic (0.00s)
=== RUN   TestAccCodePipelineWebhook_tags
    webhook_test.go:165: skipping test; environment variable GITHUB_TOKEN must be set. Usage: token with GitHub permissions to repository for CodePipeline webhook creation
--- SKIP: TestAccCodePipelineWebhook_tags (0.00s)
=== CONT  TestAccCodePipeline_basic
=== CONT  TestAccCodePipelineCustomActionType_basic
--- PASS: TestAccCodePipelineCustomActionType_basic (85.07s)
=== CONT  TestAccCodePipelineCustomActionType_tags
--- PASS: TestAccCodePipeline_basic (177.37s)
=== CONT  TestAccCodePipeline_MultiRegion_basic
--- PASS: TestAccCodePipelineCustomActionType_tags (171.30s)
=== CONT  TestAccCodePipeline_tags
--- PASS: TestAccCodePipeline_MultiRegion_basic (131.22s)
--- PASS: TestAccCodePipeline_tags (208.70s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codepipeline	489.091s
=== RUN   TestAccCodeStarConnectionsConnectionDataSource_basic
=== PAUSE TestAccCodeStarConnectionsConnectionDataSource_basic
=== RUN   TestAccCodeStarConnectionsConnectionDataSource_tags
=== PAUSE TestAccCodeStarConnectionsConnectionDataSource_tags
=== RUN   TestAccCodeStarConnectionsConnection_basic
=== PAUSE TestAccCodeStarConnectionsConnection_basic
=== RUN   TestAccCodeStarConnectionsConnection_tags
=== PAUSE TestAccCodeStarConnectionsConnection_tags
=== RUN   TestAccCodeStarConnectionsHost_basic
=== PAUSE TestAccCodeStarConnectionsHost_basic
=== CONT  TestAccCodeStarConnectionsConnectionDataSource_basic
=== CONT  TestAccCodeStarConnectionsConnection_tags
--- PASS: TestAccCodeStarConnectionsConnectionDataSource_basic (59.45s)
=== CONT  TestAccCodeStarConnectionsHost_basic
--- PASS: TestAccCodeStarConnectionsHost_basic (68.40s)
=== CONT  TestAccCodeStarConnectionsConnection_basic
--- PASS: TestAccCodeStarConnectionsConnection_tags (156.19s)
=== CONT  TestAccCodeStarConnectionsConnectionDataSource_tags
--- PASS: TestAccCodeStarConnectionsConnection_basic (61.89s)
--- PASS: TestAccCodeStarConnectionsConnectionDataSource_tags (50.61s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codestarconnections	229.952s
=== RUN   TestAccCodeStarNotificationsNotificationRule_basic
=== PAUSE TestAccCodeStarNotificationsNotificationRule_basic
=== RUN   TestAccCodeStarNotificationsNotificationRule_tags
=== PAUSE TestAccCodeStarNotificationsNotificationRule_tags
=== CONT  TestAccCodeStarNotificationsNotificationRule_basic
=== CONT  TestAccCodeStarNotificationsNotificationRule_tags
=== CONT  TestAccCodeStarNotificationsNotificationRule_basic
    notification_rule_test.go:28: Step 1/2 error: Error running apply: exit status 1
        
        Error: creating CodeStar Notification Rule: ConfigurationException: AWS CodeStar Notifications could not create the AWS CloudWatch Events managed rule in your AWS account. If this is your first time creating a notification rule, the service-linked role for AWS CodeStar Notifications might not yet exist. Creation of this role might take up to 15 minutes. Until it exists, notification rule creation will fail. Wait 15 minutes, and then try again. If this is is not the first time you are creating a notification rule, there might be a problem with a network connection, or one or more AWS services might be experiencing issues. Verify your network connection and check to see if there are any issues with AWS services in your AWS Region before trying again.
        
          with aws_codestarnotifications_notification_rule.test,
          on terraform_plugin_test.tf line 10, in resource "aws_codestarnotifications_notification_rule" "test":
          10: resource "aws_codestarnotifications_notification_rule" "test" {
        
=== CONT  TestAccCodeStarNotificationsNotificationRule_tags
    notification_rule_test.go:136: Step 1/4 error: Error running apply: exit status 1
        
        Error: creating CodeStar Notification Rule: ConfigurationException: The notification rule could not be created because the service-linked role for AWS CodeStar Notifications is not currently available. This might have been caused by another user deleting the role at the same time you created the notification rule. Wait a few minutes, and then try again. The service-linked role will be recreated when you create the rule.
        
          with aws_codestarnotifications_notification_rule.test,
          on terraform_plugin_test.tf line 10, in resource "aws_codestarnotifications_notification_rule" "test":
          10: resource "aws_codestarnotifications_notification_rule" "test" {
        
--- FAIL: TestAccCodeStarNotificationsNotificationRule_tags (35.86s)
--- FAIL: TestAccCodeStarNotificationsNotificationRule_basic (35.97s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/codestarnotifications	57.249s
=== RUN   TestAccCognitoIdentityPoolProviderPrincipalTags_basic
=== PAUSE TestAccCognitoIdentityPoolProviderPrincipalTags_basic
=== RUN   TestAccCognitoIdentityPoolRolesAttachment_basic
=== PAUSE TestAccCognitoIdentityPoolRolesAttachment_basic
=== RUN   TestAccCognitoIdentityPool_basic
=== PAUSE TestAccCognitoIdentityPool_basic
=== RUN   TestAccCognitoIdentityPool_tags
=== PAUSE TestAccCognitoIdentityPool_tags
=== CONT  TestAccCognitoIdentityPoolProviderPrincipalTags_basic
=== CONT  TestAccCognitoIdentityPool_basic
--- PASS: TestAccCognitoIdentityPoolProviderPrincipalTags_basic (81.94s)
=== CONT  TestAccCognitoIdentityPoolRolesAttachment_basic
--- PASS: TestAccCognitoIdentityPool_basic (127.17s)
=== CONT  TestAccCognitoIdentityPool_tags
--- PASS: TestAccCognitoIdentityPoolRolesAttachment_basic (79.79s)
--- PASS: TestAccCognitoIdentityPool_tags (85.04s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidentity	236.037s
=== RUN   TestAccCognitoIDPIdentityProvider_basic
=== PAUSE TestAccCognitoIDPIdentityProvider_basic
=== RUN   TestAccCognitoIDPManagedUserPoolClient_basic
=== PAUSE TestAccCognitoIDPManagedUserPoolClient_basic
=== RUN   TestAccCognitoIDPResourceServer_basic
=== PAUSE TestAccCognitoIDPResourceServer_basic
=== RUN   TestAccCognitoIDPUserGroup_basic
=== PAUSE TestAccCognitoIDPUserGroup_basic
=== RUN   TestAccCognitoIDPUserInGroup_basic
=== PAUSE TestAccCognitoIDPUserInGroup_basic
=== RUN   TestAccCognitoIDPUserPoolClientDataSource_basic
=== PAUSE TestAccCognitoIDPUserPoolClientDataSource_basic
=== RUN   TestAccCognitoIDPUserPoolClient_basic
=== PAUSE TestAccCognitoIDPUserPoolClient_basic
=== RUN   TestAccCognitoIDPUserPoolClientsDataSource_basic
=== PAUSE TestAccCognitoIDPUserPoolClientsDataSource_basic
=== RUN   TestAccCognitoIDPUserPoolDomain_basic
=== PAUSE TestAccCognitoIDPUserPoolDomain_basic
=== RUN   TestAccCognitoIDPUserPoolSigningCertificateDataSource_basic
=== PAUSE TestAccCognitoIDPUserPoolSigningCertificateDataSource_basic
=== RUN   TestAccCognitoIDPUserPool_basic
=== PAUSE TestAccCognitoIDPUserPool_basic
=== RUN   TestAccCognitoIDPUserPoolsDataSource_basic
=== PAUSE TestAccCognitoIDPUserPoolsDataSource_basic
=== RUN   TestAccCognitoIDPUser_basic
=== PAUSE TestAccCognitoIDPUser_basic
=== CONT  TestAccCognitoIDPIdentityProvider_basic
=== CONT  TestAccCognitoIDPUserPool_basic
--- PASS: TestAccCognitoIDPUserPool_basic (88.86s)
=== CONT  TestAccCognitoIDPUserPoolSigningCertificateDataSource_basic
--- PASS: TestAccCognitoIDPIdentityProvider_basic (112.43s)
=== CONT  TestAccCognitoIDPUser_basic
--- PASS: TestAccCognitoIDPUserPoolSigningCertificateDataSource_basic (32.68s)
=== CONT  TestAccCognitoIDPUserPoolsDataSource_basic
--- PASS: TestAccCognitoIDPUser_basic (44.94s)
=== CONT  TestAccCognitoIDPUserPoolDomain_basic
--- PASS: TestAccCognitoIDPUserPoolsDataSource_basic (36.62s)
=== CONT  TestAccCognitoIDPUserInGroup_basic
--- PASS: TestAccCognitoIDPUserInGroup_basic (31.43s)
=== CONT  TestAccCognitoIDPUserPoolClient_basic
--- PASS: TestAccCognitoIDPUserPoolDomain_basic (33.59s)
=== CONT  TestAccCognitoIDPUserPoolClientDataSource_basic
--- PASS: TestAccCognitoIDPUserPoolClientDataSource_basic (17.22s)
=== CONT  TestAccCognitoIDPResourceServer_basic
--- PASS: TestAccCognitoIDPUserPoolClient_basic (18.69s)
=== CONT  TestAccCognitoIDPUserGroup_basic
--- PASS: TestAccCognitoIDPResourceServer_basic (32.97s)
=== CONT  TestAccCognitoIDPManagedUserPoolClient_basic
--- PASS: TestAccCognitoIDPUserGroup_basic (34.24s)
=== CONT  TestAccCognitoIDPUserPoolClientsDataSource_basic
--- PASS: TestAccCognitoIDPUserPoolClientsDataSource_basic (16.15s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_basic (1612.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp	1876.122s
=== RUN   TestAccComprehendDocumentClassifier_basic
=== PAUSE TestAccComprehendDocumentClassifier_basic
=== RUN   TestAccComprehendDocumentClassifier_multiLabel_basic
=== PAUSE TestAccComprehendDocumentClassifier_multiLabel_basic
=== RUN   TestAccComprehendDocumentClassifier_outputDataConfig_basic
=== PAUSE TestAccComprehendDocumentClassifier_outputDataConfig_basic
=== RUN   TestAccComprehendDocumentClassifier_tags
=== PAUSE TestAccComprehendDocumentClassifier_tags
=== RUN   TestAccComprehendEntityRecognizer_basic
=== PAUSE TestAccComprehendEntityRecognizer_basic
=== RUN   TestAccComprehendEntityRecognizer_annotations_basic
=== PAUSE TestAccComprehendEntityRecognizer_annotations_basic
=== RUN   TestAccComprehendEntityRecognizer_tags
=== PAUSE TestAccComprehendEntityRecognizer_tags
=== CONT  TestAccComprehendDocumentClassifier_basic
=== CONT  TestAccComprehendEntityRecognizer_basic
--- PASS: TestAccComprehendEntityRecognizer_basic (1260.10s)
=== CONT  TestAccComprehendEntityRecognizer_tags
--- PASS: TestAccComprehendDocumentClassifier_basic (2411.55s)
=== CONT  TestAccComprehendDocumentClassifier_outputDataConfig_basic
--- PASS: TestAccComprehendEntityRecognizer_tags (1260.25s)
=== CONT  TestAccComprehendDocumentClassifier_tags
--- PASS: TestAccComprehendDocumentClassifier_outputDataConfig_basic (2322.41s)
=== CONT  TestAccComprehendDocumentClassifier_multiLabel_basic
--- PASS: TestAccComprehendDocumentClassifier_tags (2342.10s)
=== CONT  TestAccComprehendEntityRecognizer_annotations_basic
--- PASS: TestAccComprehendEntityRecognizer_annotations_basic (1287.52s)
--- PASS: TestAccComprehendDocumentClassifier_multiLabel_basic (3063.25s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/comprehend	7822.129s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/computeoptimizer	[no test files]
=== RUN   TestAccConfigServiceConfigurationAggregator_tags
=== PAUSE TestAccConfigServiceConfigurationAggregator_tags
=== CONT  TestAccConfigServiceConfigurationAggregator_tags
--- PASS: TestAccConfigServiceConfigurationAggregator_tags (98.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/configservice	120.598s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/connect	13.946s [no tests to run]
=== RUN   TestAccControlTowerControlsDataSource_basic
=== PAUSE TestAccControlTowerControlsDataSource_basic
=== CONT  TestAccControlTowerControlsDataSource_basic
    acctest.go:912: this AWS account must be the management account of an AWS Organization
--- SKIP: TestAccControlTowerControlsDataSource_basic (0.72s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/controltower	19.466s
=== RUN   TestAccCURReportDefinitionDataSource_basic
=== PAUSE TestAccCURReportDefinitionDataSource_basic
=== CONT  TestAccCURReportDefinitionDataSource_basic
    acctest.go:834: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccCURReportDefinitionDataSource_basic (0.49s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cur	20.246s
FAIL
make: *** [testacc] Error 1
```
```console
% make testacc TESTARGS='-run=TestAccCloudFrontDistributionDataSource_basic\|TestAccCloudFrontDistribution_basic\|TestAccCloudFrontDistribution_tags' PKG=cloudfront ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudfront/... -v -count 1 -parallel 2  -run=TestAccCloudFrontDistributionDataSource_basic\|TestAccCloudFrontDistribution_basic\|TestAccCloudFrontDistribution_tags -timeout 180m
=== RUN   TestAccCloudFrontDistributionDataSource_basic
=== PAUSE TestAccCloudFrontDistributionDataSource_basic
=== RUN   TestAccCloudFrontDistribution_basic
=== PAUSE TestAccCloudFrontDistribution_basic
=== RUN   TestAccCloudFrontDistribution_tags
=== PAUSE TestAccCloudFrontDistribution_tags
=== CONT  TestAccCloudFrontDistributionDataSource_basic
=== CONT  TestAccCloudFrontDistribution_tags
--- PASS: TestAccCloudFrontDistributionDataSource_basic (255.47s)
=== CONT  TestAccCloudFrontDistribution_basic
--- PASS: TestAccCloudFrontDistribution_basic (260.13s)
--- PASS: TestAccCloudFrontDistribution_tags (735.93s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	742.125s
```
