### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin SDK resources `k*` (Phase 3c)

### DIFF
--- a/internal/service/kafka/cluster.go
+++ b/internal/service/kafka/cluster.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_msk_cluster")
+// @SDKResource("aws_msk_cluster", name="Cluster")
+// @Tags(identifierAttribute="id")
 func ResourceCluster() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClusterCreate,
@@ -466,8 +468,8 @@ func ResourceCluster() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validation.StringInSlice(kafka.StorageMode_Values(), true),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"zookeeper_connect_string": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -482,15 +484,13 @@ func ResourceCluster() *schema.Resource {
 
 func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).KafkaConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("cluster_name").(string)
 	input := &kafka.CreateClusterInput{
 		ClusterName:         aws.String(name),
 		KafkaVersion:        aws.String(d.Get("kafka_version").(string)),
 		NumberOfBrokerNodes: aws.Int64(int64(d.Get("number_of_broker_nodes").(int))),
-		Tags:                Tags(tags.IgnoreAWS()),
+		Tags:                GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("broker_node_group_info"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
@@ -544,8 +544,6 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).KafkaConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	cluster, err := FindClusterByARN(ctx, conn, d.Id())
 
@@ -638,16 +636,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("zookeeper_connect_string", SortEndpointsString(aws.StringValue(cluster.ZookeeperConnectString)))
 	d.Set("zookeeper_connect_string_tls", SortEndpointsString(aws.StringValue(cluster.ZookeeperConnectStringTls)))
 
-	tags := KeyValueTags(ctx, cluster.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, cluster.Tags)
 
 	return nil
 }
@@ -932,14 +921,6 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		// refresh the current_version attribute after each update
 		if err := refreshClusterVersion(ctx, d, meta); err != nil {
 			return diag.FromErr(err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return diag.Errorf("updating MSK Cluster (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/kafka/serverless_cluster.go
+++ b/internal/service/kafka/serverless_cluster.go
@@ -15,9 +15,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_msk_serverless_cluster")
+// @SDKResource("aws_msk_serverless_cluster", name="Serverless Cluster")
+// @Tags(identifierAttribute="id")
 func ResourceServerlessCluster() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceServerlessClusterCreate,
@@ -82,8 +84,8 @@ func ResourceServerlessCluster() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(1, 64),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vpc_config": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -116,8 +118,6 @@ func ResourceServerlessCluster() *schema.Resource {
 
 func resourceServerlessClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).KafkaConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("cluster_name").(string)
 	input := &kafka.CreateClusterV2Input{
@@ -126,7 +126,7 @@ func resourceServerlessClusterCreate(ctx context.Context, d *schema.ResourceData
 			ClientAuthentication: expandServerlessClientAuthentication(d.Get("client_authentication").([]interface{})[0].(map[string]interface{})),
 			VpcConfigs:           expandVpcConfigs(d.Get("vpc_config").([]interface{})),
 		},
-		Tags: Tags(tags.IgnoreAWS()),
+		Tags: GetTagsIn(ctx),
 	}
 
 	log.Printf("[DEBUG] Creating MSK Serverless Cluster: %s", input)
@@ -149,8 +149,6 @@ func resourceServerlessClusterCreate(ctx context.Context, d *schema.ResourceData
 
 func resourceServerlessClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).KafkaConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	cluster, err := FindServerlessClusterByARN(ctx, conn, d.Id())
 
@@ -177,31 +175,13 @@ func resourceServerlessClusterRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("setting vpc_config: %s", err)
 	}
 
-	tags := KeyValueTags(ctx, cluster.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, cluster.Tags)
 
 	return nil
 }
 
 func resourceServerlessClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).KafkaConn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return diag.Errorf("updating MSK Serverless Cluster (%s) tags: %s", d.Id(), err)
-		}
-	}
-
+	// Tags only.
 	return resourceServerlessClusterRead(ctx, d, meta)
 }
 

--- a/internal/service/kafka/service_package_gen.go
+++ b/internal/service/kafka/service_package_gen.go
@@ -45,6 +45,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCluster,
 			TypeName: "aws_msk_cluster",
+			Name:     "Cluster",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceConfiguration,
@@ -57,6 +61,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceServerlessCluster,
 			TypeName: "aws_msk_serverless_cluster",
+			Name:     "Serverless Cluster",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }

--- a/internal/service/kendra/data_source.go
+++ b/internal/service/kendra/data_source.go
@@ -25,6 +25,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 const (
@@ -34,7 +35,8 @@ const (
 	validationExceptionMessageDataSourceSecrets = "Secrets Manager throws the exception"
 )
 
-// @SDKResource("aws_kendra_data_source")
+// @SDKResource("aws_kendra_data_source", name="Data Source")
+// @Tags(identifierAttribute="arn")
 func ResourceDataSource() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDataSourceCreate,
@@ -468,8 +470,8 @@ func ResourceDataSource() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:tftags.TagsSchema(),
+names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -587,15 +589,13 @@ func documentAttributeValueSchema() *schema.Schema {
 
 func resourceDataSourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).KendraClient()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
-
 	input := &kendra.CreateDataSourceInput{
 		ClientToken: aws.String(id.UniqueId()),
 		IndexId:     aws.String(d.Get("index_id").(string)),
 		Name:        aws.String(name),
+		Tags: GetTagsIn(ctx),
 		Type:        types.DataSourceType(d.Get("type").(string)),
 	}
 
@@ -622,12 +622,6 @@ func resourceDataSourceCreate(ctx context.Context, d *schema.ResourceData, meta 
 	if v, ok := d.GetOk("schedule"); ok {
 		input.Schedule = aws.String(v.(string))
 	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
-	log.Printf("[DEBUG] Creating Kendra Data Source %#v", input)
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
@@ -668,8 +662,6 @@ func resourceDataSourceCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 func resourceDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).KendraClient()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	id, indexId, err := DataSourceParseResourceID(d.Id())
 	if err != nil {
@@ -716,21 +708,6 @@ func resourceDataSourceRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	if err := d.Set("custom_document_enrichment_configuration", flattenCustomDocumentEnrichmentConfiguration(resp.CustomDocumentEnrichmentConfiguration)); err != nil {
 		return diag.FromErr(err)
-	}
-
-	tags, err := ListTags(ctx, conn, arn)
-	if err != nil {
-		return diag.Errorf("listing tags for resource (%s): %s", arn, err)
-	}
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
 	}
 
 	return nil
@@ -801,14 +778,6 @@ func resourceDataSourceUpdate(ctx context.Context, d *schema.ResourceData, meta 
 
 		if _, err := waitDataSourceUpdated(ctx, conn, id, indexId, d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return diag.Errorf("waiting for Kendra Data Source (%s) update: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.FromErr(fmt.Errorf("updating Kendra Data Source (%s) tags: %s", d.Id(), err))
 		}
 	}
 

--- a/internal/service/kendra/data_source.go
+++ b/internal/service/kendra/data_source.go
@@ -470,8 +470,8 @@ func ResourceDataSource() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			names.AttrTags:tftags.TagsSchema(),
-names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -595,7 +595,7 @@ func resourceDataSourceCreate(ctx context.Context, d *schema.ResourceData, meta 
 		ClientToken: aws.String(id.UniqueId()),
 		IndexId:     aws.String(d.Get("index_id").(string)),
 		Name:        aws.String(name),
-		Tags: GetTagsIn(ctx),
+		Tags:        GetTagsIn(ctx),
 		Type:        types.DataSourceType(d.Get("type").(string)),
 	}
 

--- a/internal/service/kendra/query_suggestions_block_list.go
+++ b/internal/service/kendra/query_suggestions_block_list.go
@@ -21,9 +21,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_kendra_query_suggestions_block_list")
+// @SDKResource("aws_kendra_query_suggestions_block_list", name="Query Suggestions Block List")
+// @Tags(identifierAttribute="arn")
 func ResourceQuerySuggestionsBlockList() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceQuerySuggestionsBlockListCreate,
@@ -89,8 +91,8 @@ func ResourceQuerySuggestionsBlockList() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -99,8 +101,6 @@ func ResourceQuerySuggestionsBlockList() *schema.Resource {
 
 func resourceQuerySuggestionsBlockListCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).KendraClient()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	in := &kendra.CreateQuerySuggestionsBlockListInput{
 		ClientToken:  aws.String(id.UniqueId()),
@@ -108,14 +108,11 @@ func resourceQuerySuggestionsBlockListCreate(ctx context.Context, d *schema.Reso
 		Name:         aws.String(d.Get("name").(string)),
 		RoleArn:      aws.String(d.Get("role_arn").(string)),
 		SourceS3Path: expandSourceS3Path(d.Get("source_s3_path").([]interface{})),
+		Tags:         GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
 		in.Description = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		in.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
@@ -156,8 +153,6 @@ func resourceQuerySuggestionsBlockListCreate(ctx context.Context, d *schema.Reso
 
 func resourceQuerySuggestionsBlockListRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).KendraClient()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	id, indexId, err := QuerySuggestionsBlockListParseResourceID(d.Id())
 	if err != nil {
@@ -194,22 +189,6 @@ func resourceQuerySuggestionsBlockListRead(ctx context.Context, d *schema.Resour
 
 	if err := d.Set("source_s3_path", flattenSourceS3Path(out.SourceS3Path)); err != nil {
 		return diag.Errorf("setting complex argument: %s", err)
-	}
-
-	tags, err := ListTags(ctx, conn, arn)
-	if err != nil {
-		return diag.Errorf("listing tags for Kendra QuerySuggestionsBlockList (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
 	}
 
 	return nil
@@ -268,14 +247,6 @@ func resourceQuerySuggestionsBlockListUpdate(ctx context.Context, d *schema.Reso
 
 		if _, err := waitQuerySuggestionsBlockListUpdated(ctx, conn, id, indexId, d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return diag.Errorf("waiting for Kendra QuerySuggestionsBlockList (%s) update: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.FromErr(fmt.Errorf("error updating Kendra QuerySuggestionsBlockList (%s) tags: %s", d.Id(), err))
 		}
 	}
 

--- a/internal/service/kendra/service_package_gen.go
+++ b/internal/service/kendra/service_package_gen.go
@@ -49,6 +49,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDataSource,
 			TypeName: "aws_kendra_data_source",
+			Name:     "Data Source",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceExperience,
@@ -57,18 +61,34 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceFaq,
 			TypeName: "aws_kendra_faq",
+			Name:     "FAQ",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceIndex,
 			TypeName: "aws_kendra_index",
+			Name:     "Index",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceQuerySuggestionsBlockList,
 			TypeName: "aws_kendra_query_suggestions_block_list",
+			Name:     "Query Suggestions Block List",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceThesaurus,
 			TypeName: "aws_kendra_thesaurus",
+			Name:     "Thesaurus",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/kendra/thesaurus.go
+++ b/internal/service/kendra/thesaurus.go
@@ -21,9 +21,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_kendra_thesaurus")
+// @SDKResource("aws_kendra_thesaurus", name="Thesaurus")
+// @Tags(identifierAttribute="arn")
 func ResourceThesaurus() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceThesaurusCreate,
@@ -89,8 +91,8 @@ func ResourceThesaurus() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -99,8 +101,6 @@ func ResourceThesaurus() *schema.Resource {
 
 func resourceThesaurusCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).KendraClient()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &kendra.CreateThesaurusInput{
 		ClientToken:  aws.String(id.UniqueId()),
@@ -108,14 +108,11 @@ func resourceThesaurusCreate(ctx context.Context, d *schema.ResourceData, meta i
 		Name:         aws.String(d.Get("name").(string)),
 		RoleArn:      aws.String(d.Get("role_arn").(string)),
 		SourceS3Path: expandSourceS3Path(d.Get("source_s3_path").([]interface{})),
+		Tags:         GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
@@ -157,8 +154,6 @@ func resourceThesaurusCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 func resourceThesaurusRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).KendraClient()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	id, indexId, err := ThesaurusParseResourceID(d.Id())
 	if err != nil {
@@ -195,22 +190,6 @@ func resourceThesaurusRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	if err := d.Set("source_s3_path", flattenSourceS3Path(out.SourceS3Path)); err != nil {
 		return diag.Errorf("setting complex argument: %s", err)
-	}
-
-	tags, err := ListTags(ctx, conn, arn)
-	if err != nil {
-		return diag.Errorf("listing tags for Kendra Thesaurus (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
 	}
 
 	return nil
@@ -269,14 +248,6 @@ func resourceThesaurusUpdate(ctx context.Context, d *schema.ResourceData, meta i
 
 		if _, err := waitThesaurusUpdated(ctx, conn, id, indexId, d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return diag.Errorf("waiting for Kendra Thesaurus (%s) update: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.FromErr(fmt.Errorf("error updating Kendra Thesaurus (%s) tags: %s", d.Id(), err))
 		}
 	}
 

--- a/internal/service/keyspaces/service_package_gen.go
+++ b/internal/service/keyspaces/service_package_gen.go
@@ -28,10 +28,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceKeyspace,
 			TypeName: "aws_keyspaces_keyspace",
+			Name:     "Keyspace",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceTable,
 			TypeName: "aws_keyspaces_table",
+			Name:     "Table",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/kinesis/service_package_gen.go
+++ b/internal/service/kinesis/service_package_gen.go
@@ -37,6 +37,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceStream,
 			TypeName: "aws_kinesis_stream",
+			Name:     "Stream",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "name",
+			},
 		},
 		{
 			Factory:  ResourceStreamConsumer,

--- a/internal/service/kinesis/stream.go
+++ b/internal/service/kinesis/stream.go
@@ -21,9 +21,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_kinesis_stream")
+// @SDKResource("aws_kinesis_stream", name="Stream")
+// @Tags(identifierAttribute="name")
 func ResourceStream() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceStreamCreate,
@@ -134,8 +136,8 @@ func ResourceStream() *schema.Resource {
 				},
 				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -143,8 +145,6 @@ func ResourceStream() *schema.Resource {
 func resourceStreamCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KinesisConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &kinesis.CreateStreamInput{
@@ -241,7 +241,7 @@ func resourceStreamCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 	}
 
-	if len(tags) > 0 {
+	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
 		if err := UpdateTags(ctx, conn, name, nil, tags); err != nil {
 			return sdkdiag.AppendErrorf(diags, "adding Kinesis Stream (%s) tags: %s", name, err)
 		}
@@ -253,10 +253,8 @@ func resourceStreamCreate(ctx context.Context, d *schema.ResourceData, meta inte
 func resourceStreamRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KinesisConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-	name := d.Get("name").(string)
 
+	name := d.Get("name").(string)
 	stream, err := FindStreamByName(ctx, conn, name)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
@@ -299,23 +297,6 @@ func resourceStreamRead(ctx context.Context, d *schema.ResourceData, meta interf
 		d.Set("stream_mode_details", nil)
 	}
 
-	tags, err := ListTags(ctx, conn, name)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Kinesis Stream (%s): %s", name, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
@@ -323,14 +304,6 @@ func resourceStreamUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KinesisConn()
 	name := d.Get("name").(string)
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, name, o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Kinesis Stream (%s) tags: %s", name, err)
-		}
-	}
 
 	if d.HasChange("stream_mode_details.0.stream_mode") {
 		input := &kinesis.UpdateStreamModeInput{

--- a/internal/service/kinesisanalytics/service_package_gen.go
+++ b/internal/service/kinesisanalytics/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceApplication,
 			TypeName: "aws_kinesis_analytics_application",
+			Name:     "Application",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/kinesisanalyticsv2/service_package_gen.go
+++ b/internal/service/kinesisanalyticsv2/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceApplication,
 			TypeName: "aws_kinesisanalyticsv2_application",
+			Name:     "Application",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceApplicationSnapshot,

--- a/internal/service/kinesisvideo/service_package_gen.go
+++ b/internal/service/kinesisvideo/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceStream,
 			TypeName: "aws_kinesis_video_stream",
+			Name:     "Stream",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }

--- a/internal/service/kinesisvideo/stream.go
+++ b/internal/service/kinesisvideo/stream.go
@@ -17,9 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_kinesis_video_stream")
+// @SDKResource("aws_kinesis_video_stream", name="Stream")
+// @Tags(identifierAttribute="id")
 func ResourceStream() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceStreamCreate,
@@ -88,9 +90,8 @@ func ResourceStream() *schema.Resource {
 				Computed: true,
 			},
 
-			"tags": tftags.TagsSchema(),
-
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -98,31 +99,26 @@ func ResourceStream() *schema.Resource {
 func resourceStreamCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KinesisVideoConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
-	createOpts := &kinesisvideo.CreateStreamInput{
+	input := &kinesisvideo.CreateStreamInput{
 		StreamName:           aws.String(d.Get("name").(string)),
 		DataRetentionInHours: aws.Int64(int64(d.Get("data_retention_in_hours").(int))),
+		Tags:                 GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("device_name"); ok {
-		createOpts.DeviceName = aws.String(v.(string))
+		input.DeviceName = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("kms_key_id"); ok {
-		createOpts.KmsKeyId = aws.String(v.(string))
+		input.KmsKeyId = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("media_type"); ok {
-		createOpts.MediaType = aws.String(v.(string))
+		input.MediaType = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		createOpts.Tags = Tags(tags.IgnoreAWS())
-	}
-
-	resp, err := conn.CreateStreamWithContext(ctx, createOpts)
+	resp, err := conn.CreateStreamWithContext(ctx, input)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Kinesis Video Stream: %s", err)
 	}
@@ -149,8 +145,6 @@ func resourceStreamCreate(ctx context.Context, d *schema.ResourceData, meta inte
 func resourceStreamRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KinesisVideoConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	descOpts := &kinesisvideo.DescribeStreamInput{
 		StreamARN: aws.String(d.Id()),
@@ -177,23 +171,6 @@ func resourceStreamRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 	d.Set("version", resp.StreamInfo.Version)
 
-	tags, err := ListTags(ctx, conn, d.Id())
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Kinesis Video Stream (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
@@ -216,14 +193,6 @@ func resourceStreamUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	if _, err := conn.UpdateStreamWithContext(ctx, updateOpts); err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating Kinesis Video Stream (%s): %s", d.Id(), err)
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Kinesis Video Stream (%s) tags: %s", d.Id(), err)
-		}
 	}
 
 	stateConf := &retry.StateChangeConf{


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin SDK.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30421.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30430.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30449.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30454.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30461.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30463.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30476.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30477.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30478.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30483.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30484.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30491.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30509.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30510.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30512.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=k... ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/k.../... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccKafkaBrokerNodesDataSource_basic
=== PAUSE TestAccKafkaBrokerNodesDataSource_basic
=== RUN   TestAccKafkaClusterDataSource_basic
=== PAUSE TestAccKafkaClusterDataSource_basic
=== RUN   TestAccKafkaCluster_basic
=== PAUSE TestAccKafkaCluster_basic
=== RUN   TestAccKafkaCluster_tags
=== PAUSE TestAccKafkaCluster_tags
=== RUN   TestAccKafkaConfiguration_basic
=== PAUSE TestAccKafkaConfiguration_basic
=== RUN   TestAccKafkaKafkaVersionDataSource_basic
=== PAUSE TestAccKafkaKafkaVersionDataSource_basic
=== RUN   TestAccKafkaScramSecretAssociation_basic
=== PAUSE TestAccKafkaScramSecretAssociation_basic
=== RUN   TestAccKafkaServerlessCluster_basic
=== PAUSE TestAccKafkaServerlessCluster_basic
=== RUN   TestAccKafkaServerlessCluster_tags
=== PAUSE TestAccKafkaServerlessCluster_tags
=== CONT  TestAccKafkaBrokerNodesDataSource_basic
=== CONT  TestAccKafkaKafkaVersionDataSource_basic
=== CONT  TestAccKafkaServerlessCluster_tags
--- PASS: TestAccKafkaKafkaVersionDataSource_basic (81.76s)
=== CONT  TestAccKafkaServerlessCluster_basic
=== CONT  TestAccKafkaServerlessCluster_tags
    serverless_cluster_test.go:86: Step 1/4 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        
        Terraform will perform the following actions:
        
          # aws_msk_serverless_cluster.test must be replaced
        -/+ resource "aws_msk_serverless_cluster" "test" {
              ~ arn          = "arn:aws:kafka:us-west-2:123456789012:cluster/tf-acc-test-735421940149360127/08eba591-72e8-4c65-855f-540d41caceac-s2" -> (known after apply)
              ~ id           = "arn:aws:kafka:us-west-2:123456789012:cluster/tf-acc-test-735421940149360127/08eba591-72e8-4c65-855f-540d41caceac-s2" -> (known after apply)
                tags         = {
                    "key1" = "value1"
                }
                # (2 unchanged attributes hidden)
        
        
              ~ vpc_config {
                  - security_group_ids = [
                      - "sg-0685fa6b41dca9ea2",
                    ] -> null # forces replacement
                    # (1 unchanged attribute hidden)
                }
                # (1 unchanged block hidden)
            }
        
        Plan: 1 to add, 0 to change, 1 to destroy.
=== CONT  TestAccKafkaServerlessCluster_basic
    serverless_cluster_test.go:25: Step 1/2 error: Check failed: 1 error occurred:
        	* Check 10/11 error: aws_msk_serverless_cluster.test: Attribute 'vpc_config.0.security_group_ids.#' expected "0", got "1"
        
--- FAIL: TestAccKafkaServerlessCluster_tags (330.43s)
=== CONT  TestAccKafkaScramSecretAssociation_basic
--- FAIL: TestAccKafkaServerlessCluster_basic (327.16s)
=== CONT  TestAccKafkaCluster_tags
--- PASS: TestAccKafkaCluster_tags (1526.37s)
=== CONT  TestAccKafkaConfiguration_basic
--- PASS: TestAccKafkaScramSecretAssociation_basic (1606.09s)
=== CONT  TestAccKafkaCluster_basic
--- PASS: TestAccKafkaBrokerNodesDataSource_basic (1938.39s)
=== CONT  TestAccKafkaClusterDataSource_basic
--- PASS: TestAccKafkaConfiguration_basic (60.58s)
--- PASS: TestAccKafkaCluster_basic (1779.69s)
--- PASS: TestAccKafkaClusterDataSource_basic (1779.86s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/kafka	3780.388s
=== RUN   TestAccKafkaConnectConnectorDataSource_basic
=== PAUSE TestAccKafkaConnectConnectorDataSource_basic
=== RUN   TestAccKafkaConnectConnector_basic
=== PAUSE TestAccKafkaConnectConnector_basic
=== RUN   TestAccKafkaConnectCustomPluginDataSource_basic
=== PAUSE TestAccKafkaConnectCustomPluginDataSource_basic
=== RUN   TestAccKafkaConnectCustomPlugin_basic
=== PAUSE TestAccKafkaConnectCustomPlugin_basic
=== RUN   TestAccKafkaConnectWorkerConfigurationDataSource_basic
=== PAUSE TestAccKafkaConnectWorkerConfigurationDataSource_basic
=== RUN   TestAccKafkaConnectWorkerConfiguration_basic
=== PAUSE TestAccKafkaConnectWorkerConfiguration_basic
=== CONT  TestAccKafkaConnectConnectorDataSource_basic
=== CONT  TestAccKafkaConnectCustomPlugin_basic
=== CONT  TestAccKafkaConnectWorkerConfiguration_basic
--- PASS: TestAccKafkaConnectWorkerConfiguration_basic (115.03s)
=== CONT  TestAccKafkaConnectCustomPluginDataSource_basic
--- PASS: TestAccKafkaConnectCustomPlugin_basic (147.26s)
=== CONT  TestAccKafkaConnectWorkerConfigurationDataSource_basic
--- PASS: TestAccKafkaConnectCustomPluginDataSource_basic (77.35s)
=== CONT  TestAccKafkaConnectConnector_basic
--- PASS: TestAccKafkaConnectWorkerConfigurationDataSource_basic (54.99s)
--- PASS: TestAccKafkaConnectConnectorDataSource_basic (2392.07s)
--- PASS: TestAccKafkaConnectConnector_basic (2217.62s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kafkaconnect	2457.724s
=== RUN   TestAccKendraDataSource_basic
=== PAUSE TestAccKendraDataSource_basic
=== RUN   TestAccKendraDataSource_tags
=== PAUSE TestAccKendraDataSource_tags
=== RUN   TestAccKendraExperienceDataSource_basic
=== PAUSE TestAccKendraExperienceDataSource_basic
=== RUN   TestAccKendraExperience_basic
=== PAUSE TestAccKendraExperience_basic
=== RUN   TestAccKendraFaqDataSource_basic
=== PAUSE TestAccKendraFaqDataSource_basic
=== RUN   TestAccKendraFaq_basic
=== PAUSE TestAccKendraFaq_basic
=== RUN   TestAccKendraFaq_tags
=== PAUSE TestAccKendraFaq_tags
=== RUN   TestAccKendraIndexDataSource_basic
=== PAUSE TestAccKendraIndexDataSource_basic
=== RUN   TestAccKendraIndex_basic
=== PAUSE TestAccKendraIndex_basic
=== RUN   TestAccKendraQuerySuggestionsBlockListDataSource_basic
=== PAUSE TestAccKendraQuerySuggestionsBlockListDataSource_basic
=== RUN   TestAccKendraQuerySuggestionsBlockList_basic
=== PAUSE TestAccKendraQuerySuggestionsBlockList_basic
=== RUN   TestAccKendraQuerySuggestionsBlockList_tags
=== PAUSE TestAccKendraQuerySuggestionsBlockList_tags
=== RUN   TestAccKendraThesaurusDataSource_basic
=== PAUSE TestAccKendraThesaurusDataSource_basic
=== RUN   TestAccKendraThesaurus_basic
=== PAUSE TestAccKendraThesaurus_basic
=== RUN   TestAccKendraThesaurus_tags
=== PAUSE TestAccKendraThesaurus_tags
=== CONT  TestAccKendraDataSource_basic
=== CONT  TestAccKendraIndex_basic
=== CONT  TestAccKendraThesaurusDataSource_basic
--- PASS: TestAccKendraIndex_basic (948.02s)
=== CONT  TestAccKendraThesaurus_tags
--- PASS: TestAccKendraThesaurusDataSource_basic (988.62s)
=== CONT  TestAccKendraThesaurus_basic
--- PASS: TestAccKendraDataSource_basic (1855.52s)
=== CONT  TestAccKendraFaqDataSource_basic
--- PASS: TestAccKendraThesaurus_basic (1394.20s)
=== CONT  TestAccKendraFaq_tags
--- PASS: TestAccKendraThesaurus_tags (1503.89s)
=== CONT  TestAccKendraIndexDataSource_basic
--- PASS: TestAccKendraFaqDataSource_basic (1298.42s)
=== CONT  TestAccKendraExperienceDataSource_basic
    acctest.go:912: this AWS account must be the management account of an AWS Organization
--- SKIP: TestAccKendraExperienceDataSource_basic (0.39s)
=== CONT  TestAccKendraFaq_basic
--- PASS: TestAccKendraFaq_tags (1209.80s)
=== CONT  TestAccKendraExperience_basic
    acctest.go:912: this AWS account must be the management account of an AWS Organization
--- SKIP: TestAccKendraExperience_basic (0.33s)
=== CONT  TestAccKendraDataSource_tags
--- PASS: TestAccKendraFaq_basic (899.32s)
=== CONT  TestAccKendraQuerySuggestionsBlockList_basic
--- PASS: TestAccKendraIndexDataSource_basic (2108.10s)
=== CONT  TestAccKendraQuerySuggestionsBlockList_tags
--- PASS: TestAccKendraDataSource_tags (1957.91s)
=== CONT  TestAccKendraQuerySuggestionsBlockListDataSource_basic
--- PASS: TestAccKendraQuerySuggestionsBlockList_basic (1684.94s)
--- PASS: TestAccKendraQuerySuggestionsBlockList_tags (1624.51s)
--- PASS: TestAccKendraQuerySuggestionsBlockListDataSource_basic (1292.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kendra	6920.608s
=== RUN   TestAccKeyspacesKeyspace_basic
=== PAUSE TestAccKeyspacesKeyspace_basic
=== RUN   TestAccKeyspacesKeyspace_tags
=== PAUSE TestAccKeyspacesKeyspace_tags
=== RUN   TestAccKeyspacesTable_basic
=== PAUSE TestAccKeyspacesTable_basic
=== RUN   TestAccKeyspacesTable_tags
=== PAUSE TestAccKeyspacesTable_tags
=== CONT  TestAccKeyspacesKeyspace_basic
=== CONT  TestAccKeyspacesTable_basic
=== CONT  TestAccKeyspacesKeyspace_tags
--- PASS: TestAccKeyspacesKeyspace_basic (166.86s)
=== CONT  TestAccKeyspacesTable_tags
--- PASS: TestAccKeyspacesTable_basic (188.33s)
--- PASS: TestAccKeyspacesKeyspace_tags (243.17s)
--- PASS: TestAccKeyspacesTable_tags (191.59s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/keyspaces	393.820s
=== RUN   TestAccKinesisStreamConsumerDataSource_basic
=== PAUSE TestAccKinesisStreamConsumerDataSource_basic
=== RUN   TestAccKinesisStreamConsumer_basic
=== PAUSE TestAccKinesisStreamConsumer_basic
=== RUN   TestAccKinesisStreamDataSource_basic
=== PAUSE TestAccKinesisStreamDataSource_basic
=== RUN   TestAccKinesisStream_basic
=== PAUSE TestAccKinesisStream_basic
=== RUN   TestAccKinesisStream_tags
=== PAUSE TestAccKinesisStream_tags
=== CONT  TestAccKinesisStreamConsumerDataSource_basic
=== CONT  TestAccKinesisStream_basic
=== CONT  TestAccKinesisStream_tags
--- PASS: TestAccKinesisStream_basic (107.92s)
=== CONT  TestAccKinesisStreamDataSource_basic
--- PASS: TestAccKinesisStreamConsumerDataSource_basic (113.68s)
=== CONT  TestAccKinesisStreamConsumer_basic
--- PASS: TestAccKinesisStream_tags (183.12s)
--- PASS: TestAccKinesisStreamConsumer_basic (107.31s)
--- PASS: TestAccKinesisStreamDataSource_basic (147.42s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesis	349.489s
=== RUN   TestAccKinesisAnalyticsApplication_basic
=== PAUSE TestAccKinesisAnalyticsApplication_basic
=== RUN   TestAccKinesisAnalyticsApplication_tags
=== PAUSE TestAccKinesisAnalyticsApplication_tags
=== CONT  TestAccKinesisAnalyticsApplication_basic
=== CONT  TestAccKinesisAnalyticsApplication_tags
--- PASS: TestAccKinesisAnalyticsApplication_basic (107.88s)
--- PASS: TestAccKinesisAnalyticsApplication_tags (191.21s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalytics	213.118s
=== RUN   TestAccKinesisAnalyticsV2ApplicationSnapshot_basic
=== PAUSE TestAccKinesisAnalyticsV2ApplicationSnapshot_basic
=== RUN   TestAccKinesisAnalyticsV2Application_tags
=== PAUSE TestAccKinesisAnalyticsV2Application_tags
=== CONT  TestAccKinesisAnalyticsV2ApplicationSnapshot_basic
=== CONT  TestAccKinesisAnalyticsV2Application_tags
--- PASS: TestAccKinesisAnalyticsV2Application_tags (167.52s)
--- PASS: TestAccKinesisAnalyticsV2ApplicationSnapshot_basic (280.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalyticsv2	371.175s
=== RUN   TestAccKinesisVideoStream_basic
=== PAUSE TestAccKinesisVideoStream_basic
=== RUN   TestAccKinesisVideoStream_tags
=== PAUSE TestAccKinesisVideoStream_tags
=== CONT  TestAccKinesisVideoStream_basic
=== CONT  TestAccKinesisVideoStream_tags
--- PASS: TestAccKinesisVideoStream_tags (241.01s)
--- PASS: TestAccKinesisVideoStream_basic (256.39s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesisvideo	342.781s
=== RUN   TestAccKMSAlias_basic
=== PAUSE TestAccKMSAlias_basic
=== RUN   TestAccKMSCiphertextDataSource_basic
=== PAUSE TestAccKMSCiphertextDataSource_basic
=== RUN   TestAccKMSCiphertext_Resource_basic
=== PAUSE TestAccKMSCiphertext_Resource_basic
=== RUN   TestAccKMSCustomKeyStoreDataSource_basic
    custom_key_store_data_source_test.go:17: CLOUD_HSM_CLUSTER_ID environment variable not set
--- SKIP: TestAccKMSCustomKeyStoreDataSource_basic (0.00s)
=== RUN   TestAccKMSExternalKey_basic
=== PAUSE TestAccKMSExternalKey_basic
=== RUN   TestAccKMSExternalKey_tags
=== PAUSE TestAccKMSExternalKey_tags
=== RUN   TestAccKMSGrant_basic
=== PAUSE TestAccKMSGrant_basic
=== RUN   TestAccKMSKeyPolicy_basic
=== PAUSE TestAccKMSKeyPolicy_basic
=== RUN   TestAccKMSKey_basic
=== PAUSE TestAccKMSKey_basic
=== RUN   TestAccKMSKey_Policy_basic
=== PAUSE TestAccKMSKey_Policy_basic
=== RUN   TestAccKMSKey_tags
=== PAUSE TestAccKMSKey_tags
=== RUN   TestAccKMSPublicKeyDataSource_basic
=== PAUSE TestAccKMSPublicKeyDataSource_basic
=== RUN   TestAccKMSReplicaExternalKey_basic
=== PAUSE TestAccKMSReplicaExternalKey_basic
=== RUN   TestAccKMSReplicaExternalKey_tags
=== PAUSE TestAccKMSReplicaExternalKey_tags
=== RUN   TestAccKMSReplicaKey_basic
=== PAUSE TestAccKMSReplicaKey_basic
=== RUN   TestAccKMSReplicaKey_tags
=== PAUSE TestAccKMSReplicaKey_tags
=== RUN   TestAccKMSSecretsDataSource_basic
=== PAUSE TestAccKMSSecretsDataSource_basic
=== CONT  TestAccKMSAlias_basic
=== CONT  TestAccKMSKey_Policy_basic
=== CONT  TestAccKMSReplicaExternalKey_tags
--- PASS: TestAccKMSAlias_basic (38.56s)
=== CONT  TestAccKMSExternalKey_tags
--- PASS: TestAccKMSKey_Policy_basic (61.13s)
=== CONT  TestAccKMSKey_basic
--- PASS: TestAccKMSKey_basic (37.74s)
=== CONT  TestAccKMSKeyPolicy_basic
--- PASS: TestAccKMSExternalKey_tags (105.19s)
=== CONT  TestAccKMSGrant_basic
--- PASS: TestAccKMSKeyPolicy_basic (81.96s)
=== CONT  TestAccKMSReplicaKey_tags
--- PASS: TestAccKMSGrant_basic (51.50s)
=== CONT  TestAccKMSSecretsDataSource_basic
--- PASS: TestAccKMSReplicaExternalKey_tags (205.81s)
=== CONT  TestAccKMSReplicaKey_basic
--- PASS: TestAccKMSSecretsDataSource_basic (51.97s)
=== CONT  TestAccKMSPublicKeyDataSource_basic
--- PASS: TestAccKMSReplicaKey_basic (65.50s)
=== CONT  TestAccKMSReplicaExternalKey_basic
--- PASS: TestAccKMSPublicKeyDataSource_basic (26.86s)
=== CONT  TestAccKMSCiphertext_Resource_basic
--- PASS: TestAccKMSCiphertext_Resource_basic (25.94s)
=== CONT  TestAccKMSExternalKey_basic
--- PASS: TestAccKMSExternalKey_basic (26.23s)
=== CONT  TestAccKMSCiphertextDataSource_basic
--- PASS: TestAccKMSReplicaKey_tags (153.76s)
=== CONT  TestAccKMSKey_tags
--- PASS: TestAccKMSReplicaExternalKey_basic (76.64s)
--- PASS: TestAccKMSCiphertextDataSource_basic (28.12s)
--- PASS: TestAccKMSKey_tags (81.91s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	433.646s
FAIL
make: *** [testacc] Error 1
```
