### PR TITLE
Add role_last_used attribute to iam_role resource

### DIFF
--- a/.changelog/30750.txt
+++ b/.changelog/30750.txt
@@ -1,4 +1,7 @@
 ```release-note:enhancement
 resource/aws_iam_role: Add `role_last_used` attribute
+```
+
+```release-note:enhancement
 data-source/aws_iam_role: Add `role_last_used` attribute
 ```

--- a/.changelog/30750.txt
+++ b/.changelog/30750.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+resource/aws_iam_role: Add `role_last_used` attribute
+data-source/aws_iam_role: Add `role_last_used` attribute
+```

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -327,10 +327,8 @@ func resourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 		return sdkdiag.AppendErrorf(diags, "reading inline policies for IAM role %s, error: %s", d.Id(), err)
 	}
 
-	if role.RoleLastUsed != nil && role.RoleLastUsed.LastUsedDate != nil {
-		if err := d.Set("role_last_used", flattenRoleLastUsed(role.RoleLastUsed)); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting role_last_used: %s", err)
-		}
+	if err := d.Set("role_last_used", flattenRoleLastUsed(role.RoleLastUsed)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting role_last_used: %s", err)
 	}
 
 	var configPoliciesList []*iam.PutRolePolicyInput

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -160,6 +160,22 @@ func ResourceRole() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: verify.ValidARN,
 			},
+			"role_last_used": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"region": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"last_used_date": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"unique_id": {
@@ -309,6 +325,12 @@ func resourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	inlinePolicies, err := readRoleInlinePolicies(ctx, aws.StringValue(role.RoleName), meta)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading inline policies for IAM role %s, error: %s", d.Id(), err)
+	}
+
+	if role.RoleLastUsed != nil && role.RoleLastUsed.LastUsedDate != nil {
+		if err := d.Set("role_last_used", flattenRoleLastUsed(role.RoleLastUsed)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting role_last_used: %s", err)
+		}
 	}
 
 	var configPoliciesList []*iam.PutRolePolicyInput
@@ -711,6 +733,21 @@ func deleteRoleInlinePolicies(ctx context.Context, conn *iam.IAM, roleName strin
 	}
 
 	return nil
+}
+
+func flattenRoleLastUsed(apiObject *iam.RoleLastUsed) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{
+		"region": aws.StringValue(apiObject.Region),
+	}
+
+	if apiObject.LastUsedDate != nil {
+		tfMap["last_used_date"] = apiObject.LastUsedDate.Format(time.RFC3339)
+	}
+	return []interface{}{tfMap}
 }
 
 func flattenRoleInlinePolicy(apiObject *iam.PutRolePolicyInput) map[string]interface{} {

--- a/internal/service/iam/role_data_source.go
+++ b/internal/service/iam/role_data_source.go
@@ -98,10 +98,8 @@ func dataSourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return sdkdiag.AppendErrorf(diags, "setting create_date: %s", err)
 	}
 
-	if output.Role.RoleLastUsed != nil && output.Role.RoleLastUsed.LastUsedDate != nil {
-		if err := d.Set("role_last_used", flattenRoleLastUsed(output.Role.RoleLastUsed)); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting role_last_used: %s", err)
-		}
+	if err := d.Set("role_last_used", flattenRoleLastUsed(output.Role.RoleLastUsed)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting role_last_used: %s", err)
 	}
 
 	d.Set("description", output.Role.Description)

--- a/internal/service/iam/role_data_source.go
+++ b/internal/service/iam/role_data_source.go
@@ -28,6 +28,22 @@ func DataSourceRole() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"create_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"max_session_duration": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
 			"path": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -36,27 +52,6 @@ func DataSourceRole() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"unique_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"description": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"create_date": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"max_session_duration": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"tags": tftags.TagsSchemaComputed(),
 			"role_last_used": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -72,6 +67,11 @@ func DataSourceRole() *schema.Resource {
 						},
 					},
 				},
+			},
+			"tags": tftags.TagsSchemaComputed(),
+			"unique_id": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}

--- a/internal/service/iam/role_data_source.go
+++ b/internal/service/iam/role_data_source.go
@@ -57,6 +57,22 @@ func DataSourceRole() *schema.Resource {
 				Computed: true,
 			},
 			"tags": tftags.TagsSchemaComputed(),
+			"role_last_used": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"region": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"last_used_date": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -81,6 +97,13 @@ func dataSourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if err := d.Set("create_date", output.Role.CreateDate.Format(time.RFC3339)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting create_date: %s", err)
 	}
+
+	if output.Role.RoleLastUsed != nil && output.Role.RoleLastUsed.LastUsedDate != nil {
+		if err := d.Set("role_last_used", flattenRoleLastUsed(output.Role.RoleLastUsed)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting role_last_used: %s", err)
+		}
+	}
+
 	d.Set("description", output.Role.Description)
 	d.Set("max_session_duration", output.Role.MaxSessionDuration)
 	d.Set("name", output.Role.RoleName)

--- a/website/docs/d/iam_role.html.markdown
+++ b/website/docs/d/iam_role.html.markdown
@@ -34,5 +34,11 @@ data "aws_iam_role" "example" {
 * `max_session_duration` - Maximum session duration.
 * `path` - Path to the role.
 * `permissions_boundary` - The ARN of the policy that is used to set the permissions boundary for the role.
+* `role_last_used` - Contains information about the last time that an IAM role was used. See [`role_last_used`](#role_last_used) for details.
 * `unique_id` - Stable and unique string identifying the role.
 * `tags` - Tags attached to the role.
+
+### role_last_used
+
+* `region` - The name of the AWS Region in which the role was last used.
+* `last_used_time` - The date and time, in RFC 3339 format, that the role was last used.

--- a/website/docs/r/iam_role.html.markdown
+++ b/website/docs/r/iam_role.html.markdown
@@ -208,8 +208,14 @@ In addition to all arguments above, the following attributes are exported:
 * `create_date` - Creation date of the IAM role.
 * `id` - Name of the role.
 * `name` - Name of the role.
+* `role_last_used` - Contains information about the last time that an IAM role was used. See [`role_last_used`](#role_last_used) for details.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `unique_id` - Stable and unique string identifying the role.
+
+### role_last_used
+
+* `region` - The name of the AWS Region in which the role was last used.
+* `last_used_time` - The date and time, in RFC 3339 format, that the role was last used.
 
 ## Import
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR adds the `role_last_used` attribute to the `aws_iam_role` resource and datasource.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
No issue that I could find relating to this.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/IAM/latest/APIReference/API_RoleLastUsed.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
This one is tough to add an acceptance test for because in order to have that value populated, you would need to create a role and then use it and then wait for AWS to populate the last used information (which takes about 15-30 min from what I've seen).

I did run the test locally for both the role and datasource and got the following on create:
```
 terraform state show aws_iam_role.role
# aws_iam_role.role:
resource "aws_iam_role" "role" {
    arn                   = "arn:aws:iam::XXXXXXXXXXXXX:role/test6"
    assume_role_policy    = jsonencode(
        {
            Statement = [
                {
                    Action    = [
                        "sts:AssumeRole",
                        "sts:TagSession",
                        "sts:SetSourceIdentity",
                    ]
                    Effect    = "Allow"
                    Principal = {
                        AWS = "arn:aws:iam::XXXXXXXXXXXXX:role/aws_devon_test-developer"
                    }
                },
            ]
            Version   = "2012-10-17"
        }
    )
    create_date           = "2023-04-14T18:27:54Z"
    force_detach_policies = false
    id                    = "test6"
    managed_policy_arns   = []
    max_session_duration  = 3600
    name                  = "test6"
    path                  = "/"
    tags_all              = {}
    unique_id             = "AROAXXXXXXXXXXXXX"

    inline_policy {
        name   = "my_inline_policy"
        policy = jsonencode(
            {
                Statement = [
                    {
                        Action   = [
                            "ec2:Describe*",
                        ]
                        Effect   = "Allow"
                        Resource = "*"
                    },
                ]
                Version   = "2012-10-17"
            }
        )
    }
}
```

Then got the following for the datasource (before using the role):
```
> terraform state show data.aws_iam_role.test
# data.aws_iam_role.test:
data "aws_iam_role" "test" {
    arn                  = "arn:aws:iam::XXXXXXXXXXXX:role/test6"
    assume_role_policy   = jsonencode(
        {
            Statement = [
                {
                    Action    = [
                        "sts:AssumeRole",
                        "sts:TagSession",
                        "sts:SetSourceIdentity",
                    ]
                    Effect    = "Allow"
                    Principal = {
                        AWS = "arn:aws:iam::XXXXXXXXXXXX:role/aws_devon_test-developer"
                    }
                },
            ]
            Version   = "2012-10-17"
        }
    )
    create_date          = "2023-04-14T18:27:54Z"
    id                   = "test6"
    max_session_duration = 3600
    name                 = "test6"
    path                 = "/"
    role_last_used       = [
        {
            last_used_date = "2023-04-14T18:30:03Z"
            region         = "us-east-1"
        },
    ]
    tags                 = {}
    unique_id            = "AROAXXXXXXXXXXXX"
}
```

I then used the role, waited a while and got the following when re-applying:
<img width="1609" alt="Screenshot 2023-04-14 at 3 56 39 PM" src="https://user-images.githubusercontent.com/46845760/232143051-1acbba4e-33d3-4f42-bab0-fffc4dd7e63a.png">

The updated state for the resource:
```
 terraform state show aws_iam_role.role
# aws_iam_role.role:
resource "aws_iam_role" "role" {
    arn                   = "arn:aws:iam::XXXXXXXXXXXX:role/test6"
    assume_role_policy    = jsonencode(
        {
            Statement = [
                {
                    Action    = [
                        "sts:AssumeRole",
                        "sts:TagSession",
                        "sts:SetSourceIdentity",
                    ]
                    Effect    = "Allow"
                    Principal = {
                        AWS = "arn:aws:iam::XXXXXXXXXXXX:role/aws_devon_test-developer"
                    }
                },
            ]
            Version   = "2012-10-17"
        }
    )
    create_date           = "2023-04-14T18:27:54Z"
    force_detach_policies = false
    id                    = "test6"
    managed_policy_arns   = []
    max_session_duration  = 3600
    name                  = "test6"
    path                  = "/"
    role_last_used        = [
        {
            last_used_date = "2023-04-14T18:30:03Z"
            region         = "us-east-1"
        },
    ]
    tags                  = {}
    tags_all              = {}
    unique_id             = "AROAXXXXXXXXXXXX"

    inline_policy {
        name   = "my_inline_policy"
        policy = jsonencode(
            {
                Statement = [
                    {
                        Action   = [
                            "ec2:DescribeRegion",
                        ]
                        Effect   = "Allow"
                        Resource = "*"
                    },
                ]
                Version   = "2012-10-17"
            }
        )
    }
}
```

The updated state for the datasource:
```
> terraform state show data.aws_iam_role.test
# data.aws_iam_role.test:
data "aws_iam_role" "test" {
    arn                  = "arn:aws:iam::XXXXXXXXXXXX:role/test6"
    assume_role_policy   = jsonencode(
        {
            Statement = [
                {
                    Action    = [
                        "sts:AssumeRole",
                        "sts:TagSession",
                        "sts:SetSourceIdentity",
                    ]
                    Effect    = "Allow"
                    Principal = {
                        AWS = "arn:aws:iam::XXXXXXXXXXXX:role/aws_devon_test-developer"
                    }
                },
            ]
            Version   = "2012-10-17"
        }
    )
    create_date          = "2023-04-14T18:27:54Z"
    id                   = "test6"
    max_session_duration = 3600
    name                 = "test6"
    path                 = "/"
    role_last_used       = [
        {
            last_used_date = "2023-04-14T18:30:03Z"
            region         = "us-east-1"
        },
    ]
    tags                 = {}
    unique_id            = "AROAXXXXXXXXXXXX"
}
```