### PR TITLE
Sweepers: Add Custom Routing Accelerator and VPC Lattice sweepers

### DIFF
--- a/internal/service/vpclattice/service.go
+++ b/internal/service/vpclattice/service.go
@@ -202,7 +202,7 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 func resourceServiceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).VPCLatticeClient()
 
-	log.Printf("[INFO] Deleting VPCLattice Service: %s", d.Id())
+	log.Printf("[INFO] Deleting VPC Lattice Service: %s", d.Id())
 	_, err := conn.DeleteService(ctx, &vpclattice.DeleteServiceInput{
 		ServiceIdentifier: aws.String(d.Id()),
 	})

--- a/internal/service/vpclattice/service_network.go
+++ b/internal/service/vpclattice/service_network.go
@@ -138,8 +138,7 @@ func resourceServiceNetworkUpdate(ctx context.Context, d *schema.ResourceData, m
 func resourceServiceNetworkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).VPCLatticeClient()
 
-	log.Printf("[INFO] Deleting VPCLattice ServiceNetwork %s", d.Id())
-
+	log.Printf("[INFO] Deleting VPC Lattice Service Network: %s", d.Id())
 	_, err := conn.DeleteServiceNetwork(ctx, &vpclattice.DeleteServiceNetworkInput{
 		ServiceNetworkIdentifier: aws.String(d.Id()),
 	})

--- a/internal/service/vpclattice/sweep.go
+++ b/internal/service/vpclattice/sweep.go
@@ -19,6 +19,14 @@ func init() {
 		Name: "aws_vpclattice_service",
 		F:    sweepServices,
 	})
+
+	resource.AddTestSweepers("aws_vpclattice_service_network", &resource.Sweeper{
+		Name: "aws_vpclattice_service_network",
+		F:    sweepServiceNetworks,
+		Dependencies: []string{
+			"aws_vpclattice_service",
+		},
+	})
 }
 
 func sweepServices(region string) error {
@@ -57,6 +65,47 @@ func sweepServices(region string) error {
 
 	if err != nil {
 		return fmt.Errorf("error sweeping VPC Lattice Services (%s): %w", region, err)
+	}
+
+	return nil
+}
+
+func sweepServiceNetworks(region string) error {
+	ctx := sweep.Context(region)
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*conns.AWSClient).VPCLatticeClient()
+	input := &vpclattice.ListServiceNetworksInput{}
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	pages := vpclattice.NewListServiceNetworksPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if sweep.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping VPC Lattice Service Network sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("error listing VPC Lattice Service Networks (%s): %w", region, err)
+		}
+
+		for _, v := range page.Items {
+			r := ResourceServiceNetwork()
+			d := r.Data(nil)
+			d.SetId(aws.ToString(v.Id))
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+	}
+
+	err = sweep.SweepOrchestratorWithContext(ctx, sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping VPC Lattice Service Networks (%s): %w", region, err)
 	}
 
 	return nil

--- a/internal/service/vpclattice/sweep.go
+++ b/internal/service/vpclattice/sweep.go
@@ -2,3 +2,62 @@
 // +build sweep
 
 package vpclattice
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_vpclattice_service", &resource.Sweeper{
+		Name: "aws_vpclattice_service",
+		F:    sweepServices,
+	})
+}
+
+func sweepServices(region string) error {
+	ctx := sweep.Context(region)
+	client, err := sweep.SharedRegionalSweepClient(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*conns.AWSClient).VPCLatticeClient()
+	input := &vpclattice.ListServicesInput{}
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	pages := vpclattice.NewListServicesPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if sweep.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping VPC Lattice Service sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("error listing VPC Lattice Services (%s): %w", region, err)
+		}
+
+		for _, v := range page.Items {
+			r := ResourceService()
+			d := r.Data(nil)
+			d.SetId(aws.ToString(v.Id))
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+	}
+
+	err = sweep.SweepOrchestratorWithContext(ctx, sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping VPC Lattice Services (%s): %w", region, err)
+	}
+
+	return nil
+}

--- a/internal/service/vpclattice/sweep.go
+++ b/internal/service/vpclattice/sweep.go
@@ -1,0 +1,4 @@
+//go:build sweep
+// +build sweep
+
+package vpclattice

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -139,6 +139,7 @@ import (
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/timestreamwrite"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/transcribe"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/transfer"
+	_ "github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/waf"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/wafregional"
 	_ "github.com/hashicorp/terraform-provider-aws/internal/service/wafv2"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds test sweepers for Global Accelerator custom routing and VPC Lattice.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/28922.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/30380.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make sweep SWEEPARGS=-sweep-run=aws_globalaccelerator_custom_routing_accelerator
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2,us-east-1,us-east-2 -sweep-run=aws_globalaccelerator_custom_routing_accelerator -timeout 60m
2023/04/06 12:28:39 [DEBUG] Running Sweepers for region (us-west-2):
2023/04/06 12:28:39 [DEBUG] Running Sweeper (aws_globalaccelerator_custom_routing_endpoint_group) in region (us-west-2)
2023/04/06 12:28:40 [DEBUG] Completed Sweeper (aws_globalaccelerator_custom_routing_endpoint_group) in region (us-west-2) in 835.967664ms
2023/04/06 12:28:40 [DEBUG] Sweeper (aws_globalaccelerator_custom_routing_accelerator) has dependency (aws_globalaccelerator_custom_routing_listener), running..
2023/04/06 12:28:40 [DEBUG] Sweeper (aws_globalaccelerator_custom_routing_listener) has dependency (aws_globalaccelerator_custom_routing_endpoint_group), running..
2023/04/06 12:28:40 [DEBUG] Sweeper (aws_globalaccelerator_custom_routing_endpoint_group) already ran in region (us-west-2)
2023/04/06 12:28:40 [DEBUG] Running Sweeper (aws_globalaccelerator_custom_routing_listener) in region (us-west-2)
2023/04/06 12:28:40 [DEBUG] Completed Sweeper (aws_globalaccelerator_custom_routing_listener) in region (us-west-2) in 133.759013ms
2023/04/06 12:28:40 [DEBUG] Running Sweeper (aws_globalaccelerator_custom_routing_accelerator) in region (us-west-2)
2023/04/06 12:28:40 [DEBUG] Completed Sweeper (aws_globalaccelerator_custom_routing_accelerator) in region (us-west-2) in 126.040119ms
2023/04/06 12:28:40 [DEBUG] Sweeper (aws_globalaccelerator_custom_routing_listener) has dependency (aws_globalaccelerator_custom_routing_endpoint_group), running..
2023/04/06 12:28:40 [DEBUG] Sweeper (aws_globalaccelerator_custom_routing_endpoint_group) already ran in region (us-west-2)
2023/04/06 12:28:40 [DEBUG] Sweeper (aws_globalaccelerator_custom_routing_listener) already ran in region (us-west-2)
2023/04/06 12:28:40 Completed Sweepers for region (us-west-2) in 1.095988496s
2023/04/06 12:28:40 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_globalaccelerator_custom_routing_endpoint_group
	- aws_globalaccelerator_custom_routing_listener
	- aws_globalaccelerator_custom_routing_accelerator
2023/04/06 12:28:40 [DEBUG] Running Sweepers for region (us-east-1):
2023/04/06 12:28:40 [DEBUG] Running Sweeper (aws_globalaccelerator_custom_routing_endpoint_group) in region (us-east-1)
2023/04/06 12:28:40 [DEBUG] Completed Sweeper (aws_globalaccelerator_custom_routing_endpoint_group) in region (us-east-1) in 493.724806ms
2023/04/06 12:28:40 [DEBUG] Sweeper (aws_globalaccelerator_custom_routing_accelerator) has dependency (aws_globalaccelerator_custom_routing_listener), running..
2023/04/06 12:28:40 [DEBUG] Sweeper (aws_globalaccelerator_custom_routing_listener) has dependency (aws_globalaccelerator_custom_routing_endpoint_group), running..
2023/04/06 12:28:40 [DEBUG] Sweeper (aws_globalaccelerator_custom_routing_endpoint_group) already ran in region (us-east-1)
2023/04/06 12:28:40 [DEBUG] Running Sweeper (aws_globalaccelerator_custom_routing_listener) in region (us-east-1)
2023/04/06 12:28:41 [DEBUG] Completed Sweeper (aws_globalaccelerator_custom_routing_listener) in region (us-east-1) in 122.429517ms
2023/04/06 12:28:41 [DEBUG] Running Sweeper (aws_globalaccelerator_custom_routing_accelerator) in region (us-east-1)
2023/04/06 12:28:41 [DEBUG] Completed Sweeper (aws_globalaccelerator_custom_routing_accelerator) in region (us-east-1) in 141.607175ms
2023/04/06 12:28:41 [DEBUG] Sweeper (aws_globalaccelerator_custom_routing_listener) has dependency (aws_globalaccelerator_custom_routing_endpoint_group), running..
2023/04/06 12:28:41 [DEBUG] Sweeper (aws_globalaccelerator_custom_routing_endpoint_group) already ran in region (us-east-1)
2023/04/06 12:28:41 [DEBUG] Sweeper (aws_globalaccelerator_custom_routing_listener) already ran in region (us-east-1)
2023/04/06 12:28:41 Completed Sweepers for region (us-east-1) in 757.839293ms
2023/04/06 12:28:41 Sweeper Tests for region (us-east-1) ran successfully:
	- aws_globalaccelerator_custom_routing_endpoint_group
	- aws_globalaccelerator_custom_routing_listener
	- aws_globalaccelerator_custom_routing_accelerator
2023/04/06 12:28:41 [DEBUG] Running Sweepers for region (us-east-2):
2023/04/06 12:28:41 [DEBUG] Running Sweeper (aws_globalaccelerator_custom_routing_endpoint_group) in region (us-east-2)
2023/04/06 12:28:41 [DEBUG] Completed Sweeper (aws_globalaccelerator_custom_routing_endpoint_group) in region (us-east-2) in 525.829736ms
2023/04/06 12:28:41 [DEBUG] Sweeper (aws_globalaccelerator_custom_routing_accelerator) has dependency (aws_globalaccelerator_custom_routing_listener), running..
2023/04/06 12:28:41 [DEBUG] Sweeper (aws_globalaccelerator_custom_routing_listener) has dependency (aws_globalaccelerator_custom_routing_endpoint_group), running..
2023/04/06 12:28:41 [DEBUG] Sweeper (aws_globalaccelerator_custom_routing_endpoint_group) already ran in region (us-east-2)
2023/04/06 12:28:41 [DEBUG] Running Sweeper (aws_globalaccelerator_custom_routing_listener) in region (us-east-2)
2023/04/06 12:28:41 [DEBUG] Completed Sweeper (aws_globalaccelerator_custom_routing_listener) in region (us-east-2) in 117.766212ms
2023/04/06 12:28:41 [DEBUG] Running Sweeper (aws_globalaccelerator_custom_routing_accelerator) in region (us-east-2)
2023/04/06 12:28:41 [DEBUG] Completed Sweeper (aws_globalaccelerator_custom_routing_accelerator) in region (us-east-2) in 125.341672ms
2023/04/06 12:28:41 [DEBUG] Sweeper (aws_globalaccelerator_custom_routing_listener) has dependency (aws_globalaccelerator_custom_routing_endpoint_group), running..
2023/04/06 12:28:41 [DEBUG] Sweeper (aws_globalaccelerator_custom_routing_endpoint_group) already ran in region (us-east-2)
2023/04/06 12:28:41 [DEBUG] Sweeper (aws_globalaccelerator_custom_routing_listener) already ran in region (us-east-2)
2023/04/06 12:28:41 Completed Sweepers for region (us-east-2) in 769.002258ms
2023/04/06 12:28:41 Sweeper Tests for region (us-east-2) ran successfully:
	- aws_globalaccelerator_custom_routing_endpoint_group
	- aws_globalaccelerator_custom_routing_listener
	- aws_globalaccelerator_custom_routing_accelerator
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	7.507s
```
```console
% make sweep SWEEPARGS=-sweep-run=aws_vpclattice_service_network
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2,us-east-1,us-east-2 -sweep-run=aws_vpclattice_service_network -timeout 60m
2023/04/06 14:11:01 [DEBUG] Running Sweepers for region (us-west-2):
2023/04/06 14:11:01 [DEBUG] Sweeper (aws_vpclattice_service_network) has dependency (aws_vpclattice_service), running..
2023/04/06 14:11:01 [DEBUG] Running Sweeper (aws_vpclattice_service) in region (us-west-2)
2023/04/06 14:11:02 [DEBUG] Completed Sweeper (aws_vpclattice_service) in region (us-west-2) in 905.218144ms
2023/04/06 14:11:02 [DEBUG] Running Sweeper (aws_vpclattice_service_network) in region (us-west-2)
2023/04/06 14:11:02 [DEBUG] Completed Sweeper (aws_vpclattice_service_network) in region (us-west-2) in 148.854371ms
2023/04/06 14:11:02 [DEBUG] Sweeper (aws_vpclattice_service) already ran in region (us-west-2)
2023/04/06 14:11:02 Completed Sweepers for region (us-west-2) in 1.054271911s
2023/04/06 14:11:02 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_vpclattice_service
	- aws_vpclattice_service_network
2023/04/06 14:11:02 [DEBUG] Running Sweepers for region (us-east-1):
2023/04/06 14:11:02 [DEBUG] Sweeper (aws_vpclattice_service_network) has dependency (aws_vpclattice_service), running..
2023/04/06 14:11:02 [DEBUG] Running Sweeper (aws_vpclattice_service) in region (us-east-1)
2023/04/06 14:11:02 [DEBUG] Completed Sweeper (aws_vpclattice_service) in region (us-east-1) in 315.702014ms
2023/04/06 14:11:02 [DEBUG] Running Sweeper (aws_vpclattice_service_network) in region (us-east-1)
2023/04/06 14:11:02 [DEBUG] Completed Sweeper (aws_vpclattice_service_network) in region (us-east-1) in 89.235793ms
2023/04/06 14:11:02 [DEBUG] Sweeper (aws_vpclattice_service) already ran in region (us-east-1)
2023/04/06 14:11:02 Completed Sweepers for region (us-east-1) in 404.984443ms
2023/04/06 14:11:02 Sweeper Tests for region (us-east-1) ran successfully:
	- aws_vpclattice_service
	- aws_vpclattice_service_network
2023/04/06 14:11:02 [DEBUG] Running Sweepers for region (us-east-2):
2023/04/06 14:11:02 [DEBUG] Sweeper (aws_vpclattice_service_network) has dependency (aws_vpclattice_service), running..
2023/04/06 14:11:02 [DEBUG] Running Sweeper (aws_vpclattice_service) in region (us-east-2)
2023/04/06 14:11:02 [DEBUG] Completed Sweeper (aws_vpclattice_service) in region (us-east-2) in 375.263352ms
2023/04/06 14:11:02 [DEBUG] Running Sweeper (aws_vpclattice_service_network) in region (us-east-2)
2023/04/06 14:11:03 [DEBUG] Completed Sweeper (aws_vpclattice_service_network) in region (us-east-2) in 88.480103ms
2023/04/06 14:11:03 [DEBUG] Sweeper (aws_vpclattice_service) already ran in region (us-east-2)
2023/04/06 14:11:03 Completed Sweepers for region (us-east-2) in 463.799392ms
2023/04/06 14:11:03 Sweeper Tests for region (us-east-2) ran successfully:
	- aws_vpclattice_service
	- aws_vpclattice_service_network
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	7.196s
```
