### PR TITLE
rds/instance: Allow replicas to have versions

### DIFF
--- a/.changelog/30703.txt
+++ b/.changelog/30703.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_instance: Allow `engine` and `engine_version` to be set when `replicate_source_db` is set
+```

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -224,13 +224,11 @@ func ResourceInstance() *schema.Resource {
 					value := v.(string)
 					return strings.ToLower(value)
 				},
-				ConflictsWith: []string{"replicate_source_db"},
 			},
 			"engine_version": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"replicate_source_db"},
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"engine_version_actual": {
 				Type:     schema.TypeString,
@@ -1940,6 +1938,9 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			if d.HasChange("engine_version") {
 				input.EngineVersion = aws.String(d.Get("engine_version").(string))
 				input.AllowMajorVersionUpgrade = d.Get("allow_major_version_upgrade").(bool)
+
+				// update read replicas first
+
 			}
 
 			if d.HasChange("parameter_group_name") {

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -1938,9 +1938,9 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			if d.HasChange("engine_version") {
 				input.EngineVersion = aws.String(d.Get("engine_version").(string))
 				input.AllowMajorVersionUpgrade = d.Get("allow_major_version_upgrade").(bool)
-
-				// update read replicas first
-
+				// if we were to make life easier for practitioners, we could loop through
+				// replicas at this point to update them first, prior to dbInstanceModify()
+				// for the source
 			}
 
 			if d.HasChange("parameter_group_name") {

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -7673,6 +7673,8 @@ resource "aws_db_instance" "test" {
   instance_class             = aws_db_instance.source.instance_class
   replicate_source_db        = aws_db_instance.source.id
   skip_final_snapshot        = true
+  engine = data.aws_rds_orderable_db_instance.test.engine
+  engine_version = data.aws_rds_orderable_db_instance.test.engine_version
 }
 `, rName, autoMinorVersionUpgrade))
 }

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -7673,8 +7673,6 @@ resource "aws_db_instance" "test" {
   instance_class             = aws_db_instance.source.instance_class
   replicate_source_db        = aws_db_instance.source.id
   skip_final_snapshot        = true
-  engine = data.aws_rds_orderable_db_instance.test.engine
-  engine_version = data.aws_rds_orderable_db_instance.test.engine_version
 }
 `, rName, autoMinorVersionUpgrade))
 }

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -169,17 +169,8 @@ for additional read replica contraints.
 * `domain` - (Optional) The ID of the Directory Service Active Directory domain to create the instance in.
 * `domain_iam_role_name` - (Optional, but required if domain is provided) The name of the IAM role to be used when making API calls to the Directory Service.
 * `enabled_cloudwatch_logs_exports` - (Optional) Set of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on `engine`). MySQL and MariaDB: `audit`, `error`, `general`, `slowquery`. PostgreSQL: `postgresql`, `upgrade`. MSSQL: `agent` , `error`. Oracle: `alert`, `audit`, `listener`, `trace`.
-* `engine` - (Required unless a `snapshot_identifier` or `replicate_source_db`
-is provided) The database engine to use.  For supported values, see the Engine parameter in [API action CreateDBInstance](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html). Cannot be specified for a replica.
-Note that for Amazon Aurora instances the engine must match the [DB cluster](/docs/providers/aws/r/rds_cluster.html)'s engine'.
-For information on the difference between the available Aurora MySQL engines
-see [Comparison between Aurora MySQL 1 and Aurora MySQL 2](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AuroraMySQL.Updates.20180206.html)
-in the Amazon RDS User Guide.
-* `engine_version` - (Optional) The engine version to use. If `auto_minor_version_upgrade`
-is enabled, you can provide a prefix of the version such as `5.7` (for `5.7.10`).
-The actual engine version used is returned in the attribute `engine_version_actual`, see [Attributes Reference](#attributes-reference) below.
-For supported values, see the EngineVersion parameter in [API action CreateDBInstance](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html).
-Note that for Amazon Aurora instances the engine version must match the [DB cluster](/docs/providers/aws/r/rds_cluster.html)'s engine version'. Cannot be specified for a replica.
+* `engine` - (Required unless a `snapshot_identifier` or `replicate_source_db` is provided) The database engine to use. For supported values, see the Engine parameter in [API action CreateDBInstance](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html). Note that for Amazon Aurora instances the engine must match the [DB cluster](/docs/providers/aws/r/rds_cluster.html)'s engine'. For information on the difference between the available Aurora MySQL engines see [Comparison between Aurora MySQL 1 and Aurora MySQL 2](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/AuroraMySQL.Updates.20180206.html) in the Amazon RDS User Guide.
+* `engine_version` - (Optional) The engine version to use. If `auto_minor_version_upgrade` is enabled, you can provide a prefix of the version such as `5.7` (for `5.7.10`). The actual engine version used is returned in the attribute `engine_version_actual`, see [Attributes Reference](#attributes-reference) below. For supported values, see the EngineVersion parameter in [API action CreateDBInstance](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html). Note that for Amazon Aurora instances the engine version must match the [DB cluster](/docs/providers/aws/r/rds_cluster.html)'s engine version'.
 * `final_snapshot_identifier` - (Optional) The name of your final DB snapshot
 when this DB instance is deleted. Must be provided if `skip_final_snapshot` is
 set to `false`. The value must begin with a letter, only contain alphanumeric characters and hyphens, and not end with a hyphen or contain two consecutive hyphens. Must not be provided when deleting a read replica.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #24887

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

(Failure unrelated to these changes.)

```console
% make t T=TestAccRDSInstance_ K=rds P=10             
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 10 -run='TestAccRDSInstance_'  -timeout 180m
=== RUN   TestAccRDSInstance_basic
=== PAUSE TestAccRDSInstance_basic
=== RUN   TestAccRDSInstance_manage_password
=== PAUSE TestAccRDSInstance_manage_password
=== RUN   TestAccRDSInstance_identifierPrefix
=== PAUSE TestAccRDSInstance_identifierPrefix
=== RUN   TestAccRDSInstance_identifierGenerated
=== PAUSE TestAccRDSInstance_identifierGenerated
=== RUN   TestAccRDSInstance_disappears
=== PAUSE TestAccRDSInstance_disappears
=== RUN   TestAccRDSInstance_tags
=== PAUSE TestAccRDSInstance_tags
=== RUN   TestAccRDSInstance_nameDeprecated
=== PAUSE TestAccRDSInstance_nameDeprecated
=== RUN   TestAccRDSInstance_onlyMajorVersion
=== PAUSE TestAccRDSInstance_onlyMajorVersion
=== RUN   TestAccRDSInstance_kmsKey
=== PAUSE TestAccRDSInstance_kmsKey
=== RUN   TestAccRDSInstance_customIAMInstanceProfile
=== PAUSE TestAccRDSInstance_customIAMInstanceProfile
=== RUN   TestAccRDSInstance_subnetGroup
=== PAUSE TestAccRDSInstance_subnetGroup
=== RUN   TestAccRDSInstance_networkType
=== PAUSE TestAccRDSInstance_networkType
=== RUN   TestAccRDSInstance_optionGroup
=== PAUSE TestAccRDSInstance_optionGroup
=== RUN   TestAccRDSInstance_iamAuth
=== PAUSE TestAccRDSInstance_iamAuth
=== RUN   TestAccRDSInstance_allowMajorVersionUpgrade
=== PAUSE TestAccRDSInstance_allowMajorVersionUpgrade
=== RUN   TestAccRDSInstance_dbSubnetGroupName
=== PAUSE TestAccRDSInstance_dbSubnetGroupName
=== RUN   TestAccRDSInstance_DBSubnetGroupName_ramShared
=== PAUSE TestAccRDSInstance_DBSubnetGroupName_ramShared
=== RUN   TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs
=== PAUSE TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs
=== RUN   TestAccRDSInstance_deletionProtection
=== PAUSE TestAccRDSInstance_deletionProtection
=== RUN   TestAccRDSInstance_finalSnapshotIdentifier
=== PAUSE TestAccRDSInstance_finalSnapshotIdentifier
=== RUN   TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot
=== PAUSE TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot
=== RUN   TestAccRDSInstance_isAlreadyBeingDeleted
=== PAUSE TestAccRDSInstance_isAlreadyBeingDeleted
=== RUN   TestAccRDSInstance_maxAllocatedStorage
=== PAUSE TestAccRDSInstance_maxAllocatedStorage
=== RUN   TestAccRDSInstance_password
=== PAUSE TestAccRDSInstance_password
=== RUN   TestAccRDSInstance_ManagedMasterPassword_managed
=== PAUSE TestAccRDSInstance_ManagedMasterPassword_managed
=== RUN   TestAccRDSInstance_ManagedMasterPassword_managedSpecificKMSKey
=== PAUSE TestAccRDSInstance_ManagedMasterPassword_managedSpecificKMSKey
=== RUN   TestAccRDSInstance_ManagedMasterPassword_convertToManaged
=== PAUSE TestAccRDSInstance_ManagedMasterPassword_convertToManaged
=== RUN   TestAccRDSInstance_ReplicateSourceDB_basic
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_basic
=== RUN   TestAccRDSInstance_ReplicateSourceDB_namePrefix
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_namePrefix
=== RUN   TestAccRDSInstance_ReplicateSourceDB_nameGenerated
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_nameGenerated
=== RUN   TestAccRDSInstance_ReplicateSourceDB_addLater
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_addLater
=== RUN   TestAccRDSInstance_ReplicateSourceDB_allocatedStorage
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_allocatedStorage
=== RUN   TestAccRDSInstance_ReplicateSourceDB_iops
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_iops
=== RUN   TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops
=== RUN   TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade
=== RUN   TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade
=== RUN   TestAccRDSInstance_ReplicateSourceDB_availabilityZone
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_availabilityZone
=== RUN   TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod
=== RUN   TestAccRDSInstance_ReplicateSourceDB_backupWindow
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_backupWindow
=== RUN   TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName
=== RUN   TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_ramShared
=== PAUSE TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_ramShared
=== RUN   TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_vpcSecurityGroupIDs
=== PAUSE TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_vpcSecurityGroupIDs
=== RUN   TestAccRDSInstance_ReplicateSourceDB_deletionProtection
    acctest.go:76: CreateDBInstanceReadReplica API currently ignores DeletionProtection=true with SourceDBInstanceIdentifier set
--- SKIP: TestAccRDSInstance_ReplicateSourceDB_deletionProtection (0.00s)
=== RUN   TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled
=== RUN   TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow
=== RUN   TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage
=== RUN   TestAccRDSInstance_ReplicateSourceDB_monitoring
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_monitoring
=== RUN   TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists
=== RUN   TestAccRDSInstance_ReplicateSourceDB_multiAZ
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_multiAZ
=== RUN   TestAccRDSInstance_ReplicateSourceDB_networkType
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_networkType
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSameSetOnBoth
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSameSetOnBoth
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica
=== RUN   TestAccRDSInstance_ReplicateSourceDB_port
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_port
=== RUN   TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs
=== RUN   TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier
=== RUN   TestAccRDSInstance_ReplicateSourceDB_replicaMode
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_replicaMode
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep
=== RUN   TestAccRDSInstance_S3Import_basic
    acctest.go:76: RestoreDBInstanceFromS3 cannot restore from MySQL version 5.6
--- SKIP: TestAccRDSInstance_S3Import_basic (0.00s)
=== RUN   TestAccRDSInstance_SnapshotIdentifier_basic
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_basic
=== RUN   TestAccRDSInstance_SnapshotIdentifier_namePrefix
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_namePrefix
=== RUN   TestAccRDSInstance_SnapshotIdentifier_nameGenerated
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_nameGenerated
=== RUN   TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved
=== RUN   TestAccRDSInstance_SnapshotIdentifier_allocatedStorage
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_allocatedStorage
=== RUN   TestAccRDSInstance_SnapshotIdentifier_io1Storage
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_io1Storage
=== RUN   TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade
=== RUN   TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade
=== RUN   TestAccRDSInstance_SnapshotIdentifier_availabilityZone
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_availabilityZone
=== RUN   TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride
=== RUN   TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset
=== RUN   TestAccRDSInstance_SnapshotIdentifier_backupWindow
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_backupWindow
=== RUN   TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName
=== RUN   TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameRAMShared
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameRAMShared
=== RUN   TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs
=== RUN   TestAccRDSInstance_SnapshotIdentifier_deletionProtection
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_deletionProtection
=== RUN   TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled
=== RUN   TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow
=== RUN   TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage
=== RUN   TestAccRDSInstance_SnapshotIdentifier_monitoring
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_monitoring
=== RUN   TestAccRDSInstance_SnapshotIdentifier_multiAZ
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_multiAZ
=== RUN   TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer
=== RUN   TestAccRDSInstance_SnapshotIdentifier_parameterGroupName
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_parameterGroupName
=== RUN   TestAccRDSInstance_SnapshotIdentifier_port
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_port
=== RUN   TestAccRDSInstance_SnapshotIdentifier_tags
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_tags
=== RUN   TestAccRDSInstance_SnapshotIdentifier_tagsRemove
    acctest.go:76: To be fixed: https://github.com/hashicorp/terraform-provider-aws/issues/26808
--- SKIP: TestAccRDSInstance_SnapshotIdentifier_tagsRemove (0.00s)
=== RUN   TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs
=== RUN   TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags
=== RUN   TestAccRDSInstance_monitoringInterval
=== PAUSE TestAccRDSInstance_monitoringInterval
=== RUN   TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled
=== PAUSE TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled
=== RUN   TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved
=== PAUSE TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved
=== RUN   TestAccRDSInstance_MonitoringRoleARN_removedToEnabled
=== PAUSE TestAccRDSInstance_MonitoringRoleARN_removedToEnabled
=== RUN   TestAccRDSInstance_separateIopsUpdate
=== PAUSE TestAccRDSInstance_separateIopsUpdate
=== RUN   TestAccRDSInstance_portUpdate
=== PAUSE TestAccRDSInstance_portUpdate
=== RUN   TestAccRDSInstance_MSSQL_tz
=== PAUSE TestAccRDSInstance_MSSQL_tz
=== RUN   TestAccRDSInstance_MSSQL_domain
=== PAUSE TestAccRDSInstance_MSSQL_domain
=== RUN   TestAccRDSInstance_MSSQL_domainSnapshotRestore
=== PAUSE TestAccRDSInstance_MSSQL_domainSnapshotRestore
=== RUN   TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion
=== PAUSE TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion
=== RUN   TestAccRDSInstance_minorVersion
=== PAUSE TestAccRDSInstance_minorVersion
=== RUN   TestAccRDSInstance_cloudWatchLogsExport
=== PAUSE TestAccRDSInstance_cloudWatchLogsExport
=== RUN   TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL
=== PAUSE TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL
=== RUN   TestAccRDSInstance_EnabledCloudWatchLogsExports_msSQL
=== PAUSE TestAccRDSInstance_EnabledCloudWatchLogsExports_msSQL
=== RUN   TestAccRDSInstance_EnabledCloudWatchLogsExports_oracle
=== PAUSE TestAccRDSInstance_EnabledCloudWatchLogsExports_oracle
=== RUN   TestAccRDSInstance_EnabledCloudWatchLogsExports_postgresql
=== PAUSE TestAccRDSInstance_EnabledCloudWatchLogsExports_postgresql
=== RUN   TestAccRDSInstance_noDeleteAutomatedBackups
=== PAUSE TestAccRDSInstance_noDeleteAutomatedBackups
=== RUN   TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled
=== PAUSE TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled
=== RUN   TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled
=== PAUSE TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled
=== RUN   TestAccRDSInstance_performanceInsightsKMSKeyID
=== PAUSE TestAccRDSInstance_performanceInsightsKMSKeyID
=== RUN   TestAccRDSInstance_performanceInsightsRetentionPeriod
=== PAUSE TestAccRDSInstance_performanceInsightsRetentionPeriod
=== RUN   TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled
=== RUN   TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled
=== RUN   TestAccRDSInstance_caCertificateIdentifier
=== PAUSE TestAccRDSInstance_caCertificateIdentifier
=== RUN   TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier
=== PAUSE TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier
=== RUN   TestAccRDSInstance_RestoreToPointInTime_sourceResourceID
=== PAUSE TestAccRDSInstance_RestoreToPointInTime_sourceResourceID
=== RUN   TestAccRDSInstance_RestoreToPointInTime_monitoring
=== PAUSE TestAccRDSInstance_RestoreToPointInTime_monitoring
=== RUN   TestAccRDSInstance_NationalCharacterSet_oracle
=== PAUSE TestAccRDSInstance_NationalCharacterSet_oracle
=== RUN   TestAccRDSInstance_NoNationalCharacterSet_oracle
=== PAUSE TestAccRDSInstance_NoNationalCharacterSet_oracle
=== RUN   TestAccRDSInstance_coIPEnabled
=== PAUSE TestAccRDSInstance_coIPEnabled
=== RUN   TestAccRDSInstance_CoIPEnabled_disabledToEnabled
=== PAUSE TestAccRDSInstance_CoIPEnabled_disabledToEnabled
=== RUN   TestAccRDSInstance_CoIPEnabled_enabledToDisabled
=== PAUSE TestAccRDSInstance_CoIPEnabled_enabledToDisabled
=== RUN   TestAccRDSInstance_CoIPEnabled_restoreToPointInTime
=== PAUSE TestAccRDSInstance_CoIPEnabled_restoreToPointInTime
=== RUN   TestAccRDSInstance_CoIPEnabled_snapshotIdentifier
=== PAUSE TestAccRDSInstance_CoIPEnabled_snapshotIdentifier
=== RUN   TestAccRDSInstance_license
=== PAUSE TestAccRDSInstance_license
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup
=== RUN   TestAccRDSInstance_BlueGreenDeployment_tags
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_tags
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups
=== RUN   TestAccRDSInstance_BlueGreenDeployment_deletionProtection
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_deletionProtection
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection
=== RUN   TestAccRDSInstance_gp3MySQL
=== PAUSE TestAccRDSInstance_gp3MySQL
=== RUN   TestAccRDSInstance_gp3Postgres
=== PAUSE TestAccRDSInstance_gp3Postgres
=== RUN   TestAccRDSInstance_gp3SQLServer
=== PAUSE TestAccRDSInstance_gp3SQLServer
=== RUN   TestAccRDSInstance_storageThroughput
=== PAUSE TestAccRDSInstance_storageThroughput
=== RUN   TestAccRDSInstance_storageTypePostgres
=== PAUSE TestAccRDSInstance_storageTypePostgres
=== CONT  TestAccRDSInstance_basic
=== CONT  TestAccRDSInstance_MSSQL_domainSnapshotRestore
=== CONT  TestAccRDSInstance_gp3MySQL
=== CONT  TestAccRDSInstance_NoNationalCharacterSet_oracle
=== CONT  TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled
=== CONT  TestAccRDSInstance_storageTypePostgres
=== CONT  TestAccRDSInstance_storageThroughput
=== CONT  TestAccRDSInstance_gp3SQLServer
=== CONT  TestAccRDSInstance_gp3Postgres
=== CONT  TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled
--- PASS: TestAccRDSInstance_basic (383.17s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled
--- PASS: TestAccRDSInstance_gp3MySQL (629.45s)
=== CONT  TestAccRDSInstance_performanceInsightsRetentionPeriod
--- PASS: TestAccRDSInstance_gp3Postgres (648.98s)
=== CONT  TestAccRDSInstance_performanceInsightsKMSKeyID
--- PASS: TestAccRDSInstance_storageThroughput (650.10s)
=== CONT  TestAccRDSInstance_EnabledCloudWatchLogsExports_msSQL
--- PASS: TestAccRDSInstance_storageTypePostgres (652.01s)
=== CONT  TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled
--- PASS: TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled (943.22s)
=== CONT  TestAccRDSInstance_noDeleteAutomatedBackups
--- PASS: TestAccRDSInstance_NoNationalCharacterSet_oracle (863.51s)
=== CONT  TestAccRDSInstance_EnabledCloudWatchLogsExports_postgresql
--- PASS: TestAccRDSInstance_gp3SQLServer (993.63s)
=== CONT  TestAccRDSInstance_EnabledCloudWatchLogsExports_oracle
--- PASS: TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled (783.94s)
=== CONT  TestAccRDSInstance_caCertificateIdentifier
    instance_test.go:4233: Step 1/1 error: Error running pre-apply refresh: exit status 1
        
        Error: multiple RDS Certificates match the criteria; try changing search query
        
          with data.aws_rds_certificate.latest,
          on terraform_plugin_test.tf line 15, in data "aws_rds_certificate" "latest":
          15: data "aws_rds_certificate" "latest" {
        
--- FAIL: TestAccRDSInstance_caCertificateIdentifier (4.80s)
=== CONT  TestAccRDSInstance_NationalCharacterSet_oracle
--- PASS: TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled (1445.17s)
=== CONT  TestAccRDSInstance_RestoreToPointInTime_monitoring
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_postgresql (620.91s)
=== CONT  TestAccRDSInstance_RestoreToPointInTime_sourceResourceID
--- PASS: TestAccRDSInstance_noDeleteAutomatedBackups (732.41s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_msSQL (1080.75s)
=== CONT  TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier
--- PASS: TestAccRDSInstance_performanceInsightsKMSKeyID (1095.80s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica
--- PASS: TestAccRDSInstance_performanceInsightsRetentionPeriod (1151.64s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_deletionProtection
--- PASS: TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled (1539.22s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_oracle (971.99s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection
--- PASS: TestAccRDSInstance_NationalCharacterSet_oracle (932.74s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass
--- PASS: TestAccRDSInstance_MSSQL_domainSnapshotRestore (2470.41s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_tags
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceResourceID (1354.62s)
=== CONT  TestAccRDSInstance_ManagedMasterPassword_managed
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier (1380.35s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists
--- PASS: TestAccRDSInstance_BlueGreenDeployment_tags (739.54s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_monitoring
--- PASS: TestAccRDSInstance_RestoreToPointInTime_monitoring (1808.89s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_multiAZ
--- PASS: TestAccRDSInstance_ManagedMasterPassword_managed (380.59s)
=== CONT  TestAccRDSInstance_MSSQL_domain
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup (2064.79s)
=== CONT  TestAccRDSInstance_MSSQL_tz
--- PASS: TestAccRDSInstance_BlueGreenDeployment_deletionProtection (2313.96s)
=== CONT  TestAccRDSInstance_portUpdate
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups (2469.41s)
=== CONT  TestAccRDSInstance_separateIopsUpdate
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists (1456.97s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring (1420.01s)
=== CONT  TestAccRDSInstance_MonitoringRoleARN_removedToEnabled
--- PASS: TestAccRDSInstance_portUpdate (674.10s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass (2271.45s)
=== CONT  TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved
--- PASS: TestAccRDSInstance_separateIopsUpdate (658.54s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica (3487.43s)
=== CONT  TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled
--- PASS: TestAccRDSInstance_MonitoringRoleARN_removedToEnabled (614.53s)
=== CONT  TestAccRDSInstance_monitoringInterval
--- PASS: TestAccRDSInstance_MSSQL_tz (1714.07s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags
--- PASS: TestAccRDSInstance_ReplicateSourceDB_multiAZ (2297.25s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved (1034.21s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_tags
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection (3993.86s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_port
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage (1524.05s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_parameterGroupName
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow (1491.57s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled (928.27s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_multiAZ
--- PASS: TestAccRDSInstance_monitoringInterval (1227.62s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_monitoring
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled (1428.71s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags (1076.06s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs (1124.14s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled
--- PASS: TestAccRDSInstance_SnapshotIdentifier_tags (1003.22s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_deletionProtection
--- PASS: TestAccRDSInstance_SnapshotIdentifier_port (1103.53s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs
--- PASS: TestAccRDSInstance_SnapshotIdentifier_parameterGroupName (1311.91s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameRAMShared
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage (1163.56s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName
--- PASS: TestAccRDSInstance_MSSQL_domain (4401.64s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_backupWindow
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow (1299.82s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset
--- PASS: TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled (1229.85s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride
--- PASS: TestAccRDSInstance_SnapshotIdentifier_monitoring (1433.55s)
=== CONT  TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_vpcSecurityGroupIDs
--- PASS: TestAccRDSInstance_SnapshotIdentifier_deletionProtection (1328.21s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_availabilityZone
--- PASS: TestAccRDSInstance_SnapshotIdentifier_multiAZ (1948.36s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs (1195.15s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade
```
