### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin SDK resources `e*` (Phase 3c)

### DIFF
--- a/.changelog/30533.txt
+++ b/.changelog/30533.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_user_group: Change `user_group_id` to [ForceNew](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#forcenew)
+```

--- a/internal/provider/fwprovider/intercept.go
+++ b/internal/provider/fwprovider/intercept.go
@@ -295,6 +295,11 @@ func (r tagsInterceptor) create(ctx context.Context, request resource.CreateRequ
 		return ctx, diags
 	}
 
+	inContext, ok := conns.FromContext(ctx)
+	if !ok {
+		return ctx, diags
+	}
+
 	tagsInContext, ok := tftags.FromContext(ctx)
 	if !ok {
 		return ctx, diags
@@ -312,14 +317,14 @@ func (r tagsInterceptor) create(ctx context.Context, request resource.CreateRequ
 		// Merge the resource's configured tags with any provider configured default_tags.
 		tags := tagsInContext.DefaultConfig.MergeTags(tftags.New(ctx, planTags))
 		// Remove system tags.
-		tags = tags.IgnoreAWS()
+		tags = tags.IgnoreSystem(inContext.ServicePackageName)
 
 		tagsInContext.TagsIn = types.Some(tags)
 	case After:
 		// Set values for unknowns.
 		// Remove any provider configured ignore_tags and system tags from those passed to the service API.
 		// Computed tags_all include any provider configured default_tags.
-		stateTagsAll := flex.FlattenFrameworkStringValueMapLegacy(ctx, tagsInContext.TagsIn.MustUnwrap().IgnoreAWS().IgnoreConfig(tagsInContext.IgnoreConfig).Map())
+		stateTagsAll := flex.FlattenFrameworkStringValueMapLegacy(ctx, tagsInContext.TagsIn.MustUnwrap().IgnoreSystem(inContext.ServicePackageName).IgnoreConfig(tagsInContext.IgnoreConfig).Map())
 		diags.Append(response.State.SetAttribute(ctx, path.Root(names.AttrTagsAll), &stateTagsAll)...)
 
 		if diags.HasError() {
@@ -336,25 +341,21 @@ func (r tagsInterceptor) read(ctx context.Context, request resource.ReadRequest,
 	}
 
 	inContext, ok := conns.FromContext(ctx)
-
 	if !ok {
 		return ctx, diags
 	}
 
 	sp, ok := meta.ServicePackages[inContext.ServicePackageName]
-
 	if !ok {
 		return ctx, diags
 	}
 
 	serviceName, err := names.HumanFriendly(inContext.ServicePackageName)
-
 	if err != nil {
 		serviceName = "<service>"
 	}
 
 	resourceName := inContext.ResourceName
-
 	if resourceName == "" {
 		resourceName = "<thing>"
 	}
@@ -409,7 +410,7 @@ func (r tagsInterceptor) read(ctx context.Context, request resource.ReadRequest,
 		stateTags := tftags.Null
 		// Remove any provider configured ignore_tags and system tags from those returned from the service API.
 		// The resource's configured tags do not include any provider configured default_tags.
-		if v := apiTags.IgnoreAWS().IgnoreConfig(tagsInContext.IgnoreConfig).RemoveDefaultConfig(tagsInContext.DefaultConfig).Map(); len(v) > 0 {
+		if v := apiTags.IgnoreSystem(inContext.ServicePackageName).IgnoreConfig(tagsInContext.IgnoreConfig).RemoveDefaultConfig(tagsInContext.DefaultConfig).Map(); len(v) > 0 {
 			stateTags = flex.FlattenFrameworkStringValueMapLegacy(ctx, v)
 		}
 		diags.Append(response.State.SetAttribute(ctx, path.Root(names.AttrTags), &stateTags)...)
@@ -419,7 +420,7 @@ func (r tagsInterceptor) read(ctx context.Context, request resource.ReadRequest,
 		}
 
 		// Computed tags_all do.
-		stateTagsAll := flex.FlattenFrameworkStringValueMapLegacy(ctx, apiTags.IgnoreAWS().IgnoreConfig(tagsInContext.IgnoreConfig).Map())
+		stateTagsAll := flex.FlattenFrameworkStringValueMapLegacy(ctx, apiTags.IgnoreSystem(inContext.ServicePackageName).IgnoreConfig(tagsInContext.IgnoreConfig).Map())
 		diags.Append(response.State.SetAttribute(ctx, path.Root(names.AttrTagsAll), &stateTagsAll)...)
 
 		if diags.HasError() {
@@ -436,25 +437,21 @@ func (r tagsInterceptor) update(ctx context.Context, request resource.UpdateRequ
 	}
 
 	inContext, ok := conns.FromContext(ctx)
-
 	if !ok {
 		return ctx, diags
 	}
 
 	sp, ok := meta.ServicePackages[inContext.ServicePackageName]
-
 	if !ok {
 		return ctx, diags
 	}
 
 	serviceName, err := names.HumanFriendly(inContext.ServicePackageName)
-
 	if err != nil {
 		serviceName = "<service>"
 	}
 
 	resourceName := inContext.ResourceName
-
 	if resourceName == "" {
 		resourceName = "<thing>"
 	}
@@ -476,7 +473,7 @@ func (r tagsInterceptor) update(ctx context.Context, request resource.UpdateRequ
 		// Merge the resource's configured tags with any provider configured default_tags.
 		tags := tagsInContext.DefaultConfig.MergeTags(tftags.New(ctx, planTags))
 		// Remove system tags.
-		tags = tags.IgnoreAWS()
+		tags = tags.IgnoreSystem(inContext.ServicePackageName)
 
 		tagsInContext.TagsIn = types.Some(tags)
 

--- a/internal/provider/fwprovider/intercept.go
+++ b/internal/provider/fwprovider/intercept.go
@@ -312,14 +312,14 @@ func (r tagsInterceptor) create(ctx context.Context, request resource.CreateRequ
 		// Merge the resource's configured tags with any provider configured default_tags.
 		tags := tagsInContext.DefaultConfig.MergeTags(tftags.New(ctx, planTags))
 		// Remove system tags.
-		tags = tags.IgnoreAWS().IgnoreElasticbeanstalk().IgnoreRDS()
+		tags = tags.IgnoreAWS()
 
 		tagsInContext.TagsIn = types.Some(tags)
 	case After:
 		// Set values for unknowns.
 		// Remove any provider configured ignore_tags and system tags from those passed to the service API.
 		// Computed tags_all include any provider configured default_tags.
-		stateTagsAll := flex.FlattenFrameworkStringValueMapLegacy(ctx, tagsInContext.TagsIn.MustUnwrap().IgnoreAWS().IgnoreElasticbeanstalk().IgnoreRDS().IgnoreConfig(tagsInContext.IgnoreConfig).Map())
+		stateTagsAll := flex.FlattenFrameworkStringValueMapLegacy(ctx, tagsInContext.TagsIn.MustUnwrap().IgnoreAWS().IgnoreConfig(tagsInContext.IgnoreConfig).Map())
 		diags.Append(response.State.SetAttribute(ctx, path.Root(names.AttrTagsAll), &stateTagsAll)...)
 
 		if diags.HasError() {
@@ -409,7 +409,7 @@ func (r tagsInterceptor) read(ctx context.Context, request resource.ReadRequest,
 		stateTags := tftags.Null
 		// Remove any provider configured ignore_tags and system tags from those returned from the service API.
 		// The resource's configured tags do not include any provider configured default_tags.
-		if v := apiTags.IgnoreAWS().IgnoreElasticbeanstalk().IgnoreRDS().IgnoreConfig(tagsInContext.IgnoreConfig).RemoveDefaultConfig(tagsInContext.DefaultConfig).Map(); len(v) > 0 {
+		if v := apiTags.IgnoreAWS().IgnoreConfig(tagsInContext.IgnoreConfig).RemoveDefaultConfig(tagsInContext.DefaultConfig).Map(); len(v) > 0 {
 			stateTags = flex.FlattenFrameworkStringValueMapLegacy(ctx, v)
 		}
 		diags.Append(response.State.SetAttribute(ctx, path.Root(names.AttrTags), &stateTags)...)
@@ -419,7 +419,7 @@ func (r tagsInterceptor) read(ctx context.Context, request resource.ReadRequest,
 		}
 
 		// Computed tags_all do.
-		stateTagsAll := flex.FlattenFrameworkStringValueMapLegacy(ctx, apiTags.IgnoreAWS().IgnoreElasticbeanstalk().IgnoreRDS().IgnoreConfig(tagsInContext.IgnoreConfig).Map())
+		stateTagsAll := flex.FlattenFrameworkStringValueMapLegacy(ctx, apiTags.IgnoreAWS().IgnoreConfig(tagsInContext.IgnoreConfig).Map())
 		diags.Append(response.State.SetAttribute(ctx, path.Root(names.AttrTagsAll), &stateTagsAll)...)
 
 		if diags.HasError() {
@@ -476,7 +476,7 @@ func (r tagsInterceptor) update(ctx context.Context, request resource.UpdateRequ
 		// Merge the resource's configured tags with any provider configured default_tags.
 		tags := tagsInContext.DefaultConfig.MergeTags(tftags.New(ctx, planTags))
 		// Remove system tags.
-		tags = tags.IgnoreAWS().IgnoreElasticbeanstalk().IgnoreRDS()
+		tags = tags.IgnoreAWS()
 
 		tagsInContext.TagsIn = types.Some(tags)
 

--- a/internal/provider/fwprovider/intercept.go
+++ b/internal/provider/fwprovider/intercept.go
@@ -312,14 +312,14 @@ func (r tagsInterceptor) create(ctx context.Context, request resource.CreateRequ
 		// Merge the resource's configured tags with any provider configured default_tags.
 		tags := tagsInContext.DefaultConfig.MergeTags(tftags.New(ctx, planTags))
 		// Remove system tags.
-		tags = tags.IgnoreAWS()
+		tags = tags.IgnoreAWS().IgnoreElasticbeanstalk().IgnoreRDS()
 
 		tagsInContext.TagsIn = types.Some(tags)
 	case After:
 		// Set values for unknowns.
 		// Remove any provider configured ignore_tags and system tags from those passed to the service API.
 		// Computed tags_all include any provider configured default_tags.
-		stateTagsAll := flex.FlattenFrameworkStringValueMapLegacy(ctx, tagsInContext.TagsIn.MustUnwrap().IgnoreAWS().IgnoreConfig(tagsInContext.IgnoreConfig).Map())
+		stateTagsAll := flex.FlattenFrameworkStringValueMapLegacy(ctx, tagsInContext.TagsIn.MustUnwrap().IgnoreAWS().IgnoreElasticbeanstalk().IgnoreRDS().IgnoreConfig(tagsInContext.IgnoreConfig).Map())
 		diags.Append(response.State.SetAttribute(ctx, path.Root(names.AttrTagsAll), &stateTagsAll)...)
 
 		if diags.HasError() {
@@ -409,7 +409,7 @@ func (r tagsInterceptor) read(ctx context.Context, request resource.ReadRequest,
 		stateTags := tftags.Null
 		// Remove any provider configured ignore_tags and system tags from those returned from the service API.
 		// The resource's configured tags do not include any provider configured default_tags.
-		if v := apiTags.IgnoreAWS().IgnoreConfig(tagsInContext.IgnoreConfig).RemoveDefaultConfig(tagsInContext.DefaultConfig).Map(); len(v) > 0 {
+		if v := apiTags.IgnoreAWS().IgnoreElasticbeanstalk().IgnoreRDS().IgnoreConfig(tagsInContext.IgnoreConfig).RemoveDefaultConfig(tagsInContext.DefaultConfig).Map(); len(v) > 0 {
 			stateTags = flex.FlattenFrameworkStringValueMapLegacy(ctx, v)
 		}
 		diags.Append(response.State.SetAttribute(ctx, path.Root(names.AttrTags), &stateTags)...)
@@ -419,7 +419,7 @@ func (r tagsInterceptor) read(ctx context.Context, request resource.ReadRequest,
 		}
 
 		// Computed tags_all do.
-		stateTagsAll := flex.FlattenFrameworkStringValueMapLegacy(ctx, apiTags.IgnoreAWS().IgnoreConfig(tagsInContext.IgnoreConfig).Map())
+		stateTagsAll := flex.FlattenFrameworkStringValueMapLegacy(ctx, apiTags.IgnoreAWS().IgnoreElasticbeanstalk().IgnoreRDS().IgnoreConfig(tagsInContext.IgnoreConfig).Map())
 		diags.Append(response.State.SetAttribute(ctx, path.Root(names.AttrTagsAll), &stateTagsAll)...)
 
 		if diags.HasError() {
@@ -476,7 +476,7 @@ func (r tagsInterceptor) update(ctx context.Context, request resource.UpdateRequ
 		// Merge the resource's configured tags with any provider configured default_tags.
 		tags := tagsInContext.DefaultConfig.MergeTags(tftags.New(ctx, planTags))
 		// Remove system tags.
-		tags = tags.IgnoreAWS()
+		tags = tags.IgnoreAWS().IgnoreElasticbeanstalk().IgnoreRDS()
 
 		tagsInContext.TagsIn = types.Some(tags)
 

--- a/internal/provider/intercept.go
+++ b/internal/provider/intercept.go
@@ -222,7 +222,7 @@ func (r tagsInterceptor) run(ctx context.Context, d *schema.ResourceData, meta a
 			// Merge the resource's configured tags with any provider configured default_tags.
 			tags := tagsInContext.DefaultConfig.MergeTags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{})))
 			// Remove system tags.
-			tags = tags.IgnoreAWS().IgnoreElasticbeanstalk().IgnoreRDS()
+			tags = tags.IgnoreAWS()
 
 			tagsInContext.TagsIn = types.Some(tags)
 
@@ -321,7 +321,7 @@ func (r tagsInterceptor) run(ctx context.Context, d *schema.ResourceData, meta a
 			}
 
 			// Remove any provider configured ignore_tags and system tags from those returned from the service API.
-			tags := tagsInContext.TagsOut.UnwrapOrDefault().IgnoreAWS().IgnoreElasticbeanstalk().IgnoreRDS().IgnoreConfig(tagsInContext.IgnoreConfig)
+			tags := tagsInContext.TagsOut.UnwrapOrDefault().IgnoreAWS().IgnoreConfig(tagsInContext.IgnoreConfig)
 
 			// The resource's configured tags do not include any provider configured default_tags.
 			if err := d.Set(names.AttrTags, tags.RemoveDefaultConfig(tagsInContext.DefaultConfig).Map()); err != nil {

--- a/internal/provider/intercept.go
+++ b/internal/provider/intercept.go
@@ -187,25 +187,21 @@ func (r tagsInterceptor) run(ctx context.Context, d *schema.ResourceData, meta a
 	}
 
 	inContext, ok := conns.FromContext(ctx)
-
 	if !ok {
 		return ctx, diags
 	}
 
 	sp, ok := meta.(*conns.AWSClient).ServicePackages[inContext.ServicePackageName]
-
 	if !ok {
 		return ctx, diags
 	}
 
 	serviceName, err := names.HumanFriendly(inContext.ServicePackageName)
-
 	if err != nil {
 		serviceName = "<service>"
 	}
 
 	resourceName := inContext.ResourceName
-
 	if resourceName == "" {
 		resourceName = "<thing>"
 	}
@@ -222,7 +218,7 @@ func (r tagsInterceptor) run(ctx context.Context, d *schema.ResourceData, meta a
 			// Merge the resource's configured tags with any provider configured default_tags.
 			tags := tagsInContext.DefaultConfig.MergeTags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{})))
 			// Remove system tags.
-			tags = tags.IgnoreAWS()
+			tags = tags.IgnoreSystem(inContext.ServicePackageName)
 
 			tagsInContext.TagsIn = types.Some(tags)
 
@@ -321,7 +317,7 @@ func (r tagsInterceptor) run(ctx context.Context, d *schema.ResourceData, meta a
 			}
 
 			// Remove any provider configured ignore_tags and system tags from those returned from the service API.
-			tags := tagsInContext.TagsOut.UnwrapOrDefault().IgnoreAWS().IgnoreConfig(tagsInContext.IgnoreConfig)
+			tags := tagsInContext.TagsOut.UnwrapOrDefault().IgnoreSystem(inContext.ServicePackageName).IgnoreConfig(tagsInContext.IgnoreConfig)
 
 			// The resource's configured tags do not include any provider configured default_tags.
 			if err := d.Set(names.AttrTags, tags.RemoveDefaultConfig(tagsInContext.DefaultConfig).Map()); err != nil {

--- a/internal/provider/intercept.go
+++ b/internal/provider/intercept.go
@@ -222,7 +222,7 @@ func (r tagsInterceptor) run(ctx context.Context, d *schema.ResourceData, meta a
 			// Merge the resource's configured tags with any provider configured default_tags.
 			tags := tagsInContext.DefaultConfig.MergeTags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{})))
 			// Remove system tags.
-			tags = tags.IgnoreAWS()
+			tags = tags.IgnoreAWS().IgnoreElasticbeanstalk().IgnoreRDS()
 
 			tagsInContext.TagsIn = types.Some(tags)
 
@@ -321,7 +321,7 @@ func (r tagsInterceptor) run(ctx context.Context, d *schema.ResourceData, meta a
 			}
 
 			// Remove any provider configured ignore_tags and system tags from those returned from the service API.
-			tags := tagsInContext.TagsOut.UnwrapOrDefault().IgnoreAWS().IgnoreConfig(tagsInContext.IgnoreConfig)
+			tags := tagsInContext.TagsOut.UnwrapOrDefault().IgnoreAWS().IgnoreElasticbeanstalk().IgnoreRDS().IgnoreConfig(tagsInContext.IgnoreConfig)
 
 			// The resource's configured tags do not include any provider configured default_tags.
 			if err := d.Set(names.AttrTags, tags.RemoveDefaultConfig(tagsInContext.DefaultConfig).Map()); err != nil {

--- a/internal/service/ecr/service_package_gen.go
+++ b/internal/service/ecr/service_package_gen.go
@@ -61,6 +61,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceRepository,
 			TypeName: "aws_ecr_repository",
+			Name:     "Repository",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRepositoryPolicy,

--- a/internal/service/ecrpublic/service_package_gen.go
+++ b/internal/service/ecrpublic/service_package_gen.go
@@ -33,6 +33,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceRepository,
 			TypeName: "aws_ecrpublic_repository",
+			Name:     "Repository",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceRepositoryPolicy,

--- a/internal/service/ecs/service_package_gen.go
+++ b/internal/service/ecs/service_package_gen.go
@@ -53,10 +53,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCapacityProvider,
 			TypeName: "aws_ecs_capacity_provider",
+			Name:     "Capacity Provider",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceCluster,
 			TypeName: "aws_ecs_cluster",
+			Name:     "Cluster",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceClusterCapacityProviders,
@@ -65,6 +73,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceService,
 			TypeName: "aws_ecs_service",
+			Name:     "Service",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTag,
@@ -73,10 +85,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceTaskDefinition,
 			TypeName: "aws_ecs_task_definition",
+			Name:     "Task Definition",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTaskSet,
 			TypeName: "aws_ecs_task_set",
+			Name:     "Task Set",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }

--- a/internal/service/ecs/service_package_gen.go
+++ b/internal/service/ecs/service_package_gen.go
@@ -87,7 +87,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			TypeName: "aws_ecs_task_definition",
 			Name:     "Task Definition",
 			Tags: &types.ServicePackageResourceTags{
-				IdentifierAttribute: "id",
+				IdentifierAttribute: "arn",
 			},
 		},
 		{

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -27,7 +27,7 @@ import (
 )
 
 // @SDKResource("aws_ecs_task_definition", name="Task Definition")
-// @Tags(identifierAttribute="id")
+// @Tags(identifierAttribute="arn")
 func ResourceTaskDefinition() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -23,9 +23,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ecs_task_definition")
+// @SDKResource("aws_ecs_task_definition", name="Task Definition")
+// @Tags(identifierAttribute="id")
 func ResourceTaskDefinition() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{
@@ -261,8 +263,8 @@ func ResourceTaskDefinition() *schema.Resource {
 				Default:  false,
 				Optional: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"task_role_arn": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -440,8 +442,6 @@ func ValidTaskDefinitionContainerDefinitions(v interface{}, k string) (ws []stri
 func resourceTaskDefinitionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	rawDefinitions := d.Get("container_definitions").(string)
 	definitions, err := expandContainerDefinitions(rawDefinitions)
@@ -452,11 +452,7 @@ func resourceTaskDefinitionCreate(ctx context.Context, d *schema.ResourceData, m
 	input := ecs.RegisterTaskDefinitionInput{
 		ContainerDefinitions: definitions,
 		Family:               aws.String(d.Get("family").(string)),
-	}
-
-	// ClientException: Tags can not be empty.
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
+		Tags:                 GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("task_role_arn"); ok {
@@ -548,7 +544,7 @@ func resourceTaskDefinitionCreate(ctx context.Context, d *schema.ResourceData, m
 	d.Set("arn_without_revision", StripRevision(aws.StringValue(taskDefinition.TaskDefinitionArn)))
 
 	// Some partitions (i.e., ISO) may not support tag-on-create, attempt tag after create
-	if input.Tags == nil && len(tags) > 0 {
+	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(ctx, conn, aws.StringValue(taskDefinition.TaskDefinitionArn), nil, tags)
 
 		// If default tags only, log and continue. Otherwise, error.
@@ -568,10 +564,6 @@ func resourceTaskDefinitionCreate(ctx context.Context, d *schema.ResourceData, m
 func resourceTaskDefinitionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-
-	log.Printf("[DEBUG] Reading task definition %s", d.Id())
 
 	input := ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: aws.String(d.Get("arn").(string)),
@@ -659,16 +651,7 @@ func resourceTaskDefinitionRead(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "setting ephemeral_storage: %s", err)
 	}
 
-	tags := KeyValueTags(ctx, out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, out.Tags)
 
 	return diags
 }
@@ -737,25 +720,10 @@ func flattenProxyConfiguration(pc *ecs.ProxyConfiguration) []map[string]interfac
 
 func resourceTaskDefinitionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).ECSConn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
+	// Tags only.
 
-		err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n)
-
-		// Some partitions (i.e., ISO) may not support tagging, giving error
-		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
-			log.Printf("[WARN] ECS tagging failed updating tags for Task Definition (%s): %s", d.Id(), err)
-			return diags
-		}
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "ECS tagging failed updating tags for Task Definition (%s): %s", d.Id(), err)
-		}
-	}
-
-	return diags
+	return append(diags, resourceTaskDefinitionRead(ctx, d, meta)...)
 }
 
 func resourceTaskDefinitionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/efs/file_system.go
+++ b/internal/service/efs/file_system.go
@@ -19,9 +19,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_efs_file_system")
+// @SDKResource("aws_efs_file_system", name="File System")
+// @Tags(identifierAttribute="id")
 func ResourceFileSystem() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceFileSystemCreate,
@@ -133,8 +135,8 @@ func ResourceFileSystem() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"throughput_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -147,8 +149,6 @@ func ResourceFileSystem() *schema.Resource {
 
 func resourceFileSystemCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EFSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	creationToken := ""
 	if v, ok := d.GetOk("creation_token"); ok {
@@ -160,7 +160,7 @@ func resourceFileSystemCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	input := &efs.CreateFileSystemInput{
 		CreationToken:  aws.String(creationToken),
-		Tags:           Tags(tags.IgnoreAWS()),
+		Tags:           GetTagsIn(ctx),
 		ThroughputMode: aws.String(throughputMode),
 	}
 
@@ -219,8 +219,6 @@ func resourceFileSystemCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 func resourceFileSystemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EFSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	fs, err := FindFileSystemByID(ctx, conn, d.Id())
 
@@ -247,16 +245,7 @@ func resourceFileSystemRead(ctx context.Context, d *schema.ResourceData, meta in
 	d.Set("provisioned_throughput_in_mibps", fs.ProvisionedThroughputInMibps)
 	d.Set("throughput_mode", fs.ThroughputMode)
 
-	tags := KeyValueTags(ctx, fs.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, fs.Tags)
 
 	if err := d.Set("size_in_bytes", flattenFileSystemSizeInBytes(fs.SizeInBytes)); err != nil {
 		return diag.Errorf("setting size_in_bytes: %s", err)
@@ -320,14 +309,6 @@ func resourceFileSystemUpdate(ctx context.Context, d *schema.ResourceData, meta 
 
 		if err != nil {
 			return diag.Errorf("putting EFS file system (%s) lifecycle configuration: %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return diag.Errorf("updating EFS file system (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/efs/service_package_gen.go
+++ b/internal/service/efs/service_package_gen.go
@@ -45,6 +45,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceAccessPoint,
 			TypeName: "aws_efs_access_point",
+			Name:     "Access Point",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceBackupPolicy,
@@ -53,6 +57,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceFileSystem,
 			TypeName: "aws_efs_file_system",
+			Name:     "File System",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceFileSystemPolicy,

--- a/internal/service/eks/fargate_profile.go
+++ b/internal/service/eks/fargate_profile.go
@@ -20,9 +20,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_eks_fargate_profile")
+// @SDKResource("aws_eks_fargate_profile", name="Fargate Profile")
+// @Tags(identifierAttribute="arn")
 func ResourceFargateProfile() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceFargateProfileCreate,
@@ -96,8 +98,8 @@ func ResourceFargateProfile() *schema.Resource {
 				MinItems: 1,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -105,13 +107,10 @@ func ResourceFargateProfile() *schema.Resource {
 func resourceFargateProfileCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EKSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	clusterName := d.Get("cluster_name").(string)
 	fargateProfileName := d.Get("fargate_profile_name").(string)
 	profileID := FargateProfileCreateResourceID(clusterName, fargateProfileName)
-
 	input := &eks.CreateFargateProfileInput{
 		ClientRequestToken:  aws.String(id.UniqueId()),
 		ClusterName:         aws.String(clusterName),
@@ -119,10 +118,7 @@ func resourceFargateProfileCreate(ctx context.Context, d *schema.ResourceData, m
 		PodExecutionRoleArn: aws.String(d.Get("pod_execution_role_arn").(string)),
 		Selectors:           expandFargateProfileSelectors(d.Get("selector").(*schema.Set).List()),
 		Subnets:             flex.ExpandStringSet(d.Get("subnet_ids").(*schema.Set)),
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
+		Tags:                GetTagsIn(ctx),
 	}
 
 	// mutex lock for creation/deletion serialization
@@ -168,8 +164,6 @@ func resourceFargateProfileCreate(ctx context.Context, d *schema.ResourceData, m
 func resourceFargateProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EKSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	clusterName, fargateProfileName, err := FargateProfileParseResourceID(d.Id())
 
@@ -204,30 +198,15 @@ func resourceFargateProfileRead(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "setting subnet_ids: %s", err)
 	}
 
-	tags := KeyValueTags(ctx, fargateProfile.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, fargateProfile.Tags)
 
 	return diags
 }
 
 func resourceFargateProfileUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).EKSConn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating tags: %s", err)
-		}
-	}
+	// Tags only.
 
 	return append(diags, resourceFargateProfileRead(ctx, d, meta)...)
 }

--- a/internal/service/eks/node_group.go
+++ b/internal/service/eks/node_group.go
@@ -19,9 +19,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_eks_node_group")
+// @SDKResource("aws_eks_node_group", name="Node Group")
+// @Tags(identifierAttribute="arn")
 func ResourceNodeGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceNodeGroupCreate,
@@ -222,8 +224,8 @@ func ResourceNodeGroup() *schema.Resource {
 				MinItems: 1,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"taint": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -287,19 +289,17 @@ func ResourceNodeGroup() *schema.Resource {
 
 func resourceNodeGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EKSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	clusterName := d.Get("cluster_name").(string)
 	nodeGroupName := create.Name(d.Get("node_group_name").(string), d.Get("node_group_name_prefix").(string))
 	groupID := NodeGroupCreateResourceID(clusterName, nodeGroupName)
-
 	input := &eks.CreateNodegroupInput{
 		ClientRequestToken: aws.String(id.UniqueId()),
 		ClusterName:        aws.String(clusterName),
 		NodegroupName:      aws.String(nodeGroupName),
 		NodeRole:           aws.String(d.Get("node_role_arn").(string)),
 		Subnets:            flex.ExpandStringSet(d.Get("subnet_ids").(*schema.Set)),
+		Tags:               GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("ami_type"); ok {
@@ -350,10 +350,6 @@ func resourceNodeGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 		input.Version = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
 	_, err := conn.CreateNodegroupWithContext(ctx, input)
 
 	if err != nil {
@@ -373,8 +369,6 @@ func resourceNodeGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 func resourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EKSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	clusterName, nodeGroupName, err := NodeGroupParseResourceID(d.Id())
 
@@ -453,16 +447,7 @@ func resourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	d.Set("version", nodeGroup.Version)
 
-	tags := KeyValueTags(ctx, nodeGroup.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("error setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, nodeGroup.Tags)
 
 	return nil
 }
@@ -564,13 +549,6 @@ func resourceNodeGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 
 		if err != nil {
 			return diag.Errorf("error waiting for EKS Node Group (%s) config update (%s): %s", d.Id(), updateID, err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.Errorf("error updating tags: %s", err)
 		}
 	}
 

--- a/internal/service/eks/service_package_gen.go
+++ b/internal/service/eks/service_package_gen.go
@@ -57,22 +57,42 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceAddon,
 			TypeName: "aws_eks_addon",
+			Name:     "Add-On",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceCluster,
 			TypeName: "aws_eks_cluster",
+			Name:     "Cluster",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceFargateProfile,
 			TypeName: "aws_eks_fargate_profile",
+			Name:     "Fargate Profile",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceIdentityProviderConfig,
 			TypeName: "aws_eks_identity_provider_config",
+			Name:     "Identity Provider Config",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceNodeGroup,
 			TypeName: "aws_eks_node_group",
+			Name:     "Node Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/elasticache/find.go
+++ b/internal/service/elasticache/find.go
@@ -183,25 +183,6 @@ func FindGlobalReplicationGroupMemberByID(ctx context.Context, conn *elasticache
 	}
 }
 
-func FindUserGroupByID(ctx context.Context, conn *elasticache.ElastiCache, groupID string) (*elasticache.UserGroup, error) {
-	input := &elasticache.DescribeUserGroupsInput{
-		UserGroupId: aws.String(groupID),
-	}
-	out, err := conn.DescribeUserGroupsWithContext(ctx, input)
-	if err != nil {
-		return nil, err
-	}
-
-	switch count := len(out.UserGroups); count {
-	case 0:
-		return nil, tfresource.NewEmptyResultError(input)
-	case 1:
-		return out.UserGroups[0], nil
-	default:
-		return nil, tfresource.NewTooManyResultsError(count, input)
-	}
-}
-
 func FindParameterGroupByName(ctx context.Context, conn *elasticache.ElastiCache, name string) (*elasticache.CacheParameterGroup, error) {
 	input := elasticache.DescribeCacheParameterGroupsInput{
 		CacheParameterGroupName: aws.String(name),

--- a/internal/service/elasticache/parameter_group.go
+++ b/internal/service/elasticache/parameter_group.go
@@ -20,9 +20,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_elasticache_parameter_group")
+// @SDKResource("aws_elasticache_parameter_group", name="Parameter Group")
+// @Tags(identifierAttribute="arn")
 func ResourceParameterGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceParameterGroupCreate,
@@ -73,8 +75,8 @@ func ResourceParameterGroup() *schema.Resource {
 				},
 				Set: ParameterHash,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 		CustomizeDiff: verify.SetTagsDiff,
 	}
@@ -83,27 +85,21 @@ func ResourceParameterGroup() *schema.Resource {
 func resourceParameterGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
-	createOpts := elasticache.CreateCacheParameterGroupInput{
+	input := elasticache.CreateCacheParameterGroupInput{
 		CacheParameterGroupName:   aws.String(d.Get("name").(string)),
 		CacheParameterGroupFamily: aws.String(d.Get("family").(string)),
 		Description:               aws.String(d.Get("description").(string)),
+		Tags:                      GetTagsIn(ctx),
 	}
 
-	if len(tags) > 0 {
-		createOpts.Tags = Tags(tags.IgnoreAWS())
-	}
+	resp, err := conn.CreateCacheParameterGroupWithContext(ctx, &input)
 
-	log.Printf("[DEBUG] Create ElastiCache Parameter Group: %#v", createOpts)
-	resp, err := conn.CreateCacheParameterGroupWithContext(ctx, &createOpts)
-
-	if createOpts.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating ElastiCache Parameter Group with tags: %s. Trying create without tags.", err)
 
-		createOpts.Tags = nil
-		resp, err = conn.CreateCacheParameterGroupWithContext(ctx, &createOpts)
+		input.Tags = nil
+		resp, err = conn.CreateCacheParameterGroupWithContext(ctx, &input)
 	}
 
 	if err != nil {
@@ -120,8 +116,6 @@ func resourceParameterGroupCreate(ctx context.Context, d *schema.ResourceData, m
 func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	parameterGroup, err := FindParameterGroupByName(ctx, conn, d.Id())
 	if err != nil {
@@ -145,29 +139,6 @@ func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	d.Set("parameter", FlattenParameters(describeParametersResp.Parameters))
-
-	tags, err := ListTags(ctx, conn, aws.StringValue(parameterGroup.ARN))
-
-	if err != nil && !verify.ErrorISOUnsupported(conn.PartitionID, err) {
-		return sdkdiag.AppendErrorf(diags, "listing tags for ElastiCache Parameter Group (%s): %s", d.Id(), err)
-	}
-
-	if err != nil {
-		log.Printf("[WARN] failed listing tags for ElastiCache Parameter Group (%s): %s", d.Id(), err)
-	}
-
-	if tags != nil {
-		tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-		//lintignore:AWSR002
-		if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-		}
-
-		if err := d.Set("tags_all", tags.Map()); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-		}
-	}
 
 	return diags
 }
@@ -288,21 +259,6 @@ func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "modifying ElastiCache Parameter Group: %s", err)
 			}
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n)
-
-		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.ErrorISOUnsupported(conn.PartitionID, err) {
-				// explicitly setting tags or not an iso-unsupported error
-				return sdkdiag.AppendErrorf(diags, "updating ElastiCache Parameter Group (%s) tags: %s", d.Get("arn").(string), err)
-			}
-
-			log.Printf("[WARN] failed updating tags for ElastiCache Parameter Group (%s): %s", d.Get("arn").(string), err)
 		}
 	}
 

--- a/internal/service/elasticache/service_package_gen.go
+++ b/internal/service/elasticache/service_package_gen.go
@@ -93,6 +93,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceUserGroup,
 			TypeName: "aws_elasticache_user_group",
+			Name:     "User Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceUserGroupAssociation,

--- a/internal/service/elasticache/service_package_gen.go
+++ b/internal/service/elasticache/service_package_gen.go
@@ -45,6 +45,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCluster,
 			TypeName: "aws_elasticache_cluster",
+			Name:     "Cluster",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceGlobalReplicationGroup,
@@ -53,10 +57,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceParameterGroup,
 			TypeName: "aws_elasticache_parameter_group",
+			Name:     "Parameter Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceReplicationGroup,
 			TypeName: "aws_elasticache_replication_group",
+			Name:     "Replication Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceSecurityGroup,
@@ -65,10 +77,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceSubnetGroup,
 			TypeName: "aws_elasticache_subnet_group",
+			Name:     "Subnet Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceUser,
 			TypeName: "aws_elasticache_user",
+			Name:     "User",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceUserGroup,

--- a/internal/service/elasticache/user.go
+++ b/internal/service/elasticache/user.go
@@ -122,7 +122,7 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 		Engine:             aws.String(d.Get("engine").(string)),
 		NoPasswordRequired: aws.Bool(d.Get("no_password_required").(bool)),
 		Tags:               GetTagsIn(ctx),
-		UserId:             aws.String(d.Get("user_id").(string)),
+		UserId:             aws.String(userID),
 		UserName:           aws.String(d.Get("user_name").(string)),
 	}
 
@@ -169,8 +169,6 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	user, err := FindUserByID(ctx, conn, d.Id())
 
@@ -202,30 +200,6 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	d.Set("engine", user.Engine)
 	d.Set("user_id", user.UserId)
 	d.Set("user_name", user.UserName)
-
-	tags, err := ListTags(ctx, conn, aws.StringValue(user.ARN))
-
-	if err != nil && !verify.ErrorISOUnsupported(conn.PartitionID, err) {
-		return sdkdiag.AppendErrorf(diags, "listing tags for ElastiCache User (%s): %s", aws.StringValue(user.ARN), err)
-	}
-
-	// tags not supported in all partitions
-	if err != nil {
-		log.Printf("[WARN] failed listing tags for ElastiCache User (%s): %s", aws.StringValue(user.ARN), err)
-	}
-
-	if tags != nil {
-		tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-		//lintignore:AWSR002
-		if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-		}
-
-		if err := d.Set("tags_all", tags.Map()); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-		}
-	}
 
 	return diags
 }
@@ -268,21 +242,6 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		}
 	}
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n)
-
-		if err != nil {
-			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.ErrorISOUnsupported(conn.PartitionID, err) {
-				// explicitly setting tags or not an iso-unsupported error
-				return sdkdiag.AppendErrorf(diags, "updating ElastiCache User (%s) tags: %s", d.Get("arn").(string), err)
-			}
-
-			log.Printf("[WARN] failed updating tags for ElastiCache User (%s): %s", d.Get("arn").(string), err)
-		}
-	}
-
 	return append(diags, resourceUserRead(ctx, d, meta)...)
 }
 
@@ -310,9 +269,9 @@ func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	return diags
 }
 
-func FindUserByID(ctx context.Context, conn *elasticache.ElastiCache, userID string) (*elasticache.User, error) {
+func FindUserByID(ctx context.Context, conn *elasticache.ElastiCache, id string) (*elasticache.User, error) {
 	input := &elasticache.DescribeUsersInput{
-		UserId: aws.String(userID),
+		UserId: aws.String(id),
 	}
 
 	output, err := conn.DescribeUsersWithContext(ctx, input)
@@ -341,7 +300,7 @@ func FindUserByID(ctx context.Context, conn *elasticache.ElastiCache, userID str
 
 func statusUser(ctx context.Context, conn *elasticache.ElastiCache, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		user, err := FindUserByID(ctx, conn, id)
+		output, err := FindUserByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil
@@ -351,14 +310,14 @@ func statusUser(ctx context.Context, conn *elasticache.ElastiCache, id string) r
 			return nil, "", err
 		}
 
-		return user, aws.StringValue(user.Status), nil
+		return output, aws.StringValue(output.Status), nil
 	}
 }
 
 const (
-	UserStatusActive    = "active"
-	UserStatusDeleting  = "deleting"
-	UserStatusModifying = "modifying"
+	userStatusActive    = "active"
+	userStatusDeleting  = "deleting"
+	userStatusModifying = "modifying"
 )
 
 func waitUserUpdated(ctx context.Context, conn *elasticache.ElastiCache, id string) (*elasticache.User, error) {
@@ -366,8 +325,8 @@ func waitUserUpdated(ctx context.Context, conn *elasticache.ElastiCache, id stri
 		timeout = 5 * time.Minute
 	)
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{UserStatusModifying},
-		Target:  []string{UserStatusActive},
+		Pending: []string{userStatusModifying},
+		Target:  []string{userStatusActive},
 		Refresh: statusUser(ctx, conn, id),
 		Timeout: timeout,
 	}
@@ -386,7 +345,7 @@ func waitUserDeleted(ctx context.Context, conn *elasticache.ElastiCache, id stri
 		timeout = 5 * time.Minute
 	)
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{UserStatusDeleting},
+		Pending: []string{userStatusDeleting},
 		Target:  []string{},
 		Refresh: statusUser(ctx, conn, id),
 		Timeout: timeout,

--- a/internal/service/elasticache/user_group.go
+++ b/internal/service/elasticache/user_group.go
@@ -22,13 +22,15 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_elasticache_user_group")
+// @SDKResource("aws_elasticache_user_group", name="User Group")
+// @Tags(identifierAttribute="arn")
 func ResourceUserGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceUserGroupCreate,
 		ReadWithoutTimeout:   resourceUserGroupRead,
 		UpdateWithoutTimeout: resourceUserGroupUpdate,
 		DeleteWithoutTimeout: resourceUserGroupDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -37,7 +39,6 @@ func ResourceUserGroup() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"engine": {
@@ -54,6 +55,7 @@ func ResourceUserGroup() *schema.Resource {
 			"user_group_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"user_ids": {
 				Type:     schema.TypeSet,
@@ -64,58 +66,43 @@ func ResourceUserGroup() *schema.Resource {
 	}
 }
 
-var resourceUserGroupPendingStates = []string{
-	"creating",
-	"modifying",
-}
-
 func resourceUserGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheConn()
 
+	userGroupID := d.Get("user_group_id").(string)
 	input := &elasticache.CreateUserGroupInput{
 		Engine:      aws.String(d.Get("engine").(string)),
 		Tags:        GetTagsIn(ctx),
-		UserGroupId: aws.String(d.Get("user_group_id").(string)),
+		UserGroupId: aws.String(userGroupID),
 	}
 
-	if v, ok := d.GetOk("user_ids"); ok {
+	if v, ok := d.GetOk("user_ids"); ok && v.(*schema.Set).Len() > 0 {
 		input.UserIds = flex.ExpandStringSet(v.(*schema.Set))
 	}
 
-	out, err := conn.CreateUserGroupWithContext(ctx, input)
+	output, err := conn.CreateUserGroupWithContext(ctx, input)
 
 	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] failed creating ElastiCache User Group with tags: %s. Trying create without tags.", err)
 
 		input.Tags = nil
-		out, err = conn.CreateUserGroupWithContext(ctx, input)
+		output, err = conn.CreateUserGroupWithContext(ctx, input)
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating ElastiCache User Group (%s): %s", d.Get("user_group_id").(string), err)
+		return sdkdiag.AppendErrorf(diags, "creating ElastiCache User Group (%s): %s", userGroupID, err)
 	}
 
-	d.SetId(aws.StringValue(out.UserGroupId))
+	d.SetId(aws.StringValue(output.UserGroupId))
 
-	stateConf := &retry.StateChangeConf{
-		Pending:    resourceUserGroupPendingStates,
-		Target:     []string{"active"},
-		Refresh:    resourceUserGroupStateRefreshFunc(ctx, d.Get("user_group_id").(string), conn),
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		MinTimeout: 10 * time.Second,
-		Delay:      30 * time.Second, // Wait 30 secs before starting
-	}
-
-	log.Printf("[INFO] Waiting for ElastiCache User Group (%s) to be available", d.Id())
-	_, err = stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating ElastiCache User Group: %s", err)
+	if _, err := waitUserGroupCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for ElastiCache User Group (%s) create: %s", d.Id(), err)
 	}
 
 	// In some partitions, only post-create tagging supported
 	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); input.Tags == nil && len(tags) > 0 {
-		err := UpdateTags(ctx, conn, aws.StringValue(out.ARN), nil, tags)
+		err := UpdateTags(ctx, conn, aws.StringValue(output.ARN), nil, tags)
 
 		if err != nil {
 			if v, ok := d.GetOk("tags"); (ok && len(v.(map[string]interface{})) > 0) || !verify.ErrorISOUnsupported(conn.PartitionID, err) {
@@ -134,21 +121,22 @@ func resourceUserGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheConn()
 
-	resp, err := FindUserGroupByID(ctx, conn, d.Id())
-	if !d.IsNewResource() && (tfresource.NotFound(err) || tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserGroupNotFoundFault)) {
+	userGroup, err := FindUserGroupByID(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] ElastiCache User Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		log.Printf("[DEBUG] ElastiCache User Group (%s) not found", d.Id())
 		return diags
 	}
 
-	if err != nil && !tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserGroupNotFoundFault) {
-		return sdkdiag.AppendErrorf(diags, "describing ElastiCache User Group (%s): %s", d.Id(), err)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading ElastiCache User Group (%s): %s", d.Id(), err)
 	}
 
-	d.Set("arn", resp.ARN)
-	d.Set("engine", resp.Engine)
-	d.Set("user_ids", resp.UserIds)
-	d.Set("user_group_id", resp.UserGroupId)
+	d.Set("arn", userGroup.ARN)
+	d.Set("engine", userGroup.Engine)
+	d.Set("user_ids", aws.StringValueSlice(userGroup.UserIds))
+	d.Set("user_group_id", userGroup.UserGroupId)
 
 	return diags
 }
@@ -156,47 +144,33 @@ func resourceUserGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 func resourceUserGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheConn()
-	hasChange := false
 
 	if d.HasChangesExcept("tags", "tags_all") {
-		req := &elasticache.ModifyUserGroupInput{
+		input := &elasticache.ModifyUserGroupInput{
 			UserGroupId: aws.String(d.Get("user_group_id").(string)),
 		}
 
 		if d.HasChange("user_ids") {
 			o, n := d.GetChange("user_ids")
-			usersRemove := o.(*schema.Set).Difference(n.(*schema.Set))
-			usersAdd := n.(*schema.Set).Difference(o.(*schema.Set))
+			del := o.(*schema.Set).Difference(n.(*schema.Set))
+			add := n.(*schema.Set).Difference(o.(*schema.Set))
 
-			if usersAdd.Len() > 0 {
-				req.UserIdsToAdd = flex.ExpandStringSet(usersAdd)
-				hasChange = true
+			if add.Len() > 0 {
+				input.UserIdsToAdd = flex.ExpandStringSet(add)
 			}
-			if usersRemove.Len() > 0 {
-				req.UserIdsToRemove = flex.ExpandStringSet(usersRemove)
-				hasChange = true
+			if del.Len() > 0 {
+				input.UserIdsToRemove = flex.ExpandStringSet(del)
 			}
 		}
 
-		if hasChange {
-			_, err := conn.ModifyUserGroupWithContext(ctx, req)
-			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "updating ElastiCache User Group (%q): %s", d.Id(), err)
-			}
-			stateConf := &retry.StateChangeConf{
-				Pending:    resourceUserGroupPendingStates,
-				Target:     []string{"active"},
-				Refresh:    resourceUserGroupStateRefreshFunc(ctx, d.Get("user_group_id").(string), conn),
-				Timeout:    d.Timeout(schema.TimeoutCreate),
-				MinTimeout: 10 * time.Second,
-				Delay:      30 * time.Second, // Wait 30 secs before starting
-			}
+		_, err := conn.ModifyUserGroupWithContext(ctx, input)
 
-			log.Printf("[INFO] Waiting for ElastiCache User Group (%s) to be available", d.Id())
-			_, err = stateConf.WaitForStateContext(ctx)
-			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "updating ElastiCache User Group (%q): %s", d.Id(), err)
-			}
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating ElastiCache User Group (%q): %s", d.Id(), err)
+		}
+
+		if _, err := waitUserGroupUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for ElastiCache User Group (%s) update: %s", d.Id(), err)
 		}
 	}
 
@@ -207,52 +181,131 @@ func resourceUserGroupDelete(ctx context.Context, d *schema.ResourceData, meta i
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheConn()
 
-	input := &elasticache.DeleteUserGroupInput{
+	log.Printf("[INFO] Deleting ElastiCache User Group: %s", d.Id())
+	_, err := conn.DeleteUserGroupWithContext(ctx, &elasticache.DeleteUserGroupInput{
 		UserGroupId: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserGroupNotFoundFault) {
+		return diags
 	}
 
-	_, err := conn.DeleteUserGroupWithContext(ctx, input)
-	if err != nil && !tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserGroupNotFoundFault) {
-		return sdkdiag.AppendErrorf(diags, "deleting ElastiCache User Group: %s", err)
-	}
-	stateConf := &retry.StateChangeConf{
-		Pending:    []string{"deleting"},
-		Target:     []string{},
-		Refresh:    resourceUserGroupStateRefreshFunc(ctx, d.Get("user_group_id").(string), conn),
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		MinTimeout: 10 * time.Second,
-		Delay:      30 * time.Second, // Wait 30 secs before starting
-	}
-
-	log.Printf("[INFO] Waiting for ElastiCache User Group (%s) to be available", d.Id())
-	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserGroupNotFoundFault) || tfawserr.ErrCodeEquals(err, elasticache.ErrCodeInvalidUserGroupStateFault) {
-			return diags
-		}
-		return sdkdiag.AppendErrorf(diags, "ElastiCache User Group cannot be deleted: %s", err)
+		return sdkdiag.AppendErrorf(diags, "deleting ElastiCache User Group (%s): %s", d.Id(), err)
+	}
+
+	if _, err := waitUserGroupDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for ElastiCache User Group (%s) delete: %s", d.Id(), err)
 	}
 
 	return diags
 }
 
-func resourceUserGroupStateRefreshFunc(ctx context.Context, id string, conn *elasticache.ElastiCache) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		v, err := FindUserGroupByID(ctx, conn, id)
+func FindUserGroupByID(ctx context.Context, conn *elasticache.ElastiCache, id string) (*elasticache.UserGroup, error) {
+	input := &elasticache.DescribeUserGroupsInput{
+		UserGroupId: aws.String(id),
+	}
 
-		if err != nil {
-			log.Printf("Error on retrieving ElastiCache User Group when waiting: %s", err)
-			return nil, "", err
+	output, err := conn.DescribeUserGroupsWithContext(ctx, input)
+
+	if tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserGroupNotFoundFault) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
 		}
+	}
 
-		if v == nil {
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.UserGroups) == 0 || output.UserGroups[0] == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	if count := len(output.UserGroups); count > 1 {
+		return nil, tfresource.NewTooManyResultsError(count, input)
+	}
+
+	return output.UserGroups[0], nil
+}
+
+func statusUserGroup(ctx context.Context, conn *elasticache.ElastiCache, id string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindUserGroupByID(ctx, conn, id)
+
+		if tfresource.NotFound(err) {
 			return nil, "", nil
 		}
 
-		if v.Status != nil {
-			log.Printf("[DEBUG] ElastiCache User Group status for instance %s: %s", id, *v.Status)
+		if err != nil {
+			return nil, "", err
 		}
 
-		return v, *v.Status, nil
+		return output, aws.StringValue(output.Status), nil
 	}
+}
+
+const (
+	userGroupStatusActive    = "active"
+	userGroupStatusCreating  = "creating"
+	userGroupStatusDeleting  = "deleting"
+	userGroupStatusModifying = "modifying"
+)
+
+func waitUserGroupCreated(ctx context.Context, conn *elasticache.ElastiCache, id string, timeout time.Duration) (*elasticache.UserGroup, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:    []string{userGroupStatusCreating, userGroupStatusModifying},
+		Target:     []string{userGroupStatusActive},
+		Refresh:    statusUserGroup(ctx, conn, id),
+		Timeout:    timeout,
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*elasticache.UserGroup); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitUserGroupUpdated(ctx context.Context, conn *elasticache.ElastiCache, id string, timeout time.Duration) (*elasticache.UserGroup, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:    []string{userGroupStatusModifying},
+		Target:     []string{userGroupStatusActive},
+		Refresh:    statusUserGroup(ctx, conn, id),
+		Timeout:    timeout,
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*elasticache.UserGroup); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitUserGroupDeleted(ctx context.Context, conn *elasticache.ElastiCache, id string, timeout time.Duration) (*elasticache.UserGroup, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:    []string{userGroupStatusDeleting},
+		Target:     []string{},
+		Refresh:    statusUserGroup(ctx, conn, id),
+		Timeout:    timeout,
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*elasticache.UserGroup); ok {
+		return output, err
+	}
+
+	return nil, err
 }

--- a/internal/service/elasticache/user_group.go
+++ b/internal/service/elasticache/user_group.go
@@ -272,7 +272,7 @@ func waitUserGroupCreated(ctx context.Context, conn *elasticache.ElastiCache, id
 	return nil, err
 }
 
-func waitUserGroupUpdated(ctx context.Context, conn *elasticache.ElastiCache, id string, timeout time.Duration) (*elasticache.UserGroup, error) {
+func waitUserGroupUpdated(ctx context.Context, conn *elasticache.ElastiCache, id string, timeout time.Duration) (*elasticache.UserGroup, error) { //nolint:unparam
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{userGroupStatusModifying},
 		Target:     []string{userGroupStatusActive},

--- a/internal/service/elasticache/user_group_association.go
+++ b/internal/service/elasticache/user_group_association.go
@@ -24,6 +24,7 @@ func ResourceUserGroupAssociation() *schema.Resource {
 		CreateWithoutTimeout: resourceUserGroupAssociationCreate,
 		ReadWithoutTimeout:   resourceUserGroupAssociationRead,
 		DeleteWithoutTimeout: resourceUserGroupAssociationDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -47,39 +48,26 @@ func resourceUserGroupAssociationCreate(ctx context.Context, d *schema.ResourceD
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheConn()
 
+	userGroupID := d.Get("user_group_id").(string)
+	userID := d.Get("user_id").(string)
+	id := userGroupAssociationCreateResourceID(userGroupID, userID)
 	input := &elasticache.ModifyUserGroupInput{
-		UserGroupId:  aws.String(d.Get("user_group_id").(string)),
-		UserIdsToAdd: aws.StringSlice([]string{d.Get("user_id").(string)}),
+		UserGroupId:  aws.String(userGroupID),
+		UserIdsToAdd: aws.StringSlice([]string{userID}),
 	}
 
-	id := userGroupAssociationID(d.Get("user_group_id").(string), d.Get("user_id").(string))
-
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 10*time.Minute, func() (interface{}, error) {
-		return tfresource.RetryWhenNotFound(ctx, 30*time.Second, func() (interface{}, error) {
-			return conn.ModifyUserGroupWithContext(ctx, input)
-		})
+		return conn.ModifyUserGroupWithContext(ctx, input)
 	}, elasticache.ErrCodeInvalidUserGroupStateFault)
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating ElastiCache User Group Association (%q): %s", id, err)
+		return sdkdiag.AppendErrorf(diags, "creating ElastiCache User Group Association (%s): %s", id, err)
 	}
 
 	d.SetId(id)
 
-	stateConf := &retry.StateChangeConf{
-		Pending:        []string{"modifying", ""},
-		Target:         []string{"active"},
-		Refresh:        resourceUserGroupStateRefreshFunc(ctx, d.Get("user_group_id").(string), conn),
-		Timeout:        d.Timeout(schema.TimeoutCreate),
-		MinTimeout:     2 * time.Second,
-		NotFoundChecks: 5,
-		Delay:          10 * time.Second,
-	}
-
-	log.Printf("[INFO] Waiting for ElastiCache User Group (%s) to be available", d.Id())
-	_, err = stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating ElastiCache User Group Association (%q): %s", d.Id(), err)
+	if _, err := waitUserGroupUpdated(ctx, conn, userGroupID, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for ElastiCache User Group Association (%s) create: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceUserGroupAssociationRead(ctx, d, meta)...)
@@ -89,42 +77,26 @@ func resourceUserGroupAssociationRead(ctx context.Context, d *schema.ResourceDat
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheConn()
 
-	groupID, userID, err := UserGroupAssociationParseID(d.Id())
+	userGroupID, userID, err := UserGroupAssociationParseResourceID(d.Id())
+
+	if err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
+	}
+
+	err = FindUserGroupAssociation(ctx, conn, userGroupID, userID)
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] ElastiCache User Group Association (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
+	}
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading ElastiCache User Group Association (%s): %s", d.Id(), err)
 	}
 
-	output, err := FindUserGroupByID(ctx, conn, groupID)
-	if !d.IsNewResource() && (tfresource.NotFound(err) || tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserGroupNotFoundFault)) {
-		d.SetId("")
-		log.Printf("[DEBUG] ElastiCache User Group Association (%s) not found", d.Id())
-		return diags
-	}
-
-	if err != nil && !tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserGroupNotFoundFault) {
-		return sdkdiag.AppendErrorf(diags, "describing ElastiCache User Group (%s): %s", d.Id(), err)
-	}
-
-	gotUserID := ""
-	for _, v := range output.UserIds {
-		if aws.StringValue(v) == userID {
-			gotUserID = aws.StringValue(v)
-			break
-		}
-	}
-
-	if !d.IsNewResource() && gotUserID == "" {
-		d.SetId("")
-		log.Printf("[DEBUG] ElastiCache User Group Association (%s) not found", d.Id())
-		return diags
-	}
-
-	if gotUserID == "" {
-		return sdkdiag.AppendErrorf(diags, "reading ElastiCache User Group Association, user ID (%s) not associated with user group (%s)", userID, groupID)
-	}
-
-	d.Set("user_id", gotUserID)
-	d.Set("user_group_id", groupID)
+	d.Set("user_group_id", userGroupID)
+	d.Set("user_id", userID)
 
 	return diags
 }
@@ -133,48 +105,64 @@ func resourceUserGroupAssociationDelete(ctx context.Context, d *schema.ResourceD
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheConn()
 
-	input := &elasticache.ModifyUserGroupInput{
-		UserGroupId:     aws.String(d.Get("user_group_id").(string)),
-		UserIdsToRemove: aws.StringSlice([]string{d.Get("user_id").(string)}),
+	userGroupID, userID, err := UserGroupAssociationParseResourceID(d.Id())
+
+	if err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 10*time.Minute, func() (interface{}, error) {
-		return conn.ModifyUserGroupWithContext(ctx, input)
+	log.Printf("[INFO] Deleting ElastiCache User Group Association: %s", d.Id())
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, 10*time.Minute, func() (interface{}, error) {
+		return conn.ModifyUserGroupWithContext(ctx, &elasticache.ModifyUserGroupInput{
+			UserGroupId:     aws.String(userGroupID),
+			UserIdsToRemove: aws.StringSlice([]string{userID}),
+		})
 	}, elasticache.ErrCodeInvalidUserGroupStateFault)
 
-	if err != nil && !tfawserr.ErrMessageContains(err, elasticache.ErrCodeInvalidParameterValueException, "not a member") {
-		return sdkdiag.AppendErrorf(diags, "deleting ElastiCache User Group Association (%q): %s", d.Id(), err)
+	if tfawserr.ErrMessageContains(err, elasticache.ErrCodeInvalidParameterValueException, "not a member") {
+		return diags
 	}
 
-	stateConf := &retry.StateChangeConf{
-		Pending:    []string{"modifying"},
-		Target:     []string{"active"},
-		Refresh:    resourceUserGroupStateRefreshFunc(ctx, d.Get("user_group_id").(string), conn),
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		MinTimeout: 10 * time.Second,
-		Delay:      30 * time.Second, // Wait 30 secs before starting
-	}
-
-	log.Printf("[INFO] Waiting for ElastiCache User Group (%s) to be available", d.Id())
-	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "waiting for ElastiCache User Group Association delete (%q): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting ElastiCache User Group Association (%s): %s", d.Id(), err)
+	}
+
+	if _, err := waitUserGroupUpdated(ctx, conn, userGroupID, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for ElastiCache User Group Association (%s) delete: %s", d.Id(), err)
 	}
 
 	return diags
 }
 
-func userGroupAssociationID(userGroupID, userID string) string {
+func FindUserGroupAssociation(ctx context.Context, conn *elasticache.ElastiCache, userGroupID, userID string) error {
+	userGroup, err := FindUserGroupByID(ctx, conn, userGroupID)
+
+	if err != nil {
+		return err
+	}
+
+	for _, v := range userGroup.UserIds {
+		if aws.StringValue(v) == userID {
+			return nil
+		}
+	}
+
+	return &retry.NotFoundError{}
+}
+
+const userGroupAssociationResourceIDSeparator = ","
+
+func userGroupAssociationCreateResourceID(userGroupID, userID string) string {
 	parts := []string{userGroupID, userID}
-	id := strings.Join(parts, ",")
+	id := strings.Join(parts, userGroupAssociationResourceIDSeparator)
 	return id
 }
 
-func UserGroupAssociationParseID(id string) (string, string, error) {
-	parts := strings.Split(id, ",")
+func UserGroupAssociationParseResourceID(id string) (string, string, error) {
+	parts := strings.Split(id, userGroupAssociationResourceIDSeparator)
 	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
 		return parts[0], parts[1], nil
 	}
 
-	return "", "", fmt.Errorf("unexpected format for ElastiCache User Group Association ID (%q), expected '<user group ID>,<user ID>'", id)
+	return "", "", fmt.Errorf("unexpected format for ID (%[1]s), expected '<user group ID>%[2]s<user ID>'", id, userGroupAssociationResourceIDSeparator)
 }

--- a/internal/service/elasticache/user_group_association_test.go
+++ b/internal/service/elasticache/user_group_association_test.go
@@ -5,16 +5,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfelasticache "github.com/hashicorp/terraform-provider-aws/internal/service/elasticache"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccElastiCacheUserGroupAssociation_basic(t *testing.T) {
@@ -139,44 +137,30 @@ func TestAccElastiCacheUserGroupAssociation_multiple(t *testing.T) {
 
 func testAccCheckUserGroupAssociationDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		return testAccCheckUserGroupAssociationDestroyWithProvider(ctx)(s, acctest.Provider)
-	}
-}
-
-func testAccCheckUserGroupAssociationDestroyWithProvider(ctx context.Context) acctest.TestCheckWithProviderFunc {
-	return func(s *terraform.State, provider *schema.Provider) error {
-		conn := provider.Meta().(*conns.AWSClient).ElastiCacheConn()
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheConn()
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_elasticache_user_group_association" {
 				continue
 			}
 
-			groupID, userID, err := tfelasticache.UserGroupAssociationParseID(rs.Primary.ID)
+			userGroupID, userID, err := tfelasticache.UserGroupAssociationParseResourceID(rs.Primary.ID)
+
 			if err != nil {
-				return fmt.Errorf("parsing User Group Association ID (%s): %w", rs.Primary.ID, err)
+				return err
 			}
 
-			output, err := tfelasticache.FindUserGroupByID(ctx, conn, groupID)
+			err = tfelasticache.FindUserGroupAssociation(ctx, conn, userGroupID, userID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
 			if err != nil {
-				if tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserGroupNotFoundFault) {
-					return nil
-				}
+				return err
 			}
 
-			gotUserID := ""
-			for _, v := range output.UserIds {
-				if aws.StringValue(v) == userID {
-					gotUserID = aws.StringValue(v)
-					break
-				}
-			}
-
-			if gotUserID != "" {
-				return fmt.Errorf("ElastiCache User Group Association (%s) found, should be deleted", rs.Primary.ID)
-			}
-
-			return nil
+			return fmt.Errorf("ElastiCache User Group Association (%s) still exists", rs.Primary.ID)
 		}
 
 		return nil
@@ -184,10 +168,6 @@ func testAccCheckUserGroupAssociationDestroyWithProvider(ctx context.Context) ac
 }
 
 func testAccCheckUserGroupAssociationExists(ctx context.Context, n string) resource.TestCheckFunc {
-	return testAccCheckUserGroupAssociationExistsWithProvider(ctx, n, func() *schema.Provider { return acctest.Provider })
-}
-
-func testAccCheckUserGroupAssociationExistsWithProvider(ctx context.Context, n string, providerF func() *schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -198,35 +178,21 @@ func testAccCheckUserGroupAssociationExistsWithProvider(ctx context.Context, n s
 			return fmt.Errorf("No ElastiCache User Group Association ID is set")
 		}
 
-		groupID, userID, err := tfelasticache.UserGroupAssociationParseID(rs.Primary.ID)
+		userGroupID, userID, err := tfelasticache.UserGroupAssociationParseResourceID(rs.Primary.ID)
+
 		if err != nil {
-			return fmt.Errorf("parsing User Group Association ID (%s): %w", rs.Primary.ID, err)
+			return err
 		}
 
-		provider := providerF()
-		conn := provider.Meta().(*conns.AWSClient).ElastiCacheConn()
-		output, err := tfelasticache.FindUserGroupByID(ctx, conn, groupID)
-		if err != nil {
-			return fmt.Errorf("ElastiCache User Group Association (%s) not found: %w", rs.Primary.ID, err)
-		}
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheConn()
 
-		gotUserID := ""
-		for _, v := range output.UserIds {
-			if aws.StringValue(v) == userID {
-				gotUserID = aws.StringValue(v)
-				break
-			}
-		}
+		err = tfelasticache.FindUserGroupAssociation(ctx, conn, userGroupID, userID)
 
-		if gotUserID == "" {
-			return fmt.Errorf("ElastiCache User Group Association (%s) not found", rs.Primary.ID)
-		}
-
-		return nil
+		return err
 	}
 }
 
-func testAccUserGroupAssociationBaseConfig(rName string) string {
+func testAccUserGroupAssociationConfig_base(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -259,9 +225,7 @@ resource "aws_elasticache_user_group" "test" {
 }
 
 func testAccUserGroupAssociationConfig_basic(rName string) string {
-	return acctest.ConfigCompose(
-		testAccUserGroupAssociationBaseConfig(rName),
-		`
+	return acctest.ConfigCompose(testAccUserGroupAssociationConfig_base(rName), `
 resource "aws_elasticache_user_group_association" "test" {
   user_group_id = aws_elasticache_user_group.test.user_group_id
   user_id       = aws_elasticache_user.test2.user_id
@@ -270,9 +234,7 @@ resource "aws_elasticache_user_group_association" "test" {
 }
 
 func testAccUserGroupAssociationConfig_preUpdate(rName string) string {
-	return acctest.ConfigCompose(
-		testAccUserGroupAssociationBaseConfig(rName),
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccUserGroupAssociationConfig_base(rName), fmt.Sprintf(`
 resource "aws_elasticache_user" "test3" {
   user_id       = "%[1]s-3"
   user_name     = "username2"
@@ -289,9 +251,7 @@ resource "aws_elasticache_user_group_association" "test" {
 }
 
 func testAccUserGroupAssociationConfig_update(rName string) string {
-	return acctest.ConfigCompose(
-		testAccUserGroupAssociationBaseConfig(rName),
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccUserGroupAssociationConfig_base(rName), fmt.Sprintf(`
 resource "aws_elasticache_user" "test3" {
   user_id       = "%[1]s-3"
   user_name     = "username2"
@@ -308,9 +268,7 @@ resource "aws_elasticache_user_group_association" "test" {
 }
 
 func testAccUserGroupAssociationConfig_preMultiple(rName string) string {
-	return acctest.ConfigCompose(
-		testAccUserGroupAssociationBaseConfig(rName),
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccUserGroupAssociationConfig_base(rName), fmt.Sprintf(`
 resource "aws_elasticache_user" "test3" {
   user_id       = "%[1]s-3"
   user_name     = "username2"
@@ -322,9 +280,7 @@ resource "aws_elasticache_user" "test3" {
 }
 
 func testAccUserGroupAssociationConfig_multiple(rName string) string {
-	return acctest.ConfigCompose(
-		testAccUserGroupAssociationBaseConfig(rName),
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccUserGroupAssociationConfig_base(rName), fmt.Sprintf(`
 resource "aws_elasticache_user" "test3" {
   user_id       = "%[1]s-3"
   user_name     = "username2"

--- a/internal/service/elasticache/user_group_test.go
+++ b/internal/service/elasticache/user_group_test.go
@@ -6,14 +6,13 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/elasticache"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfelasticache "github.com/hashicorp/terraform-provider-aws/internal/service/elasticache"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func TestAccElastiCacheUserGroup_basic(t *testing.T) {
@@ -156,13 +155,7 @@ func TestAccElastiCacheUserGroup_disappears(t *testing.T) {
 
 func testAccCheckUserGroupDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		return testAccCheckUserGroupDestroyWithProvider(ctx)(s, acctest.Provider)
-	}
-}
-
-func testAccCheckUserGroupDestroyWithProvider(ctx context.Context) acctest.TestCheckWithProviderFunc {
-	return func(s *terraform.State, provider *schema.Provider) error {
-		conn := provider.Meta().(*conns.AWSClient).ElastiCacheConn()
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheConn()
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_elasticache_user_group" {
@@ -170,13 +163,16 @@ func testAccCheckUserGroupDestroyWithProvider(ctx context.Context) acctest.TestC
 			}
 
 			_, err := tfelasticache.FindUserGroupByID(ctx, conn, rs.Primary.ID)
-			if err != nil {
-				if tfawserr.ErrCodeEquals(err, elasticache.ErrCodeUserGroupNotFoundFault) {
-					return nil
-				}
+
+			if tfresource.NotFound(err) {
+				continue
 			}
 
-			return err
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("ElastiCache User Group (%s) still exists", rs.Primary.ID)
 		}
 
 		return nil
@@ -184,10 +180,6 @@ func testAccCheckUserGroupDestroyWithProvider(ctx context.Context) acctest.TestC
 }
 
 func testAccCheckUserGroupExists(ctx context.Context, n string, v *elasticache.UserGroup) resource.TestCheckFunc {
-	return testAccCheckUserGroupExistsWithProvider(ctx, n, v, func() *schema.Provider { return acctest.Provider })
-}
-
-func testAccCheckUserGroupExistsWithProvider(ctx context.Context, n string, v *elasticache.UserGroup, providerF func() *schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -198,14 +190,15 @@ func testAccCheckUserGroupExistsWithProvider(ctx context.Context, n string, v *e
 			return fmt.Errorf("No ElastiCache User Group ID is set")
 		}
 
-		provider := providerF()
-		conn := provider.Meta().(*conns.AWSClient).ElastiCacheConn()
-		resp, err := tfelasticache.FindUserGroupByID(ctx, conn, rs.Primary.ID)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheConn()
+
+		output, err := tfelasticache.FindUserGroupByID(ctx, conn, rs.Primary.ID)
+
 		if err != nil {
-			return fmt.Errorf("ElastiCache User Group (%s) not found: %w", rs.Primary.ID, err)
+			return err
 		}
 
-		*v = *resp
+		*v = *output
 
 		return nil
 	}

--- a/internal/service/elasticbeanstalk/application_version.go
+++ b/internal/service/elasticbeanstalk/application_version.go
@@ -14,9 +14,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_elastic_beanstalk_application_version")
+// @SDKResource("aws_elastic_beanstalk_application_version", name="Application Version")
+// @Tags(identifierAttribute="arn")
 func ResourceApplicationVersion() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceApplicationVersionCreate,
@@ -60,8 +62,8 @@ func ResourceApplicationVersion() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:tftags.TagsSchema(),
+names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -69,8 +71,6 @@ func ResourceApplicationVersion() *schema.Resource {
 func resourceApplicationVersionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElasticBeanstalkConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	application := d.Get("application").(string)
 	description := d.Get("description").(string)
@@ -87,7 +87,7 @@ func resourceApplicationVersionCreate(ctx context.Context, d *schema.ResourceDat
 		ApplicationName: aws.String(application),
 		Description:     aws.String(description),
 		SourceBundle:    &s3Location,
-		Tags:            Tags(tags.IgnoreElasticbeanstalk()),
+		Tags:            GetTagsIn(ctx),
 		VersionLabel:    aws.String(name),
 	}
 
@@ -104,8 +104,6 @@ func resourceApplicationVersionCreate(ctx context.Context, d *schema.ResourceDat
 func resourceApplicationVersionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElasticBeanstalkConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	resp, err := conn.DescribeApplicationVersionsWithContext(ctx, &elasticbeanstalk.DescribeApplicationVersionsInput{
 		ApplicationName: aws.String(d.Get("application").(string)),
@@ -130,23 +128,6 @@ func resourceApplicationVersionRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("arn", arn)
 	d.Set("description", resp.ApplicationVersions[0].Description)
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Elastic Beanstalk Application version (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreElasticbeanstalk().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
@@ -157,15 +138,6 @@ func resourceApplicationVersionUpdate(ctx context.Context, d *schema.ResourceDat
 	if d.HasChange("description") {
 		if err := resourceApplicationVersionDescriptionUpdate(ctx, conn, d); err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Elastic Beanstalk Application Version (%s): %s", d.Id(), err)
-		}
-	}
-
-	arn := d.Get("arn").(string)
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, arn, o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Elastic Beanstalk Application Version (%s): setting tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/elasticbeanstalk/application_version.go
+++ b/internal/service/elasticbeanstalk/application_version.go
@@ -62,8 +62,8 @@ func ResourceApplicationVersion() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
-			names.AttrTags:tftags.TagsSchema(),
-names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }

--- a/internal/service/elasticbeanstalk/environment.go
+++ b/internal/service/elasticbeanstalk/environment.go
@@ -26,6 +26,7 @@ import ( // nosemgrep:ci.aws-sdk-go-multiple-service-imports
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 	"golang.org/x/exp/slices"
 )
 
@@ -73,7 +74,8 @@ var (
 	environmentCNAMERegex = regexp.MustCompile(`(^[^.]+)(.\w{2}-\w{4,9}-\d)?\.(elasticbeanstalk\.com|eb\.amazonaws\.com\.cn)$`)
 )
 
-// @SDKResource("aws_elastic_beanstalk_environment")
+// @SDKResource("aws_elastic_beanstalk_environment", name="Environment")
+// @Tags(identifierAttribute="arn")
 func ResourceEnvironment() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{
@@ -177,8 +179,8 @@ func ResourceEnvironment() *schema.Resource {
 				Computed:      true,
 				ConflictsWith: []string{"platform_arn", "template_name"},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"template_name": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -214,15 +216,13 @@ func ResourceEnvironment() *schema.Resource {
 func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElasticBeanstalkConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &elasticbeanstalk.CreateEnvironmentInput{
 		ApplicationName: aws.String(d.Get("application").(string)),
 		EnvironmentName: aws.String(name),
 		OptionSettings:  extractOptionSettings(d.Get("setting").(*schema.Set)),
-		Tags:            Tags(tags.IgnoreElasticbeanstalk()),
+		Tags:            GetTagsIn(ctx),
 	}
 
 	if v := d.Get("description"); v.(string) != "" {
@@ -304,8 +304,6 @@ func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta
 func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElasticBeanstalkConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	env, err := FindEnvironmentByID(ctx, conn, d.Id())
 
@@ -428,23 +426,6 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta i
 		return sdkdiag.AppendErrorf(diags, "setting setting: %s", err)
 	}
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Elastic Beanstalk Environment (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreElasticbeanstalk().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
@@ -565,26 +546,6 @@ func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Elastic Beanstalk Environment (%s): %s", d.Id(), err)
-		}
-
-		if _, err := waitEnvironmentReady(ctx, conn, d.Id(), pollInterval, waitForReadyTimeOut); err != nil {
-			return sdkdiag.AppendErrorf(diags, "waiting for Elastic Beanstalk Environment (%s) update: %s", d.Id(), err)
-		}
-
-		err = findEnvironmentErrorsByID(ctx, conn, d.Id(), opTime)
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Elastic Beanstalk Environment (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		arn := d.Get("arn").(string)
-		o, n := d.GetChange("tags_all")
-
-		opTime := time.Now()
-		if err := UpdateTags(ctx, conn, arn, o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Elastic Beanstalk Environment (%s) tags: %s", arn, err)
 		}
 
 		if _, err := waitEnvironmentReady(ctx, conn, d.Id(), pollInterval, waitForReadyTimeOut); err != nil {

--- a/internal/service/elasticbeanstalk/service_package_gen.go
+++ b/internal/service/elasticbeanstalk/service_package_gen.go
@@ -41,10 +41,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceApplication,
 			TypeName: "aws_elastic_beanstalk_application",
+			Name:     "Application",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceApplicationVersion,
 			TypeName: "aws_elastic_beanstalk_application_version",
+			Name:     "Application Version",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceConfigurationTemplate,
@@ -53,6 +61,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceEnvironment,
 			TypeName: "aws_elastic_beanstalk_environment",
+			Name:     "Environment",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/elasticbeanstalk/solution_stack_data_source_test.go
+++ b/internal/service/elasticbeanstalk/solution_stack_data_source_test.go
@@ -1,18 +1,18 @@
 package elasticbeanstalk_test
 
 import (
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 )
 
 func TestAccElasticBeanstalkSolutionStackDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_elastic_beanstalk_solution_stack.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, elasticbeanstalk.EndpointsID),
@@ -21,32 +21,18 @@ func TestAccElasticBeanstalkSolutionStackDataSource_basic(t *testing.T) {
 			{
 				Config: testAccSolutionStackDataSourceConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSolutionStackIDDataSource("data.aws_elastic_beanstalk_solution_stack.multi_docker"),
-					resource.TestMatchResourceAttr("data.aws_elastic_beanstalk_solution_stack.multi_docker", "name", regexp.MustCompile("^64bit Amazon Linux (.*) Multi-container Docker (.*)$")),
+					resource.TestMatchResourceAttr(dataSourceName, "name", regexp.MustCompile("^64bit Amazon Linux (.*) running Python (.*)$")),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckSolutionStackIDDataSource(n string) resource.TestCheckFunc {
-	// Wait for solution stacks
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Can't find solution stack data source: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("Solution stack data source ID not set")
-		}
-		return nil
-	}
-}
-
 const testAccSolutionStackDataSourceConfig_basic = `
-data "aws_elastic_beanstalk_solution_stack" "multi_docker" {
+data "aws_elastic_beanstalk_solution_stack" "test" {
   most_recent = true
-  name_regex  = "^64bit Amazon Linux (.*) Multi-container Docker (.*)$"
+
+  # e.g. "64bit Amazon Linux 2018.03 v2.10.14 running Python 3.6"
+  name_regex = "^64bit Amazon Linux (.*) running Python (.*)$"
 }
 `

--- a/internal/service/elasticsearch/domain.go
+++ b/internal/service/elasticsearch/domain.go
@@ -23,9 +23,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_elasticsearch_domain")
+// @SDKResource("aws_elasticsearch_domain", name="Domain")
+// @Tags(identifierAttribute="id")
 func ResourceDomain() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDomainCreate,
@@ -494,8 +496,8 @@ func ResourceDomain() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vpc_options": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -535,8 +537,6 @@ func ResourceDomain() *schema.Resource {
 func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElasticsearchConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	// The API doesn't check for duplicate names
 	// so w/out this check Create would act as upsert
@@ -551,7 +551,7 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	input := &elasticsearch.CreateElasticsearchDomainInput{
 		DomainName:           aws.String(name),
 		ElasticsearchVersion: aws.String(d.Get("elasticsearch_version").(string)),
-		TagList:              Tags(tags.IgnoreAWS()),
+		TagList:              GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("access_policies"); ok {
@@ -714,8 +714,6 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElasticsearchConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	name := d.Get("domain_name").(string)
 	ds, err := FindDomainByName(ctx, conn, name)
@@ -836,23 +834,6 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	d.Set("arn", ds.ARN)
-
-	tags, err := ListTags(ctx, conn, d.Id())
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for Elasticsearch Domain (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
 
 	return diags
 }
@@ -993,14 +974,6 @@ func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			if _, err := waitUpgradeSucceeded(ctx, conn, name, d.Timeout(schema.TimeoutUpdate)); err != nil {
 				return sdkdiag.AppendErrorf(diags, "waiting for Elasticsearch Domain (%s) upgrade: %s", d.Id(), err)
 			}
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Elasticsearch Domain (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/elasticsearch/service_package_gen.go
+++ b/internal/service/elasticsearch/service_package_gen.go
@@ -33,6 +33,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDomain,
 			TypeName: "aws_elasticsearch_domain",
+			Name:     "Domain",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceDomainPolicy,

--- a/internal/service/elb/load_balancer.go
+++ b/internal/service/elb/load_balancer.go
@@ -29,9 +29,11 @@ import ( // nosemgrep:ci.aws-sdk-go-multiple-service-imports
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_elb")
+// @SDKResource("aws_elb", name="Classic Load Balancer")
+// @Tags(identifierAttribute="id")
 func ResourceLoadBalancer() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceLoadBalancerCreate,
@@ -235,8 +237,8 @@ func ResourceLoadBalancer() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"zone_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -248,8 +250,6 @@ func ResourceLoadBalancer() *schema.Resource {
 func resourceLoadBalancerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ELBConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	var elbName string
 	if v, ok := d.GetOk("name"); ok {
@@ -269,33 +269,30 @@ func resourceLoadBalancerCreate(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "creating ELB Classic Load Balancer (%s): %s", elbName, err)
 	}
 	// Provision the elb
-	elbOpts := &elb.CreateLoadBalancerInput{
+	input := &elb.CreateLoadBalancerInput{
 		LoadBalancerName: aws.String(elbName),
 		Listeners:        listeners,
-	}
-
-	if len(tags) > 0 {
-		elbOpts.Tags = Tags(tags.IgnoreAWS())
+		Tags:             GetTagsIn(ctx),
 	}
 
 	if _, ok := d.GetOk("internal"); ok {
-		elbOpts.Scheme = aws.String("internal")
+		input.Scheme = aws.String("internal")
 	}
 
 	if v, ok := d.GetOk("availability_zones"); ok {
-		elbOpts.AvailabilityZones = flex.ExpandStringSet(v.(*schema.Set))
+		input.AvailabilityZones = flex.ExpandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("security_groups"); ok {
-		elbOpts.SecurityGroups = flex.ExpandStringSet(v.(*schema.Set))
+		input.SecurityGroups = flex.ExpandStringSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk("subnets"); ok {
-		elbOpts.Subnets = flex.ExpandStringSet(v.(*schema.Set))
+		input.Subnets = flex.ExpandStringSet(v.(*schema.Set))
 	}
 
 	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute, func() (interface{}, error) {
-		return conn.CreateLoadBalancerWithContext(ctx, elbOpts)
+		return conn.CreateLoadBalancerWithContext(ctx, input)
 	}, elb.ErrCodeCertificateNotFoundException)
 
 	if err != nil {
@@ -312,8 +309,6 @@ func resourceLoadBalancerCreate(ctx context.Context, d *schema.ResourceData, met
 func resourceLoadBalancerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ELBConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	lb, err := FindLoadBalancerByName(ctx, conn, d.Id())
 
@@ -336,14 +331,14 @@ func resourceLoadBalancerRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 	d.Set("arn", arn.String())
 
-	if err := flattenLoadBalancerResource(ctx, d, meta.(*conns.AWSClient).EC2Conn(), conn, lb, ignoreTagsConfig, defaultTagsConfig); err != nil {
+	if err := flattenLoadBalancerResource(ctx, d, meta.(*conns.AWSClient).EC2Conn(), conn, lb); err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 	return diags
 }
 
 // flattenLoadBalancerResource takes a *elb.LoadBalancerDescription and populates all respective resource fields.
-func flattenLoadBalancerResource(ctx context.Context, d *schema.ResourceData, ec2conn *ec2.EC2, elbconn *elb.ELB, lb *elb.LoadBalancerDescription, ignoreTagsConfig *tftags.IgnoreConfig, defaultTagsConfig *tftags.DefaultConfig) error {
+func flattenLoadBalancerResource(ctx context.Context, d *schema.ResourceData, ec2conn *ec2.EC2, elbconn *elb.ELB, lb *elb.LoadBalancerDescription) error {
 	describeAttrsOpts := &elb.DescribeLoadBalancerAttributesInput{
 		LoadBalancerName: aws.String(d.Id()),
 	}
@@ -422,23 +417,6 @@ func flattenLoadBalancerResource(ctx context.Context, d *schema.ResourceData, ec
 		case "elb.http.desyncmitigationmode":
 			d.Set("desync_mitigation_mode", attr.Value)
 		}
-	}
-
-	tags, err := ListTags(ctx, elbconn, d.Id())
-
-	if err != nil {
-		return fmt.Errorf("listing tags for ELB (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return fmt.Errorf("setting tags: %w", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return fmt.Errorf("setting tags_all: %w", err)
 	}
 
 	// There's only one health check, so save that to state as we
@@ -751,14 +729,6 @@ func resourceLoadBalancerUpdate(ctx context.Context, d *schema.ResourceData, met
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "Failure adding ELB subnets: %s", err)
 			}
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating ELB(%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/elb/service_package_gen.go
+++ b/internal/service/elb/service_package_gen.go
@@ -45,6 +45,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceLoadBalancer,
 			TypeName: "aws_elb",
+			Name:     "Classic Load Balancer",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceAttachment,

--- a/internal/service/elbv2/listener_rule.go
+++ b/internal/service/elbv2/listener_rule.go
@@ -25,6 +25,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 const (
@@ -36,8 +37,9 @@ const (
 	listenerActionOrderMax = 50_000
 )
 
-// @SDKResource("aws_alb_listener_rule")
-// @SDKResource("aws_lb_listener_rule")
+// @SDKResource("aws_alb_listener_rule", name="Listener Rule")
+// @SDKResource("aws_lb_listener_rule", name="Listener Rule")
+// @Tags(identifierAttribute="id")
 func ResourceListenerRule() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceListenerRuleCreate,
@@ -466,8 +468,8 @@ func ResourceListenerRule() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 		CustomizeDiff: customdiff.Sequence(
 			verify.SetTagsDiff,
@@ -494,35 +496,31 @@ func resourceListenerRuleCreate(ctx context.Context, d *schema.ResourceData, met
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ELBV2Conn()
 	listenerArn := d.Get("listener_arn").(string)
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
-	params := &elbv2.CreateRuleInput{
+	input := &elbv2.CreateRuleInput{
 		ListenerArn: aws.String(listenerArn),
-	}
-	if len(tags) > 0 {
-		params.Tags = Tags(tags.IgnoreAWS())
+		Tags:        GetTagsIn(ctx),
 	}
 
 	var err error
 
-	params.Actions, err = expandLbListenerActions(d.Get("action").([]interface{}))
+	input.Actions, err = expandLbListenerActions(d.Get("action").([]interface{}))
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating LB Listener Rule for Listener (%s): %s", listenerArn, err)
 	}
 
-	params.Conditions, err = lbListenerRuleConditions(d.Get("condition").(*schema.Set).List())
+	input.Conditions, err = lbListenerRuleConditions(d.Get("condition").(*schema.Set).List())
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating LB Listener Rule for Listener (%s): %s", listenerArn, err)
 	}
 
-	resp, err := retryListenerRuleCreate(ctx, conn, d, params, listenerArn)
+	resp, err := retryListenerRuleCreate(ctx, conn, d, input, listenerArn)
 
 	// Some partitions may not support tag-on-create
-	if params.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
+	if input.Tags != nil && verify.ErrorISOUnsupported(conn.PartitionID, err) {
 		log.Printf("[WARN] ELBv2 Listener Rule (%s) create failed (%s) with tags. Trying create without tags.", listenerArn, err)
-		params.Tags = nil
-		resp, err = retryListenerRuleCreate(ctx, conn, d, params, listenerArn)
+		input.Tags = nil
+		resp, err = retryListenerRuleCreate(ctx, conn, d, input, listenerArn)
 	}
 
 	if err != nil {
@@ -532,7 +530,7 @@ func resourceListenerRuleCreate(ctx context.Context, d *schema.ResourceData, met
 	d.SetId(aws.StringValue(resp.Rules[0].RuleArn))
 
 	// Post-create tagging supported in some partitions
-	if params.Tags == nil && len(tags) > 0 {
+	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); input.Tags == nil && len(tags) > 0 {
 		err := UpdateTags(ctx, conn, d.Id(), nil, tags)
 
 		if v, ok := d.GetOk("tags"); (!ok || len(v.(map[string]interface{})) == 0) && verify.ErrorISOUnsupported(conn.PartitionID, err) {
@@ -552,8 +550,6 @@ func resourceListenerRuleCreate(ctx context.Context, d *schema.ResourceData, met
 func resourceListenerRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ELBV2Conn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	var resp *elbv2.DescribeRulesOutput
 	var req = &elbv2.DescribeRulesInput{
@@ -771,29 +767,6 @@ func resourceListenerRuleRead(ctx context.Context, d *schema.ResourceData, meta 
 		return sdkdiag.AppendErrorf(diags, "setting condition: %s", err)
 	}
 
-	// tags at the end because, if not supported, will skip the rest of Read
-	tags, err := ListTags(ctx, conn, d.Id())
-
-	if verify.ErrorISOUnsupported(conn.PartitionID, err) {
-		log.Printf("[WARN] Unable to list tags for ELBv2 Listener Rule %s: %s", d.Id(), err)
-		return diags
-	}
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
@@ -848,39 +821,6 @@ func resourceListenerRuleUpdate(ctx context.Context, d *schema.ResourceData, met
 
 		if len(resp.Rules) == 0 {
 			return sdkdiag.AppendErrorf(diags, "modifying creating LB Listener Rule: no rules returned in response")
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		err := retry.RetryContext(ctx, loadBalancerTagPropagationTimeout, func() *retry.RetryError {
-			err := UpdateTags(ctx, conn, d.Id(), o, n)
-
-			if tfawserr.ErrCodeEquals(err, elbv2.ErrCodeLoadBalancerNotFoundException) {
-				log.Printf("[DEBUG] Retrying tagging of LB Listener Rule (%s) after error: %s", d.Id(), err)
-				return retry.RetryableError(err)
-			}
-
-			if err != nil {
-				return retry.NonRetryableError(err)
-			}
-
-			return nil
-		})
-
-		if tfresource.TimedOut(err) {
-			err = UpdateTags(ctx, conn, d.Id(), o, n)
-		}
-
-		// ISO partitions may not support tagging, giving error
-		if verify.ErrorISOUnsupported(conn.PartitionID, err) {
-			log.Printf("[WARN] Unable to update tags for ELBv2 Listener Rule %s: %s", d.Id(), err)
-			return append(diags, resourceListenerRuleRead(ctx, d, meta)...)
-		}
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating LB (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/elbv2/service_package_gen.go
+++ b/internal/service/elbv2/service_package_gen.go
@@ -61,10 +61,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceLoadBalancer,
 			TypeName: "aws_alb",
+			Name:     "Load Balancer",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceListener,
 			TypeName: "aws_alb_listener",
+			Name:     "Listener",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceListenerCertificate,
@@ -73,10 +81,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceListenerRule,
 			TypeName: "aws_alb_listener_rule",
+			Name:     "Listener Rule",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTargetGroup,
 			TypeName: "aws_alb_target_group",
+			Name:     "Target Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTargetGroupAttachment,
@@ -85,10 +101,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceLoadBalancer,
 			TypeName: "aws_lb",
+			Name:     "Load Balancer",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceListener,
 			TypeName: "aws_lb_listener",
+			Name:     "Listener",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceListenerCertificate,
@@ -97,10 +121,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceListenerRule,
 			TypeName: "aws_lb_listener_rule",
+			Name:     "Listener Rule",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTargetGroup,
 			TypeName: "aws_lb_target_group",
+			Name:     "Target Group",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceTargetGroupAttachment,

--- a/internal/service/emr/cluster.go
+++ b/internal/service/emr/cluster.go
@@ -28,10 +28,12 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 	"golang.org/x/exp/slices"
 )
 
-// @SDKResource("aws_emr_cluster")
+// @SDKResource("aws_emr_cluster", name="Cluster")
+// @Tags(identifierAttribute="id")
 func ResourceCluster() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClusterCreate,
@@ -541,8 +543,8 @@ func ResourceCluster() *schema.Resource {
 				Default:      1,
 				ValidateFunc: validation.IntBetween(1, 256),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"termination_protection": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -740,12 +742,8 @@ func instanceFleetConfigSchema() *schema.Resource {
 func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EMRConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
-	log.Printf("[DEBUG] Creating EMR cluster")
 	applications := d.Get("applications").(*schema.Set).List()
-
 	keepJobFlowAliveWhenNoSteps := true
 	if v, ok := d.GetOkExists("keep_job_flow_alive_when_no_steps"); ok {
 		keepJobFlowAliveWhenNoSteps = v.(bool)
@@ -884,7 +882,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		ReleaseLabel:      aws.String(d.Get("release_label").(string)),
 		ServiceRole:       aws.String(d.Get("service_role").(string)),
 		VisibleToAllUsers: aws.Bool(d.Get("visible_to_all_users").(bool)),
-		Tags:              Tags(tags.IgnoreAWS()),
+		Tags:              GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("additional_info"); ok {
@@ -1018,8 +1016,6 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EMRConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	cluster, err := FindClusterByID(ctx, conn, d.Id())
 
@@ -1074,16 +1070,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 	}
 
-	tags := KeyValueTags(ctx, cluster.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, cluster.Tags)
 
 	d.Set("name", cluster.Name)
 
@@ -1376,14 +1363,6 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 					break
 				}
 			}
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating EMR Cluster (%s): setting tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/emr/service_package_gen.go
+++ b/internal/service/emr/service_package_gen.go
@@ -37,6 +37,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCluster,
 			TypeName: "aws_emr_cluster",
+			Name:     "Cluster",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceInstanceFleet,
@@ -57,6 +61,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceStudio,
 			TypeName: "aws_emr_studio",
+			Name:     "Studio",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceStudioSessionMapping,

--- a/internal/service/emr/studio.go
+++ b/internal/service/emr/studio.go
@@ -17,9 +17,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_emr_studio")
+// @SDKResource("aws_emr_studio", name="Studio")
+// @Tags(identifierAttribute="id")
 func ResourceStudio() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceStudioCreate,
@@ -85,8 +87,8 @@ func ResourceStudio() *schema.Resource {
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"user_role": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -114,8 +116,6 @@ func ResourceStudio() *schema.Resource {
 func resourceStudioCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EMRConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &emr.CreateStudioInput{
 		AuthMode:                 aws.String(d.Get("auth_mode").(string)),
@@ -124,6 +124,7 @@ func resourceStudioCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		Name:                     aws.String(d.Get("name").(string)),
 		ServiceRole:              aws.String(d.Get("service_role").(string)),
 		SubnetIds:                flex.ExpandStringSet(d.Get("subnet_ids").(*schema.Set)),
+		Tags:                     GetTagsIn(ctx),
 		VpcId:                    aws.String(d.Get("vpc_id").(string)),
 		WorkspaceSecurityGroupId: aws.String(d.Get("workspace_security_group_id").(string)),
 	}
@@ -142,10 +143,6 @@ func resourceStudioCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	if v, ok := d.GetOk("user_role"); ok {
 		input.UserRole = aws.String(v.(string))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	var result *emr.CreateStudioOutput
@@ -199,13 +196,11 @@ func resourceStudioUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		if d.HasChange("subnet_ids") {
 			input.SubnetIds = flex.ExpandStringSet(d.Get("subnet_ids").(*schema.Set))
 		}
-	}
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
+		_, err := conn.UpdateStudioWithContext(ctx, input)
 
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating EMR Studio (%s) tags: %s", d.Id(), err)
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating EMR Studio: %s", err)
 		}
 	}
 
@@ -215,8 +210,6 @@ func resourceStudioUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 func resourceStudioRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EMRConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	studio, err := FindStudioByID(ctx, conn, d.Id())
 	if !d.IsNewResource() && tfresource.NotFound(err) {
@@ -244,16 +237,7 @@ func resourceStudioRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("workspace_security_group_id", studio.WorkspaceSecurityGroupId)
 	d.Set("subnet_ids", flex.FlattenStringSet(studio.SubnetIds))
 
-	tags := KeyValueTags(ctx, studio.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, studio.Tags)
 
 	return diags
 }

--- a/internal/service/emrcontainers/service_package_gen.go
+++ b/internal/service/emrcontainers/service_package_gen.go
@@ -33,6 +33,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceVirtualCluster,
 			TypeName: "aws_emrcontainers_virtual_cluster",
+			Name:     "Virtual Cluster",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/emrserverless/application.go
+++ b/internal/service/emrserverless/application.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_emrserverless_application")
+// @SDKResource("aws_emrserverless_application", name="Application")
+// @Tags(identifierAttribute="arn")
 func ResourceApplication() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceApplicationCreate,
@@ -201,8 +203,8 @@ func ResourceApplication() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:tftags.TagsSchema(),
+names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -218,14 +220,13 @@ func ResourceApplication() *schema.Resource {
 func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EMRServerlessConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &emrserverless.CreateApplicationInput{
 		ClientToken:  aws.String(id.UniqueId()),
 		ReleaseLabel: aws.String(d.Get("release_label").(string)),
 		Name:         aws.String(name),
+		Tags: GetTagsIn(ctx),
 		Type:         aws.String(d.Get("type").(string)),
 	}
 
@@ -257,11 +258,6 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 		input.NetworkConfiguration = expandNetworkConfiguration(v.([]interface{})[0].(map[string]interface{}))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
-	log.Printf("[DEBUG] Creating EMR Serveless Application: %s", input)
 	result, err := conn.CreateApplicationWithContext(ctx, input)
 
 	if err != nil {
@@ -280,8 +276,6 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EMRServerlessConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	application, err := FindApplicationByID(ctx, conn, d.Id())
 
@@ -325,16 +319,7 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 		return sdkdiag.AppendErrorf(diags, "setting network_configuration: %s", err)
 	}
 
-	tags := KeyValueTags(ctx, application.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, application.Tags)
 
 	return diags
 }
@@ -382,14 +367,6 @@ func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating EMR Serveless Application (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating EMR Serverless Application (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/emrserverless/application.go
+++ b/internal/service/emrserverless/application.go
@@ -203,8 +203,8 @@ func ResourceApplication() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			names.AttrTags:tftags.TagsSchema(),
-names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -226,7 +226,7 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 		ClientToken:  aws.String(id.UniqueId()),
 		ReleaseLabel: aws.String(d.Get("release_label").(string)),
 		Name:         aws.String(name),
-		Tags: GetTagsIn(ctx),
+		Tags:         GetTagsIn(ctx),
 		Type:         aws.String(d.Get("type").(string)),
 	}
 

--- a/internal/service/emrserverless/service_package_gen.go
+++ b/internal/service/emrserverless/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceApplication,
 			TypeName: "aws_emrserverless_application",
+			Name:     "Application",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/events/service_package_gen.go
+++ b/internal/service/events/service_package_gen.go
@@ -49,6 +49,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceBus,
 			TypeName: "aws_cloudwatch_event_bus",
+			Name:     "Event Bus",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceBusPolicy,
@@ -65,6 +69,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceRule,
 			TypeName: "aws_cloudwatch_event_rule",
+			Name:     "Rule",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceTarget,

--- a/internal/service/evidently/feature.go
+++ b/internal/service/evidently/feature.go
@@ -21,9 +21,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_evidently_feature")
+// @SDKResource("aws_evidently_feature", name="Feature")
+// @Tags(identifierAttribute="arn")
 func ResourceFeature() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceFeatureCreate,
@@ -127,8 +129,8 @@ func ResourceFeature() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"value_type": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -195,15 +197,13 @@ func ResourceFeature() *schema.Resource {
 
 func resourceFeatureCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EvidentlyConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	project := d.Get("project").(string)
-
 	input := &cloudwatchevidently.CreateFeatureInput{
 		Name:       aws.String(name),
 		Project:    aws.String(project),
+		Tags:       GetTagsIn(ctx),
 		Variations: expandVariations(d.Get("variations").(*schema.Set).List()),
 	}
 
@@ -223,11 +223,6 @@ func resourceFeatureCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.EvaluationStrategy = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
-	log.Printf("[DEBUG] Creating CloudWatch Evidently Feature: %s", input)
 	output, err := conn.CreateFeatureWithContext(ctx, input)
 
 	if err != nil {
@@ -247,8 +242,6 @@ func resourceFeatureCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 func resourceFeatureRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EvidentlyConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	featureName, projectNameOrARN, err := FeatureParseID(d.Id())
 
@@ -288,15 +281,7 @@ func resourceFeatureRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("status", feature.Status)
 	d.Set("value_type", feature.ValueType)
 
-	tags := KeyValueTags(ctx, feature.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, feature.Tags)
 
 	return nil
 }
@@ -335,14 +320,6 @@ func resourceFeatureUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		if _, err := waitFeatureUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return diag.Errorf("waiting for CloudWatch Evidently Feature (%s) for Project (%s) update: %s", name, project, err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return diag.Errorf("updating tags: %s", err)
 		}
 	}
 

--- a/internal/service/evidently/segment.go
+++ b/internal/service/evidently/segment.go
@@ -17,9 +17,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_evidently_segment")
+// @SDKResource("aws_evidently_segment", name="Segment")
+// @Tags(identifierAttribute="arn")
 func ResourceSegment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSegmentCreate,
@@ -81,8 +83,8 @@ func ResourceSegment() *schema.Resource {
 					return json
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -91,24 +93,18 @@ func ResourceSegment() *schema.Resource {
 
 func resourceSegmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EvidentlyConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	name := d.Get("name").(string)
 	input := &cloudwatchevidently.CreateSegmentInput{
 		Name:    aws.String(name),
 		Pattern: aws.String(d.Get("pattern").(string)),
+		Tags:    GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
-	log.Printf("[DEBUG] Creating CloudWatch Evidently Segment: %s", input)
 	output, err := conn.CreateSegmentWithContext(ctx, input)
 
 	if err != nil {
@@ -122,8 +118,6 @@ func resourceSegmentCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 func resourceSegmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EvidentlyConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	segment, err := FindSegmentByNameOrARN(ctx, conn, d.Id())
 
@@ -146,30 +140,13 @@ func resourceSegmentRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("name", segment.Name)
 	d.Set("pattern", segment.Pattern)
 
-	tags := KeyValueTags(ctx, segment.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, segment.Tags)
 
 	return nil
 }
 
 func resourceSegmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).EvidentlyConn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return diag.Errorf("updating tags: %s", err)
-		}
-	}
-
+	// Tags only.
 	return resourceSegmentRead(ctx, d, meta)
 }
 

--- a/internal/service/evidently/service_package_gen.go
+++ b/internal/service/evidently/service_package_gen.go
@@ -28,18 +28,34 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceFeature,
 			TypeName: "aws_evidently_feature",
+			Name:     "Feature",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceLaunch,
 			TypeName: "aws_evidently_launch",
+			Name:     "Launch",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceProject,
 			TypeName: "aws_evidently_project",
+			Name:     "Project",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceSegment,
 			TypeName: "aws_evidently_segment",
+			Name:     "Segment",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/tags/key_value_tags.go
+++ b/internal/tags/key_value_tags.go
@@ -12,13 +12,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 const (
 	awsTagKeyPrefix                             = `aws:` // nosemgrep:ci.aws-in-const-name,ci.aws-in-var-name
 	ElasticbeanstalkTagKeyPrefix                = `elasticbeanstalk:`
 	NameTagKey                                  = `Name`
-	RDSTagKeyPrefix                             = `rds:`
 	ServerlessApplicationRepositoryTagKeyPrefix = `serverlessrepo:`
 )
 
@@ -38,19 +38,6 @@ type IgnoreConfig struct {
 // its own Go struct type representing a resource tag. To standardize logic
 // across all these Go types, we convert them into this Go type.
 type KeyValueTags map[string]*TagData
-
-// IgnoreAWS returns non-AWS tag keys.
-func (tags KeyValueTags) IgnoreAWS() KeyValueTags { // nosemgrep:ci.aws-in-func-name
-	result := make(KeyValueTags)
-
-	for k, v := range tags {
-		if !strings.HasPrefix(k, awsTagKeyPrefix) {
-			result[k] = v
-		}
-	}
-
-	return result
-}
 
 // GetTags is convenience method that returns the DefaultConfig's Tags, if any
 func (dc *DefaultConfig) GetTags() KeyValueTags {
@@ -89,6 +76,19 @@ func (dc *DefaultConfig) TagsEqual(tags KeyValueTags) bool {
 	}
 
 	return dc.Tags.ContainsAll(tags)
+}
+
+// IgnoreAWS returns non-AWS tag keys.
+func (tags KeyValueTags) IgnoreAWS() KeyValueTags { // nosemgrep:ci.aws-in-func-name
+	result := make(KeyValueTags)
+
+	for k, v := range tags {
+		if !strings.HasPrefix(k, awsTagKeyPrefix) {
+			result[k] = v
+		}
+	}
+
+	return result
 }
 
 // IgnoreConfig returns any tags not removed by a given configuration.
@@ -150,25 +150,6 @@ func (tags KeyValueTags) IgnorePrefixes(ignoreTagPrefixes KeyValueTags) KeyValue
 	return result
 }
 
-// IgnoreRDS returns non-AWS and non-RDS tag keys.
-func (tags KeyValueTags) IgnoreRDS() KeyValueTags {
-	result := make(KeyValueTags)
-
-	for k, v := range tags {
-		if strings.HasPrefix(k, awsTagKeyPrefix) {
-			continue
-		}
-
-		if strings.HasPrefix(k, RDSTagKeyPrefix) {
-			continue
-		}
-
-		result[k] = v
-	}
-
-	return result
-}
-
 // IgnoreServerlessApplicationRepository returns non-AWS and non-ServerlessApplicationRepository tag keys.
 func (tags KeyValueTags) IgnoreServerlessApplicationRepository() KeyValueTags {
 	result := make(KeyValueTags)
@@ -186,6 +167,19 @@ func (tags KeyValueTags) IgnoreServerlessApplicationRepository() KeyValueTags {
 	}
 
 	return result
+}
+
+// IgnoreAWS returns non-system tag keys.
+// The ignored keys vary on the specified service.
+func (tags KeyValueTags) IgnoreSystem(serviceName string) KeyValueTags {
+	switch serviceName {
+	case names.ElasticBeanstalk:
+		return tags.IgnoreElasticbeanstalk()
+	case names.ServerlessRepo:
+		return tags.IgnoreServerlessApplicationRepository()
+	default:
+		return tags.IgnoreAWS()
+	}
 }
 
 // Ignore returns non-matching tag keys.

--- a/internal/tags/key_value_tags_test.go
+++ b/internal/tags/key_value_tags_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestKeyValueTagsDefaultConfigGetTags(t *testing.T) {
@@ -735,43 +736,49 @@ func TestKeyValueTagsIgnorePrefixes(t *testing.T) {
 	}
 }
 
-func TestKeyValueTagsIgnoreRDS(t *testing.T) {
+func TestKeyValueTagsIgnoreSystem(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	testCases := []struct {
-		name string
-		tags KeyValueTags
-		want map[string]string
+		name        string
+		serviceName string
+		tags        KeyValueTags
+		want        map[string]string
 	}{
 		{
-			name: "empty",
-			tags: New(ctx, map[string]string{}),
-			want: map[string]string{},
+			name:        "empty",
+			serviceName: names.EC2,
+			tags:        New(ctx, map[string]string{}),
+			want:        map[string]string{},
 		},
 		{
-			name: "all",
+			name:        "all",
+			serviceName: names.ElasticBeanstalk,
 			tags: New(ctx, map[string]string{
 				"aws:cloudformation:key1": "value1",
-				"rds:key2":                "value2",
+				"elasticbeanstalk:key2":   "value2",
 			}),
 			want: map[string]string{},
 		},
 		{
-			name: "mixed",
+			name:        "mixed",
+			serviceName: names.S3,
 			tags: New(ctx, map[string]string{
 				"aws:cloudformation:key1": "value1",
 				"key2":                    "value2",
-				"rds:key3":                "value3",
+				"elasticbeanstalk:key3":   "value3",
 				"key4":                    "value4",
 			}),
 			want: map[string]string{
-				"key2": "value2",
-				"key4": "value4",
+				"key2":                  "value2",
+				"elasticbeanstalk:key3": "value3",
+				"key4":                  "value4",
 			},
 		},
 		{
-			name: "none",
+			name:        "none",
+			serviceName: names.RDS,
 			tags: New(ctx, map[string]string{
 				"key1": "value1",
 				"key2": "value2",
@@ -790,7 +797,7 @@ func TestKeyValueTagsIgnoreRDS(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := testCase.tags.IgnoreRDS()
+			got := testCase.tags.IgnoreSystem(testCase.serviceName)
 
 			testKeyValueTagsVerifyMap(t, got.Map(), testCase.want)
 		})


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin SDK.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30421.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30430.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30449.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30454.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30461.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30463.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30476.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30477.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30478.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30483.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30484.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30491.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30509.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30510.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30512.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30516.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30517.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
=== RUN   TestAccECRAuthorizationTokenDataSource_basic
--- PASS: TestAccECRAuthorizationTokenDataSource_basic (43.27s)
=== RUN   TestAccECRImageDataSource_basic
=== PAUSE TestAccECRImageDataSource_basic
=== RUN   TestAccECRLifecyclePolicy_basic
=== PAUSE TestAccECRLifecyclePolicy_basic
=== RUN   TestAccECRPullThroughCacheRule_basic
=== PAUSE TestAccECRPullThroughCacheRule_basic
=== RUN   TestAccECRRepositoryDataSource_basic
=== PAUSE TestAccECRRepositoryDataSource_basic
=== RUN   TestAccECRRepositoryPolicy_basic
=== PAUSE TestAccECRRepositoryPolicy_basic
=== RUN   TestAccECRRepositoryPolicy_IAM_basic
=== PAUSE TestAccECRRepositoryPolicy_IAM_basic
=== RUN   TestAccECRRepository_basic
=== PAUSE TestAccECRRepository_basic
=== RUN   TestAccECRRepository_tags
=== PAUSE TestAccECRRepository_tags
=== CONT  TestAccECRImageDataSource_basic
=== CONT  TestAccECRRepositoryPolicy_basic
=== CONT  TestAccECRPullThroughCacheRule_basic
=== CONT  TestAccECRImageDataSource_basic
    image_data_source_test.go:19: Step 1/1 error: Check failed: Check 10/10 error: "data.aws_ecr_image.by_most_recent" error: no TypeSet element "image_tags.*", with value "latest" in state: map[string]string{"%":"9", "id":"sha256:d748bbe0733b25a9d7c86bed33381bc0cee532a0235aa6b9b56f3aee7cfba5bc", "image_digest":"sha256:d748bbe0733b25a9d7c86bed33381bc0cee532a0235aa6b9b56f3aee7cfba5bc", "image_pushed_at":"1680822832", "image_size_in_bytes":"64121512", "image_tags.#":"2", "image_tags.0":"2", "image_tags.1":"2.0.20230404.0", "most_recent":"true", "registry_id":"137112412989", "repository_name":"amazonlinux"}
--- FAIL: TestAccECRImageDataSource_basic (14.92s)
=== CONT  TestAccECRLifecyclePolicy_basic
--- PASS: TestAccECRPullThroughCacheRule_basic (33.80s)
=== CONT  TestAccECRRepository_basic
--- PASS: TestAccECRLifecyclePolicy_basic (39.06s)
=== CONT  TestAccECRRepository_tags
--- PASS: TestAccECRRepositoryPolicy_basic (57.83s)
=== CONT  TestAccECRRepositoryPolicy_IAM_basic
--- PASS: TestAccECRRepository_basic (32.93s)
=== CONT  TestAccECRRepositoryDataSource_basic
--- PASS: TestAccECRRepositoryDataSource_basic (19.66s)
--- PASS: TestAccECRRepositoryPolicy_IAM_basic (37.55s)
--- PASS: TestAccECRRepository_tags (48.27s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ecr	154.276s
=== RUN   TestAccECRPublicAuthorizationTokenDataSource_basic
    acctest.go:834: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccECRPublicAuthorizationTokenDataSource_basic (0.46s)
=== RUN   TestAccECRPublicRepositoryPolicy_basic
=== PAUSE TestAccECRPublicRepositoryPolicy_basic
=== RUN   TestAccECRPublicRepository_basic
=== PAUSE TestAccECRPublicRepository_basic
=== RUN   TestAccECRPublicRepository_tags
=== PAUSE TestAccECRPublicRepository_tags
=== CONT  TestAccECRPublicRepositoryPolicy_basic
=== CONT  TestAccECRPublicRepository_tags
=== CONT  TestAccECRPublicRepository_basic
=== CONT  TestAccECRPublicRepositoryPolicy_basic
    acctest.go:834: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccECRPublicRepositoryPolicy_basic (0.00s)
=== CONT  TestAccECRPublicRepository_basic
    acctest.go:834: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
=== CONT  TestAccECRPublicRepository_tags
    acctest.go:834: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccECRPublicRepository_basic (0.00s)
--- SKIP: TestAccECRPublicRepository_tags (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecrpublic	6.107s
```
```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=ecs ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccECSCapacityProvider_basic
=== PAUSE TestAccECSCapacityProvider_basic
=== RUN   TestAccECSCapacityProvider_tags
=== PAUSE TestAccECSCapacityProvider_tags
=== RUN   TestAccECSClusterCapacityProviders_basic
=== PAUSE TestAccECSClusterCapacityProviders_basic
=== RUN   TestAccECSClusterDataSource_tags
=== PAUSE TestAccECSClusterDataSource_tags
=== RUN   TestAccECSCluster_basic
=== PAUSE TestAccECSCluster_basic
=== RUN   TestAccECSCluster_tags
=== PAUSE TestAccECSCluster_tags
=== RUN   TestAccECSServiceDataSource_basic
=== PAUSE TestAccECSServiceDataSource_basic
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSService_CapacityProviderStrategy_basic
=== PAUSE TestAccECSService_CapacityProviderStrategy_basic
=== RUN   TestAccECSService_DeploymentValues_basic
=== PAUSE TestAccECSService_DeploymentValues_basic
=== RUN   TestAccECSService_PlacementStrategy_basic
=== PAUSE TestAccECSService_PlacementStrategy_basic
=== RUN   TestAccECSService_PlacementConstraints_basic
=== PAUSE TestAccECSService_PlacementConstraints_basic
=== RUN   TestAccECSService_LaunchTypeFargate_basic
=== PAUSE TestAccECSService_LaunchTypeFargate_basic
=== RUN   TestAccECSService_DaemonSchedulingStrategy_basic
=== PAUSE TestAccECSService_DaemonSchedulingStrategy_basic
=== RUN   TestAccECSService_ServiceRegistries_basic
=== PAUSE TestAccECSService_ServiceRegistries_basic
=== RUN   TestAccECSService_ServiceConnect_basic
=== PAUSE TestAccECSService_ServiceConnect_basic
=== RUN   TestAccECSService_Tags_basic
=== PAUSE TestAccECSService_Tags_basic
=== RUN   TestAccECSTag_basic
=== PAUSE TestAccECSTag_basic
=== RUN   TestContainerDefinitionsAreEquivalent_basic
=== PAUSE TestContainerDefinitionsAreEquivalent_basic
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== RUN   TestAccECSTaskDefinition_DockerVolume_basic
=== PAUSE TestAccECSTaskDefinition_DockerVolume_basic
=== RUN   TestAccECSTaskDefinition_EFSVolume_basic
=== PAUSE TestAccECSTaskDefinition_EFSVolume_basic
=== RUN   TestAccECSTaskDefinition_Fargate_basic
=== PAUSE TestAccECSTaskDefinition_Fargate_basic
=== RUN   TestAccECSTaskDefinition_tags
=== PAUSE TestAccECSTaskDefinition_tags
=== RUN   TestAccECSTaskExecutionDataSource_basic
=== PAUSE TestAccECSTaskExecutionDataSource_basic
=== RUN   TestAccECSTaskExecutionDataSource_tags
=== PAUSE TestAccECSTaskExecutionDataSource_tags
=== RUN   TestAccECSTaskSet_basic
=== PAUSE TestAccECSTaskSet_basic
=== CONT  TestAccECSCapacityProvider_basic
=== CONT  TestAccECSTaskSet_basic
=== CONT  TestAccECSTaskExecutionDataSource_tags
--- PASS: TestAccECSTaskSet_basic (50.25s)
=== CONT  TestAccECSTaskExecutionDataSource_basic
--- PASS: TestAccECSCapacityProvider_basic (52.15s)
=== CONT  TestAccECSTaskDefinition_tags
    task_definition_test.go:959: Step 3/4 error: Error running apply: exit status 1
        
        Error: updating tags for ECS (Elastic Container) Task Definition (tf-acc-test-4027247348140162317): tagging resource (tf-acc-test-4027247348140162317): InvalidParameterException: The ARN provided is invalid.
        
          with aws_ecs_task_definition.test,
          on terraform_plugin_test.tf line 6, in resource "aws_ecs_task_definition" "test":
           6: resource "aws_ecs_task_definition" "test" {
        
--- FAIL: TestAccECSTaskDefinition_tags (30.92s)
=== CONT  TestAccECSTaskDefinition_Fargate_basic
--- PASS: TestAccECSTaskDefinition_Fargate_basic (21.24s)
=== CONT  TestAccECSTaskDefinition_EFSVolume_basic
--- PASS: TestAccECSTaskDefinition_EFSVolume_basic (24.38s)
=== CONT  TestAccECSTaskDefinition_DockerVolume_basic
--- PASS: TestAccECSTaskDefinition_DockerVolume_basic (15.06s)
=== CONT  TestAccECSTaskDefinition_basic
--- PASS: TestAccECSTaskDefinition_basic (26.07s)
=== CONT  TestContainerDefinitionsAreEquivalent_basic
--- PASS: TestContainerDefinitionsAreEquivalent_basic (0.00s)
=== CONT  TestAccECSTag_basic
--- PASS: TestAccECSTag_basic (26.95s)
=== CONT  TestAccECSService_Tags_basic
--- PASS: TestAccECSService_Tags_basic (96.59s)
=== CONT  TestAccECSService_ServiceConnect_basic
--- PASS: TestAccECSTaskExecutionDataSource_tags (302.05s)
=== CONT  TestAccECSService_ServiceRegistries_basic
--- PASS: TestAccECSTaskExecutionDataSource_basic (311.11s)
=== CONT  TestAccECSService_DaemonSchedulingStrategy_basic
--- PASS: TestAccECSService_DaemonSchedulingStrategy_basic (32.37s)
=== CONT  TestAccECSService_LaunchTypeFargate_basic
--- PASS: TestAccECSService_ServiceConnect_basic (172.89s)
=== CONT  TestAccECSService_PlacementConstraints_basic
--- PASS: TestAccECSService_ServiceRegistries_basic (166.67s)
=== CONT  TestAccECSService_PlacementStrategy_basic
--- PASS: TestAccECSService_PlacementConstraints_basic (85.08s)
=== CONT  TestAccECSService_DeploymentValues_basic
--- PASS: TestAccECSService_PlacementStrategy_basic (94.18s)
=== CONT  TestAccECSService_CapacityProviderStrategy_basic
--- PASS: TestAccECSService_LaunchTypeFargate_basic (180.07s)
=== CONT  TestAccECSService_basic
--- PASS: TestAccECSService_DeploymentValues_basic (81.90s)
=== CONT  TestAccECSServiceDataSource_basic
--- PASS: TestAccECSService_basic (93.85s)
=== CONT  TestAccECSCluster_tags
--- PASS: TestAccECSCluster_tags (46.78s)
=== CONT  TestAccECSCluster_basic
--- PASS: TestAccECSServiceDataSource_basic (82.28s)
=== CONT  TestAccECSClusterDataSource_tags
--- PASS: TestAccECSService_CapacityProviderStrategy_basic (172.23s)
=== CONT  TestAccECSClusterCapacityProviders_basic
--- PASS: TestAccECSClusterDataSource_tags (24.35s)
=== CONT  TestAccECSCapacityProvider_tags
--- PASS: TestAccECSCluster_basic (26.64s)
--- PASS: TestAccECSClusterCapacityProviders_basic (48.09s)
--- PASS: TestAccECSCapacityProvider_tags (83.24s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	828.284s
FAIL
make: *** [testacc] Error 1
```
```console
% make testacc TESTARGS='-run=TestAccECSTaskDefinition_tags\|TestAccECSTaskDefinition_basic' PKG=ecs ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 3  -run=TestAccECSTaskDefinition_tags\|TestAccECSTaskDefinition_basic -timeout 180m
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== RUN   TestAccECSTaskDefinition_tags
=== PAUSE TestAccECSTaskDefinition_tags
=== CONT  TestAccECSTaskDefinition_basic
=== CONT  TestAccECSTaskDefinition_tags
--- PASS: TestAccECSTaskDefinition_basic (43.22s)
--- PASS: TestAccECSTaskDefinition_tags (67.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	76.160s
```
```console
% make testacc TESTARGS='-run=TestAccEMRCluster_basic$$\|TestAccEMRCluster_tags\|TestAccEMRContainersVirtualCluster_basic$$\|TestAccEMRContainersVirtualCluster_tags\|TestAccEMRServerlessApplication_basic$$\|TestAccEMRServerlessApplication_tags' PKG=emr... ACCTEST_PARALLELISM=3 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/emr.../... -v -count 1 -parallel 3  -run=TestAccEMRCluster_basic$\|TestAccEMRCluster_tags\|TestAccEMRContainersVirtualCluster_basic$\|TestAccEMRContainersVirtualCluster_tags\|TestAccEMRServerlessApplication_basic$\|TestAccEMRServerlessApplication_tags -timeout 180m
q=== RUN   TestAccEMRCluster_basic
=== PAUSE TestAccEMRCluster_basic
=== RUN   TestAccEMRCluster_tags
=== PAUSE TestAccEMRCluster_tags
=== CONT  TestAccEMRCluster_basic
=== CONT  TestAccEMRCluster_tags
--- PASS: TestAccEMRCluster_basic (384.07s)
--- PASS: TestAccEMRCluster_tags (712.83s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/emr	724.867s
=== RUN   TestAccEMRContainersVirtualCluster_basic
=== PAUSE TestAccEMRContainersVirtualCluster_basic
=== RUN   TestAccEMRContainersVirtualCluster_tags
=== PAUSE TestAccEMRContainersVirtualCluster_tags
=== CONT  TestAccEMRContainersVirtualCluster_basic
=== CONT  TestAccEMRContainersVirtualCluster_tags
--- PASS: TestAccEMRContainersVirtualCluster_tags (1029.97s)
--- PASS: TestAccEMRContainersVirtualCluster_basic (1141.29s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/emrcontainers	1146.948s
=== RUN   TestAccEMRServerlessApplication_basic
=== PAUSE TestAccEMRServerlessApplication_basic
=== RUN   TestAccEMRServerlessApplication_tags
=== PAUSE TestAccEMRServerlessApplication_tags
=== CONT  TestAccEMRServerlessApplication_basic
=== CONT  TestAccEMRServerlessApplication_tags
--- PASS: TestAccEMRServerlessApplication_basic (80.06s)
--- PASS: TestAccEMRServerlessApplication_tags (102.03s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/emrserverless	110.808s
```
```console
% make testacc TESTARGS='-run=TestAccElasticsearchDomain_basic$$\|TestAccElasticsearchDomain_tags' PKG=elasticsearch
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticsearch/... -v -count 1 -parallel 20  -run=TestAccElasticsearchDomain_basic$\|TestAccElasticsearchDomain_tags -timeout 180m
=== RUN   TestAccElasticsearchDomain_basic
=== PAUSE TestAccElasticsearchDomain_basic
=== RUN   TestAccElasticsearchDomain_tags
=== PAUSE TestAccElasticsearchDomain_tags
=== CONT  TestAccElasticsearchDomain_basic
=== CONT  TestAccElasticsearchDomain_tags
--- PASS: TestAccElasticsearchDomain_basic (1328.35s)
--- PASS: TestAccElasticsearchDomain_tags (1357.86s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticsearch	1363.304s
```
```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=ev... ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ev.../... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccEventsAPIDestination_basic
=== PAUSE TestAccEventsAPIDestination_basic
=== RUN   TestAccEventsArchive_basic
=== PAUSE TestAccEventsArchive_basic
=== RUN   TestAccEventsBusDataSource_basic
=== PAUSE TestAccEventsBusDataSource_basic
=== RUN   TestAccEventsBusPolicy_basic
=== PAUSE TestAccEventsBusPolicy_basic
=== RUN   TestAccEventsBus_basic
=== PAUSE TestAccEventsBus_basic
=== RUN   TestAccEventsBus_tags
=== PAUSE TestAccEventsBus_tags
=== RUN   TestAccEventsConnectionDataSource_Connection_basic
=== PAUSE TestAccEventsConnectionDataSource_Connection_basic
=== RUN   TestAccEventsConnection_basic
=== PAUSE TestAccEventsConnection_basic
=== RUN   TestAccEventsPermission_basic
=== PAUSE TestAccEventsPermission_basic
=== RUN   TestAccEventsRule_basic
=== PAUSE TestAccEventsRule_basic
=== RUN   TestAccEventsRule_tags
=== PAUSE TestAccEventsRule_tags
=== RUN   TestAccEventsSourceDataSource_basic
    source_data_source_test.go:19: Environment variable EVENT_BRIDGE_PARTNER_EVENT_SOURCE_NAME is not set
--- SKIP: TestAccEventsSourceDataSource_basic (0.00s)
=== RUN   TestAccEventsTarget_basic
=== PAUSE TestAccEventsTarget_basic
=== CONT  TestAccEventsAPIDestination_basic
=== CONT  TestAccEventsTarget_basic
=== CONT  TestAccEventsRule_tags
--- PASS: TestAccEventsTarget_basic (42.37s)
=== CONT  TestAccEventsRule_basic
--- PASS: TestAccEventsAPIDestination_basic (68.95s)
=== CONT  TestAccEventsPermission_basic
--- PASS: TestAccEventsRule_tags (89.93s)
=== CONT  TestAccEventsConnection_basic
--- PASS: TestAccEventsRule_basic (75.68s)
=== CONT  TestAccEventsConnectionDataSource_Connection_basic
--- PASS: TestAccEventsPermission_basic (70.36s)
=== CONT  TestAccEventsBus_tags
--- PASS: TestAccEventsConnectionDataSource_Connection_basic (27.45s)
=== CONT  TestAccEventsBus_basic
--- PASS: TestAccEventsConnection_basic (62.35s)
=== CONT  TestAccEventsBusPolicy_basic
--- PASS: TestAccEventsBusPolicy_basic (32.30s)
=== CONT  TestAccEventsBusDataSource_basic
--- PASS: TestAccEventsBus_basic (45.66s)
=== CONT  TestAccEventsArchive_basic
--- PASS: TestAccEventsBusDataSource_basic (16.62s)
--- PASS: TestAccEventsBus_tags (62.41s)
--- PASS: TestAccEventsArchive_basic (19.85s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	218.440s
=== RUN   TestAccEvidentlyFeature_basic
=== PAUSE TestAccEvidentlyFeature_basic
=== RUN   TestAccEvidentlyFeature_tags
=== PAUSE TestAccEvidentlyFeature_tags
=== RUN   TestAccEvidentlyLaunch_basic
=== PAUSE TestAccEvidentlyLaunch_basic
=== RUN   TestAccEvidentlyLaunch_tags
=== PAUSE TestAccEvidentlyLaunch_tags
=== RUN   TestAccEvidentlyProject_basic
=== PAUSE TestAccEvidentlyProject_basic
=== RUN   TestAccEvidentlyProject_tags
=== PAUSE TestAccEvidentlyProject_tags
=== RUN   TestAccEvidentlySegment_basic
=== PAUSE TestAccEvidentlySegment_basic
=== RUN   TestAccEvidentlySegment_tags
=== PAUSE TestAccEvidentlySegment_tags
=== CONT  TestAccEvidentlyFeature_basic
=== CONT  TestAccEvidentlyLaunch_basic
=== CONT  TestAccEvidentlyProject_basic
--- PASS: TestAccEvidentlyFeature_basic (22.45s)
=== CONT  TestAccEvidentlySegment_tags
--- PASS: TestAccEvidentlyLaunch_basic (24.12s)
=== CONT  TestAccEvidentlySegment_basic
--- PASS: TestAccEvidentlyProject_basic (38.06s)
=== CONT  TestAccEvidentlyProject_tags
--- PASS: TestAccEvidentlySegment_basic (26.91s)
=== CONT  TestAccEvidentlyLaunch_tags
--- PASS: TestAccEvidentlySegment_tags (68.26s)
=== CONT  TestAccEvidentlyFeature_tags
--- PASS: TestAccEvidentlyProject_tags (77.47s)
--- PASS: TestAccEvidentlyLaunch_tags (78.32s)
--- PASS: TestAccEvidentlyFeature_tags (69.72s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/evidently	166.796s
```
```
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=elb... ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elb.../... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccELBAppCookieStickinessPolicy_basic
=== PAUSE TestAccELBAppCookieStickinessPolicy_basic
=== RUN   TestAccELBAttachment_basic
=== PAUSE TestAccELBAttachment_basic
=== RUN   TestAccELBBackendServerPolicy_basic
=== PAUSE TestAccELBBackendServerPolicy_basic
=== RUN   TestAccELBHostedZoneIDDataSource_basic
=== PAUSE TestAccELBHostedZoneIDDataSource_basic
=== RUN   TestAccELBCookieStickinessPolicy_basic
=== PAUSE TestAccELBCookieStickinessPolicy_basic
=== RUN   TestAccELBSSLNegotiationPolicy_basic
=== PAUSE TestAccELBSSLNegotiationPolicy_basic
=== RUN   TestAccELBListenerPolicy_basic
=== PAUSE TestAccELBListenerPolicy_basic
=== RUN   TestAccELBLoadBalancerDataSource_basic
=== PAUSE TestAccELBLoadBalancerDataSource_basic
=== RUN   TestAccELBLoadBalancer_basic
=== PAUSE TestAccELBLoadBalancer_basic
=== RUN   TestAccELBLoadBalancer_tags
=== PAUSE TestAccELBLoadBalancer_tags
=== RUN   TestAccELBPolicy_basic
=== PAUSE TestAccELBPolicy_basic
=== RUN   TestAccELBProxyProtocolPolicy_basic
=== PAUSE TestAccELBProxyProtocolPolicy_basic
=== RUN   TestAccELBServiceAccountDataSource_basic
=== PAUSE TestAccELBServiceAccountDataSource_basic
=== CONT  TestAccELBAppCookieStickinessPolicy_basic
=== CONT  TestAccELBLoadBalancerDataSource_basic
=== CONT  TestAccELBCookieStickinessPolicy_basic
--- PASS: TestAccELBLoadBalancerDataSource_basic (45.77s)
=== CONT  TestAccELBListenerPolicy_basic
--- PASS: TestAccELBCookieStickinessPolicy_basic (46.76s)
=== CONT  TestAccELBSSLNegotiationPolicy_basic
--- PASS: TestAccELBAppCookieStickinessPolicy_basic (50.05s)
=== CONT  TestAccELBBackendServerPolicy_basic
--- PASS: TestAccELBListenerPolicy_basic (25.64s)
=== CONT  TestAccELBHostedZoneIDDataSource_basic
--- PASS: TestAccELBBackendServerPolicy_basic (32.77s)
=== CONT  TestAccELBAttachment_basic
--- PASS: TestAccELBSSLNegotiationPolicy_basic (38.63s)
=== CONT  TestAccELBPolicy_basic
--- PASS: TestAccELBHostedZoneIDDataSource_basic (22.70s)
=== CONT  TestAccELBServiceAccountDataSource_basic
--- PASS: TestAccELBServiceAccountDataSource_basic (12.64s)
=== CONT  TestAccELBProxyProtocolPolicy_basic
--- PASS: TestAccELBPolicy_basic (23.29s)
=== CONT  TestAccELBLoadBalancer_tags
--- PASS: TestAccELBProxyProtocolPolicy_basic (41.66s)
=== CONT  TestAccELBLoadBalancer_basic
--- PASS: TestAccELBLoadBalancer_tags (61.16s)
--- PASS: TestAccELBLoadBalancer_basic (25.51s)
--- PASS: TestAccELBAttachment_basic (179.06s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elb	267.436s
=== RUN   TestAccELBV2HostedZoneIDDataSource_basic
=== PAUSE TestAccELBV2HostedZoneIDDataSource_basic
=== RUN   TestAccELBV2ListenerCertificate_basic
=== PAUSE TestAccELBV2ListenerCertificate_basic
=== RUN   TestAccELBV2ListenerDataSource_basic
=== PAUSE TestAccELBV2ListenerDataSource_basic
=== RUN   TestAccELBV2ListenerRule_basic
=== PAUSE TestAccELBV2ListenerRule_basic
=== RUN   TestAccELBV2ListenerRule_tags
=== PAUSE TestAccELBV2ListenerRule_tags
=== RUN   TestAccELBV2Listener_basic
=== PAUSE TestAccELBV2Listener_basic
=== RUN   TestAccELBV2Listener_tags
=== PAUSE TestAccELBV2Listener_tags
=== RUN   TestAccELBV2LoadBalancerDataSource_basic
=== PAUSE TestAccELBV2LoadBalancerDataSource_basic
=== RUN   TestAccELBV2LoadBalancer_ALB_basic
=== PAUSE TestAccELBV2LoadBalancer_ALB_basic
=== RUN   TestAccELBV2LoadBalancer_NLB_basic
=== PAUSE TestAccELBV2LoadBalancer_NLB_basic
=== RUN   TestAccELBV2LoadBalancer_tags
=== PAUSE TestAccELBV2LoadBalancer_tags
=== RUN   TestAccELBV2LoadBalancersDataSource_basic
=== PAUSE TestAccELBV2LoadBalancersDataSource_basic
=== RUN   TestAccELBV2TargetGroupAttachment_basic
=== PAUSE TestAccELBV2TargetGroupAttachment_basic
=== RUN   TestAccELBV2TargetGroupDataSource_basic
=== PAUSE TestAccELBV2TargetGroupDataSource_basic
=== RUN   TestAccELBV2TargetGroupDataSource_tags
=== PAUSE TestAccELBV2TargetGroupDataSource_tags
=== RUN   TestAccELBV2TargetGroup_ProtocolVersion_basic
=== PAUSE TestAccELBV2TargetGroup_ProtocolVersion_basic
=== RUN   TestAccELBV2TargetGroup_basic
=== PAUSE TestAccELBV2TargetGroup_basic
=== RUN   TestAccELBV2TargetGroup_Geneve_basic
=== PAUSE TestAccELBV2TargetGroup_Geneve_basic
=== RUN   TestAccELBV2TargetGroup_tags
=== PAUSE TestAccELBV2TargetGroup_tags
=== RUN   TestAccELBV2TargetGroup_ALBAlias_basic
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_basic
=== RUN   TestAccELBV2TargetGroup_ALBAlias_tags
=== PAUSE TestAccELBV2TargetGroup_ALBAlias_tags
=== CONT  TestAccELBV2HostedZoneIDDataSource_basic
=== CONT  TestAccELBV2LoadBalancersDataSource_basic
=== CONT  TestAccELBV2TargetGroup_ALBAlias_tags
--- PASS: TestAccELBV2TargetGroup_ALBAlias_tags (42.62s)
=== CONT  TestAccELBV2TargetGroup_ALBAlias_basic
--- PASS: TestAccELBV2HostedZoneIDDataSource_basic (47.69s)
=== CONT  TestAccELBV2TargetGroup_tags
--- PASS: TestAccELBV2TargetGroup_ALBAlias_basic (24.39s)
=== CONT  TestAccELBV2TargetGroup_Geneve_basic
--- PASS: TestAccELBV2TargetGroup_Geneve_basic (25.86s)
=== CONT  TestAccELBV2TargetGroup_basic
--- PASS: TestAccELBV2TargetGroup_tags (56.97s)
=== CONT  TestAccELBV2TargetGroup_ProtocolVersion_basic
--- PASS: TestAccELBV2TargetGroup_basic (22.11s)
=== CONT  TestAccELBV2TargetGroupDataSource_tags
--- PASS: TestAccELBV2TargetGroupDataSource_tags (21.59s)
=== CONT  TestAccELBV2TargetGroupDataSource_basic
--- PASS: TestAccELBV2TargetGroup_ProtocolVersion_basic (41.14s)
=== CONT  TestAccELBV2TargetGroupAttachment_basic
--- PASS: TestAccELBV2LoadBalancersDataSource_basic (170.87s)
=== CONT  TestAccELBV2Listener_tags
--- PASS: TestAccELBV2TargetGroupAttachment_basic (91.59s)
=== CONT  TestAccELBV2LoadBalancer_tags
--- PASS: TestAccELBV2TargetGroupDataSource_basic (159.13s)
=== CONT  TestAccELBV2LoadBalancer_NLB_basic
--- PASS: TestAccELBV2Listener_tags (199.81s)
=== CONT  TestAccELBV2LoadBalancer_ALB_basic
--- PASS: TestAccELBV2LoadBalancer_tags (245.01s)
=== CONT  TestAccELBV2LoadBalancerDataSource_basic
--- PASS: TestAccELBV2LoadBalancer_NLB_basic (231.74s)
=== CONT  TestAccELBV2ListenerRule_basic
--- PASS: TestAccELBV2LoadBalancer_ALB_basic (165.05s)
=== CONT  TestAccELBV2Listener_basic
--- PASS: TestAccELBV2LoadBalancerDataSource_basic (159.74s)
=== CONT  TestAccELBV2ListenerRule_tags
--- PASS: TestAccELBV2ListenerRule_basic (157.59s)
=== CONT  TestAccELBV2ListenerDataSource_basic
--- PASS: TestAccELBV2Listener_basic (158.59s)
=== CONT  TestAccELBV2ListenerCertificate_basic
--- PASS: TestAccELBV2ListenerRule_tags (181.46s)
--- PASS: TestAccELBV2ListenerDataSource_basic (157.91s)
--- PASS: TestAccELBV2ListenerCertificate_basic (166.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	869.109s
```
```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=efs ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/efs/... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccEFSAccessPointDataSource_basic
=== PAUSE TestAccEFSAccessPointDataSource_basic
=== RUN   TestAccEFSAccessPoint_basic
=== PAUSE TestAccEFSAccessPoint_basic
=== RUN   TestAccEFSAccessPoint_tags
=== PAUSE TestAccEFSAccessPoint_tags
=== RUN   TestAccEFSAccessPointsDataSource_basic
=== PAUSE TestAccEFSAccessPointsDataSource_basic
=== RUN   TestAccEFSBackupPolicy_basic
=== PAUSE TestAccEFSBackupPolicy_basic
=== RUN   TestAccEFSFileSystemDataSource_tags
=== PAUSE TestAccEFSFileSystemDataSource_tags
=== RUN   TestAccEFSFileSystemDataSource_nonExistent_tags
=== PAUSE TestAccEFSFileSystemDataSource_nonExistent_tags
=== RUN   TestAccEFSFileSystemPolicy_basic
=== PAUSE TestAccEFSFileSystemPolicy_basic
=== RUN   TestAccEFSFileSystem_basic
=== PAUSE TestAccEFSFileSystem_basic
=== RUN   TestAccEFSFileSystem_tags
=== PAUSE TestAccEFSFileSystem_tags
=== RUN   TestAccEFSMountTargetDataSource_basic
=== PAUSE TestAccEFSMountTargetDataSource_basic
=== RUN   TestAccEFSMountTarget_basic
=== PAUSE TestAccEFSMountTarget_basic
=== RUN   TestAccEFSReplicationConfiguration_basic
=== PAUSE TestAccEFSReplicationConfiguration_basic
=== CONT  TestAccEFSAccessPointDataSource_basic
=== CONT  TestAccEFSFileSystemPolicy_basic
=== CONT  TestAccEFSMountTargetDataSource_basic
--- PASS: TestAccEFSAccessPointDataSource_basic (28.46s)
=== CONT  TestAccEFSReplicationConfiguration_basic
--- PASS: TestAccEFSFileSystemPolicy_basic (38.60s)
=== CONT  TestAccEFSFileSystem_tags
--- PASS: TestAccEFSFileSystem_tags (66.91s)
=== CONT  TestAccEFSFileSystem_basic
--- PASS: TestAccEFSFileSystem_basic (23.46s)
=== CONT  TestAccEFSBackupPolicy_basic
--- PASS: TestAccEFSMountTargetDataSource_basic (134.26s)
=== CONT  TestAccEFSFileSystemDataSource_nonExistent_tags
--- PASS: TestAccEFSFileSystemDataSource_nonExistent_tags (21.88s)
=== CONT  TestAccEFSFileSystemDataSource_tags
--- PASS: TestAccEFSBackupPolicy_basic (27.36s)
=== CONT  TestAccEFSMountTarget_basic
--- PASS: TestAccEFSFileSystemDataSource_tags (21.56s)
=== CONT  TestAccEFSAccessPoint_tags
--- PASS: TestAccEFSAccessPoint_tags (49.16s)
=== CONT  TestAccEFSAccessPointsDataSource_basic
--- PASS: TestAccEFSAccessPointsDataSource_basic (25.45s)
=== CONT  TestAccEFSAccessPoint_basic
--- PASS: TestAccEFSAccessPoint_basic (28.49s)
--- PASS: TestAccEFSMountTarget_basic (234.97s)
--- PASS: TestAccEFSReplicationConfiguration_basic (543.62s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/efs	577.811s
```
```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=eks ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/eks/... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccEKSAddonDataSource_basic
=== PAUSE TestAccEKSAddonDataSource_basic
=== RUN   TestAccEKSAddon_basic
=== PAUSE TestAccEKSAddon_basic
=== RUN   TestAccEKSAddon_tags
=== PAUSE TestAccEKSAddon_tags
=== RUN   TestAccEKSAddonVersionDataSource_basic
=== PAUSE TestAccEKSAddonVersionDataSource_basic
=== RUN   TestAccEKSClusterAuthDataSource_basic
=== PAUSE TestAccEKSClusterAuthDataSource_basic
=== RUN   TestAccEKSClusterDataSource_basic
=== PAUSE TestAccEKSClusterDataSource_basic
=== RUN   TestAccEKSCluster_basic
=== PAUSE TestAccEKSCluster_basic
=== RUN   TestAccEKSCluster_tags
=== PAUSE TestAccEKSCluster_tags
=== RUN   TestAccEKSClustersDataSource_basic
=== PAUSE TestAccEKSClustersDataSource_basic
=== RUN   TestAccEKSFargateProfile_basic
=== PAUSE TestAccEKSFargateProfile_basic
=== RUN   TestAccEKSFargateProfile_tags
=== PAUSE TestAccEKSFargateProfile_tags
=== RUN   TestAccEKSIdentityProviderConfig_basic
=== PAUSE TestAccEKSIdentityProviderConfig_basic
=== RUN   TestAccEKSIdentityProviderConfig_tags
=== PAUSE TestAccEKSIdentityProviderConfig_tags
=== RUN   TestAccEKSNodeGroupDataSource_basic
--- PASS: TestAccEKSNodeGroupDataSource_basic (1101.32s)
=== RUN   TestAccEKSNodeGroup_basic
=== PAUSE TestAccEKSNodeGroup_basic
=== RUN   TestAccEKSNodeGroup_tags
=== PAUSE TestAccEKSNodeGroup_tags
=== RUN   TestAccEKSNodeGroupsDataSource_basic
--- PASS: TestAccEKSNodeGroupsDataSource_basic (884.71s)
=== CONT  TestAccEKSAddonDataSource_basic
=== CONT  TestAccEKSClustersDataSource_basic
=== CONT  TestAccEKSClusterAuthDataSource_basic
--- PASS: TestAccEKSClusterAuthDataSource_basic (9.89s)
=== CONT  TestAccEKSCluster_basic
--- PASS: TestAccEKSCluster_basic (720.34s)
=== CONT  TestAccEKSCluster_tags
--- PASS: TestAccEKSClustersDataSource_basic (766.98s)
=== CONT  TestAccEKSAddon_tags
--- PASS: TestAccEKSAddonDataSource_basic (773.11s)
=== CONT  TestAccEKSAddonVersionDataSource_basic
--- PASS: TestAccEKSAddon_tags (690.38s)
=== CONT  TestAccEKSAddon_basic
--- PASS: TestAccEKSAddonVersionDataSource_basic (752.40s)
=== CONT  TestAccEKSIdentityProviderConfig_tags
--- PASS: TestAccEKSCluster_tags (817.22s)
=== CONT  TestAccEKSClusterDataSource_basic
--- PASS: TestAccEKSAddon_basic (754.48s)
=== CONT  TestAccEKSNodeGroup_tags
--- PASS: TestAccEKSClusterDataSource_basic (730.86s)
=== CONT  TestAccEKSFargateProfile_tags
--- PASS: TestAccEKSIdentityProviderConfig_tags (1582.79s)
=== CONT  TestAccEKSNodeGroup_basic
--- PASS: TestAccEKSNodeGroup_tags (1124.87s)
=== CONT  TestAccEKSIdentityProviderConfig_basic
--- PASS: TestAccEKSFargateProfile_tags (1089.71s)
=== CONT  TestAccEKSFargateProfile_basic
--- PASS: TestAccEKSNodeGroup_basic (1174.47s)
--- PASS: TestAccEKSFargateProfile_basic (1043.77s)
--- PASS: TestAccEKSIdentityProviderConfig_basic (1557.08s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/eks	6885.174s
```
```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=elasticache ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccElastiCacheClusterDataSource_Data_basic
=== PAUSE TestAccElastiCacheClusterDataSource_Data_basic
=== RUN   TestAccElastiCacheCluster_tags
=== PAUSE TestAccElastiCacheCluster_tags
=== RUN   TestAccElastiCacheGlobalReplicationGroup_basic
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_basic
=== RUN   TestAccElastiCacheGlobalReplicationGroup_clusterMode_basic
=== PAUSE TestAccElastiCacheGlobalReplicationGroup_clusterMode_basic
=== RUN   TestAccElastiCacheParameterGroup_basic
=== PAUSE TestAccElastiCacheParameterGroup_basic
=== RUN   TestAccElastiCacheParameterGroup_tags
=== PAUSE TestAccElastiCacheParameterGroup_tags
=== RUN   TestAccElastiCacheReplicationGroupDataSource_basic
=== PAUSE TestAccElastiCacheReplicationGroupDataSource_basic
=== RUN   TestAccElastiCacheReplicationGroup_basic
=== PAUSE TestAccElastiCacheReplicationGroup_basic
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_basic
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_basic
=== RUN   TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic
=== PAUSE TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic
=== RUN   TestAccElastiCacheReplicationGroup_tags
=== PAUSE TestAccElastiCacheReplicationGroup_tags
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
=== RUN   TestAccElastiCacheSubnetGroupDataSource_basic
=== PAUSE TestAccElastiCacheSubnetGroupDataSource_basic
=== RUN   TestAccElastiCacheSubnetGroup_basic
=== PAUSE TestAccElastiCacheSubnetGroup_basic
=== RUN   TestAccElastiCacheSubnetGroup_tags
=== PAUSE TestAccElastiCacheSubnetGroup_tags
=== RUN   TestAccElastiCacheUserDataSource_basic
=== PAUSE TestAccElastiCacheUserDataSource_basic
=== RUN   TestAccElastiCacheUserGroupAssociation_basic
=== PAUSE TestAccElastiCacheUserGroupAssociation_basic
=== RUN   TestAccElastiCacheUserGroup_basic
=== PAUSE TestAccElastiCacheUserGroup_basic
=== RUN   TestAccElastiCacheUserGroup_tags
=== PAUSE TestAccElastiCacheUserGroup_tags
=== RUN   TestAccElastiCacheUser_basic
=== PAUSE TestAccElastiCacheUser_basic
=== RUN   TestAccElastiCacheUser_tags
=== PAUSE TestAccElastiCacheUser_tags
=== CONT  TestAccElastiCacheClusterDataSource_Data_basic
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic
=== CONT  TestAccElastiCacheReplicationGroupDataSource_basic
--- PASS: TestAccElastiCacheClusterDataSource_Data_basic (493.63s)
=== CONT  TestAccElastiCacheReplicationGroup_tags
--- PASS: TestAccElastiCacheReplicationGroupDataSource_basic (835.95s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic
--- PASS: TestAccElastiCacheReplicationGroup_tags (958.16s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_basic
    replication_group_test.go:844: Step 1/2 error: Error running apply: exit status 1
        
        Error: creating ElastiCache Replication Group (tf-acc-test-8157821005691262992): InsufficientCacheClusterCapacity: Cannot create a cache cluster because there is no availability zone corresponding to the subnets in the cache subnet group with sufficient capacity.
        	status code: 400, request id: 0b9a8128-f1ec-4057-aada-bd77554cc00e
        
          with aws_elasticache_replication_group.test,
          on terraform_plugin_test.tf line 68, in resource "aws_elasticache_replication_group" "test":
          68: resource "aws_elasticache_replication_group" "test" {
        
--- FAIL: TestAccElastiCacheReplicationGroup_ClusterMode_basic (14.29s)
=== CONT  TestAccElastiCacheReplicationGroup_basic
--- PASS: TestAccElastiCacheReplicationGroup_basic (701.36s)
=== CONT  TestAccElastiCacheUserGroupAssociation_basic
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic (2179.18s)
=== CONT  TestAccElastiCacheUser_tags
=== CONT  TestAccElastiCacheUserGroupAssociation_basic
    user_group_association_test.go:29: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_elasticache_user_group.test will be updated in-place
          ~ resource "aws_elasticache_user_group" "test" {
                id            = "tf-acc-test-6886862716508271850"
              + tags_all      = (known after apply)
                # (4 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
=== CONT  TestAccElastiCacheUser_tags
    user_test.go:234: Step 3/3 error: Error running apply: exit status 1
        
        Error: updating ElastiCache User (arn:aws:elasticache:us-west-2:187416307283:user:tf-acc-3993335464908762191) tags: untagging resource (arn:aws:elasticache:us-west-2:187416307283:user:tf-acc-3993335464908762191): TagNotFound: Failing request. These tags are not present : tagKey
        	status code: 404, request id: 1da01320-c4e5-43f7-ac42-190d2ea8d205
        
          with aws_elasticache_user.test,
          on terraform_plugin_test.tf line 2, in resource "aws_elasticache_user" "test":
           2: resource "aws_elasticache_user" "test" {
        
--- FAIL: TestAccElastiCacheUser_tags (131.14s)
=== CONT  TestAccElastiCacheUser_basic
--- PASS: TestAccElastiCacheUser_basic (60.84s)
=== CONT  TestAccElastiCacheUserGroup_tags
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic (1572.73s)
=== CONT  TestAccElastiCacheUserGroup_basic
--- FAIL: TestAccElastiCacheUserGroupAssociation_basic (267.60s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_clusterMode_basic
=== CONT  TestAccElastiCacheUserGroup_basic
    user_group_test.go:25: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_elasticache_user_group.test will be updated in-place
          ~ resource "aws_elasticache_user_group" "test" {
                id            = "tf-acc-3778340698101280489"
              + tags_all      = (known after apply)
                # (4 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccElastiCacheUserGroup_basic (149.16s)
=== CONT  TestAccElastiCacheParameterGroup_tags
--- PASS: TestAccElastiCacheUserGroup_tags (187.61s)
=== CONT  TestAccElastiCacheParameterGroup_basic
--- PASS: TestAccElastiCacheParameterGroup_basic (16.56s)
=== CONT  TestAccElastiCacheSubnetGroup_basic
--- PASS: TestAccElastiCacheParameterGroup_tags (39.15s)
=== CONT  TestAccElastiCacheUserDataSource_basic
--- PASS: TestAccElastiCacheSubnetGroup_basic (24.19s)
=== CONT  TestAccElastiCacheSubnetGroup_tags
--- PASS: TestAccElastiCacheSubnetGroup_tags (55.66s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_basic
--- PASS: TestAccElastiCacheUserDataSource_basic (79.66s)
=== CONT  TestAccElastiCacheSubnetGroupDataSource_basic
--- PASS: TestAccElastiCacheSubnetGroupDataSource_basic (23.15s)
=== CONT  TestAccElastiCacheCluster_tags
--- PASS: TestAccElastiCacheCluster_tags (505.71s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
--- PASS: TestAccElastiCacheGlobalReplicationGroup_basic (815.23s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_clusterMode_basic (1170.69s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic (3491.62s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	6702.209s
FAIL
make: *** [testacc] Error 1
```
```console
% make testacc TESTARGS='-run=TestAccElastiCacheUser_\|TestAccElastiCacheUserGroup_\|TestAccElastiCacheUserGroupAssociation_' PKG=elasticache ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 3  -run=TestAccElastiCacheUser_\|TestAccElastiCacheUserGroup_\|TestAccElastiCacheUserGroupAssociation_ -timeout 180m
=== RUN   TestAccElastiCacheUserGroupAssociation_basic
=== PAUSE TestAccElastiCacheUserGroupAssociation_basic
=== RUN   TestAccElastiCacheUserGroupAssociation_update
=== PAUSE TestAccElastiCacheUserGroupAssociation_update
=== RUN   TestAccElastiCacheUserGroupAssociation_disappears
=== PAUSE TestAccElastiCacheUserGroupAssociation_disappears
=== RUN   TestAccElastiCacheUserGroupAssociation_multiple
=== PAUSE TestAccElastiCacheUserGroupAssociation_multiple
=== RUN   TestAccElastiCacheUserGroup_basic
=== PAUSE TestAccElastiCacheUserGroup_basic
=== RUN   TestAccElastiCacheUserGroup_update
=== PAUSE TestAccElastiCacheUserGroup_update
=== RUN   TestAccElastiCacheUserGroup_tags
=== PAUSE TestAccElastiCacheUserGroup_tags
=== RUN   TestAccElastiCacheUserGroup_disappears
=== PAUSE TestAccElastiCacheUserGroup_disappears
=== RUN   TestAccElastiCacheUser_basic
=== PAUSE TestAccElastiCacheUser_basic
=== RUN   TestAccElastiCacheUser_password_auth_mode
=== PAUSE TestAccElastiCacheUser_password_auth_mode
=== RUN   TestAccElastiCacheUser_iam_auth_mode
=== PAUSE TestAccElastiCacheUser_iam_auth_mode
=== RUN   TestAccElastiCacheUser_update
=== PAUSE TestAccElastiCacheUser_update
=== RUN   TestAccElastiCacheUser_update_password_auth_mode
=== PAUSE TestAccElastiCacheUser_update_password_auth_mode
=== RUN   TestAccElastiCacheUser_tags
=== PAUSE TestAccElastiCacheUser_tags
=== RUN   TestAccElastiCacheUser_disappears
=== PAUSE TestAccElastiCacheUser_disappears
=== CONT  TestAccElastiCacheUserGroupAssociation_basic
=== CONT  TestAccElastiCacheUser_basic
=== CONT  TestAccElastiCacheUserGroup_basic
--- PASS: TestAccElastiCacheUser_basic (24.98s)
=== CONT  TestAccElastiCacheUserGroup_disappears
--- PASS: TestAccElastiCacheUserGroup_basic (146.06s)
=== CONT  TestAccElastiCacheUserGroup_tags
--- PASS: TestAccElastiCacheUserGroup_disappears (186.12s)
=== CONT  TestAccElastiCacheUserGroup_update
--- PASS: TestAccElastiCacheUserGroupAssociation_basic (270.34s)
=== CONT  TestAccElastiCacheUserGroupAssociation_disappears
--- PASS: TestAccElastiCacheUserGroup_tags (189.44s)
=== CONT  TestAccElastiCacheUserGroupAssociation_multiple
--- PASS: TestAccElastiCacheUserGroup_update (302.18s)
=== CONT  TestAccElastiCacheUserGroupAssociation_update
--- PASS: TestAccElastiCacheUserGroupAssociation_disappears (297.51s)
=== CONT  TestAccElastiCacheUser_iam_auth_mode
--- PASS: TestAccElastiCacheUser_iam_auth_mode (60.49s)
=== CONT  TestAccElastiCacheUser_update
--- PASS: TestAccElastiCacheUserGroupAssociation_multiple (417.40s)
=== CONT  TestAccElastiCacheUser_password_auth_mode
--- PASS: TestAccElastiCacheUser_update (127.39s)
=== CONT  TestAccElastiCacheUser_disappears
--- PASS: TestAccElastiCacheUser_password_auth_mode (60.57s)
=== CONT  TestAccElastiCacheUser_tags
--- PASS: TestAccElastiCacheUser_disappears (66.40s)
=== CONT  TestAccElastiCacheUser_update_password_auth_mode
--- PASS: TestAccElastiCacheUser_tags (59.41s)
--- PASS: TestAccElastiCacheUserGroupAssociation_update (423.01s)
--- PASS: TestAccElastiCacheUser_update_password_auth_mode (177.44s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	1004.964s
```
```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=elasticbeanstalk ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticbeanstalk/... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccElasticBeanstalkApplicationDataSource_basic
=== PAUSE TestAccElasticBeanstalkApplicationDataSource_basic
=== RUN   TestAccElasticBeanstalkApplication_BeanstalkApp_basic
=== PAUSE TestAccElasticBeanstalkApplication_BeanstalkApp_basic
=== RUN   TestAccElasticBeanstalkApplication_BeanstalkApp_tags
=== PAUSE TestAccElasticBeanstalkApplication_BeanstalkApp_tags
=== RUN   TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_basic
=== PAUSE TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_basic
=== RUN   TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_tags
=== PAUSE TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_tags
=== RUN   TestAccElasticBeanstalkConfigurationTemplate_basic
=== PAUSE TestAccElasticBeanstalkConfigurationTemplate_basic
=== RUN   TestAccElasticBeanstalkEnvironment_basic
=== PAUSE TestAccElasticBeanstalkEnvironment_basic
=== RUN   TestAccElasticBeanstalkEnvironment_tags
=== PAUSE TestAccElasticBeanstalkEnvironment_tags
=== RUN   TestAccElasticBeanstalkHostedZoneDataSource_basic
=== PAUSE TestAccElasticBeanstalkHostedZoneDataSource_basic
=== RUN   TestAccElasticBeanstalkSolutionStackDataSource_basic
=== PAUSE TestAccElasticBeanstalkSolutionStackDataSource_basic
=== CONT  TestAccElasticBeanstalkApplicationDataSource_basic
=== CONT  TestAccElasticBeanstalkConfigurationTemplate_basic
=== CONT  TestAccElasticBeanstalkHostedZoneDataSource_basic
--- PASS: TestAccElasticBeanstalkHostedZoneDataSource_basic (12.42s)
=== CONT  TestAccElasticBeanstalkSolutionStackDataSource_basic
    solution_stack_data_source_test.go:16: Step 1/1 error: Error running pre-apply refresh: exit status 1
        
        Error: Your query returned no results. Please change your search criteria and try again.
        
          with data.aws_elastic_beanstalk_solution_stack.multi_docker,
          on terraform_plugin_test.tf line 2, in data "aws_elastic_beanstalk_solution_stack" "multi_docker":
           2: data "aws_elastic_beanstalk_solution_stack" "multi_docker" {
        
--- FAIL: TestAccElasticBeanstalkSolutionStackDataSource_basic (2.95s)
=== CONT  TestAccElasticBeanstalkEnvironment_tags
--- PASS: TestAccElasticBeanstalkApplicationDataSource_basic (20.30s)
=== CONT  TestAccElasticBeanstalkEnvironment_basic
--- PASS: TestAccElasticBeanstalkConfigurationTemplate_basic (24.69s)
=== CONT  TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_basic
--- PASS: TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_basic (20.73s)
=== CONT  TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_tags
--- PASS: TestAccElasticBeanstalkApplicationVersion_BeanstalkApp_tags (76.51s)
=== CONT  TestAccElasticBeanstalkApplication_BeanstalkApp_tags
--- PASS: TestAccElasticBeanstalkApplication_BeanstalkApp_tags (53.53s)
=== CONT  TestAccElasticBeanstalkApplication_BeanstalkApp_basic
=== CONT  TestAccElasticBeanstalkEnvironment_tags
    environment_test.go:240: Step 3/4 error: Check failed: Check 2/4 error: aws_elastic_beanstalk_environment.test: Attribute 'tags.%' expected "2", got "1"
--- PASS: TestAccElasticBeanstalkApplication_BeanstalkApp_basic (21.38s)
--- PASS: TestAccElasticBeanstalkEnvironment_basic (311.28s)
--- FAIL: TestAccElasticBeanstalkEnvironment_tags (386.38s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/elasticbeanstalk	407.209s
FAIL
make: *** [testacc] Error 1
```
```console
% make testacc TESTARGS='-run=TestAccElasticBeanstalkSolutionStackDataSource_' PKG=elasticbeanstalk ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticbeanstalk/... -v -count 1 -parallel 3  -run=TestAccElasticBeanstalkSolutionStackDataSource_ -timeout 180m
=== RUN   TestAccElasticBeanstalkSolutionStackDataSource_basic
=== PAUSE TestAccElasticBeanstalkSolutionStackDataSource_basic
=== CONT  TestAccElasticBeanstalkSolutionStackDataSource_basic
--- PASS: TestAccElasticBeanstalkSolutionStackDataSource_basic (13.66s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticbeanstalk	19.004s
```
```console
% make testacc TESTARGS='-run=TestAccElasticBeanstalkEnvironment_' PKG=elasticbeanstalk ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticbeanstalk/... -v -count 1 -parallel 3  -run=TestAccElasticBeanstalkEnvironment_ -timeout 180m
=== RUN   TestAccElasticBeanstalkEnvironment_basic
=== PAUSE TestAccElasticBeanstalkEnvironment_basic
=== RUN   TestAccElasticBeanstalkEnvironment_disappears
=== PAUSE TestAccElasticBeanstalkEnvironment_disappears
=== RUN   TestAccElasticBeanstalkEnvironment_tier
=== PAUSE TestAccElasticBeanstalkEnvironment_tier
=== RUN   TestAccElasticBeanstalkEnvironment_cnamePrefix
=== PAUSE TestAccElasticBeanstalkEnvironment_cnamePrefix
=== RUN   TestAccElasticBeanstalkEnvironment_beanstalkEnv
=== PAUSE TestAccElasticBeanstalkEnvironment_beanstalkEnv
=== RUN   TestAccElasticBeanstalkEnvironment_resource
=== PAUSE TestAccElasticBeanstalkEnvironment_resource
=== RUN   TestAccElasticBeanstalkEnvironment_tags
=== PAUSE TestAccElasticBeanstalkEnvironment_tags
=== RUN   TestAccElasticBeanstalkEnvironment_changeStack
=== PAUSE TestAccElasticBeanstalkEnvironment_changeStack
=== RUN   TestAccElasticBeanstalkEnvironment_update
=== PAUSE TestAccElasticBeanstalkEnvironment_update
=== RUN   TestAccElasticBeanstalkEnvironment_label
=== PAUSE TestAccElasticBeanstalkEnvironment_label
=== RUN   TestAccElasticBeanstalkEnvironment_settingWithJSONValue
=== PAUSE TestAccElasticBeanstalkEnvironment_settingWithJSONValue
=== RUN   TestAccElasticBeanstalkEnvironment_platformARN
=== PAUSE TestAccElasticBeanstalkEnvironment_platformARN
=== CONT  TestAccElasticBeanstalkEnvironment_basic
=== CONT  TestAccElasticBeanstalkEnvironment_tags
=== CONT  TestAccElasticBeanstalkEnvironment_label
--- PASS: TestAccElasticBeanstalkEnvironment_basic (318.93s)
=== CONT  TestAccElasticBeanstalkEnvironment_update
--- PASS: TestAccElasticBeanstalkEnvironment_label (430.79s)
=== CONT  TestAccElasticBeanstalkEnvironment_changeStack
--- PASS: TestAccElasticBeanstalkEnvironment_tags (532.28s)
=== CONT  TestAccElasticBeanstalkEnvironment_cnamePrefix
--- PASS: TestAccElasticBeanstalkEnvironment_update (524.56s)
=== CONT  TestAccElasticBeanstalkEnvironment_resource
--- PASS: TestAccElasticBeanstalkEnvironment_changeStack (446.89s)
=== CONT  TestAccElasticBeanstalkEnvironment_beanstalkEnv
--- PASS: TestAccElasticBeanstalkEnvironment_cnamePrefix (350.23s)
=== CONT  TestAccElasticBeanstalkEnvironment_tier
--- PASS: TestAccElasticBeanstalkEnvironment_resource (289.14s)
=== CONT  TestAccElasticBeanstalkEnvironment_platformARN
--- PASS: TestAccElasticBeanstalkEnvironment_beanstalkEnv (441.72s)
=== CONT  TestAccElasticBeanstalkEnvironment_settingWithJSONValue
--- PASS: TestAccElasticBeanstalkEnvironment_platformARN (340.31s)
=== CONT  TestAccElasticBeanstalkEnvironment_disappears
--- PASS: TestAccElasticBeanstalkEnvironment_tier (628.75s)
--- PASS: TestAccElasticBeanstalkEnvironment_settingWithJSONValue (342.66s)
--- PASS: TestAccElasticBeanstalkEnvironment_disappears (362.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticbeanstalk	1843.556s
```