### PR TITLE
integrate chime sdk voice streaming with media insights configuration

### DIFF
--- a/internal/service/chime/voice_connector_streaming.go
+++ b/internal/service/chime/voice_connector_streaming.go
@@ -5,12 +5,13 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/chime"
+	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 // @SDKResource("aws_chime_voice_connector_streaming")
@@ -36,6 +37,25 @@ func ResourceVoiceConnectorStreaming() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"media_insights_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"configuration_arn": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: verify.ValidARN,
+						},
+						"disabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+					},
+				},
+			},
 			"streaming_notification_targets": {
 				Type:     schema.TypeSet,
 				MinItems: 1,
@@ -43,7 +63,7 @@ func ResourceVoiceConnectorStreaming() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.StringInSlice(chime.NotificationTarget_Values(), false),
+					ValidateFunc: validation.StringInSlice(chimesdkvoice.NotificationTarget_Values(), false),
 				},
 			},
 			"voice_connector_id": {
@@ -56,20 +76,24 @@ func ResourceVoiceConnectorStreaming() *schema.Resource {
 }
 
 func resourceVoiceConnectorStreamingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn()
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn()
 
 	vcId := d.Get("voice_connector_id").(string)
-	input := &chime.PutVoiceConnectorStreamingConfigurationInput{
+	input := &chimesdkvoice.PutVoiceConnectorStreamingConfigurationInput{
 		VoiceConnectorId: aws.String(vcId),
 	}
 
-	config := &chime.StreamingConfiguration{
+	config := &chimesdkvoice.StreamingConfiguration{
 		DataRetentionInHours: aws.Int64(int64(d.Get("data_retention").(int))),
 		Disabled:             aws.Bool(d.Get("disabled").(bool)),
 	}
 
 	if v, ok := d.GetOk("streaming_notification_targets"); ok && v.(*schema.Set).Len() > 0 {
 		config.StreamingNotificationTargets = expandStreamingNotificationTargets(v.(*schema.Set).List())
+	}
+
+	if v, ok := d.GetOk("media_insights_configuration"); ok && v.(*schema.Set).Len() > 0 {
+		config.MediaInsightsConfiguration = expandMediaInsightsConfiguration(v.([]interface{}))
 	}
 
 	input.StreamingConfiguration = config
@@ -84,14 +108,14 @@ func resourceVoiceConnectorStreamingCreate(ctx context.Context, d *schema.Resour
 }
 
 func resourceVoiceConnectorStreamingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn()
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn()
 
-	input := &chime.GetVoiceConnectorStreamingConfigurationInput{
+	input := &chimesdkvoice.GetVoiceConnectorStreamingConfigurationInput{
 		VoiceConnectorId: aws.String(d.Id()),
 	}
 
 	resp, err := conn.GetVoiceConnectorStreamingConfigurationWithContext(ctx, input)
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, chime.ErrCodeNotFoundException) {
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
 		log.Printf("[WARN] Chime Voice Connector (%s) streaming not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -113,26 +137,34 @@ func resourceVoiceConnectorStreamingRead(ctx context.Context, d *schema.Resource
 		return diag.Errorf("error setting Chime Voice Connector streaming configuration targets (%s): %s", d.Id(), err)
 	}
 
+	if err := d.Set("media_insights_configuration", flattenMediaInsightsConfiguration(resp.StreamingConfiguration.MediaInsightsConfiguration)); err != nil {
+		return diag.Errorf("error setting Chime Voice Connector streaming configuration media insights configuration (%s): %s", d.Id(), err)
+	}
+
 	return nil
 }
 
 func resourceVoiceConnectorStreamingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn()
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn()
 
 	vcId := d.Get("voice_connector_id").(string)
 
-	if d.HasChanges("data_retention", "disabled", "streaming_notification_targets") {
-		input := &chime.PutVoiceConnectorStreamingConfigurationInput{
+	if d.HasChanges("data_retention", "disabled", "streaming_notification_targets", "media_insights_configuration") {
+		input := &chimesdkvoice.PutVoiceConnectorStreamingConfigurationInput{
 			VoiceConnectorId: aws.String(vcId),
 		}
 
-		config := &chime.StreamingConfiguration{
+		config := &chimesdkvoice.StreamingConfiguration{
 			DataRetentionInHours: aws.Int64(int64(d.Get("data_retention").(int))),
 			Disabled:             aws.Bool(d.Get("disabled").(bool)),
 		}
 
 		if v, ok := d.GetOk("streaming_notification_targets"); ok && v.(*schema.Set).Len() > 0 {
 			config.StreamingNotificationTargets = expandStreamingNotificationTargets(v.(*schema.Set).List())
+		}
+
+		if v, ok := d.GetOk("media_insights_configuration"); ok && len(v.([]interface{})) > 0 {
+			config.MediaInsightsConfiguration = expandMediaInsightsConfiguration(v.([]interface{}))
 		}
 
 		input.StreamingConfiguration = config
@@ -146,15 +178,15 @@ func resourceVoiceConnectorStreamingUpdate(ctx context.Context, d *schema.Resour
 }
 
 func resourceVoiceConnectorStreamingDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).ChimeConn()
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn()
 
-	input := &chime.DeleteVoiceConnectorStreamingConfigurationInput{
+	input := &chimesdkvoice.DeleteVoiceConnectorStreamingConfigurationInput{
 		VoiceConnectorId: aws.String(d.Id()),
 	}
 
 	_, err := conn.DeleteVoiceConnectorStreamingConfigurationWithContext(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, chime.ErrCodeNotFoundException) {
+	if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
 		return nil
 	}
 
@@ -165,11 +197,11 @@ func resourceVoiceConnectorStreamingDelete(ctx context.Context, d *schema.Resour
 	return nil
 }
 
-func expandStreamingNotificationTargets(data []interface{}) []*chime.StreamingNotificationTarget {
-	var streamingTargets []*chime.StreamingNotificationTarget
+func expandStreamingNotificationTargets(data []interface{}) []*chimesdkvoice.StreamingNotificationTarget {
+	var streamingTargets []*chimesdkvoice.StreamingNotificationTarget
 
 	for _, item := range data {
-		streamingTargets = append(streamingTargets, &chime.StreamingNotificationTarget{
+		streamingTargets = append(streamingTargets, &chimesdkvoice.StreamingNotificationTarget{
 			NotificationTarget: aws.String(item.(string)),
 		})
 	}
@@ -177,7 +209,26 @@ func expandStreamingNotificationTargets(data []interface{}) []*chime.StreamingNo
 	return streamingTargets
 }
 
-func flattenStreamingNotificationTargets(targets []*chime.StreamingNotificationTarget) []*string {
+func expandMediaInsightsConfiguration(data []interface{}) *chimesdkvoice.MediaInsightsConfiguration {
+	if data == nil {
+		return nil
+	}
+	mediaInsightsConfiguration := &chimesdkvoice.MediaInsightsConfiguration{}
+
+	if len(data) != 1 {
+		return nil
+	}
+	tfMediaInsightsConfiguration := data[0].(map[string]interface{})
+	if v, ok := tfMediaInsightsConfiguration["disabled"]; ok {
+		mediaInsightsConfiguration.Disabled = aws.Bool(v.(bool))
+	}
+	if v, ok := tfMediaInsightsConfiguration["configuration_arn"]; ok {
+		mediaInsightsConfiguration.ConfigurationArn = aws.String(v.(string))
+	}
+	return mediaInsightsConfiguration
+}
+
+func flattenStreamingNotificationTargets(targets []*chimesdkvoice.StreamingNotificationTarget) []*string {
 	var rawTargets []*string
 
 	for _, t := range targets {
@@ -185,4 +236,15 @@ func flattenStreamingNotificationTargets(targets []*chime.StreamingNotificationT
 	}
 
 	return rawTargets
+}
+
+func flattenMediaInsightsConfiguration(mediaInsightsConfiguration *chimesdkvoice.MediaInsightsConfiguration) []interface{} {
+	if mediaInsightsConfiguration == nil {
+		return nil
+	}
+	tfConfig := map[string]interface{}{}
+	tfConfig["disabled"] = mediaInsightsConfiguration.Disabled
+	tfConfig["configuration_arn"] = mediaInsightsConfiguration.ConfigurationArn
+
+	return []interface{}{tfConfig}
 }

--- a/internal/service/chime/voice_connector_streaming_test.go
+++ b/internal/service/chime/voice_connector_streaming_test.go
@@ -3,10 +3,12 @@ package chime_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/chime"
+	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -92,6 +94,12 @@ func TestAccChimeVoiceConnectorStreaming_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "data_retention", "2"),
 					resource.TestCheckResourceAttr(resourceName, "disabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "streaming_notification_targets.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "media_insights_configuration.0.disabled", "false"),
+					acctest.MatchResourceAttrRegionalARN(resourceName,
+						"media_insights_configuration.0.configuration_arn",
+						"chime",
+						regexp.MustCompile(fmt.Sprintf(`media-insights-pipeline-configuration/test-config-%s`, name)),
+					),
 				),
 			},
 			{
@@ -133,6 +141,51 @@ resource "aws_chime_voice_connector_streaming" "test" {
   disabled                       = false
   data_retention                 = 2
   streaming_notification_targets = ["SQS", "SNS"]
+  media_insights_configuration {
+    disabled          = false
+    configuration_arn = aws_chimesdkmediapipelines_media_insights_pipeline_configuration.test.arn
+  }
+}
+
+resource "aws_chimesdkmediapipelines_media_insights_pipeline_configuration" "test" {
+  name                     = "test-config-%[1]s"
+  resource_access_role_arn = aws_iam_role.test.arn
+  elements {
+    type = "AmazonTranscribeCallAnalyticsProcessor"
+    amazon_transcribe_call_analytics_processor_configuration {
+      language_code = "en-US"
+    }
+  }
+
+  elements {
+    type = "KinesisDataStreamSink"
+    kinesis_data_stream_sink_configuration {
+      insights_target = aws_kinesis_stream.test.arn
+    }
+  }
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["mediapipelines.chime.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name               = "resource_access_role-%[1]s"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_kinesis_stream" "test" {
+  name        = "kvs-%[1]s"
+  shard_count = 2
 }
 `, name)
 }
@@ -148,8 +201,8 @@ func testAccCheckVoiceConnectorStreamingExists(ctx context.Context, name string)
 			return fmt.Errorf("no Chime Voice Connector streaming configuration ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeConn()
-		input := &chime.GetVoiceConnectorStreamingConfigurationInput{
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn()
+		input := &chimesdkvoice.GetVoiceConnectorStreamingConfigurationInput{
 			VoiceConnectorId: aws.String(rs.Primary.ID),
 		}
 
@@ -172,13 +225,13 @@ func testAccCheckVoiceConnectorStreamingDestroy(ctx context.Context) resource.Te
 			if rs.Type != "aws_chime_voice_connector_termination" {
 				continue
 			}
-			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeConn()
-			input := &chime.GetVoiceConnectorStreamingConfigurationInput{
+			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn()
+			input := &chimesdkvoice.GetVoiceConnectorStreamingConfigurationInput{
 				VoiceConnectorId: aws.String(rs.Primary.ID),
 			}
 			resp, err := conn.GetVoiceConnectorStreamingConfigurationWithContext(ctx, input)
 
-			if tfawserr.ErrCodeEquals(err, chime.ErrCodeNotFoundException) {
+			if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
 				continue
 			}
 

--- a/website/docs/r/chime_voice_connector_streaming.html.markdown
+++ b/website/docs/r/chime_voice_connector_streaming.html.markdown
@@ -27,6 +27,67 @@ resource "aws_chime_voice_connector_streaming" "default" {
 }
 ```
 
+### Example usage with media insights
+
+```terraform
+resource "aws_chime_voice_connector" "default" {
+  name               = "vc-name-test"
+  require_encryption = true
+}
+
+resource "aws_chime_voice_connector_streaming" "default" {
+  disabled                       = false
+  voice_connector_id             = aws_chime_voice_connector.default.id
+  data_retention                 = 7
+  streaming_notification_targets = ["SQS"]
+  media_insights_configuration {
+    disabled          = false
+    configuration_arn = aws_chimesdkmediapipelines_media_insights_pipeline_configuration.example.arn
+  }
+}
+
+resource "aws_chimesdkmediapipelines_media_insights_pipeline_configuration" "example" {
+  name                     = "ExampleConfig"
+  resource_access_role_arn = aws_iam_role.example.arn
+  elements {
+    type = "AmazonTranscribeCallAnalyticsProcessor"
+    amazon_transcribe_call_analytics_processor_configuration {
+      language_code = "en-US"
+    }
+  }
+
+  elements {
+    type = "KinesisDataStreamSink"
+    kinesis_data_stream_sink_configuration {
+      insights_target = aws_kinesis_stream.example.arn
+    }
+  }
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["mediapipelines.chime.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "example" {
+  name               = "ExampleResourceAccessRole"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_kinesis_stream" "example" {
+  name        = "ExampleStream"
+  shard_count = 2
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -35,6 +96,9 @@ The following arguments are supported:
 * `data_retention`  - (Required) The retention period, in hours, for the Amazon Kinesis data.
 * `disabled` - (Optional) When true, media streaming to Amazon Kinesis is turned off. Default: `false`
 * `streaming_notification_targets` - (Optional) The streaming notification targets. Valid Values: `EventBridge | SNS | SQS`
+* `media_insights_configuration` - (Optional) The media insights configuration.
+    * `disabled` - (Optional) When true, the media insights configuration is not enabled. Default: `false`
+    * `configuration_arn` - (Optional) The media insights configuration that will be invoked by the Voice Connector.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Description
- updated `voice_connector_streaming.go` to use the `chimesdkvoice` namespace instead of the `chime` namespace. New changes to `PutVoiceConnectorStreaming` api ([reference](https://docs.aws.amazon.com/chime-sdk/latest/APIReference/API_voice-chime_PutVoiceConnectorStreamingConfiguration.html)) are only available in the new namespace.
- integrated `aws_chime_voice_connector_streaming` with ` aws_chimesdkmediapipelines_media_insights_pipeline_configuration` introduced by https://github.com/hashicorp/terraform-provider-aws/pull/30603


### Relations
Closes https://github.com/hashicorp/terraform-provider-aws/issues/30300

### References
- chime sdk voice namespace API reference: https://docs.aws.amazon.com/chime-sdk/latest/APIReference/API_voice-chime_PutVoiceConnectorStreamingConfiguration.html
- media insights pipeline configuration API reference: https://docs.aws.amazon.com/chime-sdk/latest/APIReference/API_media-pipelines-chime_CreateMediaInsightsPipelineConfiguration.html


### Output from Acceptance Testing
```
```
