### PR TITLE
`skaff`: Add Plugin-Framework support

### DIFF
--- a/skaff/cmd/datasource.go
+++ b/skaff/cmd/datasource.go
@@ -9,7 +9,7 @@ var datasourceCmd = &cobra.Command{
 	Use:   "datasource",
 	Short: "Create scaffolding for a data source",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return datasource.Create(name, snakeName, !clearComments, force, !v1)
+		return datasource.Create(name, snakeName, !clearComments, force, !v1, pluginFramework)
 	},
 }
 
@@ -20,4 +20,5 @@ func init() {
 	datasourceCmd.Flags().StringVarP(&name, "name", "n", "", "name of the entity")
 	datasourceCmd.Flags().BoolVarP(&force, "force", "f", false, "force creation, overwriting existing files")
 	datasourceCmd.Flags().BoolVarP(&v1, "v1", "o", false, "generate for AWS Go SDK v1 (some existing services)")
+	datasourceCmd.Flags().BoolVarP(&pluginFramework, "plugin-framework", "p", false, "generate for Terraform Plugin-Framework")
 }

--- a/skaff/cmd/resource.go
+++ b/skaff/cmd/resource.go
@@ -6,18 +6,19 @@ import (
 )
 
 var (
-	snakeName     string
-	clearComments bool
-	name          string
-	force         bool
-	v1            bool
+	snakeName       string
+	clearComments   bool
+	name            string
+	force           bool
+	v1              bool
+	pluginFramework bool
 )
 
 var resourceCmd = &cobra.Command{
 	Use:   "resource",
 	Short: "Create scaffolding for a resource",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return resource.Create(name, snakeName, !clearComments, force, !v1)
+		return resource.Create(name, snakeName, !clearComments, force, !v1, pluginFramework)
 	},
 }
 
@@ -28,4 +29,5 @@ func init() {
 	resourceCmd.Flags().StringVarP(&name, "name", "n", "", "name of the entity")
 	resourceCmd.Flags().BoolVarP(&force, "force", "f", false, "force creation, overwriting existing files")
 	resourceCmd.Flags().BoolVarP(&v1, "v1", "o", false, "generate for AWS Go SDK v1 (some existing services)")
+	resourceCmd.Flags().BoolVarP(&pluginFramework, "plugin-framework", "p", false, "generate for Terraform Plugin-Framework")
 }

--- a/skaff/datasource/datasource.go
+++ b/skaff/datasource/datasource.go
@@ -18,6 +18,9 @@ import (
 //go:embed datasource.tmpl
 var datasourceTmpl string
 
+//go:embed datasourcefw.tmpl
+var datasourceFrameworkTmpl string
+
 //go:embed datasourcetest.tmpl
 var datasourceTestTmpl string
 
@@ -35,11 +38,12 @@ type TemplateData struct {
 	ServiceLower         string
 	AWSServiceName       string
 	AWSGoSDKV2           bool
+	PluginFramework      bool
 	HumanDataSourceName  string
 	ProviderResourceName string
 }
 
-func Create(dsName, snakeName string, comments, force, v2 bool) error {
+func Create(dsName, snakeName string, comments, force, v2, pluginFramework bool) error {
 	wd, err := os.Getwd() // os.Getenv("GOPACKAGE") not available since this is not run with go generate
 	if err != nil {
 		return fmt.Errorf("error reading working directory: %s", err)
@@ -87,12 +91,17 @@ func Create(dsName, snakeName string, comments, force, v2 bool) error {
 		ServiceLower:         strings.ToLower(s),
 		AWSServiceName:       sn,
 		AWSGoSDKV2:           v2,
+		PluginFramework:      pluginFramework,
 		HumanDataSourceName:  resource.HumanResName(dsName),
 		ProviderResourceName: resource.ProviderResourceName(servicePackage, snakeName),
 	}
 
+	tmpl := datasourceTmpl
+	if pluginFramework {
+		tmpl = datasourceFrameworkTmpl
+	}
 	f := fmt.Sprintf("%s_data_source.go", snakeName)
-	if err = writeTemplate("newds", f, datasourceTmpl, force, templateData); err != nil {
+	if err = writeTemplate("newds", f, tmpl, force, templateData); err != nil {
 		return fmt.Errorf("writing datasource template: %w", err)
 	}
 

--- a/skaff/datasource/datasourcefw.tmpl
+++ b/skaff/datasource/datasourcefw.tmpl
@@ -1,0 +1,251 @@
+package {{ .ServicePackage }}
+
+{{- if .IncludeComments }}
+// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
+//
+// TIP: ==== INTRODUCTION ====
+// Thank you for trying the skaff tool!
+//
+// You have opted to include these helpful comments. They all include "TIP:"
+// to help you find and remove them when you're done with them.
+//
+// While some aspects of this file are customized to your input, the
+// scaffold tool does *not* look at the AWS API and ensure it has correct
+// function, structure, and variable names. It makes guesses based on
+// commonalities. You will need to make significant adjustments.
+//
+// In other words, as generated, this is a rough outline of the work you will
+// need to do. If something doesn't make sense for your situation, get rid of
+// it.{{- end }}
+
+import (
+{{- if .IncludeComments }}
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+{{- end }}
+{{- if and .IncludeComments .AWSGoSDKV2 }}
+	//
+	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
+	// using the services/{{ .ServicePackage }}/types package. If so, you'll
+	// need to import types and reference the nested types, e.g., as
+	// awstypes.<Type Name>.
+{{- end }}
+	"context"
+{{ if .AWSGoSDKV2 }}
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/{{ .ServicePackage }}"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/{{ .ServicePackage }}/types"
+{{- else }}
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/{{ .ServicePackage }}"
+{{- end }}
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+{{ if .IncludeComments }}
+// TIP: ==== FILE STRUCTURE ====
+// All data sources should follow this basic outline. Improve this data source's
+// maintainability by sticking to it.
+//
+// 1. Package declaration
+// 2. Imports
+// 3. Main data source struct with schema method
+// 4. Read method
+// 5. Other functions (flatteners, expanders, waiters, finders, etc.)
+{{- end }}
+
+// Function annotations are used for datasource registration to the Provider. DO NOT EDIT.
+// @FrameworkDataSource(name="{{ .HumanDataSourceName }}")
+func newDataSource{{ .DataSource }}(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSource{{ .DataSource }}{}, nil
+}
+
+const (
+	DSName{{ .DataSource }} = "{{ .HumanDataSourceName }} Data Source"
+)
+
+type dataSource{{ .DataSource }} struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSource{{ .DataSource }}) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
+	resp.TypeName = "aws_{{ .ServicePackage }}_{{ .DataSourceSnake }}"
+}
+{{ if .IncludeComments }}
+// TIP: ==== SCHEMA ====
+// In the schema, add each of the arguments and attributes in snake
+// case (e.g., delete_automated_backups).
+// * Alphabetize arguments to make them easier to find.
+// * Do not add a blank line between arguments/attributes.
+//
+// Users can configure argument values while attribute values cannot be
+// configured and are used as output. Arguments have either:
+// Required: true,
+// Optional: true,
+//
+// All attributes will be computed and some arguments. If users will
+// want to read updated information or detect drift for an argument,
+// it should be computed:
+// Computed: true,
+//
+// You will typically find arguments in the input struct
+// (e.g., CreateDBInstanceInput) for the create operation. Sometimes
+// they are only in the input struct (e.g., ModifyDBInstanceInput) for
+// the modify operation.
+//
+// For more about schema options, visit
+// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/schemas?page=schemas
+{{- end }}
+func (d *dataSource{{ .DataSource }}) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"arn": framework.ARNAttributeComputedOnly(),
+			"description": schema.StringAttribute{
+				Computed: true,
+			},
+			"id": framework.IDAttribute(),
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			names.AttrTags: tftags.TagsAttribute(),
+			"type": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"complex_argument": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						{{- if .IncludeComments }}
+						// TIP: Attributes that are required on a corresponding resource will be 
+						// computed on the data source (unless required as part of the search criteria).
+						{{- end }}
+						"nested_required": schema.StringAttribute{
+							Computed: true,
+						},
+						"nested_computed": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+{{- if .IncludeComments }}
+// TIP: ==== ASSIGN CRUD METHODS ====
+// Data sources only have a read method.
+{{- end }}
+func (d *dataSource{{ .DataSource }}) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	{{- if .IncludeComments }}
+	// TIP: ==== DATA SOURCE READ ====
+	// Generally, the Read function should do the following things. Make
+	// sure there is a good reason if you don't do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Fetch the config
+	// 3. Get information about a resource from AWS
+	// 4. Set the ID, arguments, and attributes
+	// 5. Set the tags
+	// 6. Set the state
+	{{- end }}
+
+	{{- if .IncludeComments }}
+	// TIP: -- 1. Get a client connection to the relevant service
+	{{- end }}
+	conn := d.Meta().{{ .Service }}{{ if .AWSGoSDKV2 }}Client(){{ else }}Conn(){{ end }}
+	{{ if .IncludeComments }}
+	// TIP: -- 2. Fetch the config
+	{{- end }}
+	var data dataSource{{ .DataSource }}Data
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	{{ if .IncludeComments }}
+	// TIP: -- 3. Get information about a resource from AWS
+	{{- end }}
+	out, err := find{{ .DataSource }}ByName(ctx, conn, data.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.{{ .Service }}, create.ErrActionReading, DSName{{ .DataSource }}, data.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	{{ if .IncludeComments }}
+	// TIP: -- 4. Set the ID, arguments, and attributes
+	//
+	// For simple data types (i.e., schema.StringAttribute, schema.BoolAttribute,
+	// schema.Int64Attribute, and schema.Float64Attribue), simply setting the  
+	// appropriate data struct field is sufficient. The flex package implements
+	// helpers for converting between Go and Plugin-Framework types seamlessly. No 
+	// error or nil checking is necessary.
+	//
+	// However, there are some situations where more handling is needed such as
+	// complex data types (e.g., schema.ListAttribute, schema.SetAttribute). In 
+	// these cases the flatten function may have a diagnostics return value, which
+	// should be appended to resp.Diagnostics.
+	{{- end }}
+	data.ARN = flex.StringToFramework(ctx, out.Arn)
+	data.ID = flex.StringToFramework(ctx, out.{{ .DataSource }}Id)
+	data.Name = flex.StringToFramework(ctx, out.{{ .DataSource }}Name)
+	data.Type = flex.StringToFramework(ctx, out.{{ .DataSource }}Type)
+	{{ if .IncludeComments }}
+	// TIP: Setting a complex type.
+	{{- end }}
+	complexArgument, diag := flattenComplexArgument(ctx, out.ComplexArgument)
+	resp.Diagnostics.Append(diag...)
+	data.ComplexArgument = complexArgument
+	{{ if .IncludeComments }}
+	// TIP: -- 5. Set the tags
+	{{- end }}
+	ignoreTagsConfig := d.Meta().IgnoreTagsConfig
+	tags := KeyValueTags(ctx, out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+	data.Tags = flex.FlattenFrameworkStringValueMapLegacy(ctx, tags.Map())
+	{{ if .IncludeComments }}
+	// TIP: -- 6. Set the state
+	{{- end }}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+{{ if .IncludeComments }}
+// TIP: ==== DATA STRUCTURES ====
+// With Terraform Plugin-Framework configurations are deserialized into
+// Go types, providing type safety without the need for type assertions.
+// These structs should match the schema definition exactly, and the `tfsdk`
+// tag value should match the attribute name. 
+//
+// Nested objects are represented in their own data struct. These will 
+// also have a corresponding attribute type mapping for use inside flex
+// functions.
+//
+// See more:
+// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/accessing-values
+{{- end }}
+type dataSource{{ .DataSource }}Data struct {
+	ARN             types.String   `tfsdk:"arn"`
+	ComplexArgument types.List     `tfsdk:"complex_argument"`
+	Description     types.String   `tfsdk:"description"`
+	ID              types.String   `tfsdk:"id"`
+	Name            types.String   `tfsdk:"name"`
+	Tags            types.Map      `tfsdk:"tags"`
+	Type            types.String   `tfsdk:"type"`
+}
+
+type complexArgumentData struct {
+	NestedRequired types.String `tfsdk:"nested_required"`
+	NestedOptional types.String `tfsdk:"nested_optional"`
+}

--- a/skaff/resource/resource.go
+++ b/skaff/resource/resource.go
@@ -18,6 +18,9 @@ import (
 //go:embed resource.tmpl
 var resourceTmpl string
 
+//go:embed resourcefw.tmpl
+var resourceFrameworkTmpl string
+
 //go:embed resourcetest.tmpl
 var resourceTestTmpl string
 
@@ -35,6 +38,7 @@ type TemplateData struct {
 	ServiceLower         string
 	AWSServiceName       string
 	AWSGoSDKV2           bool
+	PluginFramework      bool
 	HumanResourceName    string
 	ProviderResourceName string
 }
@@ -63,7 +67,7 @@ func ProviderResourceName(servicePackage, snakeName string) string {
 	return fmt.Sprintf("aws_%s_%s", servicePackage, snakeName)
 }
 
-func Create(resName, snakeName string, comments, force, v2 bool) error {
+func Create(resName, snakeName string, comments, force, v2, pluginFramework bool) error {
 	wd, err := os.Getwd() // os.Getenv("GOPACKAGE") not available since this is not run with go generate
 	if err != nil {
 		return fmt.Errorf("error reading working directory: %s", err)
@@ -111,12 +115,17 @@ func Create(resName, snakeName string, comments, force, v2 bool) error {
 		ServiceLower:         strings.ToLower(s),
 		AWSServiceName:       sn,
 		AWSGoSDKV2:           v2,
+		PluginFramework:      pluginFramework,
 		HumanResourceName:    HumanResName(resName),
 		ProviderResourceName: ProviderResourceName(servicePackage, snakeName),
 	}
 
+	tmpl := resourceTmpl
+	if pluginFramework {
+		tmpl = resourceFrameworkTmpl
+	}
 	f := fmt.Sprintf("%s.go", snakeName)
-	if err = writeTemplate("newres", f, resourceTmpl, force, templateData); err != nil {
+	if err = writeTemplate("newres", f, tmpl, force, templateData); err != nil {
 		return fmt.Errorf("writing resource template: %w", err)
 	}
 

--- a/skaff/resource/resourcefw.tmpl
+++ b/skaff/resource/resourcefw.tmpl
@@ -1,0 +1,971 @@
+package {{ .ServicePackage }}
+
+{{- if .IncludeComments }}
+// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
+//
+// TIP: ==== INTRODUCTION ====
+// Thank you for trying the skaff tool!
+//
+// You have opted to include these helpful comments. They all include "TIP:"
+// to help you find and remove them when you're done with them.
+//
+// While some aspects of this file are customized to your input, the
+// scaffold tool does *not* look at the AWS API and ensure it has correct
+// function, structure, and variable names. It makes guesses based on
+// commonalities. You will need to make significant adjustments.
+//
+// In other words, as generated, this is a rough outline of the work you will
+// need to do. If something doesn't make sense for your situation, get rid of
+// it.{{- end }}
+
+import (
+{{- if .IncludeComments }}
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+{{- end }}
+{{- if and .IncludeComments .AWSGoSDKV2 }}
+	//
+	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
+	// using the services/{{ .ServicePackage }}/types package. If so, you'll
+	// need to import types and reference the nested types, e.g., as
+	// awstypes.<Type Name>.
+{{- end }}
+	"context"
+	"errors"
+	"time"
+{{ if .AWSGoSDKV2 }}
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/{{ .ServicePackage }}"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/{{ .ServicePackage }}/types"
+{{- else }}
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/{{ .ServicePackage }}"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+{{- end }}
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+{{- if .IncludeComments }}
+// TIP: ==== FILE STRUCTURE ====
+// All resources should follow this basic outline. Improve this resource's
+// maintainability by sticking to it.
+//
+// 1. Package declaration
+// 2. Imports
+// 3. Main resource struct with schema method
+// 4. Create, read, update, delete methods (in that order)
+// 5. Other functions (flatteners, expanders, waiters, finders, etc.)
+{{- end }}
+
+// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
+// @FrameworkResource(name="{{ .HumanResourceName }}")
+// @Tags(identifierAttribute="arn")
+func newResource{{ .Resource }}(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resource{{ .Resource }}{}
+	{{ if .IncludeComments }}
+	// TIP: ==== CONFIGURABLE TIMEOUTS ====
+	// Users can configure timeout lengths but you need to use the times they
+	// provide. Access the timeout they configure (or the defaults) using,
+	// e.g., r.CreateTimeout(ctx, plan.Timeouts) (see below). The times here are
+	// the defaults if they don't configure timeouts.
+	{{- end }}
+	r.SetDefaultCreateTimeout(30 * time.Minute)
+	r.SetDefaultUpdateTimeout(30 * time.Minute)
+	r.SetDefaultDeleteTimeout(30 * time.Minute)
+
+	return r, nil
+}
+
+const (
+	ResName{{ .Resource }} = "{{ .HumanResourceName }}"
+)
+
+type resource{{ .Resource }} struct {
+	framework.ResourceWithConfigure
+	framework.WithTimeouts
+}
+
+func (r *resource{{ .Resource }}) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_{{ .ServicePackage }}_{{ .ResourceSnake }}"
+}
+{{ if .IncludeComments }}
+// TIP: ==== SCHEMA ====
+// In the schema, add each of the attributes in snake case (e.g.,
+// delete_automated_backups).
+//
+// Formatting rules:
+// * Alphabetize attributes to make them easier to find.
+// * Do not add a blank line between attributes.
+//
+// Attribute basics:
+// * If a user can provide a value ("configure a value") for an
+//   attribute (e.g., instances = 5), we call the attribute an
+//   "argument."
+// * You change the way users interact with attributes using:
+//     - Required
+//     - Optional
+//     - Computed
+// * There are only four valid combinations:
+//
+// 1. Required only - the user must provide a value
+// Required: true,
+//
+// 2. Optional only - the user can configure or omit a value; do not
+//    use Default or DefaultFunc
+// Optional: true,
+//
+// 3. Computed only - the provider can provide a value but the user
+//    cannot, i.e., read-only
+// Computed: true,
+//
+// 4. Optional AND Computed - the provider or user can provide a value;
+//    use this combination if you are using Default
+// Optional: true,
+// Computed: true,
+//
+// You will typically find arguments in the input struct
+// (e.g., CreateDBInstanceInput) for the create operation. Sometimes
+// they are only in the input struct (e.g., ModifyDBInstanceInput) for
+// the modify operation.
+//
+// For more about schema options, visit
+// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/schemas?page=schemas
+{{- end }}
+func (r *resource{{ .Resource }}) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"arn": framework.ARNAttributeComputedOnly(),
+			"description": schema.StringAttribute{
+				Optional: true,
+			},
+			"id": framework.IDAttribute(),
+			"name": schema.StringAttribute{
+				Required: true,
+				{{- if .IncludeComments }}
+				// TIP: ==== PLAN MODIFIERS ====
+				// Plan modifiers were introduced with Plugin-Framework to provide a mechanism
+				// for adjusting planned changes prior to apply. The planmodifier subpackage
+				// provides built-in modifiers for many common use cases such as 
+				// requiring replacement on a value change ("ForceNew: true" in Plugin-SDK 
+				// resources).
+				//
+				// See more:
+				// https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification
+				{{- end }}
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			names.AttrTags:    tftags.TagsAttribute(),
+			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+			"type": schema.StringAttribute{
+				Required: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"complex_argument": schema.ListNestedBlock{
+				{{- if .IncludeComments }}
+				// TIP: ==== LIST VALIDATORS ====
+				// List and set validators take the place of MaxItems and MinItems in 
+				// Plugin-Framework based resources. Use listvalidator.SizeAtLeast(1) to
+				// make a nested object required. Similar to Plugin-SDK, complex objects 
+				// can be represented as lists or sets with listvalidator.SizeAtMost(1).
+				//
+				// For a complete mapping of Plugin-SDK to Plugin-Framework schema fields, 
+				// see:
+				// https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-blocks/blocks
+				{{- end }}
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"nested_required": schema.StringAttribute{
+							Required: true,
+						},
+						"nested_computed": schema.StringAttribute{
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+					},
+				},
+			},
+			"timeouts": timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+func (r *resource{{ .Resource }}) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	{{- if .IncludeComments }}
+	// TIP: ==== RESOURCE CREATE ====
+	// Generally, the Create function should do the following things. Make
+	// sure there is a good reason if you don't do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Fetch the plan
+	// 3. Populate a create input structure
+	// 4. Call the AWS create/put function
+	// 5. Using the output from the create function, set the minimum arguments
+	//    and attributes for the Read function to work, as well as any computed
+	//    only attributes. 
+	// 6. Use a waiter to wait for create to complete
+	// 7. Save the request plan to response state
+	{{- end }}
+	{{- if .IncludeComments }}
+
+	// TIP: -- 1. Get a client connection to the relevant service
+	{{- end }}
+	conn := r.Meta().{{ .Service }}{{ if .AWSGoSDKV2 }}Client(){{ else }}Conn(){{ end }}
+	{{ if .IncludeComments }}
+	// TIP: -- 2. Fetch the plan
+	{{- end }}
+	var plan resource{{ .Resource }}Data
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	{{ if .IncludeComments }}
+	// TIP: -- 3. Populate a create input structure
+	{{- end }}
+	in := &{{ .ServicePackage }}.Create{{ .Resource }}Input{
+		{{- if .IncludeComments }}
+		// TIP: Mandatory or fields that will always be present can be set when
+		// you create the Input structure. (Replace these with real fields.)
+		{{- end }}
+		{{ .Resource }}Name: aws.String(plan.Name.ValueString()),
+		{{ .Resource }}Type: aws.String(plan.Type.ValueString()),
+	}
+
+	if !plan.Description.IsNull() {
+		{{- if .IncludeComments }}
+		// TIP: Optional fields should be set based on whether or not they are
+		// used.
+		{{- end }}
+		in.Description = aws.String(plan.Description.ValueString())
+	}
+	if !plan.ComplexArgument.IsNull() {
+		{{- if .IncludeComments }}
+		// TIP: Use an expander to assign a complex argument. The elements must be
+		// deserialized into the appropriate struct before being passed to the expander.
+		{{- end }}
+		var tfList []complexArgumentData
+		resp.Diagnostics.Append(plan.ComplexArgument.ElementsAs(ctx, &tfList, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		in.ComplexArgument = expandComplexArgument(tfList)
+	}
+	{{ if .IncludeComments }}
+	// TIP: -- 4. Call the AWS create function
+	{{- end }}
+	{{- if .AWSGoSDKV2 }}
+	out, err := conn.Create{{ .Resource }}(ctx, in)
+	{{- else }}
+	out, err := conn.Create{{ .Resource }}WithContext(ctx, in)
+	{{- end }}
+	if err != nil {
+		{{- if .IncludeComments }}
+		// TIP: Since ID has not been set yet, you cannot use plan.ID.String()
+		// in error messages at this point.
+		{{- end }}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.{{ .Service }}, create.ErrActionCreating, ResName{{ .Resource }}, plan.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil || out.{{ .Resource }} == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.{{ .Service }}, create.ErrActionCreating, ResName{{ .Resource }}, plan.Name.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+	{{ if .IncludeComments }}
+	// TIP: -- 5. Using the output from the create function, set the minimum attributes
+	{{- end }}
+	plan.ARN = flex.StringToFramework(ctx, out.{{ .Resource }}.Arn)
+	plan.ID = flex.StringToFramework(ctx, out.{{ .Resource }}.{{ .Resource }}Id)
+	{{ if .IncludeComments }}
+	// TIP: -- 6. Use a waiter to wait for create to complete
+	{{- end }}
+	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
+	_, err = wait{{ .Resource }}Created(ctx, conn, plan.ID.ValueString(), createTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.{{ .Service }}, create.ErrActionWaitingForCreation, ResName{{ .Resource }}, plan.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	{{ if .IncludeComments }}
+	// TIP: -- 7. Save the request plan to response state
+	{{- end }}
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resource{{ .Resource }}) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	{{- if .IncludeComments }}
+	// TIP: ==== RESOURCE READ ====
+	// Generally, the Read function should do the following things. Make
+	// sure there is a good reason if you don't do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Fetch the state
+	// 3. Get the resource from AWS
+	// 4. Remove resource from state if it is not found
+	// 5. Set the arguments and attributes
+	// 6. Set the state
+	{{- end }}
+	{{- if .IncludeComments }}
+
+	// TIP: -- 1. Get a client connection to the relevant service
+	{{- end }}
+	conn := r.Meta().{{ .Service }}{{ if .AWSGoSDKV2 }}Client(){{ else }}Conn(){{ end }}
+	{{ if .IncludeComments }}
+	// TIP: -- 2. Fetch the state
+	{{- end }}
+	var state resource{{ .Resource }}Data
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	{{ if .IncludeComments }}
+	// TIP: -- 3. Get the resource from AWS using an API Get, List, or Describe-
+	// type function, or, better yet, using a finder.
+	{{- end }}
+	out, err := find{{ .Resource }}ByID(ctx, conn, state.ID.ValueString())
+	{{- if .IncludeComments }}
+	// TIP: -- 4. Remove resource from state if it is not found
+	{{- end }}
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.{{ .Service }}, create.ErrActionSetting, ResName{{ .Resource }}, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	{{ if .IncludeComments }}
+	// TIP: -- 5. Set the arguments and attributes
+	//
+	// For simple data types (i.e., schema.StringAttribute, schema.BoolAttribute,
+	// schema.Int64Attribute, and schema.Float64Attribue), simply setting the  
+	// appropriate data struct field is sufficient. The flex package implements
+	// helpers for converting between Go and Plugin-Framework types seamlessly. No 
+	// error or nil checking is necessary.
+	//
+	// However, there are some situations where more handling is needed such as
+	// complex data types (e.g., schema.ListAttribute, schema.SetAttribute). In 
+	// these cases the flatten function may have a diagnostics return value, which
+	// should be appended to resp.Diagnostics.
+	{{- end }}
+	state.ARN = flex.StringToFramework(ctx, out.Arn)
+	state.ID = flex.StringToFramework(ctx, out.{{ .Resource }}Id)
+	state.Name = flex.StringToFramework(ctx, out.{{ .Resource }}Name)
+	state.Type = flex.StringToFramework(ctx, out.{{ .Resource }}Type)
+	{{ if .IncludeComments }}
+	// TIP: Setting a complex type.
+	{{- end }}
+	complexArgument, d := flattenComplexArgument(ctx, out.ComplexArgument)
+	resp.Diagnostics.Append(d...)
+	state.ComplexArgument = complexArgument
+	{{ if .IncludeComments }}
+	// TIP: -- 6. Set the state
+	{{- end }}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resource{{ .Resource }}) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	{{- if .IncludeComments }}
+	// TIP: ==== RESOURCE UPDATE ====
+	// Not all resources have Update functions. There are a few reasons:
+	// a. The AWS API does not support changing a resource
+	// b. All arguments have RequiresReplace() plan modifiers
+	// c. The AWS API uses a create call to modify an existing resource
+	//
+	// In the cases of a. and b., the resource will not have an update method
+	// defined. In the case of c., Update and Create can be refactored to call
+	// the same underlying function.
+	//
+	// The rest of the time, there should be an Update function and it should
+	// do the following things. Make sure there is a good reason if you don't
+	// do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Fetch the plan and state
+	// 3. Populate a modify input structure and check for changes
+	// 4. Call the AWS modify/update function
+	// 5. Use a waiter to wait for update to complete
+	// 6. Save the request plan to response state
+	{{- end }}
+
+	{{- if .IncludeComments }}
+	// TIP: -- 1. Get a client connection to the relevant service
+	{{- end }}
+	conn := r.Meta().{{ .Service }}{{ if .AWSGoSDKV2 }}Client(){{ else }}Conn(){{ end }}
+	{{ if .IncludeComments }}
+	// TIP: -- 2. Fetch the plan
+	{{- end }}
+	var plan, state resource{{ .Resource }}Data
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	{{ if .IncludeComments }}
+	// TIP: -- 3. Populate a modify input structure and check for changes
+	{{- end }}
+	if !plan.Name.Equal(state.Name) ||
+		!plan.Description.Equal(state.Description) ||
+		!plan.ComplexArgument.Equal(state.ComplexArgument) ||
+		!plan.Type.Equal(state.Type) {
+
+		in := &{{ .ServicePackage }}.Update{{ .Resource }}Input{
+			{{- if .IncludeComments }}
+			// TIP: Mandatory or fields that will always be present can be set when
+			// you create the Input structure. (Replace these with real fields.)
+			{{- end }}
+			{{ .Resource }}Id:   aws.String(plan.ID.ValueString()),
+			{{ .Resource }}Name: aws.String(plan.Name.ValueString()),
+			{{ .Resource }}Type: aws.String(plan.Type.ValueString()),
+		}
+
+		if !plan.Description.IsNull() {
+			{{- if .IncludeComments }}
+			// TIP: Optional fields should be set based on whether or not they are
+			// used.
+			{{- end }}
+			in.Description = aws.String(plan.Description.ValueString())
+		}
+		if !plan.ComplexArgument.IsNull() {
+			{{- if .IncludeComments }}
+			// TIP: Use an expander to assign a complex argument. The elements must be
+			// deserialized into the appropriate struct before being passed to the expander.
+			{{- end }}
+			var tfList []complexArgumentData
+			resp.Diagnostics.Append(plan.ComplexArgument.ElementsAs(ctx, &tfList, false)...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			in.ComplexArgument = expandComplexArgument(tfList)
+		}
+		{{ if .IncludeComments }}
+		// TIP: -- 4. Call the AWS modify/update function
+		{{- end }}
+		{{- if .AWSGoSDKV2 }}
+		out, err := conn.Update{{ .Resource }}(ctx, in)
+		{{- else }}
+		out, err := conn.Update{{ .Resource }}WithContext(ctx, in)
+		{{- end }}
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.{{ .Service }}, create.ErrActionUpdating, ResName{{ .Resource }}, plan.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		if out == nil || out.{{ .Resource }} == nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.{{ .Service }}, create.ErrActionUpdating, ResName{{ .Resource }}, plan.ID.String(), nil),
+				errors.New("empty output").Error(),
+			)
+			return
+		}
+		{{ if .IncludeComments }}
+		// TIP: Using the output from the update function, re-set any computed attributes
+		{{- end }}
+		plan.ARN = flex.StringToFramework(ctx, out.{{ .Resource }}.Arn)
+		plan.ID = flex.StringToFramework(ctx, out.{{ .Resource }}.{{ .Resource }}Id)
+	}
+
+	{{ if .IncludeComments }}
+	// TIP: -- 5. Use a waiter to wait for update to complete
+	{{- end }}
+	updateTimeout := r.UpdateTimeout(ctx, plan.Timeouts)
+	_, err := wait{{ .Resource }}Updated(ctx, conn, plan.ID.ValueString(), updateTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.{{ .Service }}, create.ErrActionWaitingForUpdate, ResName{{ .Resource }}, plan.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	{{ if .IncludeComments }}
+	// TIP: -- 6. Save the request plan to response state
+	{{- end }}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resource{{ .Resource }}) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	{{- if .IncludeComments }}
+	// TIP: ==== RESOURCE DELETE ====
+	// Most resources have Delete functions. There are rare situations
+	// where you might not need a delete:
+	// a. The AWS API does not provide a way to delete the resource
+	// b. The point of your resource is to perform an action (e.g., reboot a
+	//    server) and deleting serves no purpose.
+	//
+	// The Delete function should do the following things. Make sure there
+	// is a good reason if you don't do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Fetch the state
+	// 3. Populate a delete input structure
+	// 4. Call the AWS delete function
+	// 5. Use a waiter to wait for delete to complete
+	{{- end }}
+
+	{{- if .IncludeComments }}
+	// TIP: -- 1. Get a client connection to the relevant service
+	{{- end }}
+	conn := r.Meta().{{ .Service }}{{ if .AWSGoSDKV2 }}Client(){{ else }}Conn(){{ end }}
+	{{ if .IncludeComments }}
+	// TIP: -- 2. Fetch the state
+	{{- end }}
+	var state resource{{ .Resource }}Data
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	{{ if .IncludeComments }}
+	// TIP: -- 3. Populate a delete input structure
+	{{- end }}
+	in := &{{ .ServiceLower }}.Delete{{ .Resource }}Input{
+		{{ .Resource }}Id: aws.String(state.ID.ValueString()),
+	}
+	{{ if .IncludeComments }}
+	// TIP: -- 4. Call the AWS delete function
+	{{- end }}
+	{{- if .AWSGoSDKV2 }}
+	_, err := conn.Delete{{ .Resource }}(ctx, in)
+	{{- else }}
+	_, err := conn.Delete{{ .Resource }}WithContext(ctx, in)
+	{{- end }}
+	{{- if .IncludeComments }}
+	// TIP: On rare occassions, the API returns a not found error after deleting a
+	// resource. If that happens, we don't want it to show up as an error.
+	{{- end }}
+	if err != nil {
+		{{- if .AWSGoSDKV2 }}
+		var nfe *awstypes.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return
+		}
+		{{- else }}
+		if tfawserr.ErrCodeEquals(err, {{ .ServiceLower }}.ErrCodeResourceNotFoundException) {
+			return 
+		}
+		{{- end }}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.{{ .Service }}, create.ErrActionDeleting, ResName{{ .Resource }}, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	{{ if .IncludeComments }}
+	// TIP: -- 5. Use a waiter to wait for delete to complete
+	{{- end }}
+	deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
+	_, err = wait{{ .Resource }}Deleted(ctx, conn, state.ID.ValueString(), deleteTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.{{ .Service }}, create.ErrActionWaitingForDeletion, ResName{{ .Resource }}, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+{{ if .IncludeComments }}
+// TIP: ==== TERRAFORM IMPORTING ====
+// If Read can get all the information it needs from the Identifier
+// (i.e., path.Root("id")), you can use the PassthroughID importer. Otherwise,
+// you'll need a custom import function.
+//
+// See more:
+// https://developer.hashicorp.com/terraform/plugin/framework/resources/import
+{{- end }}
+func (r *resource{{ .Resource }}) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+{{ if .IncludeComments }}
+// TIP: ==== STATUS CONSTANTS ====
+// Create constants for states and statuses if the service does not
+// already have suitable constants. We prefer that you use the constants
+// provided in the service if available (e.g., amp.WorkspaceStatusCodeActive).
+{{- end }}
+const (
+	statusChangePending = "Pending"
+	statusDeleting      = "Deleting"
+	statusNormal        = "Normal"
+	statusUpdated       = "Updated"
+)
+{{ if .IncludeComments }}
+// TIP: ==== WAITERS ====
+// Some resources of some services have waiters provided by the AWS API.
+// Unless they do not work properly, use them rather than defining new ones
+// here.
+//
+// Sometimes we define the wait, status, and find functions in separate
+// files, wait.go, status.go, and find.go. Follow the pattern set out in the
+// service and define these where it makes the most sense.
+//
+// If these functions are used in the _test.go file, they will need to be
+// exported (i.e., capitalized).
+//
+// You will need to adjust the parameters and names to fit the service.
+{{- end }}
+{{- if .AWSGoSDKV2 }}
+func wait{{ .Resource }}Created(ctx context.Context, conn *{{ .ServiceLower }}.Client, id string, timeout time.Duration) (*{{ .ServiceLower }}.{{ .Resource }}, error) {
+{{- else }}
+func wait{{ .Resource }}Created(ctx context.Context, conn *{{ .ServiceLower }}.{{ .Service }}, id string, timeout time.Duration) (*{{ .ServiceLower }}.{{ .Resource }}, error) {
+{{- end }}
+	stateConf := &retry.StateChangeConf{
+		Pending:                   []string{},
+		Target:                    []string{statusNormal},
+		Refresh:                   status{{ .Resource }}(ctx, conn, id),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*{{ .ServiceLower }}.{{ .Resource }}); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+{{ if .IncludeComments }}
+// TIP: It is easier to determine whether a resource is updated for some
+// resources than others. The best case is a status flag that tells you when
+// the update has been fully realized. Other times, you can check to see if a
+// key resource argument is updated to a new value or not.
+{{- end }}
+{{- if .AWSGoSDKV2 }}
+func wait{{ .Resource }}Updated(ctx context.Context, conn *{{ .ServiceLower }}.Client, id string, timeout time.Duration) (*{{ .ServiceLower }}.{{ .Resource }}, error) {
+{{- else }}
+func wait{{ .Resource }}Updated(ctx context.Context, conn *{{ .ServiceLower }}.{{ .Service }}, id string, timeout time.Duration) (*{{ .ServiceLower }}.{{ .Resource }}, error) {
+{{- end }}
+	stateConf := &retry.StateChangeConf{
+		Pending:                   []string{statusChangePending},
+		Target:                    []string{statusUpdated},
+		Refresh:                   status{{ .Resource }}(ctx, conn, id),
+		Timeout:                   timeout,
+		NotFoundChecks:            20,
+		ContinuousTargetOccurence: 2,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*{{ .ServiceLower }}.{{ .Resource }}); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+{{ if .IncludeComments }}
+// TIP: A deleted waiter is almost like a backwards created waiter. There may
+// be additional pending states, however.
+{{- end }}
+{{- if .AWSGoSDKV2 }}
+func wait{{ .Resource }}Deleted(ctx context.Context, conn *{{ .ServiceLower }}.Client, id string, timeout time.Duration) (*{{ .ServiceLower }}.{{ .Resource }}, error) {
+{{- else }}
+func wait{{ .Resource }}Deleted(ctx context.Context, conn *{{ .ServiceLower }}.{{ .Service }}, id string, timeout time.Duration) (*{{ .ServiceLower }}.{{ .Resource }}, error) {
+{{- end }}
+	stateConf := &retry.StateChangeConf{
+		Pending:                   []string{statusDeleting, statusNormal},
+		Target:                    []string{},
+		Refresh:                   status{{ .Resource }}(ctx, conn, id),
+		Timeout:                   timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+	if out, ok := outputRaw.(*{{ .ServiceLower }}.{{ .Resource }}); ok {
+		return out, err
+	}
+
+	return nil, err
+}
+{{ if .IncludeComments }}
+// TIP: ==== STATUS ====
+// The status function can return an actual status when that field is
+// available from the API (e.g., out.Status). Otherwise, you can use custom
+// statuses to communicate the states of the resource.
+//
+// Waiters consume the values returned by status functions. Design status so
+// that it can be reused by a create, update, and delete waiter, if possible.
+{{- end }}
+{{- if .AWSGoSDKV2 }}
+func status{{ .Resource }}(ctx context.Context, conn *{{ .ServiceLower }}.Client, id string) retry.StateRefreshFunc {
+{{- else }}
+func status{{ .Resource }}(ctx context.Context, conn *{{ .ServiceLower }}.{{ .Service }}, id string) retry.StateRefreshFunc {
+{{- end }}
+	return func() (interface{}, string, error) {
+		out, err := find{{ .Resource }}ByID(ctx, conn, id)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+{{ if .AWSGoSDKV2 }}
+		return out, aws.ToString(out.Status), nil
+{{- else }}
+		return out, aws.StringValue(out.Status), nil
+{{- end }}
+	}
+}
+{{ if .IncludeComments }}
+// TIP: ==== FINDERS ====
+// The find function is not strictly necessary. You could do the API
+// request from the status function. However, we have found that find often
+// comes in handy in other places besides the status function. As a result, it
+// is good practice to define it separately.
+{{- end }}
+{{- if .AWSGoSDKV2 }}
+func find{{ .Resource }}ByID(ctx context.Context, conn *{{ .ServiceLower }}.Client, id string) (*{{ .ServiceLower }}.{{ .Resource }}, error) {
+{{- else }}
+func find{{ .Resource }}ByID(ctx context.Context, conn *{{ .ServiceLower }}.{{ .Service }}, id string) (*{{ .ServiceLower }}.{{ .Resource }}, error) {
+{{- end }}
+	in := &{{ .ServiceLower }}.Get{{ .Resource }}Input{
+		Id: aws.String(id),
+	}
+	{{ if .AWSGoSDKV2 }}
+	out, err := conn.Get{{ .Resource }}(ctx, in)
+	if err != nil {
+		var nfe *awstypes.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+	{{- else }}
+	out, err := conn.Get{{ .Resource }}WithContext(ctx, in)
+	if tfawserr.ErrCodeEquals(err, {{ .ServiceLower }}.ErrCodeResourceNotFoundException) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	{{- end }}
+
+	if out == nil || out.{{ .Resource }} == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out.{{ .Resource }}, nil
+}
+{{ if .IncludeComments }}
+// TIP: ==== FLEX ====
+// Flatteners and expanders ("flex" functions) help handle complex data
+// types. Flatteners take an API data type and return the equivalent Plugin-Framework 
+// type. In other words, flatteners translate from AWS -> Terraform.
+//
+// On the other hand, expanders take a Terraform data structure and return
+// something that you can send to the AWS API. In other words, expanders
+// translate from Terraform -> AWS.
+//
+// See more:
+// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/
+{{- end }}
+func flattenComplexArgument(ctx context.Context, apiObject *{{ .ServiceLower }}.ComplexArgument) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elemType := types.ObjectType{AttrTypes: complexArgumentAttrTypes}
+
+	if apiObject == nil {
+		return types.ListNull(elemType), diags
+	}
+
+	obj := map[string]attr.Value{
+		"nested_required": flex.StringValueToFramework(ctx, apiObject.NestedRequired),
+		"nested_optional": flex.StringValueToFramework(ctx, apiObject.NestedOptional),
+	}
+	objVal, d := types.ObjectValue(complexArgumentAttrTypes, obj)
+	diags.Append(d...)
+
+	listVal, d := types.ListValue(elemType, []attr.Value{objVal})
+	diags.Append(d...)
+
+	return listVal, diags
+}
+{{ if .IncludeComments }}
+// TIP: Often the AWS API will return a slice of structures in response to a
+// request for information. Sometimes you will have set criteria (e.g., the ID)
+// that means you'll get back a one-length slice. This plural function works
+// brilliantly for that situation too.
+{{- end }}
+func flattenComplexArguments(ctx context.Context, apiObjects []*{{ .ServiceLower }}.ComplexArgument) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	elemType := types.ObjectType{AttrTypes: complexArgumentAttrTypes}
+
+	if len(apiObjects) == 0 {
+		return types.ListNull(elemType), diags
+	}
+
+	elems := []attr.Value{}
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		obj := map[string]attr.Value{
+			"nested_required": flex.StringValueToFramework(ctx, apiObject.NestedRequired),
+			"nested_optional": flex.StringValueToFramework(ctx, apiObject.NestedOptional),
+		}
+		objVal, d := types.ObjectValue(complexArgumentAttrTypes, obj)
+		diags.Append(d...)
+
+		elems = append(elems, objVal)
+	}
+
+	listVal, d := types.ListValue(elemType, elems)
+	diags.Append(d...)
+
+	return listVal, diags
+}
+{{ if .IncludeComments }}
+// TIP: Remember, as mentioned above, expanders take a Terraform data structure
+// and return something that you can send to the AWS API. In other words,
+// expanders translate from Terraform -> AWS.
+//
+// See more:
+// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/
+{{- end }}
+func expandComplexArgument(tfList []complexArgumentData) *{{ .ServiceLower }}.ComplexArgument {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	tfObj := tfList[0]
+	apiObject := &{{ .ServiceLower }}.ComplexArgument{
+		NestedRequired: aws.String(tfObj.NestedRequired.ValueString()),
+	}
+	if !tfObj.NestedOptional.IsNull() {
+		apiObject.NestedOptional = aws.String(tfObj.NestedOptional.ValueString())
+	}
+
+	return apiObject
+}
+{{ if .IncludeComments }}
+// TIP: Even when you have a list with max length of 1, this plural function
+// works brilliantly. However, if the AWS API takes a structure rather than a
+// slice of structures, you will not need it.
+{{- end }}
+func expandComplexArguments(tfList []complexArgumentData) []*{{ .ServiceLower }}.ComplexArgument {
+	{{- if .IncludeComments }}
+	// TIP: The AWS API can be picky about whether you send a nil or zero-
+	// length for an argument that should be cleared. For example, in some
+	// cases, if you send a nil value, the AWS API interprets that as "make no
+	// changes" when what you want to say is "remove everything." Sometimes
+	// using a zero-length list will cause an error.
+	//
+	// As a result, here are two options. Usually, option 1, nil, will work as
+	// expected, clearing the field. But, test going from something to nothing
+	// to make sure it works. If not, try the second option.
+	{{- end }}
+	{{- if .IncludeComments }}
+	// TIP: Option 1: Returning nil for zero-length list
+	{{- end }}
+    if len(tfList) == 0 {
+        return nil
+    }
+
+    var apiObject []*{{ .ServiceLower }}.ComplexArgument
+	{{- if .IncludeComments }}
+	// TIP: Option 2: Return zero-length list for zero-length list. If option 1 does
+	// not work, after testing going from something to nothing (if that is
+	// possible), uncomment out the next line and remove option 1.
+	//
+	{{- end }}
+	// apiObject := make([]*{{ .ServiceLower }}.ComplexArgument, 0)
+
+	for _, tfObj := range tfList {
+		item := &{{ .ServiceLower }}.ComplexArgument{
+			NestedRequired: aws.String(tfObj.NestedRequired.ValueString()),
+		}
+		if !tfObj.NestedOptional.IsNull() {
+			item.NestedOptional = aws.String(tfObj.NestedOptional.ValueString())
+		}
+
+		apiObject = append(apiObject, item)
+	}
+
+	return apiObject
+}
+{{ if .IncludeComments }}
+// TIP: ==== DATA STRUCTURES ====
+// With Terraform Plugin-Framework configurations are deserialized into
+// Go types, providing type safety without the need for type assertions.
+// These structs should match the schema definition exactly, and the `tfsdk`
+// tag value should match the attribute name. 
+//
+// Nested objects are represented in their own data struct. These will 
+// also have a corresponding attribute type mapping for use inside flex
+// functions.
+//
+// See more:
+// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/accessing-values
+{{- end }}
+type resource{{ .Resource }}Data struct {
+	ARN             types.String   `tfsdk:"arn"`
+	ComplexArgument types.List     `tfsdk:"complex_argument"`
+	Description     types.String   `tfsdk:"description"`
+	ID              types.String   `tfsdk:"id"`
+	Name            types.String   `tfsdk:"name"`
+	Tags            types.Map      `tfsdk:"tags"`
+	TagsAll         types.Map      `tfsdk:"tags_all"`
+	Timeouts        timeouts.Value `tfsdk:"timeouts"`
+	Type            types.String   `tfsdk:"type"`
+}
+
+type complexArgumentData struct {
+	NestedRequired types.String `tfsdk:"nested_required"`
+	NestedOptional types.String `tfsdk:"nested_optional"`
+}
+
+var complexArgumentAttrTypes = map[string]attr.Type{
+	"nested_required": types.StringType,
+	"nested_optional": types.StringType,
+}

--- a/skaff/resource/resourcetest.tmpl
+++ b/skaff/resource/resourcetest.tmpl
@@ -246,7 +246,19 @@ func TestAcc{{ .Service }}{{ .Resource }}_disappears(t *testing.T) {
 				Config: testAcc{{ .Resource }}Config_basic(rName, testAcc{{ .Resource }}VersionNewer),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck{{ .Resource }}Exists(resourceName, &{{ .ResourceLower }}),
+					{{- if .PluginFramework }}
+					{{- if .IncludeComments }}
+					// TIP: The Plugin-Framework disappears helper is similar to the Plugin-SDK version,
+					// but expects a new resource factory function as the third argument. To expose this
+					// private function to the testing package, you may need to add a line like the following
+					// to exports_test.go:
+					//
+					//   var Resource{{ .Resource}} = newResource{{ .Resource }}
+					{{- end }}
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tf{{ .ServicePackage }}.Resource{{ .Resource }}, resourceName),
+					{{- else }}
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tf{{ .ServicePackage }}.Resource{{ .Resource }}(), resourceName),
+					{{- end }}
 				),
 				ExpectNonEmptyPlan: true,
 			},


### PR DESCRIPTION
### Description
This PR adds Plugin-Framework based templates to `skaff`. Initially this feature will be opt-in (ie. the `-p` or `--plugin-framework` flag must be provided). 

Create Plugin-Framework based resource:
```console
$ skaff resource -n Thing -p
```

Create Plugin-Framework based data source:
```console
$ skaff datasource -n Thing -p
```

`resource` Usage:
```console
$ skaff resource -h
Create scaffolding for a resource

Usage:
  skaff resource [flags]

Flags:
  -c, --clear-comments     do not include instructional comments in source
  -f, --force              force creation, overwriting existing files
  -h, --help               help for resource
  -n, --name string        name of the entity
  -p, --plugin-framework   generate for Terraform Plugin-Framework
  -s, --snakename string   if skaff doesn't get it right, explicitly give name in snake case (e.g., db_vpc_instance)
  -o, --v1                 generate for AWS Go SDK v1 (some existing services)
```

`datasource` Usage:
```console
$ skaff datasource -h
Create scaffolding for a data source

Usage:
  skaff datasource [flags]

Flags:
  -c, --clear-comments     do not include instructional comments in source
  -f, --force              force creation, overwriting existing files
  -h, --help               help for datasource
  -n, --name string        name of the entity
  -p, --plugin-framework   generate for Terraform Plugin-Framework
  -s, --snakename string   if skaff doesn't get it right, explicitly give name in snake case (e.g., db_vpc_instance)
  -o, --v1                 generate for AWS Go SDK v1 (some existing services)
```


### Relations
Closes #28887
