### PR TITLE
Update default timeout for aws_ec2_client_vpn_route

### DIFF
--- a/.changelog/30552.txt
+++ b/.changelog/30552.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ec2_client_vpn_route: Increase Create and Delete timeouts to 4 minutes
+```

--- a/internal/service/ec2/vpnclient_route.go
+++ b/internal/service/ec2/vpnclient_route.go
@@ -28,8 +28,8 @@ func ResourceClientVPNRoute() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(ClientVPNRouteCreatedTimeout),
-			Delete: schema.DefaultTimeout(ClientVPNRouteDeletedTimeout),
+			Create: schema.DefaultTimeout(4 * time.Minute),
+			Delete: schema.DefaultTimeout(4 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/internal/service/ec2/vpnclient_route.go
+++ b/internal/service/ec2/vpnclient_route.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -329,11 +329,6 @@ func WaitClientVPNNetworkAssociationDeleted(ctx context.Context, conn *ec2.EC2, 
 	return nil, err
 }
 
-const (
-	ClientVPNRouteCreatedTimeout = 1 * time.Minute
-	ClientVPNRouteDeletedTimeout = 1 * time.Minute
-)
-
 func WaitClientVPNRouteCreated(ctx context.Context, conn *ec2.EC2, endpointID, targetSubnetID, destinationCIDR string, timeout time.Duration) (*ec2.ClientVpnRoute, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{ec2.ClientVpnRouteStatusCodeCreating},

--- a/website/docs/r/ec2_client_vpn_route.html.markdown
+++ b/website/docs/r/ec2_client_vpn_route.html.markdown
@@ -62,8 +62,8 @@ In addition to all arguments above, the following attributes are exported:
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-- `create` - (Default `1m`)
-- `delete` - (Default `1m`)
+- `create` - (Default `4m`)
+- `delete` - (Default `4m`)
 
 ## Import
 


### PR DESCRIPTION
When creating the resource aws_ec2_client_vpn_route, AWS takes between 2 and 3 minutes to create and activate the route, That means the default setting of 1 minute, is not enough, and would most likely fail to either create OR delete.

I propose to raise the default timeout to 4 minutes, which is a lot of time, sure, but  for https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/eks/node_group.go#L38 Node_group timeout is an hour, but node groups are usually active within the first 15 minutes, so I took some headroom as well..

This, _to the best of my knowledge is not an open issue_, but rather something I encountered while creating a resource of 
 `aws_ec2_client_vpn_route`.
 
 Closes: #23787.