### PR TITLE
fix: error when scaling elasticache_replication_group

### DIFF
--- a/internal/service/elasticache/wait.go
+++ b/internal/service/elasticache/wait.go
@@ -71,6 +71,7 @@ func WaitReplicationGroupMemberClustersAvailable(ctx context.Context, conn *elas
 			CacheClusterStatusCreating,
 			CacheClusterStatusDeleting,
 			CacheClusterStatusModifying,
+			CacheClusterStatusSnapshotting,
 		},
 		Target:     []string{CacheClusterStatusAvailable},
 		Refresh:    StatusReplicationGroupMemberClusters(ctx, conn, replicationGroupID),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When scaling a `aws_elasticache_replication_group` up or down (via `num_cache_clusters`), if AWS runs a snapshot during during the operation, the update will fail with error `unexpected state 'snapshotting', wanted target 'available'`:

```
Error: modifying ElastiCache Replication Group (csbb2a2560a-acf7-4106-9618-4263082cb536) clusters: error waiting for ElastiCache Replication Group (csbb2a2560a-acf7-4106-9618-4263082cb536) replica addition: unexpected state 'snapshotting', wanted target 'available'.
              last error: %!s(<nil>) with aws_elasticache_replication_group.redis, on main.tf line 46, in resource "aws_elasticache_replication_group" "redis": 46: resource "aws_elasticache_replication_group" "redis"
```

Suggestion is that as "snapshotting" is an allowed state in the [`WaitReplicationGroupAvailable()`](https://github.com/hashicorp/terraform-provider-aws/blob/077b23b5ae4c7b17aef43500a4d017d08bd05f53/internal/service/elasticache/wait.go#L29) function, for consistency it makes sense for it to also be allowed in the `WaitReplicationGroupMemberClustersAvailable()` function that gets called when scaling the replication group.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

None

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

None

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS='TestAccElastiCacheReplicationGroup_' PKG=elasticache ACCTEST_PARALLELISM=5
...
```
I wasn't able to get this to run successfully, but for reasons relating to VPC constraints rather than anything likely to relate to the change.