### PR TITLE
Add vpcid  rds subnetgroup vpcid

### DIFF
--- a/.changelog/30775.txt
+++ b/.changelog/30775.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_db_subnet_group: Add `vpc_id` attribute
+```

--- a/internal/service/rds/subnet_group.go
+++ b/internal/service/rds/subnet_group.go
@@ -130,23 +130,7 @@ func resourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 	d.Set("subnet_ids", subnetIDs)
 	d.Set("supported_network_types", aws.StringValueSlice(v.SupportedNetworkTypes))
-
-	tags, err := ListTags(ctx, conn, arn)
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "listing tags for RDS DB Subnet Group (%s): %s", arn, err)
-	}
-
-	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-
-	//lintignore:AWSR002
-	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
-	}
+	d.Set("vpc_id", v.VpcId)
 
 	return diags
 }

--- a/internal/service/rds/subnet_group.go
+++ b/internal/service/rds/subnet_group.go
@@ -68,6 +68,10 @@ func ResourceSubnetGroup() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
@@ -126,6 +130,23 @@ func resourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 	d.Set("subnet_ids", subnetIDs)
 	d.Set("supported_network_types", aws.StringValueSlice(v.SupportedNetworkTypes))
+
+	tags, err := ListTags(ctx, conn, arn)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "listing tags for RDS DB Subnet Group (%s): %s", arn, err)
+	}
+
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
+	}
+
+	if err := d.Set("tags_all", tags.Map()); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
+	}
 
 	return diags
 }

--- a/internal/service/rds/subnet_group_test.go
+++ b/internal/service/rds/subnet_group_test.go
@@ -40,6 +40,7 @@ func TestAccRDSSubnetGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "supported_network_types.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "supported_network_types.*", "IPV4"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},

--- a/website/docs/r/db_subnet_group.html.markdown
+++ b/website/docs/r/db_subnet_group.html.markdown
@@ -43,6 +43,7 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The ARN of the db subnet group.
 * `supported_network_types` - The network type of the db subnet group.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+* `vpc_id` - Provides the VPC ID of the DB subnet group.
 
 ## Import
 


### PR DESCRIPTION
### Description

Adds `vpc_id` attribute to the `aws_db_subnet_group` resource.

### Relations

N/A

### References

The `vpc_id` is provided by the AWS SDK and already present as an attribute in the <https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/db_subnet_group#vpc_id> data source. 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
make testacc TESTS=TestAccRDSSubnetGroup_basic PKG=rds
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSSubnetGroup_basic'  -timeout 180m
=== RUN   TestAccRDSSubnetGroup_basic
=== PAUSE TestAccRDSSubnetGroup_basic
=== CONT  TestAccRDSSubnetGroup_basic
--- PASS: TestAccRDSSubnetGroup_basic (46.82s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        48.170s
```

#### Manual testing

```console
$ terraform state show aws_db_subnet_group.default
# aws_db_subnet_group.default:
resource "aws_db_subnet_group" "default" {
    arn                     = "arn:aws:rds:us-east-1:609897127049:subgrp:main"
    description             = "Managed by Terraform"
    id                      = "main"
    name                    = "main"
    subnet_ids              = [
        "subnet-06266977967d53dfe",
        "subnet-0d639b1732687c398",
    ]
    supported_network_types = [
        "IPV4",
    ]
    tags                    = {
        "Name" = "borrelli-test-can-delete"
    }
    tags_all                = {
        "Name" = "borrelli-test-can-delete"
    }
    vpc_id                  = "vpc-0a43c06838b76d401"
}
```