### PR TITLE
d/aws_iam_role: check json equivalence of trust

### DIFF
--- a/internal/service/iam/role_data_source_test.go
+++ b/internal/service/iam/role_data_source_test.go
@@ -25,7 +25,7 @@ func TestAccIAMRoleDataSource_basic(t *testing.T) {
 				Config: testAccRoleDataSourceConfig_basic(roleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "assume_role_policy", resourceName, "assume_role_policy"),
+					acctest.CheckResourceAttrEquivalentJSON(dataSourceName, "assume_role_policy", testAccRoleDataSourceConfig_AssumeRolePolicy_ExpectedJSON),
 					resource.TestCheckResourceAttrPair(dataSourceName, "create_date", resourceName, "create_date"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "max_session_duration", resourceName, "max_session_duration"),
@@ -54,7 +54,7 @@ func TestAccIAMRoleDataSource_tags(t *testing.T) {
 				Config: testAccRoleDataSourceConfig_tags(roleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "assume_role_policy", resourceName, "assume_role_policy"),
+					acctest.CheckResourceAttrEquivalentJSON(dataSourceName, "assume_role_policy", testAccRoleDataSourceConfig_AssumeRolePolicy_ExpectedJSON),
 					resource.TestCheckResourceAttrPair(dataSourceName, "create_date", resourceName, "create_date"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "max_session_duration", resourceName, "max_session_duration"),
@@ -70,57 +70,57 @@ func TestAccIAMRoleDataSource_tags(t *testing.T) {
 	})
 }
 
-func testAccRoleDataSourceConfig_basic(roleName string) string {
-	return fmt.Sprintf(`
-resource "aws_iam_role" "test" {
-  name = %[1]q
-
-  assume_role_policy = <<EOF
-{
+const testAccRoleDataSourceConfig_AssumeRolePolicy_ExpectedJSON = `{
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "",
+      "Effect": "Allow",
       "Action": "sts:AssumeRole",
       "Principal": {
         "Service": "ec2.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
+      }
     }
   ]
-}
-EOF
+}`
 
-  path = "/testpath/"
+func testAccRoleDataSourceConfigBase() string {
+	return `
+data "aws_iam_policy_document" "test" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+`
+}
+
+func testAccRoleDataSourceConfig_basic(roleName string) string {
+	return acctest.ConfigCompose(
+		testAccRoleDataSourceConfigBase(),
+		fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name               = %[1]q
+  path               = "/testpath/"
+  assume_role_policy = data.aws_iam_policy_document.test.json
 }
 
 data "aws_iam_role" "test" {
   name = aws_iam_role.test.name
 }
-`, roleName)
+`, roleName))
 }
 
 func testAccRoleDataSourceConfig_tags(roleName string) string {
-	return fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		testAccRoleDataSourceConfigBase(),
+		fmt.Sprintf(`
 resource "aws_iam_role" "test" {
-  name = %q
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-
+  name               = %[1]q
+  assume_role_policy = data.aws_iam_policy_document.test.json
   tags = {
     tag1 = "test-value1"
     tag2 = "test-value2"
@@ -130,5 +130,5 @@ EOF
 data "aws_iam_role" "test" {
   name = aws_iam_role.test.name
 }
-`, roleName)
+`, roleName))
 }


### PR DESCRIPTION
### Description
Fixes failing acceptance tests caused by exact string checking of JSON attributes.

```
=== NAME  TestAccIAMRoleDataSource_basic
    role_data_source_test.go:19: Step 1/1 error: Check failed: 1 error occurred:
                * Check 2/9 error: data.aws_iam_role.test: Attribute 'assume_role_policy' expected "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Sid\":\"\"}],\"Version\":\"2012-10-17\"}", got "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"

--- FAIL: TestAccIAMRoleDataSource_basic (7.24s)
```

### Output from Acceptance Testing

```console
$ make testacc PKG=iam TESTS=TestAccIAMRoleDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRoleDataSource_'  -timeout 180m
=== RUN   TestAccIAMRoleDataSource_basic
=== PAUSE TestAccIAMRoleDataSource_basic
=== RUN   TestAccIAMRoleDataSource_tags
=== PAUSE TestAccIAMRoleDataSource_tags
=== CONT  TestAccIAMRoleDataSource_basic
=== CONT  TestAccIAMRoleDataSource_tags
--- PASS: TestAccIAMRoleDataSource_basic (10.47s)
--- PASS: TestAccIAMRoleDataSource_tags (10.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        13.584s
```
