### PR TITLE
new service aws_vpclattice_service_network_vpc_association

### DIFF
--- a/.changelog/30411.txt
+++ b/.changelog/30411.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_vpclattice_service_network_vpc_association
+```

--- a/internal/service/vpclattice/service_network_vpc_association.go
+++ b/internal/service/vpclattice/service_network_vpc_association.go
@@ -25,12 +25,12 @@ import (
 
 // @SDKResource("aws_vpclattice_service_network_vpc_association")
 // @Tags(identifierAttribute="arn")
-func ResourceServiceNetworkVpcAssociation() *schema.Resource {
+func ResourceServiceNetworkVPCAssociation() *schema.Resource {
 	return &schema.Resource{
-		CreateWithoutTimeout: resourceServiceNetworkVpcAssociationCreate,
-		ReadWithoutTimeout:   resourceServiceNetworkVpcAssociationRead,
-		UpdateWithoutTimeout: resourceServiceNetworkVpcAssociationUpdate,
-		DeleteWithoutTimeout: resourceServiceNetworkVpcAssociationDelete,
+		CreateWithoutTimeout: resourceServiceNetworkVPCAssociationCreate,
+		ReadWithoutTimeout:   resourceServiceNetworkVPCAssociationRead,
+		UpdateWithoutTimeout: resourceServiceNetworkVPCAssociationUpdate,
+		DeleteWithoutTimeout: resourceServiceNetworkVPCAssociationDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -80,10 +80,10 @@ func ResourceServiceNetworkVpcAssociation() *schema.Resource {
 }
 
 const (
-	ResNameServiceNetworkVpcAssociation = "ServiceNetworkVpcAssociation"
+	ResNameServiceNetworkVPCAssociation = "ServiceNetworkVPCAssociation"
 )
 
-func resourceServiceNetworkVpcAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceNetworkVPCAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).VPCLatticeClient()
 
 	in := &vpclattice.CreateServiceNetworkVpcAssociationInput{
@@ -99,26 +99,26 @@ func resourceServiceNetworkVpcAssociationCreate(ctx context.Context, d *schema.R
 
 	out, err := conn.CreateServiceNetworkVpcAssociation(ctx, in)
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionCreating, ResNameServiceNetworkVpcAssociation, "", err)
+		return create.DiagError(names.VPCLattice, create.ErrActionCreating, ResNameServiceNetworkVPCAssociation, "", err)
 	}
 
 	if out == nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionCreating, ResNameServiceNetworkVpcAssociation, "", errors.New("empty output"))
+		return create.DiagError(names.VPCLattice, create.ErrActionCreating, ResNameServiceNetworkVPCAssociation, "", errors.New("empty output"))
 	}
 
 	d.SetId(aws.ToString(out.Id))
 
-	if _, err := waitServiceNetworkVpcAssociationCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionWaitingForCreation, ResNameServiceNetworkVpcAssociation, d.Id(), err)
+	if _, err := waitServiceNetworkVPCAssociationCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return create.DiagError(names.VPCLattice, create.ErrActionWaitingForCreation, ResNameServiceNetworkVPCAssociation, d.Id(), err)
 	}
 
-	return resourceServiceNetworkVpcAssociationRead(ctx, d, meta)
+	return resourceServiceNetworkVPCAssociationRead(ctx, d, meta)
 }
 
-func resourceServiceNetworkVpcAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceNetworkVPCAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).VPCLatticeClient()
 
-	out, err := findServiceNetworkVpcAssociationByID(ctx, conn, d.Id())
+	out, err := findServiceNetworkVPCAssociationByID(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] VPCLattice Service Network VPC Association (%s) not found, removing from state", d.Id())
@@ -127,7 +127,7 @@ func resourceServiceNetworkVpcAssociationRead(ctx context.Context, d *schema.Res
 	}
 
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionReading, ResNameServiceNetworkVpcAssociation, d.Id(), err)
+		return create.DiagError(names.VPCLattice, create.ErrActionReading, ResNameServiceNetworkVPCAssociation, d.Id(), err)
 	}
 
 	d.Set("arn", out.Arn)
@@ -140,7 +140,7 @@ func resourceServiceNetworkVpcAssociationRead(ctx context.Context, d *schema.Res
 	return nil
 }
 
-func resourceServiceNetworkVpcAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceNetworkVPCAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).VPCLatticeClient()
 	if d.HasChangesExcept("tags", "tags_all") {
 		in := &vpclattice.UpdateServiceNetworkVpcAssociationInput{
@@ -154,15 +154,14 @@ func resourceServiceNetworkVpcAssociationUpdate(ctx context.Context, d *schema.R
 		log.Printf("[DEBUG] Updating VPCLattice ServiceNetwork VPC Association (%s): %#v", d.Id(), in)
 		_, err := conn.UpdateServiceNetworkVpcAssociation(ctx, in)
 		if err != nil {
-			return create.DiagError(names.VPCLattice, create.ErrActionUpdating, ResNameServiceNetworkVpcAssociation, d.Id(), err)
+			return create.DiagError(names.VPCLattice, create.ErrActionUpdating, ResNameServiceNetworkVPCAssociation, d.Id(), err)
 		}
-
 	}
 
-	return resourceServiceNetworkVpcAssociationRead(ctx, d, meta)
+	return resourceServiceNetworkVPCAssociationRead(ctx, d, meta)
 }
 
-func resourceServiceNetworkVpcAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceNetworkVPCAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).VPCLatticeClient()
 
 	log.Printf("[INFO] Deleting VPCLattice Service Network VPC Association %s", d.Id())
@@ -177,17 +176,17 @@ func resourceServiceNetworkVpcAssociationDelete(ctx context.Context, d *schema.R
 			return nil
 		}
 
-		return create.DiagError(names.VPCLattice, create.ErrActionDeleting, ResNameServiceNetworkVpcAssociation, d.Id(), err)
+		return create.DiagError(names.VPCLattice, create.ErrActionDeleting, ResNameServiceNetworkVPCAssociation, d.Id(), err)
 	}
 
-	if _, err := waitServiceNetworkVpcAssociationDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionWaitingForDeletion, ResNameServiceNetworkVpcAssociation, d.Id(), err)
+	if _, err := waitServiceNetworkVPCAssociationDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+		return create.DiagError(names.VPCLattice, create.ErrActionWaitingForDeletion, ResNameServiceNetworkVPCAssociation, d.Id(), err)
 	}
 
 	return nil
 }
 
-func findServiceNetworkVpcAssociationByID(ctx context.Context, conn *vpclattice.Client, id string) (*vpclattice.GetServiceNetworkVpcAssociationOutput, error) {
+func findServiceNetworkVPCAssociationByID(ctx context.Context, conn *vpclattice.Client, id string) (*vpclattice.GetServiceNetworkVpcAssociationOutput, error) {
 	in := &vpclattice.GetServiceNetworkVpcAssociationInput{
 		ServiceNetworkVpcAssociationIdentifier: aws.String(id),
 	}
@@ -211,11 +210,11 @@ func findServiceNetworkVpcAssociationByID(ctx context.Context, conn *vpclattice.
 	return out, nil
 }
 
-func waitServiceNetworkVpcAssociationCreated(ctx context.Context, conn *vpclattice.Client, id string, timeout time.Duration) (*vpclattice.GetServiceNetworkVpcAssociationOutput, error) {
+func waitServiceNetworkVPCAssociationCreated(ctx context.Context, conn *vpclattice.Client, id string, timeout time.Duration) (*vpclattice.GetServiceNetworkVpcAssociationOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending:                   enum.Slice(types.ServiceNetworkVpcAssociationStatusCreateInProgress),
 		Target:                    enum.Slice(types.ServiceNetworkVpcAssociationStatusActive),
-		Refresh:                   statusServiceNetworkVpcAssociation(ctx, conn, id),
+		Refresh:                   statusServiceNetworkVPCAssociation(ctx, conn, id),
 		Timeout:                   timeout,
 		NotFoundChecks:            20,
 		ContinuousTargetOccurence: 2,
@@ -229,11 +228,11 @@ func waitServiceNetworkVpcAssociationCreated(ctx context.Context, conn *vpclatti
 	return nil, err
 }
 
-func waitServiceNetworkVpcAssociationDeleted(ctx context.Context, conn *vpclattice.Client, id string, timeout time.Duration) (*vpclattice.GetServiceNetworkVpcAssociationOutput, error) {
+func waitServiceNetworkVPCAssociationDeleted(ctx context.Context, conn *vpclattice.Client, id string, timeout time.Duration) (*vpclattice.GetServiceNetworkVpcAssociationOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(types.ServiceNetworkVpcAssociationStatusDeleteInProgress, types.ServiceNetworkVpcAssociationStatusActive),
 		Target:  []string{},
-		Refresh: statusServiceNetworkVpcAssociation(ctx, conn, id),
+		Refresh: statusServiceNetworkVPCAssociation(ctx, conn, id),
 		Timeout: timeout,
 	}
 
@@ -245,9 +244,9 @@ func waitServiceNetworkVpcAssociationDeleted(ctx context.Context, conn *vpclatti
 	return nil, err
 }
 
-func statusServiceNetworkVpcAssociation(ctx context.Context, conn *vpclattice.Client, id string) retry.StateRefreshFunc {
+func statusServiceNetworkVPCAssociation(ctx context.Context, conn *vpclattice.Client, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		out, err := findServiceNetworkVpcAssociationByID(ctx, conn, id)
+		out, err := findServiceNetworkVPCAssociationByID(ctx, conn, id)
 		if tfresource.NotFound(err) {
 			return nil, "", nil
 		}

--- a/internal/service/vpclattice/service_network_vpc_association.go
+++ b/internal/service/vpclattice/service_network_vpc_association.go
@@ -1,0 +1,261 @@
+package vpclattice
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKResource("aws_vpclattice_service_network_vpc_association")
+// @Tags(identifierAttribute="arn")
+func ResourceServiceNetworkVpcAssociation() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceServiceNetworkVpcAssociationCreate,
+		ReadWithoutTimeout:   resourceServiceNetworkVpcAssociationRead,
+		UpdateWithoutTimeout: resourceServiceNetworkVpcAssociationUpdate,
+		DeleteWithoutTimeout: resourceServiceNetworkVpcAssociationDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"security_group_ids": {
+				Type:     schema.TypeList,
+				MaxItems: 5,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"service_network_identifier": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_identifier": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"tags":     tftags.TagsSchema(),
+			"tags_all": tftags.TagsSchemaComputed(),
+		},
+
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+const (
+	ResNameServiceNetworkVpcAssociation = "ServiceNetworkVpcAssociation"
+)
+
+func resourceServiceNetworkVpcAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).VPCLatticeClient()
+
+	in := &vpclattice.CreateServiceNetworkVpcAssociationInput{
+		ClientToken:              aws.String(id.UniqueId()),
+		ServiceNetworkIdentifier: aws.String(d.Get("service_network_identifier").(string)),
+		VpcIdentifier:            aws.String(d.Get("vpc_identifier").(string)),
+		Tags:                     GetTagsIn(ctx),
+	}
+
+	if v, ok := d.GetOk("security_group_ids"); ok {
+		in.SecurityGroupIds = flex.ExpandStringValueList(v.([]interface{}))
+	}
+
+	out, err := conn.CreateServiceNetworkVpcAssociation(ctx, in)
+	if err != nil {
+		return create.DiagError(names.VPCLattice, create.ErrActionCreating, ResNameServiceNetworkVpcAssociation, "", err)
+	}
+
+	if out == nil {
+		return create.DiagError(names.VPCLattice, create.ErrActionCreating, ResNameServiceNetworkVpcAssociation, "", errors.New("empty output"))
+	}
+
+	d.SetId(aws.ToString(out.Id))
+
+	if _, err := waitServiceNetworkVpcAssociationCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return create.DiagError(names.VPCLattice, create.ErrActionWaitingForCreation, ResNameServiceNetworkVpcAssociation, d.Id(), err)
+	}
+
+	return resourceServiceNetworkVpcAssociationRead(ctx, d, meta)
+}
+
+func resourceServiceNetworkVpcAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).VPCLatticeClient()
+
+	out, err := findServiceNetworkVpcAssociationByID(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] VPCLattice Service Network VPC Association (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.VPCLattice, create.ErrActionReading, ResNameServiceNetworkVpcAssociation, d.Id(), err)
+	}
+
+	d.Set("arn", out.Arn)
+	d.Set("created_by", out.CreatedBy)
+	d.Set("vpc_identifier", out.VpcId)
+	d.Set("service_network_identifier", out.ServiceNetworkId)
+	d.Set("security_group_ids", out.SecurityGroupIds)
+	d.Set("status", out.Status)
+
+	return nil
+}
+
+func resourceServiceNetworkVpcAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).VPCLatticeClient()
+	if d.HasChangesExcept("tags", "tags_all") {
+		in := &vpclattice.UpdateServiceNetworkVpcAssociationInput{
+			ServiceNetworkVpcAssociationIdentifier: aws.String(d.Id()),
+		}
+
+		if d.HasChange("security_group_ids") {
+			in.SecurityGroupIds = flex.ExpandStringValueList(d.Get("security_group_ids").([]interface{}))
+		}
+
+		log.Printf("[DEBUG] Updating VPCLattice ServiceNetwork VPC Association (%s): %#v", d.Id(), in)
+		_, err := conn.UpdateServiceNetworkVpcAssociation(ctx, in)
+		if err != nil {
+			return create.DiagError(names.VPCLattice, create.ErrActionUpdating, ResNameServiceNetworkVpcAssociation, d.Id(), err)
+		}
+
+	}
+
+	return resourceServiceNetworkVpcAssociationRead(ctx, d, meta)
+}
+
+func resourceServiceNetworkVpcAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).VPCLatticeClient()
+
+	log.Printf("[INFO] Deleting VPCLattice Service Network VPC Association %s", d.Id())
+
+	_, err := conn.DeleteServiceNetworkVpcAssociation(ctx, &vpclattice.DeleteServiceNetworkVpcAssociationInput{
+		ServiceNetworkVpcAssociationIdentifier: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		var nfe *types.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return nil
+		}
+
+		return create.DiagError(names.VPCLattice, create.ErrActionDeleting, ResNameServiceNetworkVpcAssociation, d.Id(), err)
+	}
+
+	if _, err := waitServiceNetworkVpcAssociationDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+		return create.DiagError(names.VPCLattice, create.ErrActionWaitingForDeletion, ResNameServiceNetworkVpcAssociation, d.Id(), err)
+	}
+
+	return nil
+}
+
+func findServiceNetworkVpcAssociationByID(ctx context.Context, conn *vpclattice.Client, id string) (*vpclattice.GetServiceNetworkVpcAssociationOutput, error) {
+	in := &vpclattice.GetServiceNetworkVpcAssociationInput{
+		ServiceNetworkVpcAssociationIdentifier: aws.String(id),
+	}
+	out, err := conn.GetServiceNetworkVpcAssociation(ctx, in)
+	if err != nil {
+		var nfe *types.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}
+
+func waitServiceNetworkVpcAssociationCreated(ctx context.Context, conn *vpclattice.Client, id string, timeout time.Duration) (*vpclattice.GetServiceNetworkVpcAssociationOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:                   enum.Slice(types.ServiceNetworkVpcAssociationStatusCreateInProgress),
+		Target:                    enum.Slice(types.ServiceNetworkVpcAssociationStatusActive),
+		Refresh:                   statusServiceNetworkVpcAssociation(ctx, conn, id),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*vpclattice.GetServiceNetworkVpcAssociationOutput); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+func waitServiceNetworkVpcAssociationDeleted(ctx context.Context, conn *vpclattice.Client, id string, timeout time.Duration) (*vpclattice.GetServiceNetworkVpcAssociationOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(types.ServiceNetworkVpcAssociationStatusDeleteInProgress, types.ServiceNetworkVpcAssociationStatusActive),
+		Target:  []string{},
+		Refresh: statusServiceNetworkVpcAssociation(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*vpclattice.GetServiceNetworkVpcAssociationOutput); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+
+func statusServiceNetworkVpcAssociation(ctx context.Context, conn *vpclattice.Client, id string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		out, err := findServiceNetworkVpcAssociationByID(ctx, conn, id)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return out, string(out.Status), nil
+	}
+}

--- a/internal/service/vpclattice/service_network_vpc_association_test.go
+++ b/internal/service/vpclattice/service_network_vpc_association_test.go
@@ -74,7 +74,7 @@ func TestAccVPCLatticeServiceNetworkVpcAssociation_disappears(t *testing.T) {
 				Config: testAccServiceNetworkVpcAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceNetworkVpcAssociationExists(ctx, resourceName, &servicenetworkvpcasc),
-					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfvpclattice.ResourceServiceNetworkVpcAssociation(), resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfvpclattice.ResourceServiceNetworkVPCAssociation(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/service/vpclattice/service_network_vpc_association_test.go
+++ b/internal/service/vpclattice/service_network_vpc_association_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccVPCLatticeServiceNetworkVpcAssociation_basic(t *testing.T) {
+func TestAccVPCLatticeServiceNetworkVPCAssociation_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var servicenetworkvpcasc vpclattice.GetServiceNetworkVpcAssociationOutput
@@ -35,12 +35,12 @@ func TestAccVPCLatticeServiceNetworkVpcAssociation_basic(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServiceNetworkVpcAssociationDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceNetworkVPCAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceNetworkVpcAssociationConfig_basic(rName),
+				Config: testAccServiceNetworkVPCAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceNetworkVpcAssociationExists(ctx, resourceName, &servicenetworkvpcasc),
+					testAccCheckServiceNetworkVPCAssociationExists(ctx, resourceName, &servicenetworkvpcasc),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "vpc-lattice", regexp.MustCompile("servicenetworkvpcassociation/.+$")),
 				),
 			},
@@ -53,7 +53,7 @@ func TestAccVPCLatticeServiceNetworkVpcAssociation_basic(t *testing.T) {
 	})
 }
 
-func TestAccVPCLatticeServiceNetworkVpcAssociation_disappears(t *testing.T) {
+func TestAccVPCLatticeServiceNetworkVPCAssociation_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var servicenetworkvpcasc vpclattice.GetServiceNetworkVpcAssociationOutput
@@ -68,12 +68,12 @@ func TestAccVPCLatticeServiceNetworkVpcAssociation_disappears(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServiceNetworkVpcAssociationDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceNetworkVPCAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceNetworkVpcAssociationConfig_basic(rName),
+				Config: testAccServiceNetworkVPCAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceNetworkVpcAssociationExists(ctx, resourceName, &servicenetworkvpcasc),
+					testAccCheckServiceNetworkVPCAssociationExists(ctx, resourceName, &servicenetworkvpcasc),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfvpclattice.ResourceServiceNetworkVPCAssociation(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -82,7 +82,7 @@ func TestAccVPCLatticeServiceNetworkVpcAssociation_disappears(t *testing.T) {
 	})
 }
 
-func TestAccVPCLatticeServiceNetworkVpcAssociation_full(t *testing.T) {
+func TestAccVPCLatticeServiceNetworkVPCAssociation_full(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var servicenetworkvpcasc vpclattice.GetServiceNetworkVpcAssociationOutput
@@ -97,12 +97,12 @@ func TestAccVPCLatticeServiceNetworkVpcAssociation_full(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServiceNetworkVpcAssociationDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceNetworkVPCAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceNetworkVpcAssociationConfig_full(rName),
+				Config: testAccServiceNetworkVPCAssociationConfig_full(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceNetworkVpcAssociationExists(ctx, resourceName, &servicenetworkvpcasc),
+					testAccCheckServiceNetworkVPCAssociationExists(ctx, resourceName, &servicenetworkvpcasc),
 					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "vpc-lattice", regexp.MustCompile("servicenetworkvpcassociation/.+$")),
 					resource.TestCheckResourceAttrSet(resourceName, "service_network_identifier"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_identifier"),
@@ -118,7 +118,7 @@ func TestAccVPCLatticeServiceNetworkVpcAssociation_full(t *testing.T) {
 	})
 }
 
-func TestAccVPCLatticeServiceNetworkVpcAssociation_tags(t *testing.T) {
+func TestAccVPCLatticeServiceNetworkVPCAssociation_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var servicenetworkvpcasc1, servicenetworkvpcasc2, service3 vpclattice.GetServiceNetworkVpcAssociationOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -132,12 +132,12 @@ func TestAccVPCLatticeServiceNetworkVpcAssociation_tags(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServiceNetworkVpcAssociationDestroy(ctx),
+		CheckDestroy:             testAccCheckServiceNetworkVPCAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceNetworkVpcAssociationConfig_tags1(rName, "key1", "value1"),
+				Config: testAccServiceNetworkVPCAssociationConfig_tags1(rName, "key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceNetworkVpcAssociationExists(ctx, resourceName, &servicenetworkvpcasc1),
+					testAccCheckServiceNetworkVPCAssociationExists(ctx, resourceName, &servicenetworkvpcasc1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -148,18 +148,18 @@ func TestAccVPCLatticeServiceNetworkVpcAssociation_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccServiceNetworkVpcAssociationConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Config: testAccServiceNetworkVPCAssociationConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceNetworkVpcAssociationExists(ctx, resourceName, &servicenetworkvpcasc2),
+					testAccCheckServiceNetworkVPCAssociationExists(ctx, resourceName, &servicenetworkvpcasc2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
 			{
-				Config: testAccServiceNetworkVpcAssociationConfig_tags1(rName, "key2", "value2"),
+				Config: testAccServiceNetworkVPCAssociationConfig_tags1(rName, "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServiceNetworkVpcAssociationExists(ctx, resourceName, &service3),
+					testAccCheckServiceNetworkVPCAssociationExists(ctx, resourceName, &service3),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
@@ -168,7 +168,7 @@ func TestAccVPCLatticeServiceNetworkVpcAssociation_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckServiceNetworkVpcAssociationDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckServiceNetworkVPCAssociationDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient()
 
@@ -195,7 +195,7 @@ func testAccCheckServiceNetworkVpcAssociationDestroy(ctx context.Context) resour
 	}
 }
 
-func testAccCheckServiceNetworkVpcAssociationExists(ctx context.Context, name string, service *vpclattice.GetServiceNetworkVpcAssociationOutput) resource.TestCheckFunc {
+func testAccCheckServiceNetworkVPCAssociationExists(ctx context.Context, name string, service *vpclattice.GetServiceNetworkVpcAssociationOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -221,7 +221,7 @@ func testAccCheckServiceNetworkVpcAssociationExists(ctx context.Context, name st
 	}
 }
 
-func testAccServiceNetworkVpcAssociationConfig_basic(rName string) string {
+func testAccServiceNetworkVPCAssociationConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -238,7 +238,7 @@ resource "aws_vpclattice_service_network_vpc_association" "test" {
 `, rName)
 }
 
-func testAccServiceNetworkVpcAssociationConfig_full(rName string) string {
+func testAccServiceNetworkVPCAssociationConfig_full(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -260,7 +260,7 @@ resource "aws_vpclattice_service_network_vpc_association" "test" {
 `, rName)
 }
 
-func testAccServiceNetworkVpcAssociationConfig_tags1(rName, tagKey1, tagValue1 string) string {
+func testAccServiceNetworkVPCAssociationConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -281,7 +281,7 @@ resource "aws_vpclattice_service_network_vpc_association" "test" {
 `, rName, tagKey1, tagValue1)
 }
 
-func testAccServiceNetworkVpcAssociationConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccServiceNetworkVPCAssociationConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"

--- a/internal/service/vpclattice/service_network_vpc_association_test.go
+++ b/internal/service/vpclattice/service_network_vpc_association_test.go
@@ -1,0 +1,304 @@
+package vpclattice_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfvpclattice "github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccVPCLatticeServiceNetworkVpcAssociation_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var servicenetworkvpcasc vpclattice.GetServiceNetworkVpcAssociationOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_vpclattice_service_network_vpc_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.VPCLatticeEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckServiceNetworkVpcAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceNetworkVpcAssociationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceNetworkVpcAssociationExists(ctx, resourceName, &servicenetworkvpcasc),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "vpc-lattice", regexp.MustCompile("servicenetworkvpcassociation/.+$")),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccVPCLatticeServiceNetworkVpcAssociation_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var servicenetworkvpcasc vpclattice.GetServiceNetworkVpcAssociationOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_vpclattice_service_network_vpc_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.VPCLatticeEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckServiceNetworkVpcAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceNetworkVpcAssociationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceNetworkVpcAssociationExists(ctx, resourceName, &servicenetworkvpcasc),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfvpclattice.ResourceServiceNetworkVpcAssociation(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccVPCLatticeServiceNetworkVpcAssociation_full(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var servicenetworkvpcasc vpclattice.GetServiceNetworkVpcAssociationOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_vpclattice_service_network_vpc_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.VPCLatticeEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckServiceNetworkVpcAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceNetworkVpcAssociationConfig_full(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceNetworkVpcAssociationExists(ctx, resourceName, &servicenetworkvpcasc),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "vpc-lattice", regexp.MustCompile("servicenetworkvpcassociation/.+$")),
+					resource.TestCheckResourceAttrSet(resourceName, "service_network_identifier"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_identifier"),
+					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccVPCLatticeServiceNetworkVpcAssociation_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	var servicenetworkvpcasc1, servicenetworkvpcasc2, service3 vpclattice.GetServiceNetworkVpcAssociationOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_vpclattice_service_network_vpc_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.VPCLatticeEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckServiceNetworkVpcAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceNetworkVpcAssociationConfig_tags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceNetworkVpcAssociationExists(ctx, resourceName, &servicenetworkvpcasc1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccServiceNetworkVpcAssociationConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceNetworkVpcAssociationExists(ctx, resourceName, &servicenetworkvpcasc2),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccServiceNetworkVpcAssociationConfig_tags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceNetworkVpcAssociationExists(ctx, resourceName, &service3),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckServiceNetworkVpcAssociationDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient()
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_vpclattice_service_network_vpc_association" {
+				continue
+			}
+
+			_, err := conn.GetServiceNetworkVpcAssociation(ctx, &vpclattice.GetServiceNetworkVpcAssociationInput{
+				ServiceNetworkVpcAssociationIdentifier: aws.String(rs.Primary.ID),
+			})
+			if err != nil {
+				var nfe *types.ResourceNotFoundException
+				if errors.As(err, &nfe) {
+					return nil
+				}
+				return err
+			}
+
+			return create.Error(names.VPCLattice, create.ErrActionCheckingDestroyed, tfvpclattice.ResNameService, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckServiceNetworkVpcAssociationExists(ctx context.Context, name string, service *vpclattice.GetServiceNetworkVpcAssociationOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameService, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameService, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient()
+		resp, err := conn.GetServiceNetworkVpcAssociation(ctx, &vpclattice.GetServiceNetworkVpcAssociationInput{
+			ServiceNetworkVpcAssociationIdentifier: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameService, rs.Primary.ID, err)
+		}
+
+		*service = *resp
+
+		return nil
+	}
+}
+
+func testAccServiceNetworkVpcAssociationConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_vpclattice_service_network" "test" {
+  name = %[1]q
+}
+
+resource "aws_vpclattice_service_network_vpc_association" "test" {
+  vpc_identifier             = aws_vpc.test.id
+  service_network_identifier = aws_vpclattice_service_network.test.id
+}
+`, rName)
+}
+
+func testAccServiceNetworkVpcAssociationConfig_full(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_security_group" "test" {
+  vpc_id = aws_vpc.test.id
+}
+
+resource "aws_vpclattice_service_network" "test" {
+  name = %[1]q
+}
+
+resource "aws_vpclattice_service_network_vpc_association" "test" {
+  vpc_identifier             = aws_vpc.test.id
+  security_group_ids         = [aws_security_group.test.id]
+  service_network_identifier = aws_vpclattice_service_network.test.id
+}
+`, rName)
+}
+
+func testAccServiceNetworkVpcAssociationConfig_tags1(rName, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_vpclattice_service_network" "test" {
+  name = %[1]q
+}
+
+resource "aws_vpclattice_service_network_vpc_association" "test" {
+  vpc_identifier             = aws_vpc.test.id
+  service_network_identifier = aws_vpclattice_service_network.test.id
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1)
+}
+
+func testAccServiceNetworkVpcAssociationConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_vpclattice_service_network" "test" {
+  name = %[1]q
+}
+
+resource "aws_vpclattice_service_network_vpc_association" "test" {
+  vpc_identifier             = aws_vpc.test.id
+  service_network_identifier = aws_vpclattice_service_network.test.id
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}

--- a/internal/service/vpclattice/service_package_gen.go
+++ b/internal/service/vpclattice/service_package_gen.go
@@ -53,6 +53,13 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 				IdentifierAttribute: "arn",
 			},
 		},
+		{
+			Factory:  ResourceServiceNetworkVpcAssociation,
+			TypeName: "aws_vpclattice_service_network_vpc_association",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
+		},
 	}
 }
 

--- a/internal/service/vpclattice/service_package_gen.go
+++ b/internal/service/vpclattice/service_package_gen.go
@@ -54,7 +54,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceServiceNetworkVpcAssociation,
+			Factory:  ResourceServiceNetworkVPCAssociation,
 			TypeName: "aws_vpclattice_service_network_vpc_association",
 			Tags: &types.ServicePackageResourceTags{
 				IdentifierAttribute: "arn",

--- a/website/docs/r/vpclattice_service_network_vpc_association.html.markdown
+++ b/website/docs/r/vpclattice_service_network_vpc_association.html.markdown
@@ -1,23 +1,24 @@
 ---
 subcategory: "VPC Lattice"
 layout: "aws"
-page_title: "AWS: aws_vpclattice_service_network_service_association"
+page_title: "AWS: aws_vpclattice_service_network_vpc_association"
 description: |-
-  Terraform resource for managing an AWS VPC Lattice Service Network Service Association.
+  Terraform resource for managing an AWS VPC Lattice Service Network VPC Association.
 ---
 
-# Resource: aws_vpclattice_service_network_service_association
+# Resource: aws_vpclattice_service_network_vpc_association
 
-Terraform resource for managing an AWS VPC Lattice Service Network Service Association.
+Terraform resource for managing an AWS VPC Lattice Service Network VPC Association.
 
 ## Example Usage
 
 ### Basic Usage
 
 ```terraform
-resource "aws_vpclattice_service_network_service_association" "example" {
-  service_identifier         = aws_vpclattice_service.example.id
+resource "aws_vpclattice_service_network_vpc_association" "example" {
+  vpc_identifier             = aws_vpclattice_service.example.id
   service_network_identifier = aws_vpclattice_service_network.example.id
+  security_group_ids         = [aws_security_group.example.id]
 }
 ```
 
@@ -25,11 +26,12 @@ resource "aws_vpclattice_service_network_service_association" "example" {
 
 The following arguments are required:
 
-* `service_identifier` - (Required) The ID or Amazon Resource Identifier (ARN) of the service.
+* `vpc_identifier` - (Required) The ID of the VPC.
 * `service_network_identifier` - (Required) The ID or Amazon Resource Identifier (ARN) of the service network. You must use the ARN if the resources specified in the operation are in different accounts.
 The following arguments are optional:
 
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `security_group_ids` - (Optional) The IDs of the security groups.
 
 ## Attributes Reference
 
@@ -37,10 +39,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The ARN of the Association.
 * `created_by` - The account that created the association.
-* `custom_domain_name` - The custom domain name of the service.
-* `dns_entry` - The DNS name of the service.
-    * `domain_name` - The domain name of the service.
-    * `hosted_zone_id` - The ID of the hosted zone.
 * `id` - The ID of the association.
 * `status` - The operations status. Valid Values are CREATE_IN_PROGRESS | ACTIVE | DELETE_IN_PROGRESS | CREATE_FAILED | DELETE_FAILED
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
@@ -54,8 +52,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-VPC Lattice Service Network Service Association can be imported using the `id`, e.g.,
+VPC Lattice Service Network VPC Association can be imported using the `id`, e.g.,
 
 ```
-$ terraform import aws_vpclattice_service_network_service_association.example snsa-05e2474658a88f6ba
+$ terraform import aws_vpclattice_service_network_vpc_association.example snsa-05e2474658a88f6ba
 ```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This pull request will cater for a new resource in the VPC Lattice family - ServiceNetwork - VPC Association. For more information kindly refer to this page for details - https://docs.aws.amazon.com/vpc-lattice/latest/ug/service-network-associations.html

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #30411 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
The API Reference can be found here - https://docs.aws.amazon.com/vpc-lattice/latest/APIReference/API_CreateServiceNetworkVpcAssociation.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
:~/terraform-provider-aws (f-aws_vpclattice_service_network_vpc_association) $ make testacc PKG=vpclattice TESTS=TestAccVPCLatticeServiceNetworkVPCAssociation_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/vpclattice/... -v -count 1 -parallel 20 -run='TestAccVPCLatticeServiceNetworkVPCAssociation_'  -timeout 180m
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_basic
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_basic
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_disappears
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_disappears
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_full
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_full
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_tags
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_tags
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_basic
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_full
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_tags
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_disappears
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_tags (107.69s)
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_full (124.28s)
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_basic (136.76s)
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_disappears (184.16s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice 184.237s

...
```
