### PR TITLE
r/aws_dx_gateway: Remove `name` argument validation

### DIFF
--- a/.changelog/30739.txt
+++ b/.changelog/30739.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dx_gateway: Remove plan time validation from `name` argument 
+```

--- a/internal/service/directconnect/gateway.go
+++ b/internal/service/directconnect/gateway.go
@@ -3,7 +3,6 @@ package directconnect
 import (
 	"context"
 	"log"
-	"regexp"
 	"strconv"
 	"time"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -39,9 +37,8 @@ func ResourceGateway() *schema.Resource {
 				ValidateFunc: verify.ValidAmazonSideASN,
 			},
 			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-z0-9-]{1,100}$`), "Name must contain no more than 100 characters. Valid characters are a-z, 0-9, and hyphens (–)."),
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"owner_account_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Removes the `name` argument plan-time validation.
The guidance in the AWS Console
<img width="659" alt="Screen Shot 2023-04-14 at 8 41 22 AM" src="https://user-images.githubusercontent.com/2404182/232073575-6bc22948-a6e9-4a6e-9cd3-2cff047e9088.png">
is incorrect.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/30732.
Relates #30375.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccDirectConnectGateway_basic' PKG=directconnect
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/directconnect/... -v -count 1 -parallel 20  -run=TestAccDirectConnectGateway_basic -timeout 180m
=== RUN   TestAccDirectConnectGateway_basic
=== PAUSE TestAccDirectConnectGateway_basic
=== CONT  TestAccDirectConnectGateway_basic
--- PASS: TestAccDirectConnectGateway_basic (31.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/directconnect	42.123s
```
