### PR TITLE
Add replication subnet group datasource to dms

### DIFF
--- a/internal/service/dms/replication_subnet_group_data_source.go
+++ b/internal/service/dms/replication_subnet_group_data_source.go
@@ -1,0 +1,126 @@
+package dms
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	dms "github.com/aws/aws-sdk-go/service/databasemigrationservice"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_dms_replication_subnet_group")
+func DataSourceReplicationSubnetGroup() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceReplicationSubnetGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			"replication_subnet_group_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"replication_subnet_group_description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"replication_subnet_group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"subnet_group_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"subnet_ids": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+const (
+	DSNameReplicationSubnetGroup = "Replication Subnet Group Data Source"
+)
+
+func dataSourceReplicationSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).DMSConn()
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+
+	subnetID := d.Get("replication_subnet_group_id").(string)
+
+	out, err := FindReplicationSubnetGroupByID(ctx, conn, subnetID)
+	if err != nil {
+		return create.DiagError(names.DMS, create.ErrActionReading, DSNameReplicationSubnetGroup, d.Id(), err)
+	}
+
+	d.SetId(aws.StringValue(out.ReplicationSubnetGroupIdentifier))
+
+	arn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   "dms",
+		Region:    meta.(*conns.AWSClient).Region,
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Resource:  fmt.Sprintf("subgrp:%s", d.Id()),
+	}.String()
+	d.Set("replication_subnet_group_arn", arn)
+
+	d.Set("replication_subnet_group_description", out.ReplicationSubnetGroupDescription)
+	d.Set("replication_subnet_group_id", out.ReplicationSubnetGroupIdentifier)
+	d.Set("vpc_id", out.VpcId)
+
+	subnetIDs := []string{}
+	for _, subnet := range out.Subnets {
+		subnetIDs = append(subnetIDs, aws.StringValue(subnet.SubnetIdentifier))
+	}
+	d.Set("subnet_ids", subnetIDs)
+
+	tags, err := ListTags(ctx, conn, arn)
+	if err != nil {
+		return create.DiagError(names.DMS, create.ErrActionReading, DSNameReplicationSubnetGroup, d.Id(), err)
+	}
+
+	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	//lintignore:AWSR002
+	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		return create.DiagError(names.DMS, create.ErrActionSetting, DSNameReplicationSubnetGroup, d.Id(), err)
+	}
+	return nil
+}
+
+func FindReplicationSubnetGroupByID(ctx context.Context, conn *dms.DatabaseMigrationService, id string) (*dms.ReplicationSubnetGroup, error) {
+	input := &dms.DescribeReplicationSubnetGroupsInput{
+		Filters: []*dms.Filter{
+			{
+				Name:   aws.String("replication-subnet-group-id"),
+				Values: []*string{aws.String(id)},
+			},
+		},
+	}
+	response, err := conn.DescribeReplicationSubnetGroupsWithContext(ctx, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if response == nil || len(response.ReplicationSubnetGroups) == 0 || response.ReplicationSubnetGroups[0] == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return response.ReplicationSubnetGroups[0], nil
+}

--- a/internal/service/dms/replication_subnet_group_data_source_test.go
+++ b/internal/service/dms/replication_subnet_group_data_source_test.go
@@ -1,0 +1,97 @@
+package dms_test
+
+import (
+	"fmt"
+	"testing"
+
+	dms "github.com/aws/aws-sdk-go/service/databasemigrationservice"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccDMSReplicationSubnetGroupDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_dms_replication_subnet_group.test"
+	dataSourceName := "data.aws_dms_replication_subnet_group.test"
+
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, dms.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckReplicationSubnetGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReplicationSubnetGroupDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "replication_subnet_group_id", resourceName, "replication_subnet_group_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "replication_subnet_group_description", resourceName, "replication_subnet_group_description"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccReplicationSubnetGroupDataSourceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+resource "aws_vpc" "dms_vpc" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = "terraform-testacc-dms-replication-subnet-group-%[1]s"
+  }
+}
+
+resource "aws_subnet" "dms_subnet_1" {
+  cidr_block        = "10.1.1.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
+  vpc_id            = aws_vpc.dms_vpc.id
+
+  tags = {
+    Name = "tf-acc-dms-replication-subnet-group-1-%[1]s"
+  }
+
+  depends_on = [aws_vpc.dms_vpc]
+}
+
+resource "aws_subnet" "dms_subnet_2" {
+  cidr_block        = "10.1.2.0/24"
+  availability_zone = data.aws_availability_zones.available.names[1]
+  vpc_id            = aws_vpc.dms_vpc.id
+
+  tags = {
+    Name = "tf-acc-dms-replication-subnet-group-2-%[1]s"
+  }
+
+  depends_on = [aws_vpc.dms_vpc]
+}
+
+resource "aws_subnet" "dms_subnet_3" {
+  cidr_block        = "10.1.3.0/24"
+  availability_zone = data.aws_availability_zones.available.names[1]
+  vpc_id            = aws_vpc.dms_vpc.id
+
+  tags = {
+    Name = "tf-acc-dms-replication-subnet-group-3-%[1]s"
+  }
+
+  depends_on = [aws_vpc.dms_vpc]
+}
+
+resource "aws_dms_replication_subnet_group" "test" {
+  replication_subnet_group_id          = %[1]q
+  replication_subnet_group_description = "terraform test for replication subnet group"
+  subnet_ids                           = [aws_subnet.dms_subnet_1.id, aws_subnet.dms_subnet_2.id]
+}
+
+data "aws_dms_replication_subnet_group" "test" {
+  replication_subnet_group_id = aws_dms_replication_subnet_group.test.replication_subnet_group_id
+}
+`, rName))
+}

--- a/internal/service/dms/service_package_gen.go
+++ b/internal/service/dms/service_package_gen.go
@@ -29,6 +29,10 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			Factory:  DataSourceEndpoint,
 			TypeName: "aws_dms_endpoint",
 		},
+		{
+			Factory:  DataSourceReplicationSubnetGroup,
+			TypeName: "aws_dms_replication_subnet_group",
+		},
 	}
 }
 

--- a/website/docs/d/dms_replication_subnet_group.html.markdown
+++ b/website/docs/d/dms_replication_subnet_group.html.markdown
@@ -1,0 +1,35 @@
+---
+subcategory: "DMS (Database Migration)"
+layout: "aws"
+page_title: "AWS: aws_dms_replication_subnet_group"
+description: |-
+  Terraform data source for managing an AWS DMS (Database Migration) Replication Subnet Group.
+---
+
+# Data Source: aws_dms_replication_subnet_group
+
+Terraform data source for managing an AWS DMS (Database Migration) Replication Subnet Group.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_dms_replication_subnet_group" "test" {
+  replication_subnet_group_id = aws_dms_replication_subnet_group.test.replication_subnet_group_id
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `replication_subnet_group_id` - (Required) Name for the replication subnet group. This value is stored as a lowercase string. It must contain no more than 255 alphanumeric characters, periods, spaces, underscores, or hyphens and cannot be `default`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `replication_subnet_group_description` - Description for the subnet group.
+* `subnet_ids` - List of at least 2 EC2 subnet IDs for the subnet group. The subnets must cover at least 2 availability zones.
+* `vpc_id` - The ID of the VPC the subnet group is in.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adding replication_subnet_group datasource to dms resource

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #12713

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
> make testacc TESTARGS='-run=TestAccDMSReplicationSubnetGroupDataSource_basic' PKG=dms
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dms/... -v -count 1 -parallel 20  -run=TestAccDMSReplicationSubnetGroupDataSource_basic -timeout 180m
=== RUN   TestAccDMSReplicationSubnetGroupDataSource_basic
=== PAUSE TestAccDMSReplicationSubnetGroupDataSource_basic
=== CONT  TestAccDMSReplicationSubnetGroupDataSource_basic
--- PASS: TestAccDMSReplicationSubnetGroupDataSource_basic (17.05s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dms        23.625s

...
```
