### PR TITLE
[TechDebt]: S3 object acceptance test default security settings refactor

### DIFF
--- a/internal/service/s3/object_copy_test.go
+++ b/internal/service/s3/object_copy_test.go
@@ -156,7 +156,28 @@ resource "aws_s3_bucket" "target" {
   bucket = %[3]q
 }
 
+resource "aws_s3_bucket_public_access_block" "target" {
+  bucket = aws_s3_bucket.target.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_ownership_controls" "target" {
+  bucket = aws_s3_bucket.target.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_object_copy" "test" {
+  depends_on = [
+    aws_s3_bucket_public_access_block.target,
+    aws_s3_bucket_ownership_controls.target,
+  ]
+
   bucket = aws_s3_bucket.target.bucket
   key    = %[4]q
   source = "${aws_s3_bucket.source.bucket}/${aws_s3_object.source.key}"

--- a/internal/service/s3/object_test.go
+++ b/internal/service/s3/object_test.go
@@ -588,31 +588,31 @@ func TestAccS3Object_acl(t *testing.T) {
 		CheckDestroy:             testAccCheckObjectDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccObjectConfig_acl(rName, "some_bucket_content", "private"),
+				Config: testAccObjectConfig_acl(rName, "some_bucket_content", s3.BucketCannedACLPrivate, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckObjectExists(ctx, resourceName, &obj1),
 					testAccCheckObjectBody(&obj1, "some_bucket_content"),
-					resource.TestCheckResourceAttr(resourceName, "acl", "private"),
+					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPrivate),
 					testAccCheckObjectACL(ctx, resourceName, []string{"FULL_CONTROL"}),
 				),
 			},
 			{
-				Config: testAccObjectConfig_acl(rName, "some_bucket_content", "public-read"),
+				Config: testAccObjectConfig_acl(rName, "some_bucket_content", s3.BucketCannedACLPublicRead, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckObjectExists(ctx, resourceName, &obj2),
 					testAccCheckObjectVersionIdEquals(&obj2, &obj1),
 					testAccCheckObjectBody(&obj2, "some_bucket_content"),
-					resource.TestCheckResourceAttr(resourceName, "acl", "public-read"),
+					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPublicRead),
 					testAccCheckObjectACL(ctx, resourceName, []string{"FULL_CONTROL", "READ"}),
 				),
 			},
 			{
-				Config: testAccObjectConfig_acl(rName, "changed_some_bucket_content", "private"),
+				Config: testAccObjectConfig_acl(rName, "changed_some_bucket_content", s3.BucketCannedACLPrivate, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckObjectExists(ctx, resourceName, &obj3),
 					testAccCheckObjectVersionIdDiffers(&obj3, &obj2),
 					testAccCheckObjectBody(&obj3, "changed_some_bucket_content"),
-					resource.TestCheckResourceAttr(resourceName, "acl", "private"),
+					resource.TestCheckResourceAttr(resourceName, "acl", s3.BucketCannedACLPrivate),
 					testAccCheckObjectACL(ctx, resourceName, []string{"FULL_CONTROL"}),
 				),
 			},
@@ -1785,10 +1785,26 @@ resource "aws_s3_object" "object" {
 `, rName, source)
 }
 
-func testAccObjectConfig_acl(rName string, content, acl string) string {
+func testAccObjectConfig_acl(rName, content, acl string, blockPublicAccess bool) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
+}
+
+resource "aws_s3_bucket_public_access_block" "test" {
+  bucket = aws_s3_bucket.test.id
+
+  block_public_acls       = %[4]t
+  block_public_policy     = %[4]t
+  ignore_public_acls      = %[4]t
+  restrict_public_buckets = %[4]t
+}
+
+resource "aws_s3_bucket_ownership_controls" "test" {
+  bucket = aws_s3_bucket.test.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
 }
 
 resource "aws_s3_bucket_versioning" "test" {
@@ -1799,13 +1815,18 @@ resource "aws_s3_bucket_versioning" "test" {
 }
 
 resource "aws_s3_object" "object" {
-  # Must have bucket versioning enabled first
-  bucket  = aws_s3_bucket_versioning.test.bucket
+  depends_on = [
+    aws_s3_bucket_public_access_block.test,
+    aws_s3_bucket_ownership_controls.test,
+    aws_s3_bucket_versioning.test,
+  ]
+
+  bucket  = aws_s3_bucket.test.id
   key     = "test-key"
   content = %[2]q
   acl     = %[3]q
 }
-`, rName, content, acl)
+`, rName, content, acl, blockPublicAccess)
 }
 
 func testAccObjectConfig_storageClass(rName string, storage_class string) string {


### PR DESCRIPTION
### Description
Updates object level tests using ACL configurations missed in #30589.


### Relations
Relates #28353
Relates #30589

### References
- https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/


### Output from Acceptance Testing

```
$ make testacc PKG=s3 TESTS="TestAccS3ObjectCopy_basic|TestAccS3BucketObject_acl|TestAccS3Object_acl"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3ObjectCopy_basic|TestAccS3BucketObject_acl|TestAccS3Object_acl'  -timeout 180m
=== RUN   TestAccS3BucketObject_acl
=== PAUSE TestAccS3BucketObject_acl
=== RUN   TestAccS3ObjectCopy_basic
=== PAUSE TestAccS3ObjectCopy_basic
=== RUN   TestAccS3Object_acl
=== PAUSE TestAccS3Object_acl
=== CONT  TestAccS3BucketObject_acl
=== CONT  TestAccS3Object_acl
=== CONT  TestAccS3ObjectCopy_basic
--- PASS: TestAccS3ObjectCopy_basic (17.51s)
--- PASS: TestAccS3Object_acl (53.72s)
--- PASS: TestAccS3BucketObject_acl (53.72s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 56.872s
```
