### PR TITLE
Correctly persist `create_columns_operation.expression` field

### DIFF
--- a/.changelog/30708.txt
+++ b/.changelog/30708.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_quicksight_data_set: Correctly persist `create_columns_operation.expression` field
+```

--- a/internal/service/quicksight/data_set.go
+++ b/internal/service/quicksight/data_set.go
@@ -2017,7 +2017,7 @@ func flattenCalculatedColumns(apiObject []*quicksight.CalculatedColumn) interfac
 			tfMap["column_name"] = aws.StringValue(column.ColumnName)
 		}
 		if column.Expression != nil {
-			tfMap["column_id"] = aws.StringValue(column.Expression)
+			tfMap["expression"] = aws.StringValue(column.Expression)
 		}
 
 		tfList = append(tfList, tfMap)


### PR DESCRIPTION
Closes #30708
