### PR TITLE
aws_quicksight_data_set: Add support for configuring refresh properties

### DIFF
--- a/.changelog/30744.txt
+++ b/.changelog/30744.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+aws_quicksight_data_set: Add support for configuring refresh properties
+```

--- a/docs/acc-test-environment-variables.md
+++ b/docs/acc-test-environment-variables.md
@@ -74,6 +74,7 @@ Environment variables (beyond standard AWS Go SDK ones) used by acceptance testi
 | `GRAFANA_SSO_USER_ID` | AWS SSO user ID for Grafana testing. |
 | `MACIE_MEMBER_ACCOUNT_ID` | Identifier of AWS Account for Macie Member testing. **DEPRECATED:** Should be replaced with standard alternate account handling for tests. |
 | `QUICKSIGHT_NAMESPACE` | QuickSight namespace name for testing. |
+| `QUICKSIGHT_ATHENA_TESTING_ENABLED` | Enable QuickSight tests dependent on Amazon Athena resources. |
 | `ROUTE53DOMAINS_DOMAIN_NAME` | Registered domain for Route 53 Domains testing. |
 | `SAGEMAKER_IMAGE_VERSION_BASE_IMAGE` | SageMaker base image to use for tests. |
 | `SERVICEQUOTAS_INCREASE_ON_CREATE_QUOTA_CODE` | Quota Code for Service Quotas testing (submits support case). |

--- a/internal/service/quicksight/data_set.go
+++ b/internal/service/quicksight/data_set.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/quicksight"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -299,10 +300,68 @@ func ResourceDataSet() *schema.Resource {
 					},
 				},
 			},
+			"refresh_properties": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"refresh_configuration": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"incremental_refresh": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"lookback_window": {
+													Type:     schema.TypeList,
+													Required: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"column_name": {
+																Type:     schema.TypeString,
+																Required: true,
+															},
+															"size": {
+																Type:     schema.TypeInt,
+																Required: true,
+															},
+															"size_unit": {
+																Type:         schema.TypeString,
+																Required:     true,
+																ValidateFunc: validation.StringInSlice(quicksight.LookbackWindowSizeUnit_Values(), false),
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
-		CustomizeDiff: verify.SetTagsDiff,
+		CustomizeDiff: customdiff.All(
+			func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+				mode := diff.Get("import_mode").(string)
+				if v, ok := diff.Get("refresh_properties").([]interface{}); ok && v != nil && len(v) > 0 && mode == "DIRECT_QUERY" {
+					return fmt.Errorf("refresh_properties cannot be set when import_mode is 'DIRECT_QUERY'")
+				}
+				return nil
+			},
+			verify.SetTagsDiff,
+		),
 	}
 }
 
@@ -829,6 +888,19 @@ func resourceDataSetCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("error creating QuickSight Data Set: %s", err)
 	}
 
+	if v, ok := d.GetOk("refresh_properties"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input := &quicksight.PutDataSetRefreshPropertiesInput{
+			AwsAccountId:             aws.String(awsAccountId),
+			DataSetId:                aws.String(dataSetID),
+			DataSetRefreshProperties: expandDataSetRefreshProperties(v.([]interface{})),
+		}
+
+		_, err := conn.PutDataSetRefreshPropertiesWithContext(ctx, input)
+		if err != nil {
+			return diag.Errorf("error putting QuickSight Data Set Refresh Properties: %s", err)
+		}
+	}
+
 	return resourceDataSetRead(ctx, d, meta)
 }
 
@@ -917,13 +989,29 @@ func resourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if err := d.Set("permissions", flattenPermissions(permsResp.Permissions)); err != nil {
 		return diag.Errorf("error setting permissions: %s", err)
 	}
+
+	propsResp, err := conn.DescribeDataSetRefreshPropertiesWithContext(ctx, &quicksight.DescribeDataSetRefreshPropertiesInput{
+		AwsAccountId: aws.String(awsAccountId),
+		DataSetId:    aws.String(dataSetId),
+	})
+
+	if err != nil && !tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
+		return diag.Errorf("error describing refresh properties (%s): %s", d.Id(), err)
+	}
+
+	if err == nil {
+		if err := d.Set("refresh_properties", flattenRefreshProperties(propsResp.DataSetRefreshProperties)); err != nil {
+			return diag.Errorf("error setting refresh properties: %s", err)
+		}
+	}
+
 	return nil
 }
 
 func resourceDataSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).QuickSightConn()
 
-	if d.HasChangesExcept("permissions", "tags", "tags_all") {
+	if d.HasChangesExcept("permissions", "tags", "tags_all", "refresh_properties") {
 		awsAccountId, dataSetId, err := ParseDataSetID(d.Id())
 		if err != nil {
 			return diag.FromErr(err)
@@ -986,6 +1074,35 @@ func resourceDataSetUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		if err != nil {
 			return diag.Errorf("error updating QuickSight Data Set (%s) permissions: %s", dataSetId, err)
+		}
+	}
+
+	if d.HasChange("refresh_properties") {
+		awsAccountId, dataSetId, err := ParseDataSetID(d.Id())
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		oldraw, newraw := d.GetChange("refresh_properties")
+		old := oldraw.([]interface{})
+		new := newraw.([]interface{})
+		if len(old) == 1 && len(new) == 0 {
+			_, err := conn.DeleteDataSetRefreshPropertiesWithContext(ctx, &quicksight.DeleteDataSetRefreshPropertiesInput{
+				AwsAccountId: aws.String(awsAccountId),
+				DataSetId:    aws.String(dataSetId),
+			})
+			if err != nil {
+				return diag.Errorf("error deleting QuickSight Data Set Refresh Properties (%s): %s", d.Id(), err)
+			}
+		} else {
+			_, err = conn.PutDataSetRefreshPropertiesWithContext(ctx, &quicksight.PutDataSetRefreshPropertiesInput{
+				AwsAccountId:             aws.String(awsAccountId),
+				DataSetId:                aws.String(dataSetId),
+				DataSetRefreshProperties: expandDataSetRefreshProperties(d.Get("refresh_properties").([]interface{})),
+			})
+			if err != nil {
+				return diag.Errorf("error updating QuickSight Data Set Refresh Properties (%s): %s", d.Id(), err)
+			}
 		}
 	}
 
@@ -1740,6 +1857,76 @@ func expandDataSetRowLevelPermissionTagConfigurations(tfList []interface{}) *qui
 	return rowLevelPermissionTagConfiguration
 }
 
+func expandDataSetRefreshProperties(tfList []interface{}) *quicksight.DataSetRefreshProperties {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	props := &quicksight.DataSetRefreshProperties{}
+	if v, ok := tfMap["refresh_configuration"].([]interface{}); ok {
+		props.RefreshConfiguration = expandDataSetRefreshConfiguration(v)
+	}
+	return props
+}
+
+func expandDataSetRefreshConfiguration(tfList []interface{}) *quicksight.RefreshConfiguration {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	config := &quicksight.RefreshConfiguration{}
+	if v, ok := tfMap["incremental_refresh"].([]interface{}); ok {
+		config.IncrementalRefresh = expandIncrementalRefresh(v)
+	}
+	return config
+}
+
+func expandIncrementalRefresh(tfList []interface{}) *quicksight.IncrementalRefresh {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	refresh := &quicksight.IncrementalRefresh{}
+	if v, ok := tfMap["lookback_window"].([]interface{}); ok {
+		refresh.LookbackWindow = expandLookbackWindow(v)
+	}
+	return refresh
+}
+
+func expandLookbackWindow(tfList []interface{}) *quicksight.LookbackWindow {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	window := &quicksight.LookbackWindow{}
+	if v, ok := tfMap["column_name"].(string); ok {
+		window.ColumnName = aws.String(v)
+	}
+	if v, ok := tfMap["size"].(int); ok {
+		window.Size = aws.Int64(int64(v))
+	}
+	if v, ok := tfMap["size_unit"].(string); ok {
+		window.SizeUnit = aws.String(v)
+	}
+	return window
+}
+
 func expandDataSetTagRules(tfList []interface{}) []*quicksight.RowLevelPermissionTagRule {
 	if len(tfList) == 0 {
 		return nil
@@ -2418,6 +2605,64 @@ func flattenRowLevelPermissionTagConfiguration(apiObject *quicksight.RowLevelPer
 	}
 	if apiObject.TagRules != nil {
 		tfMap["tag_rules"] = flattenTagRules(apiObject.TagRules)
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenRefreshProperties(apiObject *quicksight.DataSetRefreshProperties) interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+	if apiObject.RefreshConfiguration != nil {
+		tfMap["refresh_configuration"] = flattenRefreshConfiguration(apiObject.RefreshConfiguration)
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenRefreshConfiguration(apiObject *quicksight.RefreshConfiguration) interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+	if apiObject.IncrementalRefresh != nil {
+		tfMap["incremental_refresh"] = flattenIncrementalRefresh(apiObject.IncrementalRefresh)
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenIncrementalRefresh(apiObject *quicksight.IncrementalRefresh) interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+	if apiObject.LookbackWindow != nil {
+		tfMap["lookback_window"] = flattenLookbackWindow(apiObject.LookbackWindow)
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenLookbackWindow(apiObject *quicksight.LookbackWindow) interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+	if apiObject.ColumnName != nil {
+		tfMap["column_name"] = aws.StringValue(apiObject.ColumnName)
+	}
+	if apiObject.Size != nil {
+		tfMap["size"] = aws.Int64Value(apiObject.Size)
+	}
+	if apiObject.SizeUnit != nil {
+		tfMap["size_unit"] = aws.StringValue(apiObject.SizeUnit)
 	}
 
 	return []interface{}{tfMap}

--- a/internal/service/quicksight/data_set_test.go
+++ b/internal/service/quicksight/data_set_test.go
@@ -3,6 +3,7 @@ package quicksight_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -349,6 +350,45 @@ func TestAccQuickSightDataSet_rowLevelPermissionTagConfiguration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "row_level_permission_tag_configuration.0.tag_rules.0.match_all_value", "*"),
 					resource.TestCheckResourceAttr(resourceName, "row_level_permission_tag_configuration.0.tag_rules.0.tag_multi_value_delimiter", ","),
 					resource.TestCheckResourceAttr(resourceName, "row_level_permission_tag_configuration.0.status", quicksight.StatusEnabled),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccQuickSightDataSet_refreshProperties(t *testing.T) {
+	ctx := acctest.Context(t)
+	if os.Getenv("QUICKSIGHT_ATHENA_TESTING_ENABLED") == "" {
+		t.Skip("Environment variable QUICKSIGHT_ATHENA_TESTING_ENABLED is not set")
+	}
+
+	var dataSet quicksight.DataSet
+	resourceName := "aws_quicksight_data_set.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, quicksight.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataSetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSetConfigRefreshProperties(rId, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSetExists(ctx, resourceName, &dataSet),
+					resource.TestCheckResourceAttr(resourceName, "refresh_properties.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "refresh_properties.0.refresh_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "refresh_properties.0.refresh_configuration.0.incremental_refresh.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "refresh_properties.0.refresh_configuration.0.incremental_refresh.0.lookback_window.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "refresh_properties.0.refresh_configuration.0.incremental_refresh.0.lookback_window.0.column_name", "column1"),
+					resource.TestCheckResourceAttr(resourceName, "refresh_properties.0.refresh_configuration.0.incremental_refresh.0.lookback_window.0.size", "1"),
+					resource.TestCheckResourceAttr(resourceName, "refresh_properties.0.refresh_configuration.0.incremental_refresh.0.lookback_window.0.size_unit", "DAY"),
 				),
 			},
 			{
@@ -839,6 +879,92 @@ resource "aws_quicksight_data_set" "test" {
       tag_key                   = "uniquetagkey"
       match_all_value           = "*"
       tag_multi_value_delimiter = ","
+    }
+  }
+}
+`, rId, rName))
+}
+
+func testAccDataSetConfigRefreshProperties(rId, rName string) string {
+	// NOTE: Must use Athena data source here as incremental refresh is not supported by S3
+	return acctest.ConfigCompose(
+		testAccBaseDataSourceConfig(rName),
+		fmt.Sprintf(`
+
+resource "aws_glue_catalog_database" "test" {
+  name = %[2]q
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name          = %[2]q
+  database_name = aws_glue_catalog_database.test.name
+  table_type    = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL       = "TRUE"
+    classification = "json"
+  }
+
+  storage_descriptor {
+    location      = "s3://${aws_s3_bucket.test.id}/data/"
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    ser_de_info {
+      name                  = "jsonserde"
+      serialization_library = "org.openx.data.jsonserde.JsonSerDe"
+      parameters = {
+        "serialization.format" = "1"
+      }
+    }
+    columns {
+      name = "column1"
+      type = "date"
+    }
+  }
+}
+
+resource "aws_quicksight_data_source" "test" {
+  data_source_id = %[1]q
+  name           = %[2]q
+  type           = "ATHENA"
+  parameters {
+    athena {
+      work_group = "primary"
+    }
+  }
+  ssl_properties {
+    disable_ssl = false
+  }
+}
+
+resource "aws_quicksight_data_set" "test" {
+  data_set_id = %[1]q
+  name        = %[2]q
+  import_mode = "SPICE"
+
+  physical_table_map {
+    physical_table_map_id = %[1]q
+    relational_table {
+      data_source_arn = aws_quicksight_data_source.test.arn
+      catalog         = "AwsDataCatalog"
+      schema          = aws_glue_catalog_database.test.name
+      name            = aws_glue_catalog_table.test.name
+      input_columns {
+        name = "column1"
+        type = "DATETIME"
+      }
+    }
+  }
+  refresh_properties {
+    refresh_configuration {
+      incremental_refresh {
+        lookback_window {
+          column_name = "column1"
+          size        = 1
+          size_unit   = "DAY"
+        }
+      }
     }
   }
 }

--- a/internal/service/quicksight/data_set_test.go
+++ b/internal/service/quicksight/data_set_test.go
@@ -363,6 +363,12 @@ func TestAccQuickSightDataSet_rowLevelPermissionTagConfiguration(t *testing.T) {
 
 func TestAccQuickSightDataSet_refreshProperties(t *testing.T) {
 	ctx := acctest.Context(t)
+	// This test requires additional configuration of the QuickSight service role. Ensure
+	// the role has the AWS managed "AmazonS3ReadOnlyAccess" and "AWSQuicksightAthenaAccess"
+	// identity policies attached. The default LakeFormation data catalog settings may also
+	// need adjusted, depending on the current configuration.
+	//
+	// Ref: https://docs.aws.amazon.com/lake-formation/latest/dg/change-settings.html
 	if os.Getenv("QUICKSIGHT_ATHENA_TESTING_ENABLED") == "" {
 		t.Skip("Environment variable QUICKSIGHT_ATHENA_TESTING_ENABLED is not set")
 	}
@@ -890,7 +896,6 @@ func testAccDataSetConfigRefreshProperties(rId, rName string) string {
 	return acctest.ConfigCompose(
 		testAccBaseDataSourceConfig(rName),
 		fmt.Sprintf(`
-
 resource "aws_glue_catalog_database" "test" {
   name = %[2]q
 }

--- a/website/docs/r/quicksight_data_set.html.markdown
+++ b/website/docs/r/quicksight_data_set.html.markdown
@@ -180,6 +180,7 @@ The following arguments are optional:
 * `permissions` - (Optional) A set of resource permissions on the data source. Maximum of 64 items. See [permissions](#permissions).
 * `row_level_permission_data_set` - (Optional) The row-level security configuration for the data that you want to create. See [row_level_permission_data_set](#row_level_permission_data_set).
 * `row_level_permission_tag_configuration` - (Optional) The configuration of tags on a dataset to set row-level security. Row-level security tags are currently supported for anonymous embedding only. See [row_level_permission_tag_configuration](#row_level_permission_tag_configuration).
+* `refresh_properties` - (Optional) The refresh properties for the data set. **NOTE**: Only valid when `import_mode` is set to `SPICE`. See [refresh_properties](#refresh_properties).
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### physical_table_map
@@ -361,6 +362,24 @@ For a `physical_table_map` item to be valid, only one of `custom_sql`, `relation
 
 * `tag_rules` - (Required) A set of rules associated with row-level security, such as the tag names and columns that they are assigned to. See [tag_rules](#tag_rules).
 * `status` - (Optional) The status of row-level security tags. If enabled, the status is `ENABLED`. If disabled, the status is `DISABLED`.
+
+### refresh_properties
+
+* `refresh_configuration` - (Required) The refresh configuration for the data set. See [refresh_configuration](#refresh_configuration).
+
+### refresh_configuration
+
+* `incremental_refresh` - (Required) The incremental refresh for the data set. See [incremental_refresh](#incremental_refresh).
+
+### incremental_refresh
+
+* `lookback_window` - (Required) The lookback window setup for an incremental refresh configuration. See [lookback_window](#lookback_window).
+
+### lookback_window
+
+* `column_name` - (Required) The name of the lookback window column.
+* `size` - (Required) The lookback window column size.
+* `size_unit` - (Required) The size unit that is used for the lookback window column. Valid values for this structure are `HOUR`, `DAY`, and `WEEK`.
 
 ### tag_rules
 


### PR DESCRIPTION
### Description

This PR updates the existing `aws_quicksight_data_set` resource to allow configuration of [refresh properties](https://docs.aws.amazon.com/quicksight/latest/user/refreshing-imported-data.html#refresh-spice-data-incremental).

### Relations

Closes #30744
Relates To https://github.com/hashicorp/terraform-provider-aws/issues/10990

### Output from Acceptance Testing

```
make testacc PKG=quicksight TESTS=TestAccQuickSightDataSet_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightDataSet_'  -timeout 180m
=== RUN   TestAccQuickSightDataSet_basic
=== PAUSE TestAccQuickSightDataSet_basic
=== RUN   TestAccQuickSightDataSet_disappears
=== PAUSE TestAccQuickSightDataSet_disappears
=== RUN   TestAccQuickSightDataSet_columnGroups
=== PAUSE TestAccQuickSightDataSet_columnGroups
=== RUN   TestAccQuickSightDataSet_columnLevelPermissionRules
=== PAUSE TestAccQuickSightDataSet_columnLevelPermissionRules
=== RUN   TestAccQuickSightDataSet_dataSetUsageConfiguration
=== PAUSE TestAccQuickSightDataSet_dataSetUsageConfiguration
=== RUN   TestAccQuickSightDataSet_fieldFolders
=== PAUSE TestAccQuickSightDataSet_fieldFolders
=== RUN   TestAccQuickSightDataSet_logicalTableMap
=== PAUSE TestAccQuickSightDataSet_logicalTableMap
=== RUN   TestAccQuickSightDataSet_permissions
=== PAUSE TestAccQuickSightDataSet_permissions
=== RUN   TestAccQuickSightDataSet_rowLevelPermissionTagConfiguration
=== PAUSE TestAccQuickSightDataSet_rowLevelPermissionTagConfiguration
=== RUN   TestAccQuickSightDataSet_refreshProperties
=== PAUSE TestAccQuickSightDataSet_refreshProperties
=== RUN   TestAccQuickSightDataSet_tags
=== PAUSE TestAccQuickSightDataSet_tags
=== CONT  TestAccQuickSightDataSet_basic
=== CONT  TestAccQuickSightDataSet_logicalTableMap
=== CONT  TestAccQuickSightDataSet_columnLevelPermissionRules
=== CONT  TestAccQuickSightDataSet_refreshProperties
=== CONT  TestAccQuickSightDataSet_fieldFolders
=== CONT  TestAccQuickSightDataSet_permissions
=== CONT  TestAccQuickSightDataSet_dataSetUsageConfiguration
=== CONT  TestAccQuickSightDataSet_rowLevelPermissionTagConfiguration
=== CONT  TestAccQuickSightDataSet_columnGroups
=== CONT  TestAccQuickSightDataSet_disappears
=== CONT  TestAccQuickSightDataSet_tags
--- PASS: TestAccQuickSightDataSet_disappears (41.91s)
--- PASS: TestAccQuickSightDataSet_columnGroups (44.04s)
--- PASS: TestAccQuickSightDataSet_refreshProperties (46.34s)
--- PASS: TestAccQuickSightDataSet_basic (48.23s)
--- PASS: TestAccQuickSightDataSet_dataSetUsageConfiguration (50.21s)
--- PASS: TestAccQuickSightDataSet_logicalTableMap (50.74s)
--- PASS: TestAccQuickSightDataSet_rowLevelPermissionTagConfiguration (50.82s)
--- PASS: TestAccQuickSightDataSet_fieldFolders (51.19s)
--- PASS: TestAccQuickSightDataSet_columnLevelPermissionRules (51.63s)
--- PASS: TestAccQuickSightDataSet_tags (86.45s)
--- PASS: TestAccQuickSightDataSet_permissions (93.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/quicksight	93.087s

```

