### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin SDK resources `n*` (Phase 3c)

### DIFF
--- a/internal/service/neptune/cluster_endpoint.go
+++ b/internal/service/neptune/cluster_endpoint.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_neptune_cluster_endpoint")
+// @SDKResource("aws_neptune_cluster_endpoint", name="Cluster Endpoint")
+// @Tags(identifierAttribute="arn")
 func ResourceClusterEndpoint() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClusterEndpointCreate,
@@ -68,8 +70,8 @@ func ResourceClusterEndpoint() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -79,13 +81,12 @@ func ResourceClusterEndpoint() *schema.Resource {
 func resourceClusterEndpointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).NeptuneConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &neptune.CreateDBClusterEndpointInput{
 		DBClusterEndpointIdentifier: aws.String(d.Get("cluster_endpoint_identifier").(string)),
 		DBClusterIdentifier:         aws.String(d.Get("cluster_identifier").(string)),
 		EndpointType:                aws.String(d.Get("endpoint_type").(string)),
+		Tags:                        GetTagsIn(ctx),
 	}
 
 	if attr := d.Get("static_members").(*schema.Set); attr.Len() > 0 {
@@ -97,8 +98,8 @@ func resourceClusterEndpointCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	// Tags are currently only supported in AWS Commercial.
-	if len(tags) > 0 && meta.(*conns.AWSClient).Partition == endpoints.AwsPartitionID {
-		input.Tags = Tags(tags.IgnoreAWS())
+	if meta.(*conns.AWSClient).Partition != endpoints.AwsPartitionID {
+		input.Tags = nil
 	}
 
 	out, err := conn.CreateDBClusterEndpointWithContext(ctx, input)
@@ -121,10 +122,9 @@ func resourceClusterEndpointCreate(ctx context.Context, d *schema.ResourceData, 
 func resourceClusterEndpointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).NeptuneConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	resp, err := FindEndpointByID(ctx, conn, d.Id())
+
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		d.SetId("")
 		log.Printf("[DEBUG] Neptune Cluster Endpoint (%s) not found", d.Id())
@@ -144,29 +144,6 @@ func resourceClusterEndpointRead(ctx context.Context, d *schema.ResourceData, me
 
 	arn := aws.StringValue(resp.DBClusterEndpointArn)
 	d.Set("arn", arn)
-
-	// Tags are currently only supported in AWS Commercial.
-	if meta.(*conns.AWSClient).Partition == endpoints.AwsPartitionID {
-		tags, err := ListTags(ctx, conn, arn)
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "listing tags for Neptune Cluster Endpoint (%s): %s", arn, err)
-		}
-
-		tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-		//lintignore:AWSR002
-		if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-		}
-
-		if err := d.Set("tags_all", tags.Map()); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-		}
-	} else {
-		d.Set("tags", nil)
-		d.Set("tags_all", nil)
-	}
 
 	return diags
 }
@@ -200,15 +177,6 @@ func resourceClusterEndpointUpdate(ctx context.Context, d *schema.ResourceData, 
 		_, err = WaitDBClusterEndpointAvailable(ctx, conn, d.Id())
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for Neptune Cluster Endpoint (%q) to be Available: %s", d.Id(), err)
-		}
-	}
-
-	// Tags are currently only supported in AWS Commercial.
-	if d.HasChange("tags_all") && meta.(*conns.AWSClient).Partition == endpoints.AwsPartitionID {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Neptune Cluster Endpoint (%s) tags: %s", d.Get("arn").(string), err)
 		}
 	}
 

--- a/internal/service/neptune/event_subscription.go
+++ b/internal/service/neptune/event_subscription.go
@@ -17,9 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_neptune_event_subscription")
+// @SDKResource("aws_neptune_event_subscription", name="Event Subscription")
+// @Tags(identifierAttribute="arn")
 func ResourceEventSubscription() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceEventSubscriptionCreate,
@@ -86,8 +88,8 @@ func ResourceEventSubscription() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -97,8 +99,6 @@ func ResourceEventSubscription() *schema.Resource {
 func resourceEventSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).NeptuneConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	if v, ok := d.GetOk("name"); ok {
 		d.Set("name", v.(string))
@@ -108,11 +108,11 @@ func resourceEventSubscriptionCreate(ctx context.Context, d *schema.ResourceData
 		d.Set("name", id.PrefixedUniqueId("tf-"))
 	}
 
-	request := &neptune.CreateEventSubscriptionInput{
+	input := &neptune.CreateEventSubscriptionInput{
 		SubscriptionName: aws.String(d.Get("name").(string)),
 		SnsTopicArn:      aws.String(d.Get("sns_topic_arn").(string)),
 		Enabled:          aws.Bool(d.Get("enabled").(bool)),
-		Tags:             Tags(tags.IgnoreAWS()),
+		Tags:             GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("source_ids"); ok {
@@ -121,7 +121,7 @@ func resourceEventSubscriptionCreate(ctx context.Context, d *schema.ResourceData
 		for i, sourceId := range sourceIdsSet.List() {
 			sourceIds[i] = aws.String(sourceId.(string))
 		}
-		request.SourceIds = sourceIds
+		input.SourceIds = sourceIds
 	}
 
 	if v, ok := d.GetOk("event_categories"); ok {
@@ -130,16 +130,16 @@ func resourceEventSubscriptionCreate(ctx context.Context, d *schema.ResourceData
 		for i, eventCategory := range eventCategoriesSet.List() {
 			eventCategories[i] = aws.String(eventCategory.(string))
 		}
-		request.EventCategories = eventCategories
+		input.EventCategories = eventCategories
 	}
 
 	if v, ok := d.GetOk("source_type"); ok {
-		request.SourceType = aws.String(v.(string))
+		input.SourceType = aws.String(v.(string))
 	}
 
-	log.Println("[DEBUG] Create Neptune Event Subscription:", request)
+	log.Println("[DEBUG] Create Neptune Event Subscription:", input)
 
-	output, err := conn.CreateEventSubscriptionWithContext(ctx, request)
+	output, err := conn.CreateEventSubscriptionWithContext(ctx, input)
 	if err != nil || output.EventSubscription == nil {
 		return sdkdiag.AppendErrorf(diags, "creating Neptune Event Subscription %s: %s", d.Get("name").(string), err)
 	}
@@ -169,8 +169,6 @@ func resourceEventSubscriptionCreate(ctx context.Context, d *schema.ResourceData
 func resourceEventSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).NeptuneConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	sub, err := resourceEventSubscriptionRetrieve(ctx, d.Id(), conn)
 	if err != nil {
@@ -200,23 +198,6 @@ func resourceEventSubscriptionRead(ctx context.Context, d *schema.ResourceData, 
 		if err := d.Set("event_categories", flex.FlattenStringList(sub.EventCategoriesList)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "saving Event Categories to state for Neptune Event Subscription (%s): %s", d.Id(), err)
 		}
-	}
-
-	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Neptune Event Subscription (%s): %s", d.Get("arn").(string), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
 	}
 
 	return diags
@@ -280,14 +261,6 @@ func resourceEventSubscriptionUpdate(ctx context.Context, d *schema.ResourceData
 		_, err = stateConf.WaitForStateContext(ctx)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Neptune Event Subscription (%s): waiting for completion: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Neptune Cluster Event Subscription (%s) tags: %s", d.Get("arn").(string), err)
 		}
 	}
 

--- a/internal/service/neptune/parameter_group.go
+++ b/internal/service/neptune/parameter_group.go
@@ -18,13 +18,15 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // We can only modify 20 parameters at a time, so walk them until
 // we've got them all.
 const maxParams = 20
 
-// @SDKResource("aws_neptune_parameter_group")
+// @SDKResource("aws_neptune_parameter_group", name="Parameter Group")
+// @Tags(identifierAttribute="arn")
 func ResourceParameterGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceParameterGroupCreate,
@@ -83,8 +85,8 @@ func ResourceParameterGroup() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -94,14 +96,12 @@ func ResourceParameterGroup() *schema.Resource {
 func resourceParameterGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).NeptuneConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	createOpts := neptune.CreateDBParameterGroupInput{
 		DBParameterGroupName:   aws.String(d.Get("name").(string)),
 		DBParameterGroupFamily: aws.String(d.Get("family").(string)),
 		Description:            aws.String(d.Get("description").(string)),
-		Tags:                   Tags(tags.IgnoreAWS()),
+		Tags:                   GetTagsIn(ctx),
 	}
 
 	log.Printf("[DEBUG] Create Neptune Parameter Group: %#v", createOpts)
@@ -120,8 +120,6 @@ func resourceParameterGroupCreate(ctx context.Context, d *schema.ResourceData, m
 func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).NeptuneConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	describeOpts := neptune.DescribeDBParameterGroupsInput{
 		DBParameterGroupName: aws.String(d.Id()),
@@ -170,23 +168,6 @@ func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, met
 
 	if err := d.Set("parameter", flattenParameters(parameters)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting parameter: %s", err)
-	}
-
-	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Neptune Parameter Group (%s): %s", d.Get("arn").(string), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
 	}
 
 	return diags
@@ -264,14 +245,6 @@ func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "modifying Neptune Parameter Group: %s", err)
 			}
-		}
-	}
-
-	if !d.IsNewResource() && d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Neptune Parameter Group (%s) tags: %s", d.Get("arn").(string), err)
 		}
 	}
 

--- a/internal/service/neptune/service_package_gen.go
+++ b/internal/service/neptune/service_package_gen.go
@@ -37,18 +37,34 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCluster,
 			TypeName: "aws_neptune_cluster",
+			Name:     "Cluster",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceClusterEndpoint,
 			TypeName: "aws_neptune_cluster_endpoint",
+			Name:     "Cluster Endpoint",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceClusterInstance,
 			TypeName: "aws_neptune_cluster_instance",
+			Name:     "Cluster",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceClusterParameterGroup,
 			TypeName: "aws_neptune_cluster_parameter_group",
+			Name:     "Cluster Parameter Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceClusterSnapshot,
@@ -57,6 +73,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceEventSubscription,
 			TypeName: "aws_neptune_event_subscription",
+			Name:     "Event Subscription",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceGlobalCluster,
@@ -65,10 +85,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceParameterGroup,
 			TypeName: "aws_neptune_parameter_group",
+			Name:     "Parameter Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceSubnetGroup,
 			TypeName: "aws_neptune_subnet_group",
+			Name:     "Subnet Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/networkfirewall/firewall_policy.go
+++ b/internal/service/networkfirewall/firewall_policy.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_networkfirewall_firewall_policy")
+// @SDKResource("aws_networkfirewall_firewall_policy", name="Firewall Policy")
+// @Tags(identifierAttribute="id")
 func ResourceFirewallPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceFirewallPolicyCreate,
@@ -136,8 +138,8 @@ func ResourceFirewallPolicy() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"update_token": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -157,13 +159,12 @@ func ResourceFirewallPolicy() *schema.Resource {
 
 func resourceFirewallPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &networkfirewall.CreateFirewallPolicyInput{
 		FirewallPolicy:     expandFirewallPolicy(d.Get("firewall_policy").([]interface{})),
 		FirewallPolicyName: aws.String(d.Get("name").(string)),
+		Tags:               GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -171,10 +172,6 @@ func resourceFirewallPolicyCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 	if v, ok := d.GetOk("encryption_configuration"); ok {
 		input.EncryptionConfiguration = expandEncryptionConfiguration(v.([]interface{}))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	output, err := conn.CreateFirewallPolicyWithContext(ctx, input)
@@ -190,8 +187,6 @@ func resourceFirewallPolicyCreate(ctx context.Context, d *schema.ResourceData, m
 
 func resourceFirewallPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).NetworkFirewallConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	output, err := FindFirewallPolicyByARN(ctx, conn, d.Id())
 
@@ -215,16 +210,7 @@ func resourceFirewallPolicyRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("name", response.FirewallPolicyName)
 	d.Set("update_token", output.UpdateToken)
 
-	tags := KeyValueTags(ctx, response.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, response.Tags)
 
 	return nil
 }
@@ -251,14 +237,6 @@ func resourceFirewallPolicyUpdate(ctx context.Context, d *schema.ResourceData, m
 
 		if err != nil {
 			return diag.Errorf("updating NetworkFirewall Firewall Policy (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return diag.Errorf("updating NetworkFirewall Firewall Policy (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/networkfirewall/service_package_gen.go
+++ b/internal/service/networkfirewall/service_package_gen.go
@@ -37,10 +37,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceFirewall,
 			TypeName: "aws_networkfirewall_firewall",
+			Name:     "Firewall",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceFirewallPolicy,
 			TypeName: "aws_networkfirewall_firewall_policy",
+			Name:     "Firewall Policy",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceLoggingConfiguration,
@@ -53,6 +61,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceRuleGroup,
 			TypeName: "aws_networkfirewall_rule_group",
+			Name:     "Rule Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }

--- a/internal/service/networkmanager/service_package_gen.go
+++ b/internal/service/networkmanager/service_package_gen.go
@@ -77,18 +77,34 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceConnectAttachment,
 			TypeName: "aws_networkmanager_connect_attachment",
+			Name:     "Connect Attachment",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceConnectPeer,
 			TypeName: "aws_networkmanager_connect_peer",
+			Name:     "Connect Peer",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceConnection,
 			TypeName: "aws_networkmanager_connection",
+			Name:     "Connection",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceCoreNetwork,
 			TypeName: "aws_networkmanager_core_network",
+			Name:     "Core Network",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceCoreNetworkPolicyAttachment,
@@ -101,14 +117,26 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDevice,
 			TypeName: "aws_networkmanager_device",
+			Name:     "Device",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceGlobalNetwork,
 			TypeName: "aws_networkmanager_global_network",
+			Name:     "Global Network",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceLink,
 			TypeName: "aws_networkmanager_link",
+			Name:     "Link",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceLinkAssociation,
@@ -117,10 +145,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceSite,
 			TypeName: "aws_networkmanager_site",
+			Name:     "Site",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceSiteToSiteVPNAttachment,
 			TypeName: "aws_networkmanager_site_to_site_vpn_attachment",
+			Name:     "Site To Site VPN Attachment",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceTransitGatewayConnectPeerAssociation,
@@ -129,6 +165,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceTransitGatewayPeering,
 			TypeName: "aws_networkmanager_transit_gateway_peering",
+			Name:     "Transit Gateway Peering",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceTransitGatewayRegistration,
@@ -137,10 +177,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceTransitGatewayRouteTableAttachment,
 			TypeName: "aws_networkmanager_transit_gateway_route_table_attachment",
+			Name:     "Transit Gateway Route Table Attachment",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceVPCAttachment,
 			TypeName: "aws_networkmanager_vpc_attachment",
+			Name:     "VPC Attachment",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin SDK.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30421.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30430.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30449.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30454.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30461.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30463.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30476.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30477.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30478.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30483.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30484.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=n... ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/n.../... -v -count 1 -parallel 2  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccNeptuneClusterEndpoint_basic
=== PAUSE TestAccNeptuneClusterEndpoint_basic
=== RUN   TestAccNeptuneClusterEndpoint_tags
=== PAUSE TestAccNeptuneClusterEndpoint_tags
=== RUN   TestAccNeptuneClusterInstance_basic
=== PAUSE TestAccNeptuneClusterInstance_basic
=== RUN   TestAccNeptuneClusterInstance_tags
=== PAUSE TestAccNeptuneClusterInstance_tags
=== RUN   TestAccNeptuneClusterParameterGroup_basic
=== PAUSE TestAccNeptuneClusterParameterGroup_basic
=== RUN   TestAccNeptuneClusterParameterGroup_tags
=== PAUSE TestAccNeptuneClusterParameterGroup_tags
=== RUN   TestAccNeptuneClusterSnapshot_basic
=== PAUSE TestAccNeptuneClusterSnapshot_basic
=== RUN   TestAccNeptuneCluster_basic
=== PAUSE TestAccNeptuneCluster_basic
=== RUN   TestAccNeptuneCluster_tags
=== PAUSE TestAccNeptuneCluster_tags
=== RUN   TestAccNeptuneEngineVersionDataSource_basic
=== PAUSE TestAccNeptuneEngineVersionDataSource_basic
=== RUN   TestAccNeptuneEventSubscription_basic
=== PAUSE TestAccNeptuneEventSubscription_basic
=== RUN   TestAccNeptuneGlobalCluster_basic
=== PAUSE TestAccNeptuneGlobalCluster_basic
=== RUN   TestAccNeptuneGlobalCluster_SourceDBClusterIdentifier_basic
=== PAUSE TestAccNeptuneGlobalCluster_SourceDBClusterIdentifier_basic
=== RUN   TestAccNeptuneOrderableDBInstanceDataSource_basic
=== PAUSE TestAccNeptuneOrderableDBInstanceDataSource_basic
=== RUN   TestAccNeptuneParameterGroup_basic
=== PAUSE TestAccNeptuneParameterGroup_basic
=== RUN   TestAccNeptuneParameterGroup_tags
=== PAUSE TestAccNeptuneParameterGroup_tags
=== RUN   TestAccNeptuneSubnetGroup_basic
=== PAUSE TestAccNeptuneSubnetGroup_basic
=== RUN   TestAccNeptuneSubnetGroup_tags
=== PAUSE TestAccNeptuneSubnetGroup_tags
=== CONT  TestAccNeptuneClusterEndpoint_basic
=== CONT  TestAccNeptuneEngineVersionDataSource_basic
    engine_version_data_source_test.go:21: Step 1/1 error: Error running pre-apply refresh: exit status 1
        
        Error: no Neptune engine versions found
        
          with data.aws_neptune_engine_version.test,
          on terraform_plugin_test.tf line 2, in data "aws_neptune_engine_version" "test":
           2: data "aws_neptune_engine_version" "test" {
        
--- FAIL: TestAccNeptuneEngineVersionDataSource_basic (8.00s)
=== CONT  TestAccNeptuneClusterParameterGroup_tags
=== CONT  TestAccNeptuneClusterEndpoint_basic
    cluster_endpoint_test.go:27: Step 1/2 error: Error running apply: exit status 1
        
        Error: creating Neptune Cluster (tf-acc-1944049885460282947): InvalidParameterCombination: The Parameter Group default.neptune1 with DBParameterGroupFamily neptune1 cannot be used for this instance. Please use a Parameter Group with DBParameterGroupFamily neptune1.2
        	status code: 400, request id: df5f1acb-f77c-49ef-8721-cdcd08076467
        
          with aws_neptune_cluster.test,
          on terraform_plugin_test.tf line 15, in resource "aws_neptune_cluster" "test":
          15: resource "aws_neptune_cluster" "test" {
        
=== CONT  TestAccNeptuneCluster_tags
--- FAIL: TestAccNeptuneClusterEndpoint_basic (15.83s)
--- PASS: TestAccNeptuneClusterParameterGroup_tags (57.91s)
=== CONT  TestAccNeptuneCluster_basic
--- PASS: TestAccNeptuneCluster_basic (142.32s)
=== CONT  TestAccNeptuneClusterSnapshot_basic
--- PASS: TestAccNeptuneCluster_tags (196.80s)
=== CONT  TestAccNeptuneClusterInstance_tags
--- PASS: TestAccNeptuneClusterSnapshot_basic (258.47s)
=== CONT  TestAccNeptuneClusterParameterGroup_basic
--- PASS: TestAccNeptuneClusterParameterGroup_basic (15.74s)
=== CONT  TestAccNeptuneClusterInstance_basic
--- PASS: TestAccNeptuneClusterInstance_tags (1160.27s)
=== CONT  TestAccNeptuneParameterGroup_basic
--- PASS: TestAccNeptuneParameterGroup_basic (15.74s)
=== CONT  TestAccNeptuneSubnetGroup_tags
--- PASS: TestAccNeptuneSubnetGroup_tags (55.98s)
=== CONT  TestAccNeptuneSubnetGroup_basic
--- PASS: TestAccNeptuneSubnetGroup_basic (23.85s)
=== CONT  TestAccNeptuneParameterGroup_tags
--- PASS: TestAccNeptuneParameterGroup_tags (36.97s)
=== CONT  TestAccNeptuneGlobalCluster_SourceDBClusterIdentifier_basic
--- PASS: TestAccNeptuneGlobalCluster_SourceDBClusterIdentifier_basic (160.96s)
=== CONT  TestAccNeptuneOrderableDBInstanceDataSource_basic
    orderable_db_instance_data_source_test.go:23: Step 1/1 error: Error running pre-apply refresh: exit status 1
        
        Error: reading Neptune orderable DB instance options: InvalidParameterCombination: Cannot find version 1.0.2.2 for neptune
        	status code: 400, request id: 6ba6230f-cb4c-4642-aee9-516fa968a627
        
          with data.aws_neptune_orderable_db_instance.test,
          on terraform_plugin_test.tf line 2, in data "aws_neptune_orderable_db_instance" "test":
           2: data "aws_neptune_orderable_db_instance" "test" {
        
--- FAIL: TestAccNeptuneOrderableDBInstanceDataSource_basic (3.38s)
=== CONT  TestAccNeptuneGlobalCluster_basic
--- PASS: TestAccNeptuneGlobalCluster_basic (16.67s)
=== CONT  TestAccNeptuneClusterEndpoint_tags
    cluster_endpoint_test.go:65: Step 1/4 error: Error running apply: exit status 1
        
        Error: creating Neptune Cluster (tf-acc-8278715406083454647): InvalidParameterCombination: The Parameter Group default.neptune1 with DBParameterGroupFamily neptune1 cannot be used for this instance. Please use a Parameter Group with DBParameterGroupFamily neptune1.2
        	status code: 400, request id: c8792a31-7e2f-4839-80f9-71c716c2ef57
        
          with aws_neptune_cluster.test,
          on terraform_plugin_test.tf line 15, in resource "aws_neptune_cluster" "test":
          15: resource "aws_neptune_cluster" "test" {
        
--- FAIL: TestAccNeptuneClusterEndpoint_tags (7.57s)
=== CONT  TestAccNeptuneEventSubscription_basic
--- PASS: TestAccNeptuneClusterInstance_basic (1262.35s)
--- PASS: TestAccNeptuneEventSubscription_basic (118.98s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/neptune	1822.026s
=== RUN   TestAccNetworkFirewallFirewallPolicy_basic
=== PAUSE TestAccNetworkFirewallFirewallPolicy_basic
=== RUN   TestAccNetworkFirewallFirewallPolicy_tags
=== PAUSE TestAccNetworkFirewallFirewallPolicy_tags
=== RUN   TestAccNetworkFirewallFirewall_basic
=== PAUSE TestAccNetworkFirewallFirewall_basic
=== RUN   TestAccNetworkFirewallFirewall_tags
=== PAUSE TestAccNetworkFirewallFirewall_tags
=== RUN   TestAccNetworkFirewallResourcePolicy_basic
=== PAUSE TestAccNetworkFirewallResourcePolicy_basic
=== RUN   TestAccNetworkFirewallRuleGroup_tags
=== PAUSE TestAccNetworkFirewallRuleGroup_tags
=== CONT  TestAccNetworkFirewallFirewallPolicy_basic
=== CONT  TestAccNetworkFirewallFirewall_tags
--- PASS: TestAccNetworkFirewallFirewallPolicy_basic (154.69s)
=== CONT  TestAccNetworkFirewallRuleGroup_tags
--- PASS: TestAccNetworkFirewallRuleGroup_tags (161.33s)
=== CONT  TestAccNetworkFirewallFirewall_basic
--- PASS: TestAccNetworkFirewallFirewall_tags (1104.95s)
=== CONT  TestAccNetworkFirewallResourcePolicy_basic
    acctest.go:1300: skipping test for aws/us-west-2: Error running apply: exit status 1
        
        Error: error putting NetworkFirewall Resource Policy (for resource: arn:aws:network-firewall:us-west-2:123456789012:firewall-policy/tf-acc-test-2116292379653672618): InvalidResourcePolicyException: The supplied policy does not match RAM managed permissions.
        
          with aws_networkfirewall_resource_policy.test,
          on terraform_plugin_test.tf line 14, in resource "aws_networkfirewall_resource_policy" "test":
          14: resource "aws_networkfirewall_resource_policy" "test" {
        
--- SKIP: TestAccNetworkFirewallResourcePolicy_basic (144.33s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_tags
--- PASS: TestAccNetworkFirewallFirewallPolicy_tags (162.22s)
--- PASS: TestAccNetworkFirewallFirewall_basic (1105.05s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall	1430.243s
=== RUN   TestAccNetworkManagerConnectAttachment_basic
=== PAUSE TestAccNetworkManagerConnectAttachment_basic
=== RUN   TestAccNetworkManagerConnectAttachment_tags
=== PAUSE TestAccNetworkManagerConnectAttachment_tags
=== RUN   TestAccNetworkManagerConnectPeer_basic
=== PAUSE TestAccNetworkManagerConnectPeer_basic
=== RUN   TestAccNetworkManagerConnectPeer_tags
=== PAUSE TestAccNetworkManagerConnectPeer_tags
=== RUN   TestAccNetworkManagerConnectionDataSource_basic
=== PAUSE TestAccNetworkManagerConnectionDataSource_basic
=== RUN   TestAccNetworkManagerConnectionsDataSource_basic
=== PAUSE TestAccNetworkManagerConnectionsDataSource_basic
=== RUN   TestAccNetworkManagerCoreNetworkPolicyAttachment_basic
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyAttachment_basic
=== RUN   TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== RUN   TestAccNetworkManagerCoreNetwork_basic
=== PAUSE TestAccNetworkManagerCoreNetwork_basic
=== RUN   TestAccNetworkManagerCoreNetwork_tags
=== PAUSE TestAccNetworkManagerCoreNetwork_tags
=== RUN   TestAccNetworkManagerDeviceDataSource_basic
=== PAUSE TestAccNetworkManagerDeviceDataSource_basic
=== RUN   TestAccNetworkManagerDevice_basic
=== PAUSE TestAccNetworkManagerDevice_basic
=== RUN   TestAccNetworkManagerDevice_tags
=== PAUSE TestAccNetworkManagerDevice_tags
=== RUN   TestAccNetworkManagerDevicesDataSource_basic
=== PAUSE TestAccNetworkManagerDevicesDataSource_basic
=== RUN   TestAccNetworkManagerGlobalNetworkDataSource_basic
=== PAUSE TestAccNetworkManagerGlobalNetworkDataSource_basic
=== RUN   TestAccNetworkManagerGlobalNetwork_basic
=== PAUSE TestAccNetworkManagerGlobalNetwork_basic
=== RUN   TestAccNetworkManagerGlobalNetwork_tags
=== PAUSE TestAccNetworkManagerGlobalNetwork_tags
=== RUN   TestAccNetworkManagerGlobalNetworksDataSource_basic
=== PAUSE TestAccNetworkManagerGlobalNetworksDataSource_basic
=== RUN   TestAccNetworkManagerLinkAssociation_basic
=== PAUSE TestAccNetworkManagerLinkAssociation_basic
=== RUN   TestAccNetworkManagerLinkDataSource_basic
=== PAUSE TestAccNetworkManagerLinkDataSource_basic
=== RUN   TestAccNetworkManagerLink_basic
=== PAUSE TestAccNetworkManagerLink_basic
=== RUN   TestAccNetworkManagerLink_tags
=== PAUSE TestAccNetworkManagerLink_tags
=== RUN   TestAccNetworkManagerLinksDataSource_basic
=== PAUSE TestAccNetworkManagerLinksDataSource_basic
=== RUN   TestAccNetworkManagerSiteDataSource_basic
=== PAUSE TestAccNetworkManagerSiteDataSource_basic
=== RUN   TestAccNetworkManagerSite_basic
=== PAUSE TestAccNetworkManagerSite_basic
=== RUN   TestAccNetworkManagerSite_tags
=== PAUSE TestAccNetworkManagerSite_tags
=== RUN   TestAccNetworkManagerSiteToSiteVPNAttachment_basic
=== PAUSE TestAccNetworkManagerSiteToSiteVPNAttachment_basic
=== RUN   TestAccNetworkManagerSiteToSiteVPNAttachment_tags
=== PAUSE TestAccNetworkManagerSiteToSiteVPNAttachment_tags
=== RUN   TestAccNetworkManagerSitesDataSource_basic
=== PAUSE TestAccNetworkManagerSitesDataSource_basic
=== RUN   TestAccNetworkManagerTransitGatewayPeering_basic
=== PAUSE TestAccNetworkManagerTransitGatewayPeering_basic
=== RUN   TestAccNetworkManagerTransitGatewayPeering_tags
=== PAUSE TestAccNetworkManagerTransitGatewayPeering_tags
=== RUN   TestAccNetworkManagerTransitGatewayRouteTableAttachment_basic
=== PAUSE TestAccNetworkManagerTransitGatewayRouteTableAttachment_basic
=== RUN   TestAccNetworkManagerTransitGatewayRouteTableAttachment_tags
=== PAUSE TestAccNetworkManagerTransitGatewayRouteTableAttachment_tags
=== RUN   TestAccNetworkManagerVPCAttachment_basic
=== PAUSE TestAccNetworkManagerVPCAttachment_basic
=== RUN   TestAccNetworkManagerVPCAttachment_tags
=== PAUSE TestAccNetworkManagerVPCAttachment_tags
=== CONT  TestAccNetworkManagerConnectAttachment_basic
=== CONT  TestAccNetworkManagerVPCAttachment_tags
--- PASS: TestAccNetworkManagerVPCAttachment_tags (957.19s)
=== CONT  TestAccNetworkManagerGlobalNetworksDataSource_basic
--- PASS: TestAccNetworkManagerGlobalNetworksDataSource_basic (17.25s)
=== CONT  TestAccNetworkManagerVPCAttachment_basic
--- PASS: TestAccNetworkManagerConnectAttachment_basic (1208.36s)
=== CONT  TestAccNetworkManagerTransitGatewayRouteTableAttachment_tags
--- PASS: TestAccNetworkManagerVPCAttachment_basic (852.21s)
=== CONT  TestAccNetworkManagerTransitGatewayRouteTableAttachment_basic
--- PASS: TestAccNetworkManagerTransitGatewayRouteTableAttachment_tags (1432.14s)
=== CONT  TestAccNetworkManagerTransitGatewayPeering_tags
--- PASS: TestAccNetworkManagerTransitGatewayRouteTableAttachment_basic (1502.52s)
=== CONT  TestAccNetworkManagerTransitGatewayPeering_basic
--- PASS: TestAccNetworkManagerTransitGatewayPeering_tags (1214.13s)
=== CONT  TestAccNetworkManagerSitesDataSource_basic
    sites_data_source_test.go:19: Step 1/1 error: Error running apply: exit status 1
        
        Error: error creating Network Manager Site: ValidationException: Resource already exists with ID: site-01fccffd312177278
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "685fbece-cc07-4bcd-8e1a-5ac5576949d4"
          },
          Message_: "Resource already exists with ID: site-01fccffd312177278",
          Reason: "Other"
        }
        
          with aws_networkmanager_site.test1,
          on terraform_plugin_test.tf line 8, in resource "aws_networkmanager_site" "test1":
           8: resource "aws_networkmanager_site" "test1" {
        
--- FAIL: TestAccNetworkManagerSitesDataSource_basic (11.05s)
=== CONT  TestAccNetworkManagerSiteToSiteVPNAttachment_tags
--- PASS: TestAccNetworkManagerTransitGatewayPeering_basic (971.69s)
=== CONT  TestAccNetworkManagerSiteToSiteVPNAttachment_basic
--- PASS: TestAccNetworkManagerSiteToSiteVPNAttachment_tags (1235.67s)
=== CONT  TestAccNetworkManagerSite_tags
--- PASS: TestAccNetworkManagerSite_tags (42.58s)
=== CONT  TestAccNetworkManagerSite_basic
--- PASS: TestAccNetworkManagerSite_basic (19.85s)
=== CONT  TestAccNetworkManagerSiteDataSource_basic
--- PASS: TestAccNetworkManagerSiteDataSource_basic (18.89s)
=== CONT  TestAccNetworkManagerLinksDataSource_basic
--- PASS: TestAccNetworkManagerLinksDataSource_basic (21.35s)
=== CONT  TestAccNetworkManagerLink_tags
--- PASS: TestAccNetworkManagerLink_tags (46.13s)
=== CONT  TestAccNetworkManagerLink_basic
--- PASS: TestAccNetworkManagerLink_basic (21.55s)
=== CONT  TestAccNetworkManagerLinkDataSource_basic
--- PASS: TestAccNetworkManagerLinkDataSource_basic (18.98s)
=== CONT  TestAccNetworkManagerLinkAssociation_basic
    link_association_test.go:23: Step 1/2 error: Error running apply: exit status 1
        
        Error: error creating Network Manager Link: ValidationException: Resource already exists with ID: link-07020b60190aa0669
        {
          RespMetadata: {
            StatusCode: 400,
            RequestID: "e5b1fe57-ed3c-4ce5-ad3b-0d92e1bf8833"
          },
          Message_: "Resource already exists with ID: link-07020b60190aa0669",
          Reason: "Other"
        }
        
          with aws_networkmanager_link.test,
          on terraform_plugin_test.tf line 16, in resource "aws_networkmanager_link" "test":
          16: resource "aws_networkmanager_link" "test" {
        
--- FAIL: TestAccNetworkManagerLinkAssociation_basic (12.73s)
=== CONT  TestAccNetworkManagerConnectionsDataSource_basic
--- PASS: TestAccNetworkManagerConnectionsDataSource_basic (26.75s)
=== CONT  TestAccNetworkManagerCoreNetwork_basic
--- PASS: TestAccNetworkManagerCoreNetwork_basic (45.21s)
=== CONT  TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
--- PASS: TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic (9.05s)
=== CONT  TestAccNetworkManagerCoreNetworkPolicyAttachment_basic
--- PASS: TestAccNetworkManagerSiteToSiteVPNAttachment_basic (1489.69s)
=== CONT  TestAccNetworkManagerDevicesDataSource_basic
--- PASS: TestAccNetworkManagerDevicesDataSource_basic (17.75s)
=== CONT  TestAccNetworkManagerGlobalNetwork_tags
--- PASS: TestAccNetworkManagerGlobalNetwork_tags (37.90s)
=== CONT  TestAccNetworkManagerCoreNetwork_tags
--- PASS: TestAccNetworkManagerCoreNetwork_tags (76.26s)
=== CONT  TestAccNetworkManagerDevice_tags
--- PASS: TestAccNetworkManagerDevice_tags (40.83s)
=== CONT  TestAccNetworkManagerDevice_basic
--- PASS: TestAccNetworkManagerDevice_basic (18.43s)
=== CONT  TestAccNetworkManagerDeviceDataSource_basic
--- PASS: TestAccNetworkManagerDeviceDataSource_basic (17.68s)
=== CONT  TestAccNetworkManagerGlobalNetwork_basic
--- PASS: TestAccNetworkManagerGlobalNetwork_basic (17.11s)
=== CONT  TestAccNetworkManagerConnectPeer_tags
--- PASS: TestAccNetworkManagerCoreNetworkPolicyAttachment_basic (732.32s)
=== CONT  TestAccNetworkManagerConnectionDataSource_basic
--- PASS: TestAccNetworkManagerConnectionDataSource_basic (26.51s)
=== CONT  TestAccNetworkManagerConnectPeer_basic
--- PASS: TestAccNetworkManagerConnectPeer_tags (1474.26s)
=== CONT  TestAccNetworkManagerConnectAttachment_tags
--- PASS: TestAccNetworkManagerConnectPeer_basic (1513.37s)
=== CONT  TestAccNetworkManagerGlobalNetworkDataSource_basic
--- PASS: TestAccNetworkManagerGlobalNetworkDataSource_basic (15.26s)
--- PASS: TestAccNetworkManagerConnectAttachment_tags (1258.15s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager	8764.441s
FAIL
make: *** [testacc] Error 1
```
