### PR TITLE
r/aws_msk_serverless_cluster: `vpc_config.security_group_ids` is Computed

### DIFF
--- a/.changelog/30535.txt
+++ b/.changelog/30535.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_msk_serverless_cluster: Change `vpc_config.security_group_ids` to Computed
+```

--- a/internal/service/kafka/serverless_cluster.go
+++ b/internal/service/kafka/serverless_cluster.go
@@ -95,6 +95,7 @@ func ResourceServerlessCluster() *schema.Resource {
 						"security_group_ids": {
 							Type:     schema.TypeSet,
 							Optional: true,
+							Computed: true,
 							ForceNew: true,
 							MaxItems: 5,
 							Elem: &schema.Schema{

--- a/internal/service/kafka/serverless_cluster_test.go
+++ b/internal/service/kafka/serverless_cluster_test.go
@@ -40,7 +40,7 @@ func TestAccKafkaServerlessCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "client_authentication.0.sasl.0.iam.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.security_group_ids.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.security_group_ids.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.0.subnet_ids.#", "2"),
 				),
 			},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Changes `aws_msk_serverless_cluster.vpc_config.security_group_ids` to _Computed_.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/30532.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccKafkaServerlessCluster_' PKG=kafka ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kafka/... -v -count 1 -parallel 2  -run=TestAccKafkaServerlessCluster_ -timeout 180m
=== RUN   TestAccKafkaServerlessCluster_basic
=== PAUSE TestAccKafkaServerlessCluster_basic
=== RUN   TestAccKafkaServerlessCluster_disappears
=== PAUSE TestAccKafkaServerlessCluster_disappears
=== RUN   TestAccKafkaServerlessCluster_tags
=== PAUSE TestAccKafkaServerlessCluster_tags
=== RUN   TestAccKafkaServerlessCluster_securityGroup
=== PAUSE TestAccKafkaServerlessCluster_securityGroup
=== CONT  TestAccKafkaServerlessCluster_basic
=== CONT  TestAccKafkaServerlessCluster_tags
--- PASS: TestAccKafkaServerlessCluster_tags (299.73s)
=== CONT  TestAccKafkaServerlessCluster_securityGroup
--- PASS: TestAccKafkaServerlessCluster_basic (305.60s)
=== CONT  TestAccKafkaServerlessCluster_disappears
--- PASS: TestAccKafkaServerlessCluster_disappears (194.84s)
--- PASS: TestAccKafkaServerlessCluster_securityGroup (205.48s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kafka	520.286s
```
