### PR TITLE
VPC: Ignore route table routes managed by VPC Lattice

### DIFF
--- a/.changelog/30515.txt
+++ b/.changelog/30515.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+resource/aws_route_table: Ignore routes managed by VPC Lattice
+```
+
+```release-note:enhancement
+data-source/aws_route_table: Ignore routes managed by VPC Lattice
+```
+
+```release-note:enhancement
+resource/aws_default_route_table: Ignore routes managed by VPC Lattice
+```

--- a/internal/service/ec2/sweep.go
+++ b/internal/service/ec2/sweep.go
@@ -1428,7 +1428,7 @@ func sweepRouteTables(region string) error {
 						continue
 					}
 
-					if aws.StringValue(route.GatewayId) == "local" {
+					if gatewayID := aws.StringValue(route.GatewayId); gatewayID == "local" || gatewayID == "VpcLattice" {
 						continue
 					}
 

--- a/internal/service/ec2/vpc_default_route_table.go
+++ b/internal/service/ec2/vpc_default_route_table.go
@@ -170,8 +170,7 @@ func resourceDefaultRouteTableCreate(ctx context.Context, d *schema.ResourceData
 
 	// Delete all existing routes.
 	for _, v := range routeTable.Routes {
-		// you cannot delete the local route
-		if aws.StringValue(v.GatewayId) == "local" {
+		if gatewayID := aws.StringValue(v.GatewayId); gatewayID == "local" || gatewayID == "VpcLattice" {
 			continue
 		}
 

--- a/internal/service/ec2/vpc_route_table.go
+++ b/internal/service/ec2/vpc_route_table.go
@@ -872,7 +872,7 @@ func flattenRoutes(ctx context.Context, conn *ec2.EC2, apiObjects []*ec2.Route) 
 			continue
 		}
 
-		if aws.StringValue(apiObject.GatewayId) == "local" {
+		if gatewayID := aws.StringValue(apiObject.GatewayId); gatewayID == "local" || gatewayID == "VpcLattice" {
 			continue
 		}
 

--- a/internal/service/ec2/vpc_route_table_data_source.go
+++ b/internal/service/ec2/vpc_route_table_data_source.go
@@ -259,7 +259,7 @@ func dataSourceRoutesRead(ctx context.Context, conn *ec2.EC2, ec2Routes []*ec2.R
 	routes := make([]map[string]interface{}, 0, len(ec2Routes))
 	// Loop through the routes and add them to the set
 	for _, r := range ec2Routes {
-		if aws.StringValue(r.GatewayId) == "local" {
+		if gatewayID := aws.StringValue(r.GatewayId); gatewayID == "local" || gatewayID == "VpcLattice" {
 			continue
 		}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When an [association is made](https://docs.aws.amazon.com/vpc-lattice/latest/ug/service-network-associations.html#service-network-vpc-associations) between a VPC Lattice service network and a VPC,
additional IPv4 and IPv6 destinations are added to that VPC's route tables:

```console
% aws ec2 describe-route-tables --route-table-ids rtb-b2012dc9
{
    "RouteTables": [
        {
            "Associations": [
                {
                    "Main": true,
                    "RouteTableAssociationId": "rtbassoc-6d565b10",
                    "RouteTableId": "rtb-b2012dc9",
                    "AssociationState": {
                        "State": "associated"
                    }
                }
            ],
            "PropagatingVgws": [],
            "RouteTableId": "rtb-b2012dc9",
            "Routes": [
                {
                    "DestinationCidrBlock": "172.31.0.0/16",
                    "GatewayId": "local",
                    "Origin": "CreateRouteTable",
                    "State": "active"
                },
                {
                    "DestinationCidrBlock": "0.0.0.0/0",
                    "GatewayId": "igw-6aae1a13",
                    "Origin": "CreateRoute",
                    "State": "active"
                },
                {
                    "DestinationCidrBlock": "169.254.171.0/24",
                    "GatewayId": "VpcLattice",
                    "Origin": "CreateRoute",
                    "State": "active"
                },
                {
                    "DestinationIpv6CidrBlock": "fd00:ec2:80::/64",
                    "GatewayId": "VpcLattice",
                    "Origin": "CreateRoute",
                    "State": "active"
                }
            ],
            "Tags": [],
            "VpcId": "vpc-35b2f14d",
            "OwnerId": "123456789012"
        }
    ]
}
```

Ignore these routes as they are not managed by Terraform.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/30380.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Cannot be tested via Terraform configuration until https://github.com/hashicorp/terraform-provider-aws/issues/30411 is implemented.

```console
% make testacc TESTARGS='-run=TestAccVPCRouteTable_basic\|TestAccVPCRouteTableDataSource_basic\|TestAccVPCDefaultRouteTable_basic' PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPCRouteTable_basic\|TestAccVPCRouteTableDataSource_basic\|TestAccVPCDefaultRouteTable_basic -timeout 180m
=== RUN   TestAccVPCDefaultRouteTable_basic
=== PAUSE TestAccVPCDefaultRouteTable_basic
=== RUN   TestAccVPCRouteTableDataSource_basic
=== PAUSE TestAccVPCRouteTableDataSource_basic
=== RUN   TestAccVPCRouteTable_basic
=== PAUSE TestAccVPCRouteTable_basic
=== CONT  TestAccVPCDefaultRouteTable_basic
=== CONT  TestAccVPCRouteTable_basic
=== CONT  TestAccVPCRouteTableDataSource_basic
--- PASS: TestAccVPCRouteTableDataSource_basic (23.35s)
--- PASS: TestAccVPCRouteTable_basic (23.75s)
--- PASS: TestAccVPCDefaultRouteTable_basic (30.82s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	36.348s
```
