### PR TITLE
acctests: Fixes `PreCheck` error check for `inspector2` service

### DIFF
--- a/internal/service/inspector2/delegated_admin_account_test.go
+++ b/internal/service/inspector2/delegated_admin_account_test.go
@@ -150,7 +150,7 @@ func testAccPreCheck(ctx context.Context, t *testing.T) {
 
 	_, err := conn.ListDelegatedAdminAccounts(ctx, &inspector2.ListDelegatedAdminAccountsInput{})
 
-	if acctest.PreCheckSkipError(err) {
+	if errs.IsA[*types.AccessDeniedException](err) {
 		t.Skipf("skipping acceptance testing: %s", err)
 	}
 


### PR DESCRIPTION
### Description

Acceptance tests for the `inspector2` services were failing instead of skipping when not called from an Organization Administrator account.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

In non-Organization Administrator account
```
$ make testacc PKG=inspector2 TESTS=TestAccInspector2_serial

    --- PASS: TestAccInspector2_serial/Enabler (0.59s)
        --- SKIP: TestAccInspector2_serial/Enabler/accountID (0.48s)
        --- SKIP: TestAccInspector2_serial/Enabler/disappears (0.06s)
        --- SKIP: TestAccInspector2_serial/Enabler/basic (0.05s)
    --- PASS: TestAccInspector2_serial/DelegatedAdminAccount (0.12s)
        --- SKIP: TestAccInspector2_serial/DelegatedAdminAccount/basic (0.06s)
        --- SKIP: TestAccInspector2_serial/DelegatedAdminAccount/disappears (0.06s)
    --- PASS: TestAccInspector2_serial/MemberAssociation (0.11s)
        --- SKIP: TestAccInspector2_serial/MemberAssociation/basic (0.05s)
        --- SKIP: TestAccInspector2_serial/MemberAssociation/disappears (0.06s)
    --- PASS: TestAccInspector2_serial/OrganizationConfiguration (0.26s)
        --- SKIP: TestAccInspector2_serial/OrganizationConfiguration/basic (0.06s)
        --- SKIP: TestAccInspector2_serial/OrganizationConfiguration/disappears (0.07s)
        --- SKIP: TestAccInspector2_serial/OrganizationConfiguration/ec2ECR (0.07s)
        --- SKIP: TestAccInspector2_serial/OrganizationConfiguration/lambda (0.06s)
```
