### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Plugin SDK resources `serverlessrepo` (Phase 3c)

### DIFF
--- a/internal/service/serverlessrepo/cloudformation_stack.go
+++ b/internal/service/serverlessrepo/cloudformation_stack.go
@@ -22,6 +22,7 @@ import ( // nosemgrep:ci.aws-sdk-go-multiple-service-imports
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 const (
@@ -50,11 +51,6 @@ func ResourceCloudFormationStack() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
 			"application_id": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -68,7 +64,16 @@ func ResourceCloudFormationStack() *schema.Resource {
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringInSlice(serverlessrepo.Capability_Values(), false),
 				},
-				Set: schema.HashString,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"outputs": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"parameters": {
 				Type:     schema.TypeMap,
@@ -81,13 +86,8 @@ func ResourceCloudFormationStack() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			"outputs": {
-				Type:     schema.TypeMap,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"tags":     tftags.TagsSchema(),
-			"tags_all": tftags.TagsSchemaComputed(),
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,

--- a/internal/service/serverlessrepo/cloudformation_stack.go
+++ b/internal/service/serverlessrepo/cloudformation_stack.go
@@ -32,7 +32,8 @@ const (
 	cloudFormationStackTagSemanticVersion = "serverlessrepo:semanticVersion"
 )
 
-// @SDKResource("aws_serverlessapplicationrepository_cloudformation_stack")
+// @SDKResource("aws_serverlessapplicationrepository_cloudformation_stack", name="CloudFormation Stack")
+// @Tags
 func ResourceCloudFormationStack() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceCloudFormationStackCreate,
@@ -132,8 +133,6 @@ func resourceCloudFormationStackRead(ctx context.Context, d *schema.ResourceData
 	var diags diag.Diagnostics
 	serverlessConn := meta.(*conns.AWSClient).ServerlessRepoConn()
 	cfConn := meta.(*conns.AWSClient).CloudFormationConn()
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	stack, err := tfcloudformation.FindStackByID(ctx, cfConn, d.Id())
 
@@ -166,16 +165,7 @@ func resourceCloudFormationStackRead(ctx context.Context, d *schema.ResourceData
 		return sdkdiag.AppendErrorf(diags, "describing Serverless Application Repository CloudFormation Stack (%s): missing required tag \"%s\"", d.Id(), cloudFormationStackTagSemanticVersion)
 	}
 
-	tags = tags.IgnoreServerlessApplicationRepository().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err = d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "to set tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "to set tags_all: %s", err)
-	}
+	SetTagsOut(ctx, Tags(tags))
 
 	if err = d.Set("outputs", flattenCloudFormationOutputs(stack.Outputs)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "to set outputs: %s", err)
@@ -305,15 +295,13 @@ func resourceCloudFormationStackImport(ctx context.Context, d *schema.ResourceDa
 func createCloudFormationChangeSet(ctx context.Context, d *schema.ResourceData, client *conns.AWSClient) (*cloudformation.DescribeChangeSetOutput, error) {
 	serverlessConn := client.ServerlessRepoConn()
 	cfConn := client.CloudFormationConn()
-	defaultTagsConfig := client.DefaultTagsConfig
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
 	stackName := d.Get("name").(string)
 	changeSetRequest := serverlessrepo.CreateCloudFormationChangeSetRequest{
 		StackName:     aws.String(stackName),
 		ApplicationId: aws.String(d.Get("application_id").(string)),
 		Capabilities:  flex.ExpandStringSet(d.Get("capabilities").(*schema.Set)),
-		Tags:          Tags(tags.IgnoreServerlessApplicationRepository()),
+		Tags:          GetTagsIn(ctx),
 	}
 	if v, ok := d.GetOk("semantic_version"); ok {
 		changeSetRequest.SemanticVersion = aws.String(v.(string))

--- a/internal/service/serverlessrepo/service_package_gen.go
+++ b/internal/service/serverlessrepo/service_package_gen.go
@@ -33,6 +33,8 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCloudFormationStack,
 			TypeName: "aws_serverlessapplicationrepository_cloudformation_stack",
+			Name:     "CloudFormation Stack",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 	}
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Extends the work done in Phase 2 to the remaining resources implemented using Terraform Plugin SDK.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/30280.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30417.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30421.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30430.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30449.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30454.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30461.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30463.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30476.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30477.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30478.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30483.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30484.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30491.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30509.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30510.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30512.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30516.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30517.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30533.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30534.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccServerlessRepoCloudFormationStack_' PKG=serverlessrepo ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/serverlessrepo/... -v -count 1 -parallel 3  -run=TestAccServerlessRepoCloudFormationStack_ -timeout 180m
=== RUN   TestAccServerlessRepoCloudFormationStack_basic
=== PAUSE TestAccServerlessRepoCloudFormationStack_basic
=== RUN   TestAccServerlessRepoCloudFormationStack_disappears
=== PAUSE TestAccServerlessRepoCloudFormationStack_disappears
=== RUN   TestAccServerlessRepoCloudFormationStack_versioned
=== PAUSE TestAccServerlessRepoCloudFormationStack_versioned
=== RUN   TestAccServerlessRepoCloudFormationStack_paired
=== PAUSE TestAccServerlessRepoCloudFormationStack_paired
=== RUN   TestAccServerlessRepoCloudFormationStack_tags
=== PAUSE TestAccServerlessRepoCloudFormationStack_tags
=== RUN   TestAccServerlessRepoCloudFormationStack_update
=== PAUSE TestAccServerlessRepoCloudFormationStack_update
=== CONT  TestAccServerlessRepoCloudFormationStack_basic
=== CONT  TestAccServerlessRepoCloudFormationStack_paired
=== CONT  TestAccServerlessRepoCloudFormationStack_versioned
--- PASS: TestAccServerlessRepoCloudFormationStack_paired (106.97s)
=== CONT  TestAccServerlessRepoCloudFormationStack_disappears
--- PASS: TestAccServerlessRepoCloudFormationStack_basic (127.41s)
=== CONT  TestAccServerlessRepoCloudFormationStack_update
--- PASS: TestAccServerlessRepoCloudFormationStack_disappears (97.65s)
=== CONT  TestAccServerlessRepoCloudFormationStack_tags
--- PASS: TestAccServerlessRepoCloudFormationStack_versioned (271.20s)
--- PASS: TestAccServerlessRepoCloudFormationStack_update (207.18s)
--- PASS: TestAccServerlessRepoCloudFormationStack_tags (234.05s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/serverlessrepo	444.445s
```
