### PR TITLE
servicecat/prov_product: Allow for TAINTED

### DIFF
--- a/.changelog/30522.txt
+++ b/.changelog/30522.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_servicecatalog_provisioned_product: Allow the waiting that comes with updating and deleting to not error due to a `status` of `TAINTED`
+```
+
+```release-note:note
+resource/aws_servicecatalog_provisioned_product: Previously, this resource would error or hang until timeout and then error, if a stack had a `status` of `TAINTED`. Now, the resource will continue functioning normally if the `status` is `TAINTED`. This is because the stack is in a "stable state" and "ready to perform any operation." However, although "the stack has completed the requested operation," it "is not exactly what was requested." The `status` will reflect `TAINTED` and `status_message` will provide clues as to what happened. See the `aws_servicecatalog_provisioned_product` documentation for more information and ways to use logging with this.
+```

--- a/internal/service/servicecatalog/provisioned_product_test.go
+++ b/internal/service/servicecatalog/provisioned_product_test.go
@@ -380,11 +380,6 @@ resource "aws_s3_bucket" "test" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_object" "test" {
   bucket = aws_s3_bucket.test.id
   key    = "%[1]s.json"

--- a/internal/service/servicecatalog/provisioned_product_test.go
+++ b/internal/service/servicecatalog/provisioned_product_test.go
@@ -268,8 +268,7 @@ func TestAccServiceCatalogProvisionedProduct_tainted(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccProvisionedProductConfig_updateTainted(rName, domain, acctest.DefaultEmailAddress, "10.1.0.0/16"),
-				ExpectError: regexp.MustCompile(`unexpected state 'TAINTED', wanted target 'AVAILABLE'`),
+				Config: testAccProvisionedProductConfig_updateTainted(rName, domain, acctest.DefaultEmailAddress, "10.1.0.0/16"),
 			},
 			{
 				// Check we can still run a complete plan after the previous update error

--- a/internal/service/servicecatalog/provisioned_product_test.go
+++ b/internal/service/servicecatalog/provisioned_product_test.go
@@ -16,8 +16,6 @@ import (
 	tfservicecatalog "github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog"
 )
 
-// add sweeper to delete known test servicecat provisioned products
-
 func TestAccServiceCatalogProvisionedProduct_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_provisioned_product.test"

--- a/internal/service/servicecatalog/provisioned_product_test.go
+++ b/internal/service/servicecatalog/provisioned_product_test.go
@@ -269,6 +269,10 @@ func TestAccServiceCatalogProvisionedProduct_tainted(t *testing.T) {
 			},
 			{
 				Config: testAccProvisionedProductConfig_updateTainted(rName, domain, acctest.DefaultEmailAddress, "10.1.0.0/16"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProvisionedProductExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "status", servicecatalog.ProvisionedProductStatusTainted),
+				),
 			},
 			{
 				// Check we can still run a complete plan after the previous update error

--- a/website/docs/r/servicecatalog_provisioned_product.html.markdown
+++ b/website/docs/r/servicecatalog_provisioned_product.html.markdown
@@ -14,6 +14,8 @@ A provisioned product is a resourced instance of a product. For example, provisi
 
 Like this resource, the `aws_servicecatalog_record` data source also provides information about a provisioned product. Although a Service Catalog record provides some overlapping information with this resource, a record is tied to a provisioned product event, such as provisioning, termination, and updating.
 
+~> **NOTE:** This resource will continue to function normally, _not_ returning an error unless AWS does, if a stack has a `status` of `TAINTED`. "`TAINTED`" means that Service Catalog, from its perspective, completed an update but the stack is not exactly what you requested. For example, if you request to update a stack to a new version but the request fails, AWS will roll back the stack to the current version and give a `TAINTED` status. (`status_message` also provides more information.) This is a little different than Terraform's typical declarative way. However, the approach aligns with AWS's. When `TAINTED`, the stack is in a "stable state" and "ready to perform any operation."  
+
 -> **Tip:** If you include conflicted keys as tags, AWS will report an error, "Parameter validation failed: Missing required parameter in Tags[N]:Value".
 
 -> **Tip:** A "provisioning artifact" is also referred to as a "version." A "distributor" is also referred to as a "vendor."
@@ -103,7 +105,7 @@ In addition to all arguments above, the following attributes are exported:
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `type` - Type of provisioned product. Valid values are `CFN_STACK` and `CFN_STACKSET`.
 
-### status Meanings
+### `status` Meanings
 
 ~> **NOTE:** [Enable logging](https://www.terraform.io/plugin/log/managing) to `WARN` verbosity to further investigate error messages associated with a provisioned product in the `ERROR` or `TAINTED` state which can occur during resource creation or update.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #26237
Closes #24574

Relates #24758
Relates #24804
Relates #25130

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
% make t T=TestAccServiceCatalogProvisionedProduct_ K=servicecatalog P=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicecatalog/... -v -count 1 -parallel 3 -run='TestAccServiceCatalogProvisionedProduct_'  -timeout 180m
=== RUN   TestAccServiceCatalogProvisionedProduct_basic
=== PAUSE TestAccServiceCatalogProvisionedProduct_basic
=== RUN   TestAccServiceCatalogProvisionedProduct_update
=== PAUSE TestAccServiceCatalogProvisionedProduct_update
=== RUN   TestAccServiceCatalogProvisionedProduct_computedOutputs
=== PAUSE TestAccServiceCatalogProvisionedProduct_computedOutputs
=== RUN   TestAccServiceCatalogProvisionedProduct_disappears
=== PAUSE TestAccServiceCatalogProvisionedProduct_disappears
=== RUN   TestAccServiceCatalogProvisionedProduct_tags
=== PAUSE TestAccServiceCatalogProvisionedProduct_tags
=== RUN   TestAccServiceCatalogProvisionedProduct_tainted
=== PAUSE TestAccServiceCatalogProvisionedProduct_tainted
=== CONT  TestAccServiceCatalogProvisionedProduct_basic
=== CONT  TestAccServiceCatalogProvisionedProduct_disappears
=== CONT  TestAccServiceCatalogProvisionedProduct_computedOutputs
--- PASS: TestAccServiceCatalogProvisionedProduct_disappears (136.42s)
=== CONT  TestAccServiceCatalogProvisionedProduct_tainted
--- PASS: TestAccServiceCatalogProvisionedProduct_basic (151.61s)
=== CONT  TestAccServiceCatalogProvisionedProduct_update
--- PASS: TestAccServiceCatalogProvisionedProduct_computedOutputs (251.15s)
=== CONT  TestAccServiceCatalogProvisionedProduct_tags
--- PASS: TestAccServiceCatalogProvisionedProduct_tainted (246.70s)
--- PASS: TestAccServiceCatalogProvisionedProduct_update (231.69s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags (230.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog	483.030s
```
