### PR TITLE
Update values for canned_acl_for_objects in aws_dms_s3_endpoint resource

### DIFF
--- a/.changelog/30762.txt
+++ b/.changelog/30762.txt
@@ -1,3 +1,0 @@
-```release-note:enhancement
-resource/aws_networkfirewall_rule_group: Update the allowed values for canned_acl_for_objects in aws_dms_s3_endpoint resource documentation.
-```

--- a/.changelog/30762.txt
+++ b/.changelog/30762.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_networkfirewall_rule_group: Update the allowed values for canned_acl_for_objects in aws_dms_s3_endpoint resource documentation.
+```

--- a/website/docs/r/dms_s3_endpoint.html.markdown
+++ b/website/docs/r/dms_s3_endpoint.html.markdown
@@ -106,7 +106,7 @@ The following arguments are optional:
 * `add_column_name` - (Optional) Whether to add column name information to the .csv output file. Default is `false`.
 * `add_trailing_padding_character` - (Optional) Whether to add padding. Default is `false`. (Ignored for source endpoints.)
 * `bucket_folder` - (Optional) S3 object prefix.
-* `canned_acl_for_objects` - (Optional) Predefined (canned) access control list for objects created in an S3 bucket. Valid values include `NONE`, `PRIVATE`, `PUBLIC_READ`, `PUBLIC_READ_WRITE`, `AUTHENTICATED_READ`, `AWS_EXEC_READ`, `BUCKET_OWNER_READ`, and `BUCKET_OWNER_FULL_CONTROL`. (AWS default is `NONE`.)
+* `canned_acl_for_objects` - (Optional) Predefined (canned) access control list for objects created in an S3 bucket. Valid values include `none`, `private`, `public-read`, `public-read-write`, `authenticated-read`, `aws-exec-read`, `bucket-owner-read`, and `bucket-owner-full-control`. Default is `none`.
 * `cdc_inserts_and_updates` - (Optional) Whether to write insert and update operations to .csv or .parquet output files. Default is `false`.
 * `cdc_inserts_only` - (Optional) Whether to write insert operations to .csv or .parquet output files. Default is `false`.
 * `cdc_max_batch_interval` - (Optional) Maximum length of the interval, defined in seconds, after which to output a file to Amazon S3. (AWS default is `60`.)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Update the allowed values for `canned_acl_for_objects` in `aws_dms_s3_endpoint` resource documentation.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #30741