### PR TITLE
Improves validation for `aws_cognito_user_pool_client` and `aws_cognito_managed_user_pool_client`

### DIFF
--- a/internal/service/cognitoidp/managed_user_pool_client_test.go
+++ b/internal/service/cognitoidp/managed_user_pool_client_test.go
@@ -215,6 +215,32 @@ func TestAccCognitoIDPManagedUserPoolClient_accessTokenValidity(t *testing.T) {
 	})
 }
 
+func TestAccCognitoIDManagedPUserPoolClient_accessTokenValidity_error(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := randomOpenSearchDomainName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolClientDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccManagedUserPoolClientConfig_accessTokenValidity(rName, 25),
+				ExpectError: regexp.MustCompile(`Attribute access_token_validity must have a duration between 5m0s and\s+24h0m0s, got: 25h0m0s`),
+			},
+			{
+				Config:      testAccManagedUserPoolClientConfig_accessTokenValidityUnit(rName, 2, cognitoidentityprovider.TimeUnitsTypeDays),
+				ExpectError: regexp.MustCompile(`Attribute access_token_validity must have a duration between 5m0s and\s+24h0m0s, got: 48h0m0s`),
+			},
+			{
+				Config:      testAccManagedUserPoolClientConfig_accessTokenValidityUnit(rName, 4, cognitoidentityprovider.TimeUnitsTypeMinutes),
+				ExpectError: regexp.MustCompile(`Attribute access_token_validity must have a duration between 5m0s and\s+24h0m0s, got: 4m0s`),
+			},
+		},
+	})
+}
+
 func TestAccCognitoIDPManagedUserPoolClient_idTokenValidity(t *testing.T) {
 	ctx := acctest.Context(t)
 	var client cognitoidentityprovider.UserPoolClientType
@@ -263,6 +289,32 @@ func TestAccCognitoIDPManagedUserPoolClient_idTokenValidity(t *testing.T) {
 	})
 }
 
+func TestAccCognitoIDPManagedUserPoolClient_idTokenValidity_error(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := randomOpenSearchDomainName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolClientDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccManagedUserPoolClientConfig_idTokenValidity(rName, 25),
+				ExpectError: regexp.MustCompile(`Attribute id_token_validity must have a duration between 5m0s and\s+24h0m0s,\s+got: 25h0m0s`),
+			},
+			{
+				Config:      testAccManagedUserPoolClientConfig_idTokenValidityUnit(rName, 2, cognitoidentityprovider.TimeUnitsTypeDays),
+				ExpectError: regexp.MustCompile(`Attribute id_token_validity must have a duration between 5m0s and\s+24h0m0s,\s+got: 48h0m0s`),
+			},
+			{
+				Config:      testAccManagedUserPoolClientConfig_idTokenValidityUnit(rName, 4, cognitoidentityprovider.TimeUnitsTypeMinutes),
+				ExpectError: regexp.MustCompile(`Attribute id_token_validity must have a duration between 5m0s and\s+24h0m0s,\s+got: 4m0s`),
+			},
+		},
+	})
+}
+
 func TestAccCognitoIDPManagedUserPoolClient_refreshTokenValidity(t *testing.T) {
 	ctx := acctest.Context(t)
 	var client cognitoidentityprovider.UserPoolClientType
@@ -306,6 +358,28 @@ func TestAccCognitoIDPManagedUserPoolClient_refreshTokenValidity(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"name_prefix",
 				},
+			},
+		},
+	})
+}
+
+func TestAccCognitoIDPManagedUserPoolClient_refreshTokenValidity_error(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := randomOpenSearchDomainName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolClientDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccManagedUserPoolClientConfig_refreshTokenValidity(rName, 10*365+1),
+				ExpectError: regexp.MustCompile(`Attribute refresh_token_validity must have a duration between 1h0m0s and\s+87600h0m0s,\s+got: 87624h0m0s`),
+			},
+			{
+				Config:      testAccManagedUserPoolClientConfig_refreshTokenValidityUnit(rName, 59, cognitoidentityprovider.TimeUnitsTypeMinutes),
+				ExpectError: regexp.MustCompile(`Attribute refresh_token_validity must have a duration between 1h0m0s and\s+87600h0m0s,\s+got: 59m0s`),
 			},
 		},
 	})
@@ -1045,6 +1119,27 @@ resource "aws_cognito_managed_user_pool_client" "test" {
 `, rName, validity))
 }
 
+func testAccManagedUserPoolClientConfig_accessTokenValidityUnit(rName string, validity int, unit string) string {
+	return acctest.ConfigCompose(
+		testAccManagedUserPoolClientBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_cognito_managed_user_pool_client" "test" {
+  name_prefix  = "AmazonOpenSearchService-%[1]s"
+  user_pool_id = aws_cognito_user_pool.test.id
+
+  depends_on = [
+    aws_opensearch_domain.test,
+  ]
+
+  access_token_validity = %[2]d
+
+  token_validity_units {
+    access_token = %[3]q
+  }
+}
+`, rName, validity, unit))
+}
+
 func testAccManagedUserPoolClientConfig_idTokenValidity(rName string, validity int) string {
 	return acctest.ConfigCompose(
 		testAccManagedUserPoolClientBaseConfig(rName),
@@ -1062,6 +1157,27 @@ resource "aws_cognito_managed_user_pool_client" "test" {
 `, rName, validity))
 }
 
+func testAccManagedUserPoolClientConfig_idTokenValidityUnit(rName string, validity int, unit string) string {
+	return acctest.ConfigCompose(
+		testAccManagedUserPoolClientBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_cognito_managed_user_pool_client" "test" {
+  name_prefix  = "AmazonOpenSearchService-%[1]s"
+  user_pool_id = aws_cognito_user_pool.test.id
+
+  depends_on = [
+    aws_opensearch_domain.test,
+  ]
+
+  id_token_validity = %[2]d
+
+  token_validity_units {
+    id_token = %[3]q
+  }
+}
+`, rName, validity, unit))
+}
+
 func testAccManagedUserPoolClientConfig_refreshTokenValidity(rName string, refreshTokenValidity int) string {
 	return acctest.ConfigCompose(
 		testAccManagedUserPoolClientBaseConfig(rName),
@@ -1077,6 +1193,27 @@ resource "aws_cognito_managed_user_pool_client" "test" {
   refresh_token_validity = %[2]d
 }
 `, rName, refreshTokenValidity))
+}
+
+func testAccManagedUserPoolClientConfig_refreshTokenValidityUnit(rName string, refreshTokenValidity int, unit string) string {
+	return acctest.ConfigCompose(
+		testAccManagedUserPoolClientBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_cognito_managed_user_pool_client" "test" {
+  name_prefix  = "AmazonOpenSearchService-%[1]s"
+  user_pool_id = aws_cognito_user_pool.test.id
+
+  depends_on = [
+    aws_opensearch_domain.test,
+  ]
+
+  refresh_token_validity = %[2]d
+
+  token_validity_units {
+    refresh_token = %[3]q
+  }
+}
+`, rName, refreshTokenValidity, unit))
 }
 
 func testAccManagedUserPoolClientConfig_tokenValidityUnits(rName, units string) string {

--- a/internal/service/cognitoidp/managed_user_pool_client_test.go
+++ b/internal/service/cognitoidp/managed_user_pool_client_test.go
@@ -215,7 +215,7 @@ func TestAccCognitoIDPManagedUserPoolClient_accessTokenValidity(t *testing.T) {
 	})
 }
 
-func TestAccCognitoIDManagedPUserPoolClient_accessTokenValidity_error(t *testing.T) {
+func TestAccCognitoIDPManagedUserPoolClient_accessTokenValidity_error(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := randomOpenSearchDomainName()
 

--- a/internal/service/cognitoidp/user_pool_client.go
+++ b/internal/service/cognitoidp/user_pool_client.go
@@ -487,24 +487,24 @@ func (r *resourceUserPoolClient) ImportState(ctx context.Context, request resour
 
 func (r *resourceUserPoolClient) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
-		accessTokenValidityValidator{
-			validityValidator{
+		resourceUserPoolClientAccessTokenValidityValidator{
+			resourceUserPoolClientValidityValidator{
 				attr:        "access_token_validity",
 				min:         5 * time.Minute,
 				max:         24 * time.Hour,
 				defaultUnit: time.Hour,
 			},
 		},
-		idTokenValidityValidator{
-			validityValidator{
+		resourceUserPoolClientIDTokenValidityValidator{
+			resourceUserPoolClientValidityValidator{
 				attr:        "id_token_validity",
 				min:         5 * time.Minute,
 				max:         24 * time.Hour,
 				defaultUnit: time.Hour,
 			},
 		},
-		refreshTokenValidityValidator{
-			validityValidator{
+		resourceUserPoolClientRefreshTokenValidityValidator{
+			resourceUserPoolClientValidityValidator{
 				attr:        "refresh_token_validity",
 				min:         60 * time.Minute,
 				max:         315360000 * time.Second,
@@ -739,13 +739,13 @@ func flattenTokenValidityUnits(ctx context.Context, tvu *cognitoidentityprovider
 	return types.ListValueMust(elemType, []attr.Value{val})
 }
 
-var _ resource.ConfigValidator = &accessTokenValidityValidator{}
+var _ resource.ConfigValidator = &resourceUserPoolClientAccessTokenValidityValidator{}
 
-type accessTokenValidityValidator struct {
-	validityValidator
+type resourceUserPoolClientAccessTokenValidityValidator struct {
+	resourceUserPoolClientValidityValidator
 }
 
-func (v accessTokenValidityValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+func (v resourceUserPoolClientAccessTokenValidityValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	v.validate(ctx, req, resp,
 		func(rupcd resourceUserPoolClientData) types.Int64 {
 			return rupcd.AccessTokenValidity
@@ -756,13 +756,13 @@ func (v accessTokenValidityValidator) ValidateResource(ctx context.Context, req 
 	)
 }
 
-var _ resource.ConfigValidator = &idTokenValidityValidator{}
+var _ resource.ConfigValidator = &resourceUserPoolClientIDTokenValidityValidator{}
 
-type idTokenValidityValidator struct {
-	validityValidator
+type resourceUserPoolClientIDTokenValidityValidator struct {
+	resourceUserPoolClientValidityValidator
 }
 
-func (v idTokenValidityValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+func (v resourceUserPoolClientIDTokenValidityValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	v.validate(ctx, req, resp,
 		func(rupcd resourceUserPoolClientData) types.Int64 {
 			return rupcd.IdTokenValidity
@@ -773,13 +773,13 @@ func (v idTokenValidityValidator) ValidateResource(ctx context.Context, req reso
 	)
 }
 
-var _ resource.ConfigValidator = &refreshTokenValidityValidator{}
+var _ resource.ConfigValidator = &resourceUserPoolClientRefreshTokenValidityValidator{}
 
-type refreshTokenValidityValidator struct {
-	validityValidator
+type resourceUserPoolClientRefreshTokenValidityValidator struct {
+	resourceUserPoolClientValidityValidator
 }
 
-func (v refreshTokenValidityValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+func (v resourceUserPoolClientRefreshTokenValidityValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	v.validate(ctx, req, resp,
 		func(rupcd resourceUserPoolClientData) types.Int64 {
 			return rupcd.RefreshTokenValidity
@@ -790,22 +790,22 @@ func (v refreshTokenValidityValidator) ValidateResource(ctx context.Context, req
 	)
 }
 
-type validityValidator struct {
+type resourceUserPoolClientValidityValidator struct {
 	min         time.Duration
 	max         time.Duration
 	attr        string
 	defaultUnit time.Duration
 }
 
-func (v validityValidator) Description(ctx context.Context) string {
+func (v resourceUserPoolClientValidityValidator) Description(ctx context.Context) string {
 	return v.MarkdownDescription(ctx)
 }
 
-func (v validityValidator) MarkdownDescription(_ context.Context) string {
+func (v resourceUserPoolClientValidityValidator) MarkdownDescription(_ context.Context) string {
 	return fmt.Sprintf("must have a duration between %s and %s", v.min, v.max)
 }
 
-func (v validityValidator) validate(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse, valF func(resourceUserPoolClientData) types.Int64, unitF func(*tokenValidityUnits) types.String) {
+func (v resourceUserPoolClientValidityValidator) validate(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse, valF func(resourceUserPoolClientData) types.Int64, unitF func(*tokenValidityUnits) types.String) {
 	var config resourceUserPoolClientData
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/service/cognitoidp/user_pool_client_test.go
+++ b/internal/service/cognitoidp/user_pool_client_test.go
@@ -1137,36 +1137,6 @@ resource "aws_cognito_user_pool_client" "test" {
 `, rName, revoke))
 }
 
-func testAccUserPoolClientConfig_refreshTokenValidity(rName string, refreshTokenValidity int) string {
-	return acctest.ConfigCompose(
-		testAccUserPoolClientBaseConfig(rName),
-		fmt.Sprintf(`
-resource "aws_cognito_user_pool_client" "test" {
-  name         = %[1]q
-  user_pool_id = aws_cognito_user_pool.test.id
-
-  refresh_token_validity = %[2]d
-}
-`, rName, refreshTokenValidity))
-}
-
-func testAccUserPoolClientConfig_refreshTokenValidityUnit(rName string, refreshTokenValidity int, unit string) string {
-	return acctest.ConfigCompose(
-		testAccUserPoolClientBaseConfig(rName),
-		fmt.Sprintf(`
-resource "aws_cognito_user_pool_client" "test" {
-  name         = %[1]q
-  user_pool_id = aws_cognito_user_pool.test.id
-
-  refresh_token_validity = %[2]d
-
-  token_validity_units {
-    refresh_token = %[3]q
-  }
-}
-`, rName, refreshTokenValidity, unit))
-}
-
 func testAccUserPoolClientConfig_accessTokenValidity(rName string, validity int) string {
 	return acctest.ConfigCompose(
 		testAccUserPoolClientBaseConfig(rName),
@@ -1225,6 +1195,36 @@ resource "aws_cognito_user_pool_client" "test" {
   }
 }
 `, rName, validity, unit))
+}
+
+func testAccUserPoolClientConfig_refreshTokenValidity(rName string, refreshTokenValidity int) string {
+	return acctest.ConfigCompose(
+		testAccUserPoolClientBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_cognito_user_pool_client" "test" {
+  name         = %[1]q
+  user_pool_id = aws_cognito_user_pool.test.id
+
+  refresh_token_validity = %[2]d
+}
+`, rName, refreshTokenValidity))
+}
+
+func testAccUserPoolClientConfig_refreshTokenValidityUnit(rName string, refreshTokenValidity int, unit string) string {
+	return acctest.ConfigCompose(
+		testAccUserPoolClientBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_cognito_user_pool_client" "test" {
+  name         = %[1]q
+  user_pool_id = aws_cognito_user_pool.test.id
+
+  refresh_token_validity = %[2]d
+
+  token_validity_units {
+    refresh_token = %[3]q
+  }
+}
+`, rName, refreshTokenValidity, unit))
 }
 
 func testAccUserPoolClientConfig_tokenValidityUnits(rName, value string) string {

--- a/internal/service/cognitoidp/user_pool_client_test.go
+++ b/internal/service/cognitoidp/user_pool_client_test.go
@@ -225,6 +225,32 @@ func TestAccCognitoIDPUserPoolClient_idTokenValidity(t *testing.T) {
 	})
 }
 
+func TestAccCognitoIDPUserPoolClient_idTokenValidity_error(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolClientDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccUserPoolClientConfig_idTokenValidity(rName, 25),
+				ExpectError: regexp.MustCompile(`Attribute id_token_validity must have a duration between 5m0s and\s+24h0m0s,\s+got: 25h0m0s`),
+			},
+			{
+				Config:      testAccUserPoolClientConfig_idTokenValidityUnit(rName, 2, cognitoidentityprovider.TimeUnitsTypeDays),
+				ExpectError: regexp.MustCompile(`Attribute id_token_validity must have a duration between 5m0s and\s+24h0m0s,\s+got: 48h0m0s`),
+			},
+			{
+				Config:      testAccUserPoolClientConfig_idTokenValidityUnit(rName, 4, cognitoidentityprovider.TimeUnitsTypeMinutes),
+				ExpectError: regexp.MustCompile(`Attribute id_token_validity must have a duration between 5m0s and\s+24h0m0s,\s+got: 4m0s`),
+			},
+		},
+	})
+}
+
 func TestAccCognitoIDPUserPoolClient_refreshTokenValidity(t *testing.T) {
 	ctx := acctest.Context(t)
 	var client cognitoidentityprovider.UserPoolClientType
@@ -1136,11 +1162,29 @@ func testAccUserPoolClientConfig_idTokenValidity(rName string, validity int) str
 		testAccUserPoolClientBaseConfig(rName),
 		fmt.Sprintf(`
 resource "aws_cognito_user_pool_client" "test" {
-  name              = %[1]q
+  name         = %[1]q
+  user_pool_id = aws_cognito_user_pool.test.id
+
   id_token_validity = %[2]d
-  user_pool_id      = aws_cognito_user_pool.test.id
 }
 `, rName, validity))
+}
+
+func testAccUserPoolClientConfig_idTokenValidityUnit(rName string, validity int, unit string) string {
+	return acctest.ConfigCompose(
+		testAccUserPoolClientBaseConfig(rName),
+		fmt.Sprintf(`
+resource "aws_cognito_user_pool_client" "test" {
+  name         = %[1]q
+  user_pool_id = aws_cognito_user_pool.test.id
+
+  id_token_validity = %[2]d
+
+  token_validity_units {
+    id_token = %[3]q
+  }
+}
+`, rName, validity, unit))
 }
 
 func testAccUserPoolClientConfig_tokenValidityUnits(rName, value string) string {

--- a/website/docs/r/cognito_managed_user_pool_client.html.markdown
+++ b/website/docs/r/cognito_managed_user_pool_client.html.markdown
@@ -105,7 +105,9 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `access_token_validity` - (Optional) Time limit, between 5 minutes and 1 day, after which the access token is no longer valid and cannot be used. This value will be overridden if you have entered a value in `token_validity_units`.
+* `access_token_validity` - (Optional) Time limit, between 5 minutes and 1 day, after which the access token is no longer valid and cannot be used.
+  By default, the unit is hours.
+  The unit can be overridden by a value in `token_validity_units.access_token`.
 * `allowed_oauth_flows_user_pool_client` - (Optional) Whether the client is allowed to follow the OAuth protocol when interacting with Cognito user pools.
 * `allowed_oauth_flows` - (Optional) List of allowed OAuth flows (code, implicit, client_credentials).
 * `allowed_oauth_scopes` - (Optional) List of allowed OAuth scopes (phone, email, openid, profile, and aws.cognito.signin.user.admin).
@@ -117,11 +119,15 @@ The following arguments are optional:
 * `enable_propagate_additional_user_context_data` - (Optional) Activates the propagation of additional user context data.
 * `explicit_auth_flows` - (Optional) List of authentication flows (ADMIN_NO_SRP_AUTH, CUSTOM_AUTH_FLOW_ONLY, USER_PASSWORD_AUTH, ALLOW_ADMIN_USER_PASSWORD_AUTH, ALLOW_CUSTOM_AUTH, ALLOW_USER_PASSWORD_AUTH, ALLOW_USER_SRP_AUTH, ALLOW_REFRESH_TOKEN_AUTH).
 * `generate_secret` - (Optional) Should an application secret be generated.
-* `id_token_validity` - (Optional) Time limit, between 5 minutes and 1 day, after which the ID token is no longer valid and cannot be used. This value will be overridden if you have entered a value in `token_validity_units`.
+* `id_token_validity` - (Optional) Time limit, between 5 minutes and 1 day, after which the ID token is no longer valid and cannot be used.
+  By default, the unit is hours.
+  The unit can be overridden by a value in `token_validity_units.id_token`.
 * `logout_urls` - (Optional) List of allowed logout URLs for the identity providers.
 * `prevent_user_existence_errors` - (Optional) Choose which errors and responses are returned by Cognito APIs during authentication, account confirmation, and password recovery when the user does not exist in the user pool. When set to `ENABLED` and the user does not exist, authentication returns an error indicating either the username or password was incorrect, and account confirmation and password recovery return a response indicating a code was sent to a simulated destination. When set to `LEGACY`, those APIs will return a `UserNotFoundException` exception if the user does not exist in the user pool.
 * `read_attributes` - (Optional) List of user pool attributes the application client can read from.
-* `refresh_token_validity` - (Optional) Time limit in days refresh tokens are valid for.
+* `refresh_token_validity` - (Optional) Time limit, between 60 minutes and 10 years, after which the refresh token is no longer valid and cannot be used.
+  By default, the unit is days.
+  The unit can be overridden by a value in `token_validity_units.refresh_token`.
 * `supported_identity_providers` - (Optional) List of provider names for the identity providers that are supported on this client. Uses the `provider_name` attribute of `aws_cognito_identity_provider` resource(s), or the equivalent string(s).
 * `token_validity_units` - (Optional) Configuration block for units in which the validity times are represented in. [Detailed below](#token_validity_units).
 * `write_attributes` - (Optional) List of user pool attributes the application client can write to.

--- a/website/docs/r/cognito_user_pool_client.html.markdown
+++ b/website/docs/r/cognito_user_pool_client.html.markdown
@@ -136,7 +136,9 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `access_token_validity` - (Optional) Time limit, between 5 minutes and 1 day, after which the access token is no longer valid and cannot be used. This value will be overridden if you have entered a value in `token_validity_units`.
+* `access_token_validity` - (Optional) Time limit, between 5 minutes and 1 day, after which the access token is no longer valid and cannot be used.
+  By default, the unit is a hour.
+  The unit can be overridden by a value in `token_validity_units.access_token`.
 * `allowed_oauth_flows_user_pool_client` - (Optional) Whether the client is allowed to follow the OAuth protocol when interacting with Cognito user pools.
 * `allowed_oauth_flows` - (Optional) List of allowed OAuth flows (code, implicit, client_credentials).
 * `allowed_oauth_scopes` - (Optional) List of allowed OAuth scopes (phone, email, openid, profile, and aws.cognito.signin.user.admin).

--- a/website/docs/r/cognito_user_pool_client.html.markdown
+++ b/website/docs/r/cognito_user_pool_client.html.markdown
@@ -156,7 +156,9 @@ The following arguments are optional:
 * `logout_urls` - (Optional) List of allowed logout URLs for the identity providers.
 * `prevent_user_existence_errors` - (Optional) Choose which errors and responses are returned by Cognito APIs during authentication, account confirmation, and password recovery when the user does not exist in the user pool. When set to `ENABLED` and the user does not exist, authentication returns an error indicating either the username or password was incorrect, and account confirmation and password recovery return a response indicating a code was sent to a simulated destination. When set to `LEGACY`, those APIs will return a `UserNotFoundException` exception if the user does not exist in the user pool.
 * `read_attributes` - (Optional) List of user pool attributes the application client can read from.
-* `refresh_token_validity` - (Optional) Time limit in days refresh tokens are valid for.
+* `refresh_token_validity` - (Optional) Time limit, between 60 minutes and 10 years, after which the refresh token is no longer valid and cannot be used.
+  By default, the unit is days.
+  The unit can be overridden by a value in `token_validity_units.refresh_token`.
 * `supported_identity_providers` - (Optional) List of provider names for the identity providers that are supported on this client. Uses the `provider_name` attribute of `aws_cognito_identity_provider` resource(s), or the equivalent string(s).
 * `token_validity_units` - (Optional) Configuration block for units in which the validity times are represented in. [Detailed below](#token_validity_units).
 * `write_attributes` - (Optional) List of user pool attributes the application client can write to.

--- a/website/docs/r/cognito_user_pool_client.html.markdown
+++ b/website/docs/r/cognito_user_pool_client.html.markdown
@@ -137,7 +137,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `access_token_validity` - (Optional) Time limit, between 5 minutes and 1 day, after which the access token is no longer valid and cannot be used.
-  By default, the unit is a hour.
+  By default, the unit is hours.
   The unit can be overridden by a value in `token_validity_units.access_token`.
 * `allowed_oauth_flows_user_pool_client` - (Optional) Whether the client is allowed to follow the OAuth protocol when interacting with Cognito user pools.
 * `allowed_oauth_flows` - (Optional) List of allowed OAuth flows (code, implicit, client_credentials).
@@ -150,7 +150,9 @@ The following arguments are optional:
 * `enable_propagate_additional_user_context_data` - (Optional) Activates the propagation of additional user context data.
 * `explicit_auth_flows` - (Optional) List of authentication flows (ADMIN_NO_SRP_AUTH, CUSTOM_AUTH_FLOW_ONLY, USER_PASSWORD_AUTH, ALLOW_ADMIN_USER_PASSWORD_AUTH, ALLOW_CUSTOM_AUTH, ALLOW_USER_PASSWORD_AUTH, ALLOW_USER_SRP_AUTH, ALLOW_REFRESH_TOKEN_AUTH).
 * `generate_secret` - (Optional) Should an application secret be generated.
-* `id_token_validity` - (Optional) Time limit, between 5 minutes and 1 day, after which the ID token is no longer valid and cannot be used. This value will be overridden if you have entered a value in `token_validity_units`.
+* `id_token_validity` - (Optional) Time limit, between 5 minutes and 1 day, after which the ID token is no longer valid and cannot be used.
+  By default, the unit is hours.
+  The unit can be overridden by a value in `token_validity_units.id_token`.
 * `logout_urls` - (Optional) List of allowed logout URLs for the identity providers.
 * `prevent_user_existence_errors` - (Optional) Choose which errors and responses are returned by Cognito APIs during authentication, account confirmation, and password recovery when the user does not exist in the user pool. When set to `ENABLED` and the user does not exist, authentication returns an error indicating either the username or password was incorrect, and account confirmation and password recovery return a response indicating a code was sent to a simulated destination. When set to `LEGACY`, those APIs will return a `UserNotFoundException` exception if the user does not exist in the user pool.
 * `read_attributes` - (Optional) List of user pool attributes the application client can read from.


### PR DESCRIPTION
### Description

Updates `aws_cognito_user_pool_client` and `aws_cognito_managed_user_pool_client` validation for `access_token_validity`, `id_token_validity`, and `refresh_token_validity` to account for units set in `token_validity_units`.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=cognitoidp TESTS='TestAccCognitoIDPUserPoolClient_|TestAccCognitoIDPManagedUserPoolClient_'

--- PASS: TestAccCognitoIDPManagedUserPoolClient_accessTokenValidity_error (3.92s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_refreshTokenValidity_error (6.62s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_idTokenValidity_error (7.79s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_basic (1529.58s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_tokenValidityUnitsWTokenValidity (1628.51s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_analyticsApplicationID (1665.77s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_tokenValidityUnits_AccessToken (1711.12s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_Disappears_OpenSearchDomain (1725.51s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_allFields (1750.03s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_namePattern (1757.41s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_authSessionValidity (1780.15s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_idTokenValidity (1781.54s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_emptySets (1787.23s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_enableRevocation (1804.71s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_refreshTokenValidity (1976.01s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_nulls (1991.45s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_allFieldsUpdatingOneField (2121.45s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_tokenValidityUnits (2180.86s)
--- PASS: TestAccCognitoIDPManagedUserPoolClient_accessTokenValidity (2474.51s)

--- PASS: TestAccCognitoIDPUserPoolClient_refreshTokenValidity_error (9.04s)
--- PASS: TestAccCognitoIDPUserPoolClient_accessTokenValidity_error (13.91s)
--- PASS: TestAccCognitoIDPUserPoolClient_idTokenValidity_error (18.73s)
--- PASS: TestAccCognitoIDPUserPoolClient_Disappears_userPool (59.15s)
--- PASS: TestAccCognitoIDPUserPoolClient_disappears (66.30s)
--- PASS: TestAccCognitoIDPUserPoolClient_basic (71.39s)
--- PASS: TestAccCognitoIDPUserPoolClient_allFields (73.15s)
--- PASS: TestAccCognitoIDPUserPoolClient_frameworkMigration_emptySet (97.12s)
--- PASS: TestAccCognitoIDPUserPoolClient_emptySets (97.89s)
--- PASS: TestAccCognitoIDPUserPoolClient_nulls (99.23s)
--- PASS: TestAccCognitoIDPUserPoolClient_frameworkMigration_basic (99.31s)
--- PASS: TestAccCognitoIDPUserPoolClient_frameworkMigration_nulls (101.44s)
--- PASS: TestAccCognitoIDPUserPoolClient_allFieldsUpdatingOneField (106.13s)
--- PASS: TestAccCognitoIDPUserPoolClient_authSessionValidity (111.08s)
--- PASS: TestAccCognitoIDPUserPoolClient_refreshTokenValidity (112.82s)
--- PASS: TestAccCognitoIDPUserPoolClient_tokenValidityUnitsWTokenValidity (113.30s)
--- PASS: TestAccCognitoIDPUserPoolClient_tokenValidityUnits_AccessToken (113.62s)
--- PASS: TestAccCognitoIDPUserPoolClient_name (114.71s)
--- PASS: TestAccCognitoIDPUserPoolClient_tokenValidityUnits (115.61s)
--- PASS: TestAccCognitoIDPUserPoolClient_accessTokenValidity (102.65s)
--- PASS: TestAccCognitoIDPUserPoolClient_analyticsWithARN (117.88s)
--- PASS: TestAccCognitoIDPUserPoolClient_idTokenValidity (92.14s)
--- PASS: TestAccCognitoIDPUserPoolClient_enableRevocation (72.20s)
--- PASS: TestAccCognitoIDPUserPoolClient_analyticsApplicationID (134.43s)
```
