### PR TITLE
r/aws_launch_template: Fix crash when `instance_market_options.spot_options` is empty

### DIFF
--- a/.changelog/30539.txt
+++ b/.changelog/30539.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_launch_template: Fix crash when `instance_market_options.spot_options` is empty
+```

--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -1314,7 +1314,7 @@ func expandLaunchTemplateBlockDeviceMappingRequest(tfMap map[string]interface{})
 
 	apiObject := &ec2.LaunchTemplateBlockDeviceMappingRequest{}
 
-	if v, ok := tfMap["ebs"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["ebs"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.Ebs = expandLaunchTemplateEBSBlockDeviceRequest(v[0].(map[string]interface{}))
 	}
 
@@ -1412,7 +1412,7 @@ func expandLaunchTemplateCapacityReservationSpecificationRequest(tfMap map[strin
 		apiObject.CapacityReservationPreference = aws.String(v)
 	}
 
-	if v, ok := tfMap["capacity_reservation_target"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["capacity_reservation_target"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.CapacityReservationTarget = expandCapacityReservationTarget(v[0].(map[string]interface{}))
 	}
 
@@ -1546,7 +1546,7 @@ func expandLaunchTemplateInstanceMarketOptionsRequest(tfMap map[string]interface
 		apiObject.MarketType = aws.String(v)
 	}
 
-	if v, ok := tfMap["spot_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["spot_options"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.SpotOptions = expandLaunchTemplateSpotMarketOptionsRequest(v[0].(map[string]interface{}))
 	}
 
@@ -1560,7 +1560,7 @@ func expandInstanceRequirementsRequest(tfMap map[string]interface{}) *ec2.Instan
 
 	apiObject := &ec2.InstanceRequirementsRequest{}
 
-	if v, ok := tfMap["accelerator_count"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["accelerator_count"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.AcceleratorCount = expandAcceleratorCountRequest(v[0].(map[string]interface{}))
 	}
 
@@ -1572,7 +1572,7 @@ func expandInstanceRequirementsRequest(tfMap map[string]interface{}) *ec2.Instan
 		apiObject.AcceleratorNames = flex.ExpandStringSet(v)
 	}
 
-	if v, ok := tfMap["accelerator_total_memory_mib"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["accelerator_total_memory_mib"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.AcceleratorTotalMemoryMiB = expandAcceleratorTotalMemoryMiBRequest(v[0].(map[string]interface{}))
 	}
 
@@ -1588,7 +1588,7 @@ func expandInstanceRequirementsRequest(tfMap map[string]interface{}) *ec2.Instan
 		apiObject.BareMetal = aws.String(v)
 	}
 
-	if v, ok := tfMap["baseline_ebs_bandwidth_mbps"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["baseline_ebs_bandwidth_mbps"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.BaselineEbsBandwidthMbps = expandBaselineEBSBandwidthMbpsRequest(v[0].(map[string]interface{}))
 	}
 
@@ -1616,19 +1616,19 @@ func expandInstanceRequirementsRequest(tfMap map[string]interface{}) *ec2.Instan
 		apiObject.LocalStorageTypes = flex.ExpandStringSet(v)
 	}
 
-	if v, ok := tfMap["memory_gib_per_vcpu"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["memory_gib_per_vcpu"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.MemoryGiBPerVCpu = expandMemoryGiBPerVCPURequest(v[0].(map[string]interface{}))
 	}
 
-	if v, ok := tfMap["memory_mib"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["memory_mib"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.MemoryMiB = expandMemoryMiBRequest(v[0].(map[string]interface{}))
 	}
 
-	if v, ok := tfMap["network_bandwidth_gbps"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["network_bandwidth_gbps"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.NetworkBandwidthGbps = expandNetworkBandwidthGbpsRequest(v[0].(map[string]interface{}))
 	}
 
-	if v, ok := tfMap["network_interface_count"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["network_interface_count"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.NetworkInterfaceCount = expandNetworkInterfaceCountRequest(v[0].(map[string]interface{}))
 	}
 
@@ -1644,11 +1644,11 @@ func expandInstanceRequirementsRequest(tfMap map[string]interface{}) *ec2.Instan
 		apiObject.SpotMaxPricePercentageOverLowestPrice = aws.Int64(int64(v))
 	}
 
-	if v, ok := tfMap["total_local_storage_gb"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["total_local_storage_gb"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.TotalLocalStorageGB = expandTotalLocalStorageGBRequest(v[0].(map[string]interface{}))
 	}
 
-	if v, ok := tfMap["vcpu_count"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["vcpu_count"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.VCpuCount = expandVCPUCountRangeRequest(v[0].(map[string]interface{}))
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Ibid.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29374.
Closes #24009.
Closes #27819.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccEC2LaunchTemplate_' PKG=ec2 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 2  -run=TestAccEC2LaunchTemplate_ -timeout 180m
=== RUN   TestAccEC2LaunchTemplate_basic
=== PAUSE TestAccEC2LaunchTemplate_basic
=== RUN   TestAccEC2LaunchTemplate_Name_generated
=== PAUSE TestAccEC2LaunchTemplate_Name_generated
=== RUN   TestAccEC2LaunchTemplate_Name_prefix
=== PAUSE TestAccEC2LaunchTemplate_Name_prefix
=== RUN   TestAccEC2LaunchTemplate_disappears
=== PAUSE TestAccEC2LaunchTemplate_disappears
=== RUN   TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs
=== PAUSE TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs
=== RUN   TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_deleteOnTermination
=== PAUSE TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_deleteOnTermination
=== RUN   TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_gp3
=== PAUSE TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_gp3
=== RUN   TestAccEC2LaunchTemplate_ebsOptimized
=== PAUSE TestAccEC2LaunchTemplate_ebsOptimized
=== RUN   TestAccEC2LaunchTemplate_elasticInferenceAccelerator
=== PAUSE TestAccEC2LaunchTemplate_elasticInferenceAccelerator
=== RUN   TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination
=== PAUSE TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination
=== RUN   TestAccEC2LaunchTemplate_data
=== PAUSE TestAccEC2LaunchTemplate_data
=== RUN   TestAccEC2LaunchTemplate_description
=== PAUSE TestAccEC2LaunchTemplate_description
=== RUN   TestAccEC2LaunchTemplate_update
=== PAUSE TestAccEC2LaunchTemplate_update
=== RUN   TestAccEC2LaunchTemplate_tags
=== PAUSE TestAccEC2LaunchTemplate_tags
=== RUN   TestAccEC2LaunchTemplate_CapacityReservation_preference
=== PAUSE TestAccEC2LaunchTemplate_CapacityReservation_preference
=== RUN   TestAccEC2LaunchTemplate_CapacityReservation_target
=== PAUSE TestAccEC2LaunchTemplate_CapacityReservation_target
=== RUN   TestAccEC2LaunchTemplate_cpuOptions
=== PAUSE TestAccEC2LaunchTemplate_cpuOptions
=== RUN   TestAccEC2LaunchTemplate_CreditSpecification_nonBurstable
=== PAUSE TestAccEC2LaunchTemplate_CreditSpecification_nonBurstable
=== RUN   TestAccEC2LaunchTemplate_CreditSpecification_t2
=== PAUSE TestAccEC2LaunchTemplate_CreditSpecification_t2
=== RUN   TestAccEC2LaunchTemplate_CreditSpecification_t3
=== PAUSE TestAccEC2LaunchTemplate_CreditSpecification_t3
=== RUN   TestAccEC2LaunchTemplate_CreditSpecification_t4g
=== PAUSE TestAccEC2LaunchTemplate_CreditSpecification_t4g
=== RUN   TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock
=== PAUSE TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock
=== RUN   TestAccEC2LaunchTemplate_networkInterface
=== PAUSE TestAccEC2LaunchTemplate_networkInterface
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceAddresses
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceAddresses
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceType
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceType
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceCardIndex
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceCardIndex
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes
=== RUN   TestAccEC2LaunchTemplate_associatePublicIPAddress
=== PAUSE TestAccEC2LaunchTemplate_associatePublicIPAddress
=== RUN   TestAccEC2LaunchTemplate_associateCarrierIPAddress
=== PAUSE TestAccEC2LaunchTemplate_associateCarrierIPAddress
=== RUN   TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN
=== PAUSE TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN
=== RUN   TestAccEC2LaunchTemplate_Placement_partitionNum
=== PAUSE TestAccEC2LaunchTemplate_Placement_partitionNum
=== RUN   TestAccEC2LaunchTemplate_privateDNSNameOptions
=== PAUSE TestAccEC2LaunchTemplate_privateDNSNameOptions
=== RUN   TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses
=== PAUSE TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses
=== RUN   TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount
=== PAUSE TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount
=== RUN   TestAccEC2LaunchTemplate_instanceMarketOptions
=== PAUSE TestAccEC2LaunchTemplate_instanceMarketOptions
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_allowedInstanceTypes
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_allowedInstanceTypes
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_bareMetal
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_bareMetal
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_localStorage
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_localStorage
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_networkBandwidthGbps
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_networkBandwidthGbps
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB
=== RUN   TestAccEC2LaunchTemplate_licenseSpecification
=== PAUSE TestAccEC2LaunchTemplate_licenseSpecification
=== RUN   TestAccEC2LaunchTemplate_metadataOptions
=== PAUSE TestAccEC2LaunchTemplate_metadataOptions
=== RUN   TestAccEC2LaunchTemplate_enclaveOptions
=== PAUSE TestAccEC2LaunchTemplate_enclaveOptions
=== RUN   TestAccEC2LaunchTemplate_hibernation
=== PAUSE TestAccEC2LaunchTemplate_hibernation
=== RUN   TestAccEC2LaunchTemplate_defaultVersion
=== PAUSE TestAccEC2LaunchTemplate_defaultVersion
=== RUN   TestAccEC2LaunchTemplate_updateDefaultVersion
=== PAUSE TestAccEC2LaunchTemplate_updateDefaultVersion
=== CONT  TestAccEC2LaunchTemplate_basic
=== CONT  TestAccEC2LaunchTemplate_Placement_partitionNum
--- PASS: TestAccEC2LaunchTemplate_basic (18.46s)
=== CONT  TestAccEC2LaunchTemplate_CreditSpecification_nonBurstable
--- PASS: TestAccEC2LaunchTemplate_Placement_partitionNum (30.65s)
=== CONT  TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_nonBurstable (16.64s)
=== CONT  TestAccEC2LaunchTemplate_associateCarrierIPAddress
--- PASS: TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN (18.38s)
=== CONT  TestAccEC2LaunchTemplate_associatePublicIPAddress
--- PASS: TestAccEC2LaunchTemplate_associateCarrierIPAddress (51.04s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes
--- PASS: TestAccEC2LaunchTemplate_associatePublicIPAddress (51.89s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes (15.97s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount (19.97s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes (20.46s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceCardIndex
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount (15.90s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceType
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceCardIndex (15.87s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceAddresses
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceType (15.68s)
=== CONT  TestAccEC2LaunchTemplate_networkInterface
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceAddresses (22.54s)
=== CONT  TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock
--- PASS: TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock (13.48s)
=== CONT  TestAccEC2LaunchTemplate_CreditSpecification_t4g
--- PASS: TestAccEC2LaunchTemplate_networkInterface (23.36s)
=== CONT  TestAccEC2LaunchTemplate_CreditSpecification_t3
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_t4g (16.06s)
=== CONT  TestAccEC2LaunchTemplate_CreditSpecification_t2
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_t3 (16.34s)
=== CONT  TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_t2 (16.16s)
=== CONT  TestAccEC2LaunchTemplate_cpuOptions
--- PASS: TestAccEC2LaunchTemplate_cpuOptions (13.10s)
=== CONT  TestAccEC2LaunchTemplate_CapacityReservation_target
--- PASS: TestAccEC2LaunchTemplate_CapacityReservation_target (18.78s)
=== CONT  TestAccEC2LaunchTemplate_CapacityReservation_preference
--- PASS: TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination (46.83s)
=== CONT  TestAccEC2LaunchTemplate_tags
--- PASS: TestAccEC2LaunchTemplate_CapacityReservation_preference (15.94s)
=== CONT  TestAccEC2LaunchTemplate_update
--- PASS: TestAccEC2LaunchTemplate_tags (37.40s)
=== CONT  TestAccEC2LaunchTemplate_description
--- PASS: TestAccEC2LaunchTemplate_description (26.85s)
=== CONT  TestAccEC2LaunchTemplate_data
--- PASS: TestAccEC2LaunchTemplate_data (17.57s)
=== CONT  TestAccEC2LaunchTemplate_ebsOptimized
--- PASS: TestAccEC2LaunchTemplate_update (91.75s)
=== CONT  TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_deleteOnTermination
--- PASS: TestAccEC2LaunchTemplate_ebsOptimized (58.40s)
=== CONT  TestAccEC2LaunchTemplate_elasticInferenceAccelerator
--- PASS: TestAccEC2LaunchTemplate_elasticInferenceAccelerator (26.14s)
=== CONT  TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_gp3
--- PASS: TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_deleteOnTermination (80.05s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations
--- PASS: TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_gp3 (56.01s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations (64.62s)
=== CONT  TestAccEC2LaunchTemplate_updateDefaultVersion
--- PASS: TestAccEC2LaunchTemplate_updateDefaultVersion (47.02s)
=== CONT  TestAccEC2LaunchTemplate_defaultVersion
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB (92.88s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes
--- PASS: TestAccEC2LaunchTemplate_defaultVersion (36.92s)
=== CONT  TestAccEC2LaunchTemplate_hibernation
--- PASS: TestAccEC2LaunchTemplate_hibernation (39.04s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes (67.66s)
=== CONT  TestAccEC2LaunchTemplate_enclaveOptions
--- PASS: TestAccEC2LaunchTemplate_enclaveOptions (39.32s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers (65.32s)
=== CONT  TestAccEC2LaunchTemplate_metadataOptions
--- PASS: TestAccEC2LaunchTemplate_metadataOptions (56.40s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance (89.89s)
=== CONT  TestAccEC2LaunchTemplate_licenseSpecification
--- PASS: TestAccEC2LaunchTemplate_licenseSpecification (18.69s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_bareMetal
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps (89.57s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_bareMetal (85.24s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_allowedInstanceTypes
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB (78.70s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_allowedInstanceTypes (51.03s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice (28.50s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes (50.95s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport (51.44s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount (54.99s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice (29.33s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_networkBandwidthGbps
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_networkBandwidthGbps (74.57s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount (77.12s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes (52.37s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_localStorage
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU (78.02s)
=== CONT  TestAccEC2LaunchTemplate_disappears
--- PASS: TestAccEC2LaunchTemplate_disappears (11.77s)
=== CONT  TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_localStorage (73.82s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers
--- PASS: TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs (40.57s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers (54.34s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount (79.44s)
=== CONT  TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount
--- PASS: TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount (15.84s)
=== CONT  TestAccEC2LaunchTemplate_instanceMarketOptions
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames (55.64s)
=== CONT  TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses
--- PASS: TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses (15.48s)
=== CONT  TestAccEC2LaunchTemplate_privateDNSNameOptions
--- PASS: TestAccEC2LaunchTemplate_privateDNSNameOptions (15.97s)
=== CONT  TestAccEC2LaunchTemplate_Name_prefix
--- PASS: TestAccEC2LaunchTemplate_Name_prefix (15.71s)
=== CONT  TestAccEC2LaunchTemplate_Name_generated
--- PASS: TestAccEC2LaunchTemplate_instanceMarketOptions (62.22s)
--- PASS: TestAccEC2LaunchTemplate_Name_generated (15.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	1394.538s
```
