### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin SDK resources `m*` (Phase 3c)

### DIFF
--- a/internal/service/macie2/service_package_gen.go
+++ b/internal/service/macie2/service_package_gen.go
@@ -36,14 +36,20 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceClassificationJob,
 			TypeName: "aws_macie2_classification_job",
+			Name:     "Classification Job",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
 			Factory:  ResourceCustomDataIdentifier,
 			TypeName: "aws_macie2_custom_data_identifier",
+			Name:     "Custom Data Identifier",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
 			Factory:  ResourceFindingsFilter,
 			TypeName: "aws_macie2_findings_filter",
+			Name:     "Findings Filter",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
 			Factory:  ResourceInvitationAccepter,
@@ -52,6 +58,8 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceMember,
 			TypeName: "aws_macie2_member",
+			Name:     "Member",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
 			Factory:  ResourceOrganizationAdminAccount,

--- a/internal/service/mediaconvert/service_package_gen.go
+++ b/internal/service/mediaconvert/service_package_gen.go
@@ -28,6 +28,8 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceQueue,
 			TypeName: "aws_media_convert_queue",
+			Name:     "Queue",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 	}
 }

--- a/internal/service/medialive/service_package_gen.go
+++ b/internal/service/medialive/service_package_gen.go
@@ -32,18 +32,34 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceChannel,
 			TypeName: "aws_medialive_channel",
+			Name:     "Channel",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceInput,
 			TypeName: "aws_medialive_input",
+			Name:     "Input",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceInputSecurityGroup,
 			TypeName: "aws_medialive_input_security_group",
+			Name:     "Input Security Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceMultiplex,
 			TypeName: "aws_medialive_multiplex",
+			Name:     "Multiplex",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/mediapackage/channel.go
+++ b/internal/service/mediapackage/channel.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_media_package_channel")
+// @SDKResource("aws_media_package_channel", name="Channel")
+// @Tags(identifierAttribute="arn")
 func ResourceChannel() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceChannelCreate,
@@ -75,8 +77,8 @@ func ResourceChannel() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -86,16 +88,11 @@ func ResourceChannel() *schema.Resource {
 func resourceChannelCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).MediaPackageConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &mediapackage.CreateChannelInput{
 		Id:          aws.String(d.Get("channel_id").(string)),
 		Description: aws.String(d.Get("description").(string)),
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
+		Tags:        GetTagsIn(ctx),
 	}
 
 	resp, err := conn.CreateChannelWithContext(ctx, input)
@@ -111,8 +108,6 @@ func resourceChannelCreate(ctx context.Context, d *schema.ResourceData, meta int
 func resourceChannelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).MediaPackageConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	input := &mediapackage.DescribeChannelInput{
 		Id: aws.String(d.Id()),
@@ -129,16 +124,7 @@ func resourceChannelRead(ctx context.Context, d *schema.ResourceData, meta inter
 		return sdkdiag.AppendErrorf(diags, "setting hls_ingest: %s", err)
 	}
 
-	tags := KeyValueTags(ctx, resp.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, resp.Tags)
 
 	return diags
 }
@@ -155,15 +141,6 @@ func resourceChannelUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	_, err := conn.UpdateChannelWithContext(ctx, input)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating MediaPackage Channel: %s", err)
-	}
-
-	arn := d.Get("arn").(string)
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, arn, o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating MediaPackage Channel (%s) tags: %s", arn, err)
-		}
 	}
 
 	return append(diags, resourceChannelRead(ctx, d, meta)...)

--- a/internal/service/mediapackage/service_package_gen.go
+++ b/internal/service/mediapackage/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceChannel,
 			TypeName: "aws_media_package_channel",
+			Name:     "Channel",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/mediastore/service_package_gen.go
+++ b/internal/service/mediastore/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceContainer,
 			TypeName: "aws_media_store_container",
+			Name:     "Container",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceContainerPolicy,

--- a/internal/service/memorydb/cluster.go
+++ b/internal/service/memorydb/cluster.go
@@ -20,9 +20,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_memorydb_cluster")
+// @SDKResource("aws_memorydb_cluster", name="Cluster")
+// @Tags(identifierAttribute="arn")
 func ResourceCluster() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClusterCreate,
@@ -234,8 +236,8 @@ func ResourceCluster() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"tls_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -267,8 +269,6 @@ func endpointSchema() *schema.Schema {
 
 func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).MemoryDBConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
 	input := &memorydb.CreateClusterInput{
@@ -278,7 +278,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		NodeType:                aws.String(d.Get("node_type").(string)),
 		NumReplicasPerShard:     aws.Int64(int64(d.Get("num_replicas_per_shard").(int))),
 		NumShards:               aws.Int64(int64(d.Get("num_shards").(int))),
-		Tags:                    Tags(tags.IgnoreAWS()),
+		Tags:                    GetTagsIn(ctx),
 		TLSEnabled:              aws.Bool(d.Get("tls_enabled").(bool)),
 	}
 
@@ -464,21 +464,11 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 	}
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.Errorf("error updating MemoryDB Cluster (%s) tags: %s", d.Id(), err)
-		}
-	}
-
 	return resourceClusterRead(ctx, d, meta)
 }
 
 func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).MemoryDBConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	cluster, err := FindClusterByName(ctx, conn, d.Id())
 
@@ -549,23 +539,6 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	d.Set("subnet_group_name", cluster.SubnetGroupName)
 	d.Set("tls_enabled", cluster.TLSEnabled)
-
-	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
-
-	if err != nil {
-		return diag.Errorf("error listing tags for MemoryDB Cluster (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags for MemoryDB Cluster (%s): %s", d.Id(), err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("error setting tags_all for MemoryDB Cluster (%s): %s", d.Id(), err)
-	}
 
 	return nil
 }

--- a/internal/service/memorydb/service_package_gen.go
+++ b/internal/service/memorydb/service_package_gen.go
@@ -53,26 +53,50 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceACL,
 			TypeName: "aws_memorydb_acl",
+			Name:     "ACL",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceCluster,
 			TypeName: "aws_memorydb_cluster",
+			Name:     "Cluster",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceParameterGroup,
 			TypeName: "aws_memorydb_parameter_group",
+			Name:     "Parameter Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceSnapshot,
 			TypeName: "aws_memorydb_snapshot",
+			Name:     "Snapshot",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceSubnetGroup,
 			TypeName: "aws_memorydb_subnet_group",
+			Name:     "Subnet Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceUser,
 			TypeName: "aws_memorydb_user",
+			Name:     "User",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/memorydb/snapshot.go
+++ b/internal/service/memorydb/snapshot.go
@@ -15,9 +15,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_memorydb_snapshot")
+// @SDKResource("aws_memorydb_snapshot", name="Snapshot")
+// @Tags(identifierAttribute="arn")
 func ResourceSnapshot() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSnapshotCreate,
@@ -136,22 +138,20 @@ func ResourceSnapshot() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
 
 func resourceSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).MemoryDBConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
 	input := &memorydb.CreateSnapshotInput{
 		ClusterName:  aws.String(d.Get("cluster_name").(string)),
 		SnapshotName: aws.String(name),
-		Tags:         Tags(tags.IgnoreAWS()),
+		Tags:         GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("kms_key_arn"); ok {
@@ -175,23 +175,12 @@ func resourceSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta in
 }
 
 func resourceSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).MemoryDBConn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.Errorf("error updating MemoryDB Snapshot (%s) tags: %s", d.Id(), err)
-		}
-	}
-
+	// Tags only.
 	return resourceSnapshotRead(ctx, d, meta)
 }
 
 func resourceSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).MemoryDBConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	snapshot, err := FindSnapshotByName(ctx, conn, d.Id())
 
@@ -214,23 +203,6 @@ func resourceSnapshotRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("name", snapshot.Name)
 	d.Set("name_prefix", create.NamePrefixFromName(aws.StringValue(snapshot.Name)))
 	d.Set("source", snapshot.Source)
-
-	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
-
-	if err != nil {
-		return diag.Errorf("error listing tags for MemoryDB Snapshot (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags for MemoryDB Snapshot (%s): %s", d.Id(), err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("error setting tags_all for MemoryDB Snapshot (%s): %s", d.Id(), err)
-	}
 
 	return nil
 }

--- a/internal/service/memorydb/subnet_group.go
+++ b/internal/service/memorydb/subnet_group.go
@@ -16,9 +16,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_memorydb_subnet_group")
+// @SDKResource("aws_memorydb_subnet_group", name="Subnet Group")
+// @Tags(identifierAttribute="arn")
 func ResourceSubnetGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSubnetGroupCreate,
@@ -64,8 +66,8 @@ func ResourceSubnetGroup() *schema.Resource {
 				MinItems: 1,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -76,15 +78,13 @@ func ResourceSubnetGroup() *schema.Resource {
 
 func resourceSubnetGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).MemoryDBConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
 	input := &memorydb.CreateSubnetGroupInput{
 		Description:     aws.String(d.Get("description").(string)),
 		SubnetGroupName: aws.String(name),
 		SubnetIds:       flex.ExpandStringSet(d.Get("subnet_ids").(*schema.Set)),
-		Tags:            Tags(tags.IgnoreAWS()),
+		Tags:            GetTagsIn(ctx),
 	}
 
 	log.Printf("[DEBUG] Creating MemoryDB Subnet Group: %s", input)
@@ -117,21 +117,11 @@ func resourceSubnetGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.Errorf("error updating MemoryDB Subnet Group (%s) tags: %s", d.Id(), err)
-		}
-	}
-
 	return resourceSubnetGroupRead(ctx, d, meta)
 }
 
 func resourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).MemoryDBConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	group, err := FindSubnetGroupByName(ctx, conn, d.Id())
 
@@ -156,23 +146,6 @@ func resourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("name", group.Name)
 	d.Set("name_prefix", create.NamePrefixFromName(aws.StringValue(group.Name)))
 	d.Set("vpc_id", group.VpcId)
-
-	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
-
-	if err != nil {
-		return diag.Errorf("error listing tags for MemoryDB Subnet Group (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags for MemoryDB Subnet Group (%s): %s", d.Id(), err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("error setting tags_all for MemoryDB Subnet Group (%s): %s", d.Id(), err)
-	}
 
 	return nil
 }

--- a/internal/service/mq/service_package_gen.go
+++ b/internal/service/mq/service_package_gen.go
@@ -37,10 +37,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceBroker,
 			TypeName: "aws_mq_broker",
+			Name:     "Broker",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceConfiguration,
 			TypeName: "aws_mq_configuration",
+			Name:     "Configuration",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/mwaa/service_package_gen.go
+++ b/internal/service/mwaa/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceEnvironment,
 			TypeName: "aws_mwaa_environment",
+			Name:     "Environment",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin SDK.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30421.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30430.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30449.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30454.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30461.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30463.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30476.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30477.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30478.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30483.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30484.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30491.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30509.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=m... ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/m.../... -v -count 1 -parallel 2  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccMacieMemberAccountAssociation_basic
    member_account_association_test.go:22: Environment variable MACIE_MEMBER_ACCOUNT_ID is not set
--- SKIP: TestAccMacieMemberAccountAssociation_basic (0.00s)
=== RUN   TestAccMacieS3BucketAssociation_basic
=== PAUSE TestAccMacieS3BucketAssociation_basic
=== CONT  TestAccMacieS3BucketAssociation_basic
    s3_bucket_association_test.go:162: skipping acceptance testing: RequestError: send request failed
        caused by: Post "https://macie.us-west-2.amazonaws.com/": dial tcp: lookup macie.us-west-2.amazonaws.com: no such host
--- SKIP: TestAccMacieS3BucketAssociation_basic (24.80s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/macie	32.755s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/macie2	34.829s [no tests to run]
?   	github.com/hashicorp/terraform-provider-aws/internal/service/mediaconnect	[no test files]
=== RUN   TestAccMediaConvertQueue_basic
=== PAUSE TestAccMediaConvertQueue_basic
=== CONT  TestAccMediaConvertQueue_basic
--- PASS: TestAccMediaConvertQueue_basic (46.19s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mediaconvert	66.742s
=== RUN   TestAccMediaLiveChannel_basic
=== PAUSE TestAccMediaLiveChannel_basic
=== RUN   TestAccMediaLiveInputSecurityGroup_basic
=== PAUSE TestAccMediaLiveInputSecurityGroup_basic
=== RUN   TestAccMediaLiveInput_basic
=== PAUSE TestAccMediaLiveInput_basic
=== CONT  TestAccMediaLiveChannel_basic
=== CONT  TestAccMediaLiveInput_basic
--- PASS: TestAccMediaLiveInput_basic (78.15s)
=== CONT  TestAccMediaLiveInputSecurityGroup_basic
--- PASS: TestAccMediaLiveChannel_basic (103.77s)
--- PASS: TestAccMediaLiveInputSecurityGroup_basic (26.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	140.603s
=== RUN   TestAccMediaPackageChannel_basic
=== PAUSE TestAccMediaPackageChannel_basic
=== RUN   TestAccMediaPackageChannel_tags
=== PAUSE TestAccMediaPackageChannel_tags
=== CONT  TestAccMediaPackageChannel_basic
=== CONT  TestAccMediaPackageChannel_tags
--- PASS: TestAccMediaPackageChannel_basic (50.76s)
--- PASS: TestAccMediaPackageChannel_tags (96.92s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mediapackage	112.618s
=== RUN   TestAccMediaStoreContainerPolicy_basic
=== PAUSE TestAccMediaStoreContainerPolicy_basic
=== RUN   TestAccMediaStoreContainer_basic
=== PAUSE TestAccMediaStoreContainer_basic
=== RUN   TestAccMediaStoreContainer_tags
=== PAUSE TestAccMediaStoreContainer_tags
=== CONT  TestAccMediaStoreContainerPolicy_basic
=== CONT  TestAccMediaStoreContainer_tags
--- PASS: TestAccMediaStoreContainerPolicy_basic (124.12s)
=== CONT  TestAccMediaStoreContainer_basic
--- PASS: TestAccMediaStoreContainer_tags (218.79s)
--- PASS: TestAccMediaStoreContainer_basic (174.56s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mediastore	310.498s
=== RUN   TestAccMemoryDBACLDataSource_basic
=== PAUSE TestAccMemoryDBACLDataSource_basic
=== RUN   TestAccMemoryDBACL_basic
=== PAUSE TestAccMemoryDBACL_basic
=== RUN   TestAccMemoryDBACL_update_tags
=== PAUSE TestAccMemoryDBACL_update_tags
=== RUN   TestAccMemoryDBClusterDataSource_basic
=== PAUSE TestAccMemoryDBClusterDataSource_basic
=== RUN   TestAccMemoryDBCluster_basic
=== PAUSE TestAccMemoryDBCluster_basic
=== RUN   TestAccMemoryDBCluster_Update_tags
=== PAUSE TestAccMemoryDBCluster_Update_tags
=== RUN   TestAccMemoryDBParameterGroupDataSource_basic
=== PAUSE TestAccMemoryDBParameterGroupDataSource_basic
=== RUN   TestAccMemoryDBParameterGroup_basic
=== PAUSE TestAccMemoryDBParameterGroup_basic
=== RUN   TestAccMemoryDBParameterGroup_update_tags
=== PAUSE TestAccMemoryDBParameterGroup_update_tags
=== RUN   TestAccMemoryDBSnapshotDataSource_basic
=== PAUSE TestAccMemoryDBSnapshotDataSource_basic
=== RUN   TestAccMemoryDBSnapshot_basic
=== PAUSE TestAccMemoryDBSnapshot_basic
=== RUN   TestAccMemoryDBSnapshot_update_tags
=== PAUSE TestAccMemoryDBSnapshot_update_tags
=== RUN   TestAccMemoryDBSubnetGroupDataSource_basic
=== PAUSE TestAccMemoryDBSubnetGroupDataSource_basic
=== RUN   TestAccMemoryDBSubnetGroup_basic
=== PAUSE TestAccMemoryDBSubnetGroup_basic
=== RUN   TestAccMemoryDBSubnetGroup_update_tags
=== PAUSE TestAccMemoryDBSubnetGroup_update_tags
=== RUN   TestAccMemoryDBUserDataSource_basic
=== PAUSE TestAccMemoryDBUserDataSource_basic
=== RUN   TestAccMemoryDBUser_basic
=== PAUSE TestAccMemoryDBUser_basic
=== RUN   TestAccMemoryDBUser_update_tags
=== PAUSE TestAccMemoryDBUser_update_tags
=== CONT  TestAccMemoryDBACLDataSource_basic
=== CONT  TestAccMemoryDBSnapshotDataSource_basic
--- PASS: TestAccMemoryDBACLDataSource_basic (151.27s)
=== CONT  TestAccMemoryDBSubnetGroup_update_tags
--- PASS: TestAccMemoryDBSubnetGroup_update_tags (77.52s)
=== CONT  TestAccMemoryDBUser_update_tags
--- PASS: TestAccMemoryDBUser_update_tags (102.51s)
=== CONT  TestAccMemoryDBUser_basic
--- PASS: TestAccMemoryDBUser_basic (61.50s)
=== CONT  TestAccMemoryDBUserDataSource_basic
--- PASS: TestAccMemoryDBUserDataSource_basic (59.37s)
=== CONT  TestAccMemoryDBCluster_Update_tags
--- PASS: TestAccMemoryDBCluster_Update_tags (1228.13s)
=== CONT  TestAccMemoryDBParameterGroup_update_tags
--- PASS: TestAccMemoryDBParameterGroup_update_tags (99.09s)
=== CONT  TestAccMemoryDBParameterGroup_basic
--- PASS: TestAccMemoryDBParameterGroup_basic (27.40s)
=== CONT  TestAccMemoryDBParameterGroupDataSource_basic
--- PASS: TestAccMemoryDBParameterGroupDataSource_basic (24.49s)
=== CONT  TestAccMemoryDBClusterDataSource_basic
--- PASS: TestAccMemoryDBSnapshotDataSource_basic (2250.57s)
=== CONT  TestAccMemoryDBCluster_basic
--- PASS: TestAccMemoryDBClusterDataSource_basic (1461.58s)
=== CONT  TestAccMemoryDBACL_update_tags
--- PASS: TestAccMemoryDBACL_update_tags (58.03s)
=== CONT  TestAccMemoryDBSubnetGroupDataSource_basic
--- PASS: TestAccMemoryDBSubnetGroupDataSource_basic (22.86s)
=== CONT  TestAccMemoryDBSubnetGroup_basic
--- PASS: TestAccMemoryDBSubnetGroup_basic (24.12s)
=== CONT  TestAccMemoryDBACL_basic
--- PASS: TestAccMemoryDBACL_basic (142.05s)
=== CONT  TestAccMemoryDBSnapshot_update_tags
--- PASS: TestAccMemoryDBCluster_basic (1648.41s)
=== CONT  TestAccMemoryDBSnapshot_basic
--- PASS: TestAccMemoryDBSnapshot_update_tags (2264.36s)
--- PASS: TestAccMemoryDBSnapshot_basic (2233.83s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/memorydb	6160.791s
=== RUN   TestAccMetaARNDataSource_basic
=== PAUSE TestAccMetaARNDataSource_basic
=== RUN   TestAccMetaBillingServiceAccountDataSource_basic
=== PAUSE TestAccMetaBillingServiceAccountDataSource_basic
=== RUN   TestAccMetaDefaultTagsDataSource_basic
=== PAUSE TestAccMetaDefaultTagsDataSource_basic
=== RUN   TestAccMetaIPRangesDataSource_basic
=== PAUSE TestAccMetaIPRangesDataSource_basic
=== RUN   TestAccMetaPartitionDataSource_basic
=== PAUSE TestAccMetaPartitionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_basic
=== PAUSE TestAccMetaRegionDataSource_basic
=== RUN   TestAccMetaRegionsDataSource_basic
=== PAUSE TestAccMetaRegionsDataSource_basic
=== RUN   TestAccMetaService_basic
=== PAUSE TestAccMetaService_basic
=== CONT  TestAccMetaARNDataSource_basic
=== CONT  TestAccMetaPartitionDataSource_basic
--- PASS: TestAccMetaPartitionDataSource_basic (23.79s)
=== CONT  TestAccMetaRegionDataSource_basic
--- PASS: TestAccMetaARNDataSource_basic (23.82s)
=== CONT  TestAccMetaService_basic
--- PASS: TestAccMetaRegionDataSource_basic (20.30s)
=== CONT  TestAccMetaDefaultTagsDataSource_basic
--- PASS: TestAccMetaService_basic (20.57s)
=== CONT  TestAccMetaIPRangesDataSource_basic
--- PASS: TestAccMetaDefaultTagsDataSource_basic (21.56s)
=== CONT  TestAccMetaBillingServiceAccountDataSource_basic
--- PASS: TestAccMetaIPRangesDataSource_basic (26.26s)
=== CONT  TestAccMetaRegionsDataSource_basic
--- PASS: TestAccMetaBillingServiceAccountDataSource_basic (17.64s)
--- PASS: TestAccMetaRegionsDataSource_basic (18.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	126.762s
=== RUN   TestAccMQBrokerDataSource_basic
=== PAUSE TestAccMQBrokerDataSource_basic
=== RUN   TestAccMQBrokerInstanceTypeOfferingsDataSource_basic
=== PAUSE TestAccMQBrokerInstanceTypeOfferingsDataSource_basic
=== RUN   TestAccMQBroker_basic
=== PAUSE TestAccMQBroker_basic
=== RUN   TestAccMQBroker_tags
=== PAUSE TestAccMQBroker_tags
=== RUN   TestAccMQBroker_RabbitMQ_basic
=== PAUSE TestAccMQBroker_RabbitMQ_basic
=== RUN   TestAccMQConfiguration_basic
=== PAUSE TestAccMQConfiguration_basic
=== RUN   TestAccMQConfiguration_tags
=== PAUSE TestAccMQConfiguration_tags
=== CONT  TestAccMQBrokerDataSource_basic
=== CONT  TestAccMQBroker_RabbitMQ_basic
--- PASS: TestAccMQBroker_RabbitMQ_basic (906.49s)
=== CONT  TestAccMQBroker_basic
--- PASS: TestAccMQBrokerDataSource_basic (1127.18s)
=== CONT  TestAccMQBroker_tags
--- PASS: TestAccMQBroker_basic (993.31s)
=== CONT  TestAccMQConfiguration_tags
--- PASS: TestAccMQConfiguration_tags (55.54s)
=== CONT  TestAccMQBrokerInstanceTypeOfferingsDataSource_basic
--- PASS: TestAccMQBrokerInstanceTypeOfferingsDataSource_basic (15.24s)
=== CONT  TestAccMQConfiguration_basic
--- PASS: TestAccMQConfiguration_basic (28.63s)
--- PASS: TestAccMQBroker_tags (1061.82s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mq	2202.645s
=== RUN   TestAccMWAAEnvironment_basic
=== PAUSE TestAccMWAAEnvironment_basic
=== CONT  TestAccMWAAEnvironment_basic
--- PASS: TestAccMWAAEnvironment_basic (3532.02s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mwaa	3542.413s
```
