### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin SDK resources `l*` (Phase 3c)

### DIFF
--- a/internal/service/lambda/service_package_gen.go
+++ b/internal/service/lambda/service_package_gen.go
@@ -69,6 +69,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceFunction,
 			TypeName: "aws_lambda_function",
+			Name:     "Function",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceFunctionEventInvokeConfig,

--- a/internal/service/licensemanager/license_configuration.go
+++ b/internal/service/licensemanager/license_configuration.go
@@ -17,9 +17,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_licensemanager_license_configuration")
+// @SDKResource("aws_licensemanager_license_configuration", name="License Configuration")
+// @Tags(identifierAttribute="id")
 func ResourceLicenseConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceLicenseConfigurationCreate,
@@ -72,8 +74,8 @@ func ResourceLicenseConfiguration() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -82,13 +84,12 @@ func ResourceLicenseConfiguration() *schema.Resource {
 
 func resourceLicenseConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).LicenseManagerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &licensemanager.CreateLicenseConfigurationInput{
 		LicenseCountingType: aws.String(d.Get("license_counting_type").(string)),
 		Name:                aws.String(name),
+		Tags:                GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -107,10 +108,6 @@ func resourceLicenseConfigurationCreate(ctx context.Context, d *schema.ResourceD
 		input.LicenseRules = flex.ExpandStringList(v.([]interface{}))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
 	log.Printf("[DEBUG] Creating License Manager License Configuration: %s", input)
 	resp, err := conn.CreateLicenseConfigurationWithContext(ctx, input)
 
@@ -125,8 +122,6 @@ func resourceLicenseConfigurationCreate(ctx context.Context, d *schema.ResourceD
 
 func resourceLicenseConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).LicenseManagerConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	output, err := FindLicenseConfigurationByARN(ctx, conn, d.Id())
 
@@ -149,16 +144,7 @@ func resourceLicenseConfigurationRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("name", output.Name)
 	d.Set("owner_account_id", output.OwnerAccountId)
 
-	tags := KeyValueTags(ctx, output.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, output.Tags)
 
 	return nil
 }
@@ -183,14 +169,6 @@ func resourceLicenseConfigurationUpdate(ctx context.Context, d *schema.ResourceD
 
 		if err != nil {
 			return diag.Errorf("updating License Manager License Configuration (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return diag.Errorf("updating License Manager License Configuration (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/licensemanager/service_package_gen.go
+++ b/internal/service/licensemanager/service_package_gen.go
@@ -53,6 +53,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceLicenseConfiguration,
 			TypeName: "aws_licensemanager_license_configuration",
+			Name:     "License Configuration",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }

--- a/internal/service/lightsail/bucket.go
+++ b/internal/service/lightsail/bucket.go
@@ -17,7 +17,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_lightsail_bucket")
+// @SDKResource("aws_lightsail_bucket", name="Bucket")
+// @Tags(identifierAttribute="id")
 func ResourceBucket() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketCreate,
@@ -58,8 +59,8 @@ func ResourceBucket() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"url": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -71,16 +72,11 @@ func ResourceBucket() *schema.Resource {
 
 func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).LightsailConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	in := lightsail.CreateBucketInput{
 		BucketName: aws.String(d.Get("name").(string)),
 		BundleId:   aws.String(d.Get("bundle_id").(string)),
-	}
-
-	if len(tags) > 0 {
-		in.Tags = Tags(tags.IgnoreAWS())
+		Tags:       GetTagsIn(ctx),
 	}
 
 	out, err := conn.CreateBucketWithContext(ctx, &in)
@@ -103,8 +99,6 @@ func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).LightsailConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	out, err := FindBucketById(ctx, conn, d.Id())
 
@@ -127,38 +121,13 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("support_code", out.SupportCode)
 	d.Set("url", out.Url)
 
-	tags := KeyValueTags(ctx, out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionReading, ResBucket, d.Id(), err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionReading, ResBucket, d.Id(), err)
-	}
+	SetTagsOut(ctx, out.Tags)
 
 	return nil
 }
 
 func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).LightsailConn()
-
-	if d.HasChange("tags") {
-		o, n := d.GetChange("tags")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return create.DiagError(names.Lightsail, create.ErrActionUpdating, ResBucket, d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return create.DiagError(names.Lightsail, create.ErrActionUpdating, ResBucket, d.Id(), err)
-		}
-	}
 
 	if d.HasChange("bundle_id") {
 		in := lightsail.UpdateBucketBundleInput{

--- a/internal/service/lightsail/distribution.go
+++ b/internal/service/lightsail/distribution.go
@@ -22,7 +22,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_lightsail_distribution")
+// @SDKResource("aws_lightsail_distribution", name="Distribution")
+// @Tags(identifierAttribute="id")
 func ResourceDistribution() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDistributionCreate,
@@ -308,8 +309,8 @@ func ResourceDistribution() *schema.Resource {
 				Computed:    true,
 				Description: "The support code. Include this code in your email to support when you have questions about your Lightsail distribution. This code enables our support team to look up your Lightsail information more easily.",
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -328,6 +329,7 @@ func resourceDistributionCreate(ctx context.Context, d *schema.ResourceData, met
 		DefaultCacheBehavior: expandCacheBehavior(d.Get("default_cache_behavior").([]interface{})[0].(map[string]interface{})),
 		DistributionName:     aws.String(d.Get("name").(string)),
 		Origin:               expandInputOrigin(d.Get("origin").([]interface{})[0].(map[string]interface{})),
+		Tags:                 GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("cache_behavior_settings"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
@@ -340,13 +342,6 @@ func resourceDistributionCreate(ctx context.Context, d *schema.ResourceData, met
 
 	if v, ok := d.GetOk("ip_address_type"); ok {
 		in.IpAddressType = aws.String(v.(string))
-	}
-
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
-
-	if len(tags) > 0 {
-		in.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	out, err := conn.CreateDistributionWithContext(ctx, in)
@@ -441,18 +436,7 @@ func resourceDistributionRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("status", out.Status)
 	d.Set("support_code", out.SupportCode)
 
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-
-	tags := KeyValueTags(ctx, out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionSetting, ResNameDistribution, d.Id(), err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return create.DiagError(names.Lightsail, create.ErrActionSetting, ResNameDistribution, d.Id(), err)
-	}
+	SetTagsOut(ctx, out.Tags)
 
 	return nil
 }

--- a/internal/service/lightsail/service_package_gen.go
+++ b/internal/service/lightsail/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceBucket,
 			TypeName: "aws_lightsail_bucket",
+			Name:     "Bucket",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceBucketAccessKey,
@@ -40,10 +44,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCertificate,
 			TypeName: "aws_lightsail_certificate",
+			Name:     "Certificate",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceContainerService,
 			TypeName: "aws_lightsail_container_service",
+			Name:     "Container Service",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceContainerServiceDeploymentVersion,
@@ -52,10 +64,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDatabase,
 			TypeName: "aws_lightsail_database",
+			Name:     "Database",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceDisk,
 			TypeName: "aws_lightsail_disk",
+			Name:     "Disk",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceDiskAttachment,
@@ -64,6 +84,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDistribution,
 			TypeName: "aws_lightsail_distribution",
+			Name:     "Distribution",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceDomain,
@@ -76,6 +100,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceInstance,
 			TypeName: "aws_lightsail_instance",
+			Name:     "Instance",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceInstancePublicPorts,
@@ -88,6 +116,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceLoadBalancer,
 			TypeName: "aws_lightsail_lb",
+			Name:     "LB",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceLoadBalancerAttachment,

--- a/internal/service/location/place_index.go
+++ b/internal/service/location/place_index.go
@@ -15,9 +15,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_location_place_index")
+// @SDKResource("aws_location_place_index", name="Map")
+// @Tags(identifierAttribute="index_arn")
 func ResourcePlaceIndex() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePlaceIndexCreate,
@@ -72,8 +74,8 @@ func ResourcePlaceIndex() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 		CustomizeDiff: verify.SetTagsDiff,
 	}
@@ -82,10 +84,10 @@ func ResourcePlaceIndex() *schema.Resource {
 func resourcePlaceIndexCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LocationConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
-	input := &locationservice.CreatePlaceIndexInput{}
+	input := &locationservice.CreatePlaceIndexInput{
+		Tags: GetTagsIn(ctx),
+	}
 
 	if v, ok := d.GetOk("data_source"); ok {
 		input.DataSource = aws.String(v.(string))
@@ -101,10 +103,6 @@ func resourcePlaceIndexCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	if v, ok := d.GetOk("index_name"); ok {
 		input.IndexName = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	output, err := conn.CreatePlaceIndexWithContext(ctx, input)
@@ -125,8 +123,6 @@ func resourcePlaceIndexCreate(ctx context.Context, d *schema.ResourceData, meta 
 func resourcePlaceIndexRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LocationConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	input := &locationservice.DescribePlaceIndexInput{
 		IndexName: aws.String(d.Id()),
@@ -161,15 +157,7 @@ func resourcePlaceIndexRead(ctx context.Context, d *schema.ResourceData, meta in
 	d.Set("index_arn", output.IndexArn)
 	d.Set("index_name", output.IndexName)
 
-	tags := KeyValueTags(ctx, output.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, output.Tags)
 
 	d.Set("update_time", aws.TimeValue(output.UpdateTime).Format(time.RFC3339))
 
@@ -199,14 +187,6 @@ func resourcePlaceIndexUpdate(ctx context.Context, d *schema.ResourceData, meta 
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Location Service Place Index (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("index_arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags for Location Service Place Index (%s): %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/location/service_package_gen.go
+++ b/internal/service/location/service_package_gen.go
@@ -57,22 +57,42 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceGeofenceCollection,
 			TypeName: "aws_location_geofence_collection",
+			Name:     "Geofence Collection",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "collection_arn",
+			},
 		},
 		{
 			Factory:  ResourceMap,
 			TypeName: "aws_location_map",
+			Name:     "Map",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "map_arn",
+			},
 		},
 		{
 			Factory:  ResourcePlaceIndex,
 			TypeName: "aws_location_place_index",
+			Name:     "Map",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "index_arn",
+			},
 		},
 		{
 			Factory:  ResourceRouteCalculator,
 			TypeName: "aws_location_route_calculator",
+			Name:     "Route Calculator",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "calculator_arn",
+			},
 		},
 		{
 			Factory:  ResourceTracker,
 			TypeName: "aws_location_tracker",
+			Name:     "Route Calculator",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "tracker_arn",
+			},
 		},
 		{
 			Factory:  ResourceTrackerAssociation,

--- a/internal/service/location/tracker.go
+++ b/internal/service/location/tracker.go
@@ -15,9 +15,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_location_tracker")
+// @SDKResource("aws_location_tracker", name="Route Calculator")
+// @Tags(identifierAttribute="tracker_arn")
 func ResourceTracker() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTrackerCreate,
@@ -49,8 +51,8 @@ func ResourceTracker() *schema.Resource {
 				Default:      locationservice.PositionFilteringTimeBased,
 				ValidateFunc: validation.StringInSlice(locationservice.PositionFiltering_Values(), false),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"tracker_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -72,10 +74,10 @@ func ResourceTracker() *schema.Resource {
 func resourceTrackerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LocationConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
-	input := &locationservice.CreateTrackerInput{}
+	input := &locationservice.CreateTrackerInput{
+		Tags: GetTagsIn(ctx),
+	}
 
 	if v, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(v.(string))
@@ -87,10 +89,6 @@ func resourceTrackerCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	if v, ok := d.GetOk("position_filtering"); ok {
 		input.PositionFiltering = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	if v, ok := d.GetOk("tracker_name"); ok {
@@ -115,8 +113,6 @@ func resourceTrackerCreate(ctx context.Context, d *schema.ResourceData, meta int
 func resourceTrackerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LocationConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	input := &locationservice.DescribeTrackerInput{
 		TrackerName: aws.String(d.Id()),
@@ -143,15 +139,7 @@ func resourceTrackerRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("kms_key_id", output.KmsKeyId)
 	d.Set("position_filtering", output.PositionFiltering)
 
-	tags := KeyValueTags(ctx, output.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, output.Tags)
 
 	d.Set("tracker_arn", output.TrackerArn)
 	d.Set("tracker_name", output.TrackerName)
@@ -181,14 +169,6 @@ func resourceTrackerUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Location Service Tracker (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("tracker_arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags for Location Service Tracker (%s): %s", d.Id(), err)
 		}
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin SDK.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30421.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30430.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30449.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30454.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30461.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30463.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30476.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30477.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30478.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30483.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30484.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30491.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30509.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30510.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=l... ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/l.../... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccLakeFormationResourceDataSource_basic
=== PAUSE TestAccLakeFormationResourceDataSource_basic
=== RUN   TestAccLakeFormationResource_basic
=== PAUSE TestAccLakeFormationResource_basic
=== CONT  TestAccLakeFormationResourceDataSource_basic
=== CONT  TestAccLakeFormationResource_basic
--- PASS: TestAccLakeFormationResource_basic (34.08s)
--- PASS: TestAccLakeFormationResourceDataSource_basic (37.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation	50.878s
=== RUN   TestAccLambdaAliasDataSource_basic
=== PAUSE TestAccLambdaAliasDataSource_basic
=== RUN   TestAccLambdaAlias_basic
=== PAUSE TestAccLambdaAlias_basic
=== RUN   TestAccLambdaCodeSigningConfigDataSource_basic
=== PAUSE TestAccLambdaCodeSigningConfigDataSource_basic
=== RUN   TestAccLambdaCodeSigningConfig_basic
=== PAUSE TestAccLambdaCodeSigningConfig_basic
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_basic
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_basic
=== RUN   TestAccLambdaEventSourceMapping_SQS_basic
=== PAUSE TestAccLambdaEventSourceMapping_SQS_basic
=== RUN   TestAccLambdaEventSourceMapping_DynamoDB_basic
=== PAUSE TestAccLambdaEventSourceMapping_DynamoDB_basic
=== RUN   TestAccLambdaFunctionDataSource_basic
=== PAUSE TestAccLambdaFunctionDataSource_basic
=== RUN   TestAccLambdaFunctionEventInvokeConfig_basic
=== PAUSE TestAccLambdaFunctionEventInvokeConfig_basic
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== RUN   TestAccLambdaFunction_tags
=== PAUSE TestAccLambdaFunction_tags
=== RUN   TestAccLambdaFunction_S3Update_basic
=== PAUSE TestAccLambdaFunction_S3Update_basic
=== RUN   TestAccLambdaFunctionURLDataSource_basic
=== PAUSE TestAccLambdaFunctionURLDataSource_basic
=== RUN   TestAccLambdaFunctionURL_basic
=== PAUSE TestAccLambdaFunctionURL_basic
=== RUN   TestAccLambdaFunctionsDataSource_basic
=== PAUSE TestAccLambdaFunctionsDataSource_basic
=== RUN   TestAccLambdaInvocationDataSource_basic
=== PAUSE TestAccLambdaInvocationDataSource_basic
=== RUN   TestAccLambdaInvocation_basic
=== PAUSE TestAccLambdaInvocation_basic
=== RUN   TestAccLambdaLayerVersionDataSource_basic
=== PAUSE TestAccLambdaLayerVersionDataSource_basic
=== RUN   TestAccLambdaLayerVersion_basic
=== PAUSE TestAccLambdaLayerVersion_basic
=== RUN   TestAccLambdaPermission_basic
=== PAUSE TestAccLambdaPermission_basic
=== RUN   TestAccLambdaProvisionedConcurrencyConfig_basic
=== PAUSE TestAccLambdaProvisionedConcurrencyConfig_basic
=== CONT  TestAccLambdaAliasDataSource_basic
=== CONT  TestAccLambdaFunction_S3Update_basic
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_basic
=== CONT  TestAccLambdaFunction_S3Update_basic
    function_test.go:1928: Step 1/3 error: Error running apply: exit status 1
        
        Error: error creating S3 bucket ACL for tf-acc-test-813466319680070139: AccessControlListNotSupported: The bucket does not allow ACLs
        	status code: 400, request id: WYBJH0GPJ4MMRSXY, host id: DhQ77g/XA4k3Dzwzj3sSkCZDJEP+ai2gAN/e+CbfjhEI1GiPGxPNUAv2gJQ06/BPxGcZjLZ8Lmk=
        
          with aws_s3_bucket_acl.artifacts,
          on terraform_plugin_test.tf line 7, in resource "aws_s3_bucket_acl" "artifacts":
           7: resource "aws_s3_bucket_acl" "artifacts" {
        
--- FAIL: TestAccLambdaFunction_S3Update_basic (61.01s)
=== CONT  TestAccLambdaCodeSigningConfig_basic
--- PASS: TestAccLambdaAliasDataSource_basic (99.10s)
=== CONT  TestAccLambdaEventSourceMapping_DynamoDB_basic
--- PASS: TestAccLambdaCodeSigningConfig_basic (88.46s)
=== CONT  TestAccLambdaEventSourceMapping_SQS_basic
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_basic (204.95s)
=== CONT  TestAccLambdaInvocation_basic
--- PASS: TestAccLambdaEventSourceMapping_DynamoDB_basic (112.52s)
=== CONT  TestAccLambdaProvisionedConcurrencyConfig_basic
--- PASS: TestAccLambdaInvocation_basic (80.24s)
=== CONT  TestAccLambdaPermission_basic
--- PASS: TestAccLambdaEventSourceMapping_SQS_basic (215.54s)
=== CONT  TestAccLambdaLayerVersion_basic
--- PASS: TestAccLambdaPermission_basic (88.18s)
=== CONT  TestAccLambdaLayerVersionDataSource_basic
--- PASS: TestAccLambdaLayerVersion_basic (66.61s)
=== CONT  TestAccLambdaCodeSigningConfigDataSource_basic
--- PASS: TestAccLambdaLayerVersionDataSource_basic (60.26s)
=== CONT  TestAccLambdaAlias_basic
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_basic (249.93s)
=== CONT  TestAccLambdaFunction_basic
--- PASS: TestAccLambdaCodeSigningConfigDataSource_basic (47.06s)
=== CONT  TestAccLambdaFunction_tags
--- PASS: TestAccLambdaFunction_basic (57.79s)
=== CONT  TestAccLambdaFunctionsDataSource_basic
--- PASS: TestAccLambdaAlias_basic (87.46s)
=== CONT  TestAccLambdaInvocationDataSource_basic
--- PASS: TestAccLambdaFunctionsDataSource_basic (40.28s)
=== CONT  TestAccLambdaFunctionURL_basic
--- PASS: TestAccLambdaFunction_tags (93.51s)
=== CONT  TestAccLambdaFunctionURLDataSource_basic
--- PASS: TestAccLambdaInvocationDataSource_basic (52.13s)
=== CONT  TestAccLambdaFunctionEventInvokeConfig_basic
--- PASS: TestAccLambdaFunctionURL_basic (44.29s)
=== CONT  TestAccLambdaFunctionDataSource_basic
--- PASS: TestAccLambdaFunctionURLDataSource_basic (37.47s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_basic (44.17s)
--- PASS: TestAccLambdaFunctionDataSource_basic (46.44s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	691.243s
=== RUN   TestAccLexModelsBotAlias_basic
=== PAUSE TestAccLexModelsBotAlias_basic
=== RUN   TestAccLexModelsBotDataSource_basic
=== PAUSE TestAccLexModelsBotDataSource_basic
=== RUN   TestAccLexModelsBot_basic
=== PAUSE TestAccLexModelsBot_basic
=== RUN   TestAccLexModelsIntentDataSource_basic
=== PAUSE TestAccLexModelsIntentDataSource_basic
=== RUN   TestAccLexModelsIntent_basic
=== PAUSE TestAccLexModelsIntent_basic
=== RUN   TestAccLexModelsSlotTypeDataSource_basic
=== PAUSE TestAccLexModelsSlotTypeDataSource_basic
=== RUN   TestAccLexModelsSlotType_basic
=== PAUSE TestAccLexModelsSlotType_basic
=== CONT  TestAccLexModelsBotAlias_basic
=== CONT  TestAccLexModelsIntent_basic
=== CONT  TestAccLexModelsBot_basic
=== CONT  TestAccLexModelsIntent_basic
    intent_test.go:28: Step 1/2 error: Check failed: 8 errors occurred:
        	* Check 5/19 error: aws_lex_intent.test: list or set attribute 'conclusion_statement' must be checked by element count key (conclusion_statement.#) or element value keys (e.g. conclusion_statement.0). Set element value checks should use TestCheckTypeSet functions instead.
        	* Check 6/19 error: aws_lex_intent.test: list or set attribute 'confirmation_prompt' must be checked by element count key (confirmation_prompt.#) or element value keys (e.g. confirmation_prompt.0). Set element value checks should use TestCheckTypeSet functions instead.
        	* Check 10/19 error: aws_lex_intent.test: list or set attribute 'dialog_code_hook' must be checked by element count key (dialog_code_hook.#) or element value keys (e.g. dialog_code_hook.0). Set element value checks should use TestCheckTypeSet functions instead.
        	* Check 11/19 error: aws_lex_intent.test: list or set attribute 'follow_up_prompt' must be checked by element count key (follow_up_prompt.#) or element value keys (e.g. follow_up_prompt.0). Set element value checks should use TestCheckTypeSet functions instead.
        	* Check 12/19 error: aws_lex_intent.test: list or set attribute 'fulfillment_activity' must be checked by element count key (fulfillment_activity.#) or element value keys (e.g. fulfillment_activity.0). Set element value checks should use TestCheckTypeSet functions instead.
        	* Check 15/19 error: aws_lex_intent.test: Attribute 'parent_intent_signature' found when not expected
        	* Check 16/19 error: aws_lex_intent.test: list or set attribute 'rejection_statement' must be checked by element count key (rejection_statement.#) or element value keys (e.g. rejection_statement.0). Set element value checks should use TestCheckTypeSet functions instead.
        	* Check 18/19 error: aws_lex_intent.test: list or set attribute 'slot' must be checked by element count key (slot.#) or element value keys (e.g. slot.0). Set element value checks should use TestCheckTypeSet functions instead.
        
=== CONT  TestAccLexModelsBot_basic
    bot_test.go:35: Step 1/2 error: Check failed: 4 errors occurred:
        	* Check 3/23 error: aws_lex_bot.test: list or set attribute 'abort_statement' must be checked by element count key (abort_statement.#) or element value keys (e.g. abort_statement.0). Set element value checks should use TestCheckTypeSet functions instead.
        	* Check 7/23 error: aws_lex_bot.test: list or set attribute 'clarification_prompt' must be checked by element count key (clarification_prompt.#) or element value keys (e.g. clarification_prompt.0). Set element value checks should use TestCheckTypeSet functions instead.
        	* Check 15/23 error: aws_lex_bot.test: list or set attribute 'intent' must be checked by element count key (intent.#) or element value keys (e.g. intent.0). Set element value checks should use TestCheckTypeSet functions instead.
        	* Check 23/23 error: aws_lex_bot.test: Attribute 'voice_id' found when not expected
        
--- FAIL: TestAccLexModelsIntent_basic (44.51s)
=== CONT  TestAccLexModelsIntentDataSource_basic
--- FAIL: TestAccLexModelsBot_basic (45.96s)
=== CONT  TestAccLexModelsSlotType_basic
--- PASS: TestAccLexModelsBotAlias_basic (99.86s)
=== CONT  TestAccLexModelsSlotTypeDataSource_basic
--- PASS: TestAccLexModelsIntentDataSource_basic (79.26s)
=== CONT  TestAccLexModelsBotDataSource_basic
--- PASS: TestAccLexModelsSlotType_basic (96.03s)
--- PASS: TestAccLexModelsSlotTypeDataSource_basic (70.62s)
--- PASS: TestAccLexModelsBotDataSource_basic (62.94s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/lexmodels	205.131s
=== RUN   TestAccLicenseManagerAssociation_basic
=== PAUSE TestAccLicenseManagerAssociation_basic
=== RUN   TestAccLicenseManagerLicenseConfiguration_basic
=== PAUSE TestAccLicenseManagerLicenseConfiguration_basic
=== RUN   TestAccLicenseManagerLicenseConfiguration_tags
=== PAUSE TestAccLicenseManagerLicenseConfiguration_tags
=== RUN   TestAccLicenseManagerReceivedLicenseDataSource_basic
    received_license_data_source_test.go:16: skipping test; environment variable TF_AWS_LICENSE_MANAGER_GRANT_LICENSE_ARN must be set. Usage: ARN for a license imported into the current account.
--- SKIP: TestAccLicenseManagerReceivedLicenseDataSource_basic (0.00s)
=== RUN   TestAccLicenseManagerReceivedLicensesDataSource_basic
    received_licenses_data_source_test.go:16: skipping test; environment variable TF_AWS_LICENSE_MANAGER_GRANT_LICENSE_ARN must be set. Usage: ARN for a license imported into the current account.
--- SKIP: TestAccLicenseManagerReceivedLicensesDataSource_basic (0.00s)
=== CONT  TestAccLicenseManagerAssociation_basic
=== CONT  TestAccLicenseManagerLicenseConfiguration_tags
=== CONT  TestAccLicenseManagerLicenseConfiguration_basic
--- PASS: TestAccLicenseManagerLicenseConfiguration_basic (87.40s)
--- PASS: TestAccLicenseManagerAssociation_basic (171.37s)
--- PASS: TestAccLicenseManagerLicenseConfiguration_tags (196.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/licensemanager	205.919s
=== RUN   TestAccLightsailBucketAccessKey_basic
=== PAUSE TestAccLightsailBucketAccessKey_basic
=== RUN   TestAccLightsailBucketResourceAccess_basic
=== PAUSE TestAccLightsailBucketResourceAccess_basic
=== RUN   TestAccLightsailBucket_basic
=== PAUSE TestAccLightsailBucket_basic
=== RUN   TestAccLightsailBucket_tags
=== PAUSE TestAccLightsailBucket_tags
=== RUN   TestAccLightsailCertificate_basic
=== PAUSE TestAccLightsailCertificate_basic
=== RUN   TestAccLightsailCertificate_tags
=== PAUSE TestAccLightsailCertificate_tags
=== RUN   TestAccLightsailContainerService_basic
=== PAUSE TestAccLightsailContainerService_basic
=== RUN   TestAccLightsailContainerService_tags
=== PAUSE TestAccLightsailContainerService_tags
=== RUN   TestAccLightsailDatabase_basic
=== PAUSE TestAccLightsailDatabase_basic
=== RUN   TestAccLightsailDatabase_tags
=== PAUSE TestAccLightsailDatabase_tags
=== RUN   TestAccLightsailDiskAttachment_basic
=== PAUSE TestAccLightsailDiskAttachment_basic
=== RUN   TestAccLightsailDisk_basic
=== PAUSE TestAccLightsailDisk_basic
=== RUN   TestAccLightsailDomainEntry_basic
=== PAUSE TestAccLightsailDomainEntry_basic
=== RUN   TestAccLightsailDomain_basic
=== PAUSE TestAccLightsailDomain_basic
=== RUN   TestAccLightsailInstancePublicPorts_basic
=== PAUSE TestAccLightsailInstancePublicPorts_basic
=== RUN   TestAccLightsailInstance_basic
=== PAUSE TestAccLightsailInstance_basic
=== RUN   TestAccLightsailInstance_tags
=== PAUSE TestAccLightsailInstance_tags
=== RUN   TestAccLightsailKeyPair_basic
=== PAUSE TestAccLightsailKeyPair_basic
=== RUN   TestAccLightsailStaticIPAttachment_basic
=== PAUSE TestAccLightsailStaticIPAttachment_basic
=== RUN   TestAccLightsailStaticIP_basic
=== PAUSE TestAccLightsailStaticIP_basic
=== CONT  TestAccLightsailBucketAccessKey_basic
=== CONT  TestAccLightsailDisk_basic
=== CONT  TestAccLightsailStaticIP_basic
--- PASS: TestAccLightsailStaticIP_basic (80.39s)
=== CONT  TestAccLightsailStaticIPAttachment_basic
--- PASS: TestAccLightsailBucketAccessKey_basic (126.07s)
=== CONT  TestAccLightsailKeyPair_basic
--- PASS: TestAccLightsailDisk_basic (143.52s)
=== CONT  TestAccLightsailInstance_tags
--- PASS: TestAccLightsailKeyPair_basic (67.92s)
=== CONT  TestAccLightsailInstance_basic
--- PASS: TestAccLightsailStaticIPAttachment_basic (134.76s)
=== CONT  TestAccLightsailInstancePublicPorts_basic
--- PASS: TestAccLightsailInstance_tags (124.52s)
=== CONT  TestAccLightsailDomain_basic
    acctest.go:834: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccLightsailDomain_basic (0.00s)
=== CONT  TestAccLightsailBucket_basic
--- PASS: TestAccLightsailInstance_basic (99.67s)
=== CONT  TestAccLightsailDomainEntry_basic
    acctest.go:834: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccLightsailDomainEntry_basic (0.00s)
=== CONT  TestAccLightsailContainerService_basic
--- PASS: TestAccLightsailInstancePublicPorts_basic (94.01s)
=== CONT  TestAccLightsailDiskAttachment_basic
--- PASS: TestAccLightsailBucket_basic (82.40s)
=== CONT  TestAccLightsailDatabase_tags
--- PASS: TestAccLightsailContainerService_basic (187.65s)
=== CONT  TestAccLightsailDatabase_basic
--- PASS: TestAccLightsailDiskAttachment_basic (259.44s)
=== CONT  TestAccLightsailContainerService_tags
--- PASS: TestAccLightsailContainerService_tags (114.01s)
=== CONT  TestAccLightsailCertificate_basic
--- PASS: TestAccLightsailCertificate_basic (55.14s)
=== CONT  TestAccLightsailCertificate_tags
--- PASS: TestAccLightsailCertificate_tags (96.00s)
=== CONT  TestAccLightsailBucket_tags
--- PASS: TestAccLightsailBucket_tags (66.11s)
=== CONT  TestAccLightsailBucketResourceAccess_basic
--- PASS: TestAccLightsailBucketResourceAccess_basic (70.73s)
--- PASS: TestAccLightsailDatabase_basic (761.30s)
--- PASS: TestAccLightsailDatabase_tags (999.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lightsail	1378.354s
=== RUN   TestAccLocationGeofenceCollectionDataSource_basic
=== PAUSE TestAccLocationGeofenceCollectionDataSource_basic
=== RUN   TestAccLocationGeofenceCollection_basic
=== PAUSE TestAccLocationGeofenceCollection_basic
=== RUN   TestAccLocationGeofenceCollection_tags
=== PAUSE TestAccLocationGeofenceCollection_tags
=== RUN   TestAccLocationMap_basic
=== PAUSE TestAccLocationMap_basic
=== RUN   TestAccLocationMap_tags
=== PAUSE TestAccLocationMap_tags
=== RUN   TestAccLocationPlaceIndex_basic
=== PAUSE TestAccLocationPlaceIndex_basic
=== RUN   TestAccLocationPlaceIndex_tags
=== PAUSE TestAccLocationPlaceIndex_tags
=== RUN   TestAccLocationRouteCalculatorDataSource_basic
=== PAUSE TestAccLocationRouteCalculatorDataSource_basic
=== RUN   TestAccLocationRouteCalculator_basic
=== PAUSE TestAccLocationRouteCalculator_basic
=== RUN   TestAccLocationRouteCalculator_tags
=== PAUSE TestAccLocationRouteCalculator_tags
=== RUN   TestAccLocationTrackerAssociationDataSource_basic
=== PAUSE TestAccLocationTrackerAssociationDataSource_basic
=== RUN   TestAccLocationTrackerAssociation_basic
=== PAUSE TestAccLocationTrackerAssociation_basic
=== RUN   TestAccLocationTrackerAssociationsDataSource_basic
=== PAUSE TestAccLocationTrackerAssociationsDataSource_basic
=== RUN   TestAccLocationTracker_basic
=== PAUSE TestAccLocationTracker_basic
=== RUN   TestAccLocationTracker_tags
=== PAUSE TestAccLocationTracker_tags
=== CONT  TestAccLocationGeofenceCollectionDataSource_basic
=== CONT  TestAccLocationTrackerAssociationsDataSource_basic
=== CONT  TestAccLocationRouteCalculator_basic
--- PASS: TestAccLocationGeofenceCollectionDataSource_basic (76.67s)
=== CONT  TestAccLocationTrackerAssociation_basic
--- PASS: TestAccLocationTrackerAssociationsDataSource_basic (77.50s)
=== CONT  TestAccLocationTrackerAssociationDataSource_basic
--- PASS: TestAccLocationRouteCalculator_basic (94.96s)
=== CONT  TestAccLocationRouteCalculator_tags
--- PASS: TestAccLocationTrackerAssociationDataSource_basic (67.98s)
=== CONT  TestAccLocationMap_tags
--- PASS: TestAccLocationTrackerAssociation_basic (78.59s)
=== CONT  TestAccLocationRouteCalculatorDataSource_basic
--- PASS: TestAccLocationRouteCalculatorDataSource_basic (42.61s)
=== CONT  TestAccLocationPlaceIndex_tags
--- PASS: TestAccLocationRouteCalculator_tags (142.53s)
=== CONT  TestAccLocationPlaceIndex_basic
--- PASS: TestAccLocationMap_tags (133.44s)
=== CONT  TestAccLocationGeofenceCollection_tags
--- PASS: TestAccLocationPlaceIndex_basic (69.56s)
=== CONT  TestAccLocationMap_basic
=== CONT  TestAccLocationTracker_tags
--- PASS: TestAccLocationPlaceIndex_tags (147.72s)
--- PASS: TestAccLocationMap_basic (62.24s)
=== CONT  TestAccLocationGeofenceCollection_basic
--- PASS: TestAccLocationGeofenceCollection_tags (152.49s)
=== CONT  TestAccLocationTracker_basic
--- PASS: TestAccLocationGeofenceCollection_basic (67.45s)
--- PASS: TestAccLocationTracker_basic (51.03s)
--- PASS: TestAccLocationTracker_tags (139.59s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/location	537.104s
=== RUN   TestAccLogsDataProtectionPolicyDocumentDataSource_basic
=== PAUSE TestAccLogsDataProtectionPolicyDocumentDataSource_basic
=== RUN   TestAccLogsDataProtectionPolicy_basic
=== PAUSE TestAccLogsDataProtectionPolicy_basic
=== RUN   TestAccLogsDestinationPolicy_basic
=== PAUSE TestAccLogsDestinationPolicy_basic
=== RUN   TestAccLogsDestination_basic
=== PAUSE TestAccLogsDestination_basic
=== RUN   TestAccLogsDestination_tags
=== PAUSE TestAccLogsDestination_tags
=== RUN   TestAccLogsGroupDataSource_basic
=== PAUSE TestAccLogsGroupDataSource_basic
=== RUN   TestAccLogsGroup_basic
=== PAUSE TestAccLogsGroup_basic
=== RUN   TestAccLogsGroup_tags
=== PAUSE TestAccLogsGroup_tags
=== RUN   TestAccLogsGroupsDataSource_basic
=== PAUSE TestAccLogsGroupsDataSource_basic
=== RUN   TestAccLogsMetricFilter_basic
=== PAUSE TestAccLogsMetricFilter_basic
=== RUN   TestAccLogsQueryDefinition_basic
=== PAUSE TestAccLogsQueryDefinition_basic
=== RUN   TestAccLogsResourcePolicy_basic
=== PAUSE TestAccLogsResourcePolicy_basic
=== RUN   TestAccLogsStream_basic
=== PAUSE TestAccLogsStream_basic
=== RUN   TestAccLogsSubscriptionFilter_basic
=== PAUSE TestAccLogsSubscriptionFilter_basic
=== CONT  TestAccLogsDataProtectionPolicyDocumentDataSource_basic
=== CONT  TestAccLogsGroup_tags
=== CONT  TestAccLogsDestination_tags
--- PASS: TestAccLogsGroup_tags (172.31s)
=== CONT  TestAccLogsResourcePolicy_basic
--- PASS: TestAccLogsDataProtectionPolicyDocumentDataSource_basic (182.87s)
=== CONT  TestAccLogsSubscriptionFilter_basic
--- PASS: TestAccLogsDestination_tags (199.81s)
=== CONT  TestAccLogsStream_basic
--- PASS: TestAccLogsStream_basic (64.44s)
=== CONT  TestAccLogsMetricFilter_basic
--- PASS: TestAccLogsResourcePolicy_basic (99.44s)
=== CONT  TestAccLogsQueryDefinition_basic
--- PASS: TestAccLogsSubscriptionFilter_basic (91.67s)
=== CONT  TestAccLogsGroup_basic
--- PASS: TestAccLogsMetricFilter_basic (61.51s)
=== CONT  TestAccLogsGroupDataSource_basic
--- PASS: TestAccLogsQueryDefinition_basic (60.73s)
=== CONT  TestAccLogsDestinationPolicy_basic
--- PASS: TestAccLogsGroup_basic (68.78s)
=== CONT  TestAccLogsDestination_basic
--- PASS: TestAccLogsGroupDataSource_basic (53.26s)
=== CONT  TestAccLogsGroupsDataSource_basic
--- PASS: TestAccLogsGroupsDataSource_basic (56.55s)
=== CONT  TestAccLogsDataProtectionPolicy_basic
--- PASS: TestAccLogsDestination_basic (111.10s)
--- PASS: TestAccLogsDestinationPolicy_basic (144.20s)
--- PASS: TestAccLogsDataProtectionPolicy_basic (50.49s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	548.544s
FAIL
make: *** [testacc] Error 1
```
