### PR TITLE
Add VPCLattice Service data source

### DIFF
--- a/.changelog/30490.txt
+++ b/.changelog/30490.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_vpclattice_service
+```

--- a/internal/service/vpclattice/service_data_source.go
+++ b/internal/service/vpclattice/service_data_source.go
@@ -1,0 +1,107 @@
+package vpclattice
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_vpclattice_service")
+func DataSourceService() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceServiceRead,
+
+		Schema: map[string]*schema.Schema{
+			names.AttrARN: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"auth_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certificate_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"custom_domain_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dns_entry": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"domain_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"hosted_zone_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_identifier": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+const (
+	DSNameService = "Service Data Source"
+)
+
+func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).VPCLatticeClient()
+
+	service_id := d.Get("service_identifier").(string)
+	out, err := findServiceByID(ctx, conn, service_id)
+	if err != nil {
+		return create.DiagError(names.VPCLattice, create.ErrActionReading, DSNameService, service_id, err)
+	}
+
+	//
+	// If you don't set the ID, the data source will not be stored in state. In
+	// fact, that's how a resource can be removed from state - clearing its ID.
+	//
+	// If this data source is a companion to a resource, often both will use the
+	// same ID. Otherwise, the ID will be a unique identifier such as an AWS
+	// identifier, ARN, or name.
+	d.SetId(aws.StringValue(out.Id))
+
+	d.Set("arn", out.Arn)
+	d.Set("auth_type", out.AuthType)
+	d.Set("certificate_arn", out.CertificateArn)
+	d.Set("custom_domain_name", out.CustomDomainName)
+	if out.DnsEntry != nil {
+		if err := d.Set("dns_entry", []interface{}{flattenDNSEntry(out.DnsEntry)}); err != nil {
+			return diag.Errorf("setting dns_entry: %s", err)
+		}
+	} else {
+		d.Set("dns_entry", nil)
+	}
+	d.Set("name", out.Name)
+	d.Set("status", out.Status)
+
+	return nil
+}

--- a/internal/service/vpclattice/service_data_source_test.go
+++ b/internal/service/vpclattice/service_data_source_test.go
@@ -1,0 +1,55 @@
+package vpclattice_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccVPCLatticeServiceDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var service vpclattice.GetServiceOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_vpclattice_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.VPCLatticeEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckServiceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceExists(ctx, dataSourceName, &service),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "auth_type", "NONE"),
+					acctest.MatchResourceAttrRegionalARN(dataSourceName, "arn", "vpc-lattice", regexp.MustCompile(`service/.+$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccServiceDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpclattice_service" "test" {
+  name = %[1]q
+}
+
+data "aws_vpclattice_service" "test" {
+  service_identifier = aws_vpclattice_service.test.id
+}
+`, rName)
+}

--- a/internal/service/vpclattice/service_package_gen.go
+++ b/internal/service/vpclattice/service_package_gen.go
@@ -20,7 +20,12 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {
-	return []*types.ServicePackageSDKDataSource{}
+	return []*types.ServicePackageSDKDataSource{
+		{
+			Factory:  DataSourceService,
+			TypeName: "aws_vpclattice_service",
+		},
+	}
 }
 
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {

--- a/website/docs/d/vpclattice_service.html.markdown
+++ b/website/docs/d/vpclattice_service.html.markdown
@@ -1,0 +1,39 @@
+---
+subcategory: "VPC Lattice"
+layout: "aws"
+page_title: "AWS: aws_vpclattice_service"
+description: |-
+  Terraform data source for managing an AWS VPC Lattice Service.
+---
+
+# Data Source: aws_vpclattice_service
+
+Terraform data source for managing an AWS VPC Lattice Service.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_vpclattice_service" "example" {
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `service_identifier` - (Required) ID or Amazon Resource Name (ARN) of the service network
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the service.
+* `auth_type` - Type of IAM policy. Either `NONE` or `AWS_IAM`.
+* `certificate_arn` - Amazon Resource Name (ARN) of the certificate.
+* `custom_domain_name` - Custom domain name of the service.
+* `dns_entry` - DNS name of the service.
+* `id` - Unique identifier for the service.
+* `status` - Status of the service.
+* `tags` - List of tags associated with the service.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #30380

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccVPCLatticeServiceDataSource_ PKG=vpclattice
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/vpclattice/... -v -count 1 -parallel 20 -run='TestAccVPCLatticeServiceDataSource_'  -timeout 180m
=== RUN   TestAccVPCLatticeServiceDataSource_basic
=== PAUSE TestAccVPCLatticeServiceDataSource_basic
=== CONT  TestAccVPCLatticeServiceDataSource_basic
--- PASS: TestAccVPCLatticeServiceDataSource_basic (18.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice	18.085s
```
