### PR TITLE
aws_nat_gateway: add association_id attribute to resource and data source

### DIFF
--- a/.changelog/30546.txt
+++ b/.changelog/30546.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_nat_gateway: Add `association_id` attribute
+```
+
+```release-note:enhancement
+data-source/aws_nat_gateway: Add `association_id` attribute
+```

--- a/internal/service/ec2/vpc_nat_gateway.go
+++ b/internal/service/ec2/vpc_nat_gateway.go
@@ -37,6 +37,10 @@ func ResourceNATGateway() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"association_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"connectivity_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -129,6 +133,7 @@ func resourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta in
 	for _, address := range ng.NatGatewayAddresses {
 		if aws.BoolValue(address.IsPrimary) {
 			d.Set("allocation_id", address.AllocationId)
+			d.Set("association_id", address.AssociationId)
 			d.Set("network_interface_id", address.NetworkInterfaceId)
 			d.Set("private_ip", address.PrivateIp)
 			d.Set("public_ip", address.PublicIp)

--- a/internal/service/ec2/vpc_nat_gateway.go
+++ b/internal/service/ec2/vpc_nat_gateway.go
@@ -126,12 +126,16 @@ func resourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("reading EC2 NAT Gateway (%s): %s", d.Id(), err)
 	}
 
-	address := ng.NatGatewayAddresses[0]
-	d.Set("allocation_id", address.AllocationId)
+	for _, address := range ng.NatGatewayAddresses {
+		if aws.BoolValue(address.IsPrimary) {
+			d.Set("allocation_id", address.AllocationId)
+			d.Set("network_interface_id", address.NetworkInterfaceId)
+			d.Set("private_ip", address.PrivateIp)
+			d.Set("public_ip", address.PublicIp)
+		}
+	}
+
 	d.Set("connectivity_type", ng.ConnectivityType)
-	d.Set("network_interface_id", address.NetworkInterfaceId)
-	d.Set("private_ip", address.PrivateIp)
-	d.Set("public_ip", address.PublicIp)
 	d.Set("subnet_id", ng.SubnetId)
 
 	SetTagsOut(ctx, ng.Tags)

--- a/internal/service/ec2/vpc_nat_gateway_data_source.go
+++ b/internal/service/ec2/vpc_nat_gateway_data_source.go
@@ -27,6 +27,10 @@ func DataSourceNATGateway() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"association_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"connectivity_type": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -116,6 +120,7 @@ func dataSourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta 
 	for _, address := range ngw.NatGatewayAddresses {
 		if aws.BoolValue(address.IsPrimary) == true {
 			d.Set("allocation_id", address.AllocationId)
+			d.Set("association_id", address.AssociationId)
 			d.Set("network_interface_id", address.NetworkInterfaceId)
 			d.Set("private_ip", address.PrivateIp)
 			d.Set("public_ip", address.PublicIp)

--- a/internal/service/ec2/vpc_nat_gateway_data_source.go
+++ b/internal/service/ec2/vpc_nat_gateway_data_source.go
@@ -118,7 +118,7 @@ func dataSourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("vpc_id", ngw.VpcId)
 
 	for _, address := range ngw.NatGatewayAddresses {
-		if aws.BoolValue(address.IsPrimary) == true {
+		if aws.BoolValue(address.IsPrimary) {
 			d.Set("allocation_id", address.AllocationId)
 			d.Set("association_id", address.AssociationId)
 			d.Set("network_interface_id", address.NetworkInterfaceId)

--- a/internal/service/ec2/vpc_nat_gateway_data_source.go
+++ b/internal/service/ec2/vpc_nat_gateway_data_source.go
@@ -114,7 +114,7 @@ func dataSourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("vpc_id", ngw.VpcId)
 
 	for _, address := range ngw.NatGatewayAddresses {
-		if aws.StringValue(address.AllocationId) != "" {
+		if aws.BoolValue(address.IsPrimary) == true {
 			d.Set("allocation_id", address.AllocationId)
 			d.Set("network_interface_id", address.NetworkInterfaceId)
 			d.Set("private_ip", address.PrivateIp)

--- a/internal/service/ec2/vpc_nat_gateway_data_source_test.go
+++ b/internal/service/ec2/vpc_nat_gateway_data_source_test.go
@@ -37,6 +37,7 @@ func TestAccVPCNATGatewayDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceNameById, "private_ip"),
 					resource.TestCheckNoResourceAttr(dataSourceNameById, "attached_vpc_id"),
 					resource.TestCheckResourceAttrSet(dataSourceNameById, "tags.OtherTag"),
+					resource.TestCheckResourceAttrPair(dataSourceNameById, "association_id", resourceName, "association_id"),
 				),
 			},
 		},

--- a/internal/service/ec2/vpc_nat_gateway_test.go
+++ b/internal/service/ec2/vpc_nat_gateway_test.go
@@ -32,6 +32,7 @@ func TestAccVPCNATGateway_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNATGatewayExists(ctx, resourceName, &natGateway),
 					resource.TestCheckResourceAttrSet(resourceName, "allocation_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "association_id"),
 					resource.TestCheckResourceAttr(resourceName, "connectivity_type", "public"),
 					resource.TestCheckResourceAttrSet(resourceName, "network_interface_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
@@ -89,6 +90,7 @@ func TestAccVPCNATGateway_ConnectivityType_private(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNATGatewayExists(ctx, resourceName, &natGateway),
 					resource.TestCheckResourceAttr(resourceName, "allocation_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "association_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "connectivity_type", "private"),
 					resource.TestCheckResourceAttrSet(resourceName, "network_interface_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
@@ -123,6 +125,7 @@ func TestAccVPCNATGateway_privateIP(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNATGatewayExists(ctx, resourceName, &natGateway),
 					resource.TestCheckResourceAttr(resourceName, "allocation_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "association_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "connectivity_type", "private"),
 					resource.TestCheckResourceAttrSet(resourceName, "network_interface_id"),
 					resource.TestCheckResourceAttr(resourceName, "private_ip", "10.0.0.8"),

--- a/website/docs/d/nat_gateway.html.markdown
+++ b/website/docs/d/nat_gateway.html.markdown
@@ -63,6 +63,7 @@ the selected Nat Gateway.
 Each attachment supports the following:
 
 * `allocation_id` - ID of the EIP allocated to the selected Nat Gateway.
+* `association_id` - The association ID of the Elastic IP address that's associated with the NAT gateway. Only available when `connectivity_type` is `public`.
 * `connectivity_type` - Connectivity type of the NAT Gateway.
 * `network_interface_id` - The ID of the ENI allocated to the selected Nat Gateway.
 * `private_ip` - Private Ip address of the selected Nat Gateway.

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -52,6 +52,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `association_id` - The association ID of the Elastic IP address that's associated with the NAT gateway. Only available when `connectivity_type` is `public`.
 * `id` - The ID of the NAT Gateway.
 * `network_interface_id` - The ID of the network interface associated with the NAT gateway.
 * `public_ip` - The Elastic IP address associated with the NAT gateway.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds the `association_id` attribute to the `aws_nat_gateway` resource and data source.

The `association_id` (and other attributes, such as `allocation_id`) are now chosen based on whether a given IP address is designated as the primary IP address of the NAT Gateway.

A subsequent PR will add secondary associations as an independent resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/29471

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccVPCNATGateway_ PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNATGateway_'  -timeout 180m
go: downloading github.com/aws/aws-sdk-go-v2/service/healthlake v1.15.7
=== RUN   TestAccVPCNATGateway_basic
=== PAUSE TestAccVPCNATGateway_basic
=== RUN   TestAccVPCNATGateway_disappears
=== PAUSE TestAccVPCNATGateway_disappears
=== RUN   TestAccVPCNATGateway_ConnectivityType_private
=== PAUSE TestAccVPCNATGateway_ConnectivityType_private
=== RUN   TestAccVPCNATGateway_privateIP
=== PAUSE TestAccVPCNATGateway_privateIP
=== RUN   TestAccVPCNATGateway_tags
=== PAUSE TestAccVPCNATGateway_tags
=== CONT  TestAccVPCNATGateway_basic
=== CONT  TestAccVPCNATGateway_privateIP
=== CONT  TestAccVPCNATGateway_ConnectivityType_private
=== CONT  TestAccVPCNATGateway_disappears
=== CONT  TestAccVPCNATGateway_tags
--- PASS: TestAccVPCNATGateway_ConnectivityType_private (188.09s)
--- PASS: TestAccVPCNATGateway_basic (195.61s)
--- PASS: TestAccVPCNATGateway_privateIP (200.23s)
--- PASS: TestAccVPCNATGateway_disappears (233.69s)
--- PASS: TestAccVPCNATGateway_tags (248.98s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        251.101s

$ make testacc TESTS=TestAccVPCNATGatewayDataSource_ PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNATGatewayDataSource_'  -timeout 180m
=== RUN   TestAccVPCNATGatewayDataSource_basic
=== PAUSE TestAccVPCNATGatewayDataSource_basic
=== CONT  TestAccVPCNATGatewayDataSource_basic
--- PASS: TestAccVPCNATGatewayDataSource_basic (206.06s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        208.112s
```
