### PR TITLE
[TechDebt]: S3 acceptance test default security settings refactor

### DIFF
--- a/internal/service/s3/bucket_acl_test.go
+++ b/internal/service/s3/bucket_acl_test.go
@@ -324,17 +324,17 @@ func TestAccS3BucketACL_migrate_aclNoChange(t *testing.T) {
 		CheckDestroy:             testAccCheckBucketDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketConfig_acl(bucketName, s3.BucketCannedACLPublicRead),
+				Config: testAccBucketConfig_acl(bucketName, s3.BucketCannedACLPrivate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketExists(ctx, bucketResourceName),
-					resource.TestCheckResourceAttr(bucketResourceName, "acl", s3.BucketCannedACLPublicRead),
+					resource.TestCheckResourceAttr(bucketResourceName, "acl", s3.BucketCannedACLPrivate),
 				),
 			},
 			{
-				Config: testAccBucketACLConfig_migrate(bucketName, s3.BucketCannedACLPublicRead),
+				Config: testAccBucketACLConfig_basic(bucketName, s3.BucketCannedACLPrivate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketACLExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPublicRead),
+					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPrivate),
 				),
 			},
 		},
@@ -354,67 +354,17 @@ func TestAccS3BucketACL_migrate_aclWithChange(t *testing.T) {
 		CheckDestroy:             testAccCheckBucketDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketConfig_acl(bucketName, s3.BucketCannedACLPublicRead),
+				Config: testAccBucketConfig_acl(bucketName, s3.BucketCannedACLPrivate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketExists(ctx, bucketResourceName),
-					resource.TestCheckResourceAttr(bucketResourceName, "acl", s3.BucketCannedACLPublicRead),
+					resource.TestCheckResourceAttr(bucketResourceName, "acl", s3.BucketCannedACLPrivate),
 				),
 			},
 			{
-				Config: testAccBucketACLConfig_migrate(bucketName, s3.BucketCannedACLPrivate),
+				Config: testAccBucketACLConfig_basic_withDisabledPublicAccessBlock(bucketName, s3.BucketCannedACLPublicRead),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketACLExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPrivate),
-				),
-			},
-		},
-	})
-}
-
-func TestAccS3BucketACL_migrate_grantsNoChange(t *testing.T) {
-	ctx := acctest.Context(t)
-	bucketName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	bucketResourceName := "aws_s3_bucket.test"
-	resourceName := "aws_s3_bucket_acl.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, s3.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBucketDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccBucketConfig_aclGrants(bucketName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketExists(ctx, bucketResourceName),
-					resource.TestCheckResourceAttr(bucketResourceName, "grant.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs(bucketResourceName, "grant.*", map[string]string{
-						"permissions.#": "2",
-						"type":          "CanonicalUser",
-					}),
-					resource.TestCheckTypeSetElemAttr(bucketResourceName, "grant.*.permissions.*", "FULL_CONTROL"),
-					resource.TestCheckTypeSetElemAttr(bucketResourceName, "grant.*.permissions.*", "WRITE"),
-				),
-			},
-			{
-				Config: testAccBucketACLConfig_migrateGrantsNoChange(bucketName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketACLExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "access_control_policy.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.grant.#", "2"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]string{
-						"grantee.#":      "1",
-						"grantee.0.type": s3.TypeCanonicalUser,
-						"permission":     s3.PermissionFullControl,
-					}),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "access_control_policy.0.grant.*", map[string]string{
-						"grantee.#":      "1",
-						"grantee.0.type": s3.TypeCanonicalUser,
-						"permission":     s3.PermissionWrite,
-					}),
-					resource.TestCheckTypeSetElemAttrPair(resourceName, "access_control_policy.0.grant.*.grantee.0.id", "data.aws_canonical_user_id.current", "id"),
-					resource.TestCheckResourceAttr(resourceName, "access_control_policy.0.owner.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "access_control_policy.0.owner.0.id", "data.aws_canonical_user_id.current", "id"),
+					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPublicRead),
 				),
 			},
 		},
@@ -434,10 +384,10 @@ func TestAccS3BucketACL_migrate_grantsWithChange(t *testing.T) {
 		CheckDestroy:             testAccCheckBucketDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketConfig_acl(bucketName, s3.BucketCannedACLPublicRead),
+				Config: testAccBucketConfig_acl(bucketName, s3.BucketCannedACLPrivate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketExists(ctx, bucketResourceName),
-					resource.TestCheckResourceAttr(bucketResourceName, "acl", s3.BucketCannedACLPublicRead),
+					resource.TestCheckResourceAttr(bucketResourceName, "acl", s3.BucketCannedACLPrivate),
 				),
 			},
 			{
@@ -480,17 +430,17 @@ func TestAccS3BucketACL_updateACL(t *testing.T) {
 		CheckDestroy:             testAccCheckBucketDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBucketACLConfig_basic(bucketName, s3.BucketCannedACLPublicRead),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketACLExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPublicRead),
-				),
-			},
-			{
 				Config: testAccBucketACLConfig_basic(bucketName, s3.BucketCannedACLPrivate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketACLExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPrivate),
+				),
+			},
+			{
+				Config: testAccBucketACLConfig_basic_withDisabledPublicAccessBlock(bucketName, s3.BucketCannedACLPublicRead),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketACLExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPublicRead),
 				),
 			},
 			{
@@ -690,7 +640,50 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
+resource "aws_s3_bucket_ownership_controls" "test" {
+  bucket = aws_s3_bucket.test.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "test" {
+  depends_on = [aws_s3_bucket_ownership_controls.test]
+
+  bucket = aws_s3_bucket.test.id
+  acl    = %[2]q
+}
+`, rName, acl)
+}
+
+func testAccBucketACLConfig_basic_withDisabledPublicAccessBlock(rName, acl string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_public_access_block" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_ownership_controls" "test" {
+  bucket = aws_s3_bucket.test.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "test" {
+  depends_on = [
+    aws_s3_bucket_public_access_block.test,
+    aws_s3_bucket_ownership_controls.test,
+  ]
+
   bucket = aws_s3_bucket.test.id
   acl    = %[2]q
 }
@@ -705,7 +698,16 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
+resource "aws_s3_bucket_ownership_controls" "test" {
+  bucket = aws_s3_bucket.test.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "test" {
+  depends_on = [aws_s3_bucket_ownership_controls.test]
+
   bucket = aws_s3_bucket.test.id
   access_control_policy {
     grant {
@@ -742,7 +744,16 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
+resource "aws_s3_bucket_ownership_controls" "test" {
+  bucket = aws_s3_bucket.test.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "test" {
+  depends_on = [aws_s3_bucket_ownership_controls.test]
+
   bucket = aws_s3_bucket.test.id
   access_control_policy {
     grant {
@@ -769,54 +780,6 @@ resource "aws_s3_bucket_acl" "test" {
 `, bucketName)
 }
 
-func testAccBucketACLConfig_migrate(rName, acl string) string {
-	return fmt.Sprintf(`
-resource "aws_s3_bucket" "test" {
-  bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = %[2]q
-}
-`, rName, acl)
-}
-
-func testAccBucketACLConfig_migrateGrantsNoChange(rName string) string {
-	return fmt.Sprintf(`
-data "aws_canonical_user_id" "current" {}
-
-resource "aws_s3_bucket" "test" {
-  bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  access_control_policy {
-    grant {
-      grantee {
-        id   = data.aws_canonical_user_id.current.id
-        type = "CanonicalUser"
-      }
-      permission = "FULL_CONTROL"
-    }
-
-    grant {
-      grantee {
-        id   = data.aws_canonical_user_id.current.id
-        type = "CanonicalUser"
-      }
-      permission = "WRITE"
-    }
-
-    owner {
-      id = data.aws_canonical_user_id.current.id
-    }
-  }
-}
-`, rName)
-}
-
 func testAccBucketACLConfig_migrateGrantsChange(rName string) string {
 	return fmt.Sprintf(`
 data "aws_canonical_user_id" "current" {}
@@ -827,7 +790,16 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
+resource "aws_s3_bucket_ownership_controls" "test" {
+  bucket = aws_s3_bucket.test.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "test" {
+  depends_on = [aws_s3_bucket_ownership_controls.test]
+
   bucket = aws_s3_bucket.test.id
   access_control_policy {
     grant {

--- a/internal/service/s3/bucket_data_source_test.go
+++ b/internal/service/s3/bucket_data_source_test.go
@@ -78,11 +78,6 @@ resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.bucket.id
-  acl    = "public-read"
-}
-
 resource "aws_s3_bucket_website_configuration" "test" {
   bucket = aws_s3_bucket.bucket.id
   index_document {

--- a/internal/service/s3/bucket_inventory_test.go
+++ b/internal/service/s3/bucket_inventory_test.go
@@ -40,7 +40,8 @@ func TestAccS3BucketInventory_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBucketInventoryExistsConfig(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "bucket", bucketName),
-					resource.TestCheckNoResourceAttr(resourceName, "filter"),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.prefix", "documents/"),
 					resource.TestCheckResourceAttr(resourceName, "name", inventoryName),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "included_object_versions", "All"),
@@ -207,11 +208,6 @@ func testAccBucketInventoryBucketConfig(name string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 `, name)
 }

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -1117,11 +1117,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
   bucket = aws_s3_bucket.test.bucket
   rule {
@@ -1140,11 +1135,6 @@ func testAccBucketLifecycleConfigurationConfig_multipleRulesNoFilterOrPrefix(rNa
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
@@ -1177,11 +1167,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
   bucket = aws_s3_bucket.test.bucket
   rule {
@@ -1200,11 +1185,6 @@ func testAccBucketLifecycleConfigurationConfig_basicUpdate(rName, date, prefix s
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
@@ -1232,11 +1212,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
   bucket = aws_s3_bucket.test.bucket
   rule {
@@ -1258,11 +1233,6 @@ func testAccBucketLifecycleConfigurationConfig_filterTag(rName, key, value strin
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
@@ -1292,11 +1262,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
   bucket = aws_s3_bucket.test.bucket
 
@@ -1318,11 +1283,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
   bucket = aws_s3_bucket.test.bucket
 
@@ -1340,11 +1300,6 @@ func testAccBucketLifecycleConfigurationConfig_ruleAbortIncompleteMultipartUploa
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
@@ -1366,11 +1321,6 @@ func testAccBucketLifecycleConfigurationConfig_multipleRules(rName, date string)
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
@@ -1430,11 +1380,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
   bucket = aws_s3_bucket.test.bucket
 
@@ -1460,11 +1405,6 @@ func testAccBucketLifecycleConfigurationConfig_nonCurrentVersionTransition(rName
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
@@ -1500,11 +1440,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
   bucket = aws_s3_bucket.test.bucket
 
@@ -1534,11 +1469,6 @@ func testAccBucketLifecycleConfigurationConfig_zeroDaysTransition(rName, storage
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
@@ -1573,11 +1503,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
   bucket = aws_s3_bucket.test.bucket
 
@@ -1610,11 +1535,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
   bucket = aws_s3_bucket.test.bucket
 
@@ -1645,11 +1565,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
   bucket = aws_s3_bucket.test.bucket
 
@@ -1676,11 +1591,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
   bucket = aws_s3_bucket.test.bucket
 
@@ -1705,11 +1615,6 @@ func testAccBucketLifecycleConfigurationConfig_filterObjectSizeRange(rName, date
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
@@ -1739,11 +1644,6 @@ func testAccBucketLifecycleConfigurationConfig_filterObjectSizeRangeAndPrefix(rN
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
@@ -1776,11 +1676,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
   bucket = aws_s3_bucket.test.id
 
@@ -1809,11 +1704,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
   bucket = aws_s3_bucket.test.id
 
@@ -1839,11 +1729,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "test" {
   bucket = aws_s3_bucket.test.bucket
 
@@ -1864,11 +1749,6 @@ func testAccBucketLifecycleConfigurationConfig_migrateChange(rName string) strin
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "test" {

--- a/internal/service/s3/bucket_logging_test.go
+++ b/internal/service/s3/bucket_logging_test.go
@@ -467,18 +467,22 @@ resource "aws_s3_bucket" "log_bucket" {
   bucket = "%[1]s-log"
 }
 
+resource "aws_s3_bucket_ownership_controls" "log_bucket_ownership" {
+  bucket = aws_s3_bucket.log_bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "log_bucket_acl" {
+  depends_on = [aws_s3_bucket_ownership_controls.log_bucket_ownership]
+
   bucket = aws_s3_bucket.log_bucket.id
   acl    = "log-delivery-write"
 }
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_s3_bucket_logging" "test" {
@@ -496,16 +500,20 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket" "log_bucket" {
   bucket = "%[2]s-log"
 }
 
+resource "aws_s3_bucket_ownership_controls" "log_bucket_ownership" {
+  bucket = aws_s3_bucket.log_bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "log_bucket_acl" {
+  depends_on = [aws_s3_bucket_ownership_controls.log_bucket_ownership]
+
   bucket = aws_s3_bucket.log_bucket.id
   acl    = "log-delivery-write"
 }
@@ -527,21 +535,30 @@ resource "aws_s3_bucket" "log_bucket" {
   bucket = "%[1]s-log"
 }
 
+resource "aws_s3_bucket_ownership_controls" "log_bucket_ownership" {
+  bucket = aws_s3_bucket.log_bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "log_bucket_acl" {
+  depends_on = [aws_s3_bucket_ownership_controls.log_bucket_ownership]
+
   bucket = aws_s3_bucket.log_bucket.id
   acl    = "log-delivery-write"
 }
-
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
+resource "aws_s3_bucket_ownership_controls" "test" {
   bucket = aws_s3_bucket.test.id
-  acl    = "private"
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
 }
-
 
 resource "aws_s3_bucket_logging" "test" {
   bucket = aws_s3_bucket.test.id
@@ -566,7 +583,16 @@ resource "aws_s3_bucket" "log_bucket" {
   bucket = "%[1]s-log"
 }
 
+resource "aws_s3_bucket_ownership_controls" "log_bucket_ownership" {
+  bucket = aws_s3_bucket.log_bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "log_bucket_acl" {
+  depends_on = [aws_s3_bucket_ownership_controls.log_bucket_ownership]
+
   bucket = aws_s3_bucket.log_bucket.id
   acl    = "log-delivery-write"
 }
@@ -575,9 +601,11 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
+resource "aws_s3_bucket_ownership_controls" "test" {
   bucket = aws_s3_bucket.test.id
-  acl    = "private"
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
 }
 
 resource "aws_s3_bucket_logging" "test" {
@@ -605,7 +633,16 @@ resource "aws_s3_bucket" "log_bucket" {
   bucket = "%[1]s-log"
 }
 
+resource "aws_s3_bucket_ownership_controls" "log_bucket_ownership" {
+  bucket = aws_s3_bucket.log_bucket.id
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
 resource "aws_s3_bucket_acl" "log_bucket_acl" {
+  depends_on = [aws_s3_bucket_ownership_controls.log_bucket_ownership]
+
   bucket = aws_s3_bucket.log_bucket.id
   acl    = "log-delivery-write"
 }
@@ -614,9 +651,11 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
+resource "aws_s3_bucket_ownership_controls" "test" {
   bucket = aws_s3_bucket.test.id
-  acl    = "private"
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
 }
 
 resource "aws_s3_bucket_logging" "test" {
@@ -643,18 +682,22 @@ resource "aws_s3_bucket" "log_bucket" {
   bucket = "%[1]s-log"
 }
 
+resource "aws_s3_bucket_ownership_controls" "log_bucket_ownership" {
+  bucket = aws_s3_bucket.log_bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "log_bucket_acl" {
+  depends_on = [aws_s3_bucket_ownership_controls.log_bucket_ownership]
+
   bucket = aws_s3_bucket.log_bucket.id
   acl    = "log-delivery-write"
 }
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_s3_bucket_logging" "test" {

--- a/internal/service/s3/bucket_metric_test.go
+++ b/internal/service/s3/bucket_metric_test.go
@@ -665,16 +665,16 @@ resource "aws_s3_bucket_acl" "test" {
 }
 
 func testAccBucketMetricConfig_emptyFilter(bucketName, metricName string) string {
-	return fmt.Sprintf(`
-%s
-
+	return acctest.ConfigCompose(
+		testAccBucketMetricsBucketConfig(bucketName),
+		fmt.Sprintf(`
 resource "aws_s3_bucket_metric" "test" {
   bucket = aws_s3_bucket.bucket.id
-  name   = "%s"
+  name   = %[1]q
 
   filter {}
 }
-`, testAccBucketMetricsBucketConfig(bucketName), metricName)
+`, metricName))
 }
 
 func testAccBucketMetricConfig_filterPrefix(bucketName, metricName, prefix string) string {

--- a/internal/service/s3/bucket_metric_test.go
+++ b/internal/service/s3/bucket_metric_test.go
@@ -651,17 +651,12 @@ func testAccCheckBucketMetricsExistsConfig(ctx context.Context, n string, res *s
 	}
 }
 
-func testAccBucketMetricsBucketConfig(name string) string {
+func testAccBucketMetricsBucketConfig(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
-  bucket = "%s"
+  bucket = %[1]q
 }
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.bucket.id
-  acl    = "public-read"
-}
-`, name)
+`, bucketName)
 }
 
 func testAccBucketMetricConfig_emptyFilter(bucketName, metricName string) string {
@@ -678,30 +673,30 @@ resource "aws_s3_bucket_metric" "test" {
 }
 
 func testAccBucketMetricConfig_filterPrefix(bucketName, metricName, prefix string) string {
-	return fmt.Sprintf(`
-%s
-
+	return acctest.ConfigCompose(
+		testAccBucketMetricsBucketConfig(bucketName),
+		fmt.Sprintf(`
 resource "aws_s3_bucket_metric" "test" {
   bucket = aws_s3_bucket.bucket.id
-  name   = "%s"
+  name   = %[1]q
 
   filter {
-    prefix = "%s"
+    prefix = %[2]q
   }
 }
-`, testAccBucketMetricsBucketConfig(bucketName), metricName, prefix)
+`, metricName, prefix))
 }
 
 func testAccBucketMetricConfig_filterPrefixAndMultipleTags(bucketName, metricName, prefix, tag1, tag2 string) string {
-	return fmt.Sprintf(`
-%s
-
+	return acctest.ConfigCompose(
+		testAccBucketMetricsBucketConfig(bucketName),
+		fmt.Sprintf(`
 resource "aws_s3_bucket_metric" "test" {
   bucket = aws_s3_bucket.bucket.id
-  name   = "%s"
+  name   = %[1]q
 
   filter {
-    prefix = "%s"
+    prefix = %[2]q
 
     tags = {
       "tag1" = "%s"
@@ -709,70 +704,70 @@ resource "aws_s3_bucket_metric" "test" {
     }
   }
 }
-`, testAccBucketMetricsBucketConfig(bucketName), metricName, prefix, tag1, tag2)
+`, metricName, prefix, tag1, tag2))
 }
 
 func testAccBucketMetricConfig_filterPrefixAndSingleTag(bucketName, metricName, prefix, tag string) string {
-	return fmt.Sprintf(`
-%s
-
+	return acctest.ConfigCompose(
+		testAccBucketMetricsBucketConfig(bucketName),
+		fmt.Sprintf(`
 resource "aws_s3_bucket_metric" "test" {
   bucket = aws_s3_bucket.bucket.id
-  name   = "%s"
+  name   = %[1]q
 
   filter {
-    prefix = "%s"
+    prefix = %[2]q
 
     tags = {
-      "tag1" = "%s"
+      "tag1" = %[3]q
     }
   }
 }
-`, testAccBucketMetricsBucketConfig(bucketName), metricName, prefix, tag)
+`, metricName, prefix, tag))
 }
 
 func testAccBucketMetricConfig_filterMultipleTags(bucketName, metricName, tag1, tag2 string) string {
-	return fmt.Sprintf(`
-%s
-
+	return acctest.ConfigCompose(
+		testAccBucketMetricsBucketConfig(bucketName),
+		fmt.Sprintf(`
 resource "aws_s3_bucket_metric" "test" {
   bucket = aws_s3_bucket.bucket.id
-  name   = "%s"
+  name   = %[1]q
 
   filter {
     tags = {
-      "tag1" = "%s"
-      "tag2" = "%s"
+      "tag1" = %[2]q
+      "tag2" = %[3]q
     }
   }
 }
-`, testAccBucketMetricsBucketConfig(bucketName), metricName, tag1, tag2)
+`, metricName, tag1, tag2))
 }
 
 func testAccBucketMetricConfig_filterSingleTag(bucketName, metricName, tag string) string {
-	return fmt.Sprintf(`
-%s
-
+	return acctest.ConfigCompose(
+		testAccBucketMetricsBucketConfig(bucketName),
+		fmt.Sprintf(`
 resource "aws_s3_bucket_metric" "test" {
   bucket = aws_s3_bucket.bucket.id
-  name   = "%s"
+  name   = %[1]q
 
   filter {
     tags = {
-      "tag1" = "%s"
+      "tag1" = %[2]q
     }
   }
 }
-`, testAccBucketMetricsBucketConfig(bucketName), metricName, tag)
+`, metricName, tag))
 }
 
 func testAccBucketMetricConfig_noFilter(bucketName, metricName string) string {
-	return fmt.Sprintf(`
-%s
-
+	return acctest.ConfigCompose(
+		testAccBucketMetricsBucketConfig(bucketName),
+		fmt.Sprintf(`
 resource "aws_s3_bucket_metric" "test" {
   bucket = aws_s3_bucket.bucket.id
-  name   = "%s"
+  name   = %[1]q
 }
-`, testAccBucketMetricsBucketConfig(bucketName), metricName)
+`, metricName))
 }

--- a/internal/service/s3/bucket_notification_test.go
+++ b/internal/service/s3/bucket_notification_test.go
@@ -22,7 +22,7 @@ import (
 func TestAccS3BucketNotification_eventbridge(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_s3_bucket_notification.notification"
+	resourceName := "aws_s3_bucket_notification.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -33,7 +33,7 @@ func TestAccS3BucketNotification_eventbridge(t *testing.T) {
 			{
 				Config: testAccBucketNotificationConfig_eventBridge(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketEventBridgeNotification(ctx, "aws_s3_bucket.bucket")),
+					testAccCheckBucketEventBridgeNotification(ctx, "aws_s3_bucket.test")),
 			},
 			{
 				ResourceName:      resourceName,
@@ -47,7 +47,7 @@ func TestAccS3BucketNotification_eventbridge(t *testing.T) {
 func TestAccS3BucketNotification_lambdaFunction(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_s3_bucket_notification.notification"
+	resourceName := "aws_s3_bucket_notification.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -58,9 +58,9 @@ func TestAccS3BucketNotification_lambdaFunction(t *testing.T) {
 			{
 				Config: testAccBucketNotificationConfig_lambdaFunction(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketLambdaFunctionConfiguration(ctx, "aws_s3_bucket.bucket",
+					testAccCheckBucketLambdaFunctionConfiguration(ctx, "aws_s3_bucket.test",
 						"notification-lambda",
-						"aws_lambda_function.func",
+						"aws_lambda_function.test",
 						[]string{"s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"},
 						&s3.KeyFilter{
 							FilterRules: []*s3.FilterRule{
@@ -120,7 +120,7 @@ func TestAccS3BucketNotification_LambdaFunctionLambdaFunctionARN_alias(t *testin
 func TestAccS3BucketNotification_queue(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_s3_bucket_notification.notification"
+	resourceName := "aws_s3_bucket_notification.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -131,9 +131,9 @@ func TestAccS3BucketNotification_queue(t *testing.T) {
 			{
 				Config: testAccBucketNotificationConfig_queue(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketQueueNotification(ctx, "aws_s3_bucket.bucket",
+					testAccCheckBucketQueueNotification(ctx, "aws_s3_bucket.test",
 						"notification-sqs",
-						"aws_sqs_queue.queue",
+						"aws_sqs_queue.test",
 						[]string{"s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"},
 						&s3.KeyFilter{
 							FilterRules: []*s3.FilterRule{
@@ -162,7 +162,7 @@ func TestAccS3BucketNotification_queue(t *testing.T) {
 func TestAccS3BucketNotification_topic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_s3_bucket_notification.notification"
+	resourceName := "aws_s3_bucket_notification.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -173,9 +173,9 @@ func TestAccS3BucketNotification_topic(t *testing.T) {
 			{
 				Config: testAccBucketNotificationConfig_topic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketTopicNotification(ctx, "aws_s3_bucket.bucket",
+					testAccCheckBucketTopicNotification(ctx, "aws_s3_bucket.test",
 						"notification-sns1",
-						"aws_sns_topic.topic",
+						"aws_sns_topic.test",
 						[]string{"s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"},
 						nil,
 					),
@@ -193,7 +193,7 @@ func TestAccS3BucketNotification_topic(t *testing.T) {
 func TestAccS3BucketNotification_Topic_multiple(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_s3_bucket_notification.notification"
+	resourceName := "aws_s3_bucket_notification.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -204,9 +204,9 @@ func TestAccS3BucketNotification_Topic_multiple(t *testing.T) {
 			{
 				Config: testAccBucketNotificationConfig_topicMultiple(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketTopicNotification(ctx, "aws_s3_bucket.bucket",
+					testAccCheckBucketTopicNotification(ctx, "aws_s3_bucket.test",
 						"notification-sns1",
-						"aws_sns_topic.topic",
+						"aws_sns_topic.test",
 						[]string{"s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"},
 						&s3.KeyFilter{
 							FilterRules: []*s3.FilterRule{
@@ -221,9 +221,9 @@ func TestAccS3BucketNotification_Topic_multiple(t *testing.T) {
 							},
 						},
 					),
-					testAccCheckBucketTopicNotification(ctx, "aws_s3_bucket.bucket",
+					testAccCheckBucketTopicNotification(ctx, "aws_s3_bucket.test",
 						"notification-sns2",
-						"aws_sns_topic.topic",
+						"aws_sns_topic.test",
 						[]string{"s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"},
 						&s3.KeyFilter{
 							FilterRules: []*s3.FilterRule{
@@ -258,9 +258,9 @@ func TestAccS3BucketNotification_update(t *testing.T) {
 			{
 				Config: testAccBucketNotificationConfig_topic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketTopicNotification(ctx, "aws_s3_bucket.bucket",
+					testAccCheckBucketTopicNotification(ctx, "aws_s3_bucket.test",
 						"notification-sns1",
-						"aws_sns_topic.topic",
+						"aws_sns_topic.test",
 						[]string{"s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"},
 						nil,
 					),
@@ -269,9 +269,9 @@ func TestAccS3BucketNotification_update(t *testing.T) {
 			{
 				Config: testAccBucketNotificationConfig_queue(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBucketQueueNotification(ctx, "aws_s3_bucket.bucket",
+					testAccCheckBucketQueueNotification(ctx, "aws_s3_bucket.test",
 						"notification-sqs",
-						"aws_sqs_queue.queue",
+						"aws_sqs_queue.test",
 						[]string{"s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"},
 						&s3.KeyFilter{
 							FilterRules: []*s3.FilterRule{
@@ -534,17 +534,38 @@ func testAccBucketNotificationConfig_eventBridge(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
-resource "aws_s3_bucket" "bucket" {
+resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
+resource "aws_s3_bucket_public_access_block" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_ownership_controls" "test" {
+  bucket = aws_s3_bucket.test.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.bucket.id
+  depends_on = [
+    aws_s3_bucket_public_access_block.test,
+    aws_s3_bucket_ownership_controls.test,
+  ]
+
+  bucket = aws_s3_bucket.test.id
   acl    = "public-read"
 }
 
-resource "aws_s3_bucket_notification" "notification" {
-  bucket = aws_s3_bucket.bucket.id
+resource "aws_s3_bucket_notification" "test" {
+  bucket = aws_s3_bucket.test.id
 
   eventbridge = true
 }
@@ -555,7 +576,7 @@ func testAccBucketNotificationConfig_topicMultiple(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
-resource "aws_sns_topic" "topic" {
+resource "aws_sns_topic" "test" {
   name = %[1]q
 
   policy = <<POLICY
@@ -570,7 +591,7 @@ resource "aws_sns_topic" "topic" {
       "Resource": "arn:${data.aws_partition.current.partition}:sns:*:*:%[1]s",
       "Condition": {
         "ArnLike": {
-          "aws:SourceArn": "${aws_s3_bucket.bucket.arn}"
+          "aws:SourceArn": "${aws_s3_bucket.test.arn}"
         }
       }
     }
@@ -579,21 +600,42 @@ resource "aws_sns_topic" "topic" {
 POLICY
 }
 
-resource "aws_s3_bucket" "bucket" {
+resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
+resource "aws_s3_bucket_public_access_block" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_ownership_controls" "test" {
+  bucket = aws_s3_bucket.test.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.bucket.id
+  depends_on = [
+    aws_s3_bucket_public_access_block.test,
+    aws_s3_bucket_ownership_controls.test,
+  ]
+
+  bucket = aws_s3_bucket.test.id
   acl    = "public-read"
 }
 
-resource "aws_s3_bucket_notification" "notification" {
-  bucket = aws_s3_bucket.bucket.id
+resource "aws_s3_bucket_notification" "test" {
+  bucket = aws_s3_bucket.test.id
 
   topic {
     id        = "notification-sns1"
-    topic_arn = aws_sns_topic.topic.arn
+    topic_arn = aws_sns_topic.test.arn
 
     events = [
       "s3:ObjectCreated:*",
@@ -606,7 +648,7 @@ resource "aws_s3_bucket_notification" "notification" {
 
   topic {
     id        = "notification-sns2"
-    topic_arn = aws_sns_topic.topic.arn
+    topic_arn = aws_sns_topic.test.arn
 
     events = [
       "s3:ObjectCreated:*",
@@ -623,7 +665,7 @@ func testAccBucketNotificationConfig_queue(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
-resource "aws_sqs_queue" "queue" {
+resource "aws_sqs_queue" "test" {
   name = %[1]q
 
   policy = <<POLICY
@@ -637,7 +679,7 @@ resource "aws_sqs_queue" "queue" {
       "Resource": "arn:${data.aws_partition.current.partition}:sqs:*:*:%[1]s",
       "Condition": {
         "ArnEquals": {
-          "aws:SourceArn": "${aws_s3_bucket.bucket.arn}"
+          "aws:SourceArn": "${aws_s3_bucket.test.arn}"
         }
       }
     }
@@ -646,21 +688,42 @@ resource "aws_sqs_queue" "queue" {
 POLICY
 }
 
-resource "aws_s3_bucket" "bucket" {
+resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
+resource "aws_s3_bucket_public_access_block" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_ownership_controls" "test" {
+  bucket = aws_s3_bucket.test.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.bucket.id
+  depends_on = [
+    aws_s3_bucket_public_access_block.test,
+    aws_s3_bucket_ownership_controls.test,
+  ]
+
+  bucket = aws_s3_bucket.test.id
   acl    = "public-read"
 }
 
-resource "aws_s3_bucket_notification" "notification" {
-  bucket = aws_s3_bucket.bucket.id
+resource "aws_s3_bucket_notification" "test" {
+  bucket = aws_s3_bucket.test.id
 
   queue {
     id        = "notification-sqs"
-    queue_arn = aws_sqs_queue.queue.arn
+    queue_arn = aws_sqs_queue.test.arn
 
     events = [
       "s3:ObjectCreated:*",
@@ -678,7 +741,7 @@ func testAccBucketNotificationConfig_lambdaFunction(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
-resource "aws_iam_role" "iam_for_lambda" {
+resource "aws_iam_role" "test" {
   name = %[1]q
 
   assume_role_policy = <<EOF
@@ -698,37 +761,58 @@ resource "aws_iam_role" "iam_for_lambda" {
 EOF
 }
 
-resource "aws_lambda_permission" "allow_bucket" {
+resource "aws_lambda_permission" "test" {
   statement_id  = "AllowExecutionFromS3Bucket"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.func.arn
+  function_name = aws_lambda_function.test.arn
   principal     = "s3.${data.aws_partition.current.dns_suffix}"
-  source_arn    = aws_s3_bucket.bucket.arn
+  source_arn    = aws_s3_bucket.test.arn
 }
 
-resource "aws_lambda_function" "func" {
+resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = %[1]q
-  role          = aws_iam_role.iam_for_lambda.arn
+  role          = aws_iam_role.test.arn
   handler       = "exports.example"
   runtime       = "nodejs16.x"
 }
 
-resource "aws_s3_bucket" "bucket" {
+resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
+resource "aws_s3_bucket_public_access_block" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_ownership_controls" "test" {
+  bucket = aws_s3_bucket.test.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.bucket.id
+  depends_on = [
+    aws_s3_bucket_public_access_block.test,
+    aws_s3_bucket_ownership_controls.test,
+  ]
+
+  bucket = aws_s3_bucket.test.id
   acl    = "public-read"
 }
 
-resource "aws_s3_bucket_notification" "notification" {
-  bucket = aws_s3_bucket.bucket.id
+resource "aws_s3_bucket_notification" "test" {
+  bucket = aws_s3_bucket.test.id
 
   lambda_function {
     id                  = "notification-lambda"
-    lambda_function_arn = aws_lambda_function.func.arn
+    lambda_function_arn = aws_lambda_function.test.arn
 
     events = [
       "s3:ObjectCreated:*",
@@ -792,11 +876,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_notification" "test" {
   bucket = aws_s3_bucket.test.id
 
@@ -813,7 +892,7 @@ func testAccBucketNotificationConfig_topic(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
-resource "aws_sns_topic" "topic" {
+resource "aws_sns_topic" "test" {
   name = %[1]q
 
   policy = <<POLICY
@@ -830,7 +909,7 @@ resource "aws_sns_topic" "topic" {
       "Resource": "arn:${data.aws_partition.current.partition}:sns:*:*:%[1]s",
       "Condition": {
         "ArnLike": {
-          "aws:SourceArn": "${aws_s3_bucket.bucket.arn}"
+          "aws:SourceArn": "${aws_s3_bucket.test.arn}"
         }
       }
     }
@@ -839,21 +918,42 @@ resource "aws_sns_topic" "topic" {
 POLICY
 }
 
-resource "aws_s3_bucket" "bucket" {
+resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
+resource "aws_s3_bucket_public_access_block" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_ownership_controls" "test" {
+  bucket = aws_s3_bucket.test.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.bucket.id
+  depends_on = [
+    aws_s3_bucket_public_access_block.test,
+    aws_s3_bucket_ownership_controls.test,
+  ]
+
+  bucket = aws_s3_bucket.test.id
   acl    = "public-read"
 }
 
-resource "aws_s3_bucket_notification" "notification" {
-  bucket = aws_s3_bucket.bucket.id
+resource "aws_s3_bucket_notification" "test" {
+  bucket = aws_s3_bucket.test.id
 
   topic {
     id        = "notification-sns1"
-    topic_arn = aws_sns_topic.topic.arn
+    topic_arn = aws_sns_topic.test.arn
 
     events = [
       "s3:ObjectCreated:*",

--- a/internal/service/s3/bucket_replication_configuration_test.go
+++ b/internal/service/s3/bucket_replication_configuration_test.go
@@ -1938,11 +1938,6 @@ resource "aws_s3_bucket" "source" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "source_acl" {
-  bucket = aws_s3_bucket.source.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_versioning" "source" {
   bucket = aws_s3_bucket.source.id
   versioning_configuration {
@@ -2016,11 +2011,6 @@ resource "aws_s3_bucket_versioning" "destination" {
 
 resource "aws_s3_bucket" "source" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "source_acl" {
-  bucket = aws_s3_bucket.source.id
-  acl    = "private"
 }
 
 resource "aws_s3_bucket_versioning" "source" {
@@ -2320,11 +2310,6 @@ POLICY
 
 resource "aws_s3_bucket" "source" {
   bucket = "%[1]s-source"
-}
-
-resource "aws_s3_bucket_acl" "source" {
-  bucket = aws_s3_bucket.source.id
-  acl    = "private"
 }
 
 resource "aws_s3_bucket_versioning" "source" {

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -2954,22 +2954,6 @@ resource "aws_s3_bucket" "test" {
 `, bucketName)
 }
 
-func testAccBucketConfig_aclGrants(bucketName string) string {
-	return fmt.Sprintf(`
-data "aws_canonical_user_id" "current" {}
-
-resource "aws_s3_bucket" "test" {
-  bucket = %[1]q
-
-  grant {
-    id          = data.aws_canonical_user_id.current.id
-    type        = "CanonicalUser"
-    permissions = ["FULL_CONTROL", "WRITE"]
-  }
-}
-`, bucketName)
-}
-
 func testAccBucketConfig_lifecycle(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -3113,12 +3113,24 @@ func testAccBucketConfig_logging(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "log_bucket" {
   bucket = "%[1]s-log"
+}
+
+resource "aws_s3_bucket_ownership_controls" "log_bucket_ownership" {
+  bucket = aws_s3_bucket.log_bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "log_bucket_acl" {
+  depends_on = [aws_s3_bucket_ownership_controls.log_bucket_ownership]
+
+  bucket = aws_s3_bucket.log_bucket.id
   acl    = "log-delivery-write"
 }
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-  acl    = "private"
 
   logging {
     target_bucket = aws_s3_bucket.log_bucket.id

--- a/internal/service/s3/bucket_versioning_test.go
+++ b/internal/service/s3/bucket_versioning_test.go
@@ -549,11 +549,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_versioning" "test" {
   bucket = aws_s3_bucket.test.id
   versioning_configuration {
@@ -567,11 +562,6 @@ func testAccBucketVersioningConfig_mfaDelete(rName, mfaDelete string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_s3_bucket_versioning" "test" {

--- a/internal/service/s3/bucket_website_configuration_test.go
+++ b/internal/service/s3/bucket_website_configuration_test.go
@@ -621,11 +621,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "public-read"
-}
-
 resource "aws_s3_bucket_website_configuration" "test" {
   bucket = aws_s3_bucket.test.id
   index_document {
@@ -640,12 +635,6 @@ func testAccBucketWebsiteConfigurationConfig_update(rName string) string {
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "public-read"
-}
-
 
 resource "aws_s3_bucket_website_configuration" "test" {
   bucket = aws_s3_bucket.test.id
@@ -667,12 +656,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "public-read"
-}
-
-
 resource "aws_s3_bucket_website_configuration" "test" {
   bucket = aws_s3_bucket.test.id
   redirect_all_requests_to {
@@ -687,12 +670,6 @@ func testAccBucketWebsiteConfigurationConfig_routingRuleOptionalRedirection(rNam
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "public-read"
-}
-
 
 resource "aws_s3_bucket_website_configuration" "test" {
   bucket = aws_s3_bucket.test.id
@@ -725,12 +702,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "public-read"
-}
-
-
 resource "aws_s3_bucket_website_configuration" "test" {
   bucket = aws_s3_bucket.test.id
 
@@ -759,12 +730,6 @@ func testAccBucketWebsiteConfigurationConfig_routingRuleRedirectToPage(rName str
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "public-read"
-}
-
 
 resource "aws_s3_bucket_website_configuration" "test" {
   bucket = aws_s3_bucket.test.id
@@ -795,11 +760,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "public-read"
-}
-
 resource "aws_s3_bucket_website_configuration" "test" {
   bucket = aws_s3_bucket.test.id
 
@@ -825,11 +785,6 @@ func testAccBucketWebsiteConfigurationConfig_routingRuleMultipleRules(rName stri
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "public-read"
 }
 
 resource "aws_s3_bucket_website_configuration" "test" {
@@ -870,11 +825,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "public-read"
-}
-
 resource "aws_s3_bucket_website_configuration" "test" {
   bucket = aws_s3_bucket.test.id
 
@@ -908,11 +858,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "public-read"
-}
-
 resource "aws_s3_bucket_website_configuration" "test" {
   bucket = aws_s3_bucket.test.id
 
@@ -929,11 +874,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "public-read"
-}
-
 resource "aws_s3_bucket_website_configuration" "test" {
   bucket = aws_s3_bucket.test.id
 
@@ -948,11 +888,6 @@ func testAccBucketWebsiteConfigurationConfig_migrateRoutingRuleNoChange(rName st
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "public-read"
 }
 
 resource "aws_s3_bucket_website_configuration" "test" {
@@ -982,11 +917,6 @@ func testAccBucketWebsiteConfigurationConfig_migrateRoutingRuleChange(rName stri
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
-}
-
-resource "aws_s3_bucket_acl" "bucket" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "public-read"
 }
 
 resource "aws_s3_bucket_website_configuration" "test" {


### PR DESCRIPTION
### Description
Updates the S3 acceptance test suite to use configurations compatible with the recent changes to S3 default security settings.

### Relations
Relates #28353 

### References
- https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/


### Output from Acceptance Testing


```console
$ make testacc PKG=s3 TESTS=TestAccS3Bucket_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3Bucket_'  -timeout 180m

--- PASS: TestAccS3Bucket_Manage_lifecycleRuleExpirationEmptyBlock (30.53s)
=== CONT  TestAccS3Bucket_Tags_withNoSystemTags
--- PASS: TestAccS3Bucket_Manage_lifecycleRuleAbortIncompleteMultipartUploadDaysNoExpiration (32.14s)
=== CONT  TestAccS3Bucket_Replication_twoDestination
--- PASS: TestAccS3Bucket_Basic_basic (35.72s)
=== CONT  TestAccS3Bucket_Replication_schemaV2
--- PASS: TestAccS3Bucket_Security_corsSingleMethodAndEmptyOrigin (36.01s)
=== CONT  TestAccS3Bucket_Replication_withoutPrefix
--- PASS: TestAccS3Bucket_Manage_objectLock_deprecatedEnabled (37.37s)
=== CONT  TestAccS3Bucket_Replication_expectVersioningValidationError
--- PASS: TestAccS3Bucket_Security_corsEmptyOrigin (37.50s)
=== CONT  TestAccS3Bucket_Replication_withoutStorageClass
--- PASS: TestAccS3Bucket_Manage_objectLockWithVersioning (37.66s)
=== CONT  TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenTypical (37.83s)
=== CONT  TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation
--- PASS: TestAccS3Bucket_Manage_objectLockWithVersioning_deprecatedEnabled (38.91s)
=== CONT  TestAccS3Bucket_Basic_acceleration
--- PASS: TestAccS3Bucket_Security_logging (39.19s)
=== CONT  TestAccS3Bucket_Duplicate_UsEast1AltAccount
    acctest.go:772: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccS3Bucket_Duplicate_UsEast1AltAccount (0.00s)
=== CONT  TestAccS3Bucket_Duplicate_UsEast1
--- PASS: TestAccS3Bucket_Tags_basic (39.41s)
=== CONT  TestAccS3Bucket_Duplicate_basic
--- PASS: TestAccS3Bucket_Manage_objectLock_migrate (41.25s)
=== CONT  TestAccS3Bucket_disappears
--- PASS: TestAccS3Bucket_Replication_schemaV2SameRegion (46.75s)
=== CONT  TestAccS3Bucket_Security_corsDelete
--- PASS: TestAccS3Bucket_Manage_lifecycleRemove (49.76s)
=== CONT  TestAccS3Bucket_Basic_requestPayer
--- PASS: TestAccS3Bucket_Duplicate_UsEast1 (11.84s)
=== CONT  TestAccS3Bucket_Security_corsUpdate
--- PASS: TestAccS3Bucket_Manage_lifecycleExpireMarkerOnly (52.65s)
=== CONT  TestAccS3Bucket_Basic_keyEnabled
--- PASS: TestAccS3Bucket_Replication_expectVersioningValidationError (17.46s)
=== CONT  TestAccS3Bucket_Basic_generatedName
--- PASS: TestAccS3Bucket_Manage_lifecycleBasic (56.65s)
=== CONT  TestAccS3Bucket_Basic_namePrefix
--- PASS: TestAccS3Bucket_Duplicate_basic (17.68s)
=== CONT  TestAccS3Bucket_Basic_emptyString
--- PASS: TestAccS3Bucket_Manage_objectLock (57.79s)
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
--- PASS: TestAccS3Bucket_Tags_ignoreTags (57.85s)
=== CONT  TestAccS3Bucket_Replication_basic
--- PASS: TestAccS3Bucket_Manage_versioning (62.07s)
=== CONT  TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter
--- PASS: TestAccS3Bucket_disappears (23.70s)
=== CONT  TestAccS3Bucket_Basic_forceDestroy
--- PASS: TestAccS3Bucket_Replication_twoDestination (39.23s)
=== CONT  TestAccS3Bucket_Web_simple
--- PASS: TestAccS3Bucket_Security_corsDelete (26.07s)
=== CONT  TestAccS3Bucket_Web_routingRules
--- PASS: TestAccS3Bucket_Replication_withoutPrefix (42.46s)
=== CONT  TestAccS3Bucket_Web_redirect
--- PASS: TestAccS3Bucket_Replication_withoutStorageClass (41.71s)
=== CONT  TestAccS3Bucket_Manage_MFADeleteDisabled
--- PASS: TestAccS3Bucket_Basic_keyEnabled (36.50s)
=== CONT  TestAccS3Bucket_Manage_versioningAndMFADeleteDisabled
--- PASS: TestAccS3Bucket_Basic_generatedName (35.08s)
=== CONT  TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled
--- PASS: TestAccS3Bucket_Basic_namePrefix (33.22s)
=== CONT  TestAccS3Bucket_Manage_versioningDisabled
--- PASS: TestAccS3Bucket_Basic_emptyString (32.91s)
=== CONT  TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (32.56s)
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
--- PASS: TestAccS3Bucket_Basic_forceDestroy (29.27s)
=== CONT  TestAccS3Bucket_Replication_RTC_valid
--- PASS: TestAccS3Bucket_Basic_acceleration (61.94s)
=== CONT  TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsNonEmptyFilter (41.77s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAccessControlTranslation (66.84s)
--- PASS: TestAccS3Bucket_Replication_ruleDestinationAddAccessControlTranslation (68.86s)
--- PASS: TestAccS3Bucket_Basic_requestPayer (57.33s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (59.57s)
--- PASS: TestAccS3Bucket_Manage_MFADeleteDisabled (33.79s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (27.06s)
--- PASS: TestAccS3Bucket_Manage_versioningAndMFADeleteDisabled (28.86s)
--- PASS: TestAccS3Bucket_Manage_versioningDisabled (30.56s)
--- PASS: TestAccS3Bucket_Security_enableDefaultEncryptionWhenAES256IsUsed (31.31s)
--- PASS: TestAccS3Bucket_Web_routingRules (49.68s)
--- PASS: TestAccS3Bucket_Tags_withNoSystemTags (97.52s)
--- PASS: TestAccS3Bucket_Replication_multipleDestinationsEmptyFilter (27.47s)
--- PASS: TestAccS3Bucket_Replication_basic (72.91s)
--- PASS: TestAccS3Bucket_Security_disableDefaultEncryptionWhenDefaultEncryptionIsEnabled (42.75s)
--- PASS: TestAccS3Bucket_Web_simple (64.56s)
--- PASS: TestAccS3Bucket_Tags_withSystemTags (139.01s)
--- PASS: TestAccS3Bucket_Web_redirect (61.38s)
--- PASS: TestAccS3Bucket_Replication_schemaV2 (111.79s)
--- PASS: TestAccS3Bucket_Replication_RTC_valid (64.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 163.286s
```

```console
$ make testacc PKG=s3 TESTS=TestAccS3BucketACL_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketACL_'  -timeout 180m

--- PASS: TestAccS3BucketACL_disappears (15.59s)
--- PASS: TestAccS3BucketACL_basic (21.05s)
--- PASS: TestAccS3BucketACL_migrate_aclNoChange (29.76s)
--- PASS: TestAccS3BucketACL_migrate_aclWithChange (30.92s)
--- PASS: TestAccS3BucketACL_migrate_grantsWithChange (31.12s)
--- PASS: TestAccS3BucketACL_updateACL (33.95s)
--- PASS: TestAccS3BucketACL_grantToACL (34.32s)
--- PASS: TestAccS3BucketACL_ACLToGrant (35.92s)
--- PASS: TestAccS3BucketACL_updateGrant (38.40s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 41.585s

```

```console
$ make testacc PKG=s3 TESTS=TestAccS3BucketInventory_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketInventory_'  -timeout 180m

--- PASS: TestAccS3BucketInventory_basic (17.87s)
--- PASS: TestAccS3BucketInventory_encryptWithSSES3 (17.88s)
--- PASS: TestAccS3BucketInventory_encryptWithSSEKMS (19.41s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 22.603s
```


```console
$ make testacc PKG=s3 TESTS=TestAccS3BucketLifecycleConfiguration_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketLifecycleConfiguration_'  -timeout 180m

--- PASS: TestAccS3BucketLifecycleConfiguration_disappears (63.74s)
=== CONT  TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly
--- PASS: TestAccS3BucketLifecycleConfiguration_migrate_withChange (197.17s)
=== CONT  TestAccS3BucketLifecycleConfiguration_multipleRules
--- PASS: TestAccS3BucketLifecycleConfiguration_migrate_noChange (197.94s)
=== CONT  TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering (203.12s)
=== CONT  TestAccS3BucketLifecycleConfiguration_prefix
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix (203.27s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa (203.43s)
=== CONT  TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering (203.89s)
=== CONT  TestAccS3BucketLifecycleConfiguration_disableRule
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange (204.64s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan (205.46s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering (206.30s)
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (207.47s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_Tag (207.71s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock (207.75s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration (207.77s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero (207.77s)
--- PASS: TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions (207.78s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix (259.16s)
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithPrefix (285.26s)
--- PASS: TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload (285.27s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly (272.63s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering (336.43s)
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules (189.69s)
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix (190.18s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan (190.57s)
--- PASS: TestAccS3BucketLifecycleConfiguration_prefix (190.74s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition (190.78s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disableRule (321.01s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 528.000s
```

```console
$ make testacc PKG=s3 TESTS=TestAccS3BucketLogging_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketLogging_'  -timeout 180m

--- PASS: TestAccS3BucketLogging_disappears (17.99s)
--- PASS: TestAccS3BucketLogging_basic (20.29s)
--- PASS: TestAccS3BucketLogging_migrate_loggingWithChange (33.00s)
--- PASS: TestAccS3BucketLogging_migrate_loggingNoChange (33.18s)
--- PASS: TestAccS3BucketLogging_TargetGrantByGroup (46.37s)
--- PASS: TestAccS3BucketLogging_update (49.52s)
--- PASS: TestAccS3BucketLogging_TargetGrantByID (49.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 53.068s
```



```console
$ make testacc PKG=s3 TESTS=TestAccS3BucketMetric_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketMetric_'  -timeout 180m

--- PASS: TestAccS3BucketMetric_withEmptyFilter (1.86s)
--- PASS: TestAccS3BucketMetric_basic (18.77s)
--- PASS: TestAccS3BucketMetric_withFilterPrefix (31.03s)
--- PASS: TestAccS3BucketMetric_withFilterPrefixAndMultipleTags (31.29s)
--- PASS: TestAccS3BucketMetric_withFilterSingleTag (31.75s)
--- PASS: TestAccS3BucketMetric_withFilterPrefixAndSingleTag (31.76s)
--- PASS: TestAccS3BucketMetric_withFilterMultipleTags (32.05s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 35.196s
```

```console
$ make testacc PKG=s3 TESTS=TestAccS3BucketNotification_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketNotification_'  -timeout 180m

--- PASS: TestAccS3BucketNotification_eventbridge (20.66s)
--- PASS: TestAccS3BucketNotification_Topic_multiple (21.29s)
--- PASS: TestAccS3BucketNotification_topic (21.51s)
--- PASS: TestAccS3BucketNotification_LambdaFunctionLambdaFunctionARN_alias (31.78s)
--- PASS: TestAccS3BucketNotification_lambdaFunction (38.26s)
--- PASS: TestAccS3BucketNotification_queue (49.57s)
--- PASS: TestAccS3BucketNotification_update (59.95s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 62.991s

```


```console
$ make testacc PKG=s3 TESTS=TestAccS3BucketPolicy_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketPolicy_'  -timeout 180m

--- PASS: TestAccS3BucketPolicy_disappears_bucket (16.18s)
--- PASS: TestAccS3BucketPolicy_disappears (19.54s)
--- PASS: TestAccS3BucketPolicy_basic (21.13s)
--- PASS: TestAccS3BucketPolicy_migrate_withChange (30.94s)
--- PASS: TestAccS3BucketPolicy_migrate_noChange (31.46s)
--- PASS: TestAccS3BucketPolicy_policyUpdate (33.33s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDoc (55.25s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal (56.83s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode (99.29s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 102.342s
```


```console
$ make testacc PKG=s3 TESTS=TestAccS3BucketReplicationConfiguration_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketReplicationConfiguration_'  -timeout 180m

--- PASS: TestAccS3BucketReplicationConfiguration_disappears (53.28s)
=== CONT  TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics
--- PASS: TestAccS3BucketReplicationConfiguration_replicaModifications (281.85s)
=== CONT  TestAccS3BucketReplicationConfiguration_schemaV2SameRegion
--- PASS: TestAccS3BucketReplicationConfiguration_filter_emptyConfigurationBlock (284.65s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsNonEmptyFilter (285.51s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutPrefix (292.60s)
--- PASS: TestAccS3BucketReplicationConfiguration_twoDestination (292.74s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_emptyPrefix (292.88s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutStorageClass (293.35s)
--- PASS: TestAccS3BucketReplicationConfiguration_replicationTimeControl (293.44s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_withoutId (293.63s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_tagFilter (293.68s)
--- PASS: TestAccS3BucketReplicationConfiguration_withoutId (293.73s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2 (293.73s)
--- PASS: TestAccS3BucketReplicationConfiguration_multipleDestinationsEmptyFilter (293.79s)
--- PASS: TestAccS3BucketReplicationConfiguration_migrate_noChange (300.36s)
--- PASS: TestAccS3BucketReplicationConfiguration_migrate_withChange (300.56s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAddAccessControlTranslation (310.89s)
--- PASS: TestAccS3BucketReplicationConfiguration_filter_andOperator (310.86s)
--- PASS: TestAccS3BucketReplicationConfiguration_configurationRuleDestinationAccessControlTranslation (311.29s)
--- PASS: TestAccS3BucketReplicationConfiguration_schemaV2DestinationMetrics (263.09s)
--- PASS: TestAccS3BucketReplicationConfiguration_basic (319.71s)
```

NOTE: Replication configuration test suite currently has one test (`TestAccS3BucketReplicationConfiguration_schemaV2SameRegion`) causing a panic unrelated to these changes. All other tests are passing.

```console
$ make testacc PKG=s3 TESTS=TestAccS3BucketVersioning_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketVersioning_'  -timeout 180m

--- PASS: TestAccS3BucketVersioning_disappears_bucket (25.80s)
--- PASS: TestAccS3BucketVersioning_disappears (28.52s)
--- PASS: TestAccS3BucketVersioning_Status_disabled (30.27s)
--- PASS: TestAccS3BucketVersioning_basic (31.17s)
--- PASS: TestAccS3BucketVersioning_MFADelete (32.39s)
--- PASS: TestAccS3BucketVersioning_Status_suspendedToDisabled (32.91s)
--- PASS: TestAccS3BucketVersioning_Status_enabledToDisabled (33.09s)
--- PASS: TestAccS3BucketVersioning_migrate_versioningDisabledNoChange (40.04s)
--- PASS: TestAccS3BucketVersioning_migrate_versioningDisabledWithChange (40.41s)
--- PASS: TestAccS3BucketVersioning_migrate_versioningEnabledNoChange (40.77s)
--- PASS: TestAccS3BucketVersioning_migrate_mfaDeleteNoChange (41.03s)
--- PASS: TestAccS3BucketVersioning_migrate_versioningEnabledWithChange (41.03s)
--- PASS: TestAccS3BucketVersioning_Status_disabledToEnabled (46.35s)
--- PASS: TestAccS3BucketVersioning_Status_disabledToSuspended (47.93s)
--- PASS: TestAccS3BucketVersioning_update (63.96s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 67.034s
```

```console
$ make testacc PKG=s3 TESTS=TestAccS3BucketWebsiteConfiguration_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketWebsiteConfiguration_'  -timeout 180m

--- PASS: TestAccS3BucketWebsiteConfiguration_disappears (25.52s)
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirect (25.69s)
--- PASS: TestAccS3BucketWebsiteConfiguration_Redirect (26.94s)
--- PASS: TestAccS3BucketWebsiteConfiguration_basic (29.90s)
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRules_ConditionAndRedirectWithEmptyString (29.92s)
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRule_RedirectOnly (30.08s)
--- PASS: TestAccS3BucketWebsiteConfiguration_migrate_websiteWithRoutingRuleNoChange (37.63s)
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRuleToRoutingRules (38.35s)
--- PASS: TestAccS3BucketWebsiteConfiguration_migrate_websiteWithRoutingRuleWithChange (39.54s)
--- PASS: TestAccS3BucketWebsiteConfiguration_migrate_websiteWithIndexDocumentNoChange (40.10s)
--- PASS: TestAccS3BucketWebsiteConfiguration_migrate_websiteWithIndexDocumentWithChange (40.24s)
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRules_updateConditionAndRedirect (40.31s)
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRule_MultipleRules (42.90s)
--- PASS: TestAccS3BucketWebsiteConfiguration_update (42.91s)
--- PASS: TestAccS3BucketWebsiteConfiguration_RoutingRule_ConditionAndRedirect (80.14s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 83.476s
```


```console
$ make testacc PKG=s3 TESTS=TestAccS3BucketDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketDataSource_'  -timeout 180m

--- PASS: TestAccS3BucketDataSource_basic (15.95s)
--- PASS: TestAccS3BucketDataSource_website (17.16s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 20.408s
```