### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin SDK resources `i*` (Phase 3c)

### DIFF
--- a/internal/service/imagebuilder/component.go
+++ b/internal/service/imagebuilder/component.go
@@ -16,9 +16,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_imagebuilder_component")
+// @SDKResource("aws_imagebuilder_component", name="Component")
+// @Tags(identifierAttribute="id")
 func ResourceComponent() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceComponentCreate,
@@ -100,8 +102,8 @@ func ResourceComponent() *schema.Resource {
 				MinItems: 1,
 				MaxItems: 25,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"type": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -127,11 +129,10 @@ func ResourceComponent() *schema.Resource {
 func resourceComponentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ImageBuilderConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &imagebuilder.CreateComponentInput{
 		ClientToken: aws.String(id.UniqueId()),
+		Tags:        GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("change_description"); ok {
@@ -162,10 +163,6 @@ func resourceComponentCreate(ctx context.Context, d *schema.ResourceData, meta i
 		input.SupportedOsVersions = flex.ExpandStringSet(v.(*schema.Set))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
 	if v, ok := d.GetOk("uri"); ok {
 		input.Uri = aws.String(v.(string))
 	}
@@ -192,8 +189,6 @@ func resourceComponentCreate(ctx context.Context, d *schema.ResourceData, meta i
 func resourceComponentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ImageBuilderConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	input := &imagebuilder.GetComponentInput{
 		ComponentBuildVersionArn: aws.String(d.Id()),
@@ -229,16 +224,7 @@ func resourceComponentRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("platform", component.Platform)
 	d.Set("supported_os_versions", aws.StringValueSlice(component.SupportedOsVersions))
 
-	tags := KeyValueTags(ctx, component.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, component.Tags)
 
 	d.Set("type", component.Type)
 	d.Set("version", component.Version)
@@ -248,15 +234,8 @@ func resourceComponentRead(ctx context.Context, d *schema.ResourceData, meta int
 
 func resourceComponentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).ImageBuilderConn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags for Image Builder Component (%s): %s", d.Id(), err)
-		}
-	}
+	// Tags only.
 
 	return append(diags, resourceComponentRead(ctx, d, meta)...)
 }

--- a/internal/service/imagebuilder/image_pipeline.go
+++ b/internal/service/imagebuilder/image_pipeline.go
@@ -16,9 +16,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_imagebuilder_image_pipeline")
+// @SDKResource("aws_imagebuilder_image_pipeline", name="Image Pipeline")
+// @Tags(identifierAttribute="id")
 func ResourceImagePipeline() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceImagePipelineCreate,
@@ -149,8 +151,8 @@ func ResourceImagePipeline() *schema.Resource {
 				Default:      imagebuilder.PipelineStatusEnabled,
 				ValidateFunc: validation.StringInSlice(imagebuilder.PipelineStatus_Values(), false),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -160,12 +162,11 @@ func ResourceImagePipeline() *schema.Resource {
 func resourceImagePipelineCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ImageBuilderConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &imagebuilder.CreateImagePipelineInput{
 		ClientToken:                  aws.String(id.UniqueId()),
 		EnhancedImageMetadataEnabled: aws.Bool(d.Get("enhanced_image_metadata_enabled").(bool)),
+		Tags:                         GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("container_recipe_arn"); ok {
@@ -204,10 +205,6 @@ func resourceImagePipelineCreate(ctx context.Context, d *schema.ResourceData, me
 		input.Status = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
 	output, err := conn.CreateImagePipelineWithContext(ctx, input)
 
 	if err != nil {
@@ -226,8 +223,6 @@ func resourceImagePipelineCreate(ctx context.Context, d *schema.ResourceData, me
 func resourceImagePipelineRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ImageBuilderConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	input := &imagebuilder.GetImagePipelineInput{
 		ImagePipelineArn: aws.String(d.Id()),
@@ -280,16 +275,7 @@ func resourceImagePipelineRead(ctx context.Context, d *schema.ResourceData, meta
 
 	d.Set("status", imagePipeline.Status)
 
-	tags := KeyValueTags(ctx, imagePipeline.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, imagePipeline.Tags)
 
 	return diags
 }

--- a/internal/service/imagebuilder/infrastructure_configuration.go
+++ b/internal/service/imagebuilder/infrastructure_configuration.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_imagebuilder_infrastructure_configuration")
+// @SDKResource("aws_imagebuilder_infrastructure_configuration", name="Infrastructure Configuration")
+// @Tags(identifierAttribute="id")
 func ResourceInfrastructureConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceInfrastructureConfigurationCreate,
@@ -135,8 +137,8 @@ func ResourceInfrastructureConfiguration() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(1, 1024),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"terminate_instance_on_failure": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -151,11 +153,10 @@ func ResourceInfrastructureConfiguration() *schema.Resource {
 func resourceInfrastructureConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ImageBuilderConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &imagebuilder.CreateInfrastructureConfigurationInput{
 		ClientToken:                aws.String(id.UniqueId()),
+		Tags:                       GetTagsIn(ctx),
 		TerminateInstanceOnFailure: aws.Bool(d.Get("terminate_instance_on_failure").(bool)),
 	}
 
@@ -203,10 +204,6 @@ func resourceInfrastructureConfigurationCreate(ctx context.Context, d *schema.Re
 		input.SubnetId = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
 	var output *imagebuilder.CreateInfrastructureConfigurationOutput
 	err := retry.RetryContext(ctx, propagationTimeout, func() *retry.RetryError {
 		var err error
@@ -244,8 +241,6 @@ func resourceInfrastructureConfigurationCreate(ctx context.Context, d *schema.Re
 func resourceInfrastructureConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ImageBuilderConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	input := &imagebuilder.GetInfrastructureConfigurationInput{
 		InfrastructureConfigurationArn: aws.String(d.Id()),
@@ -295,16 +290,9 @@ func resourceInfrastructureConfigurationRead(ctx context.Context, d *schema.Reso
 	d.Set("security_group_ids", aws.StringValueSlice(infrastructureConfiguration.SecurityGroupIds))
 	d.Set("sns_topic_arn", infrastructureConfiguration.SnsTopicArn)
 	d.Set("subnet_id", infrastructureConfiguration.SubnetId)
-	tags := KeyValueTags(ctx, infrastructureConfiguration.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
+	SetTagsOut(ctx, infrastructureConfiguration.Tags)
 
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
 	d.Set("terminate_instance_on_failure", infrastructureConfiguration.TerminateInstanceOnFailure)
 
 	return diags
@@ -392,14 +380,6 @@ func resourceInfrastructureConfigurationUpdate(ctx context.Context, d *schema.Re
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Image Builder Infrastructure Configuration (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags for Image Builder Infrastructure Configuration (%s): %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/imagebuilder/service_package_gen.go
+++ b/internal/service/imagebuilder/service_package_gen.go
@@ -81,30 +81,58 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceComponent,
 			TypeName: "aws_imagebuilder_component",
+			Name:     "Component",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceContainerRecipe,
 			TypeName: "aws_imagebuilder_container_recipe",
+			Name:     "Container Recipe",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceDistributionConfiguration,
 			TypeName: "aws_imagebuilder_distribution_configuration",
+			Name:     "Distribution Configuration",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceImage,
 			TypeName: "aws_imagebuilder_image",
+			Name:     "Image",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceImagePipeline,
 			TypeName: "aws_imagebuilder_image_pipeline",
+			Name:     "Image Pipeline",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceImageRecipe,
 			TypeName: "aws_imagebuilder_image_recipe",
+			Name:     "Image Recipe",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceInfrastructureConfiguration,
 			TypeName: "aws_imagebuilder_infrastructure_configuration",
+			Name:     "Infrastructure Configuration",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }

--- a/internal/service/iot/service_package_gen.go
+++ b/internal/service/iot/service_package_gen.go
@@ -57,6 +57,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceProvisioningTemplate,
 			TypeName: "aws_iot_provisioning_template",
+			Name:     "Provisioning Template",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRoleAlias,
@@ -69,6 +73,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceThingGroup,
 			TypeName: "aws_iot_thing_group",
+			Name:     "Thing Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceThingGroupMembership,
@@ -81,10 +89,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceThingType,
 			TypeName: "aws_iot_thing_type",
+			Name:     "Thing Type",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceTopicRule,
 			TypeName: "aws_iot_topic_rule",
+			Name:     "Topic Rule",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceTopicRuleDestination,

--- a/internal/service/iot/thing_type.go
+++ b/internal/service/iot/thing_type.go
@@ -16,10 +16,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// https://docs.aws.amazon.com/iot/latest/apireference/API_CreateThingType.html
-// @SDKResource("aws_iot_thing_type")
+// @SDKResource("aws_iot_thing_type", name="Thing Type")
+// @Tags(identifierAttribute="arn")
 func ResourceThingType() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceThingTypeCreate,
@@ -73,8 +74,8 @@ func ResourceThingType() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -88,9 +89,9 @@ func ResourceThingType() *schema.Resource {
 func resourceThingTypeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IoTConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
-	params := &iot.CreateThingTypeInput{
+
+	input := &iot.CreateThingTypeInput{
+		Tags:          GetTagsIn(ctx),
 		ThingTypeName: aws.String(d.Get("name").(string)),
 	}
 
@@ -99,15 +100,11 @@ func resourceThingTypeCreate(ctx context.Context, d *schema.ResourceData, meta i
 		config, ok := configs[0].(map[string]interface{})
 
 		if ok && config != nil {
-			params.ThingTypeProperties = expandThingTypeProperties(config)
+			input.ThingTypeProperties = expandThingTypeProperties(config)
 		}
 	}
-	if len(tags) > 0 {
-		params.Tags = Tags(tags.IgnoreAWS())
-	}
 
-	log.Printf("[DEBUG] Creating IoT Thing Type: %s", params)
-	out, err := conn.CreateThingTypeWithContext(ctx, params)
+	out, err := conn.CreateThingTypeWithContext(ctx, input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating IoT Thing Type (%s): %s", d.Get("name").(string), err)
@@ -135,9 +132,6 @@ func resourceThingTypeRead(ctx context.Context, d *schema.ResourceData, meta int
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IoTConn()
 
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-
 	params := &iot.DescribeThingTypeInput{
 		ThingTypeName: aws.String(d.Id()),
 	}
@@ -158,26 +152,6 @@ func resourceThingTypeRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	d.Set("arn", out.ThingTypeArn)
 
-	tags, err := ListTags(ctx, conn, aws.StringValue(out.ThingTypeArn))
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for IoT Thing Type (%s): %s", aws.StringValue(out.ThingTypeArn), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
-	if err := d.Set("properties", flattenThingTypeProperties(out.ThingTypeProperties)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting properties: %s", err)
-	}
-
 	return diags
 }
 
@@ -196,14 +170,6 @@ func resourceThingTypeUpdate(ctx context.Context, d *schema.ResourceData, meta i
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating IoT Thing Type (%s): deprecating Thing Type: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
 		}
 	}
 

--- a/internal/service/iot/thing_type.go
+++ b/internal/service/iot/thing_type.go
@@ -150,6 +150,10 @@ func resourceThingTypeRead(ctx context.Context, d *schema.ResourceData, meta int
 		d.Set("deprecated", out.ThingTypeMetadata.Deprecated)
 	}
 
+	if err := d.Set("properties", flattenThingTypeProperties(out.ThingTypeProperties)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting properties: %s", err)
+	}
+
 	d.Set("arn", out.ThingTypeArn)
 
 	return diags

--- a/internal/service/ivs/recording_configuration.go
+++ b/internal/service/ivs/recording_configuration.go
@@ -21,7 +21,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ivs_recording_configuration")
+// @SDKResource("aws_ivs_recording_configuration", name="Recording Configuration")
+// @Tags(identifierAttribute="id")
 func ResourceRecordingConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRecordingConfigurationCreate,
@@ -38,7 +39,6 @@ func ResourceRecordingConfiguration() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -85,8 +85,8 @@ func ResourceRecordingConfiguration() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchemaForceNew(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchemaForceNew(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"thumbnail_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -125,6 +125,7 @@ func resourceRecordingConfigurationCreate(ctx context.Context, d *schema.Resourc
 
 	in := &ivs.CreateRecordingConfigurationInput{
 		DestinationConfiguration: expandDestinationConfiguration(d.Get("destination_configuration").([]interface{})),
+		Tags:                     GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("name"); ok {
@@ -133,13 +134,6 @@ func resourceRecordingConfigurationCreate(ctx context.Context, d *schema.Resourc
 
 	if v, ok := d.GetOk("recording_reconnect_window_seconds"); ok {
 		in.RecordingReconnectWindowSeconds = aws.Int64(int64(v.(int)))
-	}
-
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
-
-	if len(tags) > 0 {
-		in.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	if v, ok := d.GetOk("thumbnail_configuration"); ok {
@@ -194,23 +188,6 @@ func resourceRecordingConfigurationRead(ctx context.Context, d *schema.ResourceD
 	d.Set("state", out.State)
 
 	if err := d.Set("thumbnail_configuration", flattenThumbnailConfiguration(out.ThumbnailConfiguration)); err != nil {
-		return create.DiagError(names.IVS, create.ErrActionSetting, ResNameRecordingConfiguration, d.Id(), err)
-	}
-
-	tags, err := ListTags(ctx, conn, d.Id())
-	if err != nil {
-		return create.DiagError(names.IVS, create.ErrActionReading, ResNameRecordingConfiguration, d.Id(), err)
-	}
-
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return create.DiagError(names.IVS, create.ErrActionSetting, ResNameRecordingConfiguration, d.Id(), err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
 		return create.DiagError(names.IVS, create.ErrActionSetting, ResNameRecordingConfiguration, d.Id(), err)
 	}
 

--- a/internal/service/ivs/service_package_gen.go
+++ b/internal/service/ivs/service_package_gen.go
@@ -33,14 +33,26 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceChannel,
 			TypeName: "aws_ivs_channel",
+			Name:     "Channel",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourcePlaybackKeyPair,
 			TypeName: "aws_ivs_playback_key_pair",
+			Name:     "Playback Key Pair",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceRecordingConfiguration,
 			TypeName: "aws_ivs_recording_configuration",
+			Name:     "Recording Configuration",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }

--- a/internal/service/ivschat/service_package_gen.go
+++ b/internal/service/ivschat/service_package_gen.go
@@ -28,10 +28,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceLoggingConfiguration,
 			TypeName: "aws_ivschat_logging_configuration",
+			Name:     "Logging Configuration",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceRoom,
 			TypeName: "aws_ivschat_room",
+			Name:     "Room",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin SDK.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30421.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30430.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30449.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30454.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30461.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30463.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30476.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30477.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30478.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30483.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30484.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30491.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30509.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30510.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30512.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30516.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=i... ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/i.../... -v -count 1 -parallel 2  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccIAMAccessKey_basic
=== PAUSE TestAccIAMAccessKey_basic
=== RUN   TestAccIAMGroupDataSource_basic
=== PAUSE TestAccIAMGroupDataSource_basic
=== RUN   TestAccIAMGroupMembership_basic
=== PAUSE TestAccIAMGroupMembership_basic
=== RUN   TestAccIAMGroupPolicyAttachment_basic
=== PAUSE TestAccIAMGroupPolicyAttachment_basic
=== RUN   TestAccIAMGroupPolicy_basic
=== PAUSE TestAccIAMGroupPolicy_basic
=== RUN   TestAccIAMGroup_basic
=== PAUSE TestAccIAMGroup_basic
=== RUN   TestAccIAMInstanceProfileDataSource_basic
=== PAUSE TestAccIAMInstanceProfileDataSource_basic
=== RUN   TestAccIAMInstanceProfile_basic
=== PAUSE TestAccIAMInstanceProfile_basic
=== RUN   TestAccIAMInstanceProfile_tags
=== PAUSE TestAccIAMInstanceProfile_tags
=== RUN   TestAccIAMInstanceProfilesDataSource_basic
=== PAUSE TestAccIAMInstanceProfilesDataSource_basic
=== RUN   TestAccIAMOpenidConnectProviderDataSource_basic
=== PAUSE TestAccIAMOpenidConnectProviderDataSource_basic
=== RUN   TestAccIAMOpenidConnectProviderDataSource_tags
=== PAUSE TestAccIAMOpenidConnectProviderDataSource_tags
=== RUN   TestAccIAMOpenIDConnectProvider_basic
=== PAUSE TestAccIAMOpenIDConnectProvider_basic
=== RUN   TestAccIAMOpenIDConnectProvider_tags
=== PAUSE TestAccIAMOpenIDConnectProvider_tags
=== RUN   TestAccIAMPolicyAttachment_basic
=== PAUSE TestAccIAMPolicyAttachment_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_basic
=== PAUSE TestAccIAMPolicyDocumentDataSource_basic
=== RUN   TestAccIAMPolicy_basic
=== PAUSE TestAccIAMPolicy_basic
=== RUN   TestAccIAMPolicy_tags
=== PAUSE TestAccIAMPolicy_tags
=== RUN   TestAccIAMRoleDataSource_basic
=== PAUSE TestAccIAMRoleDataSource_basic
=== RUN   TestAccIAMRoleDataSource_tags
=== PAUSE TestAccIAMRoleDataSource_tags
=== RUN   TestAccIAMRolePolicyAttachment_basic
=== PAUSE TestAccIAMRolePolicyAttachment_basic
=== RUN   TestAccIAMRolePolicy_basic
=== PAUSE TestAccIAMRolePolicy_basic
=== RUN   TestAccIAMRole_basic
=== PAUSE TestAccIAMRole_basic
=== RUN   TestAccIAMRole_tags
=== PAUSE TestAccIAMRole_tags
=== RUN   TestAccIAMRole_InlinePolicy_basic
=== PAUSE TestAccIAMRole_InlinePolicy_basic
=== RUN   TestAccIAMRole_ManagedPolicy_basic
=== PAUSE TestAccIAMRole_ManagedPolicy_basic
=== RUN   TestAccIAMRolesDataSource_basic
=== PAUSE TestAccIAMRolesDataSource_basic
=== RUN   TestAccIAMSAMLProviderDataSource_basic
=== PAUSE TestAccIAMSAMLProviderDataSource_basic
=== RUN   TestAccIAMSAMLProvider_basic
=== PAUSE TestAccIAMSAMLProvider_basic
=== RUN   TestAccIAMSAMLProvider_tags
=== PAUSE TestAccIAMSAMLProvider_tags
=== RUN   TestAccIAMServerCertificateDataSource_basic
=== PAUSE TestAccIAMServerCertificateDataSource_basic
=== RUN   TestAccIAMServerCertificate_basic
=== PAUSE TestAccIAMServerCertificate_basic
=== RUN   TestAccIAMServerCertificate_tags
=== PAUSE TestAccIAMServerCertificate_tags
=== RUN   TestAccIAMServiceLinkedRole_basic
=== PAUSE TestAccIAMServiceLinkedRole_basic
=== RUN   TestAccIAMServiceLinkedRole_tags
=== PAUSE TestAccIAMServiceLinkedRole_tags
=== RUN   TestAccIAMServiceSpecificCredential_basic
=== PAUSE TestAccIAMServiceSpecificCredential_basic
=== RUN   TestAccIAMSessionContextDataSource_basic
=== PAUSE TestAccIAMSessionContextDataSource_basic
=== RUN   TestAccIAMSigningCertificate_basic
=== PAUSE TestAccIAMSigningCertificate_basic
=== RUN   TestAccIAMUserDataSource_basic
=== PAUSE TestAccIAMUserDataSource_basic
=== RUN   TestAccIAMUserDataSource_tags
=== PAUSE TestAccIAMUserDataSource_tags
=== RUN   TestAccIAMUserGroupMembership_basic
=== PAUSE TestAccIAMUserGroupMembership_basic
=== RUN   TestAccIAMUserLoginProfile_basic
=== PAUSE TestAccIAMUserLoginProfile_basic
=== RUN   TestAccIAMUserPolicyAttachment_basic
=== PAUSE TestAccIAMUserPolicyAttachment_basic
=== RUN   TestAccIAMUserPolicy_basic
=== PAUSE TestAccIAMUserPolicy_basic
=== RUN   TestAccIAMUserSSHKeyDataSource_basic
=== PAUSE TestAccIAMUserSSHKeyDataSource_basic
=== RUN   TestAccIAMUserSSHKey_basic
=== PAUSE TestAccIAMUserSSHKey_basic
=== RUN   TestAccIAMUser_basic
=== PAUSE TestAccIAMUser_basic
=== RUN   TestAccIAMUser_tags
=== PAUSE TestAccIAMUser_tags
=== RUN   TestAccIAMVirtualMFADevice_basic
=== PAUSE TestAccIAMVirtualMFADevice_basic
=== RUN   TestAccIAMVirtualMFADevice_tags
=== PAUSE TestAccIAMVirtualMFADevice_tags
=== CONT  TestAccIAMAccessKey_basic
=== CONT  TestAccIAMRole_ManagedPolicy_basic
--- PASS: TestAccIAMAccessKey_basic (33.14s)
=== CONT  TestAccIAMVirtualMFADevice_tags
--- PASS: TestAccIAMRole_ManagedPolicy_basic (114.83s)
=== CONT  TestAccIAMVirtualMFADevice_basic
--- PASS: TestAccIAMVirtualMFADevice_basic (58.59s)
=== CONT  TestAccIAMUser_tags
--- PASS: TestAccIAMVirtualMFADevice_tags (145.35s)
=== CONT  TestAccIAMUser_basic
--- PASS: TestAccIAMUser_tags (93.22s)
=== CONT  TestAccIAMUserSSHKey_basic
--- PASS: TestAccIAMUser_basic (92.08s)
=== CONT  TestAccIAMUserSSHKeyDataSource_basic
--- PASS: TestAccIAMUserSSHKeyDataSource_basic (34.87s)
=== CONT  TestAccIAMUserPolicy_basic
--- PASS: TestAccIAMUserSSHKey_basic (42.82s)
=== CONT  TestAccIAMUserPolicyAttachment_basic
--- PASS: TestAccIAMUserPolicy_basic (57.33s)
=== CONT  TestAccIAMUserLoginProfile_basic
--- PASS: TestAccIAMUserPolicyAttachment_basic (56.99s)
=== CONT  TestAccIAMUserGroupMembership_basic
--- PASS: TestAccIAMUserLoginProfile_basic (47.32s)
=== CONT  TestAccIAMUserDataSource_tags
--- PASS: TestAccIAMUserDataSource_tags (26.75s)
=== CONT  TestAccIAMUserDataSource_basic
--- PASS: TestAccIAMUserDataSource_basic (24.16s)
=== CONT  TestAccIAMSigningCertificate_basic
--- PASS: TestAccIAMSigningCertificate_basic (33.13s)
=== CONT  TestAccIAMSessionContextDataSource_basic
--- PASS: TestAccIAMUserGroupMembership_basic (129.04s)
=== CONT  TestAccIAMServiceSpecificCredential_basic
--- PASS: TestAccIAMSessionContextDataSource_basic (27.33s)
=== CONT  TestAccIAMServiceLinkedRole_tags
--- PASS: TestAccIAMServiceSpecificCredential_basic (32.83s)
=== CONT  TestAccIAMServiceLinkedRole_basic
--- PASS: TestAccIAMServiceLinkedRole_basic (41.82s)
=== CONT  TestAccIAMServerCertificate_tags
--- PASS: TestAccIAMServiceLinkedRole_tags (83.77s)
=== CONT  TestAccIAMServerCertificate_basic
--- PASS: TestAccIAMServerCertificate_basic (32.54s)
=== CONT  TestAccIAMServerCertificateDataSource_basic
--- PASS: TestAccIAMServerCertificate_tags (74.06s)
=== CONT  TestAccIAMSAMLProvider_tags
--- PASS: TestAccIAMServerCertificateDataSource_basic (32.53s)
=== CONT  TestAccIAMSAMLProvider_basic
--- PASS: TestAccIAMSAMLProvider_tags (76.81s)
=== CONT  TestAccIAMSAMLProviderDataSource_basic
--- PASS: TestAccIAMSAMLProvider_basic (53.41s)
=== CONT  TestAccIAMRolesDataSource_basic
--- PASS: TestAccIAMRolesDataSource_basic (27.95s)
=== CONT  TestAccIAMRoleDataSource_tags
--- PASS: TestAccIAMSAMLProviderDataSource_basic (29.30s)
=== CONT  TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMRoleDataSource_tags
    role_data_source_test.go:48: Step 1/1 error: Check failed: 1 error occurred:
        	* Check 2/11 error: data.aws_iam_role.test: Attribute 'assume_role_policy' expected "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}", got "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
        
--- FAIL: TestAccIAMRoleDataSource_tags (15.41s)
=== CONT  TestAccIAMRole_tags
--- PASS: TestAccIAMRole_tags (54.40s)
=== CONT  TestAccIAMOpenIDConnectProvider_tags
--- PASS: TestAccIAMRole_InlinePolicy_basic (76.10s)
=== CONT  TestAccIAMRoleDataSource_basic
    role_data_source_test.go:19: Step 1/1 error: Check failed: 1 error occurred:
        	* Check 2/9 error: data.aws_iam_role.test: Attribute 'assume_role_policy' expected "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}", got "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
        
--- FAIL: TestAccIAMRoleDataSource_basic (14.28s)
=== CONT  TestAccIAMPolicy_tags
--- PASS: TestAccIAMOpenIDConnectProvider_tags (66.25s)
=== CONT  TestAccIAMPolicy_basic
--- PASS: TestAccIAMPolicy_tags (62.00s)
=== CONT  TestAccIAMPolicyDocumentDataSource_basic
--- PASS: TestAccIAMPolicy_basic (21.04s)
=== CONT  TestAccIAMRole_basic
--- PASS: TestAccIAMPolicyDocumentDataSource_basic (13.24s)
=== CONT  TestAccIAMRolePolicy_basic
--- PASS: TestAccIAMRole_basic (18.70s)
=== CONT  TestAccIAMRolePolicyAttachment_basic
--- PASS: TestAccIAMRolePolicy_basic (31.84s)
=== CONT  TestAccIAMInstanceProfile_basic
--- PASS: TestAccIAMRolePolicyAttachment_basic (31.42s)
=== CONT  TestAccIAMPolicyAttachment_basic
--- PASS: TestAccIAMInstanceProfile_basic (18.61s)
=== CONT  TestAccIAMGroupPolicy_basic
--- PASS: TestAccIAMPolicyAttachment_basic (30.06s)
=== CONT  TestAccIAMInstanceProfileDataSource_basic
--- PASS: TestAccIAMGroupPolicy_basic (33.11s)
=== CONT  TestAccIAMGroup_basic
--- PASS: TestAccIAMInstanceProfileDataSource_basic (16.40s)
=== CONT  TestAccIAMOpenIDConnectProvider_basic
--- PASS: TestAccIAMGroup_basic (21.01s)
=== CONT  TestAccIAMOpenidConnectProviderDataSource_basic
    openid_connect_provider_data_source_test.go:19: Step 1/1 error: Error running apply: exit status 1
        
        Error: creating IAM OIDC Provider: InvalidInput: Thumbprint list must contain at least one entry.
        	status code: 400, request id: b35b610a-4ee8-4245-b7df-0f739b63b123
        
          with aws_iam_openid_connect_provider.test,
          on terraform_plugin_test.tf line 2, in resource "aws_iam_openid_connect_provider" "test":
           2: resource "aws_iam_openid_connect_provider" "test" {
        
--- FAIL: TestAccIAMOpenidConnectProviderDataSource_basic (6.72s)
=== CONT  TestAccIAMInstanceProfilesDataSource_basic
--- PASS: TestAccIAMOpenIDConnectProvider_basic (32.48s)
=== CONT  TestAccIAMOpenidConnectProviderDataSource_tags
    openid_connect_provider_data_source_test.go:73: Step 1/1 error: Error running apply: exit status 1
        
        Error: creating IAM OIDC Provider: InvalidInput: Thumbprint list must contain at least one entry.
        	status code: 400, request id: 00ef37fd-7c67-4397-ba7e-606afd02666c
        
          with aws_iam_openid_connect_provider.test,
          on terraform_plugin_test.tf line 2, in resource "aws_iam_openid_connect_provider" "test":
           2: resource "aws_iam_openid_connect_provider" "test" {
        
--- FAIL: TestAccIAMOpenidConnectProviderDataSource_tags (5.28s)
=== CONT  TestAccIAMInstanceProfile_tags
--- PASS: TestAccIAMInstanceProfilesDataSource_basic (14.43s)
=== CONT  TestAccIAMGroupPolicyAttachment_basic
--- PASS: TestAccIAMGroupPolicyAttachment_basic (25.49s)
=== CONT  TestAccIAMGroupDataSource_basic
--- PASS: TestAccIAMInstanceProfile_tags (36.98s)
=== CONT  TestAccIAMGroupMembership_basic
--- PASS: TestAccIAMGroupDataSource_basic (12.71s)
--- PASS: TestAccIAMGroupMembership_basic (30.14s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/iam	1128.263s
=== RUN   TestAccIdentityStoreGroupMembership_basic
=== PAUSE TestAccIdentityStoreGroupMembership_basic
=== RUN   TestAccIdentityStoreGroup_basic
=== PAUSE TestAccIdentityStoreGroup_basic
=== RUN   TestAccIdentityStoreUserDataSource_basic
=== PAUSE TestAccIdentityStoreUserDataSource_basic
=== RUN   TestAccIdentityStoreUser_basic
=== PAUSE TestAccIdentityStoreUser_basic
=== CONT  TestAccIdentityStoreGroupMembership_basic
=== CONT  TestAccIdentityStoreUserDataSource_basic
    group_data_source_test.go:463: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::123456789012:assumed-role/tf_aws_provider2_test-admin/kewbank@hashicorp.com is not authorized to perform: sso:ListInstances
--- SKIP: TestAccIdentityStoreUserDataSource_basic (0.91s)
=== CONT  TestAccIdentityStoreGroup_basic
=== CONT  TestAccIdentityStoreGroupMembership_basic
    user_test.go:1038: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::123456789012:assumed-role/tf_aws_provider2_test-admin/kewbank@hashicorp.com is not authorized to perform: sso:ListInstances
--- SKIP: TestAccIdentityStoreGroupMembership_basic (0.91s)
=== CONT  TestAccIdentityStoreUser_basic
    user_test.go:1038: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::123456789012:assumed-role/tf_aws_provider2_test-admin/kewbank@hashicorp.com is not authorized to perform: sso:ListInstances
--- SKIP: TestAccIdentityStoreUser_basic (0.11s)
=== CONT  TestAccIdentityStoreGroup_basic
    user_test.go:1038: skipping acceptance testing: AccessDeniedException: User: arn:aws:sts::123456789012:assumed-role/tf_aws_provider2_test-admin/kewbank@hashicorp.com is not authorized to perform: sso:ListInstances
--- SKIP: TestAccIdentityStoreGroup_basic (0.12s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/identitystore	39.871s
=== RUN   TestAccImageBuilderComponent_basic
=== PAUSE TestAccImageBuilderComponent_basic
=== RUN   TestAccImageBuilderComponent_tags
=== PAUSE TestAccImageBuilderComponent_tags
=== RUN   TestAccImageBuilderContainerRecipe_basic
=== PAUSE TestAccImageBuilderContainerRecipe_basic
=== RUN   TestAccImageBuilderContainerRecipe_tags
=== PAUSE TestAccImageBuilderContainerRecipe_tags
=== RUN   TestAccImageBuilderDistributionConfiguration_basic
=== PAUSE TestAccImageBuilderDistributionConfiguration_basic
=== RUN   TestAccImageBuilderDistributionConfiguration_tags
=== PAUSE TestAccImageBuilderDistributionConfiguration_tags
=== RUN   TestAccImageBuilderImagePipeline_basic
=== PAUSE TestAccImageBuilderImagePipeline_basic
=== RUN   TestAccImageBuilderImagePipeline_tags
=== PAUSE TestAccImageBuilderImagePipeline_tags
=== RUN   TestAccImageBuilderImageRecipe_basic
=== PAUSE TestAccImageBuilderImageRecipe_basic
=== RUN   TestAccImageBuilderImageRecipe_tags
=== PAUSE TestAccImageBuilderImageRecipe_tags
=== RUN   TestAccImageBuilderImage_basic
=== PAUSE TestAccImageBuilderImage_basic
=== RUN   TestAccImageBuilderImage_tags
=== PAUSE TestAccImageBuilderImage_tags
=== RUN   TestAccImageBuilderInfrastructureConfiguration_basic
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_basic
=== RUN   TestAccImageBuilderInfrastructureConfiguration_tags
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_tags
=== CONT  TestAccImageBuilderComponent_basic
=== CONT  TestAccImageBuilderImagePipeline_tags
--- PASS: TestAccImageBuilderComponent_basic (72.94s)
=== CONT  TestAccImageBuilderDistributionConfiguration_basic
--- PASS: TestAccImageBuilderDistributionConfiguration_basic (63.77s)
=== CONT  TestAccImageBuilderImagePipeline_basic
--- PASS: TestAccImageBuilderImagePipeline_tags (167.49s)
=== CONT  TestAccImageBuilderDistributionConfiguration_tags
--- PASS: TestAccImageBuilderImagePipeline_basic (74.45s)
=== CONT  TestAccImageBuilderImage_tags
--- PASS: TestAccImageBuilderDistributionConfiguration_tags (104.13s)
=== CONT  TestAccImageBuilderInfrastructureConfiguration_tags
--- PASS: TestAccImageBuilderInfrastructureConfiguration_tags (87.54s)
=== CONT  TestAccImageBuilderInfrastructureConfiguration_basic
--- PASS: TestAccImageBuilderInfrastructureConfiguration_basic (48.10s)
=== CONT  TestAccImageBuilderContainerRecipe_basic
--- PASS: TestAccImageBuilderContainerRecipe_basic (41.21s)
=== CONT  TestAccImageBuilderContainerRecipe_tags
--- PASS: TestAccImageBuilderContainerRecipe_tags (87.33s)
=== CONT  TestAccImageBuilderComponent_tags
--- PASS: TestAccImageBuilderComponent_tags (91.05s)
=== CONT  TestAccImageBuilderImageRecipe_tags
--- PASS: TestAccImageBuilderImageRecipe_tags (92.33s)
=== CONT  TestAccImageBuilderImage_basic
--- PASS: TestAccImageBuilderImage_tags (947.57s)
=== CONT  TestAccImageBuilderImageRecipe_basic
--- PASS: TestAccImageBuilderImageRecipe_basic (23.75s)
--- PASS: TestAccImageBuilderImage_basic (888.54s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder	1656.696s
=== RUN   TestAccInspectorAssessmentTarget_basic
=== PAUSE TestAccInspectorAssessmentTarget_basic
=== RUN   TestAccInspectorAssessmentTemplate_basic
=== PAUSE TestAccInspectorAssessmentTemplate_basic
=== RUN   TestAccInspectorAssessmentTemplate_tags
=== PAUSE TestAccInspectorAssessmentTemplate_tags
=== RUN   TestAccInspectorResourceGroup_basic
=== PAUSE TestAccInspectorResourceGroup_basic
=== RUN   TestAccInspectorRulesPackagesDataSource_basic
=== PAUSE TestAccInspectorRulesPackagesDataSource_basic
=== CONT  TestAccInspectorAssessmentTarget_basic
=== CONT  TestAccInspectorResourceGroup_basic
--- PASS: TestAccInspectorAssessmentTarget_basic (63.37s)
=== CONT  TestAccInspectorAssessmentTemplate_tags
--- PASS: TestAccInspectorResourceGroup_basic (91.92s)
=== CONT  TestAccInspectorAssessmentTemplate_basic
--- PASS: TestAccInspectorAssessmentTemplate_basic (62.48s)
=== CONT  TestAccInspectorRulesPackagesDataSource_basic
--- PASS: TestAccInspectorRulesPackagesDataSource_basic (43.15s)
--- PASS: TestAccInspectorAssessmentTemplate_tags (180.57s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/inspector	262.231s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/inspector2	28.392s [no tests to run]
=== RUN   TestAccIoTAuthorizer_basic
=== PAUSE TestAccIoTAuthorizer_basic
=== RUN   TestAccIoTEndpointDataSource_basic
=== PAUSE TestAccIoTEndpointDataSource_basic
=== RUN   TestAccIoTPolicyAttachment_basic
--- PASS: TestAccIoTPolicyAttachment_basic (163.23s)
=== RUN   TestAccIoTPolicy_basic
=== PAUSE TestAccIoTPolicy_basic
=== RUN   TestAccIoTProvisioningTemplate_basic
=== PAUSE TestAccIoTProvisioningTemplate_basic
=== RUN   TestAccIoTProvisioningTemplate_tags
=== PAUSE TestAccIoTProvisioningTemplate_tags
=== RUN   TestAccIoTRoleAlias_basic
=== PAUSE TestAccIoTRoleAlias_basic
=== RUN   TestAccIoTThingGroupMembership_basic
=== PAUSE TestAccIoTThingGroupMembership_basic
=== RUN   TestAccIoTThingGroup_basic
=== PAUSE TestAccIoTThingGroup_basic
=== RUN   TestAccIoTThingGroup_tags
=== PAUSE TestAccIoTThingGroup_tags
=== RUN   TestAccIoTThingPrincipalAttachment_basic
--- PASS: TestAccIoTThingPrincipalAttachment_basic (130.85s)
=== RUN   TestAccIoTThing_basic
=== PAUSE TestAccIoTThing_basic
=== RUN   TestAccIoTThingType_basic
=== PAUSE TestAccIoTThingType_basic
=== RUN   TestAccIoTThingType_tags
=== PAUSE TestAccIoTThingType_tags
=== RUN   TestAccIoTTopicRuleDestination_basic
=== PAUSE TestAccIoTTopicRuleDestination_basic
=== RUN   TestAccIoTTopicRule_basic
=== PAUSE TestAccIoTTopicRule_basic
=== RUN   TestAccIoTTopicRule_tags
=== PAUSE TestAccIoTTopicRule_tags
=== CONT  TestAccIoTAuthorizer_basic
=== CONT  TestAccIoTThingGroup_tags
--- PASS: TestAccIoTAuthorizer_basic (56.79s)
=== CONT  TestAccIoTProvisioningTemplate_tags
--- PASS: TestAccIoTThingGroup_tags (72.33s)
=== CONT  TestAccIoTThingGroup_basic
--- PASS: TestAccIoTThingGroup_basic (32.47s)
=== CONT  TestAccIoTThingGroupMembership_basic
--- PASS: TestAccIoTThingGroupMembership_basic (33.20s)
=== CONT  TestAccIoTRoleAlias_basic
--- PASS: TestAccIoTProvisioningTemplate_tags (87.29s)
=== CONT  TestAccIoTTopicRule_tags
--- PASS: TestAccIoTTopicRule_tags (77.77s)
=== CONT  TestAccIoTTopicRule_basic
--- PASS: TestAccIoTTopicRule_basic (33.39s)
=== CONT  TestAccIoTTopicRuleDestination_basic
--- PASS: TestAccIoTRoleAlias_basic (133.16s)
=== CONT  TestAccIoTPolicy_basic
--- PASS: TestAccIoTPolicy_basic (37.00s)
=== CONT  TestAccIoTProvisioningTemplate_basic
--- PASS: TestAccIoTProvisioningTemplate_basic (52.28s)
=== CONT  TestAccIoTEndpointDataSource_basic
--- PASS: TestAccIoTEndpointDataSource_basic (25.29s)
=== CONT  TestAccIoTThingType_basic
--- PASS: TestAccIoTThingType_basic (345.20s)
=== CONT  TestAccIoTThingType_tags
--- PASS: TestAccIoTTopicRuleDestination_basic (645.31s)
=== CONT  TestAccIoTThing_basic
--- PASS: TestAccIoTThing_basic (15.20s)
--- PASS: TestAccIoTThingType_tags (345.85s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iot	1427.404s
?   	github.com/hashicorp/terraform-provider-aws/internal/service/iotanalytics	[no test files]
?   	github.com/hashicorp/terraform-provider-aws/internal/service/iotevents	[no test files]
=== RUN   TestAccIVSChannel_basic
=== PAUSE TestAccIVSChannel_basic
=== RUN   TestAccIVSChannel_tags
=== PAUSE TestAccIVSChannel_tags
=== RUN   TestAccIVSRecordingConfiguration_basic
=== PAUSE TestAccIVSRecordingConfiguration_basic
=== RUN   TestAccIVSRecordingConfiguration_tags
=== PAUSE TestAccIVSRecordingConfiguration_tags
=== RUN   TestAccIVSStreamKeyDataSource_basic
=== PAUSE TestAccIVSStreamKeyDataSource_basic
=== CONT  TestAccIVSChannel_basic
=== CONT  TestAccIVSRecordingConfiguration_tags
--- PASS: TestAccIVSChannel_basic (63.83s)
=== CONT  TestAccIVSStreamKeyDataSource_basic
--- PASS: TestAccIVSStreamKeyDataSource_basic (51.41s)
=== CONT  TestAccIVSRecordingConfiguration_basic
--- PASS: TestAccIVSRecordingConfiguration_tags (164.18s)
=== CONT  TestAccIVSChannel_tags
--- PASS: TestAccIVSRecordingConfiguration_basic (63.63s)
--- PASS: TestAccIVSChannel_tags (89.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ivs	320.658s
=== RUN   TestAccIVSChatLoggingConfiguration_tags
=== PAUSE TestAccIVSChatLoggingConfiguration_tags
=== RUN   TestAccIVSChatRoom_basic
=== PAUSE TestAccIVSChatRoom_basic
=== RUN   TestAccIVSChatRoom_tags
=== PAUSE TestAccIVSChatRoom_tags
=== CONT  TestAccIVSChatLoggingConfiguration_tags
=== CONT  TestAccIVSChatRoom_tags
--- PASS: TestAccIVSChatRoom_tags (139.61s)
=== CONT  TestAccIVSChatRoom_basic
--- PASS: TestAccIVSChatLoggingConfiguration_tags (155.30s)
--- PASS: TestAccIVSChatRoom_basic (48.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ivschat	254.761s
FAIL
make: *** [testacc] Error 1
```
