### PR TITLE
Add limit for reference_sets in aws_networkfirewall_rule_group

### DIFF
--- a/.changelog/28464.txt
+++ b/.changelog/28464.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_networkfirewall_rule_group: Add limit for `reference_sets`
+```

--- a/internal/service/networkfirewall/rule_group.go
+++ b/internal/service/networkfirewall/rule_group.go
@@ -71,6 +71,7 @@ func ResourceRuleGroup() *schema.Resource {
 									"ip_set_references": {
 										Type:     schema.TypeSet,
 										Optional: true,
+										MaxItems: 5,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"key": {

--- a/website/docs/r/networkfirewall_rule_group.html.markdown
+++ b/website/docs/r/networkfirewall_rule_group.html.markdown
@@ -288,7 +288,7 @@ The following arguments are supported:
 
 The `rule_group` block supports the following argument:
 
-* `reference_sets` - (Optional) A configuration block that defines the IP Set References for the rule group. See [Reference Sets](#reference-sets) below for details.
+* `reference_sets` - (Optional) A configuration block that defines the IP Set References for the rule group. See [Reference Sets](#reference-sets) below for details. Please notes that there can only be a maximum of 5 `reference_sets` in a `rule_group`. See the [AWS documentation](https://docs.aws.amazon.com/network-firewall/latest/developerguide/rule-groups-ip-set-references.html#rule-groups-ip-set-reference-limits) for details.
 
 * `rule_variables` - (Optional) A configuration block that defines additional settings available to use in the rules defined in the rule group. Can only be specified for **stateful** rule groups. See [Rule Variables](#rule-variables) below for details.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Add a limit of 5 `reference_sets` within a `rule_group` of `aws_networkfirewall_rule_group`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28464

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/network-firewall/latest/developerguide/rule-groups-ip-set-references.html#rule-groups-ip-set-reference-limits

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS='TestAccNetworkFirewallRuleGroup_' PKG=networkfirewall
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkfirewall/... -v -count 1 -parallel 20 -run='TestAccNetworkFirewallRuleGroup_'  -timeout 180m
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_rulesSourceList
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_rulesSourceList
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_referenceSets
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_referenceSets
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_updateReferenceSets
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_updateReferenceSets
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_statefulRule
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_statefulRule
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_statelessRule
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_statelessRule
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_rules
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_rules
=== RUN   TestAccNetworkFirewallRuleGroup_statefulRuleOptions
=== PAUSE TestAccNetworkFirewallRuleGroup_statefulRuleOptions
=== RUN   TestAccNetworkFirewallRuleGroup_updateStatefulRuleOptions
=== PAUSE TestAccNetworkFirewallRuleGroup_updateStatefulRuleOptions
=== RUN   TestAccNetworkFirewallRuleGroup_statelessRuleWithCustomAction
=== PAUSE TestAccNetworkFirewallRuleGroup_statelessRuleWithCustomAction
=== RUN   TestAccNetworkFirewallRuleGroup_updateRules
=== PAUSE TestAccNetworkFirewallRuleGroup_updateRules
=== RUN   TestAccNetworkFirewallRuleGroup_updateRulesSourceList
=== PAUSE TestAccNetworkFirewallRuleGroup_updateRulesSourceList
=== RUN   TestAccNetworkFirewallRuleGroup_rulesSourceAndRuleVariables
=== PAUSE TestAccNetworkFirewallRuleGroup_rulesSourceAndRuleVariables
=== RUN   TestAccNetworkFirewallRuleGroup_updateStatefulRule
=== PAUSE TestAccNetworkFirewallRuleGroup_updateStatefulRule
=== RUN   TestAccNetworkFirewallRuleGroup_updateMultipleStatefulRules
=== PAUSE TestAccNetworkFirewallRuleGroup_updateMultipleStatefulRules
=== RUN   TestAccNetworkFirewallRuleGroup_StatefulRule_action
=== PAUSE TestAccNetworkFirewallRuleGroup_StatefulRule_action
=== RUN   TestAccNetworkFirewallRuleGroup_StatefulRule_header
=== PAUSE TestAccNetworkFirewallRuleGroup_StatefulRule_header
=== RUN   TestAccNetworkFirewallRuleGroup_updateStatelessRule
=== PAUSE TestAccNetworkFirewallRuleGroup_updateStatelessRule
=== RUN   TestAccNetworkFirewallRuleGroup_tags
=== PAUSE TestAccNetworkFirewallRuleGroup_tags
=== RUN   TestAccNetworkFirewallRuleGroup_encryptionConfiguration
=== PAUSE TestAccNetworkFirewallRuleGroup_encryptionConfiguration
=== RUN   TestAccNetworkFirewallRuleGroup_disappears
=== PAUSE TestAccNetworkFirewallRuleGroup_disappears
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_rulesSourceList
=== CONT  TestAccNetworkFirewallRuleGroup_updateRulesSourceList
=== CONT  TestAccNetworkFirewallRuleGroup_updateStatelessRule
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_statefulRule
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_statelessRule
=== CONT  TestAccNetworkFirewallRuleGroup_StatefulRule_action
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_rules
=== CONT  TestAccNetworkFirewallRuleGroup_updateStatefulRule
=== CONT  TestAccNetworkFirewallRuleGroup_updateMultipleStatefulRules
=== CONT  TestAccNetworkFirewallRuleGroup_rulesSourceAndRuleVariables
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_updateReferenceSets
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_referenceSets
=== CONT  TestAccNetworkFirewallRuleGroup_updateRules
=== CONT  TestAccNetworkFirewallRuleGroup_statelessRuleWithCustomAction
=== CONT  TestAccNetworkFirewallRuleGroup_updateStatefulRuleOptions
=== CONT  TestAccNetworkFirewallRuleGroup_statefulRuleOptions
=== CONT  TestAccNetworkFirewallRuleGroup_StatefulRule_header
=== CONT  TestAccNetworkFirewallRuleGroup_disappears
=== CONT  TestAccNetworkFirewallRuleGroup_encryptionConfiguration
=== CONT  TestAccNetworkFirewallRuleGroup_tags
--- PASS: TestAccNetworkFirewallRuleGroup_tags (143.51s)
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_statelessRule (147.35s)
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_statefulRule (172.19s)
--- PASS: TestAccNetworkFirewallRuleGroup_statefulRuleOptions (174.53s)
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_rules (180.45s)
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_rulesSourceList (182.96s)
--- PASS: TestAccNetworkFirewallRuleGroup_statelessRuleWithCustomAction (185.00s)
--- PASS: TestAccNetworkFirewallRuleGroup_disappears (187.65s)
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_referenceSets (193.19s)
--- PASS: TestAccNetworkFirewallRuleGroup_updateRules (206.09s)
--- PASS: TestAccNetworkFirewallRuleGroup_updateStatelessRule (208.87s)
--- PASS: TestAccNetworkFirewallRuleGroup_StatefulRule_header (215.21s)
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_updateReferenceSets (215.60s)
--- PASS: TestAccNetworkFirewallRuleGroup_rulesSourceAndRuleVariables (218.87s)
--- PASS: TestAccNetworkFirewallRuleGroup_updateRulesSourceList (219.18s)
--- PASS: TestAccNetworkFirewallRuleGroup_updateStatefulRule (221.79s)
--- PASS: TestAccNetworkFirewallRuleGroup_encryptionConfiguration (247.00s)
--- PASS: TestAccNetworkFirewallRuleGroup_updateMultipleStatefulRules (249.68s)
--- PASS: TestAccNetworkFirewallRuleGroup_StatefulRule_action (250.31s)
--- PASS: TestAccNetworkFirewallRuleGroup_updateStatefulRuleOptions (339.56s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall    343.222s
```
