### PR TITLE
Documentation Update For Issue #30791

### DIFF
--- a/website/docs/r/vpclattice_service_network_vpc_association.html.markdown
+++ b/website/docs/r/vpclattice_service_network_vpc_association.html.markdown
@@ -16,7 +16,7 @@ Terraform resource for managing an AWS VPC Lattice Service Network VPC Associati
 
 ```terraform
 resource "aws_vpclattice_service_network_vpc_association" "example" {
-  vpc_identifier             = aws_vpclattice_service.example.id
+  vpc_identifier             = aws_vpc.example.id
   service_network_identifier = aws_vpclattice_service_network.example.id
   security_group_ids         = [aws_security_group.example.id]
 }


### PR DESCRIPTION
### Description
Correction of 'vpc_identifier' attribute value in the 'Basic Usage' example block for aws_vpclattice_service_network_vpc_association Resource .

### Relations
N/A

### References
The value against vpc_identifier is wrongly specified as "aws_vpclattice_service.example.id" in
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpclattice_service_network_vpc_association "Example Usage" Resouce Block 

### Output from Acceptance Testing
N/A
