### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin SDK resources `d*` (Phase 3c)

### DIFF
--- a/internal/service/dataexchange/service_package_gen.go
+++ b/internal/service/dataexchange/service_package_gen.go
@@ -28,10 +28,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDataSet,
 			TypeName: "aws_dataexchange_data_set",
+			Name:     "Data Set",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRevision,
 			TypeName: "aws_dataexchange_revision",
+			Name:     "Revision",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/datapipeline/pipeline.go
+++ b/internal/service/datapipeline/pipeline.go
@@ -17,9 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_datapipeline_pipeline")
+// @SDKResource("aws_datapipeline_pipeline", name="Pipeline")
+// @Tags(identifierAttribute="id")
 func ResourcePipeline() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePipelineCreate,
@@ -43,8 +45,8 @@ func ResourcePipeline() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -54,15 +56,12 @@ func ResourcePipeline() *schema.Resource {
 func resourcePipelineCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DataPipelineConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	uniqueID := id.UniqueId()
-
 	input := datapipeline.CreatePipelineInput{
 		Name:     aws.String(d.Get("name").(string)),
 		UniqueId: aws.String(uniqueID),
-		Tags:     Tags(tags.IgnoreAWS()),
+		Tags:     GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -83,8 +82,6 @@ func resourcePipelineCreate(ctx context.Context, d *schema.ResourceData, meta in
 func resourcePipelineRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DataPipelineConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	v, err := PipelineRetrieve(ctx, d.Id(), conn)
 	if tfawserr.ErrCodeEquals(err, datapipeline.ErrCodePipelineNotFoundException) || tfawserr.ErrCodeEquals(err, datapipeline.ErrCodePipelineDeletedException) || v == nil {
@@ -98,31 +95,16 @@ func resourcePipelineRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	d.Set("name", v.Name)
 	d.Set("description", v.Description)
-	tags := KeyValueTags(ctx, v.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, v.Tags)
 
 	return diags
 }
 
 func resourcePipelineUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).DataPipelineConn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Datapipeline Pipeline (%s) tags: %s", d.Id(), err)
-		}
-	}
+	// Tags only.
 
 	return append(diags, resourcePipelineRead(ctx, d, meta)...)
 }

--- a/internal/service/datapipeline/service_package_gen.go
+++ b/internal/service/datapipeline/service_package_gen.go
@@ -37,6 +37,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourcePipeline,
 			TypeName: "aws_datapipeline_pipeline",
+			Name:     "Pipeline",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourcePipelineDefinition,

--- a/internal/service/datasync/location_fsx_openzfs_file_system.go
+++ b/internal/service/datasync/location_fsx_openzfs_file_system.go
@@ -19,9 +19,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_datasync_location_fsx_openzfs_file_system")
+// @SDKResource("aws_datasync_location_fsx_openzfs_file_system", name="Location OpenZFS File System")
+// @Tags(identifierAttribute="id")
 func ResourceLocationFSxOpenZFSFileSystem() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceLocationFSxOpenZFSFileSystemCreate,
@@ -111,8 +113,8 @@ func ResourceLocationFSxOpenZFSFileSystem() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(1, 4096),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"uri": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -130,15 +132,13 @@ func ResourceLocationFSxOpenZFSFileSystem() *schema.Resource {
 func resourceLocationFSxOpenZFSFileSystemCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DataSyncConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
-	fsxArn := d.Get("fsx_filesystem_arn").(string)
 
+	fsxArn := d.Get("fsx_filesystem_arn").(string)
 	input := &datasync.CreateLocationFsxOpenZfsInput{
 		FsxFilesystemArn:  aws.String(fsxArn),
 		Protocol:          expandProtocol(d.Get("protocol").([]interface{})),
 		SecurityGroupArns: flex.ExpandStringSet(d.Get("security_group_arns").(*schema.Set)),
-		Tags:              Tags(tags.IgnoreAWS()),
+		Tags:              GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("subdirectory"); ok {
@@ -159,8 +159,6 @@ func resourceLocationFSxOpenZFSFileSystemCreate(ctx context.Context, d *schema.R
 func resourceLocationFSxOpenZFSFileSystemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DataSyncConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	output, err := FindFSxOpenZFSLocationByARN(ctx, conn, d.Id())
 
@@ -196,37 +194,13 @@ func resourceLocationFSxOpenZFSFileSystemRead(ctx context.Context, d *schema.Res
 		return sdkdiag.AppendErrorf(diags, "setting protocol: %s", err)
 	}
 
-	tags, err := ListTags(ctx, conn, d.Id())
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for DataSync Location Fsx OpenZfs (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
 func resourceLocationFSxOpenZFSFileSystemUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).DataSyncConn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating DataSync Location Fsx OpenZfs File System (%s) tags: %s", d.Id(), err)
-		}
-	}
+	// Tags only.
 
 	return append(diags, resourceLocationFSxOpenZFSFileSystemRead(ctx, d, meta)...)
 }

--- a/internal/service/datasync/location_hdfs.go
+++ b/internal/service/datasync/location_hdfs.go
@@ -17,9 +17,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_datasync_location_hdfs")
+// @SDKResource("aws_datasync_location_hdfs", name="Location HDFS")
+// @Tags(identifierAttribute="id")
 func ResourceLocationHDFS() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceLocationHDFSCreate,
@@ -139,8 +141,8 @@ func ResourceLocationHDFS() *schema.Resource {
 					return false
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"uri": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -154,15 +156,13 @@ func ResourceLocationHDFS() *schema.Resource {
 func resourceLocationHDFSCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DataSyncConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &datasync.CreateLocationHdfsInput{
 		AgentArns:          flex.ExpandStringSet(d.Get("agent_arns").(*schema.Set)),
 		NameNodes:          expandHDFSNameNodes(d.Get("name_node").(*schema.Set)),
 		AuthenticationType: aws.String(d.Get("authentication_type").(string)),
 		Subdirectory:       aws.String(d.Get("subdirectory").(string)),
-		Tags:               Tags(tags.IgnoreAWS()),
+		Tags:               GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("simple_user"); ok {
@@ -211,8 +211,6 @@ func resourceLocationHDFSCreate(ctx context.Context, d *schema.ResourceData, met
 func resourceLocationHDFSRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DataSyncConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	output, err := FindLocationHDFSByARN(ctx, conn, d.Id())
 
@@ -249,23 +247,6 @@ func resourceLocationHDFSRead(ctx context.Context, d *schema.ResourceData, meta 
 
 	if err := d.Set("qop_configuration", flattenHDFSQOPConfiguration(output.QopConfiguration)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting qop_configuration: %s", err)
-	}
-
-	tags, err := ListTags(ctx, conn, d.Id())
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for DataSync Location HDFS (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
 	}
 
 	return diags
@@ -334,13 +315,6 @@ func resourceLocationHDFSUpdate(ctx context.Context, d *schema.ResourceData, met
 		}
 	}
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating DataSync HDFS location (%s) tags: %s", d.Id(), err)
-		}
-	}
 	return append(diags, resourceLocationHDFSRead(ctx, d, meta)...)
 }
 

--- a/internal/service/datasync/location_nfs.go
+++ b/internal/service/datasync/location_nfs.go
@@ -16,9 +16,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_datasync_location_nfs")
+// @SDKResource("aws_datasync_location_nfs", name="Location NFS")
+// @Tags(identifierAttribute="id")
 func ResourceLocationNFS() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceLocationNFSCreate,
@@ -90,8 +92,8 @@ func ResourceLocationNFS() *schema.Resource {
 					return false
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"uri": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -105,14 +107,12 @@ func ResourceLocationNFS() *schema.Resource {
 func resourceLocationNFSCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DataSyncConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &datasync.CreateLocationNfsInput{
 		OnPremConfig:   expandOnPremConfig(d.Get("on_prem_config").([]interface{})),
 		ServerHostname: aws.String(d.Get("server_hostname").(string)),
 		Subdirectory:   aws.String(d.Get("subdirectory").(string)),
-		Tags:           Tags(tags.IgnoreAWS()),
+		Tags:           GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("mount_options"); ok {
@@ -133,8 +133,6 @@ func resourceLocationNFSCreate(ctx context.Context, d *schema.ResourceData, meta
 func resourceLocationNFSRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DataSyncConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	input := &datasync.DescribeLocationNfsInput{
 		LocationArn: aws.String(d.Id()),
@@ -172,23 +170,6 @@ func resourceLocationNFSRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("subdirectory", subdirectory)
 	d.Set("uri", output.LocationUri)
 
-	tags, err := ListTags(ctx, conn, d.Id())
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for DataSync Location NFS (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
@@ -210,14 +191,6 @@ func resourceLocationNFSUpdate(ctx context.Context, d *schema.ResourceData, meta
 		_, err := conn.UpdateLocationNfsWithContext(ctx, input)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating DataSync Location NFS (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating DataSync Location NFS (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/datasync/location_smb.go
+++ b/internal/service/datasync/location_smb.go
@@ -159,10 +159,6 @@ func resourceLocationSMBRead(ctx context.Context, d *schema.ResourceData, meta i
 		return sdkdiag.AppendErrorf(diags, "reading DataSync Location SMB (%s): %s", d.Id(), err)
 	}
 
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading DataSync Location SMB (%s) tags: %s", d.Id(), err)
-	}
-
 	subdirectory, err := SubdirectoryFromLocationURI(aws.StringValue(output.LocationUri))
 
 	if err != nil {

--- a/internal/service/datasync/location_smb.go
+++ b/internal/service/datasync/location_smb.go
@@ -15,9 +15,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_datasync_location_smb")
+// @SDKResource("aws_datasync_location_smb", name="Location SMB")
+// @Tags(identifierAttribute="id")
 func ResourceLocationSMB() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceLocationSMBCreate,
@@ -91,8 +93,8 @@ func ResourceLocationSMB() *schema.Resource {
 				},
 				*/
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"uri": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -111,8 +113,6 @@ func ResourceLocationSMB() *schema.Resource {
 func resourceLocationSMBCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DataSyncConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &datasync.CreateLocationSmbInput{
 		AgentArns:      flex.ExpandStringSet(d.Get("agent_arns").(*schema.Set)),
@@ -120,7 +120,7 @@ func resourceLocationSMBCreate(ctx context.Context, d *schema.ResourceData, meta
 		Password:       aws.String(d.Get("password").(string)),
 		ServerHostname: aws.String(d.Get("server_hostname").(string)),
 		Subdirectory:   aws.String(d.Get("subdirectory").(string)),
-		Tags:           Tags(tags.IgnoreAWS()),
+		Tags:           GetTagsIn(ctx),
 		User:           aws.String(d.Get("user").(string)),
 	}
 
@@ -141,8 +141,6 @@ func resourceLocationSMBCreate(ctx context.Context, d *schema.ResourceData, meta
 func resourceLocationSMBRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DataSyncConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	input := &datasync.DescribeLocationSmbInput{
 		LocationArn: aws.String(d.Id()),
@@ -160,13 +158,6 @@ func resourceLocationSMBRead(ctx context.Context, d *schema.ResourceData, meta i
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading DataSync Location SMB (%s): %s", d.Id(), err)
 	}
-
-	tagsInput := &datasync.ListTagsForResourceInput{
-		ResourceArn: output.LocationArn,
-	}
-
-	log.Printf("[DEBUG] Reading DataSync Location SMB tags: %s", tagsInput)
-	tagsOutput, err := conn.ListTagsForResourceWithContext(ctx, tagsInput)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading DataSync Location SMB (%s) tags: %s", d.Id(), err)
@@ -189,20 +180,7 @@ func resourceLocationSMBRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	d.Set("subdirectory", subdirectory)
-
-	tags := KeyValueTags(ctx, tagsOutput.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	d.Set("user", output.User)
-
 	d.Set("uri", output.LocationUri)
 
 	return diags
@@ -232,13 +210,6 @@ func resourceLocationSMBUpdate(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating DataSync SMB location (%s) tags: %s", d.Id(), err)
-		}
-	}
 	return append(diags, resourceLocationSMBRead(ctx, d, meta)...)
 }
 

--- a/internal/service/datasync/service_package_gen.go
+++ b/internal/service/datasync/service_package_gen.go
@@ -28,46 +28,90 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceAgent,
 			TypeName: "aws_datasync_agent",
+			Name:     "Agent",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceLocationEFS,
 			TypeName: "aws_datasync_location_efs",
+			Name:     "Location EFS",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceLocationFSxLustreFileSystem,
 			TypeName: "aws_datasync_location_fsx_lustre_file_system",
+			Name:     "Location FSx Lustre File System",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceLocationFSxOpenZFSFileSystem,
 			TypeName: "aws_datasync_location_fsx_openzfs_file_system",
+			Name:     "Location OpenZFS File System",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceLocationFSxWindowsFileSystem,
 			TypeName: "aws_datasync_location_fsx_windows_file_system",
+			Name:     "Location FSx Windows File System",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceLocationHDFS,
 			TypeName: "aws_datasync_location_hdfs",
+			Name:     "Location HDFS",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceLocationNFS,
 			TypeName: "aws_datasync_location_nfs",
+			Name:     "Location NFS",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceLocationObjectStorage,
 			TypeName: "aws_datasync_location_object_storage",
+			Name:     "Location Object Storage",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceLocationS3,
 			TypeName: "aws_datasync_location_s3",
+			Name:     "Location S3",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceLocationSMB,
 			TypeName: "aws_datasync_location_smb",
+			Name:     "Location SMB",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTask,
 			TypeName: "aws_datasync_task",
+			Name:     "Task",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }

--- a/internal/service/dax/service_package_gen.go
+++ b/internal/service/dax/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCluster,
 			TypeName: "aws_dax_cluster",
+			Name:     "Cluster",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceParameterGroup,

--- a/internal/service/deploy/deployment_group.go
+++ b/internal/service/deploy/deployment_group.go
@@ -24,9 +24,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_codedeploy_deployment_group")
+// @SDKResource("aws_codedeploy_deployment_group", name="Deployment Group")
+// @Tags(identifierAttribute="arn")
 func ResourceDeploymentGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDeploymentGroupCreate,
@@ -480,8 +482,8 @@ func ResourceDeploymentGroup() *schema.Resource {
 				},
 				Set: resourceTriggerHashConfig,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -491,18 +493,15 @@ func ResourceDeploymentGroup() *schema.Resource {
 func resourceDeploymentGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DeployConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
-	// required fields
+
 	applicationName := d.Get("app_name").(string)
 	deploymentGroupName := d.Get("deployment_group_name").(string)
 	serviceRoleArn := d.Get("service_role_arn").(string)
-
 	input := codedeploy.CreateDeploymentGroupInput{
 		ApplicationName:     aws.String(applicationName),
 		DeploymentGroupName: aws.String(deploymentGroupName),
 		ServiceRoleArn:      aws.String(serviceRoleArn),
-		Tags:                Tags(tags.IgnoreAWS()),
+		Tags:                GetTagsIn(ctx),
 	}
 
 	if attr, ok := d.GetOk("deployment_style"); ok {
@@ -592,10 +591,6 @@ func resourceDeploymentGroupCreate(ctx context.Context, d *schema.ResourceData, 
 func resourceDeploymentGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DeployConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-
-	log.Printf("[DEBUG] Reading CodeDeploy DeploymentGroup %s", d.Id())
 
 	deploymentGroupName := d.Get("deployment_group_name").(string)
 	resp, err := conn.GetDeploymentGroupWithContext(ctx, &codedeploy.GetDeploymentGroupInput{
@@ -678,23 +673,6 @@ func resourceDeploymentGroupRead(ctx context.Context, d *schema.ResourceData, me
 
 	if err := d.Set("blue_green_deployment_config", FlattenBlueGreenDeploymentConfig(group.BlueGreenDeploymentConfiguration)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting blue_green_deployment_config: %s", err)
-	}
-
-	tags, err := ListTags(ctx, conn, groupArn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for CodeDeploy Deployment Group (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
 	}
 
 	return diags
@@ -813,14 +791,6 @@ func resourceDeploymentGroupUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating CodeDeploy deployment group (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating CodeDeploy Deployment Group (%s) tags: %s", d.Get("arn").(string), err)
 		}
 	}
 

--- a/internal/service/deploy/service_package_gen.go
+++ b/internal/service/deploy/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceApp,
 			TypeName: "aws_codedeploy_app",
+			Name:     "App",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceDeploymentConfig,
@@ -36,6 +40,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDeploymentGroup,
 			TypeName: "aws_codedeploy_deployment_group",
+			Name:     "Deployment Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/detective/service_package_gen.go
+++ b/internal/service/detective/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceGraph,
 			TypeName: "aws_detective_graph",
+			Name:     "Graph",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceInvitationAccepter,

--- a/internal/service/devicefarm/service_package_gen.go
+++ b/internal/service/devicefarm/service_package_gen.go
@@ -28,22 +28,42 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDevicePool,
 			TypeName: "aws_devicefarm_device_pool",
+			Name:     "Device Pool",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceInstanceProfile,
 			TypeName: "aws_devicefarm_instance_profile",
+			Name:     "Instance Profile",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceNetworkProfile,
 			TypeName: "aws_devicefarm_network_profile",
+			Name:     "Network Profile",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceProject,
 			TypeName: "aws_devicefarm_project",
+			Name:     "Project",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceTestGridProject,
 			TypeName: "aws_devicefarm_test_grid_project",
+			Name:     "Test Grid Project",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceUpload,

--- a/internal/service/devicefarm/test_grid_project.go
+++ b/internal/service/devicefarm/test_grid_project.go
@@ -16,9 +16,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_devicefarm_test_grid_project")
+// @SDKResource("aws_devicefarm_test_grid_project", name="Test Grid Project")
+// @Tags(identifierAttribute="arn")
 func ResourceTestGridProject() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTestGridProjectCreate,
@@ -44,8 +46,8 @@ func ResourceTestGridProject() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vpc_config": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -79,8 +81,6 @@ func ResourceTestGridProject() *schema.Resource {
 func resourceTestGridProjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DeviceFarmConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &devicefarm.CreateTestGridProjectInput{
@@ -105,7 +105,7 @@ func resourceTestGridProjectCreate(ctx context.Context, d *schema.ResourceData, 
 	log.Printf("[DEBUG] Successsfully Created DeviceFarm Test Grid Project: %s", arn)
 	d.SetId(arn)
 
-	if len(tags) > 0 {
+	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
 		if err := UpdateTags(ctx, conn, arn, nil, tags); err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating DeviceFarm Test Grid Project (%s) tags: %s", arn, err)
 		}
@@ -117,8 +117,6 @@ func resourceTestGridProjectCreate(ctx context.Context, d *schema.ResourceData, 
 func resourceTestGridProjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DeviceFarmConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	project, err := FindTestGridProjectByARN(ctx, conn, d.Id())
 
@@ -138,23 +136,6 @@ func resourceTestGridProjectRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("description", project.Description)
 	if err := d.Set("vpc_config", flattenTestGridProjectVPCConfig(project.VpcConfig)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting vpc_config: %s", err)
-	}
-
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for DeviceFarm Test Grid Project (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
 	}
 
 	return diags
@@ -181,14 +162,6 @@ func resourceTestGridProjectUpdate(ctx context.Context, d *schema.ResourceData, 
 		_, err := conn.UpdateTestGridProjectWithContext(ctx, input)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "Error Updating DeviceFarm Test Grid Project: %s", err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating DeviceFarm Test Grid Project (%s) tags: %s", d.Get("arn").(string), err)
 		}
 	}
 

--- a/internal/service/directconnect/connection.go
+++ b/internal/service/directconnect/connection.go
@@ -17,9 +17,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_dx_connection")
+// @SDKResource("aws_dx_connection", name="Connection")
+// @Tags(identifierAttribute="arn")
 func ResourceConnection() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceConnectionCreate,
@@ -102,8 +104,8 @@ func ResourceConnection() *schema.Resource {
 				Default:  false,
 				Optional: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vlan_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -117,8 +119,6 @@ func ResourceConnection() *schema.Resource {
 func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DirectConnectConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &directconnect.CreateConnectionInput{
@@ -126,14 +126,11 @@ func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta 
 		ConnectionName: aws.String(name),
 		Location:       aws.String(d.Get("location").(string)),
 		RequestMACSec:  aws.Bool(d.Get("request_macsec").(bool)),
+		Tags:           GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("provider_name"); ok {
 		input.ProviderName = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	log.Printf("[DEBUG] Creating Direct Connect Connection: %s", input)
@@ -151,8 +148,6 @@ func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta 
 func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DirectConnectConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	connection, err := FindConnectionByID(ctx, conn, d.Id())
 
@@ -193,23 +188,6 @@ func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta in
 		d.Set("request_macsec", aws.Bool(false))
 	}
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Direct Connect Connection (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
@@ -231,15 +209,6 @@ func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta 
 
 		if _, err := waitConnectionConfirmed(ctx, conn, d.Id()); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for Direct Connect connection (%s) to become available: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		arn := d.Get("arn").(string)
-
-		if err := UpdateTags(ctx, conn, arn, o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Direct Connect Connection (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/directconnect/hosted_private_virtual_interface_accepter.go
+++ b/internal/service/directconnect/hosted_private_virtual_interface_accepter.go
@@ -15,9 +15,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_dx_hosted_private_virtual_interface_accepter")
+// @SDKResource("aws_dx_hosted_private_virtual_interface_accepter", name="Hosted Private Virtual Interface")
+// @Tags(identifierAttribute="arn")
 func ResourceHostedPrivateVirtualInterfaceAccepter() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceHostedPrivateVirtualInterfaceAccepterCreate,
@@ -39,8 +41,8 @@ func ResourceHostedPrivateVirtualInterfaceAccepter() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"vpn_gateway_id"},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"virtual_interface_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -104,14 +106,18 @@ func resourceHostedPrivateVirtualInterfaceAccepterCreate(ctx context.Context, d 
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
+	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
+		if err := UpdateTags(ctx, conn, arn, nil, tags); err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating Direct Connect hosted private virtual interface (%s) tags: %s", arn, err)
+		}
+	}
+
 	return append(diags, resourceHostedPrivateVirtualInterfaceAccepterUpdate(ctx, d, meta)...)
 }
 
 func resourceHostedPrivateVirtualInterfaceAccepterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DirectConnectConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	vif, err := virtualInterfaceRead(ctx, d.Id(), conn)
 	if err != nil {
@@ -133,24 +139,6 @@ func resourceHostedPrivateVirtualInterfaceAccepterRead(ctx context.Context, d *s
 	d.Set("dx_gateway_id", vif.DirectConnectGatewayId)
 	d.Set("virtual_interface_id", vif.VirtualInterfaceId)
 	d.Set("vpn_gateway_id", vif.VirtualGatewayId)
-
-	arn := d.Get("arn").(string)
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Direct Connect hosted private virtual interface (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
 
 	return diags
 }

--- a/internal/service/directconnect/hosted_public_virtual_interface_accepter.go
+++ b/internal/service/directconnect/hosted_public_virtual_interface_accepter.go
@@ -15,9 +15,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_dx_hosted_public_virtual_interface_accepter")
+// @SDKResource("aws_dx_hosted_public_virtual_interface_accepter", name="Hosted Public Virtual Interface")
+// @Tags(identifierAttribute="arn")
 func ResourceHostedPublicVirtualInterfaceAccepter() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceHostedPublicVirtualInterfaceAccepterCreate,
@@ -33,8 +35,8 @@ func ResourceHostedPublicVirtualInterfaceAccepter() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"virtual_interface_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -80,14 +82,18 @@ func resourceHostedPublicVirtualInterfaceAccepterCreate(ctx context.Context, d *
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
+	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
+		if err := UpdateTags(ctx, conn, arn, nil, tags); err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating Direct Connect hosted public virtual interface (%s) tags: %s", arn, err)
+		}
+	}
+
 	return append(diags, resourceHostedPublicVirtualInterfaceAccepterUpdate(ctx, d, meta)...)
 }
 
 func resourceHostedPublicVirtualInterfaceAccepterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DirectConnectConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	vif, err := virtualInterfaceRead(ctx, d.Id(), conn)
 	if err != nil {
@@ -108,24 +114,6 @@ func resourceHostedPublicVirtualInterfaceAccepterRead(ctx context.Context, d *sc
 	}
 
 	d.Set("virtual_interface_id", vif.VirtualInterfaceId)
-
-	arn := d.Get("arn").(string)
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Direct Connect hosted public virtual interface (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
 
 	return diags
 }

--- a/internal/service/directconnect/hosted_transit_virtual_interface_accepter.go
+++ b/internal/service/directconnect/hosted_transit_virtual_interface_accepter.go
@@ -15,9 +15,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_dx_hosted_transit_virtual_interface_accepter")
+// @SDKResource("aws_dx_hosted_transit_virtual_interface_accepter", name="Hosted Transit Virtual Interface")
+// @Tags(identifierAttribute="arn")
 func ResourceHostedTransitVirtualInterfaceAccepter() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceHostedTransitVirtualInterfaceAccepterCreate,
@@ -38,8 +40,8 @@ func ResourceHostedTransitVirtualInterfaceAccepter() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"virtual_interface_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -86,14 +88,18 @@ func resourceHostedTransitVirtualInterfaceAccepterCreate(ctx context.Context, d 
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
+	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
+		if err := UpdateTags(ctx, conn, arn, nil, tags); err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating Direct Connect hosted transit virtual interface (%s) tags: %s", arn, err)
+		}
+	}
+
 	return append(diags, resourceHostedTransitVirtualInterfaceAccepterUpdate(ctx, d, meta)...)
 }
 
 func resourceHostedTransitVirtualInterfaceAccepterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DirectConnectConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	vif, err := virtualInterfaceRead(ctx, d.Id(), conn)
 	if err != nil {
@@ -113,24 +119,6 @@ func resourceHostedTransitVirtualInterfaceAccepterRead(ctx context.Context, d *s
 
 	d.Set("dx_gateway_id", vif.DirectConnectGatewayId)
 	d.Set("virtual_interface_id", vif.VirtualInterfaceId)
-
-	arn := d.Get("arn").(string)
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Direct Connect hosted transit virtual interface (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
 
 	return diags
 }

--- a/internal/service/directconnect/service_package_gen.go
+++ b/internal/service/directconnect/service_package_gen.go
@@ -53,6 +53,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceConnection,
 			TypeName: "aws_dx_connection",
+			Name:     "Connection",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceConnectionAssociation,
@@ -85,6 +89,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceHostedPrivateVirtualInterfaceAccepter,
 			TypeName: "aws_dx_hosted_private_virtual_interface_accepter",
+			Name:     "Hosted Private Virtual Interface",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceHostedPublicVirtualInterface,
@@ -93,6 +101,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceHostedPublicVirtualInterfaceAccepter,
 			TypeName: "aws_dx_hosted_public_virtual_interface_accepter",
+			Name:     "Hosted Public Virtual Interface",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceHostedTransitVirtualInterface,
@@ -101,10 +113,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceHostedTransitVirtualInterfaceAccepter,
 			TypeName: "aws_dx_hosted_transit_virtual_interface_accepter",
+			Name:     "Hosted Transit Virtual Interface",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceLag,
 			TypeName: "aws_dx_lag",
+			Name:     "LAG",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceMacSecKeyAssociation,
@@ -113,14 +133,26 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourcePrivateVirtualInterface,
 			TypeName: "aws_dx_private_virtual_interface",
+			Name:     "Private Virtual Interface",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourcePublicVirtualInterface,
 			TypeName: "aws_dx_public_virtual_interface",
+			Name:     "Public Virtual Interface",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceTransitVirtualInterface,
 			TypeName: "aws_dx_transit_virtual_interface",
+			Name:     "Transit Virtual Interface",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/directconnect/transit_virtual_interface.go
+++ b/internal/service/directconnect/transit_virtual_interface.go
@@ -17,9 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_dx_transit_virtual_interface")
+// @SDKResource("aws_dx_transit_virtual_interface", name="Transit Virtual Interface")
+// @Tags(identifierAttribute="arn")
 func ResourceTransitVirtualInterface() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTransitVirtualInterfaceCreate,
@@ -104,8 +106,8 @@ func ResourceTransitVirtualInterface() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vlan": {
 				Type:         schema.TypeInt,
 				Required:     true,
@@ -127,8 +129,6 @@ func ResourceTransitVirtualInterface() *schema.Resource {
 func resourceTransitVirtualInterfaceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DirectConnectConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	req := &directconnect.CreateTransitVirtualInterfaceInput{
 		ConnectionId: aws.String(d.Get("connection_id").(string)),
@@ -138,6 +138,7 @@ func resourceTransitVirtualInterfaceCreate(ctx context.Context, d *schema.Resour
 			DirectConnectGatewayId: aws.String(d.Get("dx_gateway_id").(string)),
 			EnableSiteLink:         aws.Bool(d.Get("sitelink_enabled").(bool)),
 			Mtu:                    aws.Int64(int64(d.Get("mtu").(int))),
+			Tags:                   GetTagsIn(ctx),
 			VirtualInterfaceName:   aws.String(d.Get("name").(string)),
 			Vlan:                   aws.Int64(int64(d.Get("vlan").(int))),
 		},
@@ -150,9 +151,6 @@ func resourceTransitVirtualInterfaceCreate(ctx context.Context, d *schema.Resour
 	}
 	if v, ok := d.GetOk("customer_address"); ok {
 		req.NewTransitVirtualInterface.CustomerAddress = aws.String(v.(string))
-	}
-	if len(tags) > 0 {
-		req.NewTransitVirtualInterface.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	log.Printf("[DEBUG] Creating Direct Connect transit virtual interface: %s", req)
@@ -173,8 +171,6 @@ func resourceTransitVirtualInterfaceCreate(ctx context.Context, d *schema.Resour
 func resourceTransitVirtualInterfaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DirectConnectConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	vif, err := virtualInterfaceRead(ctx, d.Id(), conn)
 	if err != nil {
@@ -208,23 +204,6 @@ func resourceTransitVirtualInterfaceRead(ctx context.Context, d *schema.Resource
 	d.Set("name", vif.VirtualInterfaceName)
 	d.Set("sitelink_enabled", vif.SiteLinkEnabled)
 	d.Set("vlan", vif.Vlan)
-
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Direct Connect transit virtual interface (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
 
 	return diags
 }

--- a/internal/service/directconnect/vif.go
+++ b/internal/service/directconnect/vif.go
@@ -55,15 +55,6 @@ func virtualInterfaceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 	}
 
-	arn := d.Get("arn").(string)
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, arn, o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Direct Connect virtual interface (%s) tags: %s", arn, err)
-		}
-	}
-
 	return diags
 }
 

--- a/internal/service/dlm/service_package_gen.go
+++ b/internal/service/dlm/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceLifecyclePolicy,
 			TypeName: "aws_dlm_lifecycle_policy",
+			Name:     "Lifecycle Policy",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/dms/event_subscription.go
+++ b/internal/service/dms/event_subscription.go
@@ -19,9 +19,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_dms_event_subscription")
+// @SDKResource("aws_dms_event_subscription", name="Event Subscription")
+// @Tags(identifierAttribute="arn")
 func ResourceEventSubscription() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceEventSubscriptionCreate,
@@ -82,8 +84,8 @@ func ResourceEventSubscription() *schema.Resource {
 					"replication-task",
 				}, false),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -93,15 +95,13 @@ func ResourceEventSubscription() *schema.Resource {
 func resourceEventSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DMSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	request := &dms.CreateEventSubscriptionInput{
 		Enabled:          aws.Bool(d.Get("enabled").(bool)),
 		SnsTopicArn:      aws.String(d.Get("sns_topic_arn").(string)),
 		SubscriptionName: aws.String(d.Get("name").(string)),
 		SourceType:       aws.String(d.Get("source_type").(string)),
-		Tags:             Tags(tags.IgnoreAWS()),
+		Tags:             GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("event_categories"); ok {
@@ -137,59 +137,9 @@ func resourceEventSubscriptionCreate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceEventSubscriptionRead(ctx, d, meta)...)
 }
 
-func resourceEventSubscriptionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).DMSConn()
-
-	if d.HasChanges("enabled", "event_categories", "sns_topic_arn", "source_type") {
-		request := &dms.ModifyEventSubscriptionInput{
-			Enabled:          aws.Bool(d.Get("enabled").(bool)),
-			SnsTopicArn:      aws.String(d.Get("sns_topic_arn").(string)),
-			SubscriptionName: aws.String(d.Get("name").(string)),
-			SourceType:       aws.String(d.Get("source_type").(string)),
-		}
-
-		if v, ok := d.GetOk("event_categories"); ok {
-			request.EventCategories = flex.ExpandStringSet(v.(*schema.Set))
-		}
-
-		_, err := conn.ModifyEventSubscriptionWithContext(ctx, request)
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating DMS Event Subscription (%s): %s", d.Id(), err)
-		}
-
-		stateConf := &retry.StateChangeConf{
-			Pending:    []string{"modifying"},
-			Target:     []string{"active"},
-			Refresh:    resourceEventSubscriptionStateRefreshFunc(ctx, conn, d.Id()),
-			Timeout:    d.Timeout(schema.TimeoutUpdate),
-			MinTimeout: 10 * time.Second,
-			Delay:      10 * time.Second,
-		}
-
-		_, err = stateConf.WaitForStateContext(ctx)
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "waiting for DMS Event Subscription (%s) modification: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating DMS Event Subscription (%s) tags: %s", d.Get("arn").(string), err)
-		}
-	}
-
-	return append(diags, resourceEventSubscriptionRead(ctx, d, meta)...)
-}
-
 func resourceEventSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DMSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	request := &dms.DescribeEventSubscriptionsInput{
 		SubscriptionName: aws.String(d.Id()),
@@ -231,24 +181,47 @@ func resourceEventSubscriptionRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("event_categories", flex.FlattenStringList(subscription.EventCategoriesList))
 	d.Set("source_ids", flex.FlattenStringList(subscription.SourceIdsList))
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for DMS Event Subscription (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
+}
+
+func resourceEventSubscriptionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).DMSConn()
+
+	if d.HasChanges("enabled", "event_categories", "sns_topic_arn", "source_type") {
+		request := &dms.ModifyEventSubscriptionInput{
+			Enabled:          aws.Bool(d.Get("enabled").(bool)),
+			SnsTopicArn:      aws.String(d.Get("sns_topic_arn").(string)),
+			SubscriptionName: aws.String(d.Get("name").(string)),
+			SourceType:       aws.String(d.Get("source_type").(string)),
+		}
+
+		if v, ok := d.GetOk("event_categories"); ok {
+			request.EventCategories = flex.ExpandStringSet(v.(*schema.Set))
+		}
+
+		_, err := conn.ModifyEventSubscriptionWithContext(ctx, request)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating DMS Event Subscription (%s): %s", d.Id(), err)
+		}
+
+		stateConf := &retry.StateChangeConf{
+			Pending:    []string{"modifying"},
+			Target:     []string{"active"},
+			Refresh:    resourceEventSubscriptionStateRefreshFunc(ctx, conn, d.Id()),
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
+			MinTimeout: 10 * time.Second,
+			Delay:      10 * time.Second,
+		}
+
+		_, err = stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for DMS Event Subscription (%s) modification: %s", d.Id(), err)
+		}
+	}
+
+	return append(diags, resourceEventSubscriptionRead(ctx, d, meta)...)
 }
 
 func resourceEventSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/dms/s3_endpoint.go
+++ b/internal/service/dms/s3_endpoint.go
@@ -24,7 +24,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_dms_s3_endpoint")
+// @SDKResource("aws_dms_s3_endpoint", name="S3 Endpoint")
+// @Tags(identifierAttribute="endpoint_arn")
 func ResourceS3Endpoint() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceS3EndpointCreate,
@@ -88,8 +89,8 @@ func ResourceS3Endpoint() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 
 			/////// S3-Specific Settings
 			"add_column_name": {
@@ -319,14 +320,12 @@ const (
 func resourceS3EndpointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DMSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &dms.CreateEndpointInput{
 		EndpointIdentifier: aws.String(d.Get("endpoint_id").(string)),
 		EndpointType:       aws.String(d.Get("endpoint_type").(string)),
 		EngineName:         aws.String("s3"),
-		Tags:               Tags(tags.IgnoreAWS()),
+		Tags:               GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("certificate_arn"); ok {
@@ -389,8 +388,6 @@ func resourceS3EndpointCreate(ctx context.Context, d *schema.ResourceData, meta 
 func resourceS3EndpointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DMSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	endpoint, err := FindEndpointByID(ctx, conn, d.Id())
 
@@ -474,22 +471,6 @@ func resourceS3EndpointRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	d.Set("external_table_definition", p)
 
-	tags, err := ListTags(ctx, conn, d.Get("endpoint_arn").(string))
-	if err != nil {
-		return create.DiagError(names.DMS, create.ErrActionReading, ResNameS3Endpoint, d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return create.DiagError(names.DMS, create.ErrActionReading, ResNameS3Endpoint, d.Id(), err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return create.DiagError(names.DMS, create.ErrActionReading, ResNameS3Endpoint, d.Id(), err)
-	}
-
 	return diags
 }
 
@@ -548,15 +529,6 @@ func resourceS3EndpointUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		}
 
 		if err != nil {
-			return create.DiagError(names.DMS, create.ErrActionUpdating, ResNameS3Endpoint, d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		arn := d.Get("endpoint_arn").(string)
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, arn, o, n); err != nil {
 			return create.DiagError(names.DMS, create.ErrActionUpdating, ResNameS3Endpoint, d.Id(), err)
 		}
 	}

--- a/internal/service/dms/service_package_gen.go
+++ b/internal/service/dms/service_package_gen.go
@@ -28,30 +28,58 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCertificate,
 			TypeName: "aws_dms_certificate",
+			Name:     "Certificate",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "certificate_arn",
+			},
 		},
 		{
 			Factory:  ResourceEndpoint,
 			TypeName: "aws_dms_endpoint",
+			Name:     "Endpoint",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "endpoint_arn",
+			},
 		},
 		{
 			Factory:  ResourceEventSubscription,
 			TypeName: "aws_dms_event_subscription",
+			Name:     "Event Subscription",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceReplicationInstance,
 			TypeName: "aws_dms_replication_instance",
+			Name:     "Replication Instance",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "replication_instance_arn",
+			},
 		},
 		{
 			Factory:  ResourceReplicationSubnetGroup,
 			TypeName: "aws_dms_replication_subnet_group",
+			Name:     "Replication Subnet Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "replication_subnet_group_arn",
+			},
 		},
 		{
 			Factory:  ResourceReplicationTask,
 			TypeName: "aws_dms_replication_task",
+			Name:     "Replication Task",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "replication_task_arn",
+			},
 		},
 		{
 			Factory:  ResourceS3Endpoint,
 			TypeName: "aws_dms_s3_endpoint",
+			Name:     "S3 Endpoint",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "endpoint_arn",
+			},
 		},
 	}
 }

--- a/internal/service/docdb/cluster_instance.go
+++ b/internal/service/docdb/cluster_instance.go
@@ -164,8 +164,8 @@ func ResourceClusterInstance() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-			names.AttrTags:tftags.TagsSchema(),
-names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"writer": {
 				Type:     schema.TypeBool,
 				Computed: true,

--- a/internal/service/docdb/cluster_instance.go
+++ b/internal/service/docdb/cluster_instance.go
@@ -19,9 +19,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_docdb_cluster_instance")
+// @SDKResource("aws_docdb_cluster_instance", name="Cluster Instance")
+// @Tags(identifierAttribute="arn")
 func ResourceClusterInstance() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClusterInstanceCreate,
@@ -162,8 +164,8 @@ func ResourceClusterInstance() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:tftags.TagsSchema(),
+names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"writer": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -177,49 +179,47 @@ func ResourceClusterInstance() *schema.Resource {
 func resourceClusterInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DocDBConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
-	createOpts := &docdb.CreateDBInstanceInput{
+	input := &docdb.CreateDBInstanceInput{
 		DBInstanceClass:         aws.String(d.Get("instance_class").(string)),
 		DBClusterIdentifier:     aws.String(d.Get("cluster_identifier").(string)),
 		Engine:                  aws.String(d.Get("engine").(string)),
 		PromotionTier:           aws.Int64(int64(d.Get("promotion_tier").(int))),
 		AutoMinorVersionUpgrade: aws.Bool(d.Get("auto_minor_version_upgrade").(bool)),
-		Tags:                    Tags(tags.IgnoreAWS()),
+		Tags:                    GetTagsIn(ctx),
 	}
 
 	if attr, ok := d.GetOk("availability_zone"); ok {
-		createOpts.AvailabilityZone = aws.String(attr.(string))
+		input.AvailabilityZone = aws.String(attr.(string))
 	}
 
 	if attr, ok := d.GetOk("enable_performance_insights"); ok {
-		createOpts.EnablePerformanceInsights = aws.Bool(attr.(bool))
+		input.EnablePerformanceInsights = aws.Bool(attr.(bool))
 	}
 
 	if v, ok := d.GetOk("identifier"); ok {
-		createOpts.DBInstanceIdentifier = aws.String(v.(string))
+		input.DBInstanceIdentifier = aws.String(v.(string))
 	} else {
 		if v, ok := d.GetOk("identifier_prefix"); ok {
-			createOpts.DBInstanceIdentifier = aws.String(id.PrefixedUniqueId(v.(string)))
+			input.DBInstanceIdentifier = aws.String(id.PrefixedUniqueId(v.(string)))
 		} else {
-			createOpts.DBInstanceIdentifier = aws.String(id.PrefixedUniqueId("tf-"))
+			input.DBInstanceIdentifier = aws.String(id.PrefixedUniqueId("tf-"))
 		}
 	}
 
 	if attr, ok := d.GetOk("performance_insights_kms_key_id"); ok {
-		createOpts.PerformanceInsightsKMSKeyId = aws.String(attr.(string))
+		input.PerformanceInsightsKMSKeyId = aws.String(attr.(string))
 	}
 
 	if attr, ok := d.GetOk("preferred_maintenance_window"); ok {
-		createOpts.PreferredMaintenanceWindow = aws.String(attr.(string))
+		input.PreferredMaintenanceWindow = aws.String(attr.(string))
 	}
 
-	log.Printf("[DEBUG] Creating DocDB Instance opts: %s", createOpts)
+	log.Printf("[DEBUG] Creating DocDB Instance opts: %s", input)
 	var resp *docdb.CreateDBInstanceOutput
 	err := retry.RetryContext(ctx, propagationTimeout, func() *retry.RetryError {
 		var err error
-		resp, err = conn.CreateDBInstanceWithContext(ctx, createOpts)
+		resp, err = conn.CreateDBInstanceWithContext(ctx, input)
 		if err != nil {
 			if tfawserr.ErrMessageContains(err, "InvalidParameterValue", "IAM role ARN value is invalid or does not include the required permissions") {
 				return retry.RetryableError(err)
@@ -229,7 +229,7 @@ func resourceClusterInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 		return nil
 	})
 	if tfresource.TimedOut(err) {
-		resp, err = conn.CreateDBInstanceWithContext(ctx, createOpts)
+		resp, err = conn.CreateDBInstanceWithContext(ctx, input)
 	}
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating DocDB Instance: %s", err)
@@ -259,8 +259,6 @@ func resourceClusterInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 func resourceClusterInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DocDBConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	db, err := resourceInstanceRetrieve(ctx, conn, d.Id())
 	if !d.IsNewResource() && tfresource.NotFound(err) {
@@ -330,23 +328,6 @@ func resourceClusterInstanceRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("publicly_accessible", db.PubliclyAccessible)
 	d.Set("storage_encrypted", db.StorageEncrypted)
 	d.Set("ca_cert_identifier", db.CACertificateIdentifier)
-
-	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for DocumentDB Cluster Instance (%s): %s", d.Get("arn").(string), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
 
 	return diags
 }
@@ -428,14 +409,6 @@ func resourceClusterInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 		_, err = stateConf.WaitForStateContext(ctx)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for DocDB Instance (%s) update: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating DocumentDB Cluster Instance (%s) tags: %s", d.Get("arn").(string), err)
 		}
 	}
 

--- a/internal/service/docdb/cluster_parameter_group.go
+++ b/internal/service/docdb/cluster_parameter_group.go
@@ -19,11 +19,13 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 const clusterParameterGroupMaxParamsBulkEdit = 20
 
-// @SDKResource("aws_docdb_cluster_parameter_group")
+// @SDKResource("aws_docdb_cluster_parameter_group", name="Cluster Parameter Group")
+// @Tags(identifierAttribute="arn")
 func ResourceClusterParameterGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClusterParameterGroupCreate,
@@ -91,9 +93,8 @@ func ResourceClusterParameterGroup() *schema.Resource {
 					},
 				},
 			},
-
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -103,8 +104,6 @@ func ResourceClusterParameterGroup() *schema.Resource {
 func resourceClusterParameterGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DocDBConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	var groupName string
 	if v, ok := d.GetOk("name"); ok {
@@ -115,21 +114,21 @@ func resourceClusterParameterGroupCreate(ctx context.Context, d *schema.Resource
 		groupName = id.UniqueId()
 	}
 
-	createOpts := docdb.CreateDBClusterParameterGroupInput{
+	input := docdb.CreateDBClusterParameterGroupInput{
 		DBClusterParameterGroupName: aws.String(groupName),
 		DBParameterGroupFamily:      aws.String(d.Get("family").(string)),
 		Description:                 aws.String(d.Get("description").(string)),
-		Tags:                        Tags(tags.IgnoreAWS()),
+		Tags:                        GetTagsIn(ctx),
 	}
 
-	log.Printf("[DEBUG] Create DocDB Cluster Parameter Group: %#v", createOpts)
+	log.Printf("[DEBUG] Create DocDB Cluster Parameter Group: %#v", input)
 
-	resp, err := conn.CreateDBClusterParameterGroupWithContext(ctx, &createOpts)
+	resp, err := conn.CreateDBClusterParameterGroupWithContext(ctx, &input)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "Error creating DocDB Cluster Parameter Group: %s", err)
 	}
 
-	d.SetId(aws.StringValue(createOpts.DBClusterParameterGroupName))
+	d.SetId(aws.StringValue(input.DBClusterParameterGroupName))
 
 	d.Set("arn", resp.DBClusterParameterGroup.DBClusterParameterGroupArn)
 
@@ -139,8 +138,6 @@ func resourceClusterParameterGroupCreate(ctx context.Context, d *schema.Resource
 func resourceClusterParameterGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DocDBConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	describeOpts := &docdb.DescribeDBClusterParameterGroupsInput{
 		DBClusterParameterGroupName: aws.String(d.Id()),
@@ -178,23 +175,6 @@ func resourceClusterParameterGroupRead(ctx context.Context, d *schema.ResourceDa
 
 	if err := d.Set("parameter", flattenParameters(describeParametersResp.Parameters, d.Get("parameter").(*schema.Set).List())); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting docdb cluster parameter: %s", err)
-	}
-
-	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for DocumentDB Cluster Parameter Group (%s): %s", d.Get("arn").(string), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
 	}
 
 	return diags
@@ -238,14 +218,6 @@ func resourceClusterParameterGroupUpdate(ctx context.Context, d *schema.Resource
 					return sdkdiag.AppendErrorf(diags, "Error modifying DocDB Cluster Parameter Group: %s", err)
 				}
 			}
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating DocumentDB Cluster Parameter Group (%s) tags: %s", d.Get("arn").(string), err)
 		}
 	}
 

--- a/internal/service/docdb/service_package_gen.go
+++ b/internal/service/docdb/service_package_gen.go
@@ -37,14 +37,26 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCluster,
 			TypeName: "aws_docdb_cluster",
+			Name:     "Cluster",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceClusterInstance,
 			TypeName: "aws_docdb_cluster_instance",
+			Name:     "Cluster Instance",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceClusterParameterGroup,
 			TypeName: "aws_docdb_cluster_parameter_group",
+			Name:     "Cluster Parameter Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceClusterSnapshot,
@@ -53,6 +65,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceEventSubscription,
 			TypeName: "aws_docdb_event_subscription",
+			Name:     "Event Subscription",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceGlobalCluster,
@@ -61,6 +77,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceSubnetGroup,
 			TypeName: "aws_docdb_subnet_group",
+			Name:     "Subnet Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/ds/service_package_gen.go
+++ b/internal/service/ds/service_package_gen.go
@@ -37,6 +37,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDirectory,
 			TypeName: "aws_directory_service_directory",
+			Name:     "Directory",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceLogSubscription,

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -34,7 +34,8 @@ const (
 	ResNameTable                  = "Table"
 )
 
-// @SDKResource("aws_dynamodb_table")
+// @SDKResource("aws_dynamodb_table", name="Table")
+// @Tags(identifierAttribute="arn")
 func ResourceTable() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{
@@ -402,8 +403,6 @@ func ResourceTable() *schema.Resource {
 func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{})))
 
 	tableName := d.Get(names.AttrName).(string)
 	keySchemaMap := map[string]interface{}{
@@ -489,10 +488,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 			BillingMode: aws.String(d.Get("billing_mode").(string)),
 			KeySchema:   expandKeySchema(keySchemaMap),
 			TableName:   aws.String(tableName),
-		}
-
-		if len(tags) > 0 {
-			input.Tags = Tags(tags.IgnoreAWS())
+			Tags:        GetTagsIn(ctx),
 		}
 
 		billingMode := d.Get("billing_mode").(string)
@@ -732,26 +728,6 @@ func resourceTableRead(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	if err := d.Set("ttl", flattenTTL(ttlOut)); err != nil {
 		return create.DiagSettingError(names.DynamoDB, ResNameTable, d.Id(), "ttl", err)
-	}
-
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-
-	tags, err := ListTags(ctx, conn, d.Get(names.AttrARN).(string))
-	// When a Table is `ARCHIVED`, ListTags returns `ResourceNotFoundException`
-	if err != nil && !(tfawserr.ErrMessageContains(err, "UnknownOperationException", "Tagging is not currently supported in DynamoDB Local.") || tfresource.NotFound(err)) {
-		return create.DiagError(names.DynamoDB, create.ErrActionReading, ResNameTable, d.Id(), fmt.Errorf("tags: %w", err))
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set(names.AttrTags, tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return create.DiagSettingError(names.DynamoDB, ResNameTable, d.Id(), names.AttrTags, err)
-	}
-
-	if err := d.Set(names.AttrTagsAll, tags.Map()); err != nil {
-		return create.DiagSettingError(names.DynamoDB, ResNameTable, d.Id(), names.AttrTagsAll, err)
 	}
 
 	return diags
@@ -1005,15 +981,6 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		replicaTagsChange = true
 
 		if err := updateReplica(ctx, d, conn, meta.(*conns.AWSClient).TerraformVersion); err != nil {
-			return create.DiagError(names.DynamoDB, create.ErrActionUpdating, ResNameTable, d.Id(), err)
-		}
-	}
-
-	if d.HasChange(names.AttrTagsAll) {
-		replicaTagsChange = true
-
-		o, n := d.GetChange(names.AttrTagsAll)
-		if err := UpdateTags(ctx, conn, d.Get(names.AttrARN).(string), o, n); err != nil {
 			return create.DiagError(names.DynamoDB, create.ErrActionUpdating, ResNameTable, d.Id(), err)
 		}
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin SDK.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30421.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30430.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30449.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30454.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30461.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30463.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30476.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30477.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30478.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30483.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30484.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30491.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=d... ACCTEST_PARALLELISM=2   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/d.../... -v -count 1 -parallel 2  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccDataExchangeDataSet_basic
=== PAUSE TestAccDataExchangeDataSet_basic
=== RUN   TestAccDataExchangeDataSet_tags
=== PAUSE TestAccDataExchangeDataSet_tags
=== RUN   TestAccDataExchangeRevision_basic
=== PAUSE TestAccDataExchangeRevision_basic
=== RUN   TestAccDataExchangeRevision_tags
=== PAUSE TestAccDataExchangeRevision_tags
=== CONT  TestAccDataExchangeDataSet_basic
=== CONT  TestAccDataExchangeRevision_tags
--- PASS: TestAccDataExchangeDataSet_basic (67.46s)
=== CONT  TestAccDataExchangeRevision_basic
--- PASS: TestAccDataExchangeRevision_tags (98.36s)
=== CONT  TestAccDataExchangeDataSet_tags
--- PASS: TestAccDataExchangeRevision_basic (45.09s)
--- PASS: TestAccDataExchangeDataSet_tags (100.74s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dataexchange	208.510s
=== RUN   TestAccDataPipelinePipelineDataSource_basic
=== PAUSE TestAccDataPipelinePipelineDataSource_basic
=== RUN   TestAccDataPipelinePipelineDefinitionDataSource_basic
=== PAUSE TestAccDataPipelinePipelineDefinitionDataSource_basic
=== RUN   TestAccDataPipelinePipelineDefinition_basic
=== PAUSE TestAccDataPipelinePipelineDefinition_basic
=== RUN   TestAccDataPipelinePipeline_basic
=== PAUSE TestAccDataPipelinePipeline_basic
=== RUN   TestAccDataPipelinePipeline_tags
=== PAUSE TestAccDataPipelinePipeline_tags
=== CONT  TestAccDataPipelinePipelineDataSource_basic
=== CONT  TestAccDataPipelinePipeline_basic
--- PASS: TestAccDataPipelinePipelineDataSource_basic (36.25s)
=== CONT  TestAccDataPipelinePipeline_tags
--- PASS: TestAccDataPipelinePipeline_basic (67.99s)
=== CONT  TestAccDataPipelinePipelineDefinition_basic
--- PASS: TestAccDataPipelinePipelineDefinition_basic (44.75s)
=== CONT  TestAccDataPipelinePipelineDefinitionDataSource_basic
--- PASS: TestAccDataPipelinePipeline_tags (109.50s)
--- PASS: TestAccDataPipelinePipelineDefinitionDataSource_basic (42.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/datapipeline	173.157s
=== RUN   TestAccDataSyncAgent_basic
=== PAUSE TestAccDataSyncAgent_basic
=== RUN   TestAccDataSyncAgent_tags
=== PAUSE TestAccDataSyncAgent_tags
=== RUN   TestAccDataSyncLocationEFS_basic
=== PAUSE TestAccDataSyncLocationEFS_basic
=== RUN   TestAccDataSyncLocationEFS_tags
=== PAUSE TestAccDataSyncLocationEFS_tags
=== RUN   TestAccDataSyncLocationFSxLustreFileSystem_basic
=== PAUSE TestAccDataSyncLocationFSxLustreFileSystem_basic
=== RUN   TestAccDataSyncLocationFSxLustreFileSystem_tags
=== PAUSE TestAccDataSyncLocationFSxLustreFileSystem_tags
=== RUN   TestAccDataSyncLocationFSxOpenZFSFileSystem_basic
=== PAUSE TestAccDataSyncLocationFSxOpenZFSFileSystem_basic
=== RUN   TestAccDataSyncLocationFSxOpenZFSFileSystem_tags
=== PAUSE TestAccDataSyncLocationFSxOpenZFSFileSystem_tags
=== RUN   TestAccDataSyncLocationFSxWindowsFileSystem_basic
=== PAUSE TestAccDataSyncLocationFSxWindowsFileSystem_basic
=== RUN   TestAccDataSyncLocationFSxWindowsFileSystem_tags
=== PAUSE TestAccDataSyncLocationFSxWindowsFileSystem_tags
=== RUN   TestAccDataSyncLocationHDFS_basic
=== PAUSE TestAccDataSyncLocationHDFS_basic
=== RUN   TestAccDataSyncLocationHDFS_tags
=== PAUSE TestAccDataSyncLocationHDFS_tags
=== RUN   TestAccDataSyncLocationNFS_basic
=== PAUSE TestAccDataSyncLocationNFS_basic
=== RUN   TestAccDataSyncLocationNFS_tags
=== PAUSE TestAccDataSyncLocationNFS_tags
=== RUN   TestAccDataSyncLocationObjectStorage_basic
=== PAUSE TestAccDataSyncLocationObjectStorage_basic
=== RUN   TestAccDataSyncLocationObjectStorage_tags
=== PAUSE TestAccDataSyncLocationObjectStorage_tags
=== RUN   TestAccDataSyncLocationS3_basic
=== PAUSE TestAccDataSyncLocationS3_basic
=== RUN   TestAccDataSyncLocationS3_tags
=== PAUSE TestAccDataSyncLocationS3_tags
=== RUN   TestAccDataSyncLocationSMB_basic
=== PAUSE TestAccDataSyncLocationSMB_basic
=== RUN   TestAccDataSyncLocationSMB_tags
=== PAUSE TestAccDataSyncLocationSMB_tags
=== RUN   TestAccDataSyncTask_basic
=== PAUSE TestAccDataSyncTask_basic
=== RUN   TestAccDataSyncTask_tags
=== PAUSE TestAccDataSyncTask_tags
=== CONT  TestAccDataSyncAgent_basic
=== CONT  TestAccDataSyncTask_tags
--- PASS: TestAccDataSyncAgent_basic (122.25s)
=== CONT  TestAccDataSyncTask_basic
--- PASS: TestAccDataSyncTask_tags (277.70s)
=== CONT  TestAccDataSyncLocationSMB_tags
--- PASS: TestAccDataSyncTask_basic (281.80s)
=== CONT  TestAccDataSyncLocationSMB_basic
--- PASS: TestAccDataSyncLocationSMB_tags (171.61s)
=== CONT  TestAccDataSyncLocationS3_tags
--- PASS: TestAccDataSyncLocationS3_tags (72.29s)
=== CONT  TestAccDataSyncLocationS3_basic
--- PASS: TestAccDataSyncLocationS3_basic (31.19s)
=== CONT  TestAccDataSyncLocationObjectStorage_tags
--- PASS: TestAccDataSyncLocationSMB_basic (165.22s)
=== CONT  TestAccDataSyncLocationObjectStorage_basic
--- PASS: TestAccDataSyncLocationObjectStorage_basic (132.20s)
=== CONT  TestAccDataSyncLocationNFS_tags
    location_nfs_test.go:189: Step 1/4 error: Error running pre-apply refresh: exit status 1
        
        Error: Your query returned no results. Please change your search criteria and try again.
        
          with data.aws_ami.aws-thinstaller,
          on terraform_plugin_test.tf line 2, in data "aws_ami" "aws-thinstaller":
           2: data "aws_ami" "aws-thinstaller" {
        
--- FAIL: TestAccDataSyncLocationNFS_tags (2.61s)
=== CONT  TestAccDataSyncLocationNFS_basic
    location_nfs_test.go:26: Step 1/2 error: Error running pre-apply refresh: exit status 1
        
        Error: Your query returned no results. Please change your search criteria and try again.
        
          with data.aws_ami.aws-thinstaller,
          on terraform_plugin_test.tf line 2, in data "aws_ami" "aws-thinstaller":
           2: data "aws_ami" "aws-thinstaller" {
        
--- FAIL: TestAccDataSyncLocationNFS_basic (2.58s)
=== CONT  TestAccDataSyncLocationHDFS_tags
--- PASS: TestAccDataSyncLocationObjectStorage_tags (168.42s)
=== CONT  TestAccDataSyncLocationHDFS_basic
--- PASS: TestAccDataSyncLocationHDFS_basic (118.09s)
=== CONT  TestAccDataSyncLocationFSxWindowsFileSystem_tags
--- PASS: TestAccDataSyncLocationHDFS_tags (175.46s)
=== CONT  TestAccDataSyncLocationFSxWindowsFileSystem_basic
--- PASS: TestAccDataSyncLocationFSxWindowsFileSystem_tags (3327.23s)
=== CONT  TestAccDataSyncLocationFSxOpenZFSFileSystem_tags
--- PASS: TestAccDataSyncLocationFSxWindowsFileSystem_basic (3369.86s)
=== CONT  TestAccDataSyncLocationFSxOpenZFSFileSystem_basic
--- PASS: TestAccDataSyncLocationFSxOpenZFSFileSystem_tags (873.90s)
=== CONT  TestAccDataSyncLocationFSxLustreFileSystem_tags
--- PASS: TestAccDataSyncLocationFSxOpenZFSFileSystem_basic (794.39s)
=== CONT  TestAccDataSyncLocationFSxLustreFileSystem_basic
--- PASS: TestAccDataSyncLocationFSxLustreFileSystem_basic (732.71s)
=== CONT  TestAccDataSyncLocationEFS_tags
--- PASS: TestAccDataSyncLocationFSxLustreFileSystem_tags (778.79s)
=== CONT  TestAccDataSyncLocationEFS_basic
--- PASS: TestAccDataSyncLocationEFS_basic (145.27s)
=== CONT  TestAccDataSyncAgent_tags
--- PASS: TestAccDataSyncLocationEFS_tags (189.35s)
--- PASS: TestAccDataSyncAgent_tags (226.71s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/datasync	6204.979s
=== RUN   TestAccDAXCluster_basic
=== PAUSE TestAccDAXCluster_basic
=== RUN   TestAccDAXParameterGroup_basic
=== PAUSE TestAccDAXParameterGroup_basic
=== RUN   TestAccDAXSubnetGroup_basic
=== PAUSE TestAccDAXSubnetGroup_basic
=== CONT  TestAccDAXCluster_basic
=== CONT  TestAccDAXSubnetGroup_basic
--- PASS: TestAccDAXSubnetGroup_basic (80.36s)
=== CONT  TestAccDAXParameterGroup_basic
--- PASS: TestAccDAXParameterGroup_basic (82.27s)
--- PASS: TestAccDAXCluster_basic (752.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dax	759.098s
=== RUN   TestAccDeployApp_basic
=== PAUSE TestAccDeployApp_basic
=== RUN   TestAccDeployApp_tags
=== PAUSE TestAccDeployApp_tags
=== RUN   TestAccDeployDeploymentConfig_basic
=== PAUSE TestAccDeployDeploymentConfig_basic
=== RUN   TestAccDeployDeploymentGroup_basic
=== PAUSE TestAccDeployDeploymentGroup_basic
=== RUN   TestAccDeployDeploymentGroup_tags
=== PAUSE TestAccDeployDeploymentGroup_tags
=== RUN   TestAccDeployDeploymentGroup_Trigger_basic
=== PAUSE TestAccDeployDeploymentGroup_Trigger_basic
=== CONT  TestAccDeployApp_basic
=== CONT  TestAccDeployDeploymentGroup_basic
--- PASS: TestAccDeployApp_basic (45.05s)
=== CONT  TestAccDeployDeploymentConfig_basic
--- PASS: TestAccDeployDeploymentConfig_basic (47.64s)
=== CONT  TestAccDeployDeploymentGroup_Trigger_basic
--- PASS: TestAccDeployDeploymentGroup_basic (106.08s)
=== CONT  TestAccDeployDeploymentGroup_tags
--- PASS: TestAccDeployDeploymentGroup_Trigger_basic (85.82s)
=== CONT  TestAccDeployApp_tags
--- PASS: TestAccDeployDeploymentGroup_tags (114.84s)
--- PASS: TestAccDeployApp_tags (78.51s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/deploy	291.954s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/detective	23.011s [no tests to run]
=== RUN   TestAccDeviceFarmDevicePool_basic
=== PAUSE TestAccDeviceFarmDevicePool_basic
=== RUN   TestAccDeviceFarmDevicePool_tags
=== PAUSE TestAccDeviceFarmDevicePool_tags
=== RUN   TestAccDeviceFarmInstanceProfile_basic
=== PAUSE TestAccDeviceFarmInstanceProfile_basic
=== RUN   TestAccDeviceFarmInstanceProfile_tags
=== PAUSE TestAccDeviceFarmInstanceProfile_tags
=== RUN   TestAccDeviceFarmNetworkProfile_basic
=== PAUSE TestAccDeviceFarmNetworkProfile_basic
=== RUN   TestAccDeviceFarmNetworkProfile_tags
=== PAUSE TestAccDeviceFarmNetworkProfile_tags
=== RUN   TestAccDeviceFarmProject_basic
=== PAUSE TestAccDeviceFarmProject_basic
=== RUN   TestAccDeviceFarmProject_tags
=== PAUSE TestAccDeviceFarmProject_tags
=== RUN   TestAccDeviceFarmTestGridProject_basic
=== PAUSE TestAccDeviceFarmTestGridProject_basic
=== RUN   TestAccDeviceFarmTestGridProject_tags
=== PAUSE TestAccDeviceFarmTestGridProject_tags
=== RUN   TestAccDeviceFarmUpload_basic
=== PAUSE TestAccDeviceFarmUpload_basic
=== CONT  TestAccDeviceFarmDevicePool_basic
=== CONT  TestAccDeviceFarmProject_basic
--- PASS: TestAccDeviceFarmProject_basic (67.71s)
=== CONT  TestAccDeviceFarmInstanceProfile_tags
--- PASS: TestAccDeviceFarmDevicePool_basic (78.05s)
=== CONT  TestAccDeviceFarmNetworkProfile_tags
--- PASS: TestAccDeviceFarmInstanceProfile_tags (109.11s)
=== CONT  TestAccDeviceFarmNetworkProfile_basic
--- PASS: TestAccDeviceFarmNetworkProfile_tags (110.30s)
=== CONT  TestAccDeviceFarmInstanceProfile_basic
--- PASS: TestAccDeviceFarmNetworkProfile_basic (60.79s)
=== CONT  TestAccDeviceFarmTestGridProject_tags
--- PASS: TestAccDeviceFarmInstanceProfile_basic (59.03s)
=== CONT  TestAccDeviceFarmUpload_basic
--- PASS: TestAccDeviceFarmUpload_basic (51.40s)
=== CONT  TestAccDeviceFarmDevicePool_tags
--- PASS: TestAccDeviceFarmTestGridProject_tags (77.10s)
=== CONT  TestAccDeviceFarmTestGridProject_basic
--- PASS: TestAccDeviceFarmTestGridProject_basic (45.62s)
=== CONT  TestAccDeviceFarmProject_tags
--- PASS: TestAccDeviceFarmDevicePool_tags (77.59s)
--- PASS: TestAccDeviceFarmProject_tags (52.14s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/devicefarm	441.337s
=== RUN   TestAccDirectConnectBGPPeer_basic
    bgp_peer_test.go:24: Environment variable DX_VIRTUAL_INTERFACE_ID is not set
--- SKIP: TestAccDirectConnectBGPPeer_basic (0.00s)
=== RUN   TestAccDirectConnectConnectionAssociation_basic
=== PAUSE TestAccDirectConnectConnectionAssociation_basic
=== RUN   TestAccDirectConnectConnectionConfirmation_basic
    acctest.go:76: TEST_AWS_DX_CONNECTION_ID and TEST_AWS_DX_OWNER_ACCOUNT_ID must be set for tests involving hosted connections
--- SKIP: TestAccDirectConnectConnectionConfirmation_basic (0.00s)
=== RUN   TestAccDirectConnectConnectionDataSource_basic
=== PAUSE TestAccDirectConnectConnectionDataSource_basic
=== RUN   TestAccDirectConnectConnection_basic
=== PAUSE TestAccDirectConnectConnection_basic
=== RUN   TestAccDirectConnectConnection_tags
=== PAUSE TestAccDirectConnectConnection_tags
=== RUN   TestAccDirectConnectGatewayDataSource_basic
=== PAUSE TestAccDirectConnectGatewayDataSource_basic
=== RUN   TestAccDirectConnectGateway_basic
=== PAUSE TestAccDirectConnectGateway_basic
=== RUN   TestAccDirectConnectHostedConnection_basic
    acctest.go:76: TEST_AWS_DX_CONNECTION_ID and TEST_AWS_DX_OWNER_ACCOUNT_ID must be set for tests involving hosted connections
--- SKIP: TestAccDirectConnectHostedConnection_basic (0.00s)
=== RUN   TestAccDirectConnectHostedPrivateVirtualInterface_basic
    hosted_private_virtual_interface_test.go:24: Environment variable DX_CONNECTION_ID is not set
--- SKIP: TestAccDirectConnectHostedPrivateVirtualInterface_basic (0.00s)
=== RUN   TestAccDirectConnectHostedPublicVirtualInterface_basic
    hosted_public_virtual_interface_test.go:24: Environment variable DX_CONNECTION_ID is not set
--- SKIP: TestAccDirectConnectHostedPublicVirtualInterface_basic (0.00s)
=== RUN   TestAccDirectConnectLag_basic
=== PAUSE TestAccDirectConnectLag_basic
=== RUN   TestAccDirectConnectLag_tags
=== PAUSE TestAccDirectConnectLag_tags
=== RUN   TestAccDirectConnectLocationDataSource_basic
=== PAUSE TestAccDirectConnectLocationDataSource_basic
=== RUN   TestAccDirectConnectPrivateVirtualInterface_basic
    private_virtual_interface_test.go:24: Environment variable DX_CONNECTION_ID is not set
--- SKIP: TestAccDirectConnectPrivateVirtualInterface_basic (0.00s)
=== RUN   TestAccDirectConnectPrivateVirtualInterface_tags
    private_virtual_interface_test.go:97: Environment variable DX_CONNECTION_ID is not set
--- SKIP: TestAccDirectConnectPrivateVirtualInterface_tags (0.00s)
=== RUN   TestAccDirectConnectPublicVirtualInterface_basic
    public_virtual_interface_test.go:24: Environment variable DX_CONNECTION_ID is not set
--- SKIP: TestAccDirectConnectPublicVirtualInterface_basic (0.00s)
=== RUN   TestAccDirectConnectPublicVirtualInterface_tags
    public_virtual_interface_test.go:81: Environment variable DX_CONNECTION_ID is not set
--- SKIP: TestAccDirectConnectPublicVirtualInterface_tags (0.00s)
=== RUN   TestAccDirectConnectRouterConfigurationDataSource_basic
    router_configuration_data_source_test.go:18: Environment variable VIRTUAL_INTERFACE_ID is not set
--- SKIP: TestAccDirectConnectRouterConfigurationDataSource_basic (0.00s)
=== CONT  TestAccDirectConnectConnectionAssociation_basic
=== CONT  TestAccDirectConnectGateway_basic
=== CONT  TestAccDirectConnectConnectionAssociation_basic
    connection_association_test.go:23: Step 1/1 error: Error running apply: exit status 1
        
        Error: creating Direct Connect LAG (tf-acc-test-2820480487801587430): DirectConnectClientException: Could not find an available port in Direct Connect location DBLV1
        
          with aws_dx_lag.test,
          on terraform_plugin_test.tf line 14, in resource "aws_dx_lag" "test":
          14: resource "aws_dx_lag" "test" {
        
--- FAIL: TestAccDirectConnectConnectionAssociation_basic (21.61s)
=== CONT  TestAccDirectConnectConnection_tags
--- PASS: TestAccDirectConnectGateway_basic (56.42s)
=== CONT  TestAccDirectConnectGatewayDataSource_basic
=== CONT  TestAccDirectConnectConnection_tags
    connection_test.go:240: Step 2/4 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
        
          map[string]string{
        - 	"aws_device":             "",
        + 	"aws_device":             "ECPO1-1387dbdwbg81t",
        - 	"encryption_mode":        "",
        + 	"encryption_mode":        "unknown",
        - 	"has_logical_redundancy": "unknown",
        + 	"has_logical_redundancy": "no",
        - 	"jumbo_frame_capable":    "false",
        + 	"jumbo_frame_capable":    "true",
        - 	"port_encryption_status": "",
        + 	"port_encryption_status": "unknown",
          }
--- FAIL: TestAccDirectConnectConnection_tags (56.05s)
=== CONT  TestAccDirectConnectLag_tags
--- PASS: TestAccDirectConnectGatewayDataSource_basic (46.36s)
=== CONT  TestAccDirectConnectLocationDataSource_basic
--- PASS: TestAccDirectConnectLocationDataSource_basic (30.15s)
=== CONT  TestAccDirectConnectConnection_basic
--- PASS: TestAccDirectConnectConnection_basic (37.95s)
=== CONT  TestAccDirectConnectConnectionDataSource_basic
--- PASS: TestAccDirectConnectLag_tags (97.77s)
=== CONT  TestAccDirectConnectLag_basic
--- PASS: TestAccDirectConnectConnectionDataSource_basic (28.69s)
--- PASS: TestAccDirectConnectLag_basic (53.76s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/directconnect	248.691s
=== RUN   TestAccDLMLifecyclePolicy_basic
=== PAUSE TestAccDLMLifecyclePolicy_basic
=== RUN   TestAccDLMLifecyclePolicy_tags
=== PAUSE TestAccDLMLifecyclePolicy_tags
=== CONT  TestAccDLMLifecyclePolicy_basic
=== CONT  TestAccDLMLifecyclePolicy_tags
--- PASS: TestAccDLMLifecyclePolicy_basic (49.32s)
--- PASS: TestAccDLMLifecyclePolicy_tags (98.80s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dlm	114.388s
=== RUN   TestAccDMSCertificate_basic
=== PAUSE TestAccDMSCertificate_basic
=== RUN   TestAccDMSCertificate_tags
=== PAUSE TestAccDMSCertificate_tags
=== RUN   TestAccDMSEndpoint_basic
=== PAUSE TestAccDMSEndpoint_basic
=== RUN   TestAccDMSEndpoint_Aurora_basic
=== PAUSE TestAccDMSEndpoint_Aurora_basic
=== RUN   TestAccDMSEndpoint_AuroraPostgreSQL_basic
=== PAUSE TestAccDMSEndpoint_AuroraPostgreSQL_basic
=== RUN   TestAccDMSEndpoint_S3_basic
=== PAUSE TestAccDMSEndpoint_S3_basic
=== RUN   TestAccDMSEndpoint_OpenSearch_basic
=== PAUSE TestAccDMSEndpoint_OpenSearch_basic
=== RUN   TestAccDMSEndpoint_MongoDB_basic
=== PAUSE TestAccDMSEndpoint_MongoDB_basic
=== RUN   TestAccDMSEndpoint_MariaDB_basic
=== PAUSE TestAccDMSEndpoint_MariaDB_basic
=== RUN   TestAccDMSEndpoint_MySQL_basic
=== PAUSE TestAccDMSEndpoint_MySQL_basic
=== RUN   TestAccDMSEndpoint_Oracle_basic
=== PAUSE TestAccDMSEndpoint_Oracle_basic
=== RUN   TestAccDMSEndpoint_PostgreSQL_basic
=== PAUSE TestAccDMSEndpoint_PostgreSQL_basic
=== RUN   TestAccDMSEndpoint_SQLServer_basic
=== PAUSE TestAccDMSEndpoint_SQLServer_basic
=== RUN   TestAccDMSEndpoint_Sybase_basic
=== PAUSE TestAccDMSEndpoint_Sybase_basic
=== RUN   TestAccDMSEndpoint_db2_basic
=== PAUSE TestAccDMSEndpoint_db2_basic
=== RUN   TestAccDMSEndpoint_Redshift_basic
=== PAUSE TestAccDMSEndpoint_Redshift_basic
=== RUN   TestAccDMSEventSubscription_basic
=== PAUSE TestAccDMSEventSubscription_basic
=== RUN   TestAccDMSEventSubscription_tags
=== PAUSE TestAccDMSEventSubscription_tags
=== RUN   TestAccDMSReplicationInstance_basic
=== PAUSE TestAccDMSReplicationInstance_basic
=== RUN   TestAccDMSReplicationInstance_tags
=== PAUSE TestAccDMSReplicationInstance_tags
=== RUN   TestAccDMSReplicationSubnetGroup_basic
=== PAUSE TestAccDMSReplicationSubnetGroup_basic
=== RUN   TestAccDMSReplicationTask_basic
=== PAUSE TestAccDMSReplicationTask_basic
=== RUN   TestAccDMSS3Endpoint_basic
=== PAUSE TestAccDMSS3Endpoint_basic
=== CONT  TestAccDMSCertificate_basic
=== CONT  TestAccDMSEndpoint_SQLServer_basic
--- PASS: TestAccDMSCertificate_basic (40.75s)
=== CONT  TestAccDMSEndpoint_OpenSearch_basic
--- PASS: TestAccDMSEndpoint_SQLServer_basic (46.18s)
=== CONT  TestAccDMSEndpoint_PostgreSQL_basic
--- PASS: TestAccDMSEndpoint_OpenSearch_basic (37.66s)
=== CONT  TestAccDMSEndpoint_Oracle_basic
--- PASS: TestAccDMSEndpoint_PostgreSQL_basic (34.52s)
=== CONT  TestAccDMSEndpoint_MySQL_basic
--- PASS: TestAccDMSEndpoint_Oracle_basic (29.26s)
=== CONT  TestAccDMSEndpoint_MariaDB_basic
--- PASS: TestAccDMSEndpoint_MySQL_basic (39.47s)
=== CONT  TestAccDMSEndpoint_MongoDB_basic
--- PASS: TestAccDMSEndpoint_MariaDB_basic (33.85s)
=== CONT  TestAccDMSEndpoint_Aurora_basic
--- PASS: TestAccDMSEndpoint_MongoDB_basic (32.38s)
=== CONT  TestAccDMSEndpoint_S3_basic
--- PASS: TestAccDMSEndpoint_Aurora_basic (20.38s)
=== CONT  TestAccDMSEndpoint_AuroraPostgreSQL_basic
--- PASS: TestAccDMSEndpoint_AuroraPostgreSQL_basic (20.70s)
=== CONT  TestAccDMSEndpoint_basic
--- PASS: TestAccDMSEndpoint_S3_basic (73.30s)
=== CONT  TestAccDMSCertificate_tags
--- PASS: TestAccDMSEndpoint_basic (47.03s)
=== CONT  TestAccDMSReplicationInstance_basic
--- PASS: TestAccDMSCertificate_tags (39.61s)
=== CONT  TestAccDMSS3Endpoint_basic
--- PASS: TestAccDMSS3Endpoint_basic (30.59s)
=== CONT  TestAccDMSReplicationTask_basic
    replication_task_test.go:33: Step 1/4 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_dms_replication_task.test will be updated in-place
          ~ resource "aws_dms_replication_task" "test" {
                id                        = "tf-acc-test-5724865490022427808"
              ~ replication_task_settings = jsonencode(
                  ~ {
                      ~ Logging                             = {
                          - EnableLogContext = false -> null
                            # (2 unchanged elements hidden)
                        }
                        # (13 unchanged elements hidden)
                    }
                )
                tags                      = {
                    "Name"   = "tf-acc-test-5724865490022427808"
                    "Remove" = "to-remove"
                    "Update" = "to-update"
                }
                # (10 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- PASS: TestAccDMSReplicationInstance_basic (888.49s)
=== CONT  TestAccDMSReplicationSubnetGroup_basic
--- PASS: TestAccDMSReplicationSubnetGroup_basic (39.71s)
=== CONT  TestAccDMSReplicationInstance_tags
--- FAIL: TestAccDMSReplicationTask_basic (951.84s)
=== CONT  TestAccDMSEndpoint_Redshift_basic
--- PASS: TestAccDMSEndpoint_Redshift_basic (233.61s)
=== CONT  TestAccDMSEventSubscription_tags
--- PASS: TestAccDMSReplicationInstance_tags (929.25s)
=== CONT  TestAccDMSEventSubscription_basic
--- PASS: TestAccDMSEventSubscription_tags (1128.28s)
=== CONT  TestAccDMSEndpoint_db2_basic
--- PASS: TestAccDMSEndpoint_db2_basic (32.78s)
=== CONT  TestAccDMSEndpoint_Sybase_basic
--- PASS: TestAccDMSEndpoint_Sybase_basic (22.19s)
--- PASS: TestAccDMSEventSubscription_basic (981.45s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/dms	3081.240s
=== RUN   TestAccDocDBClusterInstance_basic
=== PAUSE TestAccDocDBClusterInstance_basic
=== RUN   TestAccDocDBClusterParameterGroup_basic
=== PAUSE TestAccDocDBClusterParameterGroup_basic
=== RUN   TestAccDocDBClusterParameterGroup_tags
=== PAUSE TestAccDocDBClusterParameterGroup_tags
=== RUN   TestAccDocDBClusterSnapshot_basic
=== PAUSE TestAccDocDBClusterSnapshot_basic
=== RUN   TestAccDocDBCluster_basic
=== PAUSE TestAccDocDBCluster_basic
=== RUN   TestAccDocDBEngineVersionDataSource_basic
=== PAUSE TestAccDocDBEngineVersionDataSource_basic
=== RUN   TestAccDocDBEventSubscription_basic
=== PAUSE TestAccDocDBEventSubscription_basic
=== RUN   TestAccDocDBEventSubscription_tags
=== PAUSE TestAccDocDBEventSubscription_tags
=== RUN   TestAccDocDBGlobalCluster_basic
=== PAUSE TestAccDocDBGlobalCluster_basic
=== RUN   TestAccDocDBGlobalCluster_SourceDBClusterIdentifier_basic
=== PAUSE TestAccDocDBGlobalCluster_SourceDBClusterIdentifier_basic
=== RUN   TestAccDocDBOrderableDBInstanceDataSource_basic
=== PAUSE TestAccDocDBOrderableDBInstanceDataSource_basic
=== RUN   TestAccDocDBSubnetGroup_basic
=== PAUSE TestAccDocDBSubnetGroup_basic
=== CONT  TestAccDocDBClusterInstance_basic
=== CONT  TestAccDocDBEventSubscription_basic
--- PASS: TestAccDocDBEventSubscription_basic (172.52s)
=== CONT  TestAccDocDBClusterSnapshot_basic
--- PASS: TestAccDocDBClusterSnapshot_basic (329.01s)
=== CONT  TestAccDocDBEngineVersionDataSource_basic
--- PASS: TestAccDocDBEngineVersionDataSource_basic (11.22s)
=== CONT  TestAccDocDBCluster_basic
--- PASS: TestAccDocDBCluster_basic (170.58s)
=== CONT  TestAccDocDBGlobalCluster_SourceDBClusterIdentifier_basic
--- PASS: TestAccDocDBGlobalCluster_SourceDBClusterIdentifier_basic (182.72s)
=== CONT  TestAccDocDBSubnetGroup_basic
--- PASS: TestAccDocDBClusterInstance_basic (884.06s)
=== CONT  TestAccDocDBOrderableDBInstanceDataSource_basic
--- PASS: TestAccDocDBSubnetGroup_basic (23.66s)
=== CONT  TestAccDocDBGlobalCluster_basic
--- PASS: TestAccDocDBOrderableDBInstanceDataSource_basic (11.82s)
=== CONT  TestAccDocDBClusterParameterGroup_tags
--- PASS: TestAccDocDBGlobalCluster_basic (17.39s)
=== CONT  TestAccDocDBEventSubscription_tags
--- PASS: TestAccDocDBClusterParameterGroup_tags (37.21s)
=== CONT  TestAccDocDBClusterParameterGroup_basic
--- PASS: TestAccDocDBClusterParameterGroup_basic (15.37s)
--- PASS: TestAccDocDBEventSubscription_tags (192.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/docdb	1114.876s
=== RUN   TestAccDSConditionalForwarder_Condition_basic
=== PAUSE TestAccDSConditionalForwarder_Condition_basic
=== RUN   TestAccDSDirectory_basic
=== PAUSE TestAccDSDirectory_basic
=== RUN   TestAccDSDirectory_tags
=== PAUSE TestAccDSDirectory_tags
=== RUN   TestAccDSLogSubscription_basic
=== PAUSE TestAccDSLogSubscription_basic
=== RUN   TestAccDSRadiusSettings_basic
    radius_settings_test.go:24: Environment variable DIRECTORY_SERVICE_RADIUS_SERVER is not set
--- SKIP: TestAccDSRadiusSettings_basic (0.00s)
=== RUN   TestAccDSRegion_basic
=== PAUSE TestAccDSRegion_basic
=== RUN   TestAccDSRegion_tags
=== PAUSE TestAccDSRegion_tags
=== RUN   TestAccDSSharedDirectoryAccepter_basic
=== PAUSE TestAccDSSharedDirectoryAccepter_basic
=== RUN   TestAccDSSharedDirectory_basic
=== PAUSE TestAccDSSharedDirectory_basic
=== CONT  TestAccDSConditionalForwarder_Condition_basic
=== CONT  TestAccDSRegion_basic
--- PASS: TestAccDSConditionalForwarder_Condition_basic (1298.49s)
=== CONT  TestAccDSSharedDirectory_basic
    acctest.go:772: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccDSSharedDirectory_basic (0.00s)
=== CONT  TestAccDSSharedDirectoryAccepter_basic
    acctest.go:772: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccDSSharedDirectoryAccepter_basic (0.00s)
=== CONT  TestAccDSRegion_tags
--- PASS: TestAccDSRegion_basic (7887.86s)
=== CONT  TestAccDSDirectory_tags
--- PASS: TestAccDSDirectory_tags (818.16s)
=== CONT  TestAccDSLogSubscription_basic
--- PASS: TestAccDSRegion_tags (7881.96s)
=== CONT  TestAccDSDirectory_basic
--- PASS: TestAccDSDirectory_basic (589.23s)
--- PASS: TestAccDSLogSubscription_basic (1297.77s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ds	10014.695s
=== RUN   TestAccDynamoDBContributorInsights_basic
=== PAUSE TestAccDynamoDBContributorInsights_basic
=== RUN   TestAccDynamoDBGlobalTable_basic
=== PAUSE TestAccDynamoDBGlobalTable_basic
=== RUN   TestAccDynamoDBKinesisStreamingDestination_basic
=== PAUSE TestAccDynamoDBKinesisStreamingDestination_basic
=== RUN   TestAccDynamoDBTableDataSource_basic
=== PAUSE TestAccDynamoDBTableDataSource_basic
=== RUN   TestAccDynamoDBTableItemDataSource_basic
=== PAUSE TestAccDynamoDBTableItemDataSource_basic
=== RUN   TestAccDynamoDBTableItem_basic
=== PAUSE TestAccDynamoDBTableItem_basic
=== RUN   TestAccDynamoDBTableReplica_basic
=== PAUSE TestAccDynamoDBTableReplica_basic
=== RUN   TestAccDynamoDBTableReplica_tags
=== PAUSE TestAccDynamoDBTableReplica_tags
=== RUN   TestAccDynamoDBTable_basic
=== PAUSE TestAccDynamoDBTable_basic
=== RUN   TestAccDynamoDBTable_tags
=== PAUSE TestAccDynamoDBTable_tags
=== RUN   TestAccDynamoDBTag_basic
=== PAUSE TestAccDynamoDBTag_basic
=== CONT  TestAccDynamoDBContributorInsights_basic
=== CONT  TestAccDynamoDBTableReplica_basic
--- PASS: TestAccDynamoDBContributorInsights_basic (102.47s)
=== CONT  TestAccDynamoDBTableDataSource_basic
--- PASS: TestAccDynamoDBTableDataSource_basic (30.89s)
=== CONT  TestAccDynamoDBTableItem_basic
--- PASS: TestAccDynamoDBTableItem_basic (25.00s)
=== CONT  TestAccDynamoDBTableItemDataSource_basic
--- PASS: TestAccDynamoDBTableReplica_basic (171.22s)
=== CONT  TestAccDynamoDBTable_tags
--- PASS: TestAccDynamoDBTableItemDataSource_basic (27.54s)
=== CONT  TestAccDynamoDBTag_basic
--- PASS: TestAccDynamoDBTag_basic (26.08s)
=== CONT  TestAccDynamoDBKinesisStreamingDestination_basic
--- PASS: TestAccDynamoDBTable_tags (46.17s)
=== CONT  TestAccDynamoDBGlobalTable_basic
--- PASS: TestAccDynamoDBGlobalTable_basic (50.41s)
=== CONT  TestAccDynamoDBTable_basic
--- PASS: TestAccDynamoDBKinesisStreamingDestination_basic (73.64s)
=== CONT  TestAccDynamoDBTableReplica_tags
--- PASS: TestAccDynamoDBTable_basic (33.27s)
--- PASS: TestAccDynamoDBTableReplica_tags (196.17s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	495.679s
FAIL
make: *** [testacc] Error 1
```
