### PR TITLE
Adding dms_endpoint data source to dms resource.

### DIFF
--- a/internal/service/dms/endpoint_data_source.go
+++ b/internal/service/dms/endpoint_data_source.go
@@ -1,0 +1,540 @@
+package dms
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_dms_endpoint")
+func DataSourceEndpoint() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceEndpointRead,
+
+		Schema: map[string]*schema.Schema{
+			"certificate_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"database_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"elasticsearch_settings": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"endpoint_uri": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"error_retry_duration": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"full_load_error_percentage": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"service_access_role_arn": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"endpoint_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"endpoint_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"endpoint_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"extra_connection_attributes": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"kafka_settings": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"broker": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"include_control_details": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"include_null_and_empty": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"include_partition_value": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"include_table_alter_operations": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"include_transaction_details": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"message_format": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"message_max_bytes": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"no_hex_prefix": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"partition_include_schema_table": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"sasl_password": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"sasl_username": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"security_protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ssl_ca_certificate_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ssl_client_certificate_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ssl_client_key_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ssl_client_key_password": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"topic": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"kinesis_settings": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"include_control_details": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"include_null_and_empty": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"include_partition_value": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"include_table_alter_operations": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"include_transaction_details": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"message_format": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"partition_include_schema_table": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"service_access_role_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"stream_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"kms_key_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"mongodb_settings": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"auth_mechanism": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"auth_source": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"auth_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"docs_to_investigate": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"extract_doc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"nesting_level": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"password": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"redis_settings": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"auth_password": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"auth_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"auth_user_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"server_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ssl_ca_certificate_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ssl_security_protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"redshift_settings": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bucket_folder": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"bucket_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"encryption_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"server_side_encryption_kms_key_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"service_access_role_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"s3_settings": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"add_column_name": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"bucket_folder": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"bucket_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"canned_acl_for_objects": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cdc_inserts_and_updates": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"cdc_inserts_only": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"cdc_max_batch_interval": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"cdc_min_file_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"cdc_path": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"compression_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"csv_delimiter": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"csv_no_sup_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"csv_null_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"csv_row_delimiter": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"data_format": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"data_page_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"date_partition_delimiter": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"date_partition_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"date_partition_sequence": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"dict_page_size_limit": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"enable_statistics": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"encoding_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"encryption_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"external_table_definition": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ignore_headers_row": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"ignore_header_rows": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"include_op_for_full_load": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"max_file_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"parquet_timestamp_in_millisecond": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"parquet_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"preserve_transactions": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"rfc_4180": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"row_group_length": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"server_side_encryption_kms_key_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"service_access_role_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"timestamp_column_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"use_csv_no_sup_value": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"use_task_start_time_for_full_load_timestamp": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"secrets_manager_access_role_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"secrets_manager_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"server_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_access_role": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ssl_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"username": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+const (
+	DSNameEndpoint = "Endpoint Data Source"
+)
+
+func dataSourceEndpointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).DMSConn()
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	endptID := d.Get("endpoint_id").(string)
+
+	out, err := FindEndpointByID(ctx, conn, endptID)
+	if err != nil {
+		create.DiagError(names.DMS, create.ErrActionReading, DSNameEndpoint, d.Id(), err)
+	}
+
+	d.SetId(aws.StringValue(out.EndpointIdentifier))
+
+	d.Set("endpoint_id", out.EndpointIdentifier)
+	d.Set("endpoint_arn", out.EndpointArn)
+	d.Set("endpoint_type", out.EndpointType)
+	d.Set("database_name", out.DatabaseName)
+	d.Set("engine_name", out.EngineName)
+	d.Set("port", out.Port)
+	d.Set("server_name", out.ServerName)
+	d.Set("ssl_mode", out.SslMode)
+	d.Set("username", out.Username)
+
+	err = resourceEndpointSetState(d, out)
+	if err != nil {
+		create.DiagError(names.DMS, create.ErrActionReading, DSNameEndpoint, d.Id(), err)
+	}
+
+	tags, err := ListTags(ctx, conn, aws.StringValue(out.EndpointArn))
+	if err != nil {
+		return create.DiagError(names.DMS, create.ErrActionReading, DSNameEndpoint, d.Id(), err)
+	}
+
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return create.DiagError(names.DMS, create.ErrActionSetting, DSNameEndpoint, d.Id(), err)
+	}
+
+	return nil
+}

--- a/internal/service/dms/endpoint_data_source_test.go
+++ b/internal/service/dms/endpoint_data_source_test.go
@@ -1,0 +1,64 @@
+package dms_test
+
+import (
+	"fmt"
+	"testing"
+
+	dms "github.com/aws/aws-sdk-go/service/databasemigrationservice"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccDMSEndpointDataSource_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_dms_endpoint.test"
+	dataSourceName := "data.aws_dms_endpoint.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointExists(ctx, dataSourceName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "endpoint_id", resourceName, "endpoint_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "endpoint_type", resourceName, "endpoint_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "engine_name", resourceName, "engine_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "port", resourceName, "port"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "server_name", resourceName, "server_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ssl_mode", resourceName, "ssl_mode"),
+				),
+			},
+		},
+	})
+}
+
+func testAccEndpointDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dms_endpoint" "test" {
+  database_name = "tf-test-dms-db"
+  endpoint_id   = %[1]q
+  endpoint_type = "source"
+  engine_name   = "aurora"
+  password      = "tftestpw"
+  port          = 3306
+  server_name   = "tftest"
+  ssl_mode      = "none"
+
+  username = "tftest"
+}
+
+data "aws_dms_endpoint" "test" {
+  endpoint_id = aws_dms_endpoint.test.endpoint_id
+}
+`, rName)
+}

--- a/internal/service/dms/service_package_gen.go
+++ b/internal/service/dms/service_package_gen.go
@@ -25,6 +25,10 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			Factory:  DataSourceCertificate,
 			TypeName: "aws_dms_certificate",
 		},
+		{
+			Factory:  DataSourceEndpoint,
+			TypeName: "aws_dms_endpoint",
+		},
 	}
 }
 

--- a/website/docs/d/dms_endpoint.html.markdown
+++ b/website/docs/d/dms_endpoint.html.markdown
@@ -1,0 +1,31 @@
+---
+subcategory: "DMS (Database Migration)"
+layout: "aws"
+page_title: "AWS: aws_dms_endpoint"
+description: |-
+  Terraform data source for managing an AWS DMS (Database Migration) Endpoint.
+---
+
+# Data Source: aws_dms_endpoint
+
+Terraform data source for managing an AWS DMS (Database Migration) Endpoint.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_dms_endpoint" "test" {
+  endpoint_id = "test_id"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `endpoint_id` - (Required) Database endpoint identifier. Identifiers must contain from 1 to 255 alphanumeric characters or hyphens, begin with a letter, contain only ASCII letters, digits, and hyphens, not end with a hyphen, and not contain two consecutive hyphens.
+
+## Attributes Reference
+
+See the [`aws_dms_endpoint` resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_endpoint) for details on the returned attributes - they are identical.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Added dms_endpoint data source to dms resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #12713

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
> make testacc TESTARGS='-run=TestAccDMSEndpointDataSource_basic' PKG=dms
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dms/... -v -count 1 -parallel 20  -run=TestAccDMSEndpointDataSource_basic -timeout 180m
=== RUN   TestAccDMSEndpointDataSource_basic
=== PAUSE TestAccDMSEndpointDataSource_basic
=== CONT  TestAccDMSEndpointDataSource_basic
--- PASS: TestAccDMSEndpointDataSource_basic (14.35s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dms        17.435s

...
```
