### PR TITLE
Fixes OpenSearch and Elasticsearch acceptance tests

### DIFF
--- a/internal/service/elasticsearch/domain_data_source_test.go
+++ b/internal/service/elasticsearch/domain_data_source_test.go
@@ -152,7 +152,6 @@ POLICY
   }
 
   cluster_config {
-    instance_type            = "t3.small.elasticsearch"
     instance_count           = 2
     dedicated_master_enabled = false
 
@@ -276,7 +275,6 @@ POLICY
   }
 
   cluster_config {
-    instance_type            = "t2.small.elasticsearch"
     instance_count           = 2
     dedicated_master_enabled = false
 

--- a/internal/service/opensearch/domain_data_source_test.go
+++ b/internal/service/opensearch/domain_data_source_test.go
@@ -153,7 +153,6 @@ POLICY
   }
 
   cluster_config {
-    instance_type            = "t3.small.search"
     instance_count           = 2
     dedicated_master_enabled = false
 
@@ -276,7 +275,6 @@ POLICY
   }
 
   cluster_config {
-    instance_type            = "t2.small.search"
     instance_count           = 2
     dedicated_master_enabled = false
 

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -544,7 +544,7 @@ func TestAccOpenSearchDomain_duplicate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(ctx, resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "OpenSearch_1.1")),
-				ExpectError: regexp.MustCompile(`domain .+ already exists`),
+				ExpectError: regexp.MustCompile(`OpenSearch Domain ".+" already exists`),
 			},
 		},
 	})


### PR DESCRIPTION
### Description

Acceptance tests for `aws_elasticsearch_domain` and `aws_opensearch_domain` data sources are failing with

> ValidationException: Autotune is not supported in t2/t3 instance types.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=elasticsearch TESTS=TestAccElasticsearchDomainDataSource_

--- PASS: TestAccElasticsearchDomainDataSource_basic (2377.19s)
--- PASS: TestAccElasticsearchDomainDataSource_advanced (3910.58s)
```


```
$ make testacc PKG=elasticsearch TESTS=TestAccOpenSearchDomainDataSource_

--- PASS: TestAccOpenSearchDomainDataSource_Data_basic (1792.44s)
--- PASS: TestAccOpenSearchDomainDataSource_Data_advanced (3037.74s)
```
