### PR TITLE
Add skip_destroy to ImageBuilder Container/Image Recipes

### DIFF
--- a/.changelog/30531.txt
+++ b/.changelog/30531.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_imagebuilder_container_recipe: Add optional skip_destroy argument
+```
+
+```release-note:enhancement
+resource/aws_imagebuilder_image_recipe: Add optional skip_destroy argument
+```

--- a/internal/service/imagebuilder/container_recipe.go
+++ b/internal/service/imagebuilder/container_recipe.go
@@ -254,6 +254,11 @@ func resourceContainerRecipe() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice([]string{"Linux", "Windows"}, false),
 			},
+			"skip_destroy": {
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"target_repository": {
@@ -423,6 +428,12 @@ func resourceContainerRecipeUpdate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceContainerRecipeDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
+
+	if v, ok := d.GetOk("skip_destroy"); ok && v.(bool) {
+		log.Printf("[DEBUG] Retaining Imagebuilder Container Recipe version %q", d.Id())
+		return diags
+	}
+
 	conn := meta.(*conns.AWSClient).ImageBuilderClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Image Builder Container Recipe: %s", d.Id())

--- a/internal/service/imagebuilder/container_recipe_test.go
+++ b/internal/service/imagebuilder/container_recipe_test.go
@@ -59,9 +59,10 @@ func TestAccImageBuilderContainerRecipe_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -111,9 +112,10 @@ func TestAccImageBuilderContainerRecipe_component(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -143,9 +145,10 @@ func TestAccImageBuilderContainerRecipe_componentParameter(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -170,9 +173,10 @@ func TestAccImageBuilderContainerRecipe_description(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -200,7 +204,7 @@ func TestAccImageBuilderContainerRecipe_dockerfileTemplateURI(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dockerfile_template_uri"},
+				ImportStateVerifyIgnore: []string{"dockerfile_template_uri", "skip_destroy"},
 			},
 		},
 	})
@@ -227,9 +231,10 @@ func TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -257,9 +262,10 @@ func TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -287,9 +293,10 @@ func TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -317,9 +324,10 @@ func TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -348,9 +356,10 @@ func TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -379,9 +388,10 @@ func TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -409,9 +419,10 @@ func TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -439,9 +450,10 @@ func TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -469,9 +481,10 @@ func TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -498,9 +511,10 @@ func TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -527,9 +541,10 @@ func TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -556,9 +571,10 @@ func TestAccImageBuilderContainerRecipe_InstanceConfiguration_Image(t *testing.T
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -584,9 +600,10 @@ func TestAccImageBuilderContainerRecipe_kmsKeyID(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -612,9 +629,10 @@ func TestAccImageBuilderContainerRecipe_tags(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 			{
 				Config: testAccContainerRecipeConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
@@ -656,9 +674,10 @@ func TestAccImageBuilderContainerRecipe_workingDirectory(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -687,7 +706,7 @@ func TestAccImageBuilderContainerRecipe_platformOverride(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"platform_override"},
+				ImportStateVerifyIgnore: []string{"platform_override", "skip_destroy"},
 			},
 		},
 	})
@@ -826,7 +845,7 @@ parameters:
   - Parameter1:
       type: string
   - Parameter2:
-      type: string  
+      type: string
 schemaVersion: 1.0
 EOF
 

--- a/internal/service/imagebuilder/image_recipe.go
+++ b/internal/service/imagebuilder/image_recipe.go
@@ -200,6 +200,11 @@ func resourceImageRecipe() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"skip_destroy": {
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+			},
 			"systems_manager_agent": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -357,6 +362,12 @@ func resourceImageRecipeUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 func resourceImageRecipeDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
+
+	if v, ok := d.GetOk("skip_destroy"); ok && v.(bool) {
+		log.Printf("[DEBUG] Retaining Imagebuilder Image Recipe version %q", d.Id())
+		return diags
+	}
+
 	conn := meta.(*conns.AWSClient).ImageBuilderClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Image Builder Image Recipe: %s", d.Id())

--- a/internal/service/imagebuilder/image_recipe_test.go
+++ b/internal/service/imagebuilder/image_recipe_test.go
@@ -50,9 +50,10 @@ func TestAccImageBuilderImageRecipe_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -103,9 +104,10 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName(t *testing.T) 
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -133,9 +135,10 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination(t 
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -163,9 +166,10 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted(t *testing.T
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -193,9 +197,10 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -222,9 +227,10 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID(t *testing.T)
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -251,9 +257,10 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID(t *testing.
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -281,9 +288,10 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_throughput(t *testing.
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -311,9 +319,10 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize(t *testing.
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -341,9 +350,10 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2(t *testi
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -371,9 +381,10 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3(t *testi
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -401,9 +412,10 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -431,9 +443,10 @@ func TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName(t *testing.T)
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -461,9 +474,10 @@ func TestAccImageBuilderImageRecipe_component(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -515,9 +529,10 @@ func TestAccImageBuilderImageRecipe_description(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -543,9 +558,10 @@ func TestAccImageBuilderImageRecipe_tags(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 			{
 				Config: testAccImageRecipeConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
@@ -587,9 +603,10 @@ func TestAccImageBuilderImageRecipe_workingDirectory(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -642,9 +659,10 @@ func TestAccImageBuilderImageRecipe_systemsManagerAgent(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -670,9 +688,10 @@ func TestAccImageBuilderImageRecipe_updateDependency(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 			{
 				Config: testAccImageRecipeConfig_componentUpdate(rName, "hello world updated"),
@@ -705,9 +724,10 @@ func TestAccImageBuilderImageRecipe_userDataBase64(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -731,9 +751,10 @@ func TestAccImageBuilderImageRecipe_windowsBaseImage(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_destroy"},
 			},
 		},
 	})
@@ -1151,7 +1172,7 @@ parameters:
   - Parameter1:
       type: string
   - Parameter2:
-      type: string  
+      type: string
 schemaVersion: 1.0
 EOF
 

--- a/website/docs/r/imagebuilder_container_recipe.html.markdown
+++ b/website/docs/r/imagebuilder_container_recipe.html.markdown
@@ -66,6 +66,7 @@ The following attributes are optional:
 * `instance_configuration` - (Optional) Configuration block used to configure an instance for building and testing container images. Detailed below.
 * `kms_key_id` - (Optional) The KMS key used to encrypt the container image.
 * `platform_override` - (Optional) Specifies the operating system platform when you use a custom base image.
+* `skip_destroy` - (Optional) Whether to retain the old version when the resource is destroyed or replacement is necessary. Defaults to `false`.
 * `tags` - (Optional) Key-value map of resource tags for the container recipe. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `working_directory` - (Optional) The working directory to be used during build and test workflows.
 

--- a/website/docs/r/imagebuilder_image_recipe.html.markdown
+++ b/website/docs/r/imagebuilder_image_recipe.html.markdown
@@ -57,6 +57,7 @@ The following attributes are optional:
 
 * `block_device_mapping` - (Optional) Configuration block(s) with block device mappings for the image recipe. Detailed below.
 * `description` - (Optional) Description of the image recipe.
+* `skip_destroy` - (Optional) Whether to retain the old version when the resource is destroyed or replacement is necessary. Defaults to `false`.
 * `systems_manager_agent` - (Optional) Configuration block for the Systems Manager Agent installed by default by Image Builder. Detailed below.
 * `tags` - (Optional) Key-value map of resource tags for the image recipe. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `user_data_base64` - (Optional) Base64 encoded user data. Use this to provide commands or a command script to run when you launch your build instance.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds the optional `skip_destroy` argument to `aws_imagebuilder_container_recipe` and `aws_imagebuilder_image_recipe` resources.

This replicates the behavior for the `aws_imagebuilder_component` resource, which is versioned in AWS the same way as the recipes.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

N/A

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS='TestAccImageBuilderContainerRecipe_' PKG=imagebuilder

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderContainerRecipe_'  -timeout 180m
=== RUN   TestAccImageBuilderContainerRecipe_basic
=== PAUSE TestAccImageBuilderContainerRecipe_basic
=== RUN   TestAccImageBuilderContainerRecipe_disappears
=== PAUSE TestAccImageBuilderContainerRecipe_disappears
=== RUN   TestAccImageBuilderContainerRecipe_component
=== PAUSE TestAccImageBuilderContainerRecipe_component
=== RUN   TestAccImageBuilderContainerRecipe_componentParameter
=== PAUSE TestAccImageBuilderContainerRecipe_componentParameter
=== RUN   TestAccImageBuilderContainerRecipe_description
=== PAUSE TestAccImageBuilderContainerRecipe_description
=== RUN   TestAccImageBuilderContainerRecipe_dockerfileTemplateURI
=== PAUSE TestAccImageBuilderContainerRecipe_dockerfileTemplateURI
=== RUN   TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping_deviceName
=== PAUSE TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping_deviceName
=== RUN   TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_deleteOnTermination
=== PAUSE TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_deleteOnTermination
=== RUN   TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_encrypted
=== PAUSE TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_encrypted
=== RUN   TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_iops
=== PAUSE TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_iops
=== RUN   TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_kmsKeyID
=== PAUSE TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_kmsKeyID
=== RUN   TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_snapshotID
=== PAUSE TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_snapshotID
=== RUN   TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_throughput
=== PAUSE TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_throughput
=== RUN   TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_volumeSize
=== PAUSE TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_volumeSize
=== RUN   TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_volumeType
=== PAUSE TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_volumeType
=== RUN   TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping_noDevice
=== PAUSE TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping_noDevice
=== RUN   TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping_virtualName
=== PAUSE TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping_virtualName
=== RUN   TestAccImageBuilderContainerRecipe_InstanceConfiguration_Image
=== PAUSE TestAccImageBuilderContainerRecipe_InstanceConfiguration_Image
=== RUN   TestAccImageBuilderContainerRecipe_kmsKeyID
=== PAUSE TestAccImageBuilderContainerRecipe_kmsKeyID
=== RUN   TestAccImageBuilderContainerRecipe_tags
=== PAUSE TestAccImageBuilderContainerRecipe_tags
=== RUN   TestAccImageBuilderContainerRecipe_workingDirectory
=== PAUSE TestAccImageBuilderContainerRecipe_workingDirectory
=== RUN   TestAccImageBuilderContainerRecipe_platformOverride
=== PAUSE TestAccImageBuilderContainerRecipe_platformOverride
=== CONT  TestAccImageBuilderContainerRecipe_basic
=== CONT  TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_snapshotID
=== CONT  TestAccImageBuilderContainerRecipe_kmsKeyID
=== CONT  TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping_noDevice
=== CONT  TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_volumeSize
=== CONT  TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_throughput
=== CONT  TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_kmsKeyID
=== CONT  TestAccImageBuilderContainerRecipe_dockerfileTemplateURI
=== CONT  TestAccImageBuilderContainerRecipe_InstanceConfiguration_Image
=== CONT  TestAccImageBuilderContainerRecipe_platformOverride
=== CONT  TestAccImageBuilderContainerRecipe_workingDirectory
=== CONT  TestAccImageBuilderContainerRecipe_tags
=== CONT  TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_volumeType
=== CONT  TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping_virtualName
=== CONT  TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping_deviceName
=== CONT  TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_encrypted
=== CONT  TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_deleteOnTermination
=== CONT  TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_iops
=== CONT  TestAccImageBuilderContainerRecipe_component
=== CONT  TestAccImageBuilderContainerRecipe_componentParameter
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping_virtualName (49.63s)
=== CONT  TestAccImageBuilderContainerRecipe_description
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_iops (49.71s)
=== CONT  TestAccImageBuilderContainerRecipe_disappears
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_encrypted (50.51s)
--- PASS: TestAccImageBuilderContainerRecipe_kmsKeyID (51.66s)
--- PASS: TestAccImageBuilderContainerRecipe_platformOverride (51.73s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_kmsKeyID (52.09s)
--- PASS: TestAccImageBuilderContainerRecipe_workingDirectory (52.24s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_volumeSize (53.46s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping_deviceName (53.67s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_volumeType (53.75s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_deleteOnTermination (54.69s)
--- PASS: TestAccImageBuilderContainerRecipe_basic (55.04s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMapping_noDevice (55.22s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_throughput (60.28s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_Image (60.81s)
--- PASS: TestAccImageBuilderContainerRecipe_dockerfileTemplateURI (60.86s)
--- PASS: TestAccImageBuilderContainerRecipe_component (64.96s)
--- PASS: TestAccImageBuilderContainerRecipe_componentParameter (67.05s)
--- PASS: TestAccImageBuilderContainerRecipe_disappears (22.33s)
--- PASS: TestAccImageBuilderContainerRecipe_description (25.81s)
--- PASS: TestAccImageBuilderContainerRecipe_InstanceConfiguration_BlockDeviceMappingEBS_snapshotID (76.17s)
--- PASS: TestAccImageBuilderContainerRecipe_tags (85.13s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder	88.007s

$ make testacc TESTS='TestAccImageBuilderImageRecipe_' PKG=imagebuilder

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderImageRecipe_'  -timeout 180m
=== RUN   TestAccImageBuilderImageRecipe_basic
=== PAUSE TestAccImageBuilderImageRecipe_basic
=== RUN   TestAccImageBuilderImageRecipe_disappears
=== PAUSE TestAccImageBuilderImageRecipe_disappears
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_throughput
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_throughput
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice
=== RUN   TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName
=== PAUSE TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName
=== RUN   TestAccImageBuilderImageRecipe_component
=== PAUSE TestAccImageBuilderImageRecipe_component
=== RUN   TestAccImageBuilderImageRecipe_componentParameter
=== PAUSE TestAccImageBuilderImageRecipe_componentParameter
=== RUN   TestAccImageBuilderImageRecipe_description
=== PAUSE TestAccImageBuilderImageRecipe_description
=== RUN   TestAccImageBuilderImageRecipe_tags
=== PAUSE TestAccImageBuilderImageRecipe_tags
=== RUN   TestAccImageBuilderImageRecipe_workingDirectory
=== PAUSE TestAccImageBuilderImageRecipe_workingDirectory
=== RUN   TestAccImageBuilderImageRecipe_pipelineUpdateDependency
=== PAUSE TestAccImageBuilderImageRecipe_pipelineUpdateDependency
=== RUN   TestAccImageBuilderImageRecipe_systemsManagerAgent
=== PAUSE TestAccImageBuilderImageRecipe_systemsManagerAgent
=== RUN   TestAccImageBuilderImageRecipe_updateDependency
=== PAUSE TestAccImageBuilderImageRecipe_updateDependency
=== RUN   TestAccImageBuilderImageRecipe_userDataBase64
=== PAUSE TestAccImageBuilderImageRecipe_userDataBase64
=== RUN   TestAccImageBuilderImageRecipe_windowsBaseImage
=== PAUSE TestAccImageBuilderImageRecipe_windowsBaseImage
=== CONT  TestAccImageBuilderImageRecipe_basic
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted
=== CONT  TestAccImageBuilderImageRecipe_pipelineUpdateDependency
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize
=== CONT  TestAccImageBuilderImageRecipe_componentParameter
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops
=== CONT  TestAccImageBuilderImageRecipe_workingDirectory
=== CONT  TestAccImageBuilderImageRecipe_windowsBaseImage
=== CONT  TestAccImageBuilderImageRecipe_userDataBase64
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_throughput
=== CONT  TestAccImageBuilderImageRecipe_systemsManagerAgent
=== CONT  TestAccImageBuilderImageRecipe_updateDependency
=== CONT  TestAccImageBuilderImageRecipe_tags
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_deleteOnTermination (44.19s)
=== CONT  TestAccImageBuilderImageRecipe_component
--- PASS: TestAccImageBuilderImageRecipe_systemsManagerAgent (46.41s)
=== CONT  TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_kmsKeyID (46.62s)
=== CONT  TestAccImageBuilderImageRecipe_description
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP2 (46.66s)
=== CONT  TestAccImageBuilderImageRecipe_disappears
--- PASS: TestAccImageBuilderImageRecipe_componentParameter (46.71s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_encrypted (46.89s)
--- PASS: TestAccImageBuilderImageRecipe_workingDirectory (47.22s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_deviceName (47.28s)
--- PASS: TestAccImageBuilderImageRecipe_windowsBaseImage (47.35s)
--- PASS: TestAccImageBuilderImageRecipe_userDataBase64 (47.87s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeTypeGP3 (51.63s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_volumeSize (52.51s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_throughput (52.72s)
--- PASS: TestAccImageBuilderImageRecipe_basic (55.61s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_iops (59.49s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_noDevice (59.77s)
--- PASS: TestAccImageBuilderImageRecipe_disappears (26.89s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMapping_virtualName (29.95s)
--- PASS: TestAccImageBuilderImageRecipe_description (30.17s)
--- PASS: TestAccImageBuilderImageRecipe_BlockDeviceMappingEBS_snapshotID (77.70s)
--- PASS: TestAccImageBuilderImageRecipe_component (34.17s)
--- PASS: TestAccImageBuilderImageRecipe_updateDependency (79.60s)
--- PASS: TestAccImageBuilderImageRecipe_pipelineUpdateDependency (80.27s)
--- PASS: TestAccImageBuilderImageRecipe_tags (98.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder	101.835s
```
