### PR TITLE
r/aws_batch_compute_environment: Fix crash when `compute_resources.launch_template` is empty

### DIFF
--- a/.changelog/30537.txt
+++ b/.changelog/30537.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_batch_compute_environment: Fix crash when `compute_resources.launch_template` is empty
+```

--- a/internal/service/batch/compute_environment.go
+++ b/internal/service/batch/compute_environment.go
@@ -660,7 +660,7 @@ func expandComputeResource(ctx context.Context, tfMap map[string]interface{}) *b
 		apiObject.InstanceTypes = flex.ExpandStringSet(v)
 	}
 
-	if v, ok := tfMap["launch_template"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["launch_template"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.LaunchTemplate = expandLaunchTemplateSpecification(v[0].(map[string]interface{}))
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Ibid.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #30378.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccBatchComputeEnvironment_basic\|TestAccBatchComputeEnvironment_launchTemplate' PKG=batch ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/batch/... -v -count 1 -parallel 2  -run=TestAccBatchComputeEnvironment_basic\|TestAccBatchComputeEnvironment_launchTemplate -timeout 180m
=== RUN   TestAccBatchComputeEnvironment_basic
=== PAUSE TestAccBatchComputeEnvironment_basic
=== RUN   TestAccBatchComputeEnvironment_launchTemplate
=== PAUSE TestAccBatchComputeEnvironment_launchTemplate
=== CONT  TestAccBatchComputeEnvironment_basic
=== CONT  TestAccBatchComputeEnvironment_launchTemplate
--- PASS: TestAccBatchComputeEnvironment_launchTemplate (37.71s)
--- PASS: TestAccBatchComputeEnvironment_basic (41.85s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/batch	47.252s
```
