### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin SDK resources `dynamodb` (Phase 3c)

### DIFF
--- a/internal/service/dynamodb/service_package_gen.go
+++ b/internal/service/dynamodb/service_package_gen.go
@@ -49,6 +49,10 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceTable,
 			TypeName: "aws_dynamodb_table",
+			Name:     "Table",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
 		},
 		{
 			Factory:  ResourceTableItem,
@@ -57,6 +61,8 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceTableReplica,
 			TypeName: "aws_dynamodb_table_replica",
+			Name:     "Table Replica",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
 			Factory:  ResourceTag,

--- a/internal/service/dynamodb/table_replica.go
+++ b/internal/service/dynamodb/table_replica.go
@@ -30,7 +30,8 @@ const (
 	ResNameTableReplica = "Table Replica"
 )
 
-// @SDKResource("aws_dynamodb_table_replica")
+// @SDKResource("aws_dynamodb_table_replica", name="Table Replica")
+// @Tags
 func ResourceTableReplica() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{
@@ -325,25 +326,13 @@ func resourceTableReplicaReadReplica(ctx context.Context, d *schema.ResourceData
 		d.Set("point_in_time_recovery", false)
 	}
 
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
-
 	tags, err := ListTags(ctx, conn, d.Get(names.AttrARN).(string))
 	// When a Table is `ARCHIVED`, ListTags returns `ResourceNotFoundException`
 	if err != nil && !(tfawserr.ErrMessageContains(err, "UnknownOperationException", "Tagging is not currently supported in DynamoDB Local.") || tfresource.NotFound(err)) {
 		return create.DiagError(names.DynamoDB, create.ErrActionReading, ResNameTableReplica, d.Id(), fmt.Errorf("tags: %w", err))
 	}
 
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set(names.AttrTags, tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return create.DiagSettingError(names.DynamoDB, ResNameTableReplica, d.Id(), names.AttrTags, err)
-	}
-
-	if err := d.Set(names.AttrTagsAll, tags.Map()); err != nil {
-		return create.DiagSettingError(names.DynamoDB, ResNameTableReplica, d.Id(), names.AttrTagsAll, err)
-	}
+	SetTagsOut(ctx, Tags(tags))
 
 	return diags
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin SDK.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30421.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30430.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30449.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30454.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30461.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30463.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30476.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30477.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30478.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30483.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30484.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30491.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30509.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30510.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30512.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30516.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30517.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30533.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30534.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccDynamoDBTable_\|TestAccDynamoDBTableReplica_' PKG=dynamodb ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 3  -run=TestAccDynamoDBTable_\|TestAccDynamoDBTableReplica_ -timeout 180m
=== RUN   TestAccDynamoDBTableReplica_basic
=== PAUSE TestAccDynamoDBTableReplica_basic
=== RUN   TestAccDynamoDBTableReplica_disappears
=== PAUSE TestAccDynamoDBTableReplica_disappears
=== RUN   TestAccDynamoDBTableReplica_pitr
=== PAUSE TestAccDynamoDBTableReplica_pitr
=== RUN   TestAccDynamoDBTableReplica_pitrKMS
=== PAUSE TestAccDynamoDBTableReplica_pitrKMS
=== RUN   TestAccDynamoDBTableReplica_pitrDefault
=== PAUSE TestAccDynamoDBTableReplica_pitrDefault
=== RUN   TestAccDynamoDBTableReplica_tags
=== PAUSE TestAccDynamoDBTableReplica_tags
=== RUN   TestAccDynamoDBTableReplica_tableClass
=== PAUSE TestAccDynamoDBTableReplica_tableClass
=== RUN   TestAccDynamoDBTableReplica_keys
=== PAUSE TestAccDynamoDBTableReplica_keys
=== RUN   TestAccDynamoDBTable_basic
=== PAUSE TestAccDynamoDBTable_basic
=== RUN   TestAccDynamoDBTable_deletion_protection
=== PAUSE TestAccDynamoDBTable_deletion_protection
=== RUN   TestAccDynamoDBTable_disappears
=== PAUSE TestAccDynamoDBTable_disappears
=== RUN   TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
=== PAUSE TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
=== RUN   TestAccDynamoDBTable_extended
=== PAUSE TestAccDynamoDBTable_extended
=== RUN   TestAccDynamoDBTable_enablePITR
=== PAUSE TestAccDynamoDBTable_enablePITR
=== RUN   TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== PAUSE TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== RUN   TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
=== PAUSE TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
=== RUN   TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
=== PAUSE TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
=== RUN   TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
=== PAUSE TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
=== RUN   TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
=== PAUSE TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
=== RUN   TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
=== PAUSE TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
=== RUN   TestAccDynamoDBTable_streamSpecification
=== PAUSE TestAccDynamoDBTable_streamSpecification
=== RUN   TestAccDynamoDBTable_streamSpecificationDiffs
=== PAUSE TestAccDynamoDBTable_streamSpecificationDiffs
=== RUN   TestAccDynamoDBTable_streamSpecificationValidation
=== PAUSE TestAccDynamoDBTable_streamSpecificationValidation
=== RUN   TestAccDynamoDBTable_tags
=== PAUSE TestAccDynamoDBTable_tags
=== RUN   TestAccDynamoDBTable_gsiUpdateCapacity
=== PAUSE TestAccDynamoDBTable_gsiUpdateCapacity
=== RUN   TestAccDynamoDBTable_gsiUpdateOtherAttributes
=== PAUSE TestAccDynamoDBTable_gsiUpdateOtherAttributes
=== RUN   TestAccDynamoDBTable_lsiNonKeyAttributes
=== PAUSE TestAccDynamoDBTable_lsiNonKeyAttributes
=== RUN   TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
=== PAUSE TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
=== RUN   TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
=== PAUSE TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
=== RUN   TestAccDynamoDBTable_TTL_enabled
=== PAUSE TestAccDynamoDBTable_TTL_enabled
=== RUN   TestAccDynamoDBTable_TTL_disabled
=== PAUSE TestAccDynamoDBTable_TTL_disabled
=== RUN   TestAccDynamoDBTable_attributeUpdate
=== PAUSE TestAccDynamoDBTable_attributeUpdate
=== RUN   TestAccDynamoDBTable_lsiUpdate
=== PAUSE TestAccDynamoDBTable_lsiUpdate
=== RUN   TestAccDynamoDBTable_attributeUpdateValidation
=== PAUSE TestAccDynamoDBTable_attributeUpdateValidation
=== RUN   TestAccDynamoDBTable_encryption
=== PAUSE TestAccDynamoDBTable_encryption
=== RUN   TestAccDynamoDBTable_Replica_multiple
=== PAUSE TestAccDynamoDBTable_Replica_multiple
=== RUN   TestAccDynamoDBTable_Replica_single
=== PAUSE TestAccDynamoDBTable_Replica_single
=== RUN   TestAccDynamoDBTable_Replica_singleStreamSpecification
=== PAUSE TestAccDynamoDBTable_Replica_singleStreamSpecification
=== RUN   TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted
=== PAUSE TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted
=== RUN   TestAccDynamoDBTable_Replica_singleCMK
=== PAUSE TestAccDynamoDBTable_Replica_singleCMK
=== RUN   TestAccDynamoDBTable_Replica_singleAddCMK
=== PAUSE TestAccDynamoDBTable_Replica_singleAddCMK
=== RUN   TestAccDynamoDBTable_Replica_pitr
=== PAUSE TestAccDynamoDBTable_Replica_pitr
=== RUN   TestAccDynamoDBTable_Replica_pitrKMS
=== PAUSE TestAccDynamoDBTable_Replica_pitrKMS
=== RUN   TestAccDynamoDBTable_Replica_tagsOneOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_tagsOneOfTwo
=== RUN   TestAccDynamoDBTable_Replica_tagsTwoOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_tagsTwoOfTwo
=== RUN   TestAccDynamoDBTable_Replica_tagsNext
=== PAUSE TestAccDynamoDBTable_Replica_tagsNext
=== RUN   TestAccDynamoDBTable_Replica_tagsUpdate
=== PAUSE TestAccDynamoDBTable_Replica_tagsUpdate
=== RUN   TestAccDynamoDBTable_tableClassInfrequentAccess
=== PAUSE TestAccDynamoDBTable_tableClassInfrequentAccess
=== RUN   TestAccDynamoDBTable_tableClassExplicitDefault
=== PAUSE TestAccDynamoDBTable_tableClassExplicitDefault
=== RUN   TestAccDynamoDBTable_tableClass_ConcurrentModification
=== PAUSE TestAccDynamoDBTable_tableClass_ConcurrentModification
=== RUN   TestAccDynamoDBTable_tableClass_migrate
=== PAUSE TestAccDynamoDBTable_tableClass_migrate
=== RUN   TestAccDynamoDBTable_backupEncryption
=== PAUSE TestAccDynamoDBTable_backupEncryption
=== RUN   TestAccDynamoDBTable_backup_overrideEncryption
=== PAUSE TestAccDynamoDBTable_backup_overrideEncryption
=== CONT  TestAccDynamoDBTableReplica_basic
=== CONT  TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
=== CONT  TestAccDynamoDBTable_Replica_singleAddCMK
--- PASS: TestAccDynamoDBTableReplica_basic (282.38s)
=== CONT  TestAccDynamoDBTable_backup_overrideEncryption
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (350.04s)
=== CONT  TestAccDynamoDBTable_backupEncryption
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (301.55s)
=== CONT  TestAccDynamoDBTable_tableClass_migrate
    table_test.go:2439: TestStep 1/2 running init: exit status 1
        
        Error: Failed to query available provider packages
        
        Could not retrieve the list of available versions for provider hashicorp/aws:
        no available releases match the given constraints 4.57.0
        
--- FAIL: TestAccDynamoDBTable_tableClass_migrate (3.22s)
=== CONT  TestAccDynamoDBTable_tableClass_ConcurrentModification
--- PASS: TestAccDynamoDBTable_tableClass_ConcurrentModification (48.23s)
=== CONT  TestAccDynamoDBTable_tableClassExplicitDefault
--- PASS: TestAccDynamoDBTable_tableClassExplicitDefault (39.04s)
=== CONT  TestAccDynamoDBTable_tableClassInfrequentAccess
--- PASS: TestAccDynamoDBTable_backupEncryption (327.60s)
=== CONT  TestAccDynamoDBTable_Replica_tagsUpdate
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (44.63s)
=== CONT  TestAccDynamoDBTable_Replica_tagsNext
=== CONT  TestAccDynamoDBTable_Replica_singleAddCMK
    table_test.go:1809: Step 2/4 error: Error running apply: exit status 1
        
        Error: updating Amazon DynamoDB Table (tf-acc-test-7426530441521771517): updating replicas, while creating: creating replica (us-east-1): ValidationException: Replica specified in the Replica Update or Replica Delete action of the request was not found.
        	status code: 400, request id: SIRSVD5JH83FI3DVC5CP15MR6VVV4KQNSO5AEMVJF66Q9ASUAAJG
        
          with aws_dynamodb_table.test,
          on terraform_plugin_test.tf line 31, in resource "aws_dynamodb_table" "test":
          31: resource "aws_dynamodb_table" "test" {
        
--- FAIL: TestAccDynamoDBTable_Replica_singleAddCMK (2048.82s)
=== CONT  TestAccDynamoDBTable_Replica_tagsTwoOfTwo
=== CONT  TestAccDynamoDBTable_Replica_tagsUpdate
    table_test.go:2232: Step 1/5 error: Error running apply: exit status 1
        
        Error: creating Amazon DynamoDB Table (tf-acc-test-3636012944921016792): replicas: waiting for replica (us-east-1) creation: timeout while waiting for state to become 'ACTIVE' (last state: 'CREATING', timeout: 30m0s)
        
          with aws_dynamodb_table.test,
          on terraform_plugin_test.tf line 10, in resource "aws_dynamodb_table" "test":
          10: resource "aws_dynamodb_table" "test" {
        
=== CONT  TestAccDynamoDBTable_Replica_tagsNext
    table_test.go:2137: Step 1/5 error: Error running apply: exit status 1
        
        Error: creating Amazon DynamoDB Table (tf-acc-test-8416085045656719806): replicas: waiting for replica (us-east-1) creation: timeout while waiting for state to become 'ACTIVE' (last state: 'CREATING', timeout: 30m0s)
        
          with aws_dynamodb_table.test,
          on terraform_plugin_test.tf line 10, in resource "aws_dynamodb_table" "test":
          10: resource "aws_dynamodb_table" "test" {
        
=== CONT  TestAccDynamoDBTable_Replica_tagsUpdate
    testing_new.go:82: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting Amazon DynamoDB Table (tf-acc-test-3636012944921016792): ValidationException: The last active replica of table: 'tf-acc-test-3636012944921016792'  in region: 'us-west-2' cannot be deleted until all writes are replicated.
        	status code: 400, request id: 7J1QR27CE717IKB1QHFGAISIU3VV4KQNSO5AEMVJF66Q9ASUAAJG
        
--- FAIL: TestAccDynamoDBTable_Replica_tagsUpdate (1858.42s)
=== CONT  TestAccDynamoDBTable_Replica_tagsOneOfTwo
=== CONT  TestAccDynamoDBTable_Replica_tagsNext
    testing_new.go:82: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting Amazon DynamoDB Table (tf-acc-test-8416085045656719806): ValidationException: The last active replica of table: 'tf-acc-test-8416085045656719806'  in region: 'us-west-2' cannot be deleted until all writes are replicated.
        	status code: 400, request id: SHBJHQN9OR2N89RHH248ISDMPFVV4KQNSO5AEMVJF66Q9ASUAAJG
        
--- FAIL: TestAccDynamoDBTable_Replica_tagsNext (1858.56s)
=== CONT  TestAccDynamoDBTable_Replica_pitrKMS
=== CONT  TestAccDynamoDBTable_Replica_tagsTwoOfTwo
    table_test.go:2097: Step 1/1 error: Error running apply: exit status 1
        
        Error: creating Amazon DynamoDB Table (tf-acc-test-3857539953357400140): replicas: waiting for replica (us-east-2) creation: timeout while waiting for state to become 'ACTIVE' (last state: 'CREATING', timeout: 30m0s)
        
          with aws_dynamodb_table.test,
          on terraform_plugin_test.tf line 18, in resource "aws_dynamodb_table" "test":
          18: resource "aws_dynamodb_table" "test" {
        
    testing_new.go:82: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting Amazon DynamoDB Table (tf-acc-test-3857539953357400140): 1 error occurred:
        	* deleting replica (us-east-1): ValidationException: Update global table operation failed because one or more replicas were not part of the global table. Please retry the request without these replicas: [us-east-1].
        	status code: 400, request id: JHJDIEORQTSDFNP3V4U5JQ665VVV4KQNSO5AEMVJF66Q9ASUAAJG
        
        
        
--- FAIL: TestAccDynamoDBTable_Replica_tagsTwoOfTwo (1821.59s)
=== CONT  TestAccDynamoDBTable_Replica_pitr
--- PASS: TestAccDynamoDBTable_Replica_pitr (348.37s)
=== CONT  TestAccDynamoDBTable_encryption
--- PASS: TestAccDynamoDBTable_Replica_pitrKMS (1641.29s)
=== CONT  TestAccDynamoDBTable_Replica_singleCMK
--- PASS: TestAccDynamoDBTable_Replica_tagsOneOfTwo (1685.58s)
=== CONT  TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted
--- PASS: TestAccDynamoDBTable_encryption (116.18s)
=== CONT  TestAccDynamoDBTable_Replica_singleStreamSpecification
--- PASS: TestAccDynamoDBTable_Replica_singleCMK (241.39s)
=== CONT  TestAccDynamoDBTable_Replica_single
--- PASS: TestAccDynamoDBTable_Replica_singleStreamSpecification (237.23s)
=== CONT  TestAccDynamoDBTable_Replica_multiple
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted (476.61s)
=== CONT  TestAccDynamoDBTable_attributeUpdateValidation
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (4.56s)
=== CONT  TestAccDynamoDBTable_TTL_enabled
--- PASS: TestAccDynamoDBTable_TTL_enabled (25.97s)
=== CONT  TestAccDynamoDBTable_TTL_disabled
--- PASS: TestAccDynamoDBTable_TTL_disabled (36.86s)
=== CONT  TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (41.45s)
=== CONT  TestAccDynamoDBTable_lsiUpdate
--- PASS: TestAccDynamoDBTable_lsiUpdate (64.90s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (52.56s)
=== CONT  TestAccDynamoDBTable_lsiNonKeyAttributes
--- PASS: TestAccDynamoDBTable_Replica_single (473.67s)
=== CONT  TestAccDynamoDBTable_gsiUpdateOtherAttributes
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (25.72s)
=== CONT  TestAccDynamoDBTable_gsiUpdateCapacity
--- PASS: TestAccDynamoDBTable_gsiUpdateCapacity (62.20s)
=== CONT  TestAccDynamoDBTable_tags
--- PASS: TestAccDynamoDBTable_Replica_multiple (471.08s)
=== CONT  TestAccDynamoDBTable_attributeUpdate
--- PASS: TestAccDynamoDBTable_tags (45.56s)
=== CONT  TestAccDynamoDBTable_streamSpecificationValidation
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (2.09s)
=== CONT  TestAccDynamoDBTable_streamSpecificationDiffs
--- PASS: TestAccDynamoDBTable_streamSpecificationDiffs (146.53s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (793.47s)
=== CONT  TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
--- PASS: TestAccDynamoDBTable_attributeUpdate (688.19s)
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (50.35s)
=== CONT  TestAccDynamoDBTable_streamSpecification
--- PASS: TestAccDynamoDBTable_streamSpecification (65.35s)
=== CONT  TestAccDynamoDBTableReplica_keys
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (835.24s)
=== CONT  TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (437.76s)
=== CONT  TestAccDynamoDBTable_enablePITR
--- PASS: TestAccDynamoDBTable_enablePITR (76.72s)
=== CONT  TestAccDynamoDBTableReplica_pitrDefault
--- PASS: TestAccDynamoDBTableReplica_keys (447.82s)
=== CONT  TestAccDynamoDBTable_extended
--- PASS: TestAccDynamoDBTableReplica_pitrDefault (257.74s)
=== CONT  TestAccDynamoDBTableReplica_tableClass
--- PASS: TestAccDynamoDBTable_extended (281.17s)
=== CONT  TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (82.51s)
=== CONT  TestAccDynamoDBTableReplica_tags
--- PASS: TestAccDynamoDBTableReplica_tags (317.97s)
=== CONT  TestAccDynamoDBTable_deletion_protection
--- PASS: TestAccDynamoDBTableReplica_tableClass (496.05s)
=== CONT  TestAccDynamoDBTable_basic
--- PASS: TestAccDynamoDBTable_deletion_protection (44.63s)
=== CONT  TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
--- PASS: TestAccDynamoDBTable_basic (30.65s)
=== CONT  TestAccDynamoDBTableReplica_pitrKMS
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (70.01s)
=== CONT  TestAccDynamoDBTableReplica_pitr
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (1097.96s)
=== CONT  TestAccDynamoDBTableReplica_disappears
--- PASS: TestAccDynamoDBTableReplica_pitrKMS (316.55s)
=== CONT  TestAccDynamoDBTable_disappears
--- PASS: TestAccDynamoDBTableReplica_pitr (252.72s)
--- PASS: TestAccDynamoDBTable_disappears (21.13s)
--- PASS: TestAccDynamoDBTableReplica_disappears (234.79s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	7379.946s
FAIL
make: *** [testacc] Error 1
```
```console
% make testacc TESTARGS='-run=TestAccDynamoDBTable_Replica_singleAddCMK\|TestAccDynamoDBTable_Replica_tagsTwoOfTwo\|TestAccDynamoDBTable_Replica_tagsNext\|TestAccDynamoDBTable_Replica_tagsUpdate' PKG=dynamodb ACCTEST_PARALLELISM=2  
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 2  -run=TestAccDynamoDBTable_Replica_singleAddCMK\|TestAccDynamoDBTable_Replica_tagsTwoOfTwo\|TestAccDynamoDBTable_Replica_tagsNext\|TestAccDynamoDBTable_Replica_tagsUpdate -timeout 180m
=== RUN   TestAccDynamoDBTable_Replica_singleAddCMK
=== PAUSE TestAccDynamoDBTable_Replica_singleAddCMK
=== RUN   TestAccDynamoDBTable_Replica_tagsTwoOfTwo
=== PAUSE TestAccDynamoDBTable_Replica_tagsTwoOfTwo
=== RUN   TestAccDynamoDBTable_Replica_tagsNext
=== PAUSE TestAccDynamoDBTable_Replica_tagsNext
=== RUN   TestAccDynamoDBTable_Replica_tagsUpdate
=== PAUSE TestAccDynamoDBTable_Replica_tagsUpdate
=== CONT  TestAccDynamoDBTable_Replica_singleAddCMK
=== CONT  TestAccDynamoDBTable_Replica_tagsNext
--- PASS: TestAccDynamoDBTable_Replica_tagsNext (550.66s)
=== CONT  TestAccDynamoDBTable_Replica_tagsTwoOfTwo
--- PASS: TestAccDynamoDBTable_Replica_singleAddCMK (695.44s)
=== CONT  TestAccDynamoDBTable_Replica_tagsUpdate
--- PASS: TestAccDynamoDBTable_Replica_tagsTwoOfTwo (275.41s)
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (359.50s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	1060.225s
```
