### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin SDK resources `o*` (Phase 3c)

### DIFF
--- a/internal/service/oam/service_package_gen.go
+++ b/internal/service/oam/service_package_gen.go
@@ -45,10 +45,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceLink,
 			TypeName: "aws_oam_link",
+			Name:     "Link",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceSink,
 			TypeName: "aws_oam_sink",
+			Name:     "Sink",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceSinkPolicy,

--- a/internal/service/oam/sink.go
+++ b/internal/service/oam/sink.go
@@ -20,7 +20,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_oam_sink")
+// @SDKResource("aws_oam_sink", name="Sink")
+// @Tags(identifierAttribute="id")
 func ResourceSink() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSinkCreate,
@@ -52,8 +53,8 @@ func ResourceSink() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -69,13 +70,7 @@ func resourceSinkCreate(ctx context.Context, d *schema.ResourceData, meta interf
 
 	in := &oam.CreateSinkInput{
 		Name: aws.String(d.Get("name").(string)),
-	}
-
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
-
-	if len(tags) > 0 {
-		in.Tags = Tags(tags.IgnoreAWS())
+		Tags: GetTagsIn(ctx),
 	}
 
 	out, err := conn.CreateSink(ctx, in)
@@ -111,40 +106,12 @@ func resourceSinkRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	d.Set("name", out.Name)
 	d.Set("sink_id", out.Id)
 
-	tags, err := ListTags(ctx, conn, d.Id())
-	if err != nil {
-		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionReading, ResNameSink, d.Id(), err)
-	}
-
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionSetting, ResNameSink, d.Id(), err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionSetting, ResNameSink, d.Id(), err)
-	}
-
 	return nil
 }
 
 func resourceSinkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient()
-
-	if d.HasChange("tags_all") {
-		log.Printf("[DEBUG] Updating ObservabilityAccessManager Sink Tags (%s): %#v", d.Id(), d.Get("tags_all"))
-		oldTags, newTags := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), oldTags, newTags); err != nil {
-			return create.DiagError(names.ObservabilityAccessManager, create.ErrActionUpdating, ResNameSink, d.Id(), err)
-		}
-
-		return resourceSinkRead(ctx, d, meta)
-	}
-
-	return nil
+	// Tags only.
+	return resourceSinkRead(ctx, d, meta)
 }
 
 func resourceSinkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -24,9 +24,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_opensearch_domain")
+// @SDKResource("aws_opensearch_domain", name="Domain")
+// @Tags(identifierAttribute="id")
 func ResourceDomain() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDomainCreate,
@@ -508,8 +510,8 @@ func ResourceDomain() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vpc_options": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -555,8 +557,6 @@ func resourceDomainImport(ctx context.Context,
 func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OpenSearchConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	// The API doesn't check for duplicate names
 	// so w/out this check Create would act as upsert
@@ -569,7 +569,7 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	inputCreateDomain := opensearchservice.CreateDomainInput{
 		DomainName:    aws.String(d.Get("domain_name").(string)),
 		EngineVersion: aws.String(d.Get("engine_version").(string)),
-		TagList:       Tags(tags.IgnoreAWS()),
+		TagList:       GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("access_policies"); ok {
@@ -750,8 +750,6 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OpenSearchConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	ds, err := FindDomainByName(ctx, conn, d.Get("domain_name").(string))
 
@@ -870,23 +868,6 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	d.Set("arn", ds.ARN)
-
-	tags, err := ListTags(ctx, conn, d.Id())
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for OpenSearch Cluster (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
 
 	return diags
 }
@@ -1033,14 +1014,6 @@ func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			if _, err := waitUpgradeSucceeded(ctx, conn, d.Get("domain_name").(string), d.Timeout(schema.TimeoutUpdate)); err != nil {
 				return sdkdiag.AppendErrorf(diags, "updating OpenSearch Domain (%s): upgrading: waiting for completion: %s", d.Id(), err)
 			}
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating OpenSearch Domain (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/opensearch/service_package_gen.go
+++ b/internal/service/opensearch/service_package_gen.go
@@ -33,6 +33,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDomain,
 			TypeName: "aws_opensearch_domain",
+			Name:     "Domain",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceDomainPolicy,

--- a/internal/service/opsworks/custom_layer.go
+++ b/internal/service/opsworks/custom_layer.go
@@ -5,7 +5,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// @SDKResource("aws_opsworks_custom_layer")
+// @SDKResource("aws_opsworks_custom_layer", name="Custom Layer")
+// @Tags(identifierAttribute="arn")
 func ResourceCustomLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
 		TypeName:        opsworks.LayerTypeCustom,

--- a/internal/service/opsworks/ecs_cluster_layer.go
+++ b/internal/service/opsworks/ecs_cluster_layer.go
@@ -6,7 +6,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_opsworks_ecs_cluster_layer")
+// @SDKResource("aws_opsworks_ecs_cluster_layer", name="ECS Cluster Layer")
+// @Tags(identifierAttribute="arn")
 func ResourceECSClusterLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
 		TypeName:         opsworks.LayerTypeEcsCluster,

--- a/internal/service/opsworks/ganglia_layer.go
+++ b/internal/service/opsworks/ganglia_layer.go
@@ -5,7 +5,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// @SDKResource("aws_opsworks_ganglia_layer")
+// @SDKResource("aws_opsworks_ganglia_layer", name="Ganglia Layer")
+// @Tags(identifierAttribute="arn")
 func ResourceGangliaLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
 		TypeName:         opsworks.LayerTypeMonitoringMaster,

--- a/internal/service/opsworks/haproxy_layer.go
+++ b/internal/service/opsworks/haproxy_layer.go
@@ -5,7 +5,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// @SDKResource("aws_opsworks_haproxy_layer")
+// @SDKResource("aws_opsworks_haproxy_layer", name="HAProxy Layer")
+// @Tags(identifierAttribute="arn")
 func ResourceHAProxyLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
 		TypeName:         opsworks.LayerTypeLb,

--- a/internal/service/opsworks/java_app_layer.go
+++ b/internal/service/opsworks/java_app_layer.go
@@ -5,7 +5,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// @SDKResource("aws_opsworks_java_app_layer")
+// @SDKResource("aws_opsworks_java_app_layer", name="Java App Layer")
+// @Tags(identifierAttribute="arn")
 func ResourceJavaAppLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
 		TypeName:         opsworks.LayerTypeJavaApp,

--- a/internal/service/opsworks/memcached_layer.go
+++ b/internal/service/opsworks/memcached_layer.go
@@ -5,7 +5,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// @SDKResource("aws_opsworks_memcached_layer")
+// @SDKResource("aws_opsworks_memcached_layer", name="Memcached Layer")
+// @Tags(identifierAttribute="arn")
 func ResourceMemcachedLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
 		TypeName:         opsworks.LayerTypeMemcached,

--- a/internal/service/opsworks/mysql_layer.go
+++ b/internal/service/opsworks/mysql_layer.go
@@ -5,7 +5,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// @SDKResource("aws_opsworks_mysql_layer")
+// @SDKResource("aws_opsworks_mysql_layer", name="MySQL Layer")
+// @Tags(identifierAttribute="arn")
 func ResourceMySQLLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
 		TypeName:         opsworks.LayerTypeDbMaster,

--- a/internal/service/opsworks/nodejs_app_layer.go
+++ b/internal/service/opsworks/nodejs_app_layer.go
@@ -5,7 +5,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// @SDKResource("aws_opsworks_nodejs_app_layer")
+// @SDKResource("aws_opsworks_nodejs_app_layer", name="NodeJS App Layer")
+// @Tags(identifierAttribute="arn")
 func ResourceNodejsAppLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
 		TypeName:         opsworks.LayerTypeNodejsApp,

--- a/internal/service/opsworks/php_app_layer.go
+++ b/internal/service/opsworks/php_app_layer.go
@@ -5,7 +5,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// @SDKResource("aws_opsworks_php_app_layer")
+// @SDKResource("aws_opsworks_php_app_layer", name="PHP App Layer")
+// @Tags(identifierAttribute="arn")
 func ResourcePHPAppLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
 		TypeName:         opsworks.LayerTypePhpApp,

--- a/internal/service/opsworks/rails_app_layer.go
+++ b/internal/service/opsworks/rails_app_layer.go
@@ -5,7 +5,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// @SDKResource("aws_opsworks_rails_app_layer")
+// @SDKResource("aws_opsworks_rails_app_layer", name="Rails App Layer")
+// @Tags(identifierAttribute="arn")
 func ResourceRailsAppLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
 		TypeName:         opsworks.LayerTypeRailsApp,

--- a/internal/service/opsworks/service_package_gen.go
+++ b/internal/service/opsworks/service_package_gen.go
@@ -32,18 +32,34 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCustomLayer,
 			TypeName: "aws_opsworks_custom_layer",
+			Name:     "Custom Layer",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceECSClusterLayer,
 			TypeName: "aws_opsworks_ecs_cluster_layer",
+			Name:     "ECS Cluster Layer",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceGangliaLayer,
 			TypeName: "aws_opsworks_ganglia_layer",
+			Name:     "Ganglia Layer",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceHAProxyLayer,
 			TypeName: "aws_opsworks_haproxy_layer",
+			Name:     "HAProxy Layer",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceInstance,
@@ -52,18 +68,34 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceJavaAppLayer,
 			TypeName: "aws_opsworks_java_app_layer",
+			Name:     "Java App Layer",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceMemcachedLayer,
 			TypeName: "aws_opsworks_memcached_layer",
+			Name:     "Memcached Layer",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceMySQLLayer,
 			TypeName: "aws_opsworks_mysql_layer",
+			Name:     "MySQL Layer",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceNodejsAppLayer,
 			TypeName: "aws_opsworks_nodejs_app_layer",
+			Name:     "NodeJS App Layer",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourcePermission,
@@ -72,10 +104,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourcePHPAppLayer,
 			TypeName: "aws_opsworks_php_app_layer",
+			Name:     "PHP App Layer",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRailsAppLayer,
 			TypeName: "aws_opsworks_rails_app_layer",
+			Name:     "Rails App Layer",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRDSDBInstance,
@@ -84,10 +124,16 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceStack,
 			TypeName: "aws_opsworks_stack",
+			Name:     "Stack",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
 			Factory:  ResourceStaticWebLayer,
 			TypeName: "aws_opsworks_static_web_layer",
+			Name:     "Static Web Layer",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceUserProfile,

--- a/internal/service/opsworks/stack.go
+++ b/internal/service/opsworks/stack.go
@@ -20,6 +20,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 const (
@@ -27,7 +28,8 @@ const (
 	securityGroupsDeletedSleepTime = 30 * time.Second
 )
 
-// @SDKResource("aws_opsworks_stack")
+// @SDKResource("aws_opsworks_stack", name="Stack")
+// @Tags
 func ResourceStack() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceStackCreate,
@@ -172,8 +174,8 @@ func ResourceStack() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"use_custom_cookbooks": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -200,8 +202,6 @@ func ResourceStack() *schema.Resource {
 func resourceStackCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OpsWorksConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	region := d.Get("region").(string)
@@ -291,7 +291,7 @@ func resourceStackCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	d.SetId(aws.StringValue(outputRaw.(*opsworks.CreateStackOutput).StackId))
 
-	if len(tags) > 0 {
+	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
 		arn := arn.ARN{
 			Partition: meta.(*conns.AWSClient).Partition,
 			Service:   opsworks.ServiceName,

--- a/internal/service/opsworks/stack.go
+++ b/internal/service/opsworks/stack.go
@@ -322,8 +322,6 @@ func resourceStackRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	var diags diag.Diagnostics
 	var err error
 	conn := meta.(*conns.AWSClient).OpsWorksConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	if v, ok := d.GetOk("stack_endpoint"); ok {
 		log.Printf(`[DEBUG] overriding region using "stack_endpoint": %s`, v)
@@ -421,16 +419,7 @@ func resourceStackRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		return sdkdiag.AppendErrorf(diags, "listing tags for OpsWorks Stack (%s): %s", arn, err)
 	}
 
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, Tags(tags))
 
 	return diags
 }

--- a/internal/service/opsworks/stack_test.go
+++ b/internal/service/opsworks/stack_test.go
@@ -45,7 +45,7 @@ func TestAccOpsWorksStack_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration_manager_name", "Chef"),
 					resource.TestCheckResourceAttr(resourceName, "configuration_manager_version", "11.10"),
 					resource.TestCheckResourceAttr(resourceName, "custom_cookbooks_source.#", "1"),
-					resource.TestCheckNoResourceAttr(resourceName, "custom_json"),
+					resource.TestCheckResourceAttr(resourceName, "custom_json", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "default_availability_zone", "data.aws_availability_zones.available", "names.0"),
 					resource.TestCheckResourceAttrSet(resourceName, "default_instance_profile_arn"),
 					resource.TestCheckResourceAttr(resourceName, "default_os", "Ubuntu 12.04 LTS"),

--- a/internal/service/opsworks/static_web_layer.go
+++ b/internal/service/opsworks/static_web_layer.go
@@ -5,7 +5,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// @SDKResource("aws_opsworks_static_web_layer")
+// @SDKResource("aws_opsworks_static_web_layer", name="Static Web Layer")
+// @Tags(identifierAttribute="arn")
 func ResourceStaticWebLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
 		TypeName:         opsworks.LayerTypeWeb,

--- a/internal/service/organizations/account.go
+++ b/internal/service/organizations/account.go
@@ -19,9 +19,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_organizations_account")
+// @SDKResource("aws_organizations_account", name="Account")
+// @Tags(identifierAttribute="id")
 func ResourceAccount() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAccountCreate,
@@ -96,8 +98,8 @@ func ResourceAccount() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -107,8 +109,6 @@ func ResourceAccount() *schema.Resource {
 func resourceAccountCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OrganizationsConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	var iamUserAccessToBilling *string
 
@@ -127,7 +127,7 @@ func resourceAccountCreate(ctx context.Context, d *schema.ResourceData, meta int
 		d.Get("email").(string),
 		iamUserAccessToBilling,
 		roleName,
-		Tags(tags.IgnoreAWS()),
+		GetTagsIn(ctx),
 		d.Get("create_govcloud").(bool),
 	)
 
@@ -171,8 +171,6 @@ func resourceAccountCreate(ctx context.Context, d *schema.ResourceData, meta int
 func resourceAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OrganizationsConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	account, err := FindAccountByID(ctx, conn, d.Id())
 
@@ -200,23 +198,6 @@ func resourceAccountRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("parent_id", parentAccountID)
 	d.Set("status", account.Status)
 
-	tags, err := ListTags(ctx, conn, d.Id())
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for AWS Organizations Account (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
@@ -235,14 +216,6 @@ func resourceAccountUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		if _, err := conn.MoveAccountWithContext(ctx, input); err != nil {
 			return sdkdiag.AppendErrorf(diags, "moving AWS Organizations Account (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating AWS Organizations Account (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/organizations/organizational_unit.go
+++ b/internal/service/organizations/organizational_unit.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_organizations_organizational_unit")
+// @SDKResource("aws_organizations_organizational_unit", name="Organizational Unit")
+// @Tags(identifierAttribute="id")
 func ResourceOrganizationalUnit() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceOrganizationalUnitCreate,
@@ -71,8 +73,8 @@ func ResourceOrganizationalUnit() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringMatch(regexp.MustCompile("^(r-[0-9a-z]{4,32})|(ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})$"), "see https://docs.aws.amazon.com/organizations/latest/APIReference/API_CreateOrganizationalUnit.html#organizations-CreateOrganizationalUnit-request-ParentId"),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -82,14 +84,12 @@ func ResourceOrganizationalUnit() *schema.Resource {
 func resourceOrganizationalUnitCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OrganizationsConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	// Create the organizational unit
 	createOpts := &organizations.CreateOrganizationalUnitInput{
 		Name:     aws.String(d.Get("name").(string)),
 		ParentId: aws.String(d.Get("parent_id").(string)),
-		Tags:     Tags(tags.IgnoreAWS()),
+		Tags:     GetTagsIn(ctx),
 	}
 
 	var err error
@@ -124,8 +124,6 @@ func resourceOrganizationalUnitCreate(ctx context.Context, d *schema.ResourceDat
 func resourceOrganizationalUnitRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OrganizationsConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	describeOpts := &organizations.DescribeOrganizationalUnitInput{
 		OrganizationalUnitId: aws.String(d.Id()),
@@ -186,23 +184,6 @@ func resourceOrganizationalUnitRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("name", ou.Name)
 	d.Set("parent_id", parentId)
 
-	tags, err := ListTags(ctx, conn, d.Id())
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Organizations Organizational Unit (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
@@ -219,14 +200,6 @@ func resourceOrganizationalUnitUpdate(ctx context.Context, d *schema.ResourceDat
 		_, err := conn.UpdateOrganizationalUnitWithContext(ctx, updateOpts)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Organizations Organizational Unit (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Organizations Organizational Unit (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/organizations/policy.go
+++ b/internal/service/organizations/policy.go
@@ -17,9 +17,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_organizations_policy")
+// @SDKResource("aws_organizations_policy", name="Policy")
+// @Tags(identifierAttribute="id")
 func ResourcePolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePolicyCreate,
@@ -54,8 +56,9 @@ func ResourcePolicy() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			"tags":            tftags.TagsSchema(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"type": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -71,17 +74,14 @@ func ResourcePolicy() *schema.Resource {
 
 func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).OrganizationsConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
-
 	input := &organizations.CreatePolicyInput{
 		Content:     aws.String(d.Get("content").(string)),
 		Description: aws.String(d.Get("description").(string)),
 		Name:        aws.String(name),
 		Type:        aws.String(d.Get("type").(string)),
-		Tags:        Tags(tags.IgnoreAWS()),
+		Tags:        GetTagsIn(ctx),
 	}
 
 	log.Printf("[DEBUG] Creating Organizations Policy (%s): %v", name, input)
@@ -117,8 +117,6 @@ func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).OrganizationsConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	input := &organizations.DescribePolicyInput{
 		PolicyId: aws.String(d.Id()),
@@ -163,22 +161,6 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interf
 		}
 	}
 
-	tags, err := ListTags(ctx, conn, d.Id())
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("error listing tags for Organizations policy (%s): %w", d.Id(), err))
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting tags: %w", err))
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.FromErr(fmt.Errorf("error setting tags_all: %w", err))
-	}
-
 	return nil
 }
 
@@ -205,13 +187,6 @@ func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	_, err := conn.UpdatePolicyWithContext(ctx, input)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating Organizations policy (%s): %w", d.Id(), err))
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return diag.FromErr(fmt.Errorf("error updating tags for Organizations policy (%s): %w", d.Id(), err))
-		}
 	}
 
 	return resourcePolicyRead(ctx, d, meta)

--- a/internal/service/organizations/policy.go
+++ b/internal/service/organizations/policy.go
@@ -56,7 +56,6 @@ func ResourcePolicy() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-			"tags":            tftags.TagsSchema(),
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"type": {

--- a/internal/service/organizations/service_package_gen.go
+++ b/internal/service/organizations/service_package_gen.go
@@ -57,6 +57,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceAccount,
 			TypeName: "aws_organizations_account",
+			Name:     "Account",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceDelegatedAdministrator,
@@ -69,10 +73,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceOrganizationalUnit,
 			TypeName: "aws_organizations_organizational_unit",
+			Name:     "Organizational Unit",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourcePolicy,
 			TypeName: "aws_organizations_policy",
+			Name:     "Policy",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourcePolicyAttachment,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin SDK.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30421.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30430.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30449.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30454.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30461.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30463.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30476.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30477.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30478.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30483.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=oam ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/oam/... -v -count 1 -parallel 2  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccObservabilityAccessManagerLinkDataSource_basic
    acctest.go:772: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccObservabilityAccessManagerLinkDataSource_basic (0.46s)
=== RUN   TestAccObservabilityAccessManagerLink_basic
    acctest.go:772: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccObservabilityAccessManagerLink_basic (0.00s)
=== RUN   TestAccObservabilityAccessManagerLink_tags
    acctest.go:772: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccObservabilityAccessManagerLink_tags (0.00s)
=== RUN   TestAccObservabilityAccessManagerLinksDataSource_basic
    acctest.go:772: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccObservabilityAccessManagerLinksDataSource_basic (0.00s)
=== RUN   TestAccObservabilityAccessManagerSinkDataSource_basic
--- PASS: TestAccObservabilityAccessManagerSinkDataSource_basic (23.78s)
=== RUN   TestAccObservabilityAccessManagerSinkPolicy_basic
--- PASS: TestAccObservabilityAccessManagerSinkPolicy_basic (27.18s)
=== RUN   TestAccObservabilityAccessManagerSink_basic
--- PASS: TestAccObservabilityAccessManagerSink_basic (30.49s)
=== RUN   TestAccObservabilityAccessManagerSink_tags
--- PASS: TestAccObservabilityAccessManagerSink_tags (60.23s)
=== RUN   TestAccObservabilityAccessManagerSinksDataSource_basic
--- PASS: TestAccObservabilityAccessManagerSinksDataSource_basic (21.38s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/oam	176.243s
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=opsworks ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opsworks/... -v -count 1 -parallel 2  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccOpsWorksApplication_basic
=== PAUSE TestAccOpsWorksApplication_basic
=== RUN   TestAccOpsWorksCustomLayer_basic
=== PAUSE TestAccOpsWorksCustomLayer_basic
=== RUN   TestAccOpsWorksECSClusterLayer_basic
=== PAUSE TestAccOpsWorksECSClusterLayer_basic
=== RUN   TestAccOpsWorksGangliaLayer_basic
=== PAUSE TestAccOpsWorksGangliaLayer_basic
=== RUN   TestAccOpsWorksHAProxyLayer_basic
=== PAUSE TestAccOpsWorksHAProxyLayer_basic
=== RUN   TestAccOpsWorksInstance_basic
=== PAUSE TestAccOpsWorksInstance_basic
=== RUN   TestAccOpsWorksJavaAppLayer_basic
=== PAUSE TestAccOpsWorksJavaAppLayer_basic
=== RUN   TestAccOpsWorksMemcachedLayer_basic
=== PAUSE TestAccOpsWorksMemcachedLayer_basic
=== RUN   TestAccOpsWorksMySQLLayer_basic
=== PAUSE TestAccOpsWorksMySQLLayer_basic
=== RUN   TestAccOpsWorksNodejsAppLayer_basic
=== PAUSE TestAccOpsWorksNodejsAppLayer_basic
=== RUN   TestAccOpsWorksPermission_basic
=== PAUSE TestAccOpsWorksPermission_basic
=== RUN   TestAccOpsWorksPHPAppLayer_basic
=== PAUSE TestAccOpsWorksPHPAppLayer_basic
=== RUN   TestAccOpsWorksRailsAppLayer_basic
=== PAUSE TestAccOpsWorksRailsAppLayer_basic
=== RUN   TestAccOpsWorksRailsAppLayer_tags
=== PAUSE TestAccOpsWorksRailsAppLayer_tags
=== RUN   TestAccOpsWorksRDSDBInstance_basic
=== PAUSE TestAccOpsWorksRDSDBInstance_basic
=== RUN   TestAccOpsWorksStack_basic
=== PAUSE TestAccOpsWorksStack_basic
=== RUN   TestAccOpsWorksStack_noVPC_basic
=== PAUSE TestAccOpsWorksStack_noVPC_basic
=== RUN   TestAccOpsWorksStack_tags
=== PAUSE TestAccOpsWorksStack_tags
=== RUN   TestAccOpsWorksStaticWebLayer_basic
=== PAUSE TestAccOpsWorksStaticWebLayer_basic
=== RUN   TestAccOpsWorksUserProfile_basic
=== PAUSE TestAccOpsWorksUserProfile_basic
=== CONT  TestAccOpsWorksApplication_basic
=== CONT  TestAccOpsWorksPermission_basic
    permission_test.go:23: Step 1/4 error: Error running apply: exit status 1
        
        Error: creating IAM User (tf-acc-test-3337797677205488215): AccessDenied: User: arn:aws:sts::123456789012:assumed-role/terraform_team1_dev-developer/kewbank@hashicorp.com is not authorized to perform: iam:CreateUser on resource: arn:aws:iam::123456789012:user/tf-acc-test-3337797677205488215 because no identity-based policy allows the iam:CreateUser action
        	status code: 403, request id: ad0356da-b2c0-47f6-b519-92d7950c9665
        
          with aws_iam_user.user,
          on terraform_plugin_test.tf line 138, in resource "aws_iam_user" "user":
         138: resource "aws_iam_user" "user" {
        
--- FAIL: TestAccOpsWorksPermission_basic (35.72s)
=== CONT  TestAccOpsWorksStack_basic
    stack_test.go:27: Step 1/2 error: Check failed: 1 error occurred:
        	* Check 9/25 error: aws_opsworks_stack.test: Attribute 'custom_json' found when not expected
        
--- FAIL: TestAccOpsWorksStack_basic (27.75s)
=== CONT  TestAccOpsWorksUserProfile_basic
    user_profile_test.go:24: Step 1/2 error: Error running apply: exit status 1
        
        Error: creating IAM User (tf-acc-test-7907551987342756527): AccessDenied: User: arn:aws:sts::123456789012:assumed-role/terraform_team1_dev-developer/kewbank@hashicorp.com is not authorized to perform: iam:CreateUser on resource: arn:aws:iam::123456789012:user/tf-acc-test-7907551987342756527 because no identity-based policy allows the iam:CreateUser action
        	status code: 403, request id: 607801f8-11a0-4d7b-b106-72ec613d89f5
        
          with aws_iam_user.test1,
          on terraform_plugin_test.tf line 7, in resource "aws_iam_user" "test1":
           7: resource "aws_iam_user" "test1" {
        
--- FAIL: TestAccOpsWorksUserProfile_basic (8.45s)
=== CONT  TestAccOpsWorksStaticWebLayer_basic
--- PASS: TestAccOpsWorksApplication_basic (75.25s)
=== CONT  TestAccOpsWorksStack_tags
    stack_test.go:186: Step 1/4 error: Check failed: Check 2/3 error: aws_opsworks_stack.test: Attribute 'tags.%' expected "1", got "0"
--- FAIL: TestAccOpsWorksStack_tags (28.02s)
=== CONT  TestAccOpsWorksStack_noVPC_basic
--- PASS: TestAccOpsWorksStaticWebLayer_basic (46.54s)
=== CONT  TestAccOpsWorksInstance_basic
--- PASS: TestAccOpsWorksStack_noVPC_basic (69.56s)
=== CONT  TestAccOpsWorksNodejsAppLayer_basic
--- PASS: TestAccOpsWorksInstance_basic (95.44s)
=== CONT  TestAccOpsWorksMySQLLayer_basic
--- PASS: TestAccOpsWorksNodejsAppLayer_basic (41.42s)
=== CONT  TestAccOpsWorksMemcachedLayer_basic
--- PASS: TestAccOpsWorksMemcachedLayer_basic (41.34s)
=== CONT  TestAccOpsWorksJavaAppLayer_basic
--- PASS: TestAccOpsWorksMySQLLayer_basic (41.84s)
=== CONT  TestAccOpsWorksRailsAppLayer_tags
--- PASS: TestAccOpsWorksJavaAppLayer_basic (40.41s)
=== CONT  TestAccOpsWorksRDSDBInstance_basic
--- PASS: TestAccOpsWorksRailsAppLayer_tags (89.86s)
=== CONT  TestAccOpsWorksRailsAppLayer_basic
--- PASS: TestAccOpsWorksRailsAppLayer_basic (45.28s)
=== CONT  TestAccOpsWorksGangliaLayer_basic
--- PASS: TestAccOpsWorksGangliaLayer_basic (38.97s)
=== CONT  TestAccOpsWorksHAProxyLayer_basic
--- PASS: TestAccOpsWorksHAProxyLayer_basic (41.58s)
=== CONT  TestAccOpsWorksECSClusterLayer_basic
--- PASS: TestAccOpsWorksECSClusterLayer_basic (33.32s)
=== CONT  TestAccOpsWorksCustomLayer_basic
--- PASS: TestAccOpsWorksCustomLayer_basic (36.95s)
=== CONT  TestAccOpsWorksPHPAppLayer_basic
--- PASS: TestAccOpsWorksPHPAppLayer_basic (37.55s)
--- PASS: TestAccOpsWorksRDSDBInstance_basic (984.95s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/opsworks	1292.341s
FAIL
make: *** [testacc] Error 1
```
```console
% make testacc TESTARGS='-run=TestAccOpsWorksStack_tags\|TestAccOpsWorksStack_basic' PKG=opsworks ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opsworks/... -v -count 1 -parallel 2  -run=TestAccOpsWorksStack_tags\|TestAccOpsWorksStack_basic -timeout 180m
=== RUN   TestAccOpsWorksStack_basic
=== PAUSE TestAccOpsWorksStack_basic
=== RUN   TestAccOpsWorksStack_tags
=== PAUSE TestAccOpsWorksStack_tags
=== RUN   TestAccOpsWorksStack_tagsAlternateRegion
=== PAUSE TestAccOpsWorksStack_tagsAlternateRegion
=== CONT  TestAccOpsWorksStack_basic
=== CONT  TestAccOpsWorksStack_tagsAlternateRegion
    acctest.go:834: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccOpsWorksStack_tagsAlternateRegion (0.90s)
=== CONT  TestAccOpsWorksStack_tags
--- PASS: TestAccOpsWorksStack_basic (37.11s)
--- PASS: TestAccOpsWorksStack_tags (69.99s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opsworks	78.237s
% make testacc TESTARGS='-run=TestAccOpenSearchDomain_tags\|TestAccOpenSearchDomain_basic' PKG=opensearch ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opensearch/... -v -count 1 -parallel 2  -run=TestAccOpenSearchDomain_tags\|TestAccOpenSearchDomain_basic -timeout 180m
=== RUN   TestAccOpenSearchDomain_basic
=== PAUSE TestAccOpenSearchDomain_basic
=== RUN   TestAccOpenSearchDomain_tags
=== PAUSE TestAccOpenSearchDomain_tags
=== CONT  TestAccOpenSearchDomain_basic
=== CONT  TestAccOpenSearchDomain_tags
--- PASS: TestAccOpenSearchDomain_basic (1598.01s)
--- PASS: TestAccOpenSearchDomain_tags (1636.46s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opensearch	1642.208s
```
