### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin SDK resources `f*` (Phase 3c)

### DIFF
--- a/internal/service/firehose/delivery_stream_test.go
+++ b/internal/service/firehose/delivery_stream_test.go
@@ -2063,11 +2063,6 @@ resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.bucket.id
-  acl    = "private"
-}
-
 resource "aws_iam_role_policy" "firehose" {
   name = %[1]q
   role = aws_iam_role.firehose.id
@@ -2249,11 +2244,6 @@ EOF
 
 resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.bucket.id
-  acl    = "private"
 }
 
 resource "aws_cloudwatch_log_group" "test" {
@@ -4026,11 +4016,6 @@ EOF
 
 resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.bucket.id
-  acl    = "private"
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {

--- a/internal/service/firehose/delivery_stream_test.go
+++ b/internal/service/firehose/delivery_stream_test.go
@@ -85,6 +85,47 @@ func TestAccFirehoseDeliveryStream_disappears(t *testing.T) {
 	})
 }
 
+func TestAccFirehoseDeliveryStream_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	var stream firehose.DeliveryStreamDescription
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_kinesis_firehose_delivery_stream.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, firehose.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDeliveryStreamDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeliveryStreamConfig_tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccDeliveryStreamConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccDeliveryStreamConfig_tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccFirehoseDeliveryStream_s3basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var stream firehose.DeliveryStreamDescription
@@ -299,48 +340,6 @@ func TestAccFirehoseDeliveryStream_s3basicWithSSEAndKeyType(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.key_type", firehose.KeyTypeAwsOwnedCmk),
-				),
-			},
-		},
-	})
-}
-
-func TestAccFirehoseDeliveryStream_s3basicWithTags(t *testing.T) {
-	ctx := acctest.Context(t)
-	var stream firehose.DeliveryStreamDescription
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_kinesis_firehose_delivery_stream.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, firehose.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeliveryStreamDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDeliveryStreamConfig_s3basicTags(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "original"),
-				),
-			},
-			{
-				Config: testAccDeliveryStreamConfig_s3basicTagsChanged(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "changed"),
-				),
-			},
-			{
-				Config: testAccDeliveryStreamConfig_s3basic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 		},
@@ -2028,7 +2027,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 `, rName)
 }
 
-func testAccDeliveryStreamBaseConfig(rName string) string {
+func testAccDeliveryStreamConfig_base(rName string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
@@ -2114,7 +2113,7 @@ EOF
 `, rName)
 }
 
-func testAccStreamSourceConfig(rName string) string {
+func testAccDeliveryStreamConfig_baseKinesisStreamSource(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kinesis_stream" "source" {
   name        = %[1]q
@@ -2276,7 +2275,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_s3basic(rName string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
@@ -2293,7 +2292,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_s3basicPrefixes(rName, prefix, errorOutputPrefix string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = ["aws_iam_role_policy.firehose"]
@@ -2312,7 +2311,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_s3basicSSE(rName string, sseEnabled bool) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
@@ -2333,7 +2332,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_s3BasicSSEAndKeyARN(rName string, sseEnabled bool) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
@@ -2361,7 +2360,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_s3basicSSEAndKeyType(rName string, sseEnabled bool, keyType string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
@@ -2381,9 +2380,9 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 `, rName, sseEnabled, keyType))
 }
 
-func testAccDeliveryStreamConfig_s3basicTags(rName string) string {
+func testAccDeliveryStreamConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
@@ -2396,16 +2395,15 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   }
 
   tags = {
-    Environment = "production"
-    Usage       = "original"
+    %[2]q = %[3]q
   }
 }
-`, rName))
+`, rName, tagKey1, tagValue1))
 }
 
-func testAccDeliveryStreamConfig_s3basicTagsChanged(rName string) string {
+func testAccDeliveryStreamConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
@@ -2418,16 +2416,17 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   }
 
   tags = {
-    Usage = "changed"
+    %[2]q = %[3]q
+    %[4]q = %[5]q
   }
 }
-`, rName))
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
 func testAccDeliveryStreamConfig_s3Source(rName string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
-		testAccStreamSourceConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
+		testAccDeliveryStreamConfig_baseKinesisStreamSource(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on = [aws_iam_role_policy.firehose, aws_iam_role_policy.kinesis_source]
@@ -2450,7 +2449,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_s3Updates(rName string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
@@ -2471,7 +2470,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 func testAccDeliveryStreamConfig_extendedS3basic(rName string) string {
 	return acctest.ConfigCompose(
 		testAccLambdaBasicConfig(rName),
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
@@ -2511,8 +2510,8 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_extendedS3Source(rName string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
-		testAccStreamSourceConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
+		testAccDeliveryStreamConfig_baseKinesisStreamSource(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on = [aws_iam_role_policy.firehose, aws_iam_role_policy.kinesis_source]
@@ -2535,7 +2534,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_extendedS3DataFormatConversionConfigurationEnabled(rName string, enabled bool) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
@@ -2603,7 +2602,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_extendedS3DataFormatConversionConfigurationHiveJSONSerDeEmpty(rName string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
@@ -2669,7 +2668,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_extendedS3ExternalUpdate(rName string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   destination = "extended_s3"
@@ -2685,7 +2684,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_extendedS3DataFormatConversionConfigurationOpenXJSONSerDeEmpty(rName string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
@@ -2751,7 +2750,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_extendedS3DataFormatConversionConfigurationOrcSerDeEmpty(rName string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
@@ -2817,7 +2816,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_extendedS3DataFormatConversionConfigurationParquetSerDeEmpty(rName string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_glue_catalog_database" "test" {
   name = %[1]q
@@ -2883,7 +2882,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_extendedS3ErrorOutputPrefix(rName, errorOutputPrefix string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   destination = "extended_s3"
@@ -2902,7 +2901,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_extendedS3S3BackUpConfigurationErrorOutputPrefix(rName, errorOutputPrefix string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   destination = "extended_s3"
@@ -2926,7 +2925,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_extendedS3ProcessingConfigurationEmpty(rName string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   destination = "extended_s3"
@@ -2947,7 +2946,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 func testAccDeliveryStreamConfig_extendedS3KMSKeyARN(rName string) string {
 	return acctest.ConfigCompose(
 		testAccLambdaBasicConfig(rName),
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description = %[1]q
@@ -2991,7 +2990,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 func testAccDeliveryStreamConfig_extendedS3DynamicPartitioning(rName string) string {
 	return acctest.ConfigCompose(
 		testAccLambdaBasicConfig(rName),
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
@@ -3047,7 +3046,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 func testAccDeliveryStreamConfig_extendedS3DynamicPartitioningBasic(rName string) string {
 	return acctest.ConfigCompose(
 		testAccLambdaBasicConfig(rName),
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
@@ -3067,7 +3066,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 func testAccDeliveryStreamConfig_extendedS3UpdatesInitial(rName string) string {
 	return acctest.ConfigCompose(
 		testAccLambdaBasicConfig(rName),
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
@@ -3116,7 +3115,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 func testAccDeliveryStreamConfig_extendedS3UpdatesRemoveProcessors(rName string) string {
 	return acctest.ConfigCompose(
 		testAccLambdaBasicConfig(rName),
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
@@ -3142,7 +3141,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamRedshiftConfigBase(rName string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2", "usgw1-az2"),
 		fmt.Sprintf(`
 resource "aws_vpc" "test" {
@@ -3325,7 +3324,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_splunkBasic(rName string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
@@ -3348,7 +3347,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 func testAccDeliveryStreamConfig_splunkUpdates(rName string) string {
 	return acctest.ConfigCompose(
 		testAccLambdaBasicConfig(rName),
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
@@ -3404,7 +3403,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_splunkErrorOutputPrefix(rName, errorOutputPrefix string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
@@ -3427,7 +3426,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_httpEndpointBasic(rName string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
@@ -3450,7 +3449,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_httpEndpointErrorOutputPrefix(rName, errorOutputPrefix string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
@@ -3474,7 +3473,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamConfig_httpEndpointRetryDuration(rName string, retryDuration int) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
@@ -3499,7 +3498,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 func testAccDeliveryStreamConfig_httpEndpointUpdates(rName string) string {
 	return acctest.ConfigCompose(
 		testAccLambdaBasicConfig(rName),
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
@@ -3550,7 +3549,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
 func testAccDeliveryStreamBaseElasticsearchConfig(rName string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test_cluster" {
   domain_name = substr(%[1]q, 0, 28)
@@ -3597,7 +3596,7 @@ EOF
 // Elasticsearch associated with VPC
 func testAccDeliveryStreamBaseElasticsearchVPCConfig(rName string) string {
 	return acctest.ConfigCompose(
-		testAccDeliveryStreamBaseConfig(rName),
+		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"

--- a/internal/service/firehose/service_package_gen.go
+++ b/internal/service/firehose/service_package_gen.go
@@ -33,6 +33,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDeliveryStream,
 			TypeName: "aws_kinesis_firehose_delivery_stream",
+			Name:     "Delivery Stream",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "name",
+			},
 		},
 	}
 }

--- a/internal/service/fis/experiment_template.go
+++ b/internal/service/fis/experiment_template.go
@@ -27,7 +27,8 @@ const (
 	ResNameExperimentTemplate = "Experiment Template"
 )
 
-// @SDKResource("aws_fis_experiment_template")
+// @SDKResource("aws_fis_experiment_template", name="Experiment Template")
+// @Tags
 func ResourceExperimentTemplate() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceExperimentTemplateCreate,
@@ -225,16 +226,14 @@ func ResourceExperimentTemplate() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchemaForceNew(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchemaForceNew(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
 
 func resourceExperimentTemplateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).FISClient()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &fis.CreateExperimentTemplateInput{
 		Actions:        expandExperimentTemplateActions(d.Get("action").(*schema.Set)),
@@ -242,10 +241,7 @@ func resourceExperimentTemplateCreate(ctx context.Context, d *schema.ResourceDat
 		Description:    aws.String(d.Get("description").(string)),
 		RoleArn:        aws.String(d.Get("role_arn").(string)),
 		StopConditions: expandExperimentTemplateStopConditions(d.Get("stop_condition").(*schema.Set)),
-	}
-
-	if len(Tags(tags.IgnoreAWS())) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
+		Tags:           GetTagsIn(ctx),
 	}
 
 	targets, err := expandExperimentTemplateTargets(d.Get("target").(*schema.Set))
@@ -266,8 +262,6 @@ func resourceExperimentTemplateCreate(ctx context.Context, d *schema.ResourceDat
 
 func resourceExperimentTemplateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).FISClient()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	input := &fis.GetExperimentTemplateInput{Id: aws.String(d.Id())}
 	out, err := conn.GetExperimentTemplate(ctx, input)
@@ -310,16 +304,7 @@ func resourceExperimentTemplateRead(ctx context.Context, d *schema.ResourceData,
 		return create.DiagSettingError(names.FIS, ResNameExperimentTemplate, d.Id(), "target", err)
 	}
 
-	tags := KeyValueTags(ctx, experimentTemplate.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return create.DiagSettingError(names.FIS, ResNameExperimentTemplate, d.Id(), "tags", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return create.DiagSettingError(names.FIS, ResNameExperimentTemplate, d.Id(), "tags_all", err)
-	}
+	SetTagsOut(ctx, experimentTemplate.Tags)
 
 	return nil
 }

--- a/internal/service/fis/service_package_gen.go
+++ b/internal/service/fis/service_package_gen.go
@@ -28,6 +28,8 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceExperimentTemplate,
 			TypeName: "aws_fis_experiment_template",
+			Name:     "Experiment Template",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 	}
 }

--- a/internal/service/fms/policy.go
+++ b/internal/service/fms/policy.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_fms_policy")
+// @SDKResource("aws_fms_policy", name="Policy")
+// @Tags(identifierAttribute="arn")
 func ResourcePolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePolicyCreate,
@@ -153,8 +155,8 @@ func ResourcePolicy() *schema.Resource {
 					},
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -162,12 +164,10 @@ func ResourcePolicy() *schema.Resource {
 func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FMSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &fms.PutPolicyInput{
 		Policy:  resourcePolicyExpandPolicy(d),
-		TagList: Tags(tags.IgnoreAWS()),
+		TagList: GetTagsIn(ctx),
 	}
 
 	output, err := conn.PutPolicyWithContext(ctx, input)
@@ -184,8 +184,6 @@ func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta inte
 func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FMSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	output, err := FindPolicyByID(ctx, conn, d.Id())
 
@@ -229,22 +227,6 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interf
 		sdkdiag.AppendErrorf(diags, "setting security_service_policy_data: %s", err)
 	}
 
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for FMS Policy (%s): %s", d.Id(), err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
-
 	return diags
 }
 
@@ -261,14 +243,6 @@ func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating FMS Policy (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating FMS Policy (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/fms/service_package_gen.go
+++ b/internal/service/fms/service_package_gen.go
@@ -32,6 +32,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourcePolicy,
 			TypeName: "aws_fms_policy",
+			Name:     "Policy",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/fsx/data_repository_association.go
+++ b/internal/service/fsx/data_repository_association.go
@@ -20,9 +20,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_fsx_data_repository_association")
+// @SDKResource("aws_fsx_data_repository_association", name="Data Repository Association")
+// @Tags(identifierAttribute="arn")
 func ResourceDataRepositoryAssociation() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDataRepositoryAssociationCreate,
@@ -142,8 +144,8 @@ func ResourceDataRepositoryAssociation() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: customdiff.Sequence(
@@ -155,14 +157,13 @@ func ResourceDataRepositoryAssociation() *schema.Resource {
 func resourceDataRepositoryAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &fsx.CreateDataRepositoryAssociationInput{
 		ClientRequestToken: aws.String(id.UniqueId()),
 		DataRepositoryPath: aws.String(d.Get("data_repository_path").(string)),
 		FileSystemId:       aws.String(d.Get("file_system_id").(string)),
 		FileSystemPath:     aws.String(d.Get("file_system_path").(string)),
+		Tags:               GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("batch_import_meta_data_on_create"); ok {
@@ -177,11 +178,6 @@ func resourceDataRepositoryAssociationCreate(ctx context.Context, d *schema.Reso
 		input.S3 = expandDataRepositoryAssociationS3(v.([]interface{}))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
-	log.Printf("[DEBUG] Creating FSx Lustre Data Repository Association: %s", input)
 	result, err := conn.CreateDataRepositoryAssociationWithContext(ctx, input)
 
 	if err != nil {
@@ -200,14 +196,6 @@ func resourceDataRepositoryAssociationCreate(ctx context.Context, d *schema.Reso
 func resourceDataRepositoryAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxConn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating FSx Lustre Data Repository Association (%s) tags: %s", d.Get("arn").(string), err)
-		}
-	}
 
 	if d.HasChangesExcept("tags_all", "tags") {
 		input := &fsx.UpdateDataRepositoryAssociationInput{
@@ -239,8 +227,6 @@ func resourceDataRepositoryAssociationUpdate(ctx context.Context, d *schema.Reso
 func resourceDataRepositoryAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	association, err := FindDataRepositoryAssociationByID(ctx, conn, d.Id())
 	if !d.IsNewResource() && tfresource.NotFound(err) {
@@ -263,16 +249,7 @@ func resourceDataRepositoryAssociationRead(ctx context.Context, d *schema.Resour
 		return sdkdiag.AppendErrorf(diags, "setting s3 data repository configuration: %s", err)
 	}
 
-	tags := KeyValueTags(ctx, association.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, association.Tags)
 
 	return diags
 }

--- a/internal/service/fsx/data_repository_association_test.go
+++ b/internal/service/fsx/data_repository_association_test.go
@@ -589,7 +589,7 @@ func testAccCheckDataRepositoryAssociationRecreated(i, j *fsx.DataRepositoryAsso
 	}
 }
 
-func testAccDataRepositoryAssociationBucketConfig(bucketName string) string {
+func testAccDataRepositoryAssociationConfig_s3Bucket(bucketName string) string {
 	return acctest.ConfigCompose(testAccLustreFileSystemBaseConfig(), fmt.Sprintf(`
 resource "aws_fsx_lustre_file_system" "test" {
   storage_capacity            = 1200
@@ -601,16 +601,11 @@ resource "aws_fsx_lustre_file_system" "test" {
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
 `, bucketName))
 }
 
 func testAccDataRepositoryAssociationConfig_fileSystemPath(bucketName, fileSystemPath string) string {
-	return acctest.ConfigCompose(testAccDataRepositoryAssociationBucketConfig(bucketName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccDataRepositoryAssociationConfig_s3Bucket(bucketName), fmt.Sprintf(`
 resource "aws_fsx_data_repository_association" "test" {
   file_system_id       = aws_fsx_lustre_file_system.test.id
   data_repository_path = "s3://%[1]s"
@@ -621,7 +616,7 @@ resource "aws_fsx_data_repository_association" "test" {
 
 func testAccDataRepositoryAssociationConfig_importedFileChunkSize(bucketName, fileSystemPath string, fileChunkSize int64) string {
 	bucketPath := fmt.Sprintf("s3://%s", bucketName)
-	return acctest.ConfigCompose(testAccDataRepositoryAssociationBucketConfig(bucketName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccDataRepositoryAssociationConfig_s3Bucket(bucketName), fmt.Sprintf(`
 resource "aws_fsx_data_repository_association" "test" {
   file_system_id           = aws_fsx_lustre_file_system.test.id
   data_repository_path     = %[1]q
@@ -633,7 +628,7 @@ resource "aws_fsx_data_repository_association" "test" {
 
 func testAccDataRepositoryAssociationConfig_deleteInFilesystem(bucketName, fileSystemPath, deleteDataInFilesystem string) string {
 	bucketPath := fmt.Sprintf("s3://%s", bucketName)
-	return acctest.ConfigCompose(testAccDataRepositoryAssociationBucketConfig(bucketName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccDataRepositoryAssociationConfig_s3Bucket(bucketName), fmt.Sprintf(`
 resource "aws_fsx_data_repository_association" "test" {
   file_system_id            = aws_fsx_lustre_file_system.test.id
   data_repository_path      = %[1]q
@@ -646,7 +641,7 @@ resource "aws_fsx_data_repository_association" "test" {
 func testAccDataRepositoryAssociationConfig_s3AutoExportPolicy(bucketName, fileSystemPath string, events []string) string {
 	bucketPath := fmt.Sprintf("s3://%s", bucketName)
 	eventsString := strings.Replace(fmt.Sprintf("%q", events), " ", ", ", -1)
-	return acctest.ConfigCompose(testAccDataRepositoryAssociationBucketConfig(bucketName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccDataRepositoryAssociationConfig_s3Bucket(bucketName), fmt.Sprintf(`
 resource "aws_fsx_data_repository_association" "test" {
   file_system_id       = aws_fsx_lustre_file_system.test.id
   data_repository_path = %[1]q
@@ -664,7 +659,7 @@ resource "aws_fsx_data_repository_association" "test" {
 func testAccDataRepositoryAssociationConfig_s3AutoImportPolicy(bucketName, fileSystemPath string, events []string) string {
 	bucketPath := fmt.Sprintf("s3://%s", bucketName)
 	eventsString := strings.Replace(fmt.Sprintf("%q", events), " ", ", ", -1)
-	return acctest.ConfigCompose(testAccDataRepositoryAssociationBucketConfig(bucketName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccDataRepositoryAssociationConfig_s3Bucket(bucketName), fmt.Sprintf(`
 resource "aws_fsx_data_repository_association" "test" {
   file_system_id       = aws_fsx_lustre_file_system.test.id
   data_repository_path = %[1]q
@@ -681,7 +676,7 @@ resource "aws_fsx_data_repository_association" "test" {
 
 func testAccDataRepositoryAssociationConfig_s3FullPolicy(bucketName, fileSystemPath string) string {
 	bucketPath := fmt.Sprintf("s3://%s", bucketName)
-	return acctest.ConfigCompose(testAccDataRepositoryAssociationBucketConfig(bucketName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccDataRepositoryAssociationConfig_s3Bucket(bucketName), fmt.Sprintf(`
 resource "aws_fsx_data_repository_association" "test" {
   file_system_id       = aws_fsx_lustre_file_system.test.id
   data_repository_path = %[1]q

--- a/internal/service/fsx/file_cache.go
+++ b/internal/service/fsx/file_cache.go
@@ -22,7 +22,8 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_fsx_file_cache")
+// @SDKResource("aws_fsx_file_cache", name="File Cache")
+// @Tags(identifierAttribute="arn")
 func ResourceFileCache() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceFileCacheCreate,
@@ -279,8 +280,8 @@ func ResourceFileCache() *schema.Resource {
 				MaxItems: 50,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -296,8 +297,6 @@ const (
 
 func resourceFileCacheCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).FSxConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &fsx.CreateFileCacheInput{
 		ClientRequestToken:   aws.String(id.UniqueId()),
@@ -305,6 +304,7 @@ func resourceFileCacheCreate(ctx context.Context, d *schema.ResourceData, meta i
 		FileCacheTypeVersion: aws.String(d.Get("file_cache_type_version").(string)),
 		StorageCapacity:      aws.Int64(int64(d.Get("storage_capacity").(int))),
 		SubnetIds:            flex.ExpandStringList(d.Get("subnet_ids").([]interface{})),
+		Tags:                 GetTagsIn(ctx),
 	}
 	if v, ok := d.GetOk("copy_tags_to_data_repository_associations"); ok {
 		input.CopyTagsToDataRepositoryAssociations = aws.Bool(v.(bool))
@@ -320,9 +320,6 @@ func resourceFileCacheCreate(ctx context.Context, d *schema.ResourceData, meta i
 	}
 	if v, ok := d.GetOk("security_group_ids"); ok {
 		input.SecurityGroupIds = flex.ExpandStringSet(v.(*schema.Set))
-	}
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	result, err := conn.CreateFileCacheWithContext(ctx, input)
@@ -342,8 +339,6 @@ func resourceFileCacheCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 func resourceFileCacheRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).FSxConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	filecache, err := findFileCacheByID(ctx, conn, d.Id())
 
@@ -385,37 +380,17 @@ func resourceFileCacheRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	dataRepositoryAssociations, err := findDataRepositoryAssociationsByIDs(ctx, conn, filecache.DataRepositoryAssociationIds)
 
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 	if err := d.Set("data_repository_association", flattenDataRepositoryAssociations(ctx, dataRepositoryAssociations, defaultTagsConfig, ignoreTagsConfig)); err != nil {
 		return create.DiagError(names.FSx, create.ErrActionSetting, ResNameFileCache, d.Id(), err)
 	}
 
-	//Cache tags do not get returned with describe call so need to make a separate list tags call
-	tags, tagserr := ListTags(ctx, conn, *filecache.ResourceARN)
-
-	if tagserr != nil {
-		return create.DiagError(names.FSx, create.ErrActionReading, ResNameFileCache, d.Id(), err)
-	} else {
-		tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-	}
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return create.DiagError(names.FSx, create.ErrActionSetting, ResNameFileCache, d.Id(), err)
-	}
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return create.DiagError(names.FSx, create.ErrActionSetting, ResNameFileCache, d.Id(), err)
-	}
 	return nil
 }
 
 func resourceFileCacheUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).FSxConn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return create.DiagError(names.FSx, create.ErrActionUpdating, ResNameFileCache, d.Id(), err)
-		}
-	}
 
 	if d.HasChangesExcept("tags_all") {
 		input := &fsx.UpdateFileCacheInput{

--- a/internal/service/fsx/file_cache.go
+++ b/internal/service/fsx/file_cache.go
@@ -380,10 +380,6 @@ func resourceFileCacheRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	dataRepositoryAssociations, err := findDataRepositoryAssociationsByIDs(ctx, conn, filecache.DataRepositoryAssociationIds)
 
-	if err != nil {
-		return create.DiagError(names.FSx, create.ErrActionSetting, ResNameFileCache, d.Id(), err)
-	}
-
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 	if err := d.Set("data_repository_association", flattenDataRepositoryAssociations(ctx, dataRepositoryAssociations, defaultTagsConfig, ignoreTagsConfig)); err != nil {

--- a/internal/service/fsx/file_cache.go
+++ b/internal/service/fsx/file_cache.go
@@ -380,6 +380,10 @@ func resourceFileCacheRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	dataRepositoryAssociations, err := findDataRepositoryAssociationsByIDs(ctx, conn, filecache.DataRepositoryAssociationIds)
 
+	if err != nil {
+		return create.DiagError(names.FSx, create.ErrActionSetting, ResNameFileCache, d.Id(), err)
+	}
+
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 	if err := d.Set("data_repository_association", flattenDataRepositoryAssociations(ctx, dataRepositoryAssociations, defaultTagsConfig, ignoreTagsConfig)); err != nil {

--- a/internal/service/fsx/file_cache.go
+++ b/internal/service/fsx/file_cache.go
@@ -378,7 +378,7 @@ func resourceFileCacheRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	// Lookup and set Data Repository Associations
 
-	dataRepositoryAssociations, err := findDataRepositoryAssociationsByIDs(ctx, conn, filecache.DataRepositoryAssociationIds)
+	dataRepositoryAssociations, _ := findDataRepositoryAssociationsByIDs(ctx, conn, filecache.DataRepositoryAssociationIds)
 
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig

--- a/internal/service/fsx/file_cache_test.go
+++ b/internal/service/fsx/file_cache_test.go
@@ -25,8 +25,8 @@ func TestAccFSxFileCache_serial(t *testing.T) {
 
 	testCases := map[string]map[string]func(t *testing.T){
 		"FSxFileCache": {
-			"basic":      TestAccFSxFileCache_basic,
-			"disappears": TestAccFSxFileCache_disappears,
+			"basic":      testAccFileCache_basic,
+			"disappears": testAccFileCache_disappears,
 			"kms_key_id": testAccFileCache_kmsKeyID,
 			"copy_tags_to_data_repository_associations": testAccFileCache_copyTagsToDataRepositoryAssociations,
 			"data_repository_association_multiple":      testAccFileCache_dataRepositoryAssociation_multiple,
@@ -40,7 +40,7 @@ func TestAccFSxFileCache_serial(t *testing.T) {
 	acctest.RunSerialTests2Levels(t, testCases, 0)
 }
 
-func TestAccFSxFileCache_basic(t *testing.T) {
+func testAccFileCache_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -85,7 +85,7 @@ func TestAccFSxFileCache_basic(t *testing.T) {
 	})
 }
 
-func TestAccFSxFileCache_disappears(t *testing.T) {
+func testAccFileCache_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")

--- a/internal/service/fsx/lustre_file_system.go
+++ b/internal/service/fsx/lustre_file_system.go
@@ -23,9 +23,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_fsx_lustre_file_system")
+// @SDKResource("aws_fsx_lustre_file_system", name="Lustre File System")
+// @Tags(identifierAttribute="arn")
 func ResourceLustreFileSystem() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceLustreFileSystemCreate,
@@ -117,8 +119,8 @@ func ResourceLustreFileSystem() *schema.Resource {
 				MaxItems: 1,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -269,8 +271,6 @@ func resourceLustreFileSystemSchemaCustomizeDiff(_ context.Context, d *schema.Re
 func resourceLustreFileSystemCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &fsx.CreateFileSystemInput{
 		ClientRequestToken: aws.String(id.UniqueId()),
@@ -281,6 +281,7 @@ func resourceLustreFileSystemCreate(ctx context.Context, d *schema.ResourceData,
 		LustreConfiguration: &fsx.CreateFileSystemLustreConfiguration{
 			DeploymentType: aws.String(d.Get("deployment_type").(string)),
 		},
+		Tags: GetTagsIn(ctx),
 	}
 
 	backupInput := &fsx.CreateFileSystemFromBackupInput{
@@ -290,6 +291,7 @@ func resourceLustreFileSystemCreate(ctx context.Context, d *schema.ResourceData,
 		LustreConfiguration: &fsx.CreateFileSystemLustreConfiguration{
 			DeploymentType: aws.String(d.Get("deployment_type").(string)),
 		},
+		Tags: GetTagsIn(ctx),
 	}
 
 	//Applicable only for TypePersistent1 and TypePersistent2
@@ -326,11 +328,6 @@ func resourceLustreFileSystemCreate(ctx context.Context, d *schema.ResourceData,
 	if v, ok := d.GetOk("security_group_ids"); ok {
 		input.SecurityGroupIds = flex.ExpandStringSet(v.(*schema.Set))
 		backupInput.SecurityGroupIds = flex.ExpandStringSet(v.(*schema.Set))
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-		backupInput.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	if v, ok := d.GetOk("weekly_maintenance_start_time"); ok {
@@ -406,14 +403,6 @@ func resourceLustreFileSystemUpdate(ctx context.Context, d *schema.ResourceData,
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxConn()
 
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating FSx Lustre File System (%s) tags: %s", d.Get("arn").(string), err)
-		}
-	}
-
 	if d.HasChangesExcept("tags_all", "tags") {
 		var waitAdminAction = false
 		input := &fsx.UpdateFileSystemInput{
@@ -473,8 +462,6 @@ func resourceLustreFileSystemUpdate(ctx context.Context, d *schema.ResourceData,
 func resourceLustreFileSystemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	filesystem, err := FindFileSystemByID(ctx, conn, d.Id())
 	if !d.IsNewResource() && tfresource.NotFound(err) {
@@ -530,16 +517,7 @@ func resourceLustreFileSystemRead(ctx context.Context, d *schema.ResourceData, m
 		return sdkdiag.AppendErrorf(diags, "setting log_configuration: %s", err)
 	}
 
-	tags := KeyValueTags(ctx, filesystem.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, filesystem.Tags)
 
 	d.Set("vpc_id", filesystem.VpcId)
 	d.Set("weekly_maintenance_start_time", lustreConfig.WeeklyMaintenanceStartTime)

--- a/internal/service/fsx/ontap_file_system.go
+++ b/internal/service/fsx/ontap_file_system.go
@@ -19,9 +19,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_fsx_ontap_file_system")
+// @SDKResource("aws_fsx_ontap_file_system", name="ONTAP File System")
+// @Tags(identifierAttribute="arn")
 func ResourceOntapFileSystem() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceOntapFileSystemCreate,
@@ -203,8 +205,8 @@ func ResourceOntapFileSystem() *schema.Resource {
 				MaxItems: 2,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"throughput_capacity": {
 				Type:         schema.TypeInt,
 				Required:     true,
@@ -232,8 +234,6 @@ func ResourceOntapFileSystem() *schema.Resource {
 func resourceOntapFileSystemCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &fsx.CreateFileSystemInput{
 		ClientRequestToken: aws.String(id.UniqueId()),
@@ -247,6 +247,7 @@ func resourceOntapFileSystemCreate(ctx context.Context, d *schema.ResourceData, 
 			ThroughputCapacity:           aws.Int64(int64(d.Get("throughput_capacity").(int))),
 			PreferredSubnetId:            aws.String(d.Get("preferred_subnet_id").(string)),
 		},
+		Tags: GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("kms_key_id"); ok {
@@ -281,11 +282,6 @@ func resourceOntapFileSystemCreate(ctx context.Context, d *schema.ResourceData, 
 		input.OntapConfiguration.WeeklyMaintenanceStartTime = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
-	log.Printf("[DEBUG] Creating FSx ONTAP File System: %s", input)
 	result, err := conn.CreateFileSystemWithContext(ctx, input)
 
 	if err != nil {
@@ -304,8 +300,6 @@ func resourceOntapFileSystemCreate(ctx context.Context, d *schema.ResourceData, 
 func resourceOntapFileSystemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	filesystem, err := FindFileSystemByID(ctx, conn, d.Id())
 
@@ -360,16 +354,7 @@ func resourceOntapFileSystemRead(ctx context.Context, d *schema.ResourceData, me
 		return sdkdiag.AppendErrorf(diags, "setting disk_iops_configuration: %s", err)
 	}
 
-	tags := KeyValueTags(ctx, filesystem.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, filesystem.Tags)
 
 	return diags
 }
@@ -377,14 +362,6 @@ func resourceOntapFileSystemRead(ctx context.Context, d *schema.ResourceData, me
 func resourceOntapFileSystemUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxConn()
-
-	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Get("arn").(string), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating FSx ONTAP File System (%s) tags: %s", d.Get("arn").(string), err)
-		}
-	}
 
 	if d.HasChangesExcept("tags_all", "tags") {
 		input := &fsx.UpdateFileSystemInput{

--- a/internal/service/fsx/ontap_storage_virtual_machine_migrate.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine_migrate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func ResourceOntapStorageVirtualMachineV0() *schema.Resource {
@@ -196,8 +197,8 @@ func ResourceOntapStorageVirtualMachineV0() *schema.Resource {
 				Sensitive:    true,
 				ValidateFunc: validation.StringLenBetween(8, 50),
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"uuid": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/internal/service/fsx/service_package_gen.go
+++ b/internal/service/fsx/service_package_gen.go
@@ -33,42 +33,82 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceBackup,
 			TypeName: "aws_fsx_backup",
+			Name:     "Backup",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceDataRepositoryAssociation,
 			TypeName: "aws_fsx_data_repository_association",
+			Name:     "Data Repository Association",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceFileCache,
 			TypeName: "aws_fsx_file_cache",
+			Name:     "File Cache",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceLustreFileSystem,
 			TypeName: "aws_fsx_lustre_file_system",
+			Name:     "Lustre File System",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceOntapFileSystem,
 			TypeName: "aws_fsx_ontap_file_system",
+			Name:     "ONTAP File System",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceOntapStorageVirtualMachine,
 			TypeName: "aws_fsx_ontap_storage_virtual_machine",
+			Name:     "ONTAP Storage Virtual Machine",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceOntapVolume,
 			TypeName: "aws_fsx_ontap_volume",
+			Name:     "ONTAP Volume",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceOpenzfsFileSystem,
 			TypeName: "aws_fsx_openzfs_file_system",
+			Name:     "OpenZFS File System",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceOpenzfsSnapshot,
 			TypeName: "aws_fsx_openzfs_snapshot",
+			Name:     "OpenZFS Snapshot",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceOpenzfsVolume,
 			TypeName: "aws_fsx_openzfs_volume",
+			Name:     "OpenZFS Volume",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceWindowsFileSystem,

--- a/internal/service/fsx/service_package_gen.go
+++ b/internal/service/fsx/service_package_gen.go
@@ -113,6 +113,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceWindowsFileSystem,
 			TypeName: "aws_fsx_windows_file_system",
+			Name:     "Windows File System",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 	}
 }

--- a/internal/service/fsx/windows_file_system.go
+++ b/internal/service/fsx/windows_file_system.go
@@ -217,8 +217,9 @@ func ResourceWindowsFileSystem() *schema.Resource {
 				MinItems: 1,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			"tags":            tftags.TagsSchema(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"throughput_capacity": {
 				Type:         schema.TypeInt,
 				Required:     true,

--- a/internal/service/fsx/windows_file_system.go
+++ b/internal/service/fsx/windows_file_system.go
@@ -22,6 +22,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @SDKResource("aws_fsx_windows_file_system", name="Windows File System")
@@ -218,7 +219,8 @@ func ResourceWindowsFileSystem() *schema.Resource {
 				MinItems: 1,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"tags": tftags.TagsSchema(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"throughput_capacity": {
 				Type:         schema.TypeInt,
 				Required:     true,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin SDK.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30421.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30430.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30449.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30454.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30461.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30463.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30476.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30477.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30478.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30483.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30484.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30491.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30509.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30510.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30512.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30516.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30517.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30533.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
=== RUN   TestAccFISExperimentTemplate_basic
=== PAUSE TestAccFISExperimentTemplate_basic
=== CONT  TestAccFISExperimentTemplate_basic
--- PASS: TestAccFISExperimentTemplate_basic (24.02s)
% make testacc TESTARGS='-run=TestAccFirehoseDeliveryStream_basic\|TestAccFirehoseDeliveryStream_tags' PKG=firehose ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/firehose/... -v -count 1 -parallel 2  -run=TestAccFirehoseDeliveryStream_basic\|TestAccFirehoseDeliveryStream_tags -timeout 180m
=== RUN   TestAccFirehoseDeliveryStream_basic
=== PAUSE TestAccFirehoseDeliveryStream_basic
=== RUN   TestAccFirehoseDeliveryStream_tags
=== PAUSE TestAccFirehoseDeliveryStream_tags
=== CONT  TestAccFirehoseDeliveryStream_basic
=== CONT  TestAccFirehoseDeliveryStream_tags
--- PASS: TestAccFirehoseDeliveryStream_tags (169.82s)
--- PASS: TestAccFirehoseDeliveryStream_basic (172.46s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/firehose	178.976s
```
```console
% ACCTEST_TIMEOUT=360m make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=fsx ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/fsx/... -v -count 1 -parallel 3  -run=_basic$\|_tags$ -timeout 360m
=== RUN   TestAccFSxBackup_basic
=== PAUSE TestAccFSxBackup_basic
=== RUN   TestAccFSxBackup_tags
=== PAUSE TestAccFSxBackup_tags
=== RUN   TestAccFSxDataRepositoryAssociation_basic
=== PAUSE TestAccFSxDataRepositoryAssociation_basic
=== RUN   TestAccFSxFileCache_basic
    file_cache_test.go:52: Step 1/2 error: Error running apply: exit status 1
        
        Error: setting Amazon FSx File Cache (fc-08be138dfd98c7965): empty result
        
          with aws_fsx_file_cache.test,
          on terraform_plugin_test.tf line 21, in resource "aws_fsx_file_cache" "test":
          21: resource "aws_fsx_file_cache" "test" {
        
--- FAIL: TestAccFSxFileCache_basic (903.25s)
=== RUN   TestAccFSxLustreFileSystem_basic
=== PAUSE TestAccFSxLustreFileSystem_basic
=== RUN   TestAccFSxLustreFileSystem_tags
=== PAUSE TestAccFSxLustreFileSystem_tags
=== RUN   TestAccFSxOntapFileSystem_basic
=== PAUSE TestAccFSxOntapFileSystem_basic
=== RUN   TestAccFSxOntapFileSystem_tags
=== PAUSE TestAccFSxOntapFileSystem_tags
=== RUN   TestAccFSxOntapStorageVirtualMachine_basic
=== PAUSE TestAccFSxOntapStorageVirtualMachine_basic
=== RUN   TestAccFSxOntapStorageVirtualMachine_tags
=== PAUSE TestAccFSxOntapStorageVirtualMachine_tags
=== RUN   TestAccFSxOntapVolume_basic
=== PAUSE TestAccFSxOntapVolume_basic
=== RUN   TestAccFSxOntapVolume_tags
=== PAUSE TestAccFSxOntapVolume_tags
=== RUN   TestAccFSxOpenzfsFileSystem_basic
=== PAUSE TestAccFSxOpenzfsFileSystem_basic
=== RUN   TestAccFSxOpenzfsFileSystem_tags
=== PAUSE TestAccFSxOpenzfsFileSystem_tags
=== RUN   TestAccFSxOpenzfsSnapshotDataSource_basic
=== PAUSE TestAccFSxOpenzfsSnapshotDataSource_basic
=== RUN   TestAccFSxOpenzfsSnapshot_basic
=== PAUSE TestAccFSxOpenzfsSnapshot_basic
=== RUN   TestAccFSxOpenzfsSnapshot_tags
=== PAUSE TestAccFSxOpenzfsSnapshot_tags
=== RUN   TestAccFSxOpenzfsVolume_basic
=== PAUSE TestAccFSxOpenzfsVolume_basic
=== RUN   TestAccFSxOpenzfsVolume_tags
=== PAUSE TestAccFSxOpenzfsVolume_tags
=== RUN   TestAccFSxWindowsFileSystem_basic
=== PAUSE TestAccFSxWindowsFileSystem_basic
=== RUN   TestAccFSxWindowsFileSystem_tags
=== PAUSE TestAccFSxWindowsFileSystem_tags
=== CONT  TestAccFSxBackup_basic
=== CONT  TestAccFSxOntapVolume_tags
=== CONT  TestAccFSxOpenzfsSnapshot_tags
--- PASS: TestAccFSxOpenzfsSnapshot_tags (825.15s)
=== CONT  TestAccFSxWindowsFileSystem_basic
--- PASS: TestAccFSxBackup_basic (865.76s)
=== CONT  TestAccFSxWindowsFileSystem_tags
--- PASS: TestAccFSxOntapVolume_tags (3400.73s)
=== CONT  TestAccFSxOntapFileSystem_basic
--- PASS: TestAccFSxWindowsFileSystem_tags (3485.48s)
=== CONT  TestAccFSxOntapVolume_basic
--- PASS: TestAccFSxWindowsFileSystem_basic (3563.36s)
=== CONT  TestAccFSxOntapStorageVirtualMachine_tags
--- PASS: TestAccFSxOntapFileSystem_basic (2436.74s)
=== CONT  TestAccFSxOntapStorageVirtualMachine_basic
--- PASS: TestAccFSxOntapStorageVirtualMachine_tags (3194.00s)
=== CONT  TestAccFSxOntapFileSystem_tags
--- PASS: TestAccFSxOntapVolume_basic (3384.68s)
=== CONT  TestAccFSxOpenzfsVolume_tags
--- PASS: TestAccFSxOpenzfsVolume_tags (867.00s)
=== CONT  TestAccFSxOpenzfsVolume_basic
--- PASS: TestAccFSxOntapStorageVirtualMachine_basic (3179.20s)
=== CONT  TestAccFSxOpenzfsSnapshotDataSource_basic
    openzfs_snapshot_data_source_test.go:21: Step 5/7 error: Check failed: Check 5/6 error: data.aws_fsx_openzfs_snapshot.test: Attribute "tags.%" is "1", but "tags.%" is not set in aws_fsx_openzfs_snapshot.test
--- PASS: TestAccFSxOpenzfsVolume_basic (820.26s)
=== CONT  TestAccFSxOpenzfsSnapshot_basic
--- FAIL: TestAccFSxOpenzfsSnapshotDataSource_basic (911.42s)
=== CONT  TestAccFSxOpenzfsFileSystem_tags
--- PASS: TestAccFSxOpenzfsSnapshot_basic (849.93s)
=== CONT  TestAccFSxOpenzfsFileSystem_basic
--- PASS: TestAccFSxOntapFileSystem_tags (2737.60s)
=== CONT  TestAccFSxLustreFileSystem_basic
--- PASS: TestAccFSxOpenzfsFileSystem_tags (728.96s)
=== CONT  TestAccFSxLustreFileSystem_tags
--- PASS: TestAccFSxOpenzfsFileSystem_basic (714.40s)
=== CONT  TestAccFSxDataRepositoryAssociation_basic
--- PASS: TestAccFSxLustreFileSystem_basic (690.74s)
=== CONT  TestAccFSxBackup_tags
=== CONT  TestAccFSxDataRepositoryAssociation_basic
    data_repository_association_test.go:34: Step 1/2 error: Error running apply: exit status 1
        
        Error: error creating S3 bucket ACL for tf-acc-test-6065719612061232000: AccessControlListNotSupported: The bucket does not allow ACLs
        	status code: 400, request id: AF1KEKC0TWP6RYCH, host id: wrIzSkw6jKJT2gZlPGC6Z8Q+poyD7BwdvCj+kCkNhKHEWEwKbapE/QHZQdeY2/BSxlAFmJF19tk=
        
          with aws_s3_bucket_acl.test,
          on terraform_plugin_test.tf line 34, in resource "aws_s3_bucket_acl" "test":
          34: resource "aws_s3_bucket_acl" "test" {
        
--- PASS: TestAccFSxLustreFileSystem_tags (704.48s)
--- FAIL: TestAccFSxDataRepositoryAssociation_basic (823.05s)
--- PASS: TestAccFSxBackup_tags (849.08s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/fsx	12768.605s
FAIL
make: *** [testacc] Error 1
```
```console
 % ACCTEST_TIMEOUT=360m make testacc TESTARGS='-run=TestAccFSxFileCache_serial/basic\|TestAccFSxFileCache_serial/tags\|TestAccFSxDataRepositoryAssociation_basic' PKG=fsx ACCTEST_PARALLELISM=3 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/fsx/... -v -count 1 -parallel 3  -run=TestAccFSxFileCache_serial/basic\|TestAccFSxFileCache_serial/tags\|TestAccFSxDataRepositoryAssociation_basic -timeout 360m
=== RUN   TestAccFSxDataRepositoryAssociation_basic
=== PAUSE TestAccFSxDataRepositoryAssociation_basic
=== RUN   TestAccFSxFileCache_serial
=== PAUSE TestAccFSxFileCache_serial
=== CONT  TestAccFSxDataRepositoryAssociation_basic
=== CONT  TestAccFSxFileCache_serial
--- PASS: TestAccFSxFileCache_serial (0.00s)
--- PASS: TestAccFSxDataRepositoryAssociation_basic (668.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/fsx	673.585s
```
```console
% ACCTEST_TIMEOUT=360m make testacc TESTARGS='-run=TestAccFSxFileCache_serial/FSxFileCache/basic\|TestAccFSxFileCache_serial/FSxFileCache/tags' PKG=fsx
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/fsx/... -v -count 1 -parallel 20  -run=TestAccFSxFileCache_serial/FSxFileCache/basic\|TestAccFSxFileCache_serial/FSxFileCache/tags -timeout 360m
=== RUN   TestAccFSxFileCache_serial
=== PAUSE TestAccFSxFileCache_serial
=== CONT  TestAccFSxFileCache_serial
=== RUN   TestAccFSxFileCache_serial/FSxFileCache
=== RUN   TestAccFSxFileCache_serial/FSxFileCache/tags
=== RUN   TestAccFSxFileCache_serial/FSxFileCache/copy_tags_to_data_repository_associations
=== RUN   TestAccFSxFileCache_serial/FSxFileCache/basic
--- PASS: TestAccFSxFileCache_serial (2838.36s)
    --- PASS: TestAccFSxFileCache_serial/FSxFileCache (2838.36s)
        --- PASS: TestAccFSxFileCache_serial/FSxFileCache/tags (1052.77s)
        --- PASS: TestAccFSxFileCache_serial/FSxFileCache/copy_tags_to_data_repository_associations (873.11s)
        --- PASS: TestAccFSxFileCache_serial/FSxFileCache/basic (912.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/fsx	2843.388s
```