### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin SDK resources `kms` (Phase 3c)

### DIFF
--- a/internal/service/kms/external_key.go
+++ b/internal/service/kms/external_key.go
@@ -150,7 +150,7 @@ func resourceExternalKeyCreate(ctx context.Context, d *schema.ResourceData, meta
 	// KMS will report this error until it can validate the policy itself.
 	// They acknowledge this here:
 	// http://docs.aws.amazon.com/kms/latest/APIReference/API_CreateKey.html
-	outputRaw, err := WaitIAMPropagation(ctx, func() (interface{}, error) {
+	output, err := WaitIAMPropagation(ctx, func() (*kms.CreateKeyOutput, error) {
 		return conn.CreateKeyWithContext(ctx, input)
 	})
 
@@ -158,7 +158,7 @@ func resourceExternalKeyCreate(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendErrorf(diags, "creating KMS External Key: %s", err)
 	}
 
-	d.SetId(aws.StringValue(outputRaw.(*kms.CreateKeyOutput).KeyMetadata.KeyId))
+	d.SetId(aws.StringValue(output.KeyMetadata.KeyId))
 
 	if v, ok := d.GetOk("key_material_base64"); ok {
 		validTo := d.Get("valid_to").(string)

--- a/internal/service/kms/external_key.go
+++ b/internal/service/kms/external_key.go
@@ -23,9 +23,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_kms_external_key")
+// @SDKResource("aws_kms_external_key", name="External Key")
+// @Tags(identifierAttribute="id")
 func ResourceExternalKey() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceExternalKeyCreate,
@@ -104,8 +106,8 @@ func ResourceExternalKey() *schema.Resource {
 					return json
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"valid_to": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -118,13 +120,12 @@ func ResourceExternalKey() *schema.Resource {
 func resourceExternalKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KMSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &kms.CreateKeyInput{
 		BypassPolicyLockoutSafetyCheck: aws.Bool(d.Get("bypass_policy_lockout_safety_check").(bool)),
 		KeyUsage:                       aws.String(kms.KeyUsageTypeEncryptDecrypt),
 		Origin:                         aws.String(kms.OriginTypeExternal),
+		Tags:                           GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -142,10 +143,6 @@ func resourceExternalKeyCreate(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 		input.Policy = aws.String(p)
-	}
-
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
 	}
 
 	// AWS requires any principal in the policy to exist before the key is created.
@@ -194,7 +191,7 @@ func resourceExternalKeyCreate(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
-	if len(tags) > 0 {
+	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
 		if err := WaitTagsPropagated(ctx, conn, d.Id(), tags); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for KMS External Key (%s) tag propagation: %s", d.Id(), err)
 		}
@@ -206,8 +203,6 @@ func resourceExternalKeyCreate(ctx context.Context, d *schema.ResourceData, meta
 func resourceExternalKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KMSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	key, err := findKey(ctx, conn, d.Id(), d.IsNewResource())
 
@@ -255,16 +250,7 @@ func resourceExternalKeyRead(ctx context.Context, d *schema.ResourceData, meta i
 		d.Set("valid_to", nil)
 	}
 
-	tags := key.tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, key.tags)
 
 	return diags
 }
@@ -316,13 +302,7 @@ func resourceExternalKeyUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating KMS External Key (%s) tags: %s", d.Id(), err)
-		}
-
-		if err := WaitTagsPropagated(ctx, conn, d.Id(), tftags.New(ctx, n)); err != nil {
+		if err := WaitTagsPropagated(ctx, conn, d.Id(), tftags.New(ctx, d.Get("tags_all").(map[string]interface{}))); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for KMS External Key (%s) tag propagation: %s", d.Id(), err)
 		}
 	}

--- a/internal/service/kms/key.go
+++ b/internal/service/kms/key.go
@@ -152,7 +152,7 @@ func resourceKeyCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	// The KMS service's awareness of principals is limited by "eventual consistency".
 	// They acknowledge this here:
 	// http://docs.aws.amazon.com/kms/latest/APIReference/API_CreateKey.html
-	outputRaw, err := WaitIAMPropagation(ctx, func() (interface{}, error) {
+	output, err := WaitIAMPropagation(ctx, func() (*kms.CreateKeyOutput, error) {
 		return conn.CreateKeyWithContext(ctx, input)
 	})
 
@@ -160,7 +160,7 @@ func resourceKeyCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 		return sdkdiag.AppendErrorf(diags, "creating KMS Key: %s", err)
 	}
 
-	d.SetId(aws.StringValue(outputRaw.(*kms.CreateKeyOutput).KeyMetadata.KeyId))
+	d.SetId(aws.StringValue(output.KeyMetadata.KeyId))
 
 	if enableKeyRotation := d.Get("enable_key_rotation").(bool); enableKeyRotation {
 		if err := updateKeyRotationEnabled(ctx, conn, d.Id(), enableKeyRotation); err != nil {

--- a/internal/service/kms/key.go
+++ b/internal/service/kms/key.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_kms_key")
+// @SDKResource("aws_kms_key", name="Key")
+// @Tags(identifierAttribute="id")
 func ResourceKey() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceKeyCreate,
@@ -107,8 +109,8 @@ func ResourceKey() *schema.Resource {
 					return json
 				},
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -116,13 +118,12 @@ func ResourceKey() *schema.Resource {
 func resourceKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KMSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	input := &kms.CreateKeyInput{
 		BypassPolicyLockoutSafetyCheck: aws.Bool(d.Get("bypass_policy_lockout_safety_check").(bool)),
 		CustomerMasterKeySpec:          aws.String(d.Get("customer_master_key_spec").(string)),
 		KeyUsage:                       aws.String(d.Get("key_usage").(string)),
+		Tags:                           GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -147,16 +148,10 @@ func resourceKeyCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 		input.CustomKeyStoreId = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
 	// AWS requires any principal in the policy to exist before the key is created.
 	// The KMS service's awareness of principals is limited by "eventual consistency".
 	// They acknowledge this here:
 	// http://docs.aws.amazon.com/kms/latest/APIReference/API_CreateKey.html
-	log.Printf("[DEBUG] Creating KMS Key: %s", input)
-
 	outputRaw, err := WaitIAMPropagation(ctx, func() (interface{}, error) {
 		return conn.CreateKeyWithContext(ctx, input)
 	})
@@ -186,7 +181,7 @@ func resourceKeyCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 		}
 	}
 
-	if len(tags) > 0 {
+	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
 		if err := WaitTagsPropagated(ctx, conn, d.Id(), tags); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for KMS Key (%s) tag propagation: %s", d.Id(), err)
 		}
@@ -198,8 +193,6 @@ func resourceKeyCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 func resourceKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KMSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	key, err := findKey(ctx, conn, d.Id(), d.IsNewResource())
 
@@ -234,16 +227,7 @@ func resourceKeyRead(ctx context.Context, d *schema.ResourceData, meta interface
 
 	d.Set("policy", policyToSet)
 
-	tags := key.tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, key.tags)
 
 	return diags
 }
@@ -285,13 +269,7 @@ func resourceKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating KMS Key (%s) tags: %s", d.Id(), err)
-		}
-
-		if err := WaitTagsPropagated(ctx, conn, d.Id(), tftags.New(ctx, n)); err != nil {
+		if err := WaitTagsPropagated(ctx, conn, d.Id(), tftags.New(ctx, d.Get("tags_all").(map[string]interface{}))); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for KMS Key (%s) tag propagation: %s", d.Id(), err)
 		}
 	}
@@ -337,7 +315,7 @@ type kmsKey struct {
 	metadata *kms.KeyMetadata
 	policy   string
 	rotation *bool
-	tags     tftags.KeyValueTags
+	tags     []*kms.Tag
 }
 
 func findKey(ctx context.Context, conn *kms.KMS, keyID string, isNewResource bool) (*kmsKey, error) {
@@ -372,7 +350,7 @@ func findKey(ctx context.Context, conn *kms.KMS, keyID string, isNewResource boo
 			}
 		}
 
-		key.tags, err = ListTags(ctx, conn, keyID)
+		tags, err := ListTags(ctx, conn, keyID)
 
 		if tfawserr.ErrCodeEquals(err, kms.ErrCodeNotFoundException) {
 			return nil, &retry.NotFoundError{LastError: err}
@@ -381,6 +359,8 @@ func findKey(ctx context.Context, conn *kms.KMS, keyID string, isNewResource boo
 		if err != nil {
 			return nil, fmt.Errorf("listing tags for KMS Key (%s): %w", keyID, err)
 		}
+
+		key.tags = Tags(tags)
 
 		return &key, nil
 	}, isNewResource)

--- a/internal/service/kms/replica_external_key.go
+++ b/internal/service/kms/replica_external_key.go
@@ -18,9 +18,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_kms_replica_external_key")
+// @SDKResource("aws_kms_replica_external_key", name="Replica External Key")
+// @Tags(identifierAttribute="id")
 func ResourceReplicaExternalKey() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceReplicaExternalKeyCreate,
@@ -95,8 +97,8 @@ func ResourceReplicaExternalKey() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: verify.ValidARN,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"valid_to": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -109,8 +111,6 @@ func ResourceReplicaExternalKey() *schema.Resource {
 func resourceReplicaExternalKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KMSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	// e.g. arn:aws:kms:us-east-2:111122223333:key/mrk-1234abcd12ab34cd56ef1234567890ab
 	primaryKeyARN, err := arn.Parse(d.Get("primary_key_arn").(string))
@@ -122,6 +122,7 @@ func resourceReplicaExternalKeyCreate(ctx context.Context, d *schema.ResourceDat
 	input := &kms.ReplicateKeyInput{
 		KeyId:         aws.String(strings.TrimPrefix(primaryKeyARN.Resource, "key/")),
 		ReplicaRegion: aws.String(meta.(*conns.AWSClient).Region),
+		Tags:          GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("bypass_policy_lockout_safety_check"); ok {
@@ -136,10 +137,6 @@ func resourceReplicaExternalKeyCreate(ctx context.Context, d *schema.ResourceDat
 		input.Policy = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
 	// Replication is initiated in the primary key's region.
 	session, err := conns.NewSessionForRegion(&conn.Config, primaryKeyARN.Region, meta.(*conns.AWSClient).TerraformVersion)
 
@@ -149,7 +146,6 @@ func resourceReplicaExternalKeyCreate(ctx context.Context, d *schema.ResourceDat
 
 	replicateConn := kms.New(session)
 
-	log.Printf("[DEBUG] Creating KMS Replica External Key: %s", input)
 	outputRaw, err := WaitIAMPropagation(ctx, func() (interface{}, error) {
 		return replicateConn.ReplicateKeyWithContext(ctx, input)
 	})
@@ -195,7 +191,7 @@ func resourceReplicaExternalKeyCreate(ctx context.Context, d *schema.ResourceDat
 		}
 	}
 
-	if len(tags) > 0 {
+	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
 		if err := WaitTagsPropagated(ctx, conn, d.Id(), tags); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for KMS Replica External Key (%s) tag propagation: %s", d.Id(), err)
 		}
@@ -207,8 +203,6 @@ func resourceReplicaExternalKeyCreate(ctx context.Context, d *schema.ResourceDat
 func resourceReplicaExternalKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KMSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	key, err := findKey(ctx, conn, d.Id(), d.IsNewResource())
 
@@ -257,16 +251,7 @@ func resourceReplicaExternalKeyRead(ctx context.Context, d *schema.ResourceData,
 		d.Set("valid_to", nil)
 	}
 
-	tags := key.tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, key.tags)
 
 	return diags
 }
@@ -318,13 +303,7 @@ func resourceReplicaExternalKeyUpdate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating KMS Replica External Key (%s) tags: %s", d.Id(), err)
-		}
-
-		if err := WaitTagsPropagated(ctx, conn, d.Id(), tftags.New(ctx, n)); err != nil {
+		if err := WaitTagsPropagated(ctx, conn, d.Id(), tftags.New(ctx, d.Get("tags_all").(map[string]interface{}))); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for KMS Replica External Key (%s) tag propagation: %s", d.Id(), err)
 		}
 	}

--- a/internal/service/kms/replica_external_key.go
+++ b/internal/service/kms/replica_external_key.go
@@ -146,7 +146,7 @@ func resourceReplicaExternalKeyCreate(ctx context.Context, d *schema.ResourceDat
 
 	replicateConn := kms.New(session)
 
-	outputRaw, err := WaitIAMPropagation(ctx, func() (interface{}, error) {
+	output, err := WaitIAMPropagation(ctx, func() (*kms.ReplicateKeyOutput, error) {
 		return replicateConn.ReplicateKeyWithContext(ctx, input)
 	})
 
@@ -154,7 +154,7 @@ func resourceReplicaExternalKeyCreate(ctx context.Context, d *schema.ResourceDat
 		return sdkdiag.AppendErrorf(diags, "creating KMS Replica External Key: %s", err)
 	}
 
-	d.SetId(aws.StringValue(outputRaw.(*kms.ReplicateKeyOutput).ReplicaKeyMetadata.KeyId))
+	d.SetId(aws.StringValue(output.ReplicaKeyMetadata.KeyId))
 
 	if _, err := WaitReplicaExternalKeyCreated(ctx, conn, d.Id()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for KMS Replica External Key (%s) create: %s", d.Id(), err)

--- a/internal/service/kms/replica_key.go
+++ b/internal/service/kms/replica_key.go
@@ -134,7 +134,7 @@ func resourceReplicaKeyCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	replicateConn := kms.New(session)
 
-	outputRaw, err := WaitIAMPropagation(ctx, func() (interface{}, error) {
+	output, err := WaitIAMPropagation(ctx, func() (*kms.ReplicateKeyOutput, error) {
 		return replicateConn.ReplicateKeyWithContext(ctx, input)
 	})
 
@@ -142,7 +142,7 @@ func resourceReplicaKeyCreate(ctx context.Context, d *schema.ResourceData, meta 
 		return sdkdiag.AppendErrorf(diags, "creating KMS Replica Key: %s", err)
 	}
 
-	d.SetId(aws.StringValue(outputRaw.(*kms.ReplicateKeyOutput).ReplicaKeyMetadata.KeyId))
+	d.SetId(aws.StringValue(output.ReplicaKeyMetadata.KeyId))
 
 	if _, err := WaitReplicaKeyCreated(ctx, conn, d.Id()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for KMS Replica Key (%s) create: %s", d.Id(), err)

--- a/internal/service/kms/replica_key.go
+++ b/internal/service/kms/replica_key.go
@@ -17,9 +17,11 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_kms_replica_key")
+// @SDKResource("aws_kms_replica_key", name="Replica Key")
+// @Tags(identifierAttribute="id")
 func ResourceReplicaKey() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceReplicaKeyCreate,
@@ -88,8 +90,8 @@ func ResourceReplicaKey() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: verify.ValidARN,
 			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
@@ -97,8 +99,6 @@ func ResourceReplicaKey() *schema.Resource {
 func resourceReplicaKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KMSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	// e.g. arn:aws:kms:us-east-2:111122223333:key/mrk-1234abcd12ab34cd56ef1234567890ab
 	primaryKeyARN, err := arn.Parse(d.Get("primary_key_arn").(string))
@@ -110,6 +110,7 @@ func resourceReplicaKeyCreate(ctx context.Context, d *schema.ResourceData, meta 
 	input := &kms.ReplicateKeyInput{
 		KeyId:         aws.String(strings.TrimPrefix(primaryKeyARN.Resource, "key/")),
 		ReplicaRegion: aws.String(meta.(*conns.AWSClient).Region),
+		Tags:          GetTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("bypass_policy_lockout_safety_check"); ok {
@@ -124,10 +125,6 @@ func resourceReplicaKeyCreate(ctx context.Context, d *schema.ResourceData, meta 
 		input.Policy = aws.String(v.(string))
 	}
 
-	if len(tags) > 0 {
-		input.Tags = Tags(tags.IgnoreAWS())
-	}
-
 	// Replication is initiated in the primary key's region.
 	session, err := conns.NewSessionForRegion(&conn.Config, primaryKeyARN.Region, meta.(*conns.AWSClient).TerraformVersion)
 
@@ -137,7 +134,6 @@ func resourceReplicaKeyCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	replicateConn := kms.New(session)
 
-	log.Printf("[DEBUG] Creating KMS Replica Key: %s", input)
 	outputRaw, err := WaitIAMPropagation(ctx, func() (interface{}, error) {
 		return replicateConn.ReplicateKeyWithContext(ctx, input)
 	})
@@ -167,7 +163,7 @@ func resourceReplicaKeyCreate(ctx context.Context, d *schema.ResourceData, meta 
 		}
 	}
 
-	if len(tags) > 0 {
+	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
 		if err := WaitTagsPropagated(ctx, conn, d.Id(), tags); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for KMS Replica Key (%s) tag propagation: %s", d.Id(), err)
 		}
@@ -179,8 +175,6 @@ func resourceReplicaKeyCreate(ctx context.Context, d *schema.ResourceData, meta 
 func resourceReplicaKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).KMSConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	key, err := findKey(ctx, conn, d.Id(), d.IsNewResource())
 
@@ -221,19 +215,9 @@ func resourceReplicaKeyRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	d.Set("policy", policyToSet)
-
 	d.Set("primary_key_arn", key.metadata.MultiRegionConfiguration.PrimaryKey.Arn)
 
-	tags := key.tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	SetTagsOut(ctx, key.tags)
 
 	return diags
 }
@@ -269,13 +253,7 @@ func resourceReplicaKeyUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	if d.HasChange("tags_all") {
-		o, n := d.GetChange("tags_all")
-
-		if err := UpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating KMS Replica Key (%s) tags: %s", d.Id(), err)
-		}
-
-		if err := WaitTagsPropagated(ctx, conn, d.Id(), tftags.New(ctx, n)); err != nil {
+		if err := WaitTagsPropagated(ctx, conn, d.Id(), tftags.New(ctx, d.Get("tags_all").(map[string]interface{}))); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for KMS Replica Key (%s) tag propagation: %s", d.Id(), err)
 		}
 	}

--- a/internal/service/kms/service_package_gen.go
+++ b/internal/service/kms/service_package_gen.go
@@ -69,6 +69,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceExternalKey,
 			TypeName: "aws_kms_external_key",
+			Name:     "External Key",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceGrant,
@@ -77,6 +81,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceKey,
 			TypeName: "aws_kms_key",
+			Name:     "Key",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceKeyPolicy,
@@ -85,10 +93,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceReplicaExternalKey,
 			TypeName: "aws_kms_replica_external_key",
+			Name:     "Replica External Key",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 		{
 			Factory:  ResourceReplicaKey,
 			TypeName: "aws_kms_replica_key",
+			Name:     "Replica Key",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }

--- a/internal/service/kms/wait.go
+++ b/internal/service/kms/wait.go
@@ -34,8 +34,18 @@ const (
 
 // WaitIAMPropagation retries the specified function if the returned error indicates an IAM eventual consistency issue.
 // If the retries time out the specified function is called one last time.
-func WaitIAMPropagation(ctx context.Context, f func() (interface{}, error)) (interface{}, error) {
-	return tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, f, kms.ErrCodeMalformedPolicyDocumentException)
+func WaitIAMPropagation[T any](ctx context.Context, f func() (T, error)) (T, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
+		return f()
+	},
+		kms.ErrCodeMalformedPolicyDocumentException)
+
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+
+	return outputRaw.(T), err
 }
 
 func WaitKeyDeleted(ctx context.Context, conn *kms.KMS, id string) (*kms.KeyMetadata, error) {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin SDK.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30421.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30430.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30449.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30454.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30461.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30463.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30476.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30477.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30478.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30483.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30484.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30491.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30509.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30510.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30512.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30516.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30517.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30533.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30534.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccKMS' PKG=kms ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kms/... -v -count 1 -parallel 2  -run=TestAccKMS -timeout 180m
=== RUN   TestAccKMSAliasDataSource_service
=== PAUSE TestAccKMSAliasDataSource_service
=== RUN   TestAccKMSAliasDataSource_cmk
=== PAUSE TestAccKMSAliasDataSource_cmk
=== RUN   TestAccKMSAlias_basic
=== PAUSE TestAccKMSAlias_basic
=== RUN   TestAccKMSAlias_disappears
=== PAUSE TestAccKMSAlias_disappears
=== RUN   TestAccKMSAlias_Name_generated
=== PAUSE TestAccKMSAlias_Name_generated
=== RUN   TestAccKMSAlias_namePrefix
=== PAUSE TestAccKMSAlias_namePrefix
=== RUN   TestAccKMSAlias_updateKeyID
=== PAUSE TestAccKMSAlias_updateKeyID
=== RUN   TestAccKMSAlias_multipleAliasesForSameKey
=== PAUSE TestAccKMSAlias_multipleAliasesForSameKey
=== RUN   TestAccKMSAlias_arnDiffSuppress
=== PAUSE TestAccKMSAlias_arnDiffSuppress
=== RUN   TestAccKMSCiphertextDataSource_basic
=== PAUSE TestAccKMSCiphertextDataSource_basic
=== RUN   TestAccKMSCiphertextDataSource_validate
=== PAUSE TestAccKMSCiphertextDataSource_validate
=== RUN   TestAccKMSCiphertextDataSource_Validate_withContext
=== PAUSE TestAccKMSCiphertextDataSource_Validate_withContext
=== RUN   TestAccKMSCiphertext_Resource_basic
=== PAUSE TestAccKMSCiphertext_Resource_basic
=== RUN   TestAccKMSCiphertext_Resource_validate
=== PAUSE TestAccKMSCiphertext_Resource_validate
=== RUN   TestAccKMSCiphertext_ResourceValidate_withContext
=== PAUSE TestAccKMSCiphertext_ResourceValidate_withContext
=== RUN   TestAccKMSCustomKeyStoreDataSource_basic
    custom_key_store_data_source_test.go:17: CLOUD_HSM_CLUSTER_ID environment variable not set
--- SKIP: TestAccKMSCustomKeyStoreDataSource_basic (0.00s)
=== RUN   TestAccKMSExternalKey_basic
=== PAUSE TestAccKMSExternalKey_basic
=== RUN   TestAccKMSExternalKey_disappears
=== PAUSE TestAccKMSExternalKey_disappears
=== RUN   TestAccKMSExternalKey_multiRegion
=== PAUSE TestAccKMSExternalKey_multiRegion
=== RUN   TestAccKMSExternalKey_deletionWindowInDays
=== PAUSE TestAccKMSExternalKey_deletionWindowInDays
=== RUN   TestAccKMSExternalKey_description
=== PAUSE TestAccKMSExternalKey_description
=== RUN   TestAccKMSExternalKey_enabled
=== PAUSE TestAccKMSExternalKey_enabled
=== RUN   TestAccKMSExternalKey_keyMaterialBase64
=== PAUSE TestAccKMSExternalKey_keyMaterialBase64
=== RUN   TestAccKMSExternalKey_policy
=== PAUSE TestAccKMSExternalKey_policy
=== RUN   TestAccKMSExternalKey_policyBypass
=== PAUSE TestAccKMSExternalKey_policyBypass
=== RUN   TestAccKMSExternalKey_tags
=== PAUSE TestAccKMSExternalKey_tags
=== RUN   TestAccKMSExternalKey_validTo
=== PAUSE TestAccKMSExternalKey_validTo
=== RUN   TestAccKMSGrant_basic
=== PAUSE TestAccKMSGrant_basic
=== RUN   TestAccKMSGrant_withConstraints
=== PAUSE TestAccKMSGrant_withConstraints
=== RUN   TestAccKMSGrant_withRetiringPrincipal
=== PAUSE TestAccKMSGrant_withRetiringPrincipal
=== RUN   TestAccKMSGrant_bare
=== PAUSE TestAccKMSGrant_bare
=== RUN   TestAccKMSGrant_arn
=== PAUSE TestAccKMSGrant_arn
=== RUN   TestAccKMSGrant_asymmetricKey
=== PAUSE TestAccKMSGrant_asymmetricKey
=== RUN   TestAccKMSGrant_disappears
=== PAUSE TestAccKMSGrant_disappears
=== RUN   TestAccKMSGrant_crossAccountARN
=== PAUSE TestAccKMSGrant_crossAccountARN
=== RUN   TestAccKMSKeyDataSource_byKeyARN
=== PAUSE TestAccKMSKeyDataSource_byKeyARN
=== RUN   TestAccKMSKeyDataSource_byKeyID
=== PAUSE TestAccKMSKeyDataSource_byKeyID
=== RUN   TestAccKMSKeyDataSource_byAliasARN
=== PAUSE TestAccKMSKeyDataSource_byAliasARN
=== RUN   TestAccKMSKeyDataSource_byAliasID
=== PAUSE TestAccKMSKeyDataSource_byAliasID
=== RUN   TestAccKMSKeyDataSource_grantToken
=== PAUSE TestAccKMSKeyDataSource_grantToken
=== RUN   TestAccKMSKeyDataSource_multiRegionConfigurationByARN
=== PAUSE TestAccKMSKeyDataSource_multiRegionConfigurationByARN
=== RUN   TestAccKMSKeyDataSource_multiRegionConfigurationByID
=== PAUSE TestAccKMSKeyDataSource_multiRegionConfigurationByID
=== RUN   TestAccKMSKeyPolicy_basic
=== PAUSE TestAccKMSKeyPolicy_basic
=== RUN   TestAccKMSKeyPolicy_disappears
=== PAUSE TestAccKMSKeyPolicy_disappears
=== RUN   TestAccKMSKeyPolicy_bypass
=== PAUSE TestAccKMSKeyPolicy_bypass
=== RUN   TestAccKMSKeyPolicy_bypassUpdate
=== PAUSE TestAccKMSKeyPolicy_bypassUpdate
=== RUN   TestAccKMSKeyPolicy_keyIsEnabled
=== PAUSE TestAccKMSKeyPolicy_keyIsEnabled
=== RUN   TestAccKMSKeyPolicy_iamRole
=== PAUSE TestAccKMSKeyPolicy_iamRole
=== RUN   TestAccKMSKeyPolicy_iamRoleUpdate
=== PAUSE TestAccKMSKeyPolicy_iamRoleUpdate
=== RUN   TestAccKMSKeyPolicy_iamRoleOrder
=== PAUSE TestAccKMSKeyPolicy_iamRoleOrder
=== RUN   TestAccKMSKeyPolicy_iamServiceLinkedRole
=== PAUSE TestAccKMSKeyPolicy_iamServiceLinkedRole
=== RUN   TestAccKMSKeyPolicy_booleanCondition
=== PAUSE TestAccKMSKeyPolicy_booleanCondition
=== RUN   TestAccKMSKey_basic
=== PAUSE TestAccKMSKey_basic
=== RUN   TestAccKMSKey_disappears
=== PAUSE TestAccKMSKey_disappears
=== RUN   TestAccKMSKey_multiRegion
=== PAUSE TestAccKMSKey_multiRegion
=== RUN   TestAccKMSKey_asymmetricKey
=== PAUSE TestAccKMSKey_asymmetricKey
=== RUN   TestAccKMSKey_hmacKey
=== PAUSE TestAccKMSKey_hmacKey
=== RUN   TestAccKMSKey_Policy_basic
=== PAUSE TestAccKMSKey_Policy_basic
=== RUN   TestAccKMSKey_Policy_bypass
=== PAUSE TestAccKMSKey_Policy_bypass
=== RUN   TestAccKMSKey_Policy_bypassUpdate
=== PAUSE TestAccKMSKey_Policy_bypassUpdate
=== RUN   TestAccKMSKey_Policy_iamRole
=== PAUSE TestAccKMSKey_Policy_iamRole
=== RUN   TestAccKMSKey_Policy_iamRoleUpdate
=== PAUSE TestAccKMSKey_Policy_iamRoleUpdate
=== RUN   TestAccKMSKey_Policy_iamRoleOrder
=== PAUSE TestAccKMSKey_Policy_iamRoleOrder
=== RUN   TestAccKMSKey_Policy_iamServiceLinkedRole
=== PAUSE TestAccKMSKey_Policy_iamServiceLinkedRole
=== RUN   TestAccKMSKey_Policy_booleanCondition
=== PAUSE TestAccKMSKey_Policy_booleanCondition
=== RUN   TestAccKMSKey_isEnabled
=== PAUSE TestAccKMSKey_isEnabled
=== RUN   TestAccKMSKey_tags
=== PAUSE TestAccKMSKey_tags
=== RUN   TestAccKMS_serial
=== PAUSE TestAccKMS_serial
=== RUN   TestAccKMSPublicKeyDataSource_basic
=== PAUSE TestAccKMSPublicKeyDataSource_basic
=== RUN   TestAccKMSPublicKeyDataSource_encrypt
=== PAUSE TestAccKMSPublicKeyDataSource_encrypt
=== RUN   TestAccKMSReplicaExternalKey_basic
=== PAUSE TestAccKMSReplicaExternalKey_basic
=== RUN   TestAccKMSReplicaExternalKey_descriptionAndEnabled
=== PAUSE TestAccKMSReplicaExternalKey_descriptionAndEnabled
=== RUN   TestAccKMSReplicaExternalKey_policy
=== PAUSE TestAccKMSReplicaExternalKey_policy
=== RUN   TestAccKMSReplicaExternalKey_tags
=== PAUSE TestAccKMSReplicaExternalKey_tags
=== RUN   TestAccKMSReplicaKey_basic
=== PAUSE TestAccKMSReplicaKey_basic
=== RUN   TestAccKMSReplicaKey_disappears
=== PAUSE TestAccKMSReplicaKey_disappears
=== RUN   TestAccKMSReplicaKey_descriptionAndEnabled
=== PAUSE TestAccKMSReplicaKey_descriptionAndEnabled
=== RUN   TestAccKMSReplicaKey_policy
=== PAUSE TestAccKMSReplicaKey_policy
=== RUN   TestAccKMSReplicaKey_tags
=== PAUSE TestAccKMSReplicaKey_tags
=== RUN   TestAccKMSReplicaKey_twoReplicas
=== PAUSE TestAccKMSReplicaKey_twoReplicas
=== RUN   TestAccKMSSecretDataSource_removed
=== PAUSE TestAccKMSSecretDataSource_removed
=== RUN   TestAccKMSSecretsDataSource_basic
=== PAUSE TestAccKMSSecretsDataSource_basic
=== RUN   TestAccKMSSecretsDataSource_asymmetric
=== PAUSE TestAccKMSSecretsDataSource_asymmetric
=== CONT  TestAccKMSAliasDataSource_service
=== CONT  TestAccKMSKeyPolicy_basic
--- PASS: TestAccKMSAliasDataSource_service (13.19s)
=== CONT  TestAccKMSKey_Policy_iamServiceLinkedRole
--- PASS: TestAccKMSKeyPolicy_basic (47.48s)
=== CONT  TestAccKMSSecretsDataSource_asymmetric
--- PASS: TestAccKMSKey_Policy_iamServiceLinkedRole (40.08s)
=== CONT  TestAccKMSSecretsDataSource_basic
--- PASS: TestAccKMSSecretsDataSource_asymmetric (27.87s)
=== CONT  TestAccKMSSecretDataSource_removed
--- PASS: TestAccKMSSecretDataSource_removed (1.93s)
=== CONT  TestAccKMSReplicaKey_twoReplicas
--- PASS: TestAccKMSSecretsDataSource_basic (28.31s)
=== CONT  TestAccKMSReplicaKey_tags
--- PASS: TestAccKMSReplicaKey_twoReplicas (45.60s)
=== CONT  TestAccKMSReplicaKey_policy
--- PASS: TestAccKMSReplicaKey_tags (105.26s)
=== CONT  TestAccKMSReplicaKey_descriptionAndEnabled
--- PASS: TestAccKMSReplicaKey_policy (73.48s)
=== CONT  TestAccKMSReplicaKey_disappears
--- PASS: TestAccKMSReplicaKey_disappears (45.55s)
=== CONT  TestAccKMSReplicaKey_basic
--- PASS: TestAccKMSReplicaKey_basic (69.51s)
=== CONT  TestAccKMSReplicaExternalKey_tags
--- PASS: TestAccKMSReplicaKey_descriptionAndEnabled (262.24s)
=== CONT  TestAccKMSReplicaExternalKey_policy
--- PASS: TestAccKMSReplicaExternalKey_tags (209.16s)
=== CONT  TestAccKMSReplicaExternalKey_descriptionAndEnabled
--- PASS: TestAccKMSReplicaExternalKey_policy (156.62s)
=== CONT  TestAccKMSReplicaExternalKey_basic
--- PASS: TestAccKMSReplicaExternalKey_basic (86.99s)
=== CONT  TestAccKMSPublicKeyDataSource_encrypt
--- PASS: TestAccKMSPublicKeyDataSource_encrypt (27.70s)
=== CONT  TestAccKMSPublicKeyDataSource_basic
--- PASS: TestAccKMSPublicKeyDataSource_basic (25.50s)
=== CONT  TestAccKMS_serial
=== RUN   TestAccKMS_serial/CustomKeyStore
=== RUN   TestAccKMS_serial/CustomKeyStore/basic
    custom_key_store_test.go:26: CLOUD_HSM_CLUSTER_ID environment variable not set
=== RUN   TestAccKMS_serial/CustomKeyStore/update
    custom_key_store_test.go:74: CLOUD_HSM_CLUSTER_ID environment variable not set
=== RUN   TestAccKMS_serial/CustomKeyStore/disappears
    custom_key_store_test.go:117: CLOUD_HSM_CLUSTER_ID environment variable not set
--- PASS: TestAccKMS_serial (0.00s)
    --- PASS: TestAccKMS_serial/CustomKeyStore (0.00s)
        --- SKIP: TestAccKMS_serial/CustomKeyStore/basic (0.00s)
        --- SKIP: TestAccKMS_serial/CustomKeyStore/update (0.00s)
        --- SKIP: TestAccKMS_serial/CustomKeyStore/disappears (0.00s)
=== CONT  TestAccKMSKey_tags
=== CONT  TestAccKMSKey_isEnabled
--- PASS: TestAccKMSReplicaExternalKey_descriptionAndEnabled (274.77s)
--- PASS: TestAccKMSKey_tags (74.14s)
=== CONT  TestAccKMSKey_Policy_booleanCondition
--- PASS: TestAccKMSKey_Policy_booleanCondition (23.75s)
=== CONT  TestAccKMSCiphertextDataSource_Validate_withContext
--- PASS: TestAccKMSCiphertextDataSource_Validate_withContext (21.38s)
=== CONT  TestAccKMSExternalKey_enabled
--- PASS: TestAccKMSKey_isEnabled (125.27s)
=== CONT  TestAccKMSExternalKey_description
--- PASS: TestAccKMSExternalKey_description (45.24s)
=== CONT  TestAccKMSExternalKey_deletionWindowInDays
--- PASS: TestAccKMSExternalKey_deletionWindowInDays (36.13s)
=== CONT  TestAccKMSExternalKey_multiRegion
--- PASS: TestAccKMSExternalKey_enabled (148.13s)
=== CONT  TestAccKMSExternalKey_disappears
--- PASS: TestAccKMSExternalKey_multiRegion (21.60s)
=== CONT  TestAccKMSExternalKey_basic
--- PASS: TestAccKMSExternalKey_disappears (15.67s)
=== CONT  TestAccKMSCiphertext_ResourceValidate_withContext
--- PASS: TestAccKMSExternalKey_basic (21.85s)
=== CONT  TestAccKMSCiphertext_Resource_validate
--- PASS: TestAccKMSCiphertext_ResourceValidate_withContext (18.66s)
=== CONT  TestAccKMSCiphertext_Resource_basic
--- PASS: TestAccKMSCiphertext_Resource_validate (18.75s)
=== CONT  TestAccKMSKey_disappears
--- PASS: TestAccKMSCiphertext_Resource_basic (17.34s)
=== CONT  TestAccKMSKey_Policy_iamRoleOrder
--- PASS: TestAccKMSKey_disappears (15.39s)
=== CONT  TestAccKMSExternalKey_keyMaterialBase64
--- PASS: TestAccKMSKey_Policy_iamRoleOrder (68.22s)
=== CONT  TestAccKMSKeyDataSource_multiRegionConfigurationByID
--- PASS: TestAccKMSKeyDataSource_multiRegionConfigurationByID (20.58s)
=== CONT  TestAccKMSKeyDataSource_multiRegionConfigurationByARN
--- PASS: TestAccKMSKeyDataSource_multiRegionConfigurationByARN (21.19s)
=== CONT  TestAccKMSKey_Policy_iamRoleUpdate
--- PASS: TestAccKMSExternalKey_keyMaterialBase64 (115.53s)
=== CONT  TestAccKMSKey_Policy_iamRole
--- PASS: TestAccKMSKey_Policy_iamRoleUpdate (60.71s)
=== CONT  TestAccKMSKey_Policy_bypassUpdate
--- PASS: TestAccKMSKey_Policy_iamRole (44.01s)
=== CONT  TestAccKMSKey_Policy_bypass
--- PASS: TestAccKMSKey_Policy_bypassUpdate (37.38s)
=== CONT  TestAccKMSKey_Policy_basic
--- PASS: TestAccKMSKey_Policy_basic (39.47s)
=== CONT  TestAccKMSKey_hmacKey
--- PASS: TestAccKMSKey_hmacKey (18.25s)
=== CONT  TestAccKMSKey_asymmetricKey
--- PASS: TestAccKMSKey_asymmetricKey (27.35s)
=== CONT  TestAccKMSKey_multiRegion
--- PASS: TestAccKMSKey_multiRegion (23.61s)
=== CONT  TestAccKMSKeyDataSource_grantToken
--- PASS: TestAccKMSKey_Policy_bypass (153.46s)
=== CONT  TestAccKMSAlias_updateKeyID
--- PASS: TestAccKMSKeyDataSource_grantToken (35.08s)
=== CONT  TestAccKMSKeyDataSource_byAliasID
--- PASS: TestAccKMSAlias_updateKeyID (38.60s)
=== CONT  TestAccKMSCiphertextDataSource_validate
--- PASS: TestAccKMSKeyDataSource_byAliasID (21.38s)
=== CONT  TestAccKMSKeyDataSource_byAliasARN
--- PASS: TestAccKMSCiphertextDataSource_validate (20.67s)
=== CONT  TestAccKMSKeyDataSource_byKeyID
--- PASS: TestAccKMSKeyDataSource_byAliasARN (20.25s)
=== CONT  TestAccKMSKeyDataSource_byKeyARN
--- PASS: TestAccKMSKeyDataSource_byKeyID (19.53s)
=== CONT  TestAccKMSGrant_crossAccountARN
    acctest.go:772: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccKMSGrant_crossAccountARN (0.00s)
=== CONT  TestAccKMSGrant_disappears
--- PASS: TestAccKMSKeyDataSource_byKeyARN (19.50s)
=== CONT  TestAccKMSCiphertextDataSource_basic
--- PASS: TestAccKMSCiphertextDataSource_basic (18.29s)
=== CONT  TestAccKMSGrant_asymmetricKey
--- PASS: TestAccKMSGrant_asymmetricKey (37.64s)
=== CONT  TestAccKMSAlias_arnDiffSuppress
--- PASS: TestAccKMSAlias_arnDiffSuppress (27.53s)
=== CONT  TestAccKMSGrant_arn
--- PASS: TestAccKMSGrant_arn (25.47s)
=== CONT  TestAccKMSAlias_multipleAliasesForSameKey
--- PASS: TestAccKMSAlias_multipleAliasesForSameKey (19.78s)
=== CONT  TestAccKMSGrant_bare
--- PASS: TestAccKMSGrant_bare (25.42s)
=== CONT  TestAccKMSExternalKey_tags
--- PASS: TestAccKMSGrant_disappears (216.88s)
=== CONT  TestAccKMSExternalKey_validTo
--- PASS: TestAccKMSExternalKey_tags (64.10s)
=== CONT  TestAccKMSExternalKey_policyBypass
--- PASS: TestAccKMSExternalKey_policyBypass (33.01s)
=== CONT  TestAccKMSGrant_withRetiringPrincipal
--- PASS: TestAccKMSGrant_withRetiringPrincipal (44.56s)
=== CONT  TestAccKMSExternalKey_policy
--- PASS: TestAccKMSExternalKey_policy (54.60s)
=== CONT  TestAccKMSGrant_withConstraints
--- PASS: TestAccKMSExternalKey_validTo (178.97s)
=== CONT  TestAccKMSGrant_basic
--- PASS: TestAccKMSGrant_withConstraints (66.44s)
=== CONT  TestAccKMSKeyPolicy_iamRoleUpdate
--- PASS: TestAccKMSGrant_basic (46.24s)
=== CONT  TestAccKMSKeyPolicy_bypassUpdate
--- PASS: TestAccKMSKeyPolicy_iamRoleUpdate (67.56s)
=== CONT  TestAccKMSKey_basic
--- PASS: TestAccKMSKeyPolicy_bypassUpdate (53.08s)
=== CONT  TestAccKMSKeyPolicy_iamRole
--- PASS: TestAccKMSKey_basic (27.11s)
=== CONT  TestAccKMSKeyPolicy_booleanCondition
--- PASS: TestAccKMSKeyPolicy_booleanCondition (31.70s)
=== CONT  TestAccKMSKeyPolicy_iamServiceLinkedRole
--- PASS: TestAccKMSKeyPolicy_iamRole (64.21s)
=== CONT  TestAccKMSKeyPolicy_iamRoleOrder
=== CONT  TestAccKMSAlias_namePrefix
--- PASS: TestAccKMSKeyPolicy_iamServiceLinkedRole (62.35s)
--- PASS: TestAccKMSKeyPolicy_iamRoleOrder (71.29s)
=== CONT  TestAccKMSAlias_basic
--- PASS: TestAccKMSAlias_namePrefix (25.18s)
=== CONT  TestAccKMSAlias_Name_generated
--- PASS: TestAccKMSAlias_basic (29.07s)
=== CONT  TestAccKMSKeyPolicy_bypass
--- PASS: TestAccKMSAlias_Name_generated (26.47s)
=== CONT  TestAccKMSKeyPolicy_disappears
--- PASS: TestAccKMSKeyPolicy_disappears (21.98s)
=== CONT  TestAccKMSAliasDataSource_cmk
--- PASS: TestAccKMSAliasDataSource_cmk (19.44s)
=== CONT  TestAccKMSKeyPolicy_keyIsEnabled
--- PASS: TestAccKMSKeyPolicy_keyIsEnabled (73.62s)
=== CONT  TestAccKMSAlias_disappears
--- PASS: TestAccKMSAlias_disappears (20.22s)
--- PASS: TestAccKMSKeyPolicy_bypass (156.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	2293.249s
```
