### PR TITLE
NetworkFirewall: Always specify current `EncryptionConfiguration` on Update

### DIFF
--- a/.changelog/30821.txt
+++ b/.changelog/30821.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_networkfirewall_firewall_policy: Fix unexpected `encryption_configuration.type` updates from `Customer_KMS` to `AWS_KMS`
+```
+
+```release-note:bug
+resource/aws_networkfirewall_rule_group: Fix unexpected `encryption_configuration.type` updates from `Customer_KMS` to `AWS_KMS`
+```

--- a/internal/service/networkfirewall/firewall_policy.go
+++ b/internal/service/networkfirewall/firewall_policy.go
@@ -220,17 +220,15 @@ func resourceFirewallPolicyUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	if d.HasChanges("description", "encryption_configuration", "firewall_policy") {
 		input := &networkfirewall.UpdateFirewallPolicyInput{
-			FirewallPolicy:    expandFirewallPolicy(d.Get("firewall_policy").([]interface{})),
-			FirewallPolicyArn: aws.String(d.Id()),
-			UpdateToken:       aws.String(d.Get("update_token").(string)),
+			EncryptionConfiguration: expandEncryptionConfiguration(d.Get("encryption_configuration").([]interface{})),
+			FirewallPolicy:          expandFirewallPolicy(d.Get("firewall_policy").([]interface{})),
+			FirewallPolicyArn:       aws.String(d.Id()),
+			UpdateToken:             aws.String(d.Get("update_token").(string)),
 		}
 
 		// Only pass non-empty description values, else API request returns an InternalServiceError
 		if v, ok := d.GetOk("description"); ok {
 			input.Description = aws.String(v.(string))
-		}
-		if d.HasChange("encryption_configuration") {
-			input.EncryptionConfiguration = expandEncryptionConfiguration(d.Get("encryption_configuration").([]interface{}))
 		}
 
 		_, err := conn.UpdateFirewallPolicyWithContext(ctx, input)

--- a/internal/service/networkfirewall/firewall_policy_test.go
+++ b/internal/service/networkfirewall/firewall_policy_test.go
@@ -65,11 +65,14 @@ func TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration(t *testing.T) 
 		CheckDestroy:             testAccCheckFirewallPolicyDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFirewallPolicyConfig_encryptionConfiguration(rName),
+				Config: testAccFirewallPolicyConfig_encryptionConfiguration(rName, "aws:pass"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFirewallPolicyExists(ctx, resourceName, &firewallPolicy),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.type", "CUSTOMER_KMS"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateless_default_actions.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "firewall_policy.0.stateless_default_actions.*", "aws:pass"),
 				),
 			},
 			{
@@ -85,11 +88,25 @@ func TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration(t *testing.T) 
 				),
 			},
 			{
-				Config: testAccFirewallPolicyConfig_encryptionConfiguration(rName),
+				Config: testAccFirewallPolicyConfig_encryptionConfiguration(rName, "aws:pass"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFirewallPolicyExists(ctx, resourceName, &firewallPolicy),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.type", "CUSTOMER_KMS"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateless_default_actions.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "firewall_policy.0.stateless_default_actions.*", "aws:pass"),
+				),
+			},
+			{
+				Config: testAccFirewallPolicyConfig_encryptionConfiguration(rName, "aws:forward_to_sfe"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFirewallPolicyExists(ctx, resourceName, &firewallPolicy),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.type", "CUSTOMER_KMS"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateless_default_actions.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "firewall_policy.0.stateless_default_actions.*", "aws:forward_to_sfe"),
 				),
 			},
 		},
@@ -1423,7 +1440,7 @@ resource "aws_networkfirewall_firewall_policy" "test" {
 `, rName))
 }
 
-func testAccFirewallPolicyConfig_encryptionConfiguration(rName string) string {
+func testAccFirewallPolicyConfig_encryptionConfiguration(rName, statelessDefaultActions string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {}
 
@@ -1437,10 +1454,10 @@ resource "aws_networkfirewall_firewall_policy" "test" {
 
   firewall_policy {
     stateless_fragment_default_actions = ["aws:drop"]
-    stateless_default_actions          = ["aws:pass"]
+    stateless_default_actions          = [%[2]q]
   }
 }
-`, rName)
+`, rName, statelessDefaultActions)
 }
 
 // The KMS key resource must stay in state while removing encryption configuration. If not

--- a/internal/service/networkfirewall/firewall_test.go
+++ b/internal/service/networkfirewall/firewall_test.go
@@ -209,7 +209,7 @@ func TestAccNetworkFirewallFirewall_encryptionConfiguration(t *testing.T) {
 		CheckDestroy:             testAccCheckFirewallDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFirewallConfig_encryptionConfiguration(rName),
+				Config: testAccFirewallConfig_encryptionConfiguration(rName, "description 1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFirewallExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
@@ -229,7 +229,15 @@ func TestAccNetworkFirewallFirewall_encryptionConfiguration(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccFirewallConfig_encryptionConfiguration(rName),
+				Config: testAccFirewallConfig_encryptionConfiguration(rName, "description 1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFirewallExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.type", "CUSTOMER_KMS"),
+				),
+			},
+			{
+				Config: testAccFirewallConfig_encryptionConfiguration(rName, "description 2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFirewallExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
@@ -624,7 +632,7 @@ resource "aws_networkfirewall_firewall" "test" {
 `, rName))
 }
 
-func testAccFirewallConfig_encryptionConfiguration(rName string) string {
+func testAccFirewallConfig_encryptionConfiguration(rName, description string) string {
 	return acctest.ConfigCompose(testAccFirewallConfig_base(rName), fmt.Sprintf(`
 resource "aws_kms_key" "test" {}
 
@@ -632,6 +640,7 @@ resource "aws_networkfirewall_firewall" "test" {
   name                = %[1]q
   firewall_policy_arn = aws_networkfirewall_firewall_policy.test.arn
   vpc_id              = aws_vpc.test.id
+  description         = %[2]q
 
   encryption_configuration {
     key_id = aws_kms_key.test.arn
@@ -642,7 +651,7 @@ resource "aws_networkfirewall_firewall" "test" {
     subnet_id = aws_subnet.test[0].id
   }
 }
-`, rName))
+`, rName, description))
 }
 
 func testAccFirewallConfig_dualstackSubnet(rName string) string {

--- a/internal/service/networkfirewall/rule_group.go
+++ b/internal/service/networkfirewall/rule_group.go
@@ -73,15 +73,6 @@ func ResourceRuleGroup() *schema.Resource {
 										Optional: true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
-												"key": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.All(
-														validation.StringLenBetween(1, 32),
-														validation.StringMatch(regexp.MustCompile(`^[A-Za-z]`), "must begin with alphabetic character"),
-														validation.StringMatch(regexp.MustCompile(`^[A-Za-z0-9_]+$`), "must contain only alphanumeric and underscore characters"),
-													),
-												},
 												"ip_set_reference": {
 													Type:     schema.TypeList,
 													Required: true,
@@ -94,6 +85,15 @@ func ResourceRuleGroup() *schema.Resource {
 															},
 														},
 													},
+												},
+												"key": {
+													Type:     schema.TypeString,
+													Required: true,
+													ValidateFunc: validation.All(
+														validation.StringLenBetween(1, 32),
+														validation.StringMatch(regexp.MustCompile(`^[A-Za-z]`), "must begin with alphabetic character"),
+														validation.StringMatch(regexp.MustCompile(`^[A-Za-z0-9_]+$`), "must contain only alphanumeric and underscore characters"),
+													),
 												},
 											},
 										},
@@ -533,17 +533,14 @@ func resourceRuleGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 
 	if d.HasChanges("description", "encryption_configuration", "rule_group", "rules", "type") {
 		input := &networkfirewall.UpdateRuleGroupInput{
-			RuleGroupArn: aws.String(d.Id()),
-			Type:         aws.String(d.Get("type").(string)),
-			UpdateToken:  aws.String(d.Get("update_token").(string)),
+			EncryptionConfiguration: expandEncryptionConfiguration(d.Get("encryption_configuration").([]interface{})),
+			RuleGroupArn:            aws.String(d.Id()),
+			Type:                    aws.String(d.Get("type").(string)),
+			UpdateToken:             aws.String(d.Get("update_token").(string)),
 		}
 
 		if v, ok := d.GetOk("description"); ok {
 			input.Description = aws.String(v.(string))
-		}
-
-		if d.HasChange("encryption_configuration") {
-			input.EncryptionConfiguration = expandEncryptionConfiguration(d.Get("encryption_configuration").([]interface{}))
 		}
 
 		// Network Firewall UpdateRuleGroup API method only allows one of Rules or RuleGroup


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes unexpected `encryption_configuration.type` updates from `Customer_KMS` to `AWS_KMS`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/30816.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccNetworkFirewallFirewallPolicy_\|TestAccNetworkFirewallRuleGroup_' PKG=networkfirewall ACCTEST_PARALLELISM=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkfirewall/... -v -count 1 -parallel 1  -run=TestAccNetworkFirewallFirewallPolicy_\|TestAccNetworkFirewallRuleGroup_ -timeout 180m
=== RUN   TestAccNetworkFirewallFirewallPolicy_basic
=== PAUSE TestAccNetworkFirewallFirewallPolicy_basic
=== RUN   TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration
=== PAUSE TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulDefaultActions
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulDefaultActions
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulEngineOption
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulEngineOption
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceManaged
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceManaged
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_multipleStatefulRuleGroupReferences
=== PAUSE TestAccNetworkFirewallFirewallPolicy_multipleStatefulRuleGroupReferences
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupPriorityReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupPriorityReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupOverrideActionReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupOverrideActionReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupPriorityReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupPriorityReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_statelessRuleGroupReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statelessRuleGroupReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatelessRuleGroupReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatelessRuleGroupReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_multipleStatelessRuleGroupReferences
=== PAUSE TestAccNetworkFirewallFirewallPolicy_multipleStatelessRuleGroupReferences
=== RUN   TestAccNetworkFirewallFirewallPolicy_statelessCustomAction
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statelessCustomAction
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatelessCustomAction
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatelessCustomAction
=== RUN   TestAccNetworkFirewallFirewallPolicy_multipleStatelessCustomActions
=== PAUSE TestAccNetworkFirewallFirewallPolicy_multipleStatelessCustomActions
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAction
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAction
=== RUN   TestAccNetworkFirewallFirewallPolicy_tags
=== PAUSE TestAccNetworkFirewallFirewallPolicy_tags
=== RUN   TestAccNetworkFirewallFirewallPolicy_disappears
=== PAUSE TestAccNetworkFirewallFirewallPolicy_disappears
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_rulesSourceList
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_rulesSourceList
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_referenceSets
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_referenceSets
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_updateReferenceSets
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_updateReferenceSets
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_statefulRule
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_statefulRule
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_statelessRule
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_statelessRule
=== RUN   TestAccNetworkFirewallRuleGroup_Basic_rules
=== PAUSE TestAccNetworkFirewallRuleGroup_Basic_rules
=== RUN   TestAccNetworkFirewallRuleGroup_statefulRuleOptions
=== PAUSE TestAccNetworkFirewallRuleGroup_statefulRuleOptions
=== RUN   TestAccNetworkFirewallRuleGroup_updateStatefulRuleOptions
=== PAUSE TestAccNetworkFirewallRuleGroup_updateStatefulRuleOptions
=== RUN   TestAccNetworkFirewallRuleGroup_statelessRuleWithCustomAction
=== PAUSE TestAccNetworkFirewallRuleGroup_statelessRuleWithCustomAction
=== RUN   TestAccNetworkFirewallRuleGroup_updateRules
=== PAUSE TestAccNetworkFirewallRuleGroup_updateRules
=== RUN   TestAccNetworkFirewallRuleGroup_updateRulesSourceList
=== PAUSE TestAccNetworkFirewallRuleGroup_updateRulesSourceList
=== RUN   TestAccNetworkFirewallRuleGroup_rulesSourceAndRuleVariables
=== PAUSE TestAccNetworkFirewallRuleGroup_rulesSourceAndRuleVariables
=== RUN   TestAccNetworkFirewallRuleGroup_updateStatefulRule
=== PAUSE TestAccNetworkFirewallRuleGroup_updateStatefulRule
=== RUN   TestAccNetworkFirewallRuleGroup_updateMultipleStatefulRules
=== PAUSE TestAccNetworkFirewallRuleGroup_updateMultipleStatefulRules
=== RUN   TestAccNetworkFirewallRuleGroup_StatefulRule_action
=== PAUSE TestAccNetworkFirewallRuleGroup_StatefulRule_action
=== RUN   TestAccNetworkFirewallRuleGroup_StatefulRule_header
=== PAUSE TestAccNetworkFirewallRuleGroup_StatefulRule_header
=== RUN   TestAccNetworkFirewallRuleGroup_updateStatelessRule
=== PAUSE TestAccNetworkFirewallRuleGroup_updateStatelessRule
=== RUN   TestAccNetworkFirewallRuleGroup_tags
=== PAUSE TestAccNetworkFirewallRuleGroup_tags
=== RUN   TestAccNetworkFirewallRuleGroup_encryptionConfiguration
=== PAUSE TestAccNetworkFirewallRuleGroup_encryptionConfiguration
=== RUN   TestAccNetworkFirewallRuleGroup_disappears
=== PAUSE TestAccNetworkFirewallRuleGroup_disappears
=== CONT  TestAccNetworkFirewallFirewallPolicy_basic
--- PASS: TestAccNetworkFirewallFirewallPolicy_basic (154.65s)
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_rulesSourceList
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_rulesSourceList (154.02s)
=== CONT  TestAccNetworkFirewallRuleGroup_disappears
--- PASS: TestAccNetworkFirewallRuleGroup_disappears (138.70s)
=== CONT  TestAccNetworkFirewallRuleGroup_encryptionConfiguration
--- PASS: TestAccNetworkFirewallRuleGroup_encryptionConfiguration (191.19s)
=== CONT  TestAccNetworkFirewallRuleGroup_tags
--- PASS: TestAccNetworkFirewallRuleGroup_tags (143.81s)
=== CONT  TestAccNetworkFirewallRuleGroup_updateStatelessRule
--- PASS: TestAccNetworkFirewallRuleGroup_updateStatelessRule (174.47s)
=== CONT  TestAccNetworkFirewallRuleGroup_StatefulRule_header
--- PASS: TestAccNetworkFirewallRuleGroup_StatefulRule_header (157.16s)
=== CONT  TestAccNetworkFirewallRuleGroup_StatefulRule_action
--- PASS: TestAccNetworkFirewallRuleGroup_StatefulRule_action (160.10s)
=== CONT  TestAccNetworkFirewallRuleGroup_updateMultipleStatefulRules
--- PASS: TestAccNetworkFirewallRuleGroup_updateMultipleStatefulRules (167.54s)
=== CONT  TestAccNetworkFirewallRuleGroup_updateStatefulRule
--- PASS: TestAccNetworkFirewallRuleGroup_updateStatefulRule (143.73s)
=== CONT  TestAccNetworkFirewallRuleGroup_rulesSourceAndRuleVariables
--- PASS: TestAccNetworkFirewallRuleGroup_rulesSourceAndRuleVariables (166.01s)
=== CONT  TestAccNetworkFirewallRuleGroup_updateRulesSourceList
--- PASS: TestAccNetworkFirewallRuleGroup_updateRulesSourceList (165.44s)
=== CONT  TestAccNetworkFirewallRuleGroup_updateRules
--- PASS: TestAccNetworkFirewallRuleGroup_updateRules (154.51s)
=== CONT  TestAccNetworkFirewallRuleGroup_statelessRuleWithCustomAction
--- PASS: TestAccNetworkFirewallRuleGroup_statelessRuleWithCustomAction (132.97s)
=== CONT  TestAccNetworkFirewallRuleGroup_updateStatefulRuleOptions
--- PASS: TestAccNetworkFirewallRuleGroup_updateStatefulRuleOptions (291.80s)
=== CONT  TestAccNetworkFirewallRuleGroup_statefulRuleOptions
--- PASS: TestAccNetworkFirewallRuleGroup_statefulRuleOptions (143.62s)
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_rules
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_rules (153.69s)
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_statelessRule
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_statelessRule (143.67s)
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_statefulRule
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_statefulRule (133.01s)
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_updateReferenceSets
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_updateReferenceSets (178.08s)
=== CONT  TestAccNetworkFirewallRuleGroup_Basic_referenceSets
--- PASS: TestAccNetworkFirewallRuleGroup_Basic_referenceSets (154.67s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatelessCustomAction
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatelessCustomAction (586.29s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_disappears
--- PASS: TestAccNetworkFirewallFirewallPolicy_disappears (147.30s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_tags
--- PASS: TestAccNetworkFirewallFirewallPolicy_tags (132.72s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAction
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAction (306.91s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_multipleStatelessCustomActions
--- PASS: TestAccNetworkFirewallFirewallPolicy_multipleStatelessCustomActions (268.49s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupPriorityReference
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupPriorityReference (159.74s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statelessCustomAction
--- PASS: TestAccNetworkFirewallFirewallPolicy_statelessCustomAction (151.60s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_multipleStatelessRuleGroupReferences
--- PASS: TestAccNetworkFirewallFirewallPolicy_multipleStatelessRuleGroupReferences (190.41s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatelessRuleGroupReference
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatelessRuleGroupReference (185.85s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statelessRuleGroupReference
--- PASS: TestAccNetworkFirewallFirewallPolicy_statelessRuleGroupReference (210.37s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulEngineOption
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulEngineOption (141.54s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReference
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReference (188.24s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption (299.19s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulDefaultActions
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulDefaultActions (131.27s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupPriorityReference
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupPriorityReference (189.06s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupOverrideActionReference
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupOverrideActionReference (143.52s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration
--- PASS: TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration (200.81s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_multipleStatefulRuleGroupReferences
--- PASS: TestAccNetworkFirewallFirewallPolicy_multipleStatefulRuleGroupReferences (200.99s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceManaged
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceManaged (153.41s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupReference
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupReference (179.82s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall	7576.139s
```
