### PR TITLE
Adding certificate_data_source to dms

### DIFF
--- a/.changelog/30498.txt
+++ b/.changelog/30498.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_dms_certificate
+```

--- a/internal/service/dms/certificate_data_source.go
+++ b/internal/service/dms/certificate_data_source.go
@@ -1,0 +1,150 @@
+package dms
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	dms "github.com/aws/aws-sdk-go/service/databasemigrationservice"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_dms_certificate")
+func DataSourceCertificate() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceCertificateRead,
+
+		Schema: map[string]*schema.Schema{
+			"certificate_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certificate_creation_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certificate_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 255),
+					validation.StringMatch(regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9-]+$"), "must start with a letter, only contain alphanumeric characters and hyphens"),
+					validation.StringDoesNotMatch(regexp.MustCompile(`--`), "cannot contain two consecutive hyphens"),
+					validation.StringDoesNotMatch(regexp.MustCompile(`-$`), "cannot end in a hyphen"),
+				),
+			},
+			"certificate_owner": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certificate_pem": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"certificate_wallet": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"key_length": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"signing_algorithm": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"valid_from_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"valid_to_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+const (
+	DSNameCertificate = "Certificate Data Source"
+)
+
+func dataSourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).DMSConn()
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	certificateID := d.Get("certificate_id").(string)
+
+	out, err := FindCertificateByID(ctx, conn, certificateID)
+
+	if err != nil {
+		create.DiagError(names.DMS, create.ErrActionReading, DSNameCertificate, d.Id(), err)
+	}
+
+	d.SetId(aws.StringValue(out.CertificateIdentifier))
+
+	d.Set("certificate_id", out.CertificateIdentifier)
+	d.Set("certificate_arn", out.CertificateArn)
+	d.Set("certificate_pem", out.CertificatePem)
+
+	if out.CertificateWallet != nil && len(out.CertificateWallet) != 0 {
+		d.Set("certificate_wallet", verify.Base64Encode(out.CertificateWallet))
+	}
+
+	d.Set("key_length", out.KeyLength)
+	d.Set("signing_algorithm", out.SigningAlgorithm)
+
+	from_date := out.ValidFromDate.String()
+	d.Set("valid_from_date", from_date)
+	to_date := out.ValidToDate.String()
+	d.Set("valid_to_date", to_date)
+
+	tags, err := ListTags(ctx, conn, aws.StringValue(out.CertificateArn))
+
+	if err != nil {
+		return create.DiagError(names.DMS, create.ErrActionReading, DSNameCertificate, d.Id(), err)
+	}
+
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return create.DiagError(names.DMS, create.ErrActionSetting, DSNameCertificate, d.Id(), err)
+	}
+
+	return nil
+}
+
+func FindCertificateByID(ctx context.Context, conn *dms.DatabaseMigrationService, id string) (*dms.Certificate, error) {
+	input := &dms.DescribeCertificatesInput{
+		Filters: []*dms.Filter{
+			{
+				Name:   aws.String("certificate-id"),
+				Values: []*string{aws.String(id)},
+			},
+		},
+	}
+	response, err := conn.DescribeCertificatesWithContext(ctx, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if response == nil || len(response.Certificates) == 0 || response.Certificates[0] == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return response.Certificates[0], nil
+}

--- a/internal/service/dms/certificate_data_source_test.go
+++ b/internal/service/dms/certificate_data_source_test.go
@@ -1,0 +1,46 @@
+package dms_test
+
+import (
+	"fmt"
+	"testing"
+
+	dms "github.com/aws/aws-sdk-go/service/databasemigrationservice"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccDMSCertificateDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_dms_certificate.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+		CheckDestroy:             testAccCheckCertificateDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCertificateExists(ctx, dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "certificate_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCertificateDataSourceConfig_basic(certId string) string {
+	return fmt.Sprintf(`
+resource "aws_dms_certificate" "test" {
+  certificate_id  = "%[1]s"
+  certificate_pem = "-----BEGIN CERTIFICATE-----\nMIID2jCCAsKgAwIBAgIJAJ58TJVjU7G1MA0GCSqGSIb3DQEBBQUAMFExCzAJBgNV\nBAYTAlVTMREwDwYDVQQIEwhDb2xvcmFkbzEPMA0GA1UEBxMGRGVudmVyMRAwDgYD\nVQQKEwdDaGFydGVyMQwwCgYDVQQLEwNDU0UwHhcNMTcwMTMwMTkyMDA4WhcNMjYx\nMjA5MTkyMDA4WjBRMQswCQYDVQQGEwJVUzERMA8GA1UECBMIQ29sb3JhZG8xDzAN\nBgNVBAcTBkRlbnZlcjEQMA4GA1UEChMHQ2hhcnRlcjEMMAoGA1UECxMDQ1NFMIIB\nIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv6dq6VLIImlAaTrckb5w3X6J\nWP7EGz2ChGAXlkEYto6dPCba0v5+f+8UlMOpeB25XGoai7gdItqNWVFpYsgmndx3\nvTad3ukO1zeElKtw5oHPH2plOaiv/gVJaDa9NTeINj0EtGZs74fCOclAzGFX5vBc\nb08ESWBceRgGjGv3nlij4JzHfqTkCKQz6P6pBivQBfk62rcOkkH5rKoaGltRHROS\nMbkwOhu2hN0KmSYTXRvts0LXnZU4N0l2ms39gmr7UNNNlKYINL2JoTs9dNBc7APD\ndZvlEHd+/FjcLCI8hC3t4g4AbfW0okIBCNG0+oVjqGb2DeONSJKsThahXt89MQID\nAQABo4G0MIGxMB0GA1UdDgQWBBQKq8JxjY1GmeZXJjfOMfW0kBIzPDCBgQYDVR0j\nBHoweIAUCqvCcY2NRpnmVyY3zjH1tJASMzyhVaRTMFExCzAJBgNVBAYTAlVTMREw\nDwYDVQQIEwhDb2xvcmFkbzEPMA0GA1UEBxMGRGVudmVyMRAwDgYDVQQKEwdDaGFy\ndGVyMQwwCgYDVQQLEwNDU0WCCQCefEyVY1OxtTAMBgNVHRMEBTADAQH/MA0GCSqG\nSIb3DQEBBQUAA4IBAQAWifoMk5kbv+yuWXvFwHiB4dWUUmMlUlPU/E300yVTRl58\np6DfOgJs7MMftd1KeWqTO+uW134QlTt7+jwI8Jq0uyKCu/O2kJhVtH/Ryog14tGl\n+wLcuIPLbwJI9CwZX4WMBrq4DnYss+6F47i8NCc+Z3MAiG4vtq9ytBmaod0dj2bI\ng4/Lac0e00dql9RnqENh1+dF0V+QgTJCoPkMqDNAlSB8vOodBW81UAb2z12t+IFi\n3X9J3WtCK2+T5brXL6itzewWJ2ALvX3QpmZx7fMHJ3tE+SjjyivE1BbOlzYHx83t\nTeYnm7pS9un7A/UzTDHbs7hPUezLek+H3xTPAnnq\n-----END CERTIFICATE-----\n"
+}
+
+data "aws_dms_certificate" "test" {
+  certificate_id = aws_dms_certificate.test.certificate_id
+}
+`, certId)
+}

--- a/internal/service/dms/service_package_gen.go
+++ b/internal/service/dms/service_package_gen.go
@@ -20,7 +20,12 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {
-	return []*types.ServicePackageSDKDataSource{}
+	return []*types.ServicePackageSDKDataSource{
+		{
+			Factory:  DataSourceCertificate,
+			TypeName: "aws_dms_certificate",
+		},
+	}
 }
 
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {

--- a/website/docs/d/dms_certificate.html.markdown
+++ b/website/docs/d/dms_certificate.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "DMS (Database Migration)"
+layout: "aws"
+page_title: "AWS: aws_dms_certificate"
+description: |-
+  Terraform data source for managing an AWS DMS (Database Migration) Certificate.
+---
+
+# Data Source: aws_dms_certificate
+
+Terraform data source for managing an AWS DMS (Database Migration) Certificate.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_dms_certificate" "example" {
+  certificate_id = aws_dms_certificate.test.certificate_id
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `certificate_id` - (Required) A customer-assigned name for the certificate. Identifiers must begin with a letter and must contain only ASCII letters, digits, and hyphens. They can't end with a hyphen or contain two consecutive hyphens.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `certificate_creation_date` - The date that the certificate was created.
+* `certificate_pem` - The contents of a .pem file, which contains an X.509 certificate.
+* `certificate_owner` - The owner of the certificate.
+* `certificate_arn` - The Amazon Resource Name (ARN) for the certificate.
+* `certificate_wallet` - The owner of the certificate.
+* `key_length` - The key length of the cryptographic algorithm being used.
+* `signing_algorithm` - The algorithm for the certificate.
+* `valid_from_date` - The beginning date that the certificate is valid.
+* `valid_to_date` - The final date that the certificate is valid.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
---> This PR adds certificate_data_source to the dms resource.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #12713

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
> make testacc TESTARGS='-run=TestAccDMSCertificateDataSource_basic' PKG=dms
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dms/... -v -count 1 -parallel 20  -run=TestAccDMSCertificateDataSource_basic -timeout 180m
=== RUN   TestAccDMSCertificateDataSource_basic
=== PAUSE TestAccDMSCertificateDataSource_basic
=== CONT  TestAccDMSCertificateDataSource_basic
--- PASS: TestAccDMSCertificateDataSource_basic (11.85s)
PASS

...
```
