### PR TITLE
Tagging: Ensure that `UpdateTags` list length checks are done after system tag removal

### DIFF
--- a/internal/generate/tags/main.go
+++ b/internal/generate/tags/main.go
@@ -22,13 +22,14 @@ const (
 )
 
 var (
-	createTags         = flag.Bool("CreateTags", false, "whether to generate CreateTags")
-	getTag             = flag.Bool("GetTag", false, "whether to generate GetTag")
-	listTags           = flag.Bool("ListTags", false, "whether to generate ListTags")
-	serviceTagsMap     = flag.Bool("ServiceTagsMap", false, "whether to generate service tags for map")
-	serviceTagsSlice   = flag.Bool("ServiceTagsSlice", false, "whether to generate service tags for slice")
-	untagInNeedTagType = flag.Bool("UntagInNeedTagType", false, "whether Untag input needs tag type")
-	updateTags         = flag.Bool("UpdateTags", false, "whether to generate UpdateTags")
+	createTags               = flag.Bool("CreateTags", false, "whether to generate CreateTags")
+	getTag                   = flag.Bool("GetTag", false, "whether to generate GetTag")
+	listTags                 = flag.Bool("ListTags", false, "whether to generate ListTags")
+	serviceTagsMap           = flag.Bool("ServiceTagsMap", false, "whether to generate service tags for map")
+	serviceTagsSlice         = flag.Bool("ServiceTagsSlice", false, "whether to generate service tags for slice")
+	untagInNeedTagType       = flag.Bool("UntagInNeedTagType", false, "whether Untag input needs tag type")
+	updateTags               = flag.Bool("UpdateTags", false, "whether to generate UpdateTags")
+	updateTagsNoIgnoreSystem = flag.Bool("UpdateTagsNoIgnoreSystem", false, "whether to not ignore system tags in UpdateTags")
 
 	createTagsFunc        = flag.String("CreateTagsFunc", "createTags", "createTagsFunc")
 	getTagFunc            = flag.String("GetTagFunc", "GetTag", "getTagFunc")
@@ -158,6 +159,7 @@ type TemplateData struct {
 	UntagInTagsElem         string
 	UntagOp                 string
 	UpdateTagsFunc          string
+	UpdateTagsIgnoreSystem  bool
 
 	// The following are specific to writing import paths in the `headerBody`;
 	// to include the package, set the corresponding field's value to true
@@ -282,6 +284,7 @@ func main() {
 		UntagInTagsElem:         *untagInTagsElem,
 		UntagOp:                 *untagOp,
 		UpdateTagsFunc:          *updateTagsFunc,
+		UpdateTagsIgnoreSystem:  !*updateTagsNoIgnoreSystem,
 	}
 
 	templateBody := newTemplateBody(*sdkVersion, *kvtValues)

--- a/internal/generate/tags/templates/v1/update_tags_body.tmpl
+++ b/internal/generate/tags/templates/v1/update_tags_body.tmpl
@@ -11,8 +11,8 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 	newTags := tftags.New(ctx, newTagsMap)
 {{- end }}
 	{{- if eq (.TagOp) (.UntagOp) }}
-	removedTags := oldTags.Removed(newTags)
-	updatedTags := oldTags.Updated(newTags)
+	removedTags := oldTags.Removed(newTags).IgnoreSystem(names.{{ .ProviderNameUpper }})
+	updatedTags := oldTags.Updated(newTags).IgnoreSystem(names.{{ .ProviderNameUpper }})
 
 	// Ensure we do not send empty requests
 	if len(removedTags) == 0 && len(updatedTags) == 0 {
@@ -33,14 +33,14 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 	}
 
 	if len(updatedTags) > 0 {
-		input.{{ .TagInTagsElem }} = Tags(updatedTags.IgnoreSystem(names.{{ .ProviderNameUpper }}))
+		input.{{ .TagInTagsElem }} = Tags(updatedTags)
 	}
 
 	if len(removedTags) > 0 {
 		{{- if .UntagInNeedTagType }}
-		input.{{ .UntagInTagsElem }} = Tags(removedTags.IgnoreSystem(names.{{ .ProviderNameUpper }}))
+		input.{{ .UntagInTagsElem }} = Tags(removedTags)
 		{{- else if .UntagInNeedTagKeyType }}
-		input.{{ .UntagInTagsElem }} = TagKeys(removedTags.IgnoreSystem(names.{{ .ProviderNameUpper }}))
+		input.{{ .UntagInTagsElem }} = TagKeys(removedTags)
 		{{- else if .UntagInCustomVal }}
 		input.{{ .UntagInTagsElem }} = {{ .UntagInCustomVal }}
 		{{- else }}
@@ -56,7 +56,7 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 
 	{{- else }}
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	if removedTags := oldTags.Removed(newTags).IgnoreSystem(names.{{ .ProviderNameUpper }}); len(removedTags) > 0 {
 		{{- if .TagOpBatchSize }}
 		for _, removedTags := range removedTags.Chunks({{ .TagOpBatchSize }}) {
 		{{- end }}
@@ -72,13 +72,13 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 			{{- end }}
 			{{- end }}
 			{{- if .UntagInNeedTagType }}
-			{{ .UntagInTagsElem }}:       Tags(removedTags.IgnoreSystem(names.{{ .ProviderNameUpper }})),
+			{{ .UntagInTagsElem }}:       Tags(removedTags),
 			{{- else if .UntagInNeedTagKeyType }}
-			{{ .UntagInTagsElem }}:       TagKeys(removedTags.IgnoreSystem(names.{{ .ProviderNameUpper }})),
+			{{ .UntagInTagsElem }}:       TagKeys(removedTags),
 			{{- else if .UntagInCustomVal }}
 			{{ .UntagInTagsElem }}:       {{ .UntagInCustomVal }},
 			{{- else }}
-			{{ .UntagInTagsElem }}:       aws.StringSlice(removedTags.IgnoreSystem(names.{{ .ProviderNameUpper }}).Keys()),
+			{{ .UntagInTagsElem }}:       aws.StringSlice(removedTags.Keys()),
 			{{- end }}
 		}
 
@@ -92,7 +92,7 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 		{{- end }}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	if updatedTags := oldTags.Updated(newTags).IgnoreSystem(names.{{ .ProviderNameUpper }}); len(updatedTags) > 0 {
 		{{- if .TagOpBatchSize }}
 		for _, updatedTags := range updatedTags.Chunks({{ .TagOpBatchSize }}) {
 		{{- end }}
@@ -110,7 +110,7 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 			{{- if .TagInCustomVal }}
 			{{ .TagInTagsElem }}:       {{ .TagInCustomVal }},
 			{{- else }}
-			{{ .TagInTagsElem }}:       Tags(updatedTags.IgnoreSystem(names.{{ .ProviderNameUpper }})),
+			{{ .TagInTagsElem }}:       Tags(updatedTags),
 			{{- end }}
 		}
 

--- a/internal/generate/tags/templates/v1/update_tags_body.tmpl
+++ b/internal/generate/tags/templates/v1/update_tags_body.tmpl
@@ -11,10 +11,16 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 	newTags := tftags.New(ctx, newTagsMap)
 {{- end }}
 	{{- if eq (.TagOp) (.UntagOp) }}
-	removedTags := oldTags.Removed(newTags).IgnoreSystem(names.{{ .ProviderNameUpper }})
-	updatedTags := oldTags.Updated(newTags).IgnoreSystem(names.{{ .ProviderNameUpper }})
+	removedTags := oldTags.Removed(newTags)
+	{{- if .UpdateTagsIgnoreSystem }}
+	removedTags = removedTags.IgnoreSystem(names.{{ .ProviderNameUpper }})
+	{{- end }}
+	updatedTags := oldTags.Updated(newTags)
+	{{- if .UpdateTagsIgnoreSystem }}
+	updatedTags = updatedTags.IgnoreSystem(names.{{ .ProviderNameUpper }})
+	{{- end }}
 
-	// Ensure we do not send empty requests
+	// Ensure we do not send empty requests.
 	if len(removedTags) == 0 && len(updatedTags) == 0 {
 		return nil
 	}
@@ -56,7 +62,11 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 
 	{{- else }}
 
-	if removedTags := oldTags.Removed(newTags).IgnoreSystem(names.{{ .ProviderNameUpper }}); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	{{- if .UpdateTagsIgnoreSystem }}
+	removedTags = removedTags.IgnoreSystem(names.{{ .ProviderNameUpper }})
+	{{- end }}
+	if len(removedTags) > 0 {
 		{{- if .TagOpBatchSize }}
 		for _, removedTags := range removedTags.Chunks({{ .TagOpBatchSize }}) {
 		{{- end }}
@@ -92,7 +102,11 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 		{{- end }}
 	}
 
-	if updatedTags := oldTags.Updated(newTags).IgnoreSystem(names.{{ .ProviderNameUpper }}); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	{{- if .UpdateTagsIgnoreSystem }}
+	updatedTags = updatedTags.IgnoreSystem(names.{{ .ProviderNameUpper }})
+	{{- end }}
+	if len(updatedTags) > 0 {
 		{{- if .TagOpBatchSize }}
 		for _, updatedTags := range updatedTags.Chunks({{ .TagOpBatchSize }}) {
 		{{- end }}

--- a/internal/generate/tags/templates/v1/update_tags_body.tmpl
+++ b/internal/generate/tags/templates/v1/update_tags_body.tmpl
@@ -5,7 +5,7 @@
 func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string, oldTagsSet, newTagsSet any) error {
 	oldTags := KeyValueTags(ctx, oldTagsSet, identifier{{ if .TagResTypeElem }}, resourceType{{ end }})
 	newTags := KeyValueTags(ctx, newTagsSet, identifier{{ if .TagResTypeElem }}, resourceType{{ end }})
-{{- else }}
+{{- else -}}
 func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/generate/tags/templates/v2/update_tags_body.tmpl
+++ b/internal/generate/tags/templates/v2/update_tags_body.tmpl
@@ -1,11 +1,11 @@
 // {{ .UpdateTagsFunc }} updates {{ .ServicePackage }} service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-{{- if  .TagTypeAddBoolElem }}
+{{if  .TagTypeAddBoolElem -}}
 func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string, oldTagsSet, newTagsSet any) error {
 	oldTags := KeyValueTags(ctx, oldTagsSet, identifier{{ if .TagResTypeElem }}, resourceType{{ end }})
 	newTags := KeyValueTags(ctx, newTagsSet, identifier{{ if .TagResTypeElem }}, resourceType{{ end }})
-{{- else }}
+{{- else -}}
 func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/generate/tags/templates/v2/update_tags_body.tmpl
+++ b/internal/generate/tags/templates/v2/update_tags_body.tmpl
@@ -11,8 +11,8 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 	newTags := tftags.New(ctx, newTagsMap)
 {{- end }}
 	{{- if eq (.TagOp) (.UntagOp) }}
-	removedTags := oldTags.Removed(newTags)
-	updatedTags := oldTags.Updated(newTags)
+	removedTags := oldTags.Removed(newTags).IgnoreSystem(names.{{ .ProviderNameUpper }})
+	updatedTags := oldTags.Updated(newTags).IgnoreSystem(names.{{ .ProviderNameUpper }})
 
 	// Ensure we do not send empty requests
 	if len(removedTags) == 0 && len(updatedTags) == 0 {
@@ -33,14 +33,14 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 	}
 
 	if len(updatedTags) > 0 {
-		input.{{ .TagInTagsElem }} = Tags(updatedTags.IgnoreSystem(names.{{ .ProviderNameUpper }}))
+		input.{{ .TagInTagsElem }} = Tags(updatedTags)
 	}
 
 	if len(removedTags) > 0 {
 		{{- if .UntagInNeedTagType }}
-		input.{{ .UntagInTagsElem }} = Tags(removedTags.IgnoreSystem(names.{{ .ProviderNameUpper }}))
+		input.{{ .UntagInTagsElem }} = Tags(removedTags)
 		{{- else if .UntagInNeedTagKeyType }}
-		input.{{ .UntagInTagsElem }} = TagKeys(removedTags.IgnoreSystem(names.{{ .ProviderNameUpper }}))
+		input.{{ .UntagInTagsElem }} = TagKeys(removedTags)
 		{{- else if .UntagInCustomVal }}
 		input.{{ .UntagInTagsElem }} = {{ .UntagInCustomVal }}
 		{{- else }}
@@ -56,7 +56,7 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 
 	{{- else }}
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	if removedTags := oldTags.Removed(newTags).IgnoreSystem(names.{{ .ProviderNameUpper }}); len(removedTags) > 0 {
 		{{- if .TagOpBatchSize }}
 		for _, removedTags := range removedTags.Chunks({{ .TagOpBatchSize }}) {
 		{{- end }}
@@ -72,13 +72,13 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 			{{- end }}
 			{{- end }}
 			{{- if .UntagInNeedTagType }}
-			{{ .UntagInTagsElem }}:       Tags(removedTags.IgnoreSystem(names.{{ .ProviderNameUpper }})),
+			{{ .UntagInTagsElem }}:       Tags(removedTags),
 			{{- else if .UntagInNeedTagKeyType }}
-			{{ .UntagInTagsElem }}:       TagKeys(removedTags.IgnoreSystem(names.{{ .ProviderNameUpper }})),
+			{{ .UntagInTagsElem }}:       TagKeys(removedTags),
 			{{- else if .UntagInCustomVal }}
 			{{ .UntagInTagsElem }}:       {{ .UntagInCustomVal }},
 			{{- else }}
-			{{ .UntagInTagsElem }}:       removedTags.IgnoreSystem(names.{{ .ProviderNameUpper }}).Keys(),
+			{{ .UntagInTagsElem }}:       removedTags.Keys(),
 			{{- end }}
 		}
 
@@ -92,7 +92,7 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 		{{- end }}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	if updatedTags := oldTags.Updated(newTags).IgnoreSystem(names.{{ .ProviderNameUpper }}); len(updatedTags) > 0 {
 		{{- if .TagOpBatchSize }}
 		for _, updatedTags := range updatedTags.Chunks({{ .TagOpBatchSize }}) {
 		{{- end }}
@@ -110,7 +110,7 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 			{{- if .TagInCustomVal }}
 			{{ .TagInTagsElem }}:       {{ .TagInCustomVal }},
 			{{- else }}
-			{{ .TagInTagsElem }}:       Tags(updatedTags.IgnoreSystem(names.{{ .ProviderNameUpper }})),
+			{{ .TagInTagsElem }}:       Tags(updatedTags),
 			{{- end }}
 		}
 

--- a/internal/generate/tags/templates/v2/update_tags_body.tmpl
+++ b/internal/generate/tags/templates/v2/update_tags_body.tmpl
@@ -11,10 +11,16 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 	newTags := tftags.New(ctx, newTagsMap)
 {{- end }}
 	{{- if eq (.TagOp) (.UntagOp) }}
-	removedTags := oldTags.Removed(newTags).IgnoreSystem(names.{{ .ProviderNameUpper }})
-	updatedTags := oldTags.Updated(newTags).IgnoreSystem(names.{{ .ProviderNameUpper }})
+	removedTags := oldTags.Removed(newTags)
+	{{- if .UpdateTagsIgnoreSystem }}
+	removedTags = removedTags.IgnoreSystem(names.{{ .ProviderNameUpper }})
+	{{- end }}
+	updatedTags := oldTags.Updated(newTags)
+	{{- if .UpdateTagsIgnoreSystem }}
+	updatedTags = updatedTags.IgnoreSystem(names.{{ .ProviderNameUpper }})
+	{{- end }}
 
-	// Ensure we do not send empty requests
+	// Ensure we do not send empty requests.
 	if len(removedTags) == 0 && len(updatedTags) == 0 {
 		return nil
 	}
@@ -56,7 +62,11 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 
 	{{- else }}
 
-	if removedTags := oldTags.Removed(newTags).IgnoreSystem(names.{{ .ProviderNameUpper }}); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	{{- if .UpdateTagsIgnoreSystem }}
+	removedTags = removedTags.IgnoreSystem(names.{{ .ProviderNameUpper }})
+	{{- end }}
+	if len(removedTags) > 0 {
 		{{- if .TagOpBatchSize }}
 		for _, removedTags := range removedTags.Chunks({{ .TagOpBatchSize }}) {
 		{{- end }}
@@ -92,7 +102,11 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 		{{- end }}
 	}
 
-	if updatedTags := oldTags.Updated(newTags).IgnoreSystem(names.{{ .ProviderNameUpper }}); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	{{- if .UpdateTagsIgnoreSystem }}
+	updatedTags = updatedTags.IgnoreSystem(names.{{ .ProviderNameUpper }})
+	{{- end }}
+	if len(updatedTags) > 0 {
 		{{- if .TagOpBatchSize }}
 		for _, updatedTags := range updatedTags.Chunks({{ .TagOpBatchSize }}) {
 		{{- end }}

--- a/internal/service/accessanalyzer/tags_gen.go
+++ b/internal/service/accessanalyzer/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates accessanalyzer service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn accessanalyzeriface.AccessAnalyzerAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/accessanalyzer/tags_gen.go
+++ b/internal/service/accessanalyzer/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn accessanalyzeriface.AccessAnalyzerAPI,
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.AccessAnalyzer)
+	if len(removedTags) > 0 {
 		input := &accessanalyzer.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.AccessAnalyzer).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn accessanalyzeriface.AccessAnalyzerAPI,
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.AccessAnalyzer)
+	if len(updatedTags) > 0 {
 		input := &accessanalyzer.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.AccessAnalyzer)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/acm/tags_gen.go
+++ b/internal/service/acm/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn acmiface.ACMAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.ACM)
+	if len(removedTags) > 0 {
 		input := &acm.RemoveTagsFromCertificateInput{
 			CertificateArn: aws.String(identifier),
-			Tags:           Tags(removedTags.IgnoreSystem(names.ACM)),
+			Tags:           Tags(removedTags),
 		}
 
 		_, err := conn.RemoveTagsFromCertificateWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn acmiface.ACMAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.ACM)
+	if len(updatedTags) > 0 {
 		input := &acm.AddTagsToCertificateInput{
 			CertificateArn: aws.String(identifier),
-			Tags:           Tags(updatedTags.IgnoreSystem(names.ACM)),
+			Tags:           Tags(updatedTags),
 		}
 
 		_, err := conn.AddTagsToCertificateWithContext(ctx, input)

--- a/internal/service/acm/tags_gen.go
+++ b/internal/service/acm/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*acm.Tag) {
 // UpdateTags updates acm service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn acmiface.ACMAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/acmpca/tags_gen.go
+++ b/internal/service/acmpca/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn acmpcaiface.ACMPCAAPI, identifier stri
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.ACMPCA)
+	if len(removedTags) > 0 {
 		input := &acmpca.UntagCertificateAuthorityInput{
 			CertificateAuthorityArn: aws.String(identifier),
-			Tags:                    Tags(removedTags.IgnoreSystem(names.ACMPCA)),
+			Tags:                    Tags(removedTags),
 		}
 
 		_, err := conn.UntagCertificateAuthorityWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn acmpcaiface.ACMPCAAPI, identifier stri
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.ACMPCA)
+	if len(updatedTags) > 0 {
 		input := &acmpca.TagCertificateAuthorityInput{
 			CertificateAuthorityArn: aws.String(identifier),
-			Tags:                    Tags(updatedTags.IgnoreSystem(names.ACMPCA)),
+			Tags:                    Tags(updatedTags),
 		}
 
 		_, err := conn.TagCertificateAuthorityWithContext(ctx, input)

--- a/internal/service/acmpca/tags_gen.go
+++ b/internal/service/acmpca/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*acmpca.Tag) {
 // UpdateTags updates acmpca service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn acmpcaiface.ACMPCAAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/amp/tags_gen.go
+++ b/internal/service/amp/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates amp service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn prometheusserviceiface.PrometheusServiceAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/amp/tags_gen.go
+++ b/internal/service/amp/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn prometheusserviceiface.PrometheusServi
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.AMP)
+	if len(removedTags) > 0 {
 		input := &prometheusservice.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.AMP).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn prometheusserviceiface.PrometheusServi
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.AMP)
+	if len(updatedTags) > 0 {
 		input := &prometheusservice.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.AMP)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/amplify/tags_gen.go
+++ b/internal/service/amplify/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates amplify service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn amplifyiface.AmplifyAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/amplify/tags_gen.go
+++ b/internal/service/amplify/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn amplifyiface.AmplifyAPI, identifier st
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Amplify)
+	if len(removedTags) > 0 {
 		input := &amplify.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Amplify).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn amplifyiface.AmplifyAPI, identifier st
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Amplify)
+	if len(updatedTags) > 0 {
 		input := &amplify.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Amplify)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/apigateway/tags_gen.go
+++ b/internal/service/apigateway/tags_gen.go
@@ -52,10 +52,12 @@ func UpdateTags(ctx context.Context, conn apigatewayiface.APIGatewayAPI, identif
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.APIGateway)
+	if len(removedTags) > 0 {
 		input := &apigateway.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.APIGateway).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -65,10 +67,12 @@ func UpdateTags(ctx context.Context, conn apigatewayiface.APIGatewayAPI, identif
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.APIGateway)
+	if len(updatedTags) > 0 {
 		input := &apigateway.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.APIGateway)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/apigateway/tags_gen.go
+++ b/internal/service/apigateway/tags_gen.go
@@ -48,7 +48,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates apigateway service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn apigatewayiface.APIGatewayAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/apigatewayv2/tags_gen.go
+++ b/internal/service/apigatewayv2/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn apigatewayv2iface.ApiGatewayV2API, ide
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.APIGatewayV2)
+	if len(removedTags) > 0 {
 		input := &apigatewayv2.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.APIGatewayV2).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn apigatewayv2iface.ApiGatewayV2API, ide
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.APIGatewayV2)
+	if len(updatedTags) > 0 {
 		input := &apigatewayv2.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.APIGatewayV2)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/apigatewayv2/tags_gen.go
+++ b/internal/service/apigatewayv2/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates apigatewayv2 service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn apigatewayv2iface.ApiGatewayV2API, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/appconfig/tags_gen.go
+++ b/internal/service/appconfig/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn appconfigiface.AppConfigAPI, identifie
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.AppConfig)
+	if len(removedTags) > 0 {
 		input := &appconfig.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.AppConfig).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn appconfigiface.AppConfigAPI, identifie
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.AppConfig)
+	if len(updatedTags) > 0 {
 		input := &appconfig.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.AppConfig)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/appconfig/tags_gen.go
+++ b/internal/service/appconfig/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates appconfig service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn appconfigiface.AppConfigAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/appflow/tags_gen.go
+++ b/internal/service/appflow/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates appflow service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn appflowiface.AppflowAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/appflow/tags_gen.go
+++ b/internal/service/appflow/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn appflowiface.AppflowAPI, identifier st
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.AppFlow)
+	if len(removedTags) > 0 {
 		input := &appflow.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.AppFlow).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn appflowiface.AppflowAPI, identifier st
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.AppFlow)
+	if len(updatedTags) > 0 {
 		input := &appflow.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.AppFlow)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/appintegrations/tags_gen.go
+++ b/internal/service/appintegrations/tags_gen.go
@@ -52,10 +52,12 @@ func UpdateTags(ctx context.Context, conn appintegrationsserviceiface.AppIntegra
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.AppIntegrations)
+	if len(removedTags) > 0 {
 		input := &appintegrationsservice.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.AppIntegrations).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -65,10 +67,12 @@ func UpdateTags(ctx context.Context, conn appintegrationsserviceiface.AppIntegra
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.AppIntegrations)
+	if len(updatedTags) > 0 {
 		input := &appintegrationsservice.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.AppIntegrations)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/appintegrations/tags_gen.go
+++ b/internal/service/appintegrations/tags_gen.go
@@ -48,7 +48,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates appintegrations service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn appintegrationsserviceiface.AppIntegrationsServiceAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/applicationinsights/tags_gen.go
+++ b/internal/service/applicationinsights/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn applicationinsightsiface.ApplicationIn
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.ApplicationInsights)
+	if len(removedTags) > 0 {
 		input := &applicationinsights.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.ApplicationInsights).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn applicationinsightsiface.ApplicationIn
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.ApplicationInsights)
+	if len(updatedTags) > 0 {
 		input := &applicationinsights.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.ApplicationInsights)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/applicationinsights/tags_gen.go
+++ b/internal/service/applicationinsights/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*applicationinsights.Tag) {
 // UpdateTags updates applicationinsights service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn applicationinsightsiface.ApplicationInsightsAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/appmesh/tags_gen.go
+++ b/internal/service/appmesh/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn appmeshiface.AppMeshAPI, identifier st
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.AppMesh)
+	if len(removedTags) > 0 {
 		input := &appmesh.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.AppMesh).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn appmeshiface.AppMeshAPI, identifier st
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.AppMesh)
+	if len(updatedTags) > 0 {
 		input := &appmesh.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.AppMesh)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/appmesh/tags_gen.go
+++ b/internal/service/appmesh/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*appmesh.TagRef) {
 // UpdateTags updates appmesh service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn appmeshiface.AppMeshAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/apprunner/tags_gen.go
+++ b/internal/service/apprunner/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*apprunner.Tag) {
 // UpdateTags updates apprunner service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn apprunneriface.AppRunnerAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/apprunner/tags_gen.go
+++ b/internal/service/apprunner/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn apprunneriface.AppRunnerAPI, identifie
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.AppRunner)
+	if len(removedTags) > 0 {
 		input := &apprunner.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.AppRunner).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn apprunneriface.AppRunnerAPI, identifie
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.AppRunner)
+	if len(updatedTags) > 0 {
 		input := &apprunner.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.AppRunner)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/appstream/tags_gen.go
+++ b/internal/service/appstream/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn appstreamiface.AppStreamAPI, identifie
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.AppStream)
+	if len(removedTags) > 0 {
 		input := &appstream.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.AppStream).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn appstreamiface.AppStreamAPI, identifie
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.AppStream)
+	if len(updatedTags) > 0 {
 		input := &appstream.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.AppStream)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/appstream/tags_gen.go
+++ b/internal/service/appstream/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates appstream service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn appstreamiface.AppStreamAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/appsync/tags_gen.go
+++ b/internal/service/appsync/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn appsynciface.AppSyncAPI, identifier st
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.AppSync)
+	if len(removedTags) > 0 {
 		input := &appsync.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.AppSync).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn appsynciface.AppSyncAPI, identifier st
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.AppSync)
+	if len(updatedTags) > 0 {
 		input := &appsync.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.AppSync)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/appsync/tags_gen.go
+++ b/internal/service/appsync/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates appsync service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn appsynciface.AppSyncAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/athena/tags_gen.go
+++ b/internal/service/athena/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*athena.Tag) {
 // UpdateTags updates athena service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn athenaiface.AthenaAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/athena/tags_gen.go
+++ b/internal/service/athena/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn athenaiface.AthenaAPI, identifier stri
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Athena)
+	if len(removedTags) > 0 {
 		input := &athena.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Athena).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn athenaiface.AthenaAPI, identifier stri
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Athena)
+	if len(updatedTags) > 0 {
 		input := &athena.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Athena)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/auditmanager/tags_gen.go
+++ b/internal/service/auditmanager/tags_gen.go
@@ -84,10 +84,12 @@ func UpdateTags(ctx context.Context, conn *auditmanager.Client, identifier strin
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.AuditManager)
+	if len(removedTags) > 0 {
 		input := &auditmanager.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     removedTags.IgnoreSystem(names.AuditManager).Keys(),
+			TagKeys:     removedTags.Keys(),
 		}
 
 		_, err := conn.UntagResource(ctx, input)
@@ -97,10 +99,12 @@ func UpdateTags(ctx context.Context, conn *auditmanager.Client, identifier strin
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.AuditManager)
+	if len(updatedTags) > 0 {
 		input := &auditmanager.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.AuditManager)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResource(ctx, input)

--- a/internal/service/autoscaling/tags_gen.go
+++ b/internal/service/autoscaling/tags_gen.go
@@ -273,9 +273,11 @@ func UpdateTags(ctx context.Context, conn autoscalingiface.AutoScalingAPI, ident
 	oldTags := KeyValueTags(ctx, oldTagsSet, identifier, resourceType)
 	newTags := KeyValueTags(ctx, newTagsSet, identifier, resourceType)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.AutoScaling)
+	if len(removedTags) > 0 {
 		input := &autoscaling.DeleteTagsInput{
-			Tags: Tags(removedTags.IgnoreSystem(names.AutoScaling)),
+			Tags: Tags(removedTags),
 		}
 
 		_, err := conn.DeleteTagsWithContext(ctx, input)
@@ -285,9 +287,11 @@ func UpdateTags(ctx context.Context, conn autoscalingiface.AutoScalingAPI, ident
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.AutoScaling)
+	if len(updatedTags) > 0 {
 		input := &autoscaling.CreateOrUpdateTagsInput{
-			Tags: Tags(updatedTags.IgnoreSystem(names.AutoScaling)),
+			Tags: Tags(updatedTags),
 		}
 
 		_, err := conn.CreateOrUpdateTagsWithContext(ctx, input)

--- a/internal/service/backup/tags_gen.go
+++ b/internal/service/backup/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates backup service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn backupiface.BackupAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/backup/tags_gen.go
+++ b/internal/service/backup/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn backupiface.BackupAPI, identifier stri
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Backup)
+	if len(removedTags) > 0 {
 		input := &backup.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeyList:  aws.StringSlice(removedTags.IgnoreSystem(names.Backup).Keys()),
+			TagKeyList:  aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn backupiface.BackupAPI, identifier stri
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Backup)
+	if len(updatedTags) > 0 {
 		input := &backup.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Backup)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/batch/tags_gen.go
+++ b/internal/service/batch/tags_gen.go
@@ -105,10 +105,12 @@ func UpdateTags(ctx context.Context, conn batchiface.BatchAPI, identifier string
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Batch)
+	if len(removedTags) > 0 {
 		input := &batch.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Batch).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -118,10 +120,12 @@ func UpdateTags(ctx context.Context, conn batchiface.BatchAPI, identifier string
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Batch)
+	if len(updatedTags) > 0 {
 		input := &batch.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Batch)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/batch/tags_gen.go
+++ b/internal/service/batch/tags_gen.go
@@ -101,7 +101,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates batch service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn batchiface.BatchAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/ce/tags_gen.go
+++ b/internal/service/ce/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn costexploreriface.CostExplorerAPI, ide
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.CE)
+	if len(removedTags) > 0 {
 		input := &costexplorer.UntagResourceInput{
 			ResourceArn:     aws.String(identifier),
-			ResourceTagKeys: aws.StringSlice(removedTags.IgnoreSystem(names.CE).Keys()),
+			ResourceTagKeys: aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn costexploreriface.CostExplorerAPI, ide
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.CE)
+	if len(updatedTags) > 0 {
 		input := &costexplorer.TagResourceInput{
 			ResourceArn:  aws.String(identifier),
-			ResourceTags: Tags(updatedTags.IgnoreSystem(names.CE)),
+			ResourceTags: Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/ce/tags_gen.go
+++ b/internal/service/ce/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*costexplorer.ResourceTag) {
 // UpdateTags updates ce service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn costexploreriface.CostExplorerAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/chimesdkmediapipelines/tags_gen.go
+++ b/internal/service/chimesdkmediapipelines/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*chimesdkmediapipelines.Tag) {
 // UpdateTags updates chimesdkmediapipelines service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn chimesdkmediapipelinesiface.ChimeSDKMediaPipelinesAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/chimesdkmediapipelines/tags_gen.go
+++ b/internal/service/chimesdkmediapipelines/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn chimesdkmediapipelinesiface.ChimeSDKMe
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.ChimeSDKMediaPipelines)
+	if len(removedTags) > 0 {
 		input := &chimesdkmediapipelines.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.ChimeSDKMediaPipelines).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn chimesdkmediapipelinesiface.ChimeSDKMe
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.ChimeSDKMediaPipelines)
+	if len(updatedTags) > 0 {
 		input := &chimesdkmediapipelines.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.ChimeSDKMediaPipelines)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/cloud9/tags_gen.go
+++ b/internal/service/cloud9/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn cloud9iface.Cloud9API, identifier stri
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Cloud9)
+	if len(removedTags) > 0 {
 		input := &cloud9.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Cloud9).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn cloud9iface.Cloud9API, identifier stri
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Cloud9)
+	if len(updatedTags) > 0 {
 		input := &cloud9.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Cloud9)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/cloud9/tags_gen.go
+++ b/internal/service/cloud9/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*cloud9.Tag) {
 // UpdateTags updates cloud9 service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn cloud9iface.Cloud9API, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/cloudfront/generate.go
+++ b/internal/service/cloudfront/generate.go
@@ -1,4 +1,4 @@
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=Resource -ListTagsOutTagsElem=Tags.Items -ServiceTagsSlice "-TagInCustomVal=&cloudfront.Tags{Items: Tags(updatedTags.IgnoreAWS())}" -TagInIDElem=Resource "-UntagInCustomVal=&cloudfront.TagKeys{Items: aws.StringSlice(removedTags.IgnoreSystem(names.CloudFront).Keys())}" -UpdateTags
+//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=Resource -ListTagsOutTagsElem=Tags.Items -ServiceTagsSlice "-TagInCustomVal=&cloudfront.Tags{Items: Tags(updatedTags)}" -TagInIDElem=Resource "-UntagInCustomVal=&cloudfront.TagKeys{Items: aws.StringSlice(removedTags.Keys())}" -UpdateTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package cloudfront

--- a/internal/service/cloudfront/tags_gen.go
+++ b/internal/service/cloudfront/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn cloudfrontiface.CloudFrontAPI, identif
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.CloudFront)
+	if len(removedTags) > 0 {
 		input := &cloudfront.UntagResourceInput{
 			Resource: aws.String(identifier),
-			TagKeys:  &cloudfront.TagKeys{Items: aws.StringSlice(removedTags.IgnoreSystem(names.CloudFront).Keys())},
+			TagKeys:  &cloudfront.TagKeys{Items: aws.StringSlice(removedTags.Keys())},
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn cloudfrontiface.CloudFrontAPI, identif
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.CloudFront)
+	if len(updatedTags) > 0 {
 		input := &cloudfront.TagResourceInput{
 			Resource: aws.String(identifier),
-			Tags:     &cloudfront.Tags{Items: Tags(updatedTags.IgnoreAWS())},
+			Tags:     &cloudfront.Tags{Items: Tags(updatedTags)},
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/cloudfront/tags_gen.go
+++ b/internal/service/cloudfront/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*cloudfront.Tag) {
 // UpdateTags updates cloudfront service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn cloudfrontiface.CloudFrontAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/cloudhsmv2/tags_gen.go
+++ b/internal/service/cloudhsmv2/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn cloudhsmv2iface.CloudHSMV2API, identif
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.CloudHSMV2)
+	if len(removedTags) > 0 {
 		input := &cloudhsmv2.UntagResourceInput{
 			ResourceId: aws.String(identifier),
-			TagKeyList: aws.StringSlice(removedTags.IgnoreSystem(names.CloudHSMV2).Keys()),
+			TagKeyList: aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn cloudhsmv2iface.CloudHSMV2API, identif
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.CloudHSMV2)
+	if len(updatedTags) > 0 {
 		input := &cloudhsmv2.TagResourceInput{
 			ResourceId: aws.String(identifier),
-			TagList:    Tags(updatedTags.IgnoreSystem(names.CloudHSMV2)),
+			TagList:    Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/cloudhsmv2/tags_gen.go
+++ b/internal/service/cloudhsmv2/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*cloudhsmv2.Tag) {
 // UpdateTags updates cloudhsmv2 service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn cloudhsmv2iface.CloudHSMV2API, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/cloudtrail/tags_gen.go
+++ b/internal/service/cloudtrail/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*cloudtrail.Tag) {
 // UpdateTags updates cloudtrail service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn cloudtrailiface.CloudTrailAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/cloudtrail/tags_gen.go
+++ b/internal/service/cloudtrail/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn cloudtrailiface.CloudTrailAPI, identif
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.CloudTrail)
+	if len(removedTags) > 0 {
 		input := &cloudtrail.RemoveTagsInput{
 			ResourceId: aws.String(identifier),
-			TagsList:   Tags(removedTags.IgnoreSystem(names.CloudTrail)),
+			TagsList:   Tags(removedTags),
 		}
 
 		_, err := conn.RemoveTagsWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn cloudtrailiface.CloudTrailAPI, identif
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.CloudTrail)
+	if len(updatedTags) > 0 {
 		input := &cloudtrail.AddTagsInput{
 			ResourceId: aws.String(identifier),
-			TagsList:   Tags(updatedTags.IgnoreSystem(names.CloudTrail)),
+			TagsList:   Tags(updatedTags),
 		}
 
 		_, err := conn.AddTagsWithContext(ctx, input)

--- a/internal/service/cloudwatch/tags_gen.go
+++ b/internal/service/cloudwatch/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*cloudwatch.Tag) {
 // UpdateTags updates cloudwatch service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn cloudwatchiface.CloudWatchAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/cloudwatch/tags_gen.go
+++ b/internal/service/cloudwatch/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn cloudwatchiface.CloudWatchAPI, identif
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.CloudWatch)
+	if len(removedTags) > 0 {
 		input := &cloudwatch.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.CloudWatch).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn cloudwatchiface.CloudWatchAPI, identif
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.CloudWatch)
+	if len(updatedTags) > 0 {
 		input := &cloudwatch.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.CloudWatch)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/codeartifact/tags_gen.go
+++ b/internal/service/codeartifact/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*codeartifact.Tag) {
 // UpdateTags updates codeartifact service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn codeartifactiface.CodeArtifactAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/codeartifact/tags_gen.go
+++ b/internal/service/codeartifact/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn codeartifactiface.CodeArtifactAPI, ide
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.CodeArtifact)
+	if len(removedTags) > 0 {
 		input := &codeartifact.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.CodeArtifact).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn codeartifactiface.CodeArtifactAPI, ide
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.CodeArtifact)
+	if len(updatedTags) > 0 {
 		input := &codeartifact.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.CodeArtifact)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/codecommit/tags_gen.go
+++ b/internal/service/codecommit/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn codecommitiface.CodeCommitAPI, identif
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.CodeCommit)
+	if len(removedTags) > 0 {
 		input := &codecommit.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.CodeCommit).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn codecommitiface.CodeCommitAPI, identif
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.CodeCommit)
+	if len(updatedTags) > 0 {
 		input := &codecommit.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.CodeCommit)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/codecommit/tags_gen.go
+++ b/internal/service/codecommit/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates codecommit service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn codecommitiface.CodeCommitAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/codegurureviewer/tags_gen.go
+++ b/internal/service/codegurureviewer/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates codegurureviewer service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn codegururevieweriface.CodeGuruReviewerAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/codegurureviewer/tags_gen.go
+++ b/internal/service/codegurureviewer/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn codegururevieweriface.CodeGuruReviewer
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.CodeGuruReviewer)
+	if len(removedTags) > 0 {
 		input := &codegurureviewer.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.CodeGuruReviewer).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn codegururevieweriface.CodeGuruReviewer
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.CodeGuruReviewer)
+	if len(updatedTags) > 0 {
 		input := &codegurureviewer.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.CodeGuruReviewer)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/codepipeline/tags_gen.go
+++ b/internal/service/codepipeline/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn codepipelineiface.CodePipelineAPI, ide
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.CodePipeline)
+	if len(removedTags) > 0 {
 		input := &codepipeline.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.CodePipeline).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn codepipelineiface.CodePipelineAPI, ide
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.CodePipeline)
+	if len(updatedTags) > 0 {
 		input := &codepipeline.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.CodePipeline)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/codepipeline/tags_gen.go
+++ b/internal/service/codepipeline/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*codepipeline.Tag) {
 // UpdateTags updates codepipeline service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn codepipelineiface.CodePipelineAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/codestarconnections/tags_gen.go
+++ b/internal/service/codestarconnections/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*codestarconnections.Tag) {
 // UpdateTags updates codestarconnections service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn codestarconnectionsiface.CodeStarConnectionsAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/codestarconnections/tags_gen.go
+++ b/internal/service/codestarconnections/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn codestarconnectionsiface.CodeStarConne
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.CodeStarConnections)
+	if len(removedTags) > 0 {
 		input := &codestarconnections.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.CodeStarConnections).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn codestarconnectionsiface.CodeStarConne
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.CodeStarConnections)
+	if len(updatedTags) > 0 {
 		input := &codestarconnections.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.CodeStarConnections)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/codestarnotifications/tags_gen.go
+++ b/internal/service/codestarnotifications/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates codestarnotifications service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn codestarnotificationsiface.CodeStarNotificationsAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/codestarnotifications/tags_gen.go
+++ b/internal/service/codestarnotifications/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn codestarnotificationsiface.CodeStarNot
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.CodeStarNotifications)
+	if len(removedTags) > 0 {
 		input := &codestarnotifications.UntagResourceInput{
 			Arn:     aws.String(identifier),
-			TagKeys: aws.StringSlice(removedTags.IgnoreSystem(names.CodeStarNotifications).Keys()),
+			TagKeys: aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn codestarnotificationsiface.CodeStarNot
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.CodeStarNotifications)
+	if len(updatedTags) > 0 {
 		input := &codestarnotifications.TagResourceInput{
 			Arn:  aws.String(identifier),
-			Tags: Tags(updatedTags.IgnoreSystem(names.CodeStarNotifications)),
+			Tags: Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/cognitoidentity/tags_gen.go
+++ b/internal/service/cognitoidentity/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates cognitoidentity service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn cognitoidentityiface.CognitoIdentityAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/cognitoidentity/tags_gen.go
+++ b/internal/service/cognitoidentity/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn cognitoidentityiface.CognitoIdentityAP
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.CognitoIdentity)
+	if len(removedTags) > 0 {
 		input := &cognitoidentity.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.CognitoIdentity).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn cognitoidentityiface.CognitoIdentityAP
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.CognitoIdentity)
+	if len(updatedTags) > 0 {
 		input := &cognitoidentity.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.CognitoIdentity)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/cognitoidp/tags_gen.go
+++ b/internal/service/cognitoidp/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn cognitoidentityprovideriface.CognitoId
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.CognitoIDP)
+	if len(removedTags) > 0 {
 		input := &cognitoidentityprovider.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.CognitoIDP).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn cognitoidentityprovideriface.CognitoId
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.CognitoIDP)
+	if len(updatedTags) > 0 {
 		input := &cognitoidentityprovider.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.CognitoIDP)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/cognitoidp/tags_gen.go
+++ b/internal/service/cognitoidp/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates cognitoidp service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn cognitoidentityprovideriface.CognitoIdentityProviderAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/comprehend/tags_gen.go
+++ b/internal/service/comprehend/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn *comprehend.Client, identifier string,
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Comprehend)
+	if len(removedTags) > 0 {
 		input := &comprehend.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     removedTags.IgnoreSystem(names.Comprehend).Keys(),
+			TagKeys:     removedTags.Keys(),
 		}
 
 		_, err := conn.UntagResource(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn *comprehend.Client, identifier string,
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Comprehend)
+	if len(updatedTags) > 0 {
 		input := &comprehend.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Comprehend)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResource(ctx, input)

--- a/internal/service/configservice/tags_gen.go
+++ b/internal/service/configservice/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*configservice.Tag) {
 // UpdateTags updates configservice service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn configserviceiface.ConfigServiceAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/configservice/tags_gen.go
+++ b/internal/service/configservice/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn configserviceiface.ConfigServiceAPI, i
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.ConfigService)
+	if len(removedTags) > 0 {
 		input := &configservice.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.ConfigService).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn configserviceiface.ConfigServiceAPI, i
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.ConfigService)
+	if len(updatedTags) > 0 {
 		input := &configservice.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.ConfigService)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/connect/tags_gen.go
+++ b/internal/service/connect/tags_gen.go
@@ -52,10 +52,12 @@ func UpdateTags(ctx context.Context, conn connectiface.ConnectAPI, identifier st
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Connect)
+	if len(removedTags) > 0 {
 		input := &connect.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Connect).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -65,10 +67,12 @@ func UpdateTags(ctx context.Context, conn connectiface.ConnectAPI, identifier st
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Connect)
+	if len(updatedTags) > 0 {
 		input := &connect.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Connect)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/connect/tags_gen.go
+++ b/internal/service/connect/tags_gen.go
@@ -48,7 +48,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates connect service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn connectiface.ConnectAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/dataexchange/tags_gen.go
+++ b/internal/service/dataexchange/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn dataexchangeiface.DataExchangeAPI, ide
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.DataExchange)
+	if len(removedTags) > 0 {
 		input := &dataexchange.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.DataExchange).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn dataexchangeiface.DataExchangeAPI, ide
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.DataExchange)
+	if len(updatedTags) > 0 {
 		input := &dataexchange.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.DataExchange)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/dataexchange/tags_gen.go
+++ b/internal/service/dataexchange/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates dataexchange service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn dataexchangeiface.DataExchangeAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/datapipeline/tags_gen.go
+++ b/internal/service/datapipeline/tags_gen.go
@@ -65,7 +65,6 @@ func SetTagsOut(ctx context.Context, tags []*datapipeline.Tag) {
 // UpdateTags updates datapipeline service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn datapipelineiface.DataPipelineAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/datapipeline/tags_gen.go
+++ b/internal/service/datapipeline/tags_gen.go
@@ -69,10 +69,12 @@ func UpdateTags(ctx context.Context, conn datapipelineiface.DataPipelineAPI, ide
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.DataPipeline)
+	if len(removedTags) > 0 {
 		input := &datapipeline.RemoveTagsInput{
 			PipelineId: aws.String(identifier),
-			TagKeys:    aws.StringSlice(removedTags.IgnoreSystem(names.DataPipeline).Keys()),
+			TagKeys:    aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.RemoveTagsWithContext(ctx, input)
@@ -82,10 +84,12 @@ func UpdateTags(ctx context.Context, conn datapipelineiface.DataPipelineAPI, ide
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.DataPipeline)
+	if len(updatedTags) > 0 {
 		input := &datapipeline.AddTagsInput{
 			PipelineId: aws.String(identifier),
-			Tags:       Tags(updatedTags.IgnoreSystem(names.DataPipeline)),
+			Tags:       Tags(updatedTags),
 		}
 
 		_, err := conn.AddTagsWithContext(ctx, input)

--- a/internal/service/datasync/tags_gen.go
+++ b/internal/service/datasync/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*datasync.TagListEntry) {
 // UpdateTags updates datasync service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn datasynciface.DataSyncAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/datasync/tags_gen.go
+++ b/internal/service/datasync/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn datasynciface.DataSyncAPI, identifier 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.DataSync)
+	if len(removedTags) > 0 {
 		input := &datasync.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Keys:        aws.StringSlice(removedTags.IgnoreSystem(names.DataSync).Keys()),
+			Keys:        aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn datasynciface.DataSyncAPI, identifier 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.DataSync)
+	if len(updatedTags) > 0 {
 		input := &datasync.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.DataSync)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/dax/tags_gen.go
+++ b/internal/service/dax/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn daxiface.DAXAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.DAX)
+	if len(removedTags) > 0 {
 		input := &dax.UntagResourceInput{
 			ResourceName: aws.String(identifier),
-			TagKeys:      aws.StringSlice(removedTags.IgnoreSystem(names.DAX).Keys()),
+			TagKeys:      aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn daxiface.DAXAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.DAX)
+	if len(updatedTags) > 0 {
 		input := &dax.TagResourceInput{
 			ResourceName: aws.String(identifier),
-			Tags:         Tags(updatedTags.IgnoreSystem(names.DAX)),
+			Tags:         Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/dax/tags_gen.go
+++ b/internal/service/dax/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*dax.Tag) {
 // UpdateTags updates dax service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn daxiface.DAXAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/deploy/tags_gen.go
+++ b/internal/service/deploy/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*codedeploy.Tag) {
 // UpdateTags updates deploy service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn codedeployiface.CodeDeployAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/deploy/tags_gen.go
+++ b/internal/service/deploy/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn codedeployiface.CodeDeployAPI, identif
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Deploy)
+	if len(removedTags) > 0 {
 		input := &codedeploy.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Deploy).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn codedeployiface.CodeDeployAPI, identif
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Deploy)
+	if len(updatedTags) > 0 {
 		input := &codedeploy.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Deploy)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/detective/tags_gen.go
+++ b/internal/service/detective/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn detectiveiface.DetectiveAPI, identifie
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Detective)
+	if len(removedTags) > 0 {
 		input := &detective.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Detective).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn detectiveiface.DetectiveAPI, identifie
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Detective)
+	if len(updatedTags) > 0 {
 		input := &detective.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Detective)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/detective/tags_gen.go
+++ b/internal/service/detective/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates detective service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn detectiveiface.DetectiveAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/devicefarm/tags_gen.go
+++ b/internal/service/devicefarm/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn devicefarmiface.DeviceFarmAPI, identif
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.DeviceFarm)
+	if len(removedTags) > 0 {
 		input := &devicefarm.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.DeviceFarm).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn devicefarmiface.DeviceFarmAPI, identif
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.DeviceFarm)
+	if len(updatedTags) > 0 {
 		input := &devicefarm.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.DeviceFarm)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/devicefarm/tags_gen.go
+++ b/internal/service/devicefarm/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*devicefarm.Tag) {
 // UpdateTags updates devicefarm service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn devicefarmiface.DeviceFarmAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/directconnect/tags_gen.go
+++ b/internal/service/directconnect/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*directconnect.Tag) {
 // UpdateTags updates directconnect service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn directconnectiface.DirectConnectAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/directconnect/tags_gen.go
+++ b/internal/service/directconnect/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn directconnectiface.DirectConnectAPI, i
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.DirectConnect)
+	if len(removedTags) > 0 {
 		input := &directconnect.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.DirectConnect).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn directconnectiface.DirectConnectAPI, i
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.DirectConnect)
+	if len(updatedTags) > 0 {
 		input := &directconnect.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.DirectConnect)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/dlm/tags_gen.go
+++ b/internal/service/dlm/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates dlm service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn dlmiface.DLMAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/dlm/tags_gen.go
+++ b/internal/service/dlm/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn dlmiface.DLMAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.DLM)
+	if len(removedTags) > 0 {
 		input := &dlm.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.DLM).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn dlmiface.DLMAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.DLM)
+	if len(updatedTags) > 0 {
 		input := &dlm.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.DLM)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/dms/tags_gen.go
+++ b/internal/service/dms/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn databasemigrationserviceiface.Database
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.DMS)
+	if len(removedTags) > 0 {
 		input := &databasemigrationservice.RemoveTagsFromResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.DMS).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.RemoveTagsFromResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn databasemigrationserviceiface.Database
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.DMS)
+	if len(updatedTags) > 0 {
 		input := &databasemigrationservice.AddTagsToResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.DMS)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.AddTagsToResourceWithContext(ctx, input)

--- a/internal/service/dms/tags_gen.go
+++ b/internal/service/dms/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*databasemigrationservice.Tag) {
 // UpdateTags updates dms service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn databasemigrationserviceiface.DatabaseMigrationServiceAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/docdb/tags_gen.go
+++ b/internal/service/docdb/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn docdbiface.DocDBAPI, identifier string
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.DocDB)
+	if len(removedTags) > 0 {
 		input := &docdb.RemoveTagsFromResourceInput{
 			ResourceName: aws.String(identifier),
-			TagKeys:      aws.StringSlice(removedTags.IgnoreSystem(names.DocDB).Keys()),
+			TagKeys:      aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.RemoveTagsFromResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn docdbiface.DocDBAPI, identifier string
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.DocDB)
+	if len(updatedTags) > 0 {
 		input := &docdb.AddTagsToResourceInput{
 			ResourceName: aws.String(identifier),
-			Tags:         Tags(updatedTags.IgnoreSystem(names.DocDB)),
+			Tags:         Tags(updatedTags),
 		}
 
 		_, err := conn.AddTagsToResourceWithContext(ctx, input)

--- a/internal/service/docdb/tags_gen.go
+++ b/internal/service/docdb/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*docdb.Tag) {
 // UpdateTags updates docdb service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn docdbiface.DocDBAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/ds/tags_gen.go
+++ b/internal/service/ds/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn directoryserviceiface.DirectoryService
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.DS)
+	if len(removedTags) > 0 {
 		input := &directoryservice.RemoveTagsFromResourceInput{
 			ResourceId: aws.String(identifier),
-			TagKeys:    aws.StringSlice(removedTags.IgnoreSystem(names.DS).Keys()),
+			TagKeys:    aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.RemoveTagsFromResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn directoryserviceiface.DirectoryService
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.DS)
+	if len(updatedTags) > 0 {
 		input := &directoryservice.AddTagsToResourceInput{
 			ResourceId: aws.String(identifier),
-			Tags:       Tags(updatedTags.IgnoreSystem(names.DS)),
+			Tags:       Tags(updatedTags),
 		}
 
 		_, err := conn.AddTagsToResourceWithContext(ctx, input)

--- a/internal/service/ds/tags_gen.go
+++ b/internal/service/ds/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*directoryservice.Tag) {
 // UpdateTags updates ds service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn directoryserviceiface.DirectoryServiceAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/dynamodb/tags_gen.go
+++ b/internal/service/dynamodb/tags_gen.go
@@ -131,10 +131,12 @@ func UpdateTags(ctx context.Context, conn dynamodbiface.DynamoDBAPI, identifier 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.DynamoDB)
+	if len(removedTags) > 0 {
 		input := &dynamodb.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.DynamoDB).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -144,10 +146,12 @@ func UpdateTags(ctx context.Context, conn dynamodbiface.DynamoDBAPI, identifier 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.DynamoDB)
+	if len(updatedTags) > 0 {
 		input := &dynamodb.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.DynamoDB)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/dynamodb/tags_gen.go
+++ b/internal/service/dynamodb/tags_gen.go
@@ -127,7 +127,6 @@ func SetTagsOut(ctx context.Context, tags []*dynamodb.Tag) {
 // UpdateTags updates dynamodb service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn dynamodbiface.DynamoDBAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/ec2/tags_gen.go
+++ b/internal/service/ec2/tags_gen.go
@@ -155,7 +155,6 @@ func SetTagsOut(ctx context.Context, tags any) {
 // UpdateTags updates ec2 service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn ec2iface.EC2API, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/ec2/tags_gen.go
+++ b/internal/service/ec2/tags_gen.go
@@ -159,10 +159,12 @@ func UpdateTags(ctx context.Context, conn ec2iface.EC2API, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.EC2)
+	if len(removedTags) > 0 {
 		input := &ec2.DeleteTagsInput{
 			Resources: aws.StringSlice([]string{identifier}),
-			Tags:      Tags(removedTags.IgnoreSystem(names.EC2)),
+			Tags:      Tags(removedTags),
 		}
 
 		_, err := conn.DeleteTagsWithContext(ctx, input)
@@ -172,10 +174,12 @@ func UpdateTags(ctx context.Context, conn ec2iface.EC2API, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.EC2)
+	if len(updatedTags) > 0 {
 		input := &ec2.CreateTagsInput{
 			Resources: aws.StringSlice([]string{identifier}),
-			Tags:      Tags(updatedTags.IgnoreSystem(names.EC2)),
+			Tags:      Tags(updatedTags),
 		}
 
 		_, err := conn.CreateTagsWithContext(ctx, input)

--- a/internal/service/ecr/tags_gen.go
+++ b/internal/service/ecr/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*ecr.Tag) {
 // UpdateTags updates ecr service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn ecriface.ECRAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/ecr/tags_gen.go
+++ b/internal/service/ecr/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn ecriface.ECRAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.ECR)
+	if len(removedTags) > 0 {
 		input := &ecr.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.ECR).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn ecriface.ECRAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.ECR)
+	if len(updatedTags) > 0 {
 		input := &ecr.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.ECR)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/ecrpublic/tags_gen.go
+++ b/internal/service/ecrpublic/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*ecrpublic.Tag) {
 // UpdateTags updates ecrpublic service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn ecrpubliciface.ECRPublicAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/ecrpublic/tags_gen.go
+++ b/internal/service/ecrpublic/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn ecrpubliciface.ECRPublicAPI, identifie
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.ECRPublic)
+	if len(removedTags) > 0 {
 		input := &ecrpublic.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.ECRPublic).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn ecrpubliciface.ECRPublicAPI, identifie
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.ECRPublic)
+	if len(updatedTags) > 0 {
 		input := &ecrpublic.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.ECRPublic)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/ecs/tags_gen.go
+++ b/internal/service/ecs/tags_gen.go
@@ -131,10 +131,12 @@ func UpdateTags(ctx context.Context, conn ecsiface.ECSAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.ECS)
+	if len(removedTags) > 0 {
 		input := &ecs.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.ECS).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -144,10 +146,12 @@ func UpdateTags(ctx context.Context, conn ecsiface.ECSAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.ECS)
+	if len(updatedTags) > 0 {
 		input := &ecs.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.ECS)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/ecs/tags_gen.go
+++ b/internal/service/ecs/tags_gen.go
@@ -127,7 +127,6 @@ func SetTagsOut(ctx context.Context, tags []*ecs.Tag) {
 // UpdateTags updates ecs service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn ecsiface.ECSAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/efs/tags_gen.go
+++ b/internal/service/efs/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*efs.Tag) {
 // UpdateTags updates efs service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn efsiface.EFSAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/efs/tags_gen.go
+++ b/internal/service/efs/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn efsiface.EFSAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.EFS)
+	if len(removedTags) > 0 {
 		input := &efs.UntagResourceInput{
 			ResourceId: aws.String(identifier),
-			TagKeys:    aws.StringSlice(removedTags.IgnoreSystem(names.EFS).Keys()),
+			TagKeys:    aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn efsiface.EFSAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.EFS)
+	if len(updatedTags) > 0 {
 		input := &efs.TagResourceInput{
 			ResourceId: aws.String(identifier),
-			Tags:       Tags(updatedTags.IgnoreSystem(names.EFS)),
+			Tags:       Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/eks/tags_gen.go
+++ b/internal/service/eks/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates eks service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn eksiface.EKSAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/eks/tags_gen.go
+++ b/internal/service/eks/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn eksiface.EKSAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.EKS)
+	if len(removedTags) > 0 {
 		input := &eks.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.EKS).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn eksiface.EKSAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.EKS)
+	if len(updatedTags) > 0 {
 		input := &eks.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.EKS)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/elasticache/tags_gen.go
+++ b/internal/service/elasticache/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn elasticacheiface.ElastiCacheAPI, ident
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.ElastiCache)
+	if len(removedTags) > 0 {
 		input := &elasticache.RemoveTagsFromResourceInput{
 			ResourceName: aws.String(identifier),
-			TagKeys:      aws.StringSlice(removedTags.IgnoreSystem(names.ElastiCache).Keys()),
+			TagKeys:      aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.RemoveTagsFromResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn elasticacheiface.ElastiCacheAPI, ident
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.ElastiCache)
+	if len(updatedTags) > 0 {
 		input := &elasticache.AddTagsToResourceInput{
 			ResourceName: aws.String(identifier),
-			Tags:         Tags(updatedTags.IgnoreSystem(names.ElastiCache)),
+			Tags:         Tags(updatedTags),
 		}
 
 		_, err := conn.AddTagsToResourceWithContext(ctx, input)

--- a/internal/service/elasticache/tags_gen.go
+++ b/internal/service/elasticache/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*elasticache.Tag) {
 // UpdateTags updates elasticache service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn elasticacheiface.ElastiCacheAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/elasticbeanstalk/tags_gen.go
+++ b/internal/service/elasticbeanstalk/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*elasticbeanstalk.Tag) {
 // UpdateTags updates elasticbeanstalk service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn elasticbeanstalkiface.ElasticBeanstalkAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/elasticbeanstalk/tags_gen.go
+++ b/internal/service/elasticbeanstalk/tags_gen.go
@@ -102,9 +102,11 @@ func UpdateTags(ctx context.Context, conn elasticbeanstalkiface.ElasticBeanstalk
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.ElasticBeanstalk)
 	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.ElasticBeanstalk)
 
-	// Ensure we do not send empty requests
+	// Ensure we do not send empty requests.
 	if len(removedTags) == 0 && len(updatedTags) == 0 {
 		return nil
 	}
@@ -114,7 +116,7 @@ func UpdateTags(ctx context.Context, conn elasticbeanstalkiface.ElasticBeanstalk
 	}
 
 	if len(updatedTags) > 0 {
-		input.TagsToAdd = Tags(updatedTags.IgnoreSystem(names.ElasticBeanstalk))
+		input.TagsToAdd = Tags(updatedTags)
 	}
 
 	if len(removedTags) > 0 {

--- a/internal/service/elasticsearch/tags_gen.go
+++ b/internal/service/elasticsearch/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*elasticsearchservice.Tag) {
 // UpdateTags updates elasticsearch service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn elasticsearchserviceiface.ElasticsearchServiceAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/elasticsearch/tags_gen.go
+++ b/internal/service/elasticsearch/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn elasticsearchserviceiface.Elasticsearc
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Elasticsearch)
+	if len(removedTags) > 0 {
 		input := &elasticsearchservice.RemoveTagsInput{
 			ARN:     aws.String(identifier),
-			TagKeys: aws.StringSlice(removedTags.IgnoreSystem(names.Elasticsearch).Keys()),
+			TagKeys: aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.RemoveTagsWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn elasticsearchserviceiface.Elasticsearc
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Elasticsearch)
+	if len(updatedTags) > 0 {
 		input := &elasticsearchservice.AddTagsInput{
 			ARN:     aws.String(identifier),
-			TagList: Tags(updatedTags.IgnoreSystem(names.Elasticsearch)),
+			TagList: Tags(updatedTags),
 		}
 
 		_, err := conn.AddTagsWithContext(ctx, input)

--- a/internal/service/elb/tags_gen.go
+++ b/internal/service/elb/tags_gen.go
@@ -117,10 +117,12 @@ func UpdateTags(ctx context.Context, conn elbiface.ELBAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.ELB)
+	if len(removedTags) > 0 {
 		input := &elb.RemoveTagsInput{
 			LoadBalancerNames: aws.StringSlice([]string{identifier}),
-			Tags:              TagKeys(removedTags.IgnoreSystem(names.ELB)),
+			Tags:              TagKeys(removedTags),
 		}
 
 		_, err := conn.RemoveTagsWithContext(ctx, input)
@@ -130,10 +132,12 @@ func UpdateTags(ctx context.Context, conn elbiface.ELBAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.ELB)
+	if len(updatedTags) > 0 {
 		input := &elb.AddTagsInput{
 			LoadBalancerNames: aws.StringSlice([]string{identifier}),
-			Tags:              Tags(updatedTags.IgnoreSystem(names.ELB)),
+			Tags:              Tags(updatedTags),
 		}
 
 		_, err := conn.AddTagsWithContext(ctx, input)

--- a/internal/service/elb/tags_gen.go
+++ b/internal/service/elb/tags_gen.go
@@ -113,7 +113,6 @@ func SetTagsOut(ctx context.Context, tags []*elb.Tag) {
 // UpdateTags updates elb service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn elbiface.ELBAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/elbv2/tags_gen.go
+++ b/internal/service/elbv2/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*elbv2.Tag) {
 // UpdateTags updates elbv2 service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn elbv2iface.ELBV2API, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/elbv2/tags_gen.go
+++ b/internal/service/elbv2/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn elbv2iface.ELBV2API, identifier string
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.ELBV2)
+	if len(removedTags) > 0 {
 		input := &elbv2.RemoveTagsInput{
 			ResourceArns: aws.StringSlice([]string{identifier}),
-			TagKeys:      aws.StringSlice(removedTags.IgnoreSystem(names.ELBV2).Keys()),
+			TagKeys:      aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.RemoveTagsWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn elbv2iface.ELBV2API, identifier string
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.ELBV2)
+	if len(updatedTags) > 0 {
 		input := &elbv2.AddTagsInput{
 			ResourceArns: aws.StringSlice([]string{identifier}),
-			Tags:         Tags(updatedTags.IgnoreSystem(names.ELBV2)),
+			Tags:         Tags(updatedTags),
 		}
 
 		_, err := conn.AddTagsWithContext(ctx, input)

--- a/internal/service/emr/tags_gen.go
+++ b/internal/service/emr/tags_gen.go
@@ -65,7 +65,6 @@ func SetTagsOut(ctx context.Context, tags []*emr.Tag) {
 // UpdateTags updates emr service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn emriface.EMRAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/emr/tags_gen.go
+++ b/internal/service/emr/tags_gen.go
@@ -69,10 +69,12 @@ func UpdateTags(ctx context.Context, conn emriface.EMRAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.EMR)
+	if len(removedTags) > 0 {
 		input := &emr.RemoveTagsInput{
 			ResourceId: aws.String(identifier),
-			TagKeys:    aws.StringSlice(removedTags.IgnoreSystem(names.EMR).Keys()),
+			TagKeys:    aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.RemoveTagsWithContext(ctx, input)
@@ -82,10 +84,12 @@ func UpdateTags(ctx context.Context, conn emriface.EMRAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.EMR)
+	if len(updatedTags) > 0 {
 		input := &emr.AddTagsInput{
 			ResourceId: aws.String(identifier),
-			Tags:       Tags(updatedTags.IgnoreSystem(names.EMR)),
+			Tags:       Tags(updatedTags),
 		}
 
 		_, err := conn.AddTagsWithContext(ctx, input)

--- a/internal/service/emrcontainers/tags_gen.go
+++ b/internal/service/emrcontainers/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn emrcontainersiface.EMRContainersAPI, i
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.EMRContainers)
+	if len(removedTags) > 0 {
 		input := &emrcontainers.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.EMRContainers).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn emrcontainersiface.EMRContainersAPI, i
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.EMRContainers)
+	if len(updatedTags) > 0 {
 		input := &emrcontainers.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.EMRContainers)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/emrcontainers/tags_gen.go
+++ b/internal/service/emrcontainers/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates emrcontainers service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn emrcontainersiface.EMRContainersAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/emrserverless/tags_gen.go
+++ b/internal/service/emrserverless/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn emrserverlessiface.EMRServerlessAPI, i
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.EMRServerless)
+	if len(removedTags) > 0 {
 		input := &emrserverless.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.EMRServerless).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn emrserverlessiface.EMRServerlessAPI, i
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.EMRServerless)
+	if len(updatedTags) > 0 {
 		input := &emrserverless.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.EMRServerless)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/emrserverless/tags_gen.go
+++ b/internal/service/emrserverless/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates emrserverless service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn emrserverlessiface.EMRServerlessAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/events/tags_gen.go
+++ b/internal/service/events/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*eventbridge.Tag) {
 // UpdateTags updates events service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn eventbridgeiface.EventBridgeAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/events/tags_gen.go
+++ b/internal/service/events/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn eventbridgeiface.EventBridgeAPI, ident
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Events)
+	if len(removedTags) > 0 {
 		input := &eventbridge.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Events).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn eventbridgeiface.EventBridgeAPI, ident
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Events)
+	if len(updatedTags) > 0 {
 		input := &eventbridge.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Events)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/evidently/tags_gen.go
+++ b/internal/service/evidently/tags_gen.go
@@ -48,7 +48,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates evidently service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn cloudwatchevidentlyiface.CloudWatchEvidentlyAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/evidently/tags_gen.go
+++ b/internal/service/evidently/tags_gen.go
@@ -52,10 +52,12 @@ func UpdateTags(ctx context.Context, conn cloudwatchevidentlyiface.CloudWatchEvi
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Evidently)
+	if len(removedTags) > 0 {
 		input := &cloudwatchevidently.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Evidently).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -65,10 +67,12 @@ func UpdateTags(ctx context.Context, conn cloudwatchevidentlyiface.CloudWatchEvi
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Evidently)
+	if len(updatedTags) > 0 {
 		input := &cloudwatchevidently.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Evidently)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/firehose/tags_gen.go
+++ b/internal/service/firehose/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn firehoseiface.FirehoseAPI, identifier 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Firehose)
+	if len(removedTags) > 0 {
 		input := &firehose.UntagDeliveryStreamInput{
 			DeliveryStreamName: aws.String(identifier),
-			TagKeys:            aws.StringSlice(removedTags.IgnoreSystem(names.Firehose).Keys()),
+			TagKeys:            aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagDeliveryStreamWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn firehoseiface.FirehoseAPI, identifier 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Firehose)
+	if len(updatedTags) > 0 {
 		input := &firehose.TagDeliveryStreamInput{
 			DeliveryStreamName: aws.String(identifier),
-			Tags:               Tags(updatedTags.IgnoreSystem(names.Firehose)),
+			Tags:               Tags(updatedTags),
 		}
 
 		_, err := conn.TagDeliveryStreamWithContext(ctx, input)

--- a/internal/service/firehose/tags_gen.go
+++ b/internal/service/firehose/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*firehose.Tag) {
 // UpdateTags updates firehose service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn firehoseiface.FirehoseAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/fis/tags_gen.go
+++ b/internal/service/fis/tags_gen.go
@@ -84,10 +84,12 @@ func UpdateTags(ctx context.Context, conn *fis.Client, identifier string, oldTag
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.FIS)
+	if len(removedTags) > 0 {
 		input := &fis.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     removedTags.IgnoreSystem(names.FIS).Keys(),
+			TagKeys:     removedTags.Keys(),
 		}
 
 		_, err := conn.UntagResource(ctx, input)
@@ -97,10 +99,12 @@ func UpdateTags(ctx context.Context, conn *fis.Client, identifier string, oldTag
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.FIS)
+	if len(updatedTags) > 0 {
 		input := &fis.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.FIS)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResource(ctx, input)

--- a/internal/service/fms/tags_gen.go
+++ b/internal/service/fms/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn fmsiface.FMSAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.FMS)
+	if len(removedTags) > 0 {
 		input := &fms.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.FMS).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn fmsiface.FMSAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.FMS)
+	if len(updatedTags) > 0 {
 		input := &fms.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagList:     Tags(updatedTags.IgnoreSystem(names.FMS)),
+			TagList:     Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/fms/tags_gen.go
+++ b/internal/service/fms/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*fms.Tag) {
 // UpdateTags updates fms service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn fmsiface.FMSAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/fsx/tags_gen.go
+++ b/internal/service/fsx/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*fsx.Tag) {
 // UpdateTags updates fsx service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn fsxiface.FSxAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/fsx/tags_gen.go
+++ b/internal/service/fsx/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn fsxiface.FSxAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.FSx)
+	if len(removedTags) > 0 {
 		input := &fsx.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.FSx).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn fsxiface.FSxAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.FSx)
+	if len(updatedTags) > 0 {
 		input := &fsx.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.FSx)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/gamelift/tags_gen.go
+++ b/internal/service/gamelift/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*gamelift.Tag) {
 // UpdateTags updates gamelift service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn gameliftiface.GameLiftAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/gamelift/tags_gen.go
+++ b/internal/service/gamelift/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn gameliftiface.GameLiftAPI, identifier 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.GameLift)
+	if len(removedTags) > 0 {
 		input := &gamelift.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.GameLift).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn gameliftiface.GameLiftAPI, identifier 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.GameLift)
+	if len(updatedTags) > 0 {
 		input := &gamelift.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.GameLift)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/glacier/tags_gen.go
+++ b/internal/service/glacier/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates glacier service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn glacieriface.GlacierAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/glacier/tags_gen.go
+++ b/internal/service/glacier/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn glacieriface.GlacierAPI, identifier st
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Glacier)
+	if len(removedTags) > 0 {
 		input := &glacier.RemoveTagsFromVaultInput{
 			VaultName: aws.String(identifier),
-			TagKeys:   aws.StringSlice(removedTags.IgnoreSystem(names.Glacier).Keys()),
+			TagKeys:   aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.RemoveTagsFromVaultWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn glacieriface.GlacierAPI, identifier st
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Glacier)
+	if len(updatedTags) > 0 {
 		input := &glacier.AddTagsToVaultInput{
 			VaultName: aws.String(identifier),
-			Tags:      Tags(updatedTags.IgnoreSystem(names.Glacier)),
+			Tags:      Tags(updatedTags),
 		}
 
 		_, err := conn.AddTagsToVaultWithContext(ctx, input)

--- a/internal/service/globalaccelerator/tags_gen.go
+++ b/internal/service/globalaccelerator/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*globalaccelerator.Tag) {
 // UpdateTags updates globalaccelerator service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn globalacceleratoriface.GlobalAcceleratorAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/globalaccelerator/tags_gen.go
+++ b/internal/service/globalaccelerator/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn globalacceleratoriface.GlobalAccelerat
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.GlobalAccelerator)
+	if len(removedTags) > 0 {
 		input := &globalaccelerator.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.GlobalAccelerator).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn globalacceleratoriface.GlobalAccelerat
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.GlobalAccelerator)
+	if len(updatedTags) > 0 {
 		input := &globalaccelerator.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.GlobalAccelerator)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/glue/tags_gen.go
+++ b/internal/service/glue/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates glue service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn glueiface.GlueAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/glue/tags_gen.go
+++ b/internal/service/glue/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn glueiface.GlueAPI, identifier string, 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Glue)
+	if len(removedTags) > 0 {
 		input := &glue.UntagResourceInput{
 			ResourceArn:  aws.String(identifier),
-			TagsToRemove: aws.StringSlice(removedTags.IgnoreSystem(names.Glue).Keys()),
+			TagsToRemove: aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn glueiface.GlueAPI, identifier string, 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Glue)
+	if len(updatedTags) > 0 {
 		input := &glue.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagsToAdd:   Tags(updatedTags.IgnoreSystem(names.Glue)),
+			TagsToAdd:   Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/grafana/tags_gen.go
+++ b/internal/service/grafana/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn managedgrafanaiface.ManagedGrafanaAPI,
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Grafana)
+	if len(removedTags) > 0 {
 		input := &managedgrafana.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Grafana).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn managedgrafanaiface.ManagedGrafanaAPI,
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Grafana)
+	if len(updatedTags) > 0 {
 		input := &managedgrafana.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Grafana)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/grafana/tags_gen.go
+++ b/internal/service/grafana/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates grafana service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn managedgrafanaiface.ManagedGrafanaAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/greengrass/tags_gen.go
+++ b/internal/service/greengrass/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates greengrass service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn greengrassiface.GreengrassAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/greengrass/tags_gen.go
+++ b/internal/service/greengrass/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn greengrassiface.GreengrassAPI, identif
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Greengrass)
+	if len(removedTags) > 0 {
 		input := &greengrass.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Greengrass).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn greengrassiface.GreengrassAPI, identif
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Greengrass)
+	if len(updatedTags) > 0 {
 		input := &greengrass.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Greengrass)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/guardduty/tags_gen.go
+++ b/internal/service/guardduty/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates guardduty service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn guarddutyiface.GuardDutyAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/guardduty/tags_gen.go
+++ b/internal/service/guardduty/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn guarddutyiface.GuardDutyAPI, identifie
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.GuardDuty)
+	if len(removedTags) > 0 {
 		input := &guardduty.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.GuardDuty).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn guarddutyiface.GuardDutyAPI, identifie
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.GuardDuty)
+	if len(updatedTags) > 0 {
 		input := &guardduty.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.GuardDuty)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/healthlake/tags_gen.go
+++ b/internal/service/healthlake/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn *healthlake.Client, identifier string,
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.HealthLake)
+	if len(removedTags) > 0 {
 		input := &healthlake.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     removedTags.IgnoreSystem(names.HealthLake).Keys(),
+			TagKeys:     removedTags.Keys(),
 		}
 
 		_, err := conn.UntagResource(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn *healthlake.Client, identifier string,
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.HealthLake)
+	if len(updatedTags) > 0 {
 		input := &healthlake.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.HealthLake)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResource(ctx, input)

--- a/internal/service/iam/tags.go
+++ b/internal/service/iam/tags.go
@@ -22,7 +22,7 @@ func roleUpdateTags(ctx context.Context, conn iamiface.IAMAPI, identifier string
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	if removedTags := oldTags.Removed(newTags).IgnoreSystem(names.IAM); len(removedTags) > 0 {
 		input := &iam.UntagRoleInput{
 			RoleName: aws.String(identifier),
 			TagKeys:  aws.StringSlice(removedTags.Keys()),
@@ -35,10 +35,10 @@ func roleUpdateTags(ctx context.Context, conn iamiface.IAMAPI, identifier string
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	if updatedTags := oldTags.Updated(newTags).IgnoreSystem(names.IAM); len(updatedTags) > 0 {
 		input := &iam.TagRoleInput{
 			RoleName: aws.String(identifier),
-			Tags:     Tags(updatedTags.IgnoreSystem(names.IAM)),
+			Tags:     Tags(updatedTags),
 		}
 
 		_, err := conn.TagRoleWithContext(ctx, input)
@@ -57,7 +57,7 @@ func userUpdateTags(ctx context.Context, conn iamiface.IAMAPI, identifier string
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	if removedTags := oldTags.Removed(newTags).IgnoreSystem(names.IAM); len(removedTags) > 0 {
 		input := &iam.UntagUserInput{
 			UserName: aws.String(identifier),
 			TagKeys:  aws.StringSlice(removedTags.Keys()),
@@ -70,10 +70,10 @@ func userUpdateTags(ctx context.Context, conn iamiface.IAMAPI, identifier string
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	if updatedTags := oldTags.Updated(newTags).IgnoreSystem(names.IAM); len(updatedTags) > 0 {
 		input := &iam.TagUserInput{
 			UserName: aws.String(identifier),
-			Tags:     Tags(updatedTags.IgnoreSystem(names.IAM)),
+			Tags:     Tags(updatedTags),
 		}
 
 		_, err := conn.TagUserWithContext(ctx, input)
@@ -92,7 +92,7 @@ func instanceProfileUpdateTags(ctx context.Context, conn iamiface.IAMAPI, identi
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	if removedTags := oldTags.Removed(newTags).IgnoreSystem(names.IAM); len(removedTags) > 0 {
 		input := &iam.UntagInstanceProfileInput{
 			InstanceProfileName: aws.String(identifier),
 			TagKeys:             aws.StringSlice(removedTags.Keys()),
@@ -105,10 +105,10 @@ func instanceProfileUpdateTags(ctx context.Context, conn iamiface.IAMAPI, identi
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	if updatedTags := oldTags.Updated(newTags).IgnoreSystem(names.IAM); len(updatedTags) > 0 {
 		input := &iam.TagInstanceProfileInput{
 			InstanceProfileName: aws.String(identifier),
-			Tags:                Tags(updatedTags.IgnoreSystem(names.IAM)),
+			Tags:                Tags(updatedTags),
 		}
 
 		_, err := conn.TagInstanceProfileWithContext(ctx, input)
@@ -127,7 +127,7 @@ func openIDConnectProviderUpdateTags(ctx context.Context, conn iamiface.IAMAPI, 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	if removedTags := oldTags.Removed(newTags).IgnoreSystem(names.IAM); len(removedTags) > 0 {
 		input := &iam.UntagOpenIDConnectProviderInput{
 			OpenIDConnectProviderArn: aws.String(identifier),
 			TagKeys:                  aws.StringSlice(removedTags.Keys()),
@@ -140,10 +140,10 @@ func openIDConnectProviderUpdateTags(ctx context.Context, conn iamiface.IAMAPI, 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	if updatedTags := oldTags.Updated(newTags).IgnoreSystem(names.IAM); len(updatedTags) > 0 {
 		input := &iam.TagOpenIDConnectProviderInput{
 			OpenIDConnectProviderArn: aws.String(identifier),
-			Tags:                     Tags(updatedTags.IgnoreSystem(names.IAM)),
+			Tags:                     Tags(updatedTags),
 		}
 
 		_, err := conn.TagOpenIDConnectProviderWithContext(ctx, input)
@@ -162,7 +162,7 @@ func policyUpdateTags(ctx context.Context, conn iamiface.IAMAPI, identifier stri
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	if removedTags := oldTags.Removed(newTags).IgnoreSystem(names.IAM); len(removedTags) > 0 {
 		input := &iam.UntagPolicyInput{
 			PolicyArn: aws.String(identifier),
 			TagKeys:   aws.StringSlice(removedTags.Keys()),
@@ -175,10 +175,10 @@ func policyUpdateTags(ctx context.Context, conn iamiface.IAMAPI, identifier stri
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	if updatedTags := oldTags.Updated(newTags).IgnoreSystem(names.IAM); len(updatedTags) > 0 {
 		input := &iam.TagPolicyInput{
 			PolicyArn: aws.String(identifier),
-			Tags:      Tags(updatedTags.IgnoreSystem(names.IAM)),
+			Tags:      Tags(updatedTags),
 		}
 
 		_, err := conn.TagPolicyWithContext(ctx, input)
@@ -197,7 +197,7 @@ func samlProviderUpdateTags(ctx context.Context, conn iamiface.IAMAPI, identifie
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	if removedTags := oldTags.Removed(newTags).IgnoreSystem(names.IAM); len(removedTags) > 0 {
 		input := &iam.UntagSAMLProviderInput{
 			SAMLProviderArn: aws.String(identifier),
 			TagKeys:         aws.StringSlice(removedTags.Keys()),
@@ -210,10 +210,10 @@ func samlProviderUpdateTags(ctx context.Context, conn iamiface.IAMAPI, identifie
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	if updatedTags := oldTags.Updated(newTags).IgnoreSystem(names.IAM); len(updatedTags) > 0 {
 		input := &iam.TagSAMLProviderInput{
 			SAMLProviderArn: aws.String(identifier),
-			Tags:            Tags(updatedTags.IgnoreSystem(names.IAM)),
+			Tags:            Tags(updatedTags),
 		}
 
 		_, err := conn.TagSAMLProviderWithContext(ctx, input)
@@ -232,7 +232,7 @@ func serverCertificateUpdateTags(ctx context.Context, conn iamiface.IAMAPI, iden
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	if removedTags := oldTags.Removed(newTags).IgnoreSystem(names.IAM); len(removedTags) > 0 {
 		input := &iam.UntagServerCertificateInput{
 			ServerCertificateName: aws.String(identifier),
 			TagKeys:               aws.StringSlice(removedTags.Keys()),
@@ -245,10 +245,10 @@ func serverCertificateUpdateTags(ctx context.Context, conn iamiface.IAMAPI, iden
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	if updatedTags := oldTags.Updated(newTags).IgnoreSystem(names.IAM); len(updatedTags) > 0 {
 		input := &iam.TagServerCertificateInput{
 			ServerCertificateName: aws.String(identifier),
-			Tags:                  Tags(updatedTags.IgnoreSystem(names.IAM)),
+			Tags:                  Tags(updatedTags),
 		}
 
 		_, err := conn.TagServerCertificateWithContext(ctx, input)
@@ -267,7 +267,7 @@ func virtualMFAUpdateTags(ctx context.Context, conn iamiface.IAMAPI, identifier 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	if removedTags := oldTags.Removed(newTags).IgnoreSystem(names.IAM); len(removedTags) > 0 {
 		input := &iam.UntagMFADeviceInput{
 			SerialNumber: aws.String(identifier),
 			TagKeys:      aws.StringSlice(removedTags.Keys()),
@@ -280,10 +280,10 @@ func virtualMFAUpdateTags(ctx context.Context, conn iamiface.IAMAPI, identifier 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	if updatedTags := oldTags.Updated(newTags).IgnoreSystem(names.IAM); len(updatedTags) > 0 {
 		input := &iam.TagMFADeviceInput{
 			SerialNumber: aws.String(identifier),
-			Tags:         Tags(updatedTags.IgnoreSystem(names.IAM)),
+			Tags:         Tags(updatedTags),
 		}
 
 		_, err := conn.TagMFADeviceWithContext(ctx, input)

--- a/internal/service/imagebuilder/tags_gen.go
+++ b/internal/service/imagebuilder/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates imagebuilder service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn imagebuilderiface.ImagebuilderAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/imagebuilder/tags_gen.go
+++ b/internal/service/imagebuilder/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn imagebuilderiface.ImagebuilderAPI, ide
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.ImageBuilder)
+	if len(removedTags) > 0 {
 		input := &imagebuilder.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.ImageBuilder).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn imagebuilderiface.ImagebuilderAPI, ide
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.ImageBuilder)
+	if len(updatedTags) > 0 {
 		input := &imagebuilder.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.ImageBuilder)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/inspector/tags.go
+++ b/internal/service/inspector/tags.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/inspector/inspectoriface"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // Custom Inspector Classic tag service update functions using the same format as generated code.
@@ -20,12 +21,12 @@ import (
 // The identifier is the resource ARN.
 func updateTags(ctx context.Context, conn inspectoriface.InspectorAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
-	newTags := tftags.New(ctx, newTagsMap)
+	newTags := tftags.New(ctx, newTagsMap).IgnoreSystem(names.Inspector)
 
 	if len(newTags) > 0 {
 		input := &inspector.SetTagsForResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(newTags.IgnoreAWS()),
+			Tags:        Tags(newTags),
 		}
 
 		_, err := conn.SetTagsForResourceWithContext(ctx, input)

--- a/internal/service/iot/tags_gen.go
+++ b/internal/service/iot/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn iotiface.IoTAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.IoT)
+	if len(removedTags) > 0 {
 		input := &iot.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.IoT).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn iotiface.IoTAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.IoT)
+	if len(updatedTags) > 0 {
 		input := &iot.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.IoT)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/iot/tags_gen.go
+++ b/internal/service/iot/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*iot.Tag) {
 // UpdateTags updates iot service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn iotiface.IoTAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/iotanalytics/tags_gen.go
+++ b/internal/service/iotanalytics/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn iotanalyticsiface.IoTAnalyticsAPI, ide
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.IoTAnalytics)
+	if len(removedTags) > 0 {
 		input := &iotanalytics.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.IoTAnalytics).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn iotanalyticsiface.IoTAnalyticsAPI, ide
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.IoTAnalytics)
+	if len(updatedTags) > 0 {
 		input := &iotanalytics.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.IoTAnalytics)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/iotanalytics/tags_gen.go
+++ b/internal/service/iotanalytics/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*iotanalytics.Tag) {
 // UpdateTags updates iotanalytics service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn iotanalyticsiface.IoTAnalyticsAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/iotevents/tags_gen.go
+++ b/internal/service/iotevents/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*iotevents.Tag) {
 // UpdateTags updates iotevents service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn ioteventsiface.IoTEventsAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/iotevents/tags_gen.go
+++ b/internal/service/iotevents/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn ioteventsiface.IoTEventsAPI, identifie
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.IoTEvents)
+	if len(removedTags) > 0 {
 		input := &iotevents.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.IoTEvents).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn ioteventsiface.IoTEventsAPI, identifie
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.IoTEvents)
+	if len(updatedTags) > 0 {
 		input := &iotevents.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.IoTEvents)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/ivs/tags_gen.go
+++ b/internal/service/ivs/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn ivsiface.IVSAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.IVS)
+	if len(removedTags) > 0 {
 		input := &ivs.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.IVS).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn ivsiface.IVSAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.IVS)
+	if len(updatedTags) > 0 {
 		input := &ivs.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.IVS)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/ivs/tags_gen.go
+++ b/internal/service/ivs/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates ivs service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn ivsiface.IVSAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/ivschat/tags_gen.go
+++ b/internal/service/ivschat/tags_gen.go
@@ -84,10 +84,12 @@ func UpdateTags(ctx context.Context, conn *ivschat.Client, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.IVSChat)
+	if len(removedTags) > 0 {
 		input := &ivschat.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     removedTags.IgnoreSystem(names.IVSChat).Keys(),
+			TagKeys:     removedTags.Keys(),
 		}
 
 		_, err := conn.UntagResource(ctx, input)
@@ -97,10 +99,12 @@ func UpdateTags(ctx context.Context, conn *ivschat.Client, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.IVSChat)
+	if len(updatedTags) > 0 {
 		input := &ivschat.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.IVSChat)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResource(ctx, input)

--- a/internal/service/kafka/tags_gen.go
+++ b/internal/service/kafka/tags_gen.go
@@ -48,7 +48,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates kafka service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn kafkaiface.KafkaAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/kafka/tags_gen.go
+++ b/internal/service/kafka/tags_gen.go
@@ -52,10 +52,12 @@ func UpdateTags(ctx context.Context, conn kafkaiface.KafkaAPI, identifier string
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Kafka)
+	if len(removedTags) > 0 {
 		input := &kafka.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Kafka).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -65,10 +67,12 @@ func UpdateTags(ctx context.Context, conn kafkaiface.KafkaAPI, identifier string
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Kafka)
+	if len(updatedTags) > 0 {
 		input := &kafka.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Kafka)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/kendra/tags_gen.go
+++ b/internal/service/kendra/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn *kendra.Client, identifier string, old
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Kendra)
+	if len(removedTags) > 0 {
 		input := &kendra.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     removedTags.IgnoreSystem(names.Kendra).Keys(),
+			TagKeys:     removedTags.Keys(),
 		}
 
 		_, err := conn.UntagResource(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn *kendra.Client, identifier string, old
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Kendra)
+	if len(updatedTags) > 0 {
 		input := &kendra.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Kendra)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResource(ctx, input)

--- a/internal/service/keyspaces/tags_gen.go
+++ b/internal/service/keyspaces/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn keyspacesiface.KeyspacesAPI, identifie
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Keyspaces)
+	if len(removedTags) > 0 {
 		input := &keyspaces.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(removedTags.IgnoreSystem(names.Keyspaces)),
+			Tags:        Tags(removedTags),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn keyspacesiface.KeyspacesAPI, identifie
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Keyspaces)
+	if len(updatedTags) > 0 {
 		input := &keyspaces.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Keyspaces)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/keyspaces/tags_gen.go
+++ b/internal/service/keyspaces/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*keyspaces.Tag) {
 // UpdateTags updates keyspaces service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn keyspacesiface.KeyspacesAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/kinesis/tags_gen.go
+++ b/internal/service/kinesis/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*kinesis.Tag) {
 // UpdateTags updates kinesis service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn kinesisiface.KinesisAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/kinesis/tags_gen.go
+++ b/internal/service/kinesis/tags_gen.go
@@ -102,11 +102,13 @@ func UpdateTags(ctx context.Context, conn kinesisiface.KinesisAPI, identifier st
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Kinesis)
+	if len(removedTags) > 0 {
 		for _, removedTags := range removedTags.Chunks(10) {
 			input := &kinesis.RemoveTagsFromStreamInput{
 				StreamName: aws.String(identifier),
-				TagKeys:    aws.StringSlice(removedTags.IgnoreSystem(names.Kinesis).Keys()),
+				TagKeys:    aws.StringSlice(removedTags.Keys()),
 			}
 
 			_, err := conn.RemoveTagsFromStreamWithContext(ctx, input)
@@ -117,7 +119,9 @@ func UpdateTags(ctx context.Context, conn kinesisiface.KinesisAPI, identifier st
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Kinesis)
+	if len(updatedTags) > 0 {
 		for _, updatedTags := range updatedTags.Chunks(10) {
 			input := &kinesis.AddTagsToStreamInput{
 				StreamName: aws.String(identifier),

--- a/internal/service/kinesisanalytics/tags_gen.go
+++ b/internal/service/kinesisanalytics/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn kinesisanalyticsiface.KinesisAnalytics
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.KinesisAnalytics)
+	if len(removedTags) > 0 {
 		input := &kinesisanalytics.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.KinesisAnalytics).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn kinesisanalyticsiface.KinesisAnalytics
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.KinesisAnalytics)
+	if len(updatedTags) > 0 {
 		input := &kinesisanalytics.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.KinesisAnalytics)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/kinesisanalytics/tags_gen.go
+++ b/internal/service/kinesisanalytics/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*kinesisanalytics.Tag) {
 // UpdateTags updates kinesisanalytics service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn kinesisanalyticsiface.KinesisAnalyticsAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/kinesisanalyticsv2/tags_gen.go
+++ b/internal/service/kinesisanalyticsv2/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn kinesisanalyticsv2iface.KinesisAnalyti
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.KinesisAnalyticsV2)
+	if len(removedTags) > 0 {
 		input := &kinesisanalyticsv2.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.KinesisAnalyticsV2).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn kinesisanalyticsv2iface.KinesisAnalyti
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.KinesisAnalyticsV2)
+	if len(updatedTags) > 0 {
 		input := &kinesisanalyticsv2.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.KinesisAnalyticsV2)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/kinesisanalyticsv2/tags_gen.go
+++ b/internal/service/kinesisanalyticsv2/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*kinesisanalyticsv2.Tag) {
 // UpdateTags updates kinesisanalyticsv2 service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn kinesisanalyticsv2iface.KinesisAnalyticsV2API, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/kinesisvideo/tags_gen.go
+++ b/internal/service/kinesisvideo/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates kinesisvideo service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn kinesisvideoiface.KinesisVideoAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/kinesisvideo/tags_gen.go
+++ b/internal/service/kinesisvideo/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn kinesisvideoiface.KinesisVideoAPI, ide
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.KinesisVideo)
+	if len(removedTags) > 0 {
 		input := &kinesisvideo.UntagStreamInput{
 			StreamARN:  aws.String(identifier),
-			TagKeyList: aws.StringSlice(removedTags.IgnoreSystem(names.KinesisVideo).Keys()),
+			TagKeyList: aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagStreamWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn kinesisvideoiface.KinesisVideoAPI, ide
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.KinesisVideo)
+	if len(updatedTags) > 0 {
 		input := &kinesisvideo.TagStreamInput{
 			StreamARN: aws.String(identifier),
-			Tags:      Tags(updatedTags.IgnoreSystem(names.KinesisVideo)),
+			Tags:      Tags(updatedTags),
 		}
 
 		_, err := conn.TagStreamWithContext(ctx, input)

--- a/internal/service/kms/tags_gen.go
+++ b/internal/service/kms/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*kms.Tag) {
 // UpdateTags updates kms service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn kmsiface.KMSAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/kms/tags_gen.go
+++ b/internal/service/kms/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn kmsiface.KMSAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.KMS)
+	if len(removedTags) > 0 {
 		input := &kms.UntagResourceInput{
 			KeyId:   aws.String(identifier),
-			TagKeys: aws.StringSlice(removedTags.IgnoreSystem(names.KMS).Keys()),
+			TagKeys: aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn kmsiface.KMSAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.KMS)
+	if len(updatedTags) > 0 {
 		input := &kms.TagResourceInput{
 			KeyId: aws.String(identifier),
-			Tags:  Tags(updatedTags.IgnoreSystem(names.KMS)),
+			Tags:  Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/lambda/tags_gen.go
+++ b/internal/service/lambda/tags_gen.go
@@ -51,10 +51,12 @@ func UpdateTags(ctx context.Context, conn *lambda.Client, identifier string, old
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Lambda)
+	if len(removedTags) > 0 {
 		input := &lambda.UntagResourceInput{
 			Resource: aws.String(identifier),
-			TagKeys:  removedTags.IgnoreSystem(names.Lambda).Keys(),
+			TagKeys:  removedTags.Keys(),
 		}
 
 		_, err := conn.UntagResource(ctx, input)
@@ -64,10 +66,12 @@ func UpdateTags(ctx context.Context, conn *lambda.Client, identifier string, old
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Lambda)
+	if len(updatedTags) > 0 {
 		input := &lambda.TagResourceInput{
 			Resource: aws.String(identifier),
-			Tags:     Tags(updatedTags.IgnoreSystem(names.Lambda)),
+			Tags:     Tags(updatedTags),
 		}
 
 		_, err := conn.TagResource(ctx, input)

--- a/internal/service/licensemanager/tags_gen.go
+++ b/internal/service/licensemanager/tags_gen.go
@@ -65,7 +65,6 @@ func SetTagsOut(ctx context.Context, tags []*licensemanager.Tag) {
 // UpdateTags updates licensemanager service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn licensemanageriface.LicenseManagerAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/licensemanager/tags_gen.go
+++ b/internal/service/licensemanager/tags_gen.go
@@ -69,10 +69,12 @@ func UpdateTags(ctx context.Context, conn licensemanageriface.LicenseManagerAPI,
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.LicenseManager)
+	if len(removedTags) > 0 {
 		input := &licensemanager.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.LicenseManager).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -82,10 +84,12 @@ func UpdateTags(ctx context.Context, conn licensemanageriface.LicenseManagerAPI,
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.LicenseManager)
+	if len(updatedTags) > 0 {
 		input := &licensemanager.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.LicenseManager)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/lightsail/tags_gen.go
+++ b/internal/service/lightsail/tags_gen.go
@@ -65,7 +65,6 @@ func SetTagsOut(ctx context.Context, tags []*lightsail.Tag) {
 // UpdateTags updates lightsail service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn lightsailiface.LightsailAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/lightsail/tags_gen.go
+++ b/internal/service/lightsail/tags_gen.go
@@ -69,10 +69,12 @@ func UpdateTags(ctx context.Context, conn lightsailiface.LightsailAPI, identifie
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Lightsail)
+	if len(removedTags) > 0 {
 		input := &lightsail.UntagResourceInput{
 			ResourceName: aws.String(identifier),
-			TagKeys:      aws.StringSlice(removedTags.IgnoreSystem(names.Lightsail).Keys()),
+			TagKeys:      aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -82,10 +84,12 @@ func UpdateTags(ctx context.Context, conn lightsailiface.LightsailAPI, identifie
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Lightsail)
+	if len(updatedTags) > 0 {
 		input := &lightsail.TagResourceInput{
 			ResourceName: aws.String(identifier),
-			Tags:         Tags(updatedTags.IgnoreSystem(names.Lightsail)),
+			Tags:         Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/location/tags_gen.go
+++ b/internal/service/location/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn locationserviceiface.LocationServiceAP
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Location)
+	if len(removedTags) > 0 {
 		input := &locationservice.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Location).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn locationserviceiface.LocationServiceAP
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Location)
+	if len(updatedTags) > 0 {
 		input := &locationservice.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Location)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/location/tags_gen.go
+++ b/internal/service/location/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates location service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn locationserviceiface.LocationServiceAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/logs/log_group_tags_gen.go
+++ b/internal/service/logs/log_group_tags_gen.go
@@ -50,7 +50,6 @@ func (p *servicePackage) ListLogGroupTags(ctx context.Context, meta any, identif
 // UpdateLogGroupTags updates logs service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateLogGroupTags(ctx context.Context, conn cloudwatchlogsiface.CloudWatchLogsAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/logs/log_group_tags_gen.go
+++ b/internal/service/logs/log_group_tags_gen.go
@@ -54,10 +54,12 @@ func UpdateLogGroupTags(ctx context.Context, conn cloudwatchlogsiface.CloudWatch
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Logs)
+	if len(removedTags) > 0 {
 		input := &cloudwatchlogs.UntagLogGroupInput{
 			LogGroupName: aws.String(identifier),
-			Tags:         aws.StringSlice(removedTags.IgnoreSystem(names.Logs).Keys()),
+			Tags:         aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagLogGroupWithContext(ctx, input)
@@ -67,10 +69,12 @@ func UpdateLogGroupTags(ctx context.Context, conn cloudwatchlogsiface.CloudWatch
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Logs)
+	if len(updatedTags) > 0 {
 		input := &cloudwatchlogs.TagLogGroupInput{
 			LogGroupName: aws.String(identifier),
-			Tags:         Tags(updatedTags.IgnoreSystem(names.Logs)),
+			Tags:         Tags(updatedTags),
 		}
 
 		_, err := conn.TagLogGroupWithContext(ctx, input)

--- a/internal/service/logs/tags_gen.go
+++ b/internal/service/logs/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn cloudwatchlogsiface.CloudWatchLogsAPI,
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Logs)
+	if len(removedTags) > 0 {
 		input := &cloudwatchlogs.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Logs).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn cloudwatchlogsiface.CloudWatchLogsAPI,
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Logs)
+	if len(updatedTags) > 0 {
 		input := &cloudwatchlogs.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Logs)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/logs/tags_gen.go
+++ b/internal/service/logs/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates logs service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn cloudwatchlogsiface.CloudWatchLogsAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/mediaconnect/tags_gen.go
+++ b/internal/service/mediaconnect/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn mediaconnectiface.MediaConnectAPI, ide
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.MediaConnect)
+	if len(removedTags) > 0 {
 		input := &mediaconnect.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.MediaConnect).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn mediaconnectiface.MediaConnectAPI, ide
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.MediaConnect)
+	if len(updatedTags) > 0 {
 		input := &mediaconnect.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.MediaConnect)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/mediaconnect/tags_gen.go
+++ b/internal/service/mediaconnect/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates mediaconnect service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn mediaconnectiface.MediaConnectAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/mediaconvert/tags_gen.go
+++ b/internal/service/mediaconvert/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn mediaconvertiface.MediaConvertAPI, ide
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.MediaConvert)
+	if len(removedTags) > 0 {
 		input := &mediaconvert.UntagResourceInput{
 			Arn:     aws.String(identifier),
-			TagKeys: aws.StringSlice(removedTags.IgnoreSystem(names.MediaConvert).Keys()),
+			TagKeys: aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn mediaconvertiface.MediaConvertAPI, ide
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.MediaConvert)
+	if len(updatedTags) > 0 {
 		input := &mediaconvert.TagResourceInput{
 			Arn:  aws.String(identifier),
-			Tags: Tags(updatedTags.IgnoreSystem(names.MediaConvert)),
+			Tags: Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/mediaconvert/tags_gen.go
+++ b/internal/service/mediaconvert/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates mediaconvert service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn mediaconvertiface.MediaConvertAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/medialive/tags_gen.go
+++ b/internal/service/medialive/tags_gen.go
@@ -84,10 +84,12 @@ func UpdateTags(ctx context.Context, conn *medialive.Client, identifier string, 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.MediaLive)
+	if len(removedTags) > 0 {
 		input := &medialive.DeleteTagsInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     removedTags.IgnoreSystem(names.MediaLive).Keys(),
+			TagKeys:     removedTags.Keys(),
 		}
 
 		_, err := conn.DeleteTags(ctx, input)
@@ -97,10 +99,12 @@ func UpdateTags(ctx context.Context, conn *medialive.Client, identifier string, 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.MediaLive)
+	if len(updatedTags) > 0 {
 		input := &medialive.CreateTagsInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.MediaLive)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.CreateTags(ctx, input)

--- a/internal/service/mediapackage/tags_gen.go
+++ b/internal/service/mediapackage/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn mediapackageiface.MediaPackageAPI, ide
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.MediaPackage)
+	if len(removedTags) > 0 {
 		input := &mediapackage.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.MediaPackage).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn mediapackageiface.MediaPackageAPI, ide
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.MediaPackage)
+	if len(updatedTags) > 0 {
 		input := &mediapackage.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.MediaPackage)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/mediapackage/tags_gen.go
+++ b/internal/service/mediapackage/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates mediapackage service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn mediapackageiface.MediaPackageAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/mediastore/tags_gen.go
+++ b/internal/service/mediastore/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*mediastore.Tag) {
 // UpdateTags updates mediastore service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn mediastoreiface.MediaStoreAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/mediastore/tags_gen.go
+++ b/internal/service/mediastore/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn mediastoreiface.MediaStoreAPI, identif
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.MediaStore)
+	if len(removedTags) > 0 {
 		input := &mediastore.UntagResourceInput{
 			Resource: aws.String(identifier),
-			TagKeys:  aws.StringSlice(removedTags.IgnoreSystem(names.MediaStore).Keys()),
+			TagKeys:  aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn mediastoreiface.MediaStoreAPI, identif
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.MediaStore)
+	if len(updatedTags) > 0 {
 		input := &mediastore.TagResourceInput{
 			Resource: aws.String(identifier),
-			Tags:     Tags(updatedTags.IgnoreSystem(names.MediaStore)),
+			Tags:     Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/memorydb/tags_gen.go
+++ b/internal/service/memorydb/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*memorydb.Tag) {
 // UpdateTags updates memorydb service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn memorydbiface.MemoryDBAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/memorydb/tags_gen.go
+++ b/internal/service/memorydb/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn memorydbiface.MemoryDBAPI, identifier 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.MemoryDB)
+	if len(removedTags) > 0 {
 		input := &memorydb.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.MemoryDB).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn memorydbiface.MemoryDBAPI, identifier 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.MemoryDB)
+	if len(updatedTags) > 0 {
 		input := &memorydb.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.MemoryDB)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/mq/tags_gen.go
+++ b/internal/service/mq/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates mq service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn mqiface.MQAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/mq/tags_gen.go
+++ b/internal/service/mq/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn mqiface.MQAPI, identifier string, oldT
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.MQ)
+	if len(removedTags) > 0 {
 		input := &mq.DeleteTagsInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.MQ).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.DeleteTagsWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn mqiface.MQAPI, identifier string, oldT
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.MQ)
+	if len(updatedTags) > 0 {
 		input := &mq.CreateTagsInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.MQ)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.CreateTagsWithContext(ctx, input)

--- a/internal/service/mwaa/tags_gen.go
+++ b/internal/service/mwaa/tags_gen.go
@@ -48,7 +48,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates mwaa service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn mwaaiface.MWAAAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/mwaa/tags_gen.go
+++ b/internal/service/mwaa/tags_gen.go
@@ -52,10 +52,12 @@ func UpdateTags(ctx context.Context, conn mwaaiface.MWAAAPI, identifier string, 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.MWAA)
+	if len(removedTags) > 0 {
 		input := &mwaa.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.MWAA).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -65,10 +67,12 @@ func UpdateTags(ctx context.Context, conn mwaaiface.MWAAAPI, identifier string, 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.MWAA)
+	if len(updatedTags) > 0 {
 		input := &mwaa.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.MWAA)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/neptune/tags_gen.go
+++ b/internal/service/neptune/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*neptune.Tag) {
 // UpdateTags updates neptune service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn neptuneiface.NeptuneAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/neptune/tags_gen.go
+++ b/internal/service/neptune/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn neptuneiface.NeptuneAPI, identifier st
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Neptune)
+	if len(removedTags) > 0 {
 		input := &neptune.RemoveTagsFromResourceInput{
 			ResourceName: aws.String(identifier),
-			TagKeys:      aws.StringSlice(removedTags.IgnoreSystem(names.Neptune).Keys()),
+			TagKeys:      aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.RemoveTagsFromResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn neptuneiface.NeptuneAPI, identifier st
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Neptune)
+	if len(updatedTags) > 0 {
 		input := &neptune.AddTagsToResourceInput{
 			ResourceName: aws.String(identifier),
-			Tags:         Tags(updatedTags.IgnoreSystem(names.Neptune)),
+			Tags:         Tags(updatedTags),
 		}
 
 		_, err := conn.AddTagsToResourceWithContext(ctx, input)

--- a/internal/service/networkfirewall/tags_gen.go
+++ b/internal/service/networkfirewall/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*networkfirewall.Tag) {
 // UpdateTags updates networkfirewall service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn networkfirewalliface.NetworkFirewallAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/networkfirewall/tags_gen.go
+++ b/internal/service/networkfirewall/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn networkfirewalliface.NetworkFirewallAP
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.NetworkFirewall)
+	if len(removedTags) > 0 {
 		input := &networkfirewall.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.NetworkFirewall).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn networkfirewalliface.NetworkFirewallAP
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.NetworkFirewall)
+	if len(updatedTags) > 0 {
 		input := &networkfirewall.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.NetworkFirewall)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/networkmanager/tags_gen.go
+++ b/internal/service/networkmanager/tags_gen.go
@@ -69,10 +69,12 @@ func UpdateTags(ctx context.Context, conn networkmanageriface.NetworkManagerAPI,
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.NetworkManager)
+	if len(removedTags) > 0 {
 		input := &networkmanager.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.NetworkManager).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -82,10 +84,12 @@ func UpdateTags(ctx context.Context, conn networkmanageriface.NetworkManagerAPI,
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.NetworkManager)
+	if len(updatedTags) > 0 {
 		input := &networkmanager.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.NetworkManager)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/networkmanager/tags_gen.go
+++ b/internal/service/networkmanager/tags_gen.go
@@ -65,7 +65,6 @@ func SetTagsOut(ctx context.Context, tags []*networkmanager.Tag) {
 // UpdateTags updates networkmanager service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn networkmanageriface.NetworkManagerAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/oam/tags_gen.go
+++ b/internal/service/oam/tags_gen.go
@@ -84,10 +84,12 @@ func UpdateTags(ctx context.Context, conn *oam.Client, identifier string, oldTag
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.ObservabilityAccessManager)
+	if len(removedTags) > 0 {
 		input := &oam.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     removedTags.IgnoreSystem(names.ObservabilityAccessManager).Keys(),
+			TagKeys:     removedTags.Keys(),
 		}
 
 		_, err := conn.UntagResource(ctx, input)
@@ -97,10 +99,12 @@ func UpdateTags(ctx context.Context, conn *oam.Client, identifier string, oldTag
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.ObservabilityAccessManager)
+	if len(updatedTags) > 0 {
 		input := &oam.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.ObservabilityAccessManager)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResource(ctx, input)

--- a/internal/service/opensearch/tags_gen.go
+++ b/internal/service/opensearch/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn opensearchserviceiface.OpenSearchServi
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.OpenSearch)
+	if len(removedTags) > 0 {
 		input := &opensearchservice.RemoveTagsInput{
 			ARN:     aws.String(identifier),
-			TagKeys: aws.StringSlice(removedTags.IgnoreSystem(names.OpenSearch).Keys()),
+			TagKeys: aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.RemoveTagsWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn opensearchserviceiface.OpenSearchServi
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.OpenSearch)
+	if len(updatedTags) > 0 {
 		input := &opensearchservice.AddTagsInput{
 			ARN:     aws.String(identifier),
-			TagList: Tags(updatedTags.IgnoreSystem(names.OpenSearch)),
+			TagList: Tags(updatedTags),
 		}
 
 		_, err := conn.AddTagsWithContext(ctx, input)

--- a/internal/service/opensearch/tags_gen.go
+++ b/internal/service/opensearch/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*opensearchservice.Tag) {
 // UpdateTags updates opensearch service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn opensearchserviceiface.OpenSearchServiceAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/opensearchserverless/tags_gen.go
+++ b/internal/service/opensearchserverless/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn *opensearchserverless.Client, identifi
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.OpenSearchServerless)
+	if len(removedTags) > 0 {
 		input := &opensearchserverless.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     removedTags.IgnoreSystem(names.OpenSearchServerless).Keys(),
+			TagKeys:     removedTags.Keys(),
 		}
 
 		_, err := conn.UntagResource(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn *opensearchserverless.Client, identifi
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.OpenSearchServerless)
+	if len(updatedTags) > 0 {
 		input := &opensearchserverless.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.OpenSearchServerless)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResource(ctx, input)

--- a/internal/service/opsworks/tags_gen.go
+++ b/internal/service/opsworks/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn opsworksiface.OpsWorksAPI, identifier 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.OpsWorks)
+	if len(removedTags) > 0 {
 		input := &opsworks.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.OpsWorks).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn opsworksiface.OpsWorksAPI, identifier 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.OpsWorks)
+	if len(updatedTags) > 0 {
 		input := &opsworks.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.OpsWorks)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/opsworks/tags_gen.go
+++ b/internal/service/opsworks/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates opsworks service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn opsworksiface.OpsWorksAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/organizations/tags_gen.go
+++ b/internal/service/organizations/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn organizationsiface.OrganizationsAPI, i
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Organizations)
+	if len(removedTags) > 0 {
 		input := &organizations.UntagResourceInput{
 			ResourceId: aws.String(identifier),
-			TagKeys:    aws.StringSlice(removedTags.IgnoreSystem(names.Organizations).Keys()),
+			TagKeys:    aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn organizationsiface.OrganizationsAPI, i
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Organizations)
+	if len(updatedTags) > 0 {
 		input := &organizations.TagResourceInput{
 			ResourceId: aws.String(identifier),
-			Tags:       Tags(updatedTags.IgnoreSystem(names.Organizations)),
+			Tags:       Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/organizations/tags_gen.go
+++ b/internal/service/organizations/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*organizations.Tag) {
 // UpdateTags updates organizations service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn organizationsiface.OrganizationsAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/outposts/tags_gen.go
+++ b/internal/service/outposts/tags_gen.go
@@ -48,7 +48,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates outposts service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn outpostsiface.OutpostsAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/outposts/tags_gen.go
+++ b/internal/service/outposts/tags_gen.go
@@ -52,10 +52,12 @@ func UpdateTags(ctx context.Context, conn outpostsiface.OutpostsAPI, identifier 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Outposts)
+	if len(removedTags) > 0 {
 		input := &outposts.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Outposts).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -65,10 +67,12 @@ func UpdateTags(ctx context.Context, conn outpostsiface.OutpostsAPI, identifier 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Outposts)
+	if len(updatedTags) > 0 {
 		input := &outposts.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Outposts)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/pinpoint/tags_gen.go
+++ b/internal/service/pinpoint/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn pinpointiface.PinpointAPI, identifier 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Pinpoint)
+	if len(removedTags) > 0 {
 		input := &pinpoint.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Pinpoint).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,7 +100,9 @@ func UpdateTags(ctx context.Context, conn pinpointiface.PinpointAPI, identifier 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Pinpoint)
+	if len(updatedTags) > 0 {
 		input := &pinpoint.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagsModel:   &pinpoint.TagsModel{Tags: Tags(updatedTags.IgnoreAWS())},

--- a/internal/service/pinpoint/tags_gen.go
+++ b/internal/service/pinpoint/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates pinpoint service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn pinpointiface.PinpointAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/pipes/tags_gen.go
+++ b/internal/service/pipes/tags_gen.go
@@ -84,10 +84,12 @@ func UpdateTags(ctx context.Context, conn *pipes.Client, identifier string, oldT
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Pipes)
+	if len(removedTags) > 0 {
 		input := &pipes.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     removedTags.IgnoreSystem(names.Pipes).Keys(),
+			TagKeys:     removedTags.Keys(),
 		}
 
 		_, err := conn.UntagResource(ctx, input)
@@ -97,10 +99,12 @@ func UpdateTags(ctx context.Context, conn *pipes.Client, identifier string, oldT
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Pipes)
+	if len(updatedTags) > 0 {
 		input := &pipes.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Pipes)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResource(ctx, input)

--- a/internal/service/qldb/tags_gen.go
+++ b/internal/service/qldb/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn qldbiface.QLDBAPI, identifier string, 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.QLDB)
+	if len(removedTags) > 0 {
 		input := &qldb.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.QLDB).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn qldbiface.QLDBAPI, identifier string, 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.QLDB)
+	if len(updatedTags) > 0 {
 		input := &qldb.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.QLDB)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/qldb/tags_gen.go
+++ b/internal/service/qldb/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates qldb service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn qldbiface.QLDBAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/quicksight/tags_gen.go
+++ b/internal/service/quicksight/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*quicksight.Tag) {
 // UpdateTags updates quicksight service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn quicksightiface.QuickSightAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/quicksight/tags_gen.go
+++ b/internal/service/quicksight/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn quicksightiface.QuickSightAPI, identif
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.QuickSight)
+	if len(removedTags) > 0 {
 		input := &quicksight.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.QuickSight).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn quicksightiface.QuickSightAPI, identif
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.QuickSight)
+	if len(updatedTags) > 0 {
 		input := &quicksight.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.QuickSight)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/ram/tags_gen.go
+++ b/internal/service/ram/tags_gen.go
@@ -69,10 +69,12 @@ func UpdateTags(ctx context.Context, conn ramiface.RAMAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.RAM)
+	if len(removedTags) > 0 {
 		input := &ram.UntagResourceInput{
 			ResourceShareArn: aws.String(identifier),
-			TagKeys:          aws.StringSlice(removedTags.IgnoreSystem(names.RAM).Keys()),
+			TagKeys:          aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -82,10 +84,12 @@ func UpdateTags(ctx context.Context, conn ramiface.RAMAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.RAM)
+	if len(updatedTags) > 0 {
 		input := &ram.TagResourceInput{
 			ResourceShareArn: aws.String(identifier),
-			Tags:             Tags(updatedTags.IgnoreSystem(names.RAM)),
+			Tags:             Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/ram/tags_gen.go
+++ b/internal/service/ram/tags_gen.go
@@ -65,7 +65,6 @@ func SetTagsOut(ctx context.Context, tags []*ram.Tag) {
 // UpdateTags updates ram service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn ramiface.RAMAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/rbin/tags_gen.go
+++ b/internal/service/rbin/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn *rbin.Client, identifier string, oldTa
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.RBin)
+	if len(removedTags) > 0 {
 		input := &rbin.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     removedTags.IgnoreSystem(names.RBin).Keys(),
+			TagKeys:     removedTags.Keys(),
 		}
 
 		_, err := conn.UntagResource(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn *rbin.Client, identifier string, oldTa
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.RBin)
+	if len(updatedTags) > 0 {
 		input := &rbin.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.RBin)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResource(ctx, input)

--- a/internal/service/rds/tags_gen.go
+++ b/internal/service/rds/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn rdsiface.RDSAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.RDS)
+	if len(removedTags) > 0 {
 		input := &rds.RemoveTagsFromResourceInput{
 			ResourceName: aws.String(identifier),
-			TagKeys:      aws.StringSlice(removedTags.IgnoreSystem(names.RDS).Keys()),
+			TagKeys:      aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.RemoveTagsFromResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn rdsiface.RDSAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.RDS)
+	if len(updatedTags) > 0 {
 		input := &rds.AddTagsToResourceInput{
 			ResourceName: aws.String(identifier),
-			Tags:         Tags(updatedTags.IgnoreSystem(names.RDS)),
+			Tags:         Tags(updatedTags),
 		}
 
 		_, err := conn.AddTagsToResourceWithContext(ctx, input)

--- a/internal/service/rds/tags_gen.go
+++ b/internal/service/rds/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*rds.Tag) {
 // UpdateTags updates rds service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn rdsiface.RDSAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/redshift/tags_gen.go
+++ b/internal/service/redshift/tags_gen.go
@@ -69,10 +69,12 @@ func UpdateTags(ctx context.Context, conn redshiftiface.RedshiftAPI, identifier 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Redshift)
+	if len(removedTags) > 0 {
 		input := &redshift.DeleteTagsInput{
 			ResourceName: aws.String(identifier),
-			TagKeys:      aws.StringSlice(removedTags.IgnoreSystem(names.Redshift).Keys()),
+			TagKeys:      aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.DeleteTagsWithContext(ctx, input)
@@ -82,10 +84,12 @@ func UpdateTags(ctx context.Context, conn redshiftiface.RedshiftAPI, identifier 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Redshift)
+	if len(updatedTags) > 0 {
 		input := &redshift.CreateTagsInput{
 			ResourceName: aws.String(identifier),
-			Tags:         Tags(updatedTags.IgnoreSystem(names.Redshift)),
+			Tags:         Tags(updatedTags),
 		}
 
 		_, err := conn.CreateTagsWithContext(ctx, input)

--- a/internal/service/redshift/tags_gen.go
+++ b/internal/service/redshift/tags_gen.go
@@ -65,7 +65,6 @@ func SetTagsOut(ctx context.Context, tags []*redshift.Tag) {
 // UpdateTags updates redshift service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn redshiftiface.RedshiftAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/redshiftserverless/tags_gen.go
+++ b/internal/service/redshiftserverless/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn redshiftserverlessiface.RedshiftServer
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.RedshiftServerless)
+	if len(removedTags) > 0 {
 		input := &redshiftserverless.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.RedshiftServerless).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn redshiftserverlessiface.RedshiftServer
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.RedshiftServerless)
+	if len(updatedTags) > 0 {
 		input := &redshiftserverless.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.RedshiftServerless)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/redshiftserverless/tags_gen.go
+++ b/internal/service/redshiftserverless/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*redshiftserverless.Tag) {
 // UpdateTags updates redshiftserverless service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn redshiftserverlessiface.RedshiftServerlessAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/resourceexplorer2/tags_gen.go
+++ b/internal/service/resourceexplorer2/tags_gen.go
@@ -84,10 +84,12 @@ func UpdateTags(ctx context.Context, conn *resourceexplorer2.Client, identifier 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.ResourceExplorer2)
+	if len(removedTags) > 0 {
 		input := &resourceexplorer2.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     removedTags.IgnoreSystem(names.ResourceExplorer2).Keys(),
+			TagKeys:     removedTags.Keys(),
 		}
 
 		_, err := conn.UntagResource(ctx, input)
@@ -97,10 +99,12 @@ func UpdateTags(ctx context.Context, conn *resourceexplorer2.Client, identifier 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.ResourceExplorer2)
+	if len(updatedTags) > 0 {
 		input := &resourceexplorer2.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.ResourceExplorer2)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResource(ctx, input)

--- a/internal/service/resourcegroups/tags_gen.go
+++ b/internal/service/resourcegroups/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates resourcegroups service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn resourcegroupsiface.ResourceGroupsAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/resourcegroups/tags_gen.go
+++ b/internal/service/resourcegroups/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn resourcegroupsiface.ResourceGroupsAPI,
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.ResourceGroups)
+	if len(removedTags) > 0 {
 		input := &resourcegroups.UntagInput{
 			Arn:  aws.String(identifier),
-			Keys: aws.StringSlice(removedTags.IgnoreSystem(names.ResourceGroups).Keys()),
+			Keys: aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn resourcegroupsiface.ResourceGroupsAPI,
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.ResourceGroups)
+	if len(updatedTags) > 0 {
 		input := &resourcegroups.TagInput{
 			Arn:  aws.String(identifier),
-			Tags: Tags(updatedTags.IgnoreSystem(names.ResourceGroups)),
+			Tags: Tags(updatedTags),
 		}
 
 		_, err := conn.TagWithContext(ctx, input)

--- a/internal/service/rolesanywhere/tags_gen.go
+++ b/internal/service/rolesanywhere/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn *rolesanywhere.Client, identifier stri
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.RolesAnywhere)
+	if len(removedTags) > 0 {
 		input := &rolesanywhere.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     removedTags.IgnoreSystem(names.RolesAnywhere).Keys(),
+			TagKeys:     removedTags.Keys(),
 		}
 
 		_, err := conn.UntagResource(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn *rolesanywhere.Client, identifier stri
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.RolesAnywhere)
+	if len(updatedTags) > 0 {
 		input := &rolesanywhere.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.RolesAnywhere)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResource(ctx, input)

--- a/internal/service/route53/tags_gen.go
+++ b/internal/service/route53/tags_gen.go
@@ -99,7 +99,6 @@ func SetTagsOut(ctx context.Context, tags []*route53.Tag) {
 // UpdateTags updates route53 service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn route53iface.Route53API, identifier, resourceType string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/route53/tags_gen.go
+++ b/internal/service/route53/tags_gen.go
@@ -103,9 +103,11 @@ func UpdateTags(ctx context.Context, conn route53iface.Route53API, identifier, r
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Route53)
 	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Route53)
 
-	// Ensure we do not send empty requests
+	// Ensure we do not send empty requests.
 	if len(removedTags) == 0 && len(updatedTags) == 0 {
 		return nil
 	}
@@ -116,7 +118,7 @@ func UpdateTags(ctx context.Context, conn route53iface.Route53API, identifier, r
 	}
 
 	if len(updatedTags) > 0 {
-		input.AddTags = Tags(updatedTags.IgnoreSystem(names.Route53))
+		input.AddTags = Tags(updatedTags)
 	}
 
 	if len(removedTags) > 0 {

--- a/internal/service/route53domains/tags_gen.go
+++ b/internal/service/route53domains/tags_gen.go
@@ -122,10 +122,12 @@ func UpdateTags(ctx context.Context, conn *route53domains.Client, identifier str
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Route53Domains)
+	if len(removedTags) > 0 {
 		input := &route53domains.DeleteTagsForDomainInput{
 			DomainName:   aws.String(identifier),
-			TagsToDelete: removedTags.IgnoreSystem(names.Route53Domains).Keys(),
+			TagsToDelete: removedTags.Keys(),
 		}
 
 		_, err := conn.DeleteTagsForDomain(ctx, input)
@@ -135,10 +137,12 @@ func UpdateTags(ctx context.Context, conn *route53domains.Client, identifier str
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Route53Domains)
+	if len(updatedTags) > 0 {
 		input := &route53domains.UpdateTagsForDomainInput{
 			DomainName:   aws.String(identifier),
-			TagsToUpdate: Tags(updatedTags.IgnoreSystem(names.Route53Domains)),
+			TagsToUpdate: Tags(updatedTags),
 		}
 
 		_, err := conn.UpdateTagsForDomain(ctx, input)

--- a/internal/service/route53recoveryreadiness/tags_gen.go
+++ b/internal/service/route53recoveryreadiness/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn route53recoveryreadinessiface.Route53R
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Route53RecoveryReadiness)
+	if len(removedTags) > 0 {
 		input := &route53recoveryreadiness.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Route53RecoveryReadiness).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn route53recoveryreadinessiface.Route53R
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Route53RecoveryReadiness)
+	if len(updatedTags) > 0 {
 		input := &route53recoveryreadiness.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Route53RecoveryReadiness)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/route53recoveryreadiness/tags_gen.go
+++ b/internal/service/route53recoveryreadiness/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates route53recoveryreadiness service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn route53recoveryreadinessiface.Route53RecoveryReadinessAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/route53resolver/tags_gen.go
+++ b/internal/service/route53resolver/tags_gen.go
@@ -118,7 +118,6 @@ func SetTagsOut(ctx context.Context, tags []*route53resolver.Tag) {
 // UpdateTags updates route53resolver service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn route53resolveriface.Route53ResolverAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/route53resolver/tags_gen.go
+++ b/internal/service/route53resolver/tags_gen.go
@@ -122,10 +122,12 @@ func UpdateTags(ctx context.Context, conn route53resolveriface.Route53ResolverAP
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Route53Resolver)
+	if len(removedTags) > 0 {
 		input := &route53resolver.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Route53Resolver).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -135,10 +137,12 @@ func UpdateTags(ctx context.Context, conn route53resolveriface.Route53ResolverAP
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Route53Resolver)
+	if len(updatedTags) > 0 {
 		input := &route53resolver.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Route53Resolver)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/rum/tags_gen.go
+++ b/internal/service/rum/tags_gen.go
@@ -48,7 +48,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates rum service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn cloudwatchrumiface.CloudWatchRUMAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/rum/tags_gen.go
+++ b/internal/service/rum/tags_gen.go
@@ -52,10 +52,12 @@ func UpdateTags(ctx context.Context, conn cloudwatchrumiface.CloudWatchRUMAPI, i
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.RUM)
+	if len(removedTags) > 0 {
 		input := &cloudwatchrum.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.RUM).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -65,10 +67,12 @@ func UpdateTags(ctx context.Context, conn cloudwatchrumiface.CloudWatchRUMAPI, i
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.RUM)
+	if len(updatedTags) > 0 {
 		input := &cloudwatchrum.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.RUM)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/s3/tags.go
+++ b/internal/service/s3/tags.go
@@ -12,10 +12,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
-	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // Custom S3 tag service update functions using the same format as generated code.
@@ -93,25 +91,9 @@ func ObjectListTags(ctx context.Context, conn s3iface.S3API, bucket, key string)
 		Key:    aws.String(key),
 	}
 
-	var output *s3.GetObjectTaggingOutput
-
-	err := retry.RetryContext(ctx, 1*time.Minute, func() *retry.RetryError {
-		var err error
-		output, err = conn.GetObjectTaggingWithContext(ctx, input)
-
-		if tfawserr.ErrCodeEquals(err, s3.ErrCodeNoSuchKey) {
-			return retry.RetryableError(fmt.Errorf("getting object tagging %s, retrying: %w", bucket, err))
-		}
-
-		if err != nil {
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
-	})
-	if tfresource.TimedOut(err) {
-		output, err = conn.GetObjectTaggingWithContext(ctx, input)
-	}
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 1*time.Minute, func() (interface{}, error) {
+		return conn.GetObjectTaggingWithContext(ctx, input)
+	}, s3.ErrCodeNoSuchKey)
 
 	if tfawserr.ErrCodeEquals(err, errCodeNoSuchTagSet, errCodeNoSuchTagSetError) {
 		return tftags.New(ctx, nil), nil
@@ -121,7 +103,7 @@ func ObjectListTags(ctx context.Context, conn s3iface.S3API, bucket, key string)
 		return tftags.New(ctx, nil), err
 	}
 
-	return KeyValueTags(ctx, output.TagSet), nil
+	return KeyValueTags(ctx, outputRaw.(*s3.GetObjectTaggingOutput).TagSet), nil
 }
 
 // ObjectUpdateTags updates S3 object tags.
@@ -143,7 +125,7 @@ func ObjectUpdateTags(ctx context.Context, conn s3iface.S3API, bucket, key strin
 			Bucket: aws.String(bucket),
 			Key:    aws.String(key),
 			Tagging: &s3.Tagging{
-				TagSet: Tags(newTags.Merge(ignoredTags).IgnoreSystem(names.S3)),
+				TagSet: Tags(newTags.Merge(ignoredTags)),
 			},
 		}
 

--- a/internal/service/sagemaker/tags_gen.go
+++ b/internal/service/sagemaker/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*sagemaker.Tag) {
 // UpdateTags updates sagemaker service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn sagemakeriface.SageMakerAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/sagemaker/tags_gen.go
+++ b/internal/service/sagemaker/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn sagemakeriface.SageMakerAPI, identifie
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.SageMaker)
+	if len(removedTags) > 0 {
 		input := &sagemaker.DeleteTagsInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.SageMaker).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.DeleteTagsWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn sagemakeriface.SageMakerAPI, identifie
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.SageMaker)
+	if len(updatedTags) > 0 {
 		input := &sagemaker.AddTagsInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.SageMaker)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.AddTagsWithContext(ctx, input)

--- a/internal/service/scheduler/tags_gen.go
+++ b/internal/service/scheduler/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn *scheduler.Client, identifier string, 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Scheduler)
+	if len(removedTags) > 0 {
 		input := &scheduler.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     removedTags.IgnoreSystem(names.Scheduler).Keys(),
+			TagKeys:     removedTags.Keys(),
 		}
 
 		_, err := conn.UntagResource(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn *scheduler.Client, identifier string, 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Scheduler)
+	if len(updatedTags) > 0 {
 		input := &scheduler.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Scheduler)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResource(ctx, input)

--- a/internal/service/schemas/tags_gen.go
+++ b/internal/service/schemas/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates schemas service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn schemasiface.SchemasAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/schemas/tags_gen.go
+++ b/internal/service/schemas/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn schemasiface.SchemasAPI, identifier st
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Schemas)
+	if len(removedTags) > 0 {
 		input := &schemas.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Schemas).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn schemasiface.SchemasAPI, identifier st
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Schemas)
+	if len(updatedTags) > 0 {
 		input := &schemas.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Schemas)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/secretsmanager/tags_gen.go
+++ b/internal/service/secretsmanager/tags_gen.go
@@ -69,10 +69,12 @@ func UpdateTags(ctx context.Context, conn secretsmanageriface.SecretsManagerAPI,
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.SecretsManager)
+	if len(removedTags) > 0 {
 		input := &secretsmanager.UntagResourceInput{
 			SecretId: aws.String(identifier),
-			TagKeys:  aws.StringSlice(removedTags.IgnoreSystem(names.SecretsManager).Keys()),
+			TagKeys:  aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -82,10 +84,12 @@ func UpdateTags(ctx context.Context, conn secretsmanageriface.SecretsManagerAPI,
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.SecretsManager)
+	if len(updatedTags) > 0 {
 		input := &secretsmanager.TagResourceInput{
 			SecretId: aws.String(identifier),
-			Tags:     Tags(updatedTags.IgnoreSystem(names.SecretsManager)),
+			Tags:     Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/secretsmanager/tags_gen.go
+++ b/internal/service/secretsmanager/tags_gen.go
@@ -65,7 +65,6 @@ func SetTagsOut(ctx context.Context, tags []*secretsmanager.Tag) {
 // UpdateTags updates secretsmanager service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn secretsmanageriface.SecretsManagerAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/securityhub/tags_gen.go
+++ b/internal/service/securityhub/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn securityhubiface.SecurityHubAPI, ident
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.SecurityHub)
+	if len(removedTags) > 0 {
 		input := &securityhub.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.SecurityHub).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn securityhubiface.SecurityHubAPI, ident
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.SecurityHub)
+	if len(updatedTags) > 0 {
 		input := &securityhub.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.SecurityHub)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/securityhub/tags_gen.go
+++ b/internal/service/securityhub/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates securityhub service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn securityhubiface.SecurityHubAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/servicecatalog/tags.go
+++ b/internal/service/servicecatalog/tags.go
@@ -24,12 +24,12 @@ func productUpdateTags(ctx context.Context, conn servicecatalogiface.ServiceCata
 		Id: aws.String(identifier),
 	}
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
-		input.RemoveTags = aws.StringSlice(removedTags.IgnoreSystem(names.ServiceCatalog).Keys())
+	if removedTags := oldTags.Removed(newTags).IgnoreSystem(names.ServiceCatalog); len(removedTags) > 0 {
+		input.RemoveTags = aws.StringSlice(removedTags.Keys())
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
-		input.AddTags = Tags(updatedTags.IgnoreSystem(names.ServiceCatalog))
+	if updatedTags := oldTags.Updated(newTags).IgnoreSystem(names.ServiceCatalog); len(updatedTags) > 0 {
+		input.AddTags = Tags(updatedTags)
 	}
 
 	_, err := conn.UpdateProductWithContext(ctx, input)

--- a/internal/service/servicediscovery/tags_gen.go
+++ b/internal/service/servicediscovery/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*servicediscovery.Tag) {
 // UpdateTags updates servicediscovery service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn servicediscoveryiface.ServiceDiscoveryAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/servicediscovery/tags_gen.go
+++ b/internal/service/servicediscovery/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn servicediscoveryiface.ServiceDiscovery
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.ServiceDiscovery)
+	if len(removedTags) > 0 {
 		input := &servicediscovery.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.ServiceDiscovery).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn servicediscoveryiface.ServiceDiscovery
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.ServiceDiscovery)
+	if len(updatedTags) > 0 {
 		input := &servicediscovery.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.ServiceDiscovery)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/sesv2/tags_gen.go
+++ b/internal/service/sesv2/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn *sesv2.Client, identifier string, oldT
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.SESV2)
+	if len(removedTags) > 0 {
 		input := &sesv2.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     removedTags.IgnoreSystem(names.SESV2).Keys(),
+			TagKeys:     removedTags.Keys(),
 		}
 
 		_, err := conn.UntagResource(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn *sesv2.Client, identifier string, oldT
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.SESV2)
+	if len(updatedTags) > 0 {
 		input := &sesv2.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.SESV2)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResource(ctx, input)

--- a/internal/service/sfn/tags_gen.go
+++ b/internal/service/sfn/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*sfn.Tag) {
 // UpdateTags updates sfn service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn sfniface.SFNAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/sfn/tags_gen.go
+++ b/internal/service/sfn/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn sfniface.SFNAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.SFN)
+	if len(removedTags) > 0 {
 		input := &sfn.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.SFN).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn sfniface.SFNAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.SFN)
+	if len(updatedTags) > 0 {
 		input := &sfn.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.SFN)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/shield/tags_gen.go
+++ b/internal/service/shield/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*shield.Tag) {
 // UpdateTags updates shield service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn shieldiface.ShieldAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/shield/tags_gen.go
+++ b/internal/service/shield/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn shieldiface.ShieldAPI, identifier stri
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Shield)
+	if len(removedTags) > 0 {
 		input := &shield.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Shield).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn shieldiface.ShieldAPI, identifier stri
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Shield)
+	if len(updatedTags) > 0 {
 		input := &shield.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Shield)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/signer/tags_gen.go
+++ b/internal/service/signer/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates signer service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn signeriface.SignerAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/signer/tags_gen.go
+++ b/internal/service/signer/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn signeriface.SignerAPI, identifier stri
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Signer)
+	if len(removedTags) > 0 {
 		input := &signer.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Signer).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn signeriface.SignerAPI, identifier stri
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Signer)
+	if len(updatedTags) > 0 {
 		input := &signer.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Signer)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/sns/tags_gen.go
+++ b/internal/service/sns/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*sns.Tag) {
 // UpdateTags updates sns service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn snsiface.SNSAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/sns/tags_gen.go
+++ b/internal/service/sns/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn snsiface.SNSAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.SNS)
+	if len(removedTags) > 0 {
 		input := &sns.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.SNS).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn snsiface.SNSAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.SNS)
+	if len(updatedTags) > 0 {
 		input := &sns.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.SNS)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/sqs/tags_gen.go
+++ b/internal/service/sqs/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates sqs service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn sqsiface.SQSAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/sqs/tags_gen.go
+++ b/internal/service/sqs/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn sqsiface.SQSAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.SQS)
+	if len(removedTags) > 0 {
 		input := &sqs.UntagQueueInput{
 			QueueUrl: aws.String(identifier),
-			TagKeys:  aws.StringSlice(removedTags.IgnoreSystem(names.SQS).Keys()),
+			TagKeys:  aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagQueueWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn sqsiface.SQSAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.SQS)
+	if len(updatedTags) > 0 {
 		input := &sqs.TagQueueInput{
 			QueueUrl: aws.String(identifier),
-			Tags:     Tags(updatedTags.IgnoreSystem(names.SQS)),
+			Tags:     Tags(updatedTags),
 		}
 
 		_, err := conn.TagQueueWithContext(ctx, input)

--- a/internal/service/ssm/tags_gen.go
+++ b/internal/service/ssm/tags_gen.go
@@ -103,11 +103,13 @@ func UpdateTags(ctx context.Context, conn ssmiface.SSMAPI, identifier, resourceT
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.SSM)
+	if len(removedTags) > 0 {
 		input := &ssm.RemoveTagsFromResourceInput{
 			ResourceId:   aws.String(identifier),
 			ResourceType: aws.String(resourceType),
-			TagKeys:      aws.StringSlice(removedTags.IgnoreSystem(names.SSM).Keys()),
+			TagKeys:      aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.RemoveTagsFromResourceWithContext(ctx, input)
@@ -117,11 +119,13 @@ func UpdateTags(ctx context.Context, conn ssmiface.SSMAPI, identifier, resourceT
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.SSM)
+	if len(updatedTags) > 0 {
 		input := &ssm.AddTagsToResourceInput{
 			ResourceId:   aws.String(identifier),
 			ResourceType: aws.String(resourceType),
-			Tags:         Tags(updatedTags.IgnoreSystem(names.SSM)),
+			Tags:         Tags(updatedTags),
 		}
 
 		_, err := conn.AddTagsToResourceWithContext(ctx, input)

--- a/internal/service/ssm/tags_gen.go
+++ b/internal/service/ssm/tags_gen.go
@@ -99,7 +99,6 @@ func SetTagsOut(ctx context.Context, tags []*ssm.Tag) {
 // UpdateTags updates ssm service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn ssmiface.SSMAPI, identifier, resourceType string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/ssoadmin/tags_gen.go
+++ b/internal/service/ssoadmin/tags_gen.go
@@ -99,7 +99,6 @@ func SetTagsOut(ctx context.Context, tags []*ssoadmin.Tag) {
 // UpdateTags updates ssoadmin service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn ssoadminiface.SSOAdminAPI, identifier, resourceType string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/ssoadmin/tags_gen.go
+++ b/internal/service/ssoadmin/tags_gen.go
@@ -103,11 +103,13 @@ func UpdateTags(ctx context.Context, conn ssoadminiface.SSOAdminAPI, identifier,
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.SSOAdmin)
+	if len(removedTags) > 0 {
 		input := &ssoadmin.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			InstanceArn: aws.String(resourceType),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.SSOAdmin).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -117,11 +119,13 @@ func UpdateTags(ctx context.Context, conn ssoadminiface.SSOAdminAPI, identifier,
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.SSOAdmin)
+	if len(updatedTags) > 0 {
 		input := &ssoadmin.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			InstanceArn: aws.String(resourceType),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.SSOAdmin)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/storagegateway/tags_gen.go
+++ b/internal/service/storagegateway/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn storagegatewayiface.StorageGatewayAPI,
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.StorageGateway)
+	if len(removedTags) > 0 {
 		input := &storagegateway.RemoveTagsFromResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.StorageGateway).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.RemoveTagsFromResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn storagegatewayiface.StorageGatewayAPI,
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.StorageGateway)
+	if len(updatedTags) > 0 {
 		input := &storagegateway.AddTagsToResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.StorageGateway)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.AddTagsToResourceWithContext(ctx, input)

--- a/internal/service/storagegateway/tags_gen.go
+++ b/internal/service/storagegateway/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*storagegateway.Tag) {
 // UpdateTags updates storagegateway service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn storagegatewayiface.StorageGatewayAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/swf/tags_gen.go
+++ b/internal/service/swf/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn swfiface.SWFAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.SWF)
+	if len(removedTags) > 0 {
 		input := &swf.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.SWF).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn swfiface.SWFAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.SWF)
+	if len(updatedTags) > 0 {
 		input := &swf.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.SWF)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/swf/tags_gen.go
+++ b/internal/service/swf/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*swf.ResourceTag) {
 // UpdateTags updates swf service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn swfiface.SWFAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/synthetics/tags_gen.go
+++ b/internal/service/synthetics/tags_gen.go
@@ -48,7 +48,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates synthetics service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn syntheticsiface.SyntheticsAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/synthetics/tags_gen.go
+++ b/internal/service/synthetics/tags_gen.go
@@ -52,10 +52,12 @@ func UpdateTags(ctx context.Context, conn syntheticsiface.SyntheticsAPI, identif
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Synthetics)
+	if len(removedTags) > 0 {
 		input := &synthetics.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.Synthetics).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -65,10 +67,12 @@ func UpdateTags(ctx context.Context, conn syntheticsiface.SyntheticsAPI, identif
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Synthetics)
+	if len(updatedTags) > 0 {
 		input := &synthetics.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Synthetics)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/timestreamwrite/tags_gen.go
+++ b/internal/service/timestreamwrite/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn timestreamwriteiface.TimestreamWriteAP
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.TimestreamWrite)
+	if len(removedTags) > 0 {
 		input := &timestreamwrite.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.TimestreamWrite).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn timestreamwriteiface.TimestreamWriteAP
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.TimestreamWrite)
+	if len(updatedTags) > 0 {
 		input := &timestreamwrite.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.TimestreamWrite)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/timestreamwrite/tags_gen.go
+++ b/internal/service/timestreamwrite/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*timestreamwrite.Tag) {
 // UpdateTags updates timestreamwrite service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn timestreamwriteiface.TimestreamWriteAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/transcribe/tags_gen.go
+++ b/internal/service/transcribe/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn *transcribe.Client, identifier string,
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Transcribe)
+	if len(removedTags) > 0 {
 		input := &transcribe.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     removedTags.IgnoreSystem(names.Transcribe).Keys(),
+			TagKeys:     removedTags.Keys(),
 		}
 
 		_, err := conn.UntagResource(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn *transcribe.Client, identifier string,
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Transcribe)
+	if len(updatedTags) > 0 {
 		input := &transcribe.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.Transcribe)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResource(ctx, input)

--- a/internal/service/transfer/generate.go
+++ b/internal/service/transfer/generate.go
@@ -1,6 +1,6 @@
 //go:generate go run ../../generate/tagresource/main.go -UpdateTagsFunc=UpdateTagsNoIgnoreSystem
 //go:generate go run ../../generate/tags/main.go -GetTag -ListTags -ListTagsInIDElem=Arn -ServiceTagsSlice -TagInIDElem=Arn -UpdateTags
-//go:generate go run ../../generate/tags/main.go "-TagInCustomVal=Tags(updatedTags)" -TagInIDElem=Arn "-UntagInCustomVal=aws.StringSlice(removedTags.Keys())" -UpdateTags -UpdateTagsFunc=UpdateTagsNoIgnoreSystem -SkipNamesImp -- update_tags_no_system_ignore_gen.go
+//go:generate go run ../../generate/tags/main.go -TagInIDElem=Arn -UpdateTags -UpdateTagsFunc=UpdateTagsNoIgnoreSystem -UpdateTagsNoIgnoreSystem -SkipNamesImp -- update_tags_no_system_ignore_gen.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package transfer

--- a/internal/service/transfer/tags_gen.go
+++ b/internal/service/transfer/tags_gen.go
@@ -118,7 +118,6 @@ func SetTagsOut(ctx context.Context, tags []*transfer.Tag) {
 // UpdateTags updates transfer service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn transferiface.TransferAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/transfer/tags_gen.go
+++ b/internal/service/transfer/tags_gen.go
@@ -122,10 +122,12 @@ func UpdateTags(ctx context.Context, conn transferiface.TransferAPI, identifier 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.Transfer)
+	if len(removedTags) > 0 {
 		input := &transfer.UntagResourceInput{
 			Arn:     aws.String(identifier),
-			TagKeys: aws.StringSlice(removedTags.IgnoreSystem(names.Transfer).Keys()),
+			TagKeys: aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -135,10 +137,12 @@ func UpdateTags(ctx context.Context, conn transferiface.TransferAPI, identifier 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.Transfer)
+	if len(updatedTags) > 0 {
 		input := &transfer.TagResourceInput{
 			Arn:  aws.String(identifier),
-			Tags: Tags(updatedTags.IgnoreSystem(names.Transfer)),
+			Tags: Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/transfer/update_tags_no_system_ignore_gen.go
+++ b/internal/service/transfer/update_tags_no_system_ignore_gen.go
@@ -15,7 +15,6 @@ import (
 // UpdateTagsNoIgnoreSystem updates transfer service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTagsNoIgnoreSystem(ctx context.Context, conn transferiface.TransferAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/transfer/update_tags_no_system_ignore_gen.go
+++ b/internal/service/transfer/update_tags_no_system_ignore_gen.go
@@ -19,7 +19,8 @@ func UpdateTagsNoIgnoreSystem(ctx context.Context, conn transferiface.TransferAP
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	if len(removedTags) > 0 {
 		input := &transfer.UntagResourceInput{
 			Arn:     aws.String(identifier),
 			TagKeys: aws.StringSlice(removedTags.Keys()),
@@ -32,7 +33,8 @@ func UpdateTagsNoIgnoreSystem(ctx context.Context, conn transferiface.TransferAP
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	if len(updatedTags) > 0 {
 		input := &transfer.TagResourceInput{
 			Arn:  aws.String(identifier),
 			Tags: Tags(updatedTags),

--- a/internal/service/vpclattice/tags_gen.go
+++ b/internal/service/vpclattice/tags_gen.go
@@ -84,10 +84,12 @@ func UpdateTags(ctx context.Context, conn *vpclattice.Client, identifier string,
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.VPCLattice)
+	if len(removedTags) > 0 {
 		input := &vpclattice.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     removedTags.IgnoreSystem(names.VPCLattice).Keys(),
+			TagKeys:     removedTags.Keys(),
 		}
 
 		_, err := conn.UntagResource(ctx, input)
@@ -97,10 +99,12 @@ func UpdateTags(ctx context.Context, conn *vpclattice.Client, identifier string,
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.VPCLattice)
+	if len(updatedTags) > 0 {
 		input := &vpclattice.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.VPCLattice)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResource(ctx, input)

--- a/internal/service/waf/tags_gen.go
+++ b/internal/service/waf/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn wafiface.WAFAPI, identifier string, ol
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.WAF)
+	if len(removedTags) > 0 {
 		input := &waf.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.WAF).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn wafiface.WAFAPI, identifier string, ol
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.WAF)
+	if len(updatedTags) > 0 {
 		input := &waf.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.WAF)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/waf/tags_gen.go
+++ b/internal/service/waf/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*waf.Tag) {
 // UpdateTags updates waf service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn wafiface.WAFAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/wafregional/tags_gen.go
+++ b/internal/service/wafregional/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*waf.Tag) {
 // UpdateTags updates wafregional service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn wafregionaliface.WAFRegionalAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/wafregional/tags_gen.go
+++ b/internal/service/wafregional/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn wafregionaliface.WAFRegionalAPI, ident
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.WAFRegional)
+	if len(removedTags) > 0 {
 		input := &waf.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.WAFRegional).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn wafregionaliface.WAFRegionalAPI, ident
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.WAFRegional)
+	if len(updatedTags) > 0 {
 		input := &waf.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.WAFRegional)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/wafv2/tags_gen.go
+++ b/internal/service/wafv2/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn wafv2iface.WAFV2API, identifier string
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.WAFV2)
+	if len(removedTags) > 0 {
 		input := &wafv2.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.WAFV2).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn wafv2iface.WAFV2API, identifier string
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.WAFV2)
+	if len(updatedTags) > 0 {
 		input := &wafv2.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.WAFV2)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/wafv2/tags_gen.go
+++ b/internal/service/wafv2/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*wafv2.Tag) {
 // UpdateTags updates wafv2 service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn wafv2iface.WAFV2API, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/worklink/tags_gen.go
+++ b/internal/service/worklink/tags_gen.go
@@ -81,7 +81,6 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates worklink service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn worklinkiface.WorkLinkAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/worklink/tags_gen.go
+++ b/internal/service/worklink/tags_gen.go
@@ -85,10 +85,12 @@ func UpdateTags(ctx context.Context, conn worklinkiface.WorkLinkAPI, identifier 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.WorkLink)
+	if len(removedTags) > 0 {
 		input := &worklink.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.WorkLink).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -98,10 +100,12 @@ func UpdateTags(ctx context.Context, conn worklinkiface.WorkLinkAPI, identifier 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.WorkLink)
+	if len(updatedTags) > 0 {
 		input := &worklink.TagResourceInput{
 			ResourceArn: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.WorkLink)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/workspaces/tags_gen.go
+++ b/internal/service/workspaces/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*workspaces.Tag) {
 // UpdateTags updates workspaces service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn workspacesiface.WorkSpacesAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)

--- a/internal/service/workspaces/tags_gen.go
+++ b/internal/service/workspaces/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn workspacesiface.WorkSpacesAPI, identif
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.WorkSpaces)
+	if len(removedTags) > 0 {
 		input := &workspaces.DeleteTagsInput{
 			ResourceId: aws.String(identifier),
-			TagKeys:    aws.StringSlice(removedTags.IgnoreSystem(names.WorkSpaces).Keys()),
+			TagKeys:    aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.DeleteTagsWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn workspacesiface.WorkSpacesAPI, identif
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.WorkSpaces)
+	if len(updatedTags) > 0 {
 		input := &workspaces.CreateTagsInput{
 			ResourceId: aws.String(identifier),
-			Tags:       Tags(updatedTags.IgnoreSystem(names.WorkSpaces)),
+			Tags:       Tags(updatedTags),
 		}
 
 		_, err := conn.CreateTagsWithContext(ctx, input)

--- a/internal/service/xray/tags_gen.go
+++ b/internal/service/xray/tags_gen.go
@@ -102,10 +102,12 @@ func UpdateTags(ctx context.Context, conn xrayiface.XRayAPI, identifier string, 
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
-	if removedTags := oldTags.Removed(newTags); len(removedTags) > 0 {
+	removedTags := oldTags.Removed(newTags)
+	removedTags = removedTags.IgnoreSystem(names.XRay)
+	if len(removedTags) > 0 {
 		input := &xray.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.IgnoreSystem(names.XRay).Keys()),
+			TagKeys:     aws.StringSlice(removedTags.Keys()),
 		}
 
 		_, err := conn.UntagResourceWithContext(ctx, input)
@@ -115,10 +117,12 @@ func UpdateTags(ctx context.Context, conn xrayiface.XRayAPI, identifier string, 
 		}
 	}
 
-	if updatedTags := oldTags.Updated(newTags); len(updatedTags) > 0 {
+	updatedTags := oldTags.Updated(newTags)
+	updatedTags = updatedTags.IgnoreSystem(names.XRay)
+	if len(updatedTags) > 0 {
 		input := &xray.TagResourceInput{
 			ResourceARN: aws.String(identifier),
-			Tags:        Tags(updatedTags.IgnoreSystem(names.XRay)),
+			Tags:        Tags(updatedTags),
 		}
 
 		_, err := conn.TagResourceWithContext(ctx, input)

--- a/internal/service/xray/tags_gen.go
+++ b/internal/service/xray/tags_gen.go
@@ -98,7 +98,6 @@ func SetTagsOut(ctx context.Context, tags []*xray.Tag) {
 // UpdateTags updates xray service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-
 func UpdateTags(ctx context.Context, conn xrayiface.XRayAPI, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Remove system tags (if appropriate) from list of tags to be added or removed in generated `UpdateTags` functions _before_ checking list lengths.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/30812.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/30643.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccSNSTopic_tags' PKG=sns
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sns/... -v -count 1 -parallel 20  -run=TestAccSNSTopic_tags -timeout 180m
=== RUN   TestAccSNSTopic_tags
=== PAUSE TestAccSNSTopic_tags
=== CONT  TestAccSNSTopic_tags
--- PASS: TestAccSNSTopic_tags (37.85s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sns	43.134s
% make testacc TESTARGS='-run=TestAccIAMRole_tags\|TestAccIAMServerCertificate_tags' PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20  -run=TestAccIAMRole_tags\|TestAccIAMServerCertificate_tags -timeout 180m
=== RUN   TestAccIAMRole_tags
=== PAUSE TestAccIAMRole_tags
=== RUN   TestAccIAMServerCertificate_tags
=== PAUSE TestAccIAMServerCertificate_tags
=== CONT  TestAccIAMRole_tags
=== CONT  TestAccIAMServerCertificate_tags
--- PASS: TestAccIAMRole_tags (25.05s)
--- PASS: TestAccIAMServerCertificate_tags (34.21s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	39.283s
% make testacc TESTARGS='-run=TestAccS3Object_tags' PKG=s3 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 3  -run=TestAccS3Object_tags -timeout 180m
=== RUN   TestAccS3Object_tags
=== PAUSE TestAccS3Object_tags
=== RUN   TestAccS3Object_tagsLeadingSingleSlash
=== PAUSE TestAccS3Object_tagsLeadingSingleSlash
=== RUN   TestAccS3Object_tagsLeadingMultipleSlashes
=== PAUSE TestAccS3Object_tagsLeadingMultipleSlashes
=== RUN   TestAccS3Object_tagsMultipleSlashes
=== PAUSE TestAccS3Object_tagsMultipleSlashes
=== CONT  TestAccS3Object_tags
=== CONT  TestAccS3Object_tagsLeadingMultipleSlashes
=== CONT  TestAccS3Object_tagsMultipleSlashes
--- PASS: TestAccS3Object_tagsMultipleSlashes (85.91s)
=== CONT  TestAccS3Object_tagsLeadingSingleSlash
--- PASS: TestAccS3Object_tagsLeadingMultipleSlashes (87.29s)
--- PASS: TestAccS3Object_tags (90.31s)
--- PASS: TestAccS3Object_tagsLeadingSingleSlash (79.99s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	171.465s
% make testacc TESTARGS='-run=TestAccElasticBeanstalkEnvironment_tags' PKG=elasticbeanstalk ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticbeanstalk/... -v -count 1 -parallel 3  -run=TestAccElasticBeanstalkEnvironment_tags -timeout 180m
=== RUN   TestAccElasticBeanstalkEnvironment_tags
=== PAUSE TestAccElasticBeanstalkEnvironment_tags
=== CONT  TestAccElasticBeanstalkEnvironment_tags
--- PASS: TestAccElasticBeanstalkEnvironment_tags (551.69s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticbeanstalk	556.817s
% make testacc TESTARGS='-run=TestAccTransfer_serial/^Tag$$' PKG=transfer
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/transfer/... -v -count 1 -parallel 20  -run=TestAccTransfer_serial/^Tag$ -timeout 180m
=== RUN   TestAccTransfer_serial
=== PAUSE TestAccTransfer_serial
=== CONT  TestAccTransfer_serial
=== RUN   TestAccTransfer_serial/Tag
=== RUN   TestAccTransfer_serial/Tag/basic
=== RUN   TestAccTransfer_serial/Tag/disappears
=== RUN   TestAccTransfer_serial/Tag/Value
=== RUN   TestAccTransfer_serial/Tag/System
--- PASS: TestAccTransfer_serial (741.80s)
    --- PASS: TestAccTransfer_serial/Tag (741.80s)
        --- PASS: TestAccTransfer_serial/Tag/basic (187.19s)
        --- PASS: TestAccTransfer_serial/Tag/disappears (181.73s)
        --- PASS: TestAccTransfer_serial/Tag/Value (191.47s)
        --- PASS: TestAccTransfer_serial/Tag/System (181.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/transfer	747.585s
% make testacc TESTARGS='-run=TestAccVPC_tags\|TestAccVPC_basic\|TestAccVPC_DefaultTags_\|TestAccVPC_defaultAndIgnoreTags' PKG=ec2 ACCTEST_PARALLELISM=2 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 2  -run=TestAccVPC_tags\|TestAccVPC_basic\|TestAccVPC_DefaultTags_\|TestAccVPC_defaultAndIgnoreTags -timeout 180m
=== RUN   TestAccVPC_basic
=== PAUSE TestAccVPC_basic
=== RUN   TestAccVPC_tags
=== PAUSE TestAccVPC_tags
=== RUN   TestAccVPC_DefaultTags_providerOnly
=== PAUSE TestAccVPC_DefaultTags_providerOnly
=== RUN   TestAccVPC_DefaultTags_updateToProviderOnly
=== PAUSE TestAccVPC_DefaultTags_updateToProviderOnly
=== RUN   TestAccVPC_DefaultTags_updateToResourceOnly
=== PAUSE TestAccVPC_DefaultTags_updateToResourceOnly
=== RUN   TestAccVPC_defaultAndIgnoreTags
=== PAUSE TestAccVPC_defaultAndIgnoreTags
=== CONT  TestAccVPC_basic
=== CONT  TestAccVPC_DefaultTags_updateToProviderOnly
--- PASS: TestAccVPC_basic (20.55s)
=== CONT  TestAccVPC_defaultAndIgnoreTags
--- PASS: TestAccVPC_DefaultTags_updateToProviderOnly (29.92s)
=== CONT  TestAccVPC_DefaultTags_updateToResourceOnly
--- PASS: TestAccVPC_defaultAndIgnoreTags (34.47s)
=== CONT  TestAccVPC_DefaultTags_providerOnly
--- PASS: TestAccVPC_DefaultTags_updateToResourceOnly (29.65s)
=== CONT  TestAccVPC_tags
--- PASS: TestAccVPC_DefaultTags_providerOnly (43.62s)
--- PASS: TestAccVPC_tags (49.92s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	115.205s
```
