### PR TITLE
iam_policy_document: Remove source_json, override_json

### DIFF
--- a/.changelog/30829.txt
+++ b/.changelog/30829.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+    data-source/aws_iam_policy_document: `source_json` and `override_json` have been removed -- use `source_policy_documents` and `override_policy_documents`, respectively, instead
+ ```
+
+ ```release-note:note
+ data-source/aws_iam_policy_document: Update configurations to use `source_policy_documents` and `override_policy_documents` instead of `source_json` and `override_json`, respectively, which have been removed
+ ```

--- a/internal/service/iam/policy_document_data_source.go
+++ b/internal/service/iam/policy_document_data_source.go
@@ -36,12 +36,6 @@ func DataSourcePolicyDocument() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"override_json": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringIsJSON,
-				Deprecated:   "Use the attribute \"override_policy_documents\" instead.",
-			},
 			"override_policy_documents": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -53,12 +47,6 @@ func DataSourcePolicyDocument() *schema.Resource {
 			"policy_id": {
 				Type:     schema.TypeString,
 				Optional: true,
-			},
-			"source_json": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringIsJSON,
-				Deprecated:   "Use the attribute \"source_policy_documents\" instead.",
 			},
 			"source_policy_documents": {
 				Type:     schema.TypeList,
@@ -131,12 +119,6 @@ func DataSourcePolicyDocument() *schema.Resource {
 func dataSourcePolicyDocumentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	mergedDoc := &IAMPolicyDoc{}
-
-	if v, ok := d.GetOk("source_json"); ok {
-		if err := json.Unmarshal([]byte(v.(string)), mergedDoc); err != nil {
-			return sdkdiag.AppendErrorf(diags, "writing IAM Policy Document: %s", err)
-		}
-	}
 
 	if v, ok := d.GetOk("source_policy_documents"); ok && len(v.([]interface{})) > 0 {
 		// generate sid map to assure there are no duplicates in source jsons
@@ -274,16 +256,6 @@ func dataSourcePolicyDocumentRead(ctx context.Context, d *schema.ResourceData, m
 
 			mergedDoc.Merge(overrideDoc)
 		}
-	}
-
-	// merge in override_json
-	if v, ok := d.GetOk("override_json"); ok {
-		overrideDoc := &IAMPolicyDoc{}
-		if err := json.Unmarshal([]byte(v.(string)), overrideDoc); err != nil {
-			return sdkdiag.AppendErrorf(diags, "writing IAM Policy Document: merging override JSON: %s", err)
-		}
-
-		mergedDoc.Merge(overrideDoc)
 	}
 
 	jsonDoc, err := json.MarshalIndent(mergedDoc, "", "  ")

--- a/internal/service/iam/policy_document_data_source_test.go
+++ b/internal/service/iam/policy_document_data_source_test.go
@@ -299,52 +299,6 @@ func TestAccIAMPolicyDocumentDataSource_overridePolicyDocumentValidJSON(t *testi
 	})
 }
 
-func TestAccIAMPolicyDocumentDataSource_overrideJSONValidJSON(t *testing.T) {
-	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccPolicyDocumentDataSourceConfig_overrideJSON_invalidJSON,
-				ExpectError: regexp.MustCompile(`"override_json" contains an invalid JSON: unexpected end of JSON input`),
-			},
-			{
-				Config: testAccPolicyDocumentDataSourceConfig_overrideJSON_emptyString,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_iam_policy_document.test", "json",
-						testAccPolicyDocumentExpectedJSONNoStatement,
-					),
-				),
-			},
-		},
-	})
-}
-
-func TestAccIAMPolicyDocumentDataSource_sourceJSONValidJSON(t *testing.T) {
-	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccPolicyDocumentDataSourceConfig_sourceJSON_invalidJSON,
-				ExpectError: regexp.MustCompile(`"source_json" contains an invalid JSON: unexpected end of JSON input`),
-			},
-			{
-				Config: testAccPolicyDocumentDataSourceConfig_sourceJSON_emptyString,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_iam_policy_document.test", "json",
-						testAccPolicyDocumentExpectedJSONNoStatement,
-					),
-				),
-			},
-		},
-	})
-}
-
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/10777
 func TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -730,7 +684,7 @@ data "aws_iam_policy_document" "test" {
 }
 
 data "aws_iam_policy_document" "test_source" {
-  source_json = data.aws_iam_policy_document.test.json
+  source_policy_documents = [data.aws_iam_policy_document.test.json]
 
   statement {
     sid       = "SourceJSONTest1"
@@ -885,7 +839,7 @@ var testAccPolicyDocumentSourceListExpectedJSON = `{
 
 var testAccPolicyDocumentDataSourceConfig_blankDeprecated = `
 data "aws_iam_policy_document" "test_source_blank" {
-  source_json = ""
+  source_policy_documents = [""]
 
   statement {
     sid       = "SourceJSONTest2"
@@ -917,7 +871,7 @@ data "aws_iam_policy_document" "test_source" {
 }
 
 data "aws_iam_policy_document" "test_source_conflicting" {
-  source_json = data.aws_iam_policy_document.test_source.json
+  source_policy_documents = [data.aws_iam_policy_document.test_source.json]
 
   statement {
     sid       = "SourceJSONTestConflicting"
@@ -994,7 +948,7 @@ data "aws_iam_policy_document" "override" {
 }
 
 data "aws_iam_policy_document" "test_override" {
-  override_json = data.aws_iam_policy_document.override.json
+  override_policy_documents = [data.aws_iam_policy_document.override.json]
 
   statement {
     actions   = ["ec2:*"]
@@ -1113,8 +1067,8 @@ data "aws_iam_policy_document" "override" {
 }
 
 data "aws_iam_policy_document" "yak_politik" {
-  source_json   = data.aws_iam_policy_document.source.json
-  override_json = data.aws_iam_policy_document.override.json
+  source_policy_documents   = [data.aws_iam_policy_document.source.json]
+  override_policy_documents = [data.aws_iam_policy_document.override.json]
 }
 `
 
@@ -1154,8 +1108,8 @@ data "aws_iam_policy_document" "override" {
 }
 
 data "aws_iam_policy_document" "yak_politik" {
-  source_json   = data.aws_iam_policy_document.source.json
-  override_json = data.aws_iam_policy_document.override.json
+  source_policy_documents   = [data.aws_iam_policy_document.source.json]
+  override_policy_documents = [data.aws_iam_policy_document.override.json]
 }
 `
 
@@ -1537,29 +1491,5 @@ data "aws_iam_policy_document" "test" {
 var testAccPolicyDocumentDataSourceConfig_overridePolicyDocument_invalidJSON = `
 data "aws_iam_policy_document" "test" {
   override_policy_documents = ["{"]
-}
-`
-
-var testAccPolicyDocumentDataSourceConfig_overrideJSON_emptyString = `
-data "aws_iam_policy_document" "test" {
-  override_json = ""
-}
-`
-
-var testAccPolicyDocumentDataSourceConfig_overrideJSON_invalidJSON = `
-data "aws_iam_policy_document" "test" {
-  override_json = "{"
-}
-`
-
-var testAccPolicyDocumentDataSourceConfig_sourceJSON_emptyString = `
-data "aws_iam_policy_document" "test" {
-  source_json = ""
-}
-`
-
-var testAccPolicyDocumentDataSourceConfig_sourceJSON_invalidJSON = `
-data "aws_iam_policy_document" "test" {
-  source_json = "{"
 }
 `

--- a/website/docs/d/iam_policy_document.html.markdown
+++ b/website/docs/d/iam_policy_document.html.markdown
@@ -486,14 +486,11 @@ data "aws_iam_policy_document" "combined" {
 
 The following arguments are optional:
 
-* `override_json` (Optional, **Deprecated** use the `override_policy_documents` attribute instead) - IAM policy document whose statements with non-blank `sid`s will override statements with the same `sid` from documents assigned to the `source_json`, `source_policy_documents`, and `override_policy_documents` arguments. Non-overriding statements will be added to the exported document.
+~> **NOTE:** Statements without a `sid` cannot be overridden. In other words, a statement without a `sid` from `source_policy_documents` cannot be overridden by statements from `override_policy_documents`.
 
-~> **NOTE:** Statements without a `sid` cannot be overridden. In other words, a statement without a `sid` from documents assigned to the `source_json` or `source_policy_documents` arguments cannot be overridden by statements from documents assigned to the `override_json` or `override_policy_documents` arguments.
-
-* `override_policy_documents` (Optional) - List of IAM policy documents that are merged together into the exported document. In merging, statements with non-blank `sid`s will override statements with the same `sid` from earlier documents in the list. Statements with non-blank `sid`s will also override statements with the same `sid` from documents provided in the `source_json` and `source_policy_documents` arguments.  Non-overriding statements will be added to the exported document.
+* `override_policy_documents` (Optional) - List of IAM policy documents that are merged together into the exported document. In merging, statements with non-blank `sid`s will override statements with the same `sid` from earlier documents in the list. Statements with non-blank `sid`s will also override statements with the same `sid` from `source_policy_documents`.  Non-overriding statements will be added to the exported document.
 * `policy_id` (Optional) - ID for the policy document.
-* `source_json` (Optional, **Deprecated** use the `source_policy_documents` attribute instead) - IAM policy document used as a base for the exported policy document. Statements with the same `sid` from documents assigned to the `override_json` and `override_policy_documents` arguments will override source statements.
-* `source_policy_documents` (Optional) - List of IAM policy documents that are merged together into the exported document. Statements defined in `source_policy_documents` or `source_json` must have unique `sid`s. Statements with the same `sid` from documents assigned to the `override_json` and `override_policy_documents` arguments will override source statements.
+* `source_policy_documents` (Optional) - List of IAM policy documents that are merged together into the exported document. Statements defined in `source_policy_documents` must have unique `sid`s. Statements with the same `sid` from `override_policy_documents` will override source statements.
 * `statement` (Optional) - Configuration block for a policy statement. Detailed below.
 * `version` (Optional) - IAM policy document version. Valid values are `2008-10-17` and `2012-10-17`. Defaults to `2012-10-17`. For more information, see the [AWS IAM User Guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_version.html).
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #00
or 
Closes #0000
--->

Closes #22906

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccIAMPolicyDocumentDataSource_ K=iam                   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMPolicyDocumentDataSource_'  -timeout 180m
=== RUN   TestAccIAMPolicyDocumentDataSource_basic
=== PAUSE TestAccIAMPolicyDocumentDataSource_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_singleConditionValue
=== PAUSE TestAccIAMPolicyDocumentDataSource_singleConditionValue
=== RUN   TestAccIAMPolicyDocumentDataSource_conditionWithBoolValue
=== PAUSE TestAccIAMPolicyDocumentDataSource_conditionWithBoolValue
=== RUN   TestAccIAMPolicyDocumentDataSource_source
=== PAUSE TestAccIAMPolicyDocumentDataSource_source
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceList
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceList
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceListConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceListConflicting
=== RUN   TestAccIAMPolicyDocumentDataSource_override
=== PAUSE TestAccIAMPolicyDocumentDataSource_override
=== RUN   TestAccIAMPolicyDocumentDataSource_overrideList
=== PAUSE TestAccIAMPolicyDocumentDataSource_overrideList
=== RUN   TestAccIAMPolicyDocumentDataSource_noStatementMerge
=== PAUSE TestAccIAMPolicyDocumentDataSource_noStatementMerge
=== RUN   TestAccIAMPolicyDocumentDataSource_noStatementOverride
=== PAUSE TestAccIAMPolicyDocumentDataSource_noStatementOverride
=== RUN   TestAccIAMPolicyDocumentDataSource_duplicateSid
=== PAUSE TestAccIAMPolicyDocumentDataSource_duplicateSid
=== RUN   TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJSON
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJSON
=== RUN   TestAccIAMPolicyDocumentDataSource_overridePolicyDocumentValidJSON
=== PAUSE TestAccIAMPolicyDocumentDataSource_overridePolicyDocumentValidJSON
=== RUN   TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice
=== PAUSE TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice
=== RUN   TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipals
=== PAUSE TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipals
=== RUN   TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipalsGov
=== PAUSE TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipalsGov
=== RUN   TestAccIAMPolicyDocumentDataSource_version20081017
=== PAUSE TestAccIAMPolicyDocumentDataSource_version20081017
=== CONT  TestAccIAMPolicyDocumentDataSource_basic
=== CONT  TestAccIAMPolicyDocumentDataSource_noStatementMerge
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== CONT  TestAccIAMPolicyDocumentDataSource_overrideList
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceListConflicting
=== CONT  TestAccIAMPolicyDocumentDataSource_version20081017
=== CONT  TestAccIAMPolicyDocumentDataSource_source
=== CONT  TestAccIAMPolicyDocumentDataSource_noStatementOverride
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceList
=== CONT  TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipalsGov
=== CONT  TestAccIAMPolicyDocumentDataSource_conditionWithBoolValue
=== CONT  TestAccIAMPolicyDocumentDataSource_overridePolicyDocumentValidJSON
=== CONT  TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipals
=== CONT  TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJSON
=== CONT  TestAccIAMPolicyDocumentDataSource_duplicateSid
=== CONT  TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice
=== CONT  TestAccIAMPolicyDocumentDataSource_override
=== CONT  TestAccIAMPolicyDocumentDataSource_singleConditionValue
=== NAME  TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipalsGov
    acctest.go:859: skipping tests; current partition (aws) does not equal aws-us-gov
--- SKIP: TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipalsGov (0.45s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceListConflicting (4.93s)
--- PASS: TestAccIAMPolicyDocumentDataSource_overrideList (29.01s)
--- PASS: TestAccIAMPolicyDocumentDataSource_basic (29.77s)
--- PASS: TestAccIAMPolicyDocumentDataSource_noStatementMerge (29.97s)
--- PASS: TestAccIAMPolicyDocumentDataSource_override (29.99s)
--- PASS: TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice (30.01s)
--- PASS: TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipals (30.45s)
--- PASS: TestAccIAMPolicyDocumentDataSource_conditionWithBoolValue (30.55s)
--- PASS: TestAccIAMPolicyDocumentDataSource_noStatementOverride (30.69s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceConflicting (31.39s)
--- PASS: TestAccIAMPolicyDocumentDataSource_singleConditionValue (31.41s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceList (31.49s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJSON (31.50s)
--- PASS: TestAccIAMPolicyDocumentDataSource_overridePolicyDocumentValidJSON (31.62s)
--- PASS: TestAccIAMPolicyDocumentDataSource_duplicateSid (32.21s)
--- PASS: TestAccIAMPolicyDocumentDataSource_version20081017 (36.46s)
--- PASS: TestAccIAMPolicyDocumentDataSource_source (39.68s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	41.477s
```
