### PR TITLE
rds/cluster: Parameter group regression fix

### DIFF
--- a/.changelog/30679.txt
+++ b/.changelog/30679.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_cluster: Prevent `db_instance_parameter_group_name` from causing errors on minor upgrades
+```

--- a/internal/service/rds/certificate_data_source.go
+++ b/internal/service/rds/certificate_data_source.go
@@ -85,7 +85,6 @@ func dataSourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta
 		}
 		return !lastPage
 	})
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading RDS Certificates: %s", err)
 	}

--- a/internal/service/rds/cluster_activity_stream.go
+++ b/internal/service/rds/cluster_activity_stream.go
@@ -72,7 +72,6 @@ func resourceClusterActivityStreamCreate(ctx context.Context, d *schema.Resource
 	}
 
 	_, err := conn.StartActivityStreamWithContext(ctx, input)
-
 	if err != nil {
 		return diag.Errorf("creating RDS Cluster Activity Stream (%s): %s", arn, err)
 	}
@@ -117,7 +116,6 @@ func resourceClusterActivityStreamDelete(ctx context.Context, d *schema.Resource
 		ApplyImmediately: aws.Bool(true),
 		ResourceArn:      aws.String(d.Id()),
 	})
-
 	if err != nil {
 		return diag.Errorf("stopping RDS Cluster Activity Stream (%s): %s", d.Id(), err)
 	}
@@ -131,7 +129,6 @@ func resourceClusterActivityStreamDelete(ctx context.Context, d *schema.Resource
 
 func FindDBClusterWithActivityStream(ctx context.Context, conn *rds.RDS, arn string) (*rds.DBCluster, error) {
 	output, err := FindDBClusterByID(ctx, conn, arn)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/rds/cluster_activity_stream_test.go
+++ b/internal/service/rds/cluster_activity_stream_test.go
@@ -90,7 +90,6 @@ func testAccCheckClusterActivityStreamExists(ctx context.Context, n string, v *r
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn()
 
 		output, err := tfrds.FindDBClusterWithActivityStream(ctx, conn, rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/rds/cluster_data_source.go
+++ b/internal/service/rds/cluster_data_source.go
@@ -170,7 +170,6 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	dbClusterID := d.Get("cluster_identifier").(string)
 	dbc, err := FindDBClusterByID(ctx, conn, dbClusterID)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading RDS Cluster (%s): %s", dbClusterID, err)
 	}
@@ -231,7 +230,6 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("vpc_security_group_ids", securityGroupIDs)
 
 	tags, err := ListTags(ctx, conn, clusterARN)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "listing tags for RDS Cluster (%s): %s", d.Id(), err)
 	}

--- a/internal/service/rds/cluster_endpoint.go
+++ b/internal/service/rds/cluster_endpoint.go
@@ -106,7 +106,6 @@ func resourceClusterEndpointCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	_, err := conn.CreateDBClusterEndpointWithContext(ctx, input)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating RDS Cluster Endpoint (%s): %s", endpointID, err)
 	}
@@ -174,7 +173,6 @@ func resourceClusterEndpointUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 
 		_, err := conn.ModifyDBClusterEndpointWithContext(ctx, input)
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "modifying RDS Cluster Endpoint (%s): %s", d.Id(), err)
 		}
@@ -191,7 +189,6 @@ func resourceClusterEndpointDelete(ctx context.Context, d *schema.ResourceData, 
 	_, err := conn.DeleteDBClusterEndpointWithContext(ctx, &rds.DeleteDBClusterEndpointInput{
 		DBClusterEndpointIdentifier: aws.String(d.Id()),
 	})
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting RDS Cluster Endpoint (%s): %s", d.Id(), err)
 	}
@@ -209,7 +206,6 @@ func FindDBClusterEndpointByID(ctx context.Context, conn *rds.RDS, id string) (*
 	}
 
 	output, err := conn.DescribeDBClusterEndpointsWithContext(ctx, input)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/rds/cluster_endpoint_test.go
+++ b/internal/service/rds/cluster_endpoint_test.go
@@ -187,7 +187,6 @@ func testAccCheckClusterEndpointExists(ctx context.Context, n string, v *rds.DBC
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn()
 
 		output, err := tfrds.FindDBClusterEndpointByID(ctx, conn, rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -301,7 +301,6 @@ func resourceClusterInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 			return conn.CreateDBInstanceWithContext(ctx, input)
 		},
 		errCodeInvalidParameterValue, "IAM role ARN value is invalid or does not include the required permissions")
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating RDS Cluster (%s) Instance (%s): %s", clusterID, identifier, err)
 	}
@@ -365,7 +364,6 @@ func resourceClusterInstanceRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	dbc, err := FindDBClusterByID(ctx, conn, dbClusterID)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading RDS Cluster (%s): %s", dbClusterID, err)
 	}
@@ -490,7 +488,6 @@ func resourceClusterInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 				return conn.ModifyDBInstanceWithContext(ctx, input)
 			},
 			errCodeInvalidParameterValue, "IAM role ARN value is invalid or does not include the required permissions")
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating RDS Cluster Instance (%s): %s", d.Id(), err)
 		}

--- a/internal/service/rds/cluster_instance_test.go
+++ b/internal/service/rds/cluster_instance_test.go
@@ -1137,7 +1137,6 @@ func testAccCheckClusterInstanceExists(ctx context.Context, n string, v *rds.DBI
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn()
 
 		output, err := tfrds.FindDBInstanceByID(ctx, conn, rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/rds/cluster_parameter_group.go
+++ b/internal/service/rds/cluster_parameter_group.go
@@ -113,7 +113,6 @@ func resourceClusterParameterGroupCreate(ctx context.Context, d *schema.Resource
 	}
 
 	output, err := conn.CreateDBClusterParameterGroupWithContext(ctx, input)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating DB Cluster Parameter Group (%s): %s", groupName, err)
 	}
@@ -249,7 +248,6 @@ func resourceClusterParameterGroupUpdate(ctx context.Context, d *schema.Resource
 				}
 
 				_, err := conn.ModifyDBClusterParameterGroupWithContext(ctx, input)
-
 				if err != nil {
 					return sdkdiag.AppendErrorf(diags, "modifying DB Cluster Parameter Group (%s): %s", d.Id(), err)
 				}

--- a/internal/service/rds/cluster_parameter_group_test.go
+++ b/internal/service/rds/cluster_parameter_group_test.go
@@ -596,7 +596,6 @@ func testAccCheckClusterParameterGroupExists(ctx context.Context, n string, v *r
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn()
 
 		output, err := tfrds.FindDBClusterParameterGroupByName(ctx, conn, rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/rds/cluster_role_association.go
+++ b/internal/service/rds/cluster_role_association.go
@@ -94,7 +94,6 @@ func resourceClusterRoleAssociationRead(ctx context.Context, d *schema.ResourceD
 	conn := meta.(*conns.AWSClient).RDSConn()
 
 	dbClusterID, roleARN, err := ClusterRoleAssociationParseResourceID(d.Id())
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "parsing RDS DB Cluster IAM Role Association ID: %s", err)
 	}
@@ -123,7 +122,6 @@ func resourceClusterRoleAssociationDelete(ctx context.Context, d *schema.Resourc
 	conn := meta.(*conns.AWSClient).RDSConn()
 
 	dbClusterID, roleARN, err := ClusterRoleAssociationParseResourceID(d.Id())
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "parsing RDS DB Cluster IAM Role Association ID: %s", err)
 	}

--- a/internal/service/rds/cluster_role_association_test.go
+++ b/internal/service/rds/cluster_role_association_test.go
@@ -131,7 +131,6 @@ func testAccCheckClusterRoleAssociationExists(ctx context.Context, resourceName 
 		}
 
 		dbClusterID, roleARN, err := tfrds.ClusterRoleAssociationParseResourceID(rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}
@@ -139,7 +138,6 @@ func testAccCheckClusterRoleAssociationExists(ctx context.Context, resourceName 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn()
 
 		role, err := tfrds.FindDBClusterRoleByDBClusterIDAndRoleARN(ctx, conn, dbClusterID, roleARN)
-
 		if err != nil {
 			return err
 		}
@@ -160,7 +158,6 @@ func testAccCheckClusterRoleAssociationDestroy(ctx context.Context) resource.Tes
 			}
 
 			dbClusterID, roleARN, err := tfrds.ClusterRoleAssociationParseResourceID(rs.Primary.ID)
-
 			if err != nil {
 				return err
 			}

--- a/internal/service/rds/cluster_snapshot_data_source.go
+++ b/internal/service/rds/cluster_snapshot_data_source.go
@@ -22,7 +22,7 @@ func DataSourceClusterSnapshot() *schema.Resource {
 		ReadWithoutTimeout: dataSourceClusterSnapshotRead,
 
 		Schema: map[string]*schema.Schema{
-			//selection criteria
+			// selection criteria
 			"db_cluster_identifier": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -55,7 +55,7 @@ func DataSourceClusterSnapshot() *schema.Resource {
 				Default:  false,
 			},
 
-			//Computed values returned
+			// Computed values returned
 			"allocated_storage": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -186,7 +186,6 @@ func dataSourceClusterSnapshotRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("vpc_id", snapshot.VpcId)
 
 	tags, err := ListTags(ctx, conn, d.Get("db_cluster_snapshot_arn").(string))
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "listing tags for RDS DB Cluster Snapshot (%s): %s", d.Get("db_cluster_snapshot_arn").(string), err)
 	}

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -4319,6 +4319,8 @@ resource "aws_rds_cluster" "test" {
 }
 
 func testAccClusterConfig_SnapshotID_preferredMaintenanceWindow(rName, preferredMaintenanceWindow string) string {
+	// This config will never need the version updated. Use as a model for changing the other
+	// tests.
 	return fmt.Sprintf(`
 data "aws_rds_engine_version" "test" {
   engine = "aurora-mysql"
@@ -4326,7 +4328,6 @@ data "aws_rds_engine_version" "test" {
 
 resource "aws_rds_cluster" "source" {
   cluster_identifier  = "%[1]s-source"
-  engine              = "aurora-mysql"
   master_password     = "barbarbarbar"
   master_username     = "foo"
   skip_final_snapshot = true
@@ -4340,7 +4341,6 @@ resource "aws_db_cluster_snapshot" "test" {
 
 resource "aws_rds_cluster" "test" {
   cluster_identifier           = %[1]q
-  engine                       = "aurora-mysql"
   preferred_maintenance_window = %[2]q
   skip_final_snapshot          = true
   snapshot_identifier          = aws_db_cluster_snapshot.test.id

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -460,6 +460,7 @@ func TestAccRDSCluster_onlyMajorVersion(t *testing.T) {
 	})
 }
 
+// https://github.com/hashicorp/terraform-provider-aws/issues/30605
 func TestAccRDSCluster_minorVersion(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -2155,6 +2156,9 @@ func TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow(t *testing.
 
 	var dbCluster, sourceDbCluster rds.DBCluster
 	var dbClusterSnapshot rds.DBClusterSnapshot
+
+	// This config is version agnostic. Use it as a model for fixing version errors
+	// in other tests.
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	sourceDbResourceName := "aws_rds_cluster.source"

--- a/internal/service/rds/clusters_data_source.go
+++ b/internal/service/rds/clusters_data_source.go
@@ -66,7 +66,6 @@ func dataSourceClustersRead(ctx context.Context, d *schema.ResourceData, meta in
 
 		return !lastPage
 	})
-
 	if err != nil {
 		return create.DiagError(names.RDS, create.ErrActionReading, DSNameClusters, "", err)
 	}

--- a/internal/service/rds/engine_version_data_source.go
+++ b/internal/service/rds/engine_version_data_source.go
@@ -190,7 +190,6 @@ func dataSourceEngineVersionRead(ctx context.Context, d *schema.ResourceData, me
 		}
 		return !lastPage
 	})
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading RDS engine versions: %s", err)
 	}

--- a/internal/service/rds/event_categories_data_source.go
+++ b/internal/service/rds/event_categories_data_source.go
@@ -43,7 +43,6 @@ func dataSourceEventCategoriesRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	output, err := findEventCategoriesMaps(ctx, conn, input)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading RDS Event Categories: %s", err)
 	}
@@ -64,7 +63,6 @@ func findEventCategoriesMaps(ctx context.Context, conn *rds.RDS, input *rds.Desc
 	var output []*rds.EventCategoriesMap
 
 	page, err := conn.DescribeEventCategoriesWithContext(ctx, input)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/rds/event_subscription.go
+++ b/internal/service/rds/event_subscription.go
@@ -124,7 +124,6 @@ func resourceEventSubscriptionCreate(ctx context.Context, d *schema.ResourceData
 
 	log.Printf("[DEBUG] Creating RDS Event Subscription: %s", input)
 	output, err := conn.CreateEventSubscriptionWithContext(ctx, input)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating RDS Event Subscription (%s): %s", name, err)
 	}
@@ -194,7 +193,6 @@ func resourceEventSubscriptionUpdate(ctx context.Context, d *schema.ResourceData
 
 		log.Printf("[DEBUG] Updating RDS Event Subscription: %s", input)
 		_, err := conn.ModifyEventSubscriptionWithContext(ctx, input)
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating RDS Event Subscription (%s): %s", d.Id(), err)
 		}
@@ -217,7 +215,6 @@ func resourceEventSubscriptionUpdate(ctx context.Context, d *schema.ResourceData
 				SourceIdentifier: aws.String(del),
 				SubscriptionName: aws.String(d.Id()),
 			})
-
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "removing RDS Event Subscription (%s) source ID (%s): %s", d.Id(), del, err)
 			}
@@ -229,7 +226,6 @@ func resourceEventSubscriptionUpdate(ctx context.Context, d *schema.ResourceData
 				SourceIdentifier: aws.String(add),
 				SubscriptionName: aws.String(d.Id()),
 			})
-
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "adding RDS Event Subscription (%s) source ID (%s): %s", d.Id(), add, err)
 			}

--- a/internal/service/rds/event_subscription_test.go
+++ b/internal/service/rds/event_subscription_test.go
@@ -312,7 +312,6 @@ func testAccCheckEventSubscriptionExists(ctx context.Context, n string, v *rds.E
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn()
 
 		output, err := tfrds.FindEventSubscriptionByID(ctx, conn, rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/rds/find.go
+++ b/internal/service/rds/find.go
@@ -68,7 +68,6 @@ func FindDBProxyEndpoint(ctx context.Context, conn *rds.RDS, id string) (*rds.DB
 
 func FindDBClusterRoleByDBClusterIDAndRoleARN(ctx context.Context, conn *rds.RDS, dbClusterID, roleARN string) (*rds.DBClusterRole, error) {
 	dbCluster, err := FindDBClusterByID(ctx, conn, dbClusterID)
-
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +274,6 @@ func FindDBInstanceAutomatedBackupByARN(ctx context.Context, conn *rds.RDS, arn 
 	}
 
 	output, err := findDBInstanceAutomatedBackup(ctx, conn, input)
-
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +298,6 @@ func FindDBInstanceAutomatedBackupByARN(ctx context.Context, conn *rds.RDS, arn 
 
 func findDBInstanceAutomatedBackup(ctx context.Context, conn *rds.RDS, input *rds.DescribeDBInstanceAutomatedBackupsInput) (*rds.DBInstanceAutomatedBackup, error) {
 	output, err := findDBInstanceAutomatedBackups(ctx, conn, input)
-
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +347,6 @@ func findDBInstanceAutomatedBackups(ctx context.Context, conn *rds.RDS, input *r
 func FindGlobalClusterByDBClusterARN(ctx context.Context, conn *rds.RDS, dbClusterARN string) (*rds.GlobalCluster, error) {
 	input := &rds.DescribeGlobalClustersInput{}
 	globalClusters, err := findGlobalClusters(ctx, conn, input)
-
 	if err != nil {
 		return nil, err
 	}
@@ -372,7 +368,6 @@ func FindGlobalClusterByID(ctx context.Context, conn *rds.RDS, id string) (*rds.
 	}
 
 	output, err := findGlobalCluster(ctx, conn, input)
-
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +384,6 @@ func FindGlobalClusterByID(ctx context.Context, conn *rds.RDS, id string) (*rds.
 
 func findGlobalCluster(ctx context.Context, conn *rds.RDS, input *rds.DescribeGlobalClustersInput) (*rds.GlobalCluster, error) {
 	output, err := findGlobalClusters(ctx, conn, input)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -331,7 +331,6 @@ func resourceGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, me
 			}
 
 			_, err := conn.RemoveFromGlobalClusterWithContext(ctx, input)
-
 			if err != nil {
 				if !tfawserr.ErrMessageContains(err, "InvalidParameterValue", "is not found in global cluster") {
 					return sdkdiag.AppendErrorf(diags, "removing RDS DB Cluster (%s) from Global Cluster (%s): %s", writerARN, d.Id(), err)
@@ -592,7 +591,6 @@ func globalClusterUpgradeMajorEngineVersion(ctx context.Context, meta interface{
 
 	err := retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 		_, err := conn.ModifyGlobalClusterWithContext(ctx, input)
-
 		if err != nil {
 			if tfawserr.ErrCodeEquals(err, rds.ErrCodeGlobalClusterNotFoundFault) {
 				return retry.NonRetryableError(err)
@@ -617,7 +615,6 @@ func globalClusterUpgradeMajorEngineVersion(ctx context.Context, meta interface{
 	}
 
 	globalCluster, err := DescribeGlobalCluster(ctx, conn, clusterID)
-
 	if err != nil {
 		return fmt.Errorf("while upgrading major version of RDS Global Cluster (%s): %w", clusterID, err)
 	}
@@ -630,7 +627,6 @@ func globalClusterUpgradeMajorEngineVersion(ctx context.Context, meta interface{
 		}
 
 		dbi, clusterRegion, err := ClusterIDRegionFromARN(arnID)
-
 		if err != nil {
 			return fmt.Errorf("while upgrading RDS Global Cluster Cluster minor engine version: %w", err)
 		}
@@ -655,7 +651,6 @@ func globalClusterUpgradeMajorEngineVersion(ctx context.Context, meta interface{
 
 func ClusterIDRegionFromARN(arnID string) (string, string, error) {
 	parsedARN, err := arn.Parse(arnID)
-
 	if err != nil {
 		return "", "", fmt.Errorf("could not parse ARN (%s): %w", arnID, err)
 	}
@@ -696,7 +691,6 @@ func globalClusterUpgradeMinorEngineVersion(ctx context.Context, meta interface{
 		arnID := clusterMember["db_cluster_arn"].(string)
 
 		dbi, clusterRegion, err := ClusterIDRegionFromARN(arnID)
-
 		if err != nil {
 			return fmt.Errorf("while upgrading RDS Global Cluster Cluster minor engine version: %w", err)
 		}
@@ -721,7 +715,6 @@ func globalClusterUpgradeMinorEngineVersion(ctx context.Context, meta interface{
 
 		err = retry.RetryContext(ctx, timeout, func() *retry.RetryError {
 			_, err := useConn.ModifyDBClusterWithContext(ctx, modInput)
-
 			if err != nil {
 				if tfawserr.ErrMessageContains(err, "InvalidParameterValue", "IAM role ARN value is invalid or does not include the required permissions") {
 					return retry.RetryableError(err)
@@ -742,7 +735,6 @@ func globalClusterUpgradeMinorEngineVersion(ctx context.Context, meta interface{
 
 		if tfresource.TimedOut(err) {
 			_, err := useConn.ModifyDBClusterWithContext(ctx, modInput)
-
 			if err != nil {
 				return err
 			}

--- a/internal/service/rds/global_cluster_test.go
+++ b/internal/service/rds/global_cluster_test.go
@@ -298,14 +298,14 @@ func TestAccRDSGlobalCluster_EngineVersion_updateMinor(t *testing.T) {
 		CheckDestroy:             testAccCheckGlobalClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				//Config: testAccGlobalClusterConfig_primaryEngineVersion(rName, "aurora", "5.6.mysql_aurora.1.22.2"),
+				// Config: testAccGlobalClusterConfig_primaryEngineVersion(rName, "aurora", "5.6.mysql_aurora.1.22.2"),
 				Config: testAccGlobalClusterConfig_primaryEngineVersion(rName, "aurora-postgresql", "13.4"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, resourceName, &globalCluster1),
 				),
 			},
 			{
-				//Config: testAccGlobalClusterConfig_primaryEngineVersion(rName, "aurora", "5.6.mysql_aurora.1.23.2"),
+				// Config: testAccGlobalClusterConfig_primaryEngineVersion(rName, "aurora", "5.6.mysql_aurora.1.23.2"),
 				Config: testAccGlobalClusterConfig_primaryEngineVersion(rName, "aurora-postgresql", "13.5"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlobalClusterExists(ctx, resourceName, &globalCluster2),
@@ -622,7 +622,6 @@ func testAccCheckGlobalClusterExists(ctx context.Context, resourceName string, g
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn()
 
 		cluster, err := tfrds.DescribeGlobalCluster(ctx, conn, rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}
@@ -680,7 +679,6 @@ func testAccCheckGlobalClusterDisappears(ctx context.Context, globalCluster *rds
 		}
 
 		_, err := conn.DeleteGlobalClusterWithContext(ctx, input)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -75,13 +75,11 @@ func ResourceInstance() *schema.Resource {
 					mas := d.Get("max_allocated_storage").(int)
 
 					newInt, err := strconv.Atoi(new)
-
 					if err != nil {
 						return false
 					}
 
 					oldInt, err := strconv.Atoi(old)
-
 					if err != nil {
 						return false
 					}
@@ -771,7 +769,6 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 				return conn.CreateDBInstanceReadReplicaWithContext(ctx, input)
 			},
 			errCodeInvalidParameterValue, "ENHANCED_MONITORING")
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating RDS DB Instance (read replica) (%s): %s", identifier, err)
 		}
@@ -1008,7 +1005,6 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 				return false, err
 			},
 		)
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating RDS DB Instance (restore from S3) (%s): %s", identifier, err)
 		}
@@ -1377,7 +1373,6 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 				return false, err
 			},
 		)
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating RDS DB Instance (restore to point-in-time) (%s): %s", identifier, err)
 		}
@@ -1568,7 +1563,6 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 				return false, err
 			},
 		)
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating RDS DB Instance (%s): %s", identifier, err)
 		}
@@ -1592,7 +1586,6 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		modifyDbInstanceInput.DBInstanceIdentifier = aws.String(d.Id())
 
 		_, err := conn.ModifyDBInstanceWithContext(ctx, modifyDbInstanceInput)
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", d.Id(), err)
 		}
@@ -1606,7 +1599,6 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		_, err := conn.RebootDBInstanceWithContext(ctx, &rds.RebootDBInstanceInput{
 			DBInstanceIdentifier: aws.String(d.Id()),
 		})
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "rebooting RDS DB Instance (%s): %s", d.Id(), err)
 		}
@@ -2198,7 +2190,6 @@ func dbInstanceModify(ctx context.Context, conn *rds_sdkv2.Client, input *rds_sd
 			return false, err
 		},
 	)
-
 	if err != nil {
 		return err
 	}

--- a/internal/service/rds/instance_automated_backups_replication.go
+++ b/internal/service/rds/instance_automated_backups_replication.go
@@ -86,7 +86,6 @@ func resourceInstanceAutomatedBackupsReplicationCreate(ctx context.Context, d *s
 
 	log.Printf("[DEBUG] Starting RDS instance automated backups replication: %s", input)
 	output, err := conn.StartDBInstanceAutomatedBackupsReplicationWithContext(ctx, input)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "starting RDS instance automated backups replication: %s", err)
 	}
@@ -140,7 +139,6 @@ func resourceInstanceAutomatedBackupsReplicationDelete(ctx context.Context, d *s
 
 	dbInstanceID := aws.StringValue(backup.DBInstanceIdentifier)
 	sourceDatabaseARN, err := arn.Parse(aws.StringValue(backup.DBInstanceArn))
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting RDS DB Instance Automated Backup (%s): %s", d.Id(), err)
 	}

--- a/internal/service/rds/instance_data_source.go
+++ b/internal/service/rds/instance_data_source.go
@@ -217,7 +217,6 @@ func dataSourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta in
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	v, err := findDBInstanceByIDSDKv1(ctx, conn, d.Get("db_instance_identifier").(string))
-
 	if err != nil {
 		return diag.FromErr(tfresource.SingularDataSourceFindError("RDS DB Instance", err))
 	}
@@ -299,7 +298,6 @@ func dataSourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	tags, err := ListTags(ctx, conn, d.Get("db_instance_arn").(string))
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "listing tags for RDS DB Instance (%s): %s", d.Get("db_instance_arn").(string), err)
 	}

--- a/internal/service/rds/instance_data_source_test.go
+++ b/internal/service/rds/instance_data_source_test.go
@@ -53,6 +53,7 @@ func TestAccRDSInstanceDataSource_basic(t *testing.T) {
 		},
 	})
 }
+
 func TestAccRDSInstanceDataSource_ManagedMasterPassword_managed(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {

--- a/internal/service/rds/instance_migrate_test.go
+++ b/internal/service/rds/instance_migrate_test.go
@@ -52,7 +52,6 @@ func TestInstanceStateUpgradeV0(t *testing.T) {
 			t.Parallel()
 
 			got, err := tfrds.InstanceStateUpgradeV0(ctx, testCase.InputState, nil)
-
 			if err != nil {
 				t.Fatalf("error migrating state: %s", err)
 			}

--- a/internal/service/rds/instance_role_association.go
+++ b/internal/service/rds/instance_role_association.go
@@ -107,7 +107,6 @@ func resourceInstanceRoleAssociationRead(ctx context.Context, d *schema.Resource
 	conn := meta.(*conns.AWSClient).RDSConn()
 
 	dbInstanceIdentifier, roleArn, err := InstanceRoleAssociationDecodeID(d.Id())
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading resource ID: %s", err)
 	}
@@ -136,7 +135,6 @@ func resourceInstanceRoleAssociationDelete(ctx context.Context, d *schema.Resour
 	conn := meta.(*conns.AWSClient).RDSConn()
 
 	dbInstanceIdentifier, roleArn, err := InstanceRoleAssociationDecodeID(d.Id())
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading resource ID: %s", err)
 	}

--- a/internal/service/rds/instance_role_association_test.go
+++ b/internal/service/rds/instance_role_association_test.go
@@ -92,7 +92,6 @@ func testAccCheckInstanceRoleAssociationExists(ctx context.Context, resourceName
 		}
 
 		dbInstanceIdentifier, roleArn, err := tfrds.InstanceRoleAssociationDecodeID(rs.Primary.ID)
-
 		if err != nil {
 			return fmt.Errorf("error reading resource ID: %s", err)
 		}
@@ -127,7 +126,6 @@ func testAccCheckInstanceRoleAssociationDestroy(ctx context.Context) resource.Te
 			}
 
 			dbInstanceIdentifier, roleArn, err := tfrds.InstanceRoleAssociationDecodeID(rs.Primary.ID)
-
 			if err != nil {
 				return fmt.Errorf("error reading resource ID: %s", err)
 			}
@@ -158,7 +156,6 @@ func testAccCheckInstanceRoleAssociationDisappears(ctx context.Context, dbInstan
 		}
 
 		_, err := conn.RemoveRoleFromDBInstanceWithContext(ctx, input)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -999,6 +999,7 @@ func TestAccRDSInstance_password(t *testing.T) {
 		},
 	})
 }
+
 func TestAccRDSInstance_ManagedMasterPassword_managed(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v rds.DBInstance
@@ -5523,13 +5524,11 @@ func testAccCheckInstanceDestroyWithFinalSnapshot(ctx context.Context) resource.
 
 			finalSnapshotID := rs.Primary.Attributes["final_snapshot_identifier"]
 			output, err := tfrds.FindDBSnapshotByID(ctx, conn, finalSnapshotID)
-
 			if err != nil {
 				return err
 			}
 
 			tags, err := tfrds.ListTags(ctx, conn, aws.StringValue(output.DBSnapshotArn))
-
 			if err != nil {
 				return err
 			}
@@ -5643,7 +5642,6 @@ func testAccCheckInstanceExists(ctx context.Context, n string, v *rds.DBInstance
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn()
 
 		output, err := tfrds.FindDBInstanceByID(ctx, conn, rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}
@@ -7868,7 +7866,7 @@ resource "aws_db_instance" "test" {
 // When testing needs to distinguish a second region and second account in the same region
 // e.g. cross-region functionality with RAM shared subnets
 func testAccAlternateAccountAndAlternateRegionProviderConfig() string {
-	//lintignore:AT004
+	// lintignore:AT004
 	return fmt.Sprintf(`
 provider "awsalternateaccountalternateregion" {
   access_key = %[1]q

--- a/internal/service/rds/instances_data_source.go
+++ b/internal/service/rds/instances_data_source.go
@@ -66,7 +66,6 @@ func dataSourceInstancesRead(ctx context.Context, d *schema.ResourceData, meta i
 
 		return !lastPage
 	})
-
 	if err != nil {
 		return create.DiagError(names.RDS, create.ErrActionReading, DSNameInstances, "", err)
 	}

--- a/internal/service/rds/option_group_test.go
+++ b/internal/service/rds/option_group_test.go
@@ -578,7 +578,6 @@ func testAccCheckOptionGroupExists(ctx context.Context, n string, v *rds.OptionG
 		}
 
 		resp, err := conn.DescribeOptionGroupsWithContext(ctx, &opts)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/rds/orderable_instance_data_source.go
+++ b/internal/service/rds/orderable_instance_data_source.go
@@ -279,7 +279,6 @@ func dataSourceOrderableInstanceRead(ctx context.Context, d *schema.ResourceData
 		}
 		return !lastPage
 	})
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading RDS Orderable DB Instance Options: %s", err)
 	}

--- a/internal/service/rds/parameter_group.go
+++ b/internal/service/rds/parameter_group.go
@@ -114,7 +114,6 @@ func resourceParameterGroupCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	output, err := conn.CreateDBParameterGroupWithContext(ctx, input)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creatingDB Parameter Group (%s): %s", name, err)
 	}
@@ -224,14 +223,13 @@ func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	tags, err := ListTags(ctx, conn, arn)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "listing tags for RDS DB Parameter Group (%s): %s", arn, err)
 	}
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-	//lintignore:AWSR002
+	// lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
@@ -279,7 +277,6 @@ func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 				}
 
 				_, err := conn.ModifyDBParameterGroupWithContext(ctx, input)
-
 				if err != nil {
 					return sdkdiag.AppendErrorf(diags, "modifying DB Parameter Group (%s): %s", d.Id(), err)
 				}
@@ -321,7 +318,6 @@ func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 				}
 
 				_, err := conn.ResetDBParameterGroupWithContext(ctx, input)
-
 				if err != nil {
 					return sdkdiag.AppendErrorf(diags, "resetting DB Parameter Group (%s): %s", d.Id(), err)
 				}

--- a/internal/service/rds/parameter_group_test.go
+++ b/internal/service/rds/parameter_group_test.go
@@ -1048,7 +1048,6 @@ func testAccCheckParameterGroupExists(ctx context.Context, n string, v *rds.DBPa
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn()
 
 		output, err := tfrds.FindDBParameterGroupByName(ctx, conn, rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/rds/proxy.go
+++ b/internal/service/rds/proxy.go
@@ -165,7 +165,6 @@ func resourceProxyCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	output, err := conn.CreateDBProxyWithContext(ctx, &input)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating RDS DB Proxy: %s", err)
 	}
@@ -234,7 +233,6 @@ func resourceProxyUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 
 		_, err := conn.ModifyDBProxyWithContext(ctx, input)
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating RDS DB Proxy (%s): %s", d.Id(), err)
 		}

--- a/internal/service/rds/proxy_data_source.go
+++ b/internal/service/rds/proxy_data_source.go
@@ -103,7 +103,6 @@ func dataSourceProxyRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	name := d.Get("name").(string)
 	dbProxy, err := FindDBProxyByName(ctx, conn, name)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading RDS DB Proxy (%s): %s", name, err)
 	}

--- a/internal/service/rds/proxy_default_target_group.go
+++ b/internal/service/rds/proxy_default_target_group.go
@@ -101,7 +101,6 @@ func resourceProxyDefaultTargetGroupRead(ctx context.Context, d *schema.Resource
 	conn := meta.(*conns.AWSClient).RDSConn()
 
 	tg, err := resourceProxyDefaultTargetGroupGet(ctx, conn, d.Id())
-
 	if err != nil {
 		if tfawserr.ErrCodeEquals(err, rds.ErrCodeDBProxyNotFoundFault) {
 			log.Printf("[WARN] DB Proxy (%s) not found, removing from state", d.Id())
@@ -215,7 +214,6 @@ func resourceProxyDefaultTargetGroupGet(ctx context.Context, conn *rds.RDS, prox
 		}
 		return !lastPage
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +225,6 @@ func resourceProxyDefaultTargetGroupGet(ctx context.Context, conn *rds.RDS, prox
 func resourceProxyDefaultTargetGroupRefreshFunc(ctx context.Context, conn *rds.RDS, proxyName string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		tg, err := resourceProxyDefaultTargetGroupGet(ctx, conn, proxyName)
-
 		if err != nil {
 			if tfawserr.ErrCodeEquals(err, rds.ErrCodeDBProxyNotFoundFault) {
 				return 42, "", nil

--- a/internal/service/rds/proxy_default_target_group_test.go
+++ b/internal/service/rds/proxy_default_target_group_test.go
@@ -374,7 +374,6 @@ func testAccCheckProxyTargetGroupExists(ctx context.Context, n string, v *rds.DB
 		}
 
 		resp, err := conn.DescribeDBProxyTargetGroupsWithContext(ctx, &opts)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/rds/proxy_endpoint.go
+++ b/internal/service/rds/proxy_endpoint.go
@@ -111,7 +111,6 @@ func resourceProxyEndpointCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	_, err := conn.CreateDBProxyEndpointWithContext(ctx, &input)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "Creating RDS DB Proxy Endpoint (%s/%s): %s", dbProxyName, dbProxyEndpointName, err)
 	}
@@ -205,7 +204,6 @@ func resourceProxyEndpointDelete(ctx context.Context, d *schema.ResourceData, me
 
 	log.Printf("[DEBUG] Delete DB Proxy Endpoint: %#v", params)
 	_, err := conn.DeleteDBProxyEndpointWithContext(ctx, &params)
-
 	if err != nil {
 		if tfawserr.ErrCodeEquals(err, rds.ErrCodeDBProxyNotFoundFault) || tfawserr.ErrCodeEquals(err, rds.ErrCodeDBProxyEndpointNotFoundFault) {
 			return diags

--- a/internal/service/rds/proxy_endpoint_test.go
+++ b/internal/service/rds/proxy_endpoint_test.go
@@ -294,7 +294,6 @@ func testAccCheckProxyEndpointExists(ctx context.Context, n string, v *rds.DBPro
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn()
 
 		dbProxyEndpoint, err := tfrds.FindDBProxyEndpoint(ctx, conn, rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/rds/proxy_target.go
+++ b/internal/service/rds/proxy_target.go
@@ -113,7 +113,6 @@ func resourceProxyTargetCreate(ctx context.Context, d *schema.ResourceData, meta
 			return conn.RegisterDBProxyTargetsWithContext(ctx, input)
 		},
 		rds.ErrCodeInvalidDBInstanceStateFault, "CREATING")
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "registering RDS DB Proxy (%s/%s) Target: %s", dbProxyName, targetGroupName, err)
 	}

--- a/internal/service/rds/proxy_target_test.go
+++ b/internal/service/rds/proxy_target_test.go
@@ -127,7 +127,6 @@ func testAccCheckProxyTargetDestroy(ctx context.Context) resource.TestCheckFunc 
 			}
 
 			dbProxyName, targetGroupName, targetType, rdsResourceId, err := tfrds.ProxyTargetParseID(rs.Primary.ID)
-
 			if err != nil {
 				return err
 			}
@@ -173,13 +172,11 @@ func testAccCheckProxyTargetExists(ctx context.Context, n string, v *rds.DBProxy
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn()
 
 		dbProxyName, targetGroupName, targetType, rdsResourceId, err := tfrds.ProxyTargetParseID(rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}
 
 		dbProxyTarget, err := tfrds.FindDBProxyTarget(ctx, conn, dbProxyName, targetGroupName, targetType, rdsResourceId)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/rds/proxy_test.go
+++ b/internal/service/rds/proxy_test.go
@@ -573,7 +573,6 @@ func testAccCheckProxyExists(ctx context.Context, n string, v *rds.DBProxy) reso
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn()
 
 		output, err := tfrds.FindDBProxyByName(ctx, conn, rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/rds/reserved_instance_offering_data_source.go
+++ b/internal/service/rds/reserved_instance_offering_data_source.go
@@ -76,7 +76,6 @@ func dataSourceReservedOfferingRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	resp, err := conn.DescribeReservedDBInstancesOfferingsWithContext(ctx, input)
-
 	if err != nil {
 		return create.DiagError(names.RDS, create.ErrActionReading, ResNameReservedInstanceOffering, "unknown", err)
 	}

--- a/internal/service/rds/reserved_instance_test.go
+++ b/internal/service/rds/reserved_instance_test.go
@@ -76,7 +76,6 @@ func testAccReservedInstanceExists(ctx context.Context, n string, reservation *r
 		}
 
 		resp, err := tfrds.FindReservedDBInstanceByID(ctx, conn, rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/rds/security_group.go
+++ b/internal/service/rds/security_group.go
@@ -192,7 +192,6 @@ func resourceSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, me
 	opts := rds.DeleteDBSecurityGroupInput{DBSecurityGroupName: aws.String(d.Id())}
 
 	_, err := conn.DeleteDBSecurityGroupWithContext(ctx, &opts)
-
 	if err != nil {
 		if tfawserr.ErrCodeEquals(err, "InvalidDBSecurityGroup.NotFound") {
 			return diags
@@ -213,7 +212,6 @@ func resourceSecurityGroupRetrieve(ctx context.Context, d *schema.ResourceData, 
 	log.Printf("[DEBUG] DB Security Group describe configuration: %#v", opts)
 
 	resp, err := conn.DescribeDBSecurityGroupsWithContext(ctx, &opts)
-
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving DB Security Groups: %s", err)
 	}
@@ -253,7 +251,6 @@ func resourceSecurityGroupAuthorizeRule(ctx context.Context, ingress interface{}
 	log.Printf("[DEBUG] Authorize ingress rule configuration: %#v", opts)
 
 	_, err := conn.AuthorizeDBSecurityGroupIngressWithContext(ctx, &opts)
-
 	if err != nil {
 		return fmt.Errorf("Error authorizing security group ingress: %s", err)
 	}
@@ -288,7 +285,6 @@ func resourceSecurityGroupRevokeRule(ctx context.Context, ingress interface{}, d
 	log.Printf("[DEBUG] Revoking ingress rule configuration: %#v", opts)
 
 	_, err := conn.RevokeDBSecurityGroupIngressWithContext(ctx, &opts)
-
 	if err != nil {
 		return fmt.Errorf("Error revoking security group ingress: %s", err)
 	}

--- a/internal/service/rds/snapshot.go
+++ b/internal/service/rds/snapshot.go
@@ -140,7 +140,6 @@ func resourceSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	output, err := conn.CreateDBSnapshotWithContext(ctx, input)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating RDS DB Snapshot (%s): %s", dbSnapshotID, err)
 	}
@@ -159,7 +158,6 @@ func resourceSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		_, err := conn.ModifyDBSnapshotAttributeWithContext(ctx, input)
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "modifying RDS DB Snapshot (%s) attribute: %s", d.Id(), err)
 		}
@@ -209,7 +207,6 @@ func resourceSnapshotRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	output, err := conn.DescribeDBSnapshotAttributesWithContext(ctx, input)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading RDS DB Snapshot (%s) attribute: %s", d.Id(), err)
 	}
@@ -239,7 +236,6 @@ func resourceSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		_, err := conn.ModifyDBSnapshotAttributeWithContext(ctx, input)
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "modifying RDS DB Snapshot (%s) attribute: %s", d.Id(), err)
 		}

--- a/internal/service/rds/snapshot_copy.go
+++ b/internal/service/rds/snapshot_copy.go
@@ -175,7 +175,6 @@ func resourceSnapshotCopyCreate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	output, err := conn.CopyDBSnapshotWithContext(ctx, input)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating RDS DB Snapshot Copy (%s): %s", targetDBSnapshotID, err)
 	}

--- a/internal/service/rds/snapshot_copy_test.go
+++ b/internal/service/rds/snapshot_copy_test.go
@@ -164,7 +164,6 @@ func testAccCheckSnapshotCopyExists(ctx context.Context, n string, v *rds.DBSnap
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn()
 
 		output, err := tfrds.FindDBSnapshotByID(ctx, conn, rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/rds/snapshot_data_source.go
+++ b/internal/service/rds/snapshot_data_source.go
@@ -20,7 +20,7 @@ func DataSourceSnapshot() *schema.Resource {
 		ReadWithoutTimeout: dataSourceSnapshotRead,
 
 		Schema: map[string]*schema.Schema{
-			//selection criteria
+			// selection criteria
 			"db_instance_identifier": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -53,7 +53,7 @@ func DataSourceSnapshot() *schema.Resource {
 				Default:  false,
 			},
 
-			//Computed values returned
+			// Computed values returned
 			"allocated_storage": {
 				Type:     schema.TypeInt,
 				Computed: true,

--- a/internal/service/rds/snapshot_test.go
+++ b/internal/service/rds/snapshot_test.go
@@ -208,7 +208,6 @@ func testAccCheckDBSnapshotExists(ctx context.Context, n string, v *rds.DBSnapsh
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn()
 
 		output, err := tfrds.FindDBSnapshotByID(ctx, conn, rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/rds/status.go
+++ b/internal/service/rds/status.go
@@ -38,7 +38,6 @@ func statusEventSubscription(ctx context.Context, conn *rds.RDS, id string) retr
 func statusDBProxyEndpoint(ctx context.Context, conn *rds.RDS, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindDBProxyEndpoint(ctx, conn, id)
-
 		if err != nil {
 			return nil, proxyEndpointStatusUnknown, err
 		}

--- a/internal/service/rds/subnet_group.go
+++ b/internal/service/rds/subnet_group.go
@@ -90,7 +90,6 @@ func resourceSubnetGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	log.Printf("[DEBUG] Creating RDS DB Subnet Group: %s", input)
 	output, err := conn.CreateDBSubnetGroupWithContext(ctx, input)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating RDS DB Subnet Group (%s): %s", name, err)
 	}
@@ -144,7 +143,6 @@ func resourceSubnetGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 		log.Printf("[DEBUG] Modifying RDS DB Subnet Group: %s", input)
 		_, err := conn.ModifyDBSubnetGroupWithContext(ctx, input)
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating RDS DB Subnet Group (%s): %s", d.Id(), err)
 		}

--- a/internal/service/rds/subnet_group_data_source.go
+++ b/internal/service/rds/subnet_group_data_source.go
@@ -56,7 +56,6 @@ func dataSourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).RDSConn()
 
 	v, err := FindDBSubnetGroupByName(ctx, conn, d.Get("name").(string))
-
 	if err != nil {
 		return sdkdiag.AppendFromErr(diags, tfresource.SingularDataSourceFindError("RDS DB Subnet Group", err))
 	}

--- a/internal/service/rds/subnet_group_test.go
+++ b/internal/service/rds/subnet_group_test.go
@@ -319,7 +319,6 @@ func testAccCheckSubnetGroupExists(ctx context.Context, n string, v *rds.DBSubne
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn()
 
 		output, err := tfrds.FindDBSubnetGroupByName(ctx, conn, rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}

--- a/internal/service/rds/sweep.go
+++ b/internal/service/rds/sweep.go
@@ -238,7 +238,6 @@ func sweepClusters(region string) error {
 
 			if engineMode := aws.StringValue(v.EngineMode); engineMode == EngineModeGlobal || engineMode == EngineModeProvisioned {
 				globalCluster, err := DescribeGlobalClusterFromClusterARN(ctx, conn, arn)
-
 				if err != nil {
 					if !tfresource.NotFound(err) {
 						sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("reading RDS Global Cluster information for DB Cluster (%s): %s", id, err))


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #30605

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Failures unrelated to current changes.

```console
% make t T=TestAccRDSCluster_ K=rds
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSCluster_'  -timeout 180m
=== RUN   TestAccRDSCluster_basic
=== PAUSE TestAccRDSCluster_basic
=== RUN   TestAccRDSCluster_disappears
=== PAUSE TestAccRDSCluster_disappears
=== RUN   TestAccRDSCluster_tags
=== PAUSE TestAccRDSCluster_tags
=== RUN   TestAccRDSCluster_identifierGenerated
=== PAUSE TestAccRDSCluster_identifierGenerated
=== RUN   TestAccRDSCluster_identifierPrefix
=== PAUSE TestAccRDSCluster_identifierPrefix
=== RUN   TestAccRDSCluster_allowMajorVersionUpgrade
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgrade
=== RUN   TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately
=== RUN   TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm
=== RUN   TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters
=== RUN   TestAccRDSCluster_onlyMajorVersion
=== PAUSE TestAccRDSCluster_onlyMajorVersion
=== RUN   TestAccRDSCluster_minorVersion
=== PAUSE TestAccRDSCluster_minorVersion
=== RUN   TestAccRDSCluster_availabilityZones
=== PAUSE TestAccRDSCluster_availabilityZones
=== RUN   TestAccRDSCluster_storageType
=== PAUSE TestAccRDSCluster_storageType
=== RUN   TestAccRDSCluster_allocatedStorage
=== PAUSE TestAccRDSCluster_allocatedStorage
=== RUN   TestAccRDSCluster_iops
=== PAUSE TestAccRDSCluster_iops
=== RUN   TestAccRDSCluster_dbClusterInstanceClass
=== PAUSE TestAccRDSCluster_dbClusterInstanceClass
=== RUN   TestAccRDSCluster_backtrackWindow
=== PAUSE TestAccRDSCluster_backtrackWindow
=== RUN   TestAccRDSCluster_dbSubnetGroupName
=== PAUSE TestAccRDSCluster_dbSubnetGroupName
=== RUN   TestAccRDSCluster_pointInTimeRestore
=== PAUSE TestAccRDSCluster_pointInTimeRestore
=== RUN   TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports
=== PAUSE TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports
=== RUN   TestAccRDSCluster_takeFinalSnapshot
=== PAUSE TestAccRDSCluster_takeFinalSnapshot
=== RUN   TestAccRDSCluster_missingUserNameCausesError
=== PAUSE TestAccRDSCluster_missingUserNameCausesError
=== RUN   TestAccRDSCluster_EnabledCloudWatchLogsExports_mySQL
=== PAUSE TestAccRDSCluster_EnabledCloudWatchLogsExports_mySQL
=== RUN   TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql
=== PAUSE TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql
=== RUN   TestAccRDSCluster_updateIAMRoles
=== PAUSE TestAccRDSCluster_updateIAMRoles
=== RUN   TestAccRDSCluster_kmsKey
=== PAUSE TestAccRDSCluster_kmsKey
=== RUN   TestAccRDSCluster_networkType
=== PAUSE TestAccRDSCluster_networkType
=== RUN   TestAccRDSCluster_encrypted
=== PAUSE TestAccRDSCluster_encrypted
=== RUN   TestAccRDSCluster_copyTagsToSnapshot
=== PAUSE TestAccRDSCluster_copyTagsToSnapshot
=== RUN   TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID
=== PAUSE TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID
=== RUN   TestAccRDSCluster_backupsUpdate
=== PAUSE TestAccRDSCluster_backupsUpdate
=== RUN   TestAccRDSCluster_iamAuth
=== PAUSE TestAccRDSCluster_iamAuth
=== RUN   TestAccRDSCluster_deletionProtection
=== PAUSE TestAccRDSCluster_deletionProtection
=== RUN   TestAccRDSCluster_engineMode
=== PAUSE TestAccRDSCluster_engineMode
=== RUN   TestAccRDSCluster_engineVersion
=== PAUSE TestAccRDSCluster_engineVersion
=== RUN   TestAccRDSCluster_engineVersionWithPrimaryInstance
=== PAUSE TestAccRDSCluster_engineVersionWithPrimaryInstance
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned
=== RUN   TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters
=== RUN   TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier
=== RUN   TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding
=== RUN   TestAccRDSCluster_ManagedMasterPassword_managed
=== PAUSE TestAccRDSCluster_ManagedMasterPassword_managed
=== RUN   TestAccRDSCluster_ManagedMasterPassword_managedSpecificKMSKey
=== PAUSE TestAccRDSCluster_ManagedMasterPassword_managedSpecificKMSKey
=== RUN   TestAccRDSCluster_ManagedMasterPassword_convertToManaged
=== PAUSE TestAccRDSCluster_ManagedMasterPassword_convertToManaged
=== RUN   TestAccRDSCluster_port
=== PAUSE TestAccRDSCluster_port
=== RUN   TestAccRDSCluster_scaling
=== PAUSE TestAccRDSCluster_scaling
=== RUN   TestAccRDSCluster_serverlessV2ScalingConfiguration
=== PAUSE TestAccRDSCluster_serverlessV2ScalingConfiguration
=== RUN   TestAccRDSCluster_Scaling_defaultMinCapacity
=== PAUSE TestAccRDSCluster_Scaling_defaultMinCapacity
=== RUN   TestAccRDSCluster_snapshotIdentifier
=== PAUSE TestAccRDSCluster_snapshotIdentifier
=== RUN   TestAccRDSCluster_SnapshotIdentifier_deletionProtection
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_deletionProtection
=== RUN   TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned
=== PAUSE TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned
=== RUN   TestAccRDSCluster_SnapshotIdentifierEngineMode_serverless
    cluster_test.go:1915: serverless does not support snapshot restore on an empty volume
--- SKIP: TestAccRDSCluster_SnapshotIdentifierEngineMode_serverless (0.00s)
=== RUN   TestAccRDSCluster_SnapshotIdentifierEngineVersion_different
=== PAUSE TestAccRDSCluster_SnapshotIdentifierEngineVersion_different
=== RUN   TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal
=== PAUSE TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal
=== RUN   TestAccRDSCluster_SnapshotIdentifier_kmsKeyID
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_kmsKeyID
=== RUN   TestAccRDSCluster_SnapshotIdentifier_masterPassword
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_masterPassword
=== RUN   TestAccRDSCluster_SnapshotIdentifier_masterUsername
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_masterUsername
=== RUN   TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow
=== RUN   TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow
=== RUN   TestAccRDSCluster_SnapshotIdentifier_tags
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_tags
=== RUN   TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs
=== RUN   TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags
=== PAUSE TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags
=== RUN   TestAccRDSCluster_SnapshotIdentifier_encryptedRestore
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_encryptedRestore
=== RUN   TestAccRDSCluster_enableHTTPEndpoint
=== PAUSE TestAccRDSCluster_enableHTTPEndpoint
=== RUN   TestAccRDSCluster_password
=== PAUSE TestAccRDSCluster_password
=== CONT  TestAccRDSCluster_basic
=== CONT  TestAccRDSCluster_engineVersion
=== CONT  TestAccRDSCluster_pointInTimeRestore
=== CONT  TestAccRDSCluster_dbSubnetGroupName
=== CONT  TestAccRDSCluster_engineMode
=== CONT  TestAccRDSCluster_deletionProtection
=== CONT  TestAccRDSCluster_iamAuth
=== CONT  TestAccRDSCluster_backupsUpdate
=== CONT  TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID
=== CONT  TestAccRDSCluster_copyTagsToSnapshot
=== CONT  TestAccRDSCluster_encrypted
=== CONT  TestAccRDSCluster_networkType
=== CONT  TestAccRDSCluster_kmsKey
=== CONT  TestAccRDSCluster_updateIAMRoles
=== CONT  TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql
=== CONT  TestAccRDSCluster_EnabledCloudWatchLogsExports_mySQL
=== CONT  TestAccRDSCluster_missingUserNameCausesError
=== CONT  TestAccRDSCluster_takeFinalSnapshot
=== CONT  TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports
=== CONT  TestAccRDSCluster_onlyMajorVersion
--- PASS: TestAccRDSCluster_missingUserNameCausesError (17.74s)
=== CONT  TestAccRDSCluster_storageType
=== NAME  TestAccRDSCluster_updateIAMRoles
    cluster_test.go:871: Step 2/3 error: Error running apply: exit status 1
        
        Error: adding IAM Role (arn:aws:iam::153029840061:role/another_rds_sample_role_3684386459593896519) to RDS Cluster (tf-aurora-cluster-3684386459593896519): adding IAM Role (arn:aws:iam::153029840061:role/another_rds_sample_role_3684386459593896519) to RDS Cluster (tf-aurora-cluster-3684386459593896519): InvalidParameterValue: IAM role ARN value is invalid or does not include the required permissions for: AWS_ROLE_INTEGRATION
        	status code: 400, request id: a351e268-6cae-4e7a-ba84-61439eca9e5a
        
          with aws_rds_cluster.test,
          on terraform_plugin_test.tf line 76, in resource "aws_rds_cluster" "test":
          76: resource "aws_rds_cluster" "test" {
        
--- PASS: TestAccRDSCluster_encrypted (149.51s)
=== CONT  TestAccRDSCluster_availabilityZones
--- PASS: TestAccRDSCluster_kmsKey (175.63s)
=== CONT  TestAccRDSCluster_minorVersion
--- PASS: TestAccRDSCluster_dbSubnetGroupName (179.23s)
=== CONT  TestAccRDSCluster_snapshotIdentifier
--- PASS: TestAccRDSCluster_basic (182.82s)
=== CONT  TestAccRDSCluster_password
--- FAIL: TestAccRDSCluster_updateIAMRoles (196.60s)
=== CONT  TestAccRDSCluster_enableHTTPEndpoint
--- PASS: TestAccRDSCluster_iamAuth (209.35s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_encryptedRestore
--- PASS: TestAccRDSCluster_deletionProtection (213.98s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags
--- PASS: TestAccRDSCluster_backupsUpdate (214.53s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs
--- PASS: TestAccRDSCluster_copyTagsToSnapshot (256.48s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_tags
--- PASS: TestAccRDSCluster_EnabledCloudWatchLogsExports_mySQL (257.19s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow
--- PASS: TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow (459.74s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow
--- PASS: TestAccRDSCluster_takeFinalSnapshot (260.19s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_masterUsername
--- PASS: TestAccRDSCluster_networkType (290.90s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_masterPassword
--- PASS: TestAccRDSCluster_availabilityZones (181.43s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_kmsKeyID
--- PASS: TestAccRDSCluster_password (230.66s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal
--- PASS: TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports (454.73s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierEngineVersion_different
--- PASS: TestAccRDSCluster_pointInTimeRestore (465.34s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned
--- PASS: TestAccRDSCluster_engineMode (496.76s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_deletionProtection
--- PASS: TestAccRDSCluster_engineVersion (507.91s)
=== CONT  TestAccRDSCluster_dbClusterInstanceClass
--- PASS: TestAccRDSCluster_enableHTTPEndpoint (394.66s)
=== CONT  TestAccRDSCluster_backtrackWindow
--- PASS: TestAccRDSCluster_snapshotIdentifier (419.75s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgrade
--- PASS: TestAccRDSCluster_SnapshotIdentifier_encryptedRestore (430.52s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters
--- PASS: TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs (425.51s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm
--- PASS: TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags (435.62s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately
--- PASS: TestAccRDSCluster_SnapshotIdentifier_masterPassword (440.57s)
=== CONT  TestAccRDSCluster_identifierGenerated
--- PASS: TestAccRDSCluster_SnapshotIdentifier_tags (491.25s)
=== CONT  TestAccRDSCluster_identifierPrefix
--- PASS: TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow (491.76s)
=== CONT  TestAccRDSCluster_tags
--- PASS: TestAccRDSCluster_SnapshotIdentifier_masterUsername (511.25s)
=== CONT  TestAccRDSCluster_iops
--- PASS: TestAccRDSCluster_backtrackWindow (200.53s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding
--- PASS: TestAccRDSCluster_SnapshotIdentifier_kmsKeyID (501.35s)
=== CONT  TestAccRDSCluster_Scaling_defaultMinCapacity
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal (444.65s)
=== CONT  TestAccRDSCluster_serverlessV2ScalingConfiguration
--- PASS: TestAccRDSCluster_identifierGenerated (148.17s)
=== CONT  TestAccRDSCluster_scaling
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned (429.95s)
=== CONT  TestAccRDSCluster_port
--- PASS: TestAccRDSCluster_tags (173.41s)
=== CONT  TestAccRDSCluster_ManagedMasterPassword_convertToManaged
--- PASS: TestAccRDSCluster_identifierPrefix (178.87s)
=== CONT  TestAccRDSCluster_ManagedMasterPassword_managedSpecificKMSKey
--- PASS: TestAccRDSCluster_SnapshotIdentifier_deletionProtection (433.65s)
=== CONT  TestAccRDSCluster_ManagedMasterPassword_managed
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineVersion_different (487.28s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update
--- PASS: TestAccRDSCluster_serverlessV2ScalingConfiguration (209.00s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier
--- PASS: TestAccRDSCluster_port (189.78s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters
--- PASS: TestAccRDSCluster_ManagedMasterPassword_managedSpecificKMSKey (158.85s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned
--- PASS: TestAccRDSCluster_ManagedMasterPassword_managed (192.25s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update (199.88s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove
--- PASS: TestAccRDSCluster_ManagedMasterPassword_convertToManaged (265.79s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global
--- PASS: TestAccRDSCluster_Scaling_defaultMinCapacity (373.49s)
=== CONT  TestAccRDSCluster_engineVersionWithPrimaryInstance
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned (181.81s)
=== CONT  TestAccRDSCluster_disappears
--- PASS: TestAccRDSCluster_minorVersion (1095.04s)
=== CONT  TestAccRDSCluster_allocatedStorage
--- PASS: TestAccRDSCluster_scaling (416.20s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add (208.00s)
--- PASS: TestAccRDSCluster_onlyMajorVersion (1335.70s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove (196.76s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global (183.12s)
--- PASS: TestAccRDSCluster_disappears (145.40s)
--- PASS: TestAccRDSCluster_storageType (1851.17s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately (1235.22s)
--- PASS: TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID (2240.72s)
--- PASS: TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql (2445.46s)
--- PASS: TestAccRDSCluster_dbClusterInstanceClass (1962.92s)
--- PASS: TestAccRDSCluster_iops (1861.29s)
--- PASS: TestAccRDSCluster_engineVersionWithPrimaryInstance (1450.69s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgrade (2121.56s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm (2266.30s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters (2556.42s)
--- PASS: TestAccRDSCluster_allocatedStorage (1931.94s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters (2830.16s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding (3185.28s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier (3128.82s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/rds	4198.577s
```
