### PR TITLE
feat: Add insecure_value to datasource aws_ssm_parameter

### DIFF
--- a/internal/service/ssm/parameter_data_source.go
+++ b/internal/service/ssm/parameter_data_source.go
@@ -21,6 +21,10 @@ func DataSourceParameter() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"insecure_value": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -69,6 +73,7 @@ func dataParameterRead(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	d.SetId(aws.StringValue(param.Name))
 	d.Set("arn", param.ARN)
+	d.Set("insecure_value", param.Value)
 	d.Set("name", param.Name)
 	d.Set("type", param.Type)
 	d.Set("value", param.Value)

--- a/internal/service/ssm/parameter_data_source_test.go
+++ b/internal/service/ssm/parameter_data_source_test.go
@@ -24,6 +24,7 @@ func TestAccSSMParameterDataSource_basic(t *testing.T) {
 				Config: testAccParameterDataSourceConfig_basic(name, "false"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_ssm_parameter.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "insecure_value", "TestValue"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "type", "String"),
 					resource.TestCheckResourceAttr(resourceName, "value", "TestValue"),
@@ -35,6 +36,7 @@ func TestAccSSMParameterDataSource_basic(t *testing.T) {
 				Config: testAccParameterDataSourceConfig_basic(name, "true"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_ssm_parameter.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "insecure_value", "TestValue"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "type", "String"),
 					resource.TestCheckResourceAttr(resourceName, "value", "TestValue"),
@@ -59,6 +61,7 @@ func TestAccSSMParameterDataSource_fullPath(t *testing.T) {
 				Config: testAccParameterDataSourceConfig_basic(name, "false"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_ssm_parameter.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "insecure_value", "TestValue"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "type", "String"),
 					resource.TestCheckResourceAttr(resourceName, "value", "TestValue"),

--- a/website/docs/d/ssm_parameter.html.markdown
+++ b/website/docs/d/ssm_parameter.html.markdown
@@ -36,4 +36,5 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - Name of the parameter.
 * `type` - Type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
 * `value` - Value of the parameter. This value is always marked as sensitive in the Terraform plan output, regardless of `type`. In Terraform CLI version 0.15 and later, this may require additional configuration handling for certain scenarios. For more information, see the [Terraform v0.15 Upgrade Guide](https://www.terraform.io/upgrade-guides/0-15.html#sensitive-output-values).
+* `insecure_value` - Value of the parameter. **Use caution:** This value is never marked as sensitive.
 * `version` - Version of the parameter.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add `insecure_value` to datasource `aws_ssm_parameter`. The idea is to have the possibility to expose the value as insecure like in the resource `aws_ssm_parameter`.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Closes #26915

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccSSMParameterDataSource_basic PKG=ssm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMParameterDataSource_basic'  -timeout 180m
=== RUN   TestAccSSMParameterDataSource_basic
=== PAUSE TestAccSSMParameterDataSource_basic
=== CONT  TestAccSSMParameterDataSource_basic
--- PASS: TestAccSSMParameterDataSource_basic (107.81s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        122.663s
```

```
$ make testacc TESTS=TestAccSSMParameterDataSource_fullPath PKG=ssm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMParameterDataSource_fullPath'  -timeout 180m
=== RUN   TestAccSSMParameterDataSource_fullPath
=== PAUSE TestAccSSMParameterDataSource_fullPath
=== CONT  TestAccSSMParameterDataSource_fullPath
--- PASS: TestAccSSMParameterDataSource_fullPath (120.89s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        137.380s
```
