### PR TITLE
aws_lambda_function_url: add invoke_mode attribute

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20230201104953-d1d05f4e2bfb
-	github.com/aws/aws-sdk-go v1.44.238
+	github.com/aws/aws-sdk-go v1.44.239
 	github.com/aws/aws-sdk-go-v2 v1.17.7
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.1
 	github.com/aws/aws-sdk-go-v2/service/auditmanager v1.24.3

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aws/aws-sdk-go v1.44.238 h1:qSWVXr/y/SsYyuvwVHYQpzcMKa2UzOjKgqPp7BTGfbo=
 github.com/aws/aws-sdk-go v1.44.238/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/aws/aws-sdk-go v1.44.239 h1:AenB6byCYGSBb30q99CGYqFbqpLpWrTidzm7MzxtuPo=
+github.com/aws/aws-sdk-go v1.44.239/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v1.17.4/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2 v1.17.7 h1:CLSjnhJSTSogvqUGhIC6LqFKATMRexcxLZ0i/Nzk9Eg=
 github.com/aws/aws-sdk-go-v2 v1.17.7/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=

--- a/internal/service/lambda/function_url_data_source.go
+++ b/internal/service/lambda/function_url_data_source.go
@@ -73,6 +73,10 @@ func DataSourceFunctionURL() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"invoke_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"last_modified_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -116,6 +120,7 @@ func dataSourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("function_arn", output.FunctionArn)
 	d.Set("function_name", name)
 	d.Set("function_url", functionURL)
+	d.Set("invoke_mode", output.InvokeMode)
 	d.Set("last_modified_time", output.LastModifiedTime)
 	d.Set("qualifier", qualifier)
 

--- a/internal/service/lambda/function_url_data_source_test.go
+++ b/internal/service/lambda/function_url_data_source_test.go
@@ -36,6 +36,7 @@ func TestAccLambdaFunctionURLDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "function_arn", resourceName, "function_arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "function_name", resourceName, "function_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "function_url", resourceName, "function_url"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "invoke_mode", resourceName, "invoke_mode"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "last_modified_time"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "qualifier", resourceName, "qualifier"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "url_id", resourceName, "url_id"),

--- a/website/docs/d/lambda_function_url.html.markdown
+++ b/website/docs/d/lambda_function_url.html.markdown
@@ -38,5 +38,6 @@ In addition to all arguments above, the following attributes are exported:
 * `creation_time` - When the function URL was created, in [ISO-8601 format](https://www.w3.org/TR/NOTE-datetime).
 * `function_arn` - ARN of the function.
 * `function_url` - HTTP URL endpoint for the function in the format `https://<url_id>.lambda-url.<region>.on.aws`.
+* `invoke_mode` - Whether the Lambda function responds in `BUFFERED` or `RESPONSE_STREAM` mode.
 * `last_modified_time` - When the function URL configuration was last updated, in [ISO-8601 format](https://www.w3.org/TR/NOTE-datetime).
 * `url_id` - Generated ID for the endpoint.

--- a/website/docs/r/lambda_function_url.html.markdown
+++ b/website/docs/r/lambda_function_url.html.markdown
@@ -41,6 +41,7 @@ resource "aws_lambda_function_url" "test_live" {
 * `authorization_type` - (Required) The type of authentication that the function URL uses. Set to `"AWS_IAM"` to restrict access to authenticated IAM users only. Set to `"NONE"` to bypass IAM authentication and create a public endpoint. See the [AWS documentation](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html) for more details.
 * `cors` - (Optional) The [cross-origin resource sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) settings for the function URL. Documented below.
 * `function_name` - (Required) The name (or ARN) of the Lambda function.
+* `invoke_mode` - (Optional) Determines how the Lambda function responds to an invocation. Valid values are `BUFFERED` (default) and `RESPONSE_STREAM`. See more in [Configuring a Lambda function to stream responses](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html).
 * `qualifier` - (Optional) The alias name or `"$LATEST"`.
 
 ### cors


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds the `invoke_mode` attribute to the `aws_lambda_function_url` resource and data source. For backwards compatibility, the default value is `BUFFERED`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/30541

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccLambdaFunctionURL_ PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunctionURL_'  -timeout 180m
=== RUN   TestAccLambdaFunctionURL_basic
=== PAUSE TestAccLambdaFunctionURL_basic
=== RUN   TestAccLambdaFunctionURL_Cors
=== PAUSE TestAccLambdaFunctionURL_Cors
=== RUN   TestAccLambdaFunctionURL_Alias
=== PAUSE TestAccLambdaFunctionURL_Alias
=== RUN   TestAccLambdaFunctionURL_TwoURLs
=== PAUSE TestAccLambdaFunctionURL_TwoURLs
=== RUN   TestAccLambdaFunctionURL_invokeMode
=== PAUSE TestAccLambdaFunctionURL_invokeMode
=== CONT  TestAccLambdaFunctionURL_basic
=== CONT  TestAccLambdaFunctionURL_TwoURLs
=== CONT  TestAccLambdaFunctionURL_invokeMode
=== CONT  TestAccLambdaFunctionURL_Alias
=== CONT  TestAccLambdaFunctionURL_Cors
--- PASS: TestAccLambdaFunctionURL_TwoURLs (44.09s)
--- PASS: TestAccLambdaFunctionURL_basic (46.16s)
--- PASS: TestAccLambdaFunctionURL_Alias (59.65s)
--- PASS: TestAccLambdaFunctionURL_invokeMode (92.12s)
--- PASS: TestAccLambdaFunctionURL_Cors (100.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     102.263s

$ make testacc TESTS=TestAccLambdaFunctionURLDataSource_ PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunctionURLDataSource_'  -timeout 180m
=== RUN   TestAccLambdaFunctionURLDataSource_basic
=== PAUSE TestAccLambdaFunctionURLDataSource_basic
=== CONT  TestAccLambdaFunctionURLDataSource_basic
--- PASS: TestAccLambdaFunctionURLDataSource_basic (44.36s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     46.421s
```
