### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin SDK resources `route53domains` (Phase 3c)

### DIFF
--- a/internal/service/route53domains/service_package_gen.go
+++ b/internal/service/route53domains/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceRegisteredDomain,
 			TypeName: "aws_route53domains_registered_domain",
+			Name:     "Registered Domain",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "id",
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin SDK.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30421.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30430.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30449.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30454.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30461.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30463.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30476.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30477.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30478.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30483.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30484.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30491.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30509.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30510.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30512.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30516.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30517.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30533.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30534.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% AWS_DEFAULT_REGION=us-east-1 ROUTE53DOMAINS_DOMAIN_NAME=terraform-provider-aws-acctest-acm.com make testacc TESTS=TestAccRoute53Domains_serial PKG=route53domains
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53domains/... -v -count 1 -parallel 20 -run='TestAccRoute53Domains_serial'  -timeout 180m
=== RUN   TestAccRoute53Domains_serial
=== PAUSE TestAccRoute53Domains_serial
=== CONT  TestAccRoute53Domains_serial
=== RUN   TestAccRoute53Domains_serial/RegisteredDomain
=== RUN   TestAccRoute53Domains_serial/RegisteredDomain/nameservers
=== RUN   TestAccRoute53Domains_serial/RegisteredDomain/transferLock
=== RUN   TestAccRoute53Domains_serial/RegisteredDomain/tags
=== RUN   TestAccRoute53Domains_serial/RegisteredDomain/autoRenew
=== RUN   TestAccRoute53Domains_serial/RegisteredDomain/contacts
=== RUN   TestAccRoute53Domains_serial/RegisteredDomain/contactPrivacy
--- PASS: TestAccRoute53Domains_serial (1206.06s)
    --- PASS: TestAccRoute53Domains_serial/RegisteredDomain (1206.06s)
        --- PASS: TestAccRoute53Domains_serial/RegisteredDomain/nameservers (247.03s)
        --- PASS: TestAccRoute53Domains_serial/RegisteredDomain/transferLock (448.46s)
        --- PASS: TestAccRoute53Domains_serial/RegisteredDomain/tags (24.39s)
        --- PASS: TestAccRoute53Domains_serial/RegisteredDomain/autoRenew (17.03s)
        --- PASS: TestAccRoute53Domains_serial/RegisteredDomain/contacts (388.00s)
        --- PASS: TestAccRoute53Domains_serial/RegisteredDomain/contactPrivacy (81.14s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53domains	1211.345s
```
