### PR TITLE
r/aws_s3_bucket: check if bucket name available on plan

### DIFF
--- a/.changelog/30757.txt
+++ b/.changelog/30757.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket: Plan now checks if bucket name is available.
+```

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -2792,10 +2792,9 @@ resource "aws_s3_bucket" "test" {
 
 func testAccBucketConfig_basic_nameAlreadyExists(bucketName string) string {
 	return fmt.Sprintf(`
-
 resource "aws_s3_bucket" "duplicate" {
-	bucket = %[1]q
-  }
+  bucket = %[1]q
+}
 `, bucketName)
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
adds custom diff to `aws_s3_bucket` resource that uses the `HeadBucket` AWS API to check if an S3 bucket exists with the given name when running plan

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #30550

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html
https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#S3.HeadBucket

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
 make testacc  PKG=s3 ACCTEST_PARALLELISM=3 TESTS=TestAccS3Bucket_Basic_basic\|TestAccS3Bucket_Basic_emptyString\|TestAccS3Bucket_Basic_generatedName\|TestAccS3Bucket_Basic_namePrefix\|TestAccS3Bucket_Basic_nameAlreadyExists
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 3 -run='TestAccS3Bucket_Basic_basic|TestAccS3Bucket_Basic_emptyString|TestAccS3Bucket_Basic_generatedName|TestAccS3Bucket_Basic_namePrefix|TestAccS3Bucket_Basic_nameAlreadyExists'  -timeout 180m
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Basic_nameAlreadyExists
=== PAUSE TestAccS3Bucket_Basic_nameAlreadyExists
=== RUN   TestAccS3Bucket_Basic_emptyString
=== PAUSE TestAccS3Bucket_Basic_emptyString
=== RUN   TestAccS3Bucket_Basic_generatedName
=== PAUSE TestAccS3Bucket_Basic_generatedName
=== RUN   TestAccS3Bucket_Basic_namePrefix
=== PAUSE TestAccS3Bucket_Basic_namePrefix
=== CONT  TestAccS3Bucket_Basic_basic
=== CONT  TestAccS3Bucket_Basic_generatedName
=== CONT  TestAccS3Bucket_Basic_namePrefix
--- PASS: TestAccS3Bucket_Basic_namePrefix (60.24s)
=== CONT  TestAccS3Bucket_Basic_emptyString
--- PASS: TestAccS3Bucket_Basic_generatedName (60.25s)
=== CONT  TestAccS3Bucket_Basic_nameAlreadyExists
--- PASS: TestAccS3Bucket_Basic_basic (64.35s)
--- PASS: TestAccS3Bucket_Basic_emptyString (49.95s)
--- PASS: TestAccS3Bucket_Basic_nameAlreadyExists (52.64s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	113.007s
```