### PR TITLE
resource/aws_db_instance: Fixes panic when updating `replica_mode`

### DIFF
--- a/.changelog/30714.txt
+++ b/.changelog/30714.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_instance: Fixes panic when updating `replica_mode`
+```

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -2138,7 +2138,7 @@ func dbInstancePopulateModify(input *rds_sdkv2.ModifyDBInstanceInput, d *schema.
 
 	if d.HasChange("replica_mode") {
 		needsModify = true
-		input.ReplicaMode = d.Get("replica_mode").(types.ReplicaMode)
+		input.ReplicaMode = types.ReplicaMode(d.Get("replica_mode").(string))
 	}
 
 	if d.HasChange("security_group_names") {

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -2170,12 +2170,34 @@ func TestAccRDSInstance_ReplicateSourceDB_replicaMode(t *testing.T) {
 		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_ReplicateSourceDB_replicaMode(rName),
+				Config: testAccInstanceConfig_ReplicateSourceDB_replicaMode(rName, rds.ReplicaModeMounted),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInstanceExists(ctx, sourceResourceName, &sourceDbInstance),
 					testAccCheckInstanceExists(ctx, resourceName, &dbInstance),
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
-					resource.TestCheckResourceAttr(resourceName, "replica_mode", "mounted"),
+					resource.TestCheckResourceAttr(resourceName, "replica_mode", rds.ReplicaModeMounted),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"final_snapshot_identifier",
+					"password",
+					"manage_master_user_password",
+					"skip_final_snapshot",
+					"delete_automated_backups",
+				},
+			},
+			{
+				Config: testAccInstanceConfig_ReplicateSourceDB_replicaMode(rName, rds.ReplicaModeOpenReadOnly),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceExists(ctx, sourceResourceName, &sourceDbInstance),
+					testAccCheckInstanceExists(ctx, resourceName, &dbInstance),
+					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "replica_mode", rds.ReplicaModeOpenReadOnly),
 				),
 			},
 		},
@@ -8596,7 +8618,7 @@ resource "aws_db_instance" "test" {
 `, rName))
 }
 
-func testAccInstanceConfig_ReplicateSourceDB_replicaMode(rName string) string {
+func testAccInstanceConfig_ReplicateSourceDB_replicaMode(rName, replicaMode string) string {
 	return fmt.Sprintf(`
 data "aws_rds_engine_version" "default" {
   engine = "oracle-ee"
@@ -8627,11 +8649,11 @@ resource "aws_db_instance" "source" {
 resource "aws_db_instance" "test" {
   identifier          = %[2]q
   instance_class      = aws_db_instance.source.instance_class
-  replica_mode        = "mounted"
+  replica_mode        = %[3]q
   replicate_source_db = aws_db_instance.source.id
   skip_final_snapshot = true
 }
-`, oraclePreferredInstanceClasses, rName)
+`, oraclePreferredInstanceClasses, rName, replicaMode)
 }
 
 func testAccInstanceConfig_ReplicateSourceDB_ParameterGroupTwoStep_setup(rName string) string {


### PR DESCRIPTION
### Description

`aws_db_instance` was panicking when `replica_mode` was updated

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=rds TESTS=TestAccRDSInstance_ReplicateSourceDB_replicaMode

--- PASS: TestAccRDSInstance_ReplicateSourceDB_replicaMode (2549.81s)
```
