### PR TITLE
New Resource: `aws_quicksight_refresh_schedule`

### DIFF
--- a/.changelog/30788.txt
+++ b/.changelog/30788.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_quicksight_refresh_schedule
+```

--- a/internal/service/quicksight/exports_test.go
+++ b/internal/service/quicksight/exports_test.go
@@ -5,4 +5,5 @@ var (
 	ResourceIAMPolicyAssignment = newResourceIAMPolicyAssignment
 	ResourceIngestion           = newResourceIngestion
 	ResourceNamespace           = newResourceNamespace
+	ResourceRefreshSchedule     = newResourceRefreshSchedule
 )

--- a/internal/service/quicksight/refresh_schedule.go
+++ b/internal/service/quicksight/refresh_schedule.go
@@ -57,7 +57,6 @@ func (r *resourceRefreshSchedule) Schema(ctx context.Context, req resource.Schem
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"arn": framework.ARNAttributeComputedOnly(),
-			"id":  framework.IDAttribute(),
 			"aws_account_id": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
@@ -72,6 +71,7 @@ func (r *resourceRefreshSchedule) Schema(ctx context.Context, req resource.Schem
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"id": framework.IDAttribute(),
 			"schedule_id": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
@@ -122,7 +122,6 @@ func (r *resourceRefreshSchedule) Schema(ctx context.Context, req resource.Schem
 											timeOfTheDayValidator(),
 										},
 									},
-
 									"timezone": schema.StringAttribute{
 										Optional: true,
 										Computed: true,
@@ -168,24 +167,24 @@ func (r *resourceRefreshSchedule) Schema(ctx context.Context, req resource.Schem
 
 type resourceRefreshScheduleData struct {
 	ARN          types.String `tfsdk:"arn"`
-	ID           types.String `tfsdk:"id"`
 	AWSAccountID types.String `tfsdk:"aws_account_id"`
 	DataSetID    types.String `tfsdk:"data_set_id"`
+	ID           types.String `tfsdk:"id"`
 	ScheduleID   types.String `tfsdk:"schedule_id"`
 	Schedule     types.List   `tfsdk:"schedule"`
 }
 
 type scheduleData struct {
 	RefreshType        types.String `tfsdk:"refresh_type"`
-	StartAfterDateTime types.String `tfsdk:"start_after_date_time"`
 	ScheduleFrequency  types.List   `tfsdk:"schedule_frequency"`
+	StartAfterDateTime types.String `tfsdk:"start_after_date_time"`
 }
 
 type refreshFrequencyData struct {
 	Interval     types.String `tfsdk:"interval"`
+	RefreshOnDay types.List   `tfsdk:"refresh_on_day"`
 	TimeOfTheDay types.String `tfsdk:"time_of_the_day"`
 	Timezone     types.String `tfsdk:"timezone"`
-	RefreshOnDay types.List   `tfsdk:"refresh_on_day"`
 }
 
 type refreshOnDayData struct {
@@ -199,23 +198,23 @@ var (
 		"day_of_week":  types.StringType,
 	}
 	refreshFrequencyAttrTypes = map[string]attr.Type{
-		"interval":        types.StringType,
-		"time_of_the_day": types.StringType,
-		"timezone":        types.StringType,
+		"interval": types.StringType,
 		"refresh_on_day": types.ListType{
 			ElemType: types.ObjectType{
 				AttrTypes: refreshOnDayAttrTypes,
 			},
 		},
+		"time_of_the_day": types.StringType,
+		"timezone":        types.StringType,
 	}
 	scheduleAttrTypes = map[string]attr.Type{
-		"refresh_type":          types.StringType,
-		"start_after_date_time": types.StringType,
+		"refresh_type": types.StringType,
 		"schedule_frequency": types.ListType{
 			ElemType: types.ObjectType{
 				AttrTypes: refreshFrequencyAttrTypes,
 			},
 		},
+		"start_after_date_time": types.StringType,
 	}
 )
 

--- a/internal/service/quicksight/refresh_schedule.go
+++ b/internal/service/quicksight/refresh_schedule.go
@@ -1,0 +1,706 @@
+package quicksight
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/quicksight"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource(name="Refresh Schedule")
+func newResourceRefreshSchedule(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceRefreshSchedule{}, nil
+}
+
+const (
+	ResNameRefreshSchedule   = "Refresh Schedule"
+	dayOfMonthRegex          = "^(?:LAST_DAY_OF_MONTH|1[0-9]|2[0-8]|[12]|[3-9])$"
+	timeOfTheDayLayout       = "15:04"
+	timeOfTheDayFormat       = "HH:MM"
+	startAfterDateTimeLayout = "2006-01-02T15:04:05"
+	startAfterDateTimeFormat = "YYYY-MM-DDTHH:MM:SS"
+)
+
+type resourceRefreshSchedule struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceRefreshSchedule) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = "aws_quicksight_refresh_schedule"
+}
+
+func (r *resourceRefreshSchedule) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"arn": framework.ARNAttributeComputedOnly(),
+			"id":  framework.IDAttribute(),
+			"aws_account_id": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"data_set_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"schedule_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"schedule": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+					listvalidator.IsRequired(),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"refresh_type": schema.StringAttribute{
+							Required: true,
+							Validators: []validator.String{
+								stringvalidator.OneOf(quicksight.IngestionType_Values()...),
+							},
+						},
+						"start_after_date_time": schema.StringAttribute{
+							Optional: true,
+							Computed: true,
+							Validators: []validator.String{
+								startAfterDateTimeValidator(),
+							},
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"schedule_frequency": schema.ListNestedBlock{
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+								listvalidator.IsRequired(),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"interval": schema.StringAttribute{
+										Required: true,
+										Validators: []validator.String{
+											stringvalidator.OneOf(quicksight.RefreshInterval_Values()...),
+										},
+									},
+									"time_of_the_day": schema.StringAttribute{
+										Optional: true,
+										Computed: true,
+										Validators: []validator.String{
+											timeOfTheDayValidator(),
+										},
+									},
+
+									"timezone": schema.StringAttribute{
+										Optional: true,
+										Computed: true,
+									},
+								},
+								Blocks: map[string]schema.Block{
+									"refresh_on_day": schema.ListNestedBlock{
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"day_of_month": schema.StringAttribute{
+													Optional: true,
+													Validators: []validator.String{
+														stringvalidator.RegexMatches(regexp.MustCompile(dayOfMonthRegex), "day of month must match regex: "+dayOfMonthRegex),
+														stringvalidator.ConflictsWith(
+															path.MatchRelative().AtParent().AtName("day_of_week"),
+														),
+													},
+												},
+												"day_of_week": schema.StringAttribute{
+													Optional: true,
+													Validators: []validator.String{
+														stringvalidator.OneOf(quicksight.DayOfWeek_Values()...),
+														stringvalidator.ConflictsWith(
+															path.MatchRelative().AtParent().AtName("day_of_month"),
+														),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type resourceRefreshScheduleData struct {
+	ARN          types.String `tfsdk:"arn"`
+	ID           types.String `tfsdk:"id"`
+	AWSAccountID types.String `tfsdk:"aws_account_id"`
+	DataSetID    types.String `tfsdk:"data_set_id"`
+	ScheduleID   types.String `tfsdk:"schedule_id"`
+	Schedule     types.List   `tfsdk:"schedule"`
+}
+
+type scheduleData struct {
+	RefreshType        types.String `tfsdk:"refresh_type"`
+	StartAfterDateTime types.String `tfsdk:"start_after_date_time"`
+	ScheduleFrequency  types.List   `tfsdk:"schedule_frequency"`
+}
+
+type refreshFrequencyData struct {
+	Interval     types.String `tfsdk:"interval"`
+	TimeOfTheDay types.String `tfsdk:"time_of_the_day"`
+	Timezone     types.String `tfsdk:"timezone"`
+	RefreshOnDay types.List   `tfsdk:"refresh_on_day"`
+}
+
+type refreshOnDayData struct {
+	DayOfMonth types.String `tfsdk:"day_of_month"`
+	DayOfWeek  types.String `tfsdk:"day_of_week"`
+}
+
+var (
+	refreshOnDayAttrTypes = map[string]attr.Type{
+		"day_of_month": types.StringType,
+		"day_of_week":  types.StringType,
+	}
+	refreshFrequencyAttrTypes = map[string]attr.Type{
+		"interval":        types.StringType,
+		"time_of_the_day": types.StringType,
+		"timezone":        types.StringType,
+		"refresh_on_day": types.ListType{
+			ElemType: types.ObjectType{
+				AttrTypes: refreshOnDayAttrTypes,
+			},
+		},
+	}
+	scheduleAttrTypes = map[string]attr.Type{
+		"refresh_type":          types.StringType,
+		"start_after_date_time": types.StringType,
+		"schedule_frequency": types.ListType{
+			ElemType: types.ObjectType{
+				AttrTypes: refreshFrequencyAttrTypes,
+			},
+		},
+	}
+)
+
+func (r *resourceRefreshSchedule) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().QuickSightConn()
+
+	var plan resourceRefreshScheduleData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if plan.AWSAccountID.IsUnknown() || plan.AWSAccountID.IsNull() {
+		plan.AWSAccountID = types.StringValue(r.Meta().AccountID)
+	}
+	plan.ID = types.StringValue(createRefreshScheduleID(plan.AWSAccountID.ValueString(), plan.DataSetID.ValueString(), plan.ScheduleID.ValueString()))
+
+	scheduleInput, d := expandSchedule(ctx, plan.ScheduleID.ValueString(), plan)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := quicksight.CreateRefreshScheduleInput{
+		AwsAccountId: aws.String(plan.AWSAccountID.ValueString()),
+		DataSetId:    aws.String(plan.DataSetID.ValueString()),
+		Schedule:     scheduleInput,
+	}
+
+	out, err := conn.CreateRefreshScheduleWithContext(ctx, &in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QuickSight, create.ErrActionCreating, ResNameRefreshSchedule, plan.ScheduleID.String(), nil),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QuickSight, create.ErrActionCreating, ResNameRefreshSchedule, plan.ScheduleID.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	_, read, err := FindRefreshScheduleByID(ctx, conn, plan.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QuickSight, create.ErrActionReading, ResNameRefreshSchedule, plan.ID.String(), nil),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(plan.refreshFromRead(ctx, out.Arn, read)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceRefreshSchedule) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().QuickSightConn()
+
+	var state resourceRefreshScheduleData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	arn, schedule, err := FindRefreshScheduleByID(ctx, conn, state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QuickSight, create.ErrActionReading, ResNameRefreshSchedule, state.ID.String(), nil),
+			err.Error(),
+		)
+		return
+	}
+	resp.Diagnostics.Append(state.refreshFromRead(ctx, arn, schedule)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceRefreshSchedule) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().QuickSightConn()
+
+	var config, plan, state resourceRefreshScheduleData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.Schedule.Equal(state.Schedule) {
+		scheduleInput, d := expandSchedule(ctx, plan.ScheduleID.ValueString(), plan)
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		in := quicksight.UpdateRefreshScheduleInput{
+			AwsAccountId: aws.String(plan.AWSAccountID.ValueString()),
+			DataSetId:    aws.String(plan.DataSetID.ValueString()),
+			Schedule:     scheduleInput,
+		}
+
+		// NOTE: Do not set StartAfterDateTime if not defined in config anymore or the value is unchanged
+
+		var configTfList, planTfList, stateTfList []scheduleData
+		resp.Diagnostics.Append(config.Schedule.ElementsAs(ctx, &configTfList, false)...)
+		resp.Diagnostics.Append(plan.Schedule.ElementsAs(ctx, &planTfList, false)...)
+		resp.Diagnostics.Append(state.Schedule.ElementsAs(ctx, &stateTfList, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		configSchedule := configTfList[0]
+		planSchedule := planTfList[0]
+		stateSchedule := stateTfList[0]
+
+		if configSchedule.StartAfterDateTime.IsNull() ||
+			planSchedule.StartAfterDateTime.Equal(stateSchedule.StartAfterDateTime) {
+			in.Schedule.StartAfterDateTime = nil
+		}
+		out, err := conn.UpdateRefreshScheduleWithContext(ctx, &in)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.QuickSight, create.ErrActionUpdating, ResNameRefreshSchedule, plan.ID.String(), nil),
+				err.Error(),
+			)
+			return
+		}
+		if out == nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.QuickSight, create.ErrActionUpdating, ResNameRefreshSchedule, plan.ID.String(), nil),
+				errors.New("empty output").Error(),
+			)
+			return
+		}
+
+		_, schedule, err := FindRefreshScheduleByID(ctx, conn, plan.ID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.QuickSight, create.ErrActionReading, ResNameRefreshSchedule, plan.ID.String(), nil),
+				err.Error(),
+			)
+			return
+		}
+
+		resp.Diagnostics.Append(plan.refreshFromRead(ctx, out.Arn, schedule)...)
+		resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+	}
+}
+
+func (r *resourceRefreshSchedule) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().QuickSightConn()
+
+	var state resourceRefreshScheduleData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, dataSetID, scheduleID, err := ParseRefreshScheduleID(state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QuickSight, create.ErrActionSetting, ResNameRefreshSchedule, state.ID.String(), nil),
+			err.Error(),
+		)
+		return
+	}
+	_, err = conn.DeleteRefreshScheduleWithContext(ctx, &quicksight.DeleteRefreshScheduleInput{
+		AwsAccountId: aws.String(state.AWSAccountID.ValueString()),
+		DataSetId:    aws.String(dataSetID),
+		ScheduleId:   aws.String(scheduleID),
+	})
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QuickSight, create.ErrActionDeleting, ResNameRefreshSchedule, state.ID.String(), nil),
+			err.Error(),
+		)
+	}
+}
+
+func (r *resourceRefreshSchedule) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *resourceRefreshSchedule) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var state resourceRefreshScheduleData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	apiObj, d := expandSchedule(ctx, "N/A", state)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	basePath := path.Root("schedule").AtName("schedule_frequency").AtName("refresh_on_day")
+
+	switch *apiObj.ScheduleFrequency.Interval {
+	case quicksight.RefreshIntervalWeekly:
+		if apiObj.ScheduleFrequency.RefreshOnDay == nil || apiObj.ScheduleFrequency.RefreshOnDay.DayOfWeek == nil {
+			resp.Diagnostics.AddAttributeError(
+				basePath.AtName("day_of_week"),
+				"Invalid Attribute Configuration",
+				"day_of_week is required with WEEKLY interval",
+			)
+		}
+	case quicksight.RefreshIntervalMonthly:
+		if apiObj.ScheduleFrequency.RefreshOnDay == nil || apiObj.ScheduleFrequency.RefreshOnDay.DayOfMonth == nil {
+			resp.Diagnostics.AddAttributeError(
+				basePath.AtName("day_of_month"),
+				"Invalid Attribute Configuration",
+				"day_of_month is required with MONTHLY interval",
+			)
+		}
+
+	default:
+		if apiObj.ScheduleFrequency.RefreshOnDay != nil {
+			resp.Diagnostics.AddAttributeError(
+				basePath,
+				"Invalid Attribute Configuration",
+				"refresh_on_day is only valid with WEEKLY or MONTHLY interval",
+			)
+		}
+	}
+}
+
+func FindRefreshScheduleByID(ctx context.Context, conn *quicksight.QuickSight, id string) (*string, *quicksight.RefreshSchedule, error) {
+	awsAccountID, dataSetID, scheduleID, err := ParseRefreshScheduleID(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	in := quicksight.DescribeRefreshScheduleInput{
+		AwsAccountId: aws.String(awsAccountID),
+		DataSetId:    aws.String(dataSetID),
+		ScheduleId:   aws.String(scheduleID),
+	}
+	out, err := conn.DescribeRefreshScheduleWithContext(ctx, &in)
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
+			return nil, nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, nil, err
+	}
+
+	if out == nil || out.RefreshSchedule == nil {
+		return nil, nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out.Arn, out.RefreshSchedule, nil
+}
+
+func (rd *resourceRefreshScheduleData) refreshFromRead(ctx context.Context, arn *string, out *quicksight.RefreshSchedule) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if out == nil {
+		return diags
+	}
+
+	// Support import
+	awsAccountID, dataSetID, scheduleID, err := ParseRefreshScheduleID(rd.ID.ValueString())
+	if err != nil {
+		diags.AddError(
+			create.ProblemStandardMessage(names.QuickSight, create.ErrActionReading, ResNameRefreshSchedule, rd.ID.String(), nil),
+			err.Error(),
+		)
+		return diags
+	}
+	rd.AWSAccountID = types.StringValue(awsAccountID)
+	rd.DataSetID = types.StringValue(dataSetID)
+	rd.ScheduleID = types.StringValue(scheduleID)
+	rd.ARN = flex.StringToFramework(ctx, arn)
+
+	schedule, d := flattenSchedule(ctx, out)
+	diags.Append(d...)
+	rd.Schedule = schedule
+
+	return diags
+}
+
+func expandSchedule(ctx context.Context, scheduleId string, plan resourceRefreshScheduleData) (*quicksight.RefreshSchedule, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var tfList []scheduleData
+	diags.Append(plan.Schedule.ElementsAs(ctx, &tfList, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	tfObj := tfList[0]
+	in := &quicksight.RefreshSchedule{
+		ScheduleId:  aws.String(scheduleId),
+		RefreshType: aws.String(tfObj.RefreshType.ValueString()),
+	}
+
+	if !tfObj.StartAfterDateTime.IsUnknown() {
+		start, _ := time.Parse(startAfterDateTimeLayout, tfObj.StartAfterDateTime.ValueString())
+		in.StartAfterDateTime = aws.Time(start)
+	}
+
+	refreshFrequency, d := expandRefreshFrequency(ctx, tfObj)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+	in.ScheduleFrequency = refreshFrequency
+	return in, diags
+}
+
+func expandRefreshFrequency(ctx context.Context, plan scheduleData) (*quicksight.RefreshFrequency, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var tfList []refreshFrequencyData
+	diags.Append(plan.ScheduleFrequency.ElementsAs(ctx, &tfList, false)...)
+	if diags.HasError() || len(tfList) == 0 {
+		return nil, diags
+	}
+
+	tfObj := tfList[0]
+	freq := &quicksight.RefreshFrequency{
+		Interval:     aws.String(tfObj.Interval.ValueString()),
+		TimeOfTheDay: aws.String(tfObj.TimeOfTheDay.ValueString()),
+		Timezone:     aws.String(tfObj.Timezone.ValueString()),
+	}
+
+	if !tfObj.RefreshOnDay.IsNull() {
+		refreshOnDay, d := expandRefreshOnDayData(ctx, tfObj)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		freq.RefreshOnDay = refreshOnDay
+	}
+	return freq, diags
+}
+
+func expandRefreshOnDayData(ctx context.Context, plan refreshFrequencyData) (*quicksight.ScheduleRefreshOnEntity, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var tfList []refreshOnDayData
+	diags.Append(plan.RefreshOnDay.ElementsAs(ctx, &tfList, false)...)
+	if diags.HasError() || len(tfList) == 0 {
+		return nil, diags
+	}
+
+	tfObj := tfList[0]
+	entity := &quicksight.ScheduleRefreshOnEntity{}
+	if !tfObj.DayOfMonth.IsNull() {
+		entity.DayOfMonth = aws.String(tfObj.DayOfMonth.ValueString())
+	}
+	if !tfObj.DayOfWeek.IsNull() {
+		entity.DayOfWeek = aws.String(tfObj.DayOfWeek.ValueString())
+	}
+	return entity, diags
+}
+
+func flattenSchedule(ctx context.Context, apiObject *quicksight.RefreshSchedule) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if apiObject == nil {
+		return types.ListNull(types.ObjectType{AttrTypes: scheduleAttrTypes}), diags
+	}
+
+	refreshFrequency, d := flattenRefreshFrequency(ctx, apiObject.ScheduleFrequency)
+	diags.Append(d...)
+
+	scheduleAttrs := map[string]attr.Value{
+		"refresh_type":       flex.StringToFramework(ctx, apiObject.RefreshType),
+		"schedule_frequency": refreshFrequency,
+	}
+
+	if apiObject.StartAfterDateTime != nil {
+		scheduleAttrs["start_after_date_time"] = types.StringValue(apiObject.StartAfterDateTime.Format(startAfterDateTimeLayout))
+	}
+
+	objVal, d := types.ObjectValue(scheduleAttrTypes, scheduleAttrs)
+	diags.Append(d...)
+	listVal, d := types.ListValue(types.ObjectType{AttrTypes: scheduleAttrTypes}, []attr.Value{objVal})
+	diags.Append(d...)
+	return listVal, diags
+}
+
+func flattenRefreshFrequency(ctx context.Context, apiObject *quicksight.RefreshFrequency) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if apiObject == nil {
+		return types.ListNull(types.ObjectType{AttrTypes: refreshFrequencyAttrTypes}), diags
+	}
+
+	refreshOnDay, d := flattenRefreshOnDay(ctx, apiObject.RefreshOnDay)
+	diags.Append(d...)
+
+	refreshFrequencyAttrs := map[string]attr.Value{
+		"interval":        flex.StringToFramework(ctx, apiObject.Interval),
+		"time_of_the_day": flex.StringToFramework(ctx, apiObject.TimeOfTheDay),
+		"timezone":        flex.StringToFramework(ctx, apiObject.Timezone),
+		"refresh_on_day":  refreshOnDay,
+	}
+
+	objVal, d := types.ObjectValue(refreshFrequencyAttrTypes, refreshFrequencyAttrs)
+	diags.Append(d...)
+	listVal, d := types.ListValue(types.ObjectType{AttrTypes: refreshFrequencyAttrTypes}, []attr.Value{objVal})
+	diags.Append(d...)
+	return listVal, diags
+}
+
+func flattenRefreshOnDay(ctx context.Context, apiObject *quicksight.ScheduleRefreshOnEntity) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if apiObject == nil {
+		return types.ListNull(types.ObjectType{AttrTypes: refreshOnDayAttrTypes}), diags
+	}
+
+	objVal, d := types.ObjectValue(refreshOnDayAttrTypes, map[string]attr.Value{
+		"day_of_month": flex.StringToFramework(ctx, apiObject.DayOfMonth),
+		"day_of_week":  flex.StringToFramework(ctx, apiObject.DayOfWeek),
+	})
+	diags.Append(d...)
+	listVal, d := types.ListValue(types.ObjectType{AttrTypes: refreshOnDayAttrTypes}, []attr.Value{objVal})
+	diags.Append(d...)
+	return listVal, diags
+}
+
+func createRefreshScheduleID(awsAccountID, dataSetId, scheduleID string) string {
+	return fmt.Sprintf("%s,%s,%s", awsAccountID, dataSetId, scheduleID)
+}
+
+func ParseRefreshScheduleID(id string) (string, string, string, error) {
+	parts := strings.SplitN(id, ",", 3)
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", "", "", fmt.Errorf("unexpected format of ID (%s), expected AWS_ACCOUNT_ID,DATA_SET_ID,SCHEDULE_ID", id)
+	}
+	return parts[0], parts[1], parts[2], nil
+}
+
+func timeOfTheDayValidator() validator.String {
+	return timeMatchesValidator{
+		layout:  timeOfTheDayLayout,
+		message: fmt.Sprintf("value must match '%s' format", timeOfTheDayFormat),
+	}
+}
+
+func startAfterDateTimeValidator() validator.String {
+	return timeMatchesValidator{
+		layout:  startAfterDateTimeLayout,
+		message: fmt.Sprintf("value must match '%s' format", startAfterDateTimeFormat),
+	}
+}
+
+type timeMatchesValidator struct {
+	layout  string
+	message string
+}
+
+func (v timeMatchesValidator) Description(_ context.Context) string {
+	return v.message
+}
+
+func (v timeMatchesValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v timeMatchesValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueString()
+
+	_, err := time.Parse(v.layout, value)
+	if err != nil {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueMatchDiagnostic(
+			request.Path,
+			v.Description(ctx),
+			value,
+		))
+	}
+}

--- a/internal/service/quicksight/refresh_schedule.go
+++ b/internal/service/quicksight/refresh_schedule.go
@@ -260,7 +260,7 @@ func (r *resourceRefreshSchedule) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	_, read, err := FindRefreshScheduleByID(ctx, conn, plan.ID.ValueString())
+	_, outFind, err := FindRefreshScheduleByID(ctx, conn, plan.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.QuickSight, create.ErrActionReading, ResNameRefreshSchedule, plan.ID.String(), nil),
@@ -269,7 +269,7 @@ func (r *resourceRefreshSchedule) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	resp.Diagnostics.Append(plan.refreshFromRead(ctx, out.Arn, read)...)
+	resp.Diagnostics.Append(plan.refreshFromRead(ctx, out.Arn, outFind)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
@@ -282,7 +282,7 @@ func (r *resourceRefreshSchedule) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	arn, schedule, err := FindRefreshScheduleByID(ctx, conn, state.ID.ValueString())
+	arn, outFind, err := FindRefreshScheduleByID(ctx, conn, state.ID.ValueString())
 	if tfresource.NotFound(err) {
 		resp.State.RemoveResource(ctx)
 		return
@@ -294,7 +294,7 @@ func (r *resourceRefreshSchedule) Read(ctx context.Context, req resource.ReadReq
 		)
 		return
 	}
-	resp.Diagnostics.Append(state.refreshFromRead(ctx, arn, schedule)...)
+	resp.Diagnostics.Append(state.refreshFromRead(ctx, arn, outFind)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -355,7 +355,7 @@ func (r *resourceRefreshSchedule) Update(ctx context.Context, req resource.Updat
 			return
 		}
 
-		_, schedule, err := FindRefreshScheduleByID(ctx, conn, plan.ID.ValueString())
+		_, outFind, err := FindRefreshScheduleByID(ctx, conn, plan.ID.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError(
 				create.ProblemStandardMessage(names.QuickSight, create.ErrActionReading, ResNameRefreshSchedule, plan.ID.String(), nil),
@@ -364,7 +364,7 @@ func (r *resourceRefreshSchedule) Update(ctx context.Context, req resource.Updat
 			return
 		}
 
-		resp.Diagnostics.Append(plan.refreshFromRead(ctx, out.Arn, schedule)...)
+		resp.Diagnostics.Append(plan.refreshFromRead(ctx, out.Arn, outFind)...)
 		resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 	}
 }
@@ -476,6 +476,8 @@ func FindRefreshScheduleByID(ctx context.Context, conn *quicksight.QuickSight, i
 		return nil, nil, tfresource.NewEmptyResultError(in)
 	}
 
+	// NOTE: out.RefreshSchedule.Arn is always empty, so the root struct field out.Arn
+	// must be included as a separate return value instead.
 	return out.Arn, out.RefreshSchedule, nil
 }
 

--- a/internal/service/quicksight/refresh_schedule_test.go
+++ b/internal/service/quicksight/refresh_schedule_test.go
@@ -1,0 +1,301 @@
+package quicksight_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/quicksight"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfquicksight "github.com/hashicorp/terraform-provider-aws/internal/service/quicksight"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccQuickSightRefreshSchedule_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var schedule quicksight.RefreshSchedule
+	resourceName := "aws_quicksight_refresh_schedule.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	sId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, quicksight.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRefreshScheduleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRefreshScheduleConfigBasic(rId, rName, sId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRefreshScheduleExists(ctx, resourceName, &schedule),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "quicksight",
+						fmt.Sprintf("dataset/%s/refresh-schedule/%s", rId, sId)),
+					resource.TestCheckResourceAttr(resourceName, "data_set_id", rId),
+					resource.TestCheckResourceAttr(resourceName, "schedule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.refresh_type", "FULL_REFRESH"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.schedule_frequency.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.schedule_frequency.0.interval", "DAILY"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.schedule_frequency.0.time_of_the_day", "12:00"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.schedule_frequency.0.timezone", "Europe/London"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccQuickSightRefreshSchedule_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	var schedule quicksight.RefreshSchedule
+	resourceName := "aws_quicksight_refresh_schedule.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	sId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, quicksight.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRefreshScheduleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRefreshScheduleConfigBasic(rId, rName, sId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRefreshScheduleExists(ctx, resourceName, &schedule),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfquicksight.ResourceRefreshSchedule, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccQuickSightRefreshSchedule_weeklyRefresh(t *testing.T) {
+	ctx := acctest.Context(t)
+	var schedule quicksight.RefreshSchedule
+	resourceName := "aws_quicksight_refresh_schedule.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	sId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, quicksight.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRefreshScheduleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRefreshScheduleConfigWeeklyRefresh(rId, rName, sId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRefreshScheduleExists(ctx, resourceName, &schedule),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "quicksight",
+						fmt.Sprintf("dataset/%s/refresh-schedule/%s", rId, sId)),
+					resource.TestCheckResourceAttr(resourceName, "data_set_id", rId),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.refresh_type", "FULL_REFRESH"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.schedule_frequency.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.schedule_frequency.0.interval", "WEEKLY"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.schedule_frequency.0.refresh_on_day.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.schedule_frequency.0.refresh_on_day.0.day_of_week", "MONDAY"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccQuickSightRefreshSchedule_monthlyRefresh(t *testing.T) {
+	ctx := acctest.Context(t)
+	var schedule quicksight.RefreshSchedule
+	resourceName := "aws_quicksight_refresh_schedule.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	sId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, quicksight.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRefreshScheduleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRefreshScheduleConfigMonthlyRefresh(rId, rName, sId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRefreshScheduleExists(ctx, resourceName, &schedule),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "quicksight",
+						fmt.Sprintf("dataset/%s/refresh-schedule/%s", rId, sId)),
+					resource.TestCheckResourceAttr(resourceName, "data_set_id", rId),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.refresh_type", "FULL_REFRESH"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.schedule_frequency.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.schedule_frequency.0.interval", "MONTHLY"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.schedule_frequency.0.refresh_on_day.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schedule.0.schedule_frequency.0.refresh_on_day.0.day_of_month", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckRefreshScheduleExists(ctx context.Context, resourceName string, schedule *quicksight.RefreshSchedule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).QuickSightConn()
+		_, output, err := tfquicksight.FindRefreshScheduleByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.QuickSight, create.ErrActionCheckingExistence, tfquicksight.ResNameRefreshSchedule, rs.Primary.ID, err)
+		}
+
+		*schedule = *output
+
+		return nil
+	}
+}
+
+func testAccCheckRefreshScheduleDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).QuickSightConn()
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_quicksight_refresh_schedule" {
+				continue
+			}
+
+			_, output, err := tfquicksight.FindRefreshScheduleByID(ctx, conn, rs.Primary.ID)
+			if err != nil {
+				if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
+					return nil
+				}
+				return err
+			}
+
+			if output != nil {
+				return create.Error(names.QuickSight, create.ErrActionCheckingDestroyed, tfquicksight.ResNameRefreshSchedule, rs.Primary.ID, err)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccBaseRefreshScheduleConfig(rId, rName string) string {
+	return acctest.ConfigCompose(
+		testAccBaseDataSourceConfig(rName),
+		fmt.Sprintf(`
+resource "aws_quicksight_data_source" "test" {
+  data_source_id = %[1]q
+  name           = %[2]q
+
+  parameters {
+    s3 {
+      manifest_file_location {
+        bucket = aws_s3_bucket.test.bucket
+        key    = aws_s3_object.test.key
+      }
+    }
+  }
+
+  type = "S3"
+}
+
+resource "aws_quicksight_data_set" "test" {
+  data_set_id = %[1]q
+  name        = %[2]q
+  import_mode = "SPICE"
+
+  physical_table_map {
+    physical_table_map_id = %[1]q
+    s3_source {
+      data_source_arn = aws_quicksight_data_source.test.arn
+      input_columns {
+        name = "Column1"
+        type = "STRING"
+      }
+      upload_settings {
+        format = "JSON"
+      }
+    }
+  }
+}
+`, rId, rName))
+}
+
+func testAccRefreshScheduleConfigBasic(rId, rName, sId string) string {
+	return acctest.ConfigCompose(
+		testAccBaseRefreshScheduleConfig(rId, rName),
+		fmt.Sprintf(`
+resource "aws_quicksight_refresh_schedule" "test" {
+  data_set_id = aws_quicksight_data_set.test.data_set_id
+  schedule_id = %[1]q
+  schedule {
+    refresh_type = "FULL_REFRESH"
+    schedule_frequency {
+      interval        = "DAILY"
+      time_of_the_day = "12:00"
+      timezone        = "Europe/London"
+    }
+  }
+}
+`, sId))
+}
+
+func testAccRefreshScheduleConfigWeeklyRefresh(rId, rName, sId string) string {
+	return acctest.ConfigCompose(
+		testAccBaseRefreshScheduleConfig(rId, rName),
+		fmt.Sprintf(`
+resource "aws_quicksight_refresh_schedule" "test" {
+  data_set_id = aws_quicksight_data_set.test.data_set_id
+  schedule_id = %[1]q
+  schedule {
+    refresh_type = "FULL_REFRESH"
+    schedule_frequency {
+      interval = "WEEKLY"
+      refresh_on_day {
+        day_of_week = "MONDAY"
+      }
+    }
+  }
+}
+`, sId))
+}
+
+func testAccRefreshScheduleConfigMonthlyRefresh(rId, rName, sId string) string {
+	return acctest.ConfigCompose(
+		testAccBaseRefreshScheduleConfig(rId, rName),
+		fmt.Sprintf(`
+resource "aws_quicksight_refresh_schedule" "test" {
+  data_set_id = aws_quicksight_data_set.test.data_set_id
+  schedule_id = %[1]q
+  schedule {
+    refresh_type = "FULL_REFRESH"
+    schedule_frequency {
+      interval = "MONTHLY"
+      refresh_on_day {
+        day_of_month = "1"
+      }
+    }
+  }
+}
+`, sId))
+}

--- a/internal/service/quicksight/service_package_gen.go
+++ b/internal/service/quicksight/service_package_gen.go
@@ -32,6 +32,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 				IdentifierAttribute: "arn",
 			},
 		},
+		{
+			Factory: newResourceRefreshSchedule,
+			Name:    "Refresh Schedule",
+		},
 	}
 }
 

--- a/website/docs/r/quicksight_refresh_schedule.html.markdown
+++ b/website/docs/r/quicksight_refresh_schedule.html.markdown
@@ -1,0 +1,119 @@
+---
+subcategory: "QuickSight"
+layout: "aws"
+page_title: "AWS: aws_quicksight_refresh_schedule"
+description: |-
+  Manages a Resource QuickSight Refresh Schedule.
+---
+
+# Resource: aws_quicksight_refresh_schedule
+
+Resource for managing a QuickSight Refresh Schedule.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_quicksight_refresh_schedule" "example" {
+  data_set_id = "dataset-id"
+  schedule_id = "schedule-id"
+
+  schedule {
+    refresh_type = "FULL_REFRESH"
+
+    schedule_frequency {
+      interval = "HOURLY"
+    }
+  }
+}
+```
+
+### With Weekly Refresh
+
+```terraform
+resource "aws_quicksight_refresh_schedule" "example" {
+  data_set_id = "dataset-id"
+  schedule_id = "schedule-id"
+
+  schedule {
+    refresh_type = "INCREMENTAL_REFRESH"
+
+    schedule_frequency {
+      interval    = "WEEKLY"
+      time_of_day = "01:00"
+      timezone    = "Europe/London"
+      refresh_on_day {
+        day_of_week = "MONDAY"
+      }
+    }
+  }
+}
+```
+
+### With Monthly Refresh
+
+```terraform
+resource "aws_quicksight_refresh_schedule" "example" {
+  data_set_id = "dataset-id"
+  schedule_id = "schedule-id"
+
+  schedule {
+    refresh_type = "INCREMENTAL_REFRESH"
+
+    schedule_frequency {
+      interval    = "MONTHLY"
+      time_of_day = "01:00"
+      timezone    = "Europe/London"
+      refresh_on_day {
+        day_of_month = "1"
+      }
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `data_set_id` - (Required, Forces new resource) The ID of the dataset.
+* `schedule_id` - (Required, Forces new resource) The ID of the refresh schedule.
+* `schedule` - (Required) The [refresh schedule](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_RefreshSchedule.html). See [schedule](#schedule)
+
+The following arguments are optional:
+
+* `aws_account_id` - (Optional, Forces new resource) AWS account ID.
+
+### schedule
+
+* `refresh_type` - (Required) The type of refresh that the dataset undergoes. Valid values are `INCREMENTAL_REFRESH` and `FULL_REFRESH`.
+* `start_after_date_time` (Optional) Time after which the refresh schedule can be started, expressed in `YYYY-MM-DDTHH:MM:SS` format.
+* `schedule_frequency` - (Optional) The configuration of the [schedule frequency](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_RefreshFrequency.html). See [schedule_frequency](#schedule_frequency).
+
+### schedule_frequency
+
+* `interval` - (Required) The interval between scheduled refreshes. Valid values are `MINUTE15`, `MINUTE30`, `HOURLY`, `DAILY`, `WEEKLY` and `MONTHLY`
+* `time_of_day` - (Optional) The time of day that you want the dataset to refresh. This value is expressed in `HH:MM` format. This field is not required for schedules that refresh hourly.
+* `timezone` - (Optional) The timezone that you want the refresh schedule to use.
+* `refresh_on_day` - (Optional) The [refresh on entity](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_ScheduleRefreshOnEntity.html) configuration for weekly or monthly schedules. See [refresh_on_day](#refresh_on_day).
+
+### refresh_on_day
+
+* `day_of_month` - (Optional) The day of the month that you want to schedule refresh on.
+* `day_of_week` - (Optional) The day of the week that you want to schedule a refresh on. Valid values are `SUNDAY`, `MONDAY`, `TUESDAY`, `WEDNESDAY`, `THURSDAY`, `FRIDAY` and `SATURDAY`
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Amazon Resource Name (ARN) of the refresh schedule.
+* `id` - A comma-delimited string joining AWS account ID, data set ID & refresh schedule ID.
+
+## Import
+
+A QuickSight Refresh Schedule can be imported using the AWS account ID, data set ID and schedule ID separated by commas (`,`) e.g.,
+
+```
+$ terraform import aws_quicksight_refresh_schedule.example 123456789012,dataset-id,schedule-id
+```

--- a/website/docs/r/quicksight_refresh_schedule.html.markdown
+++ b/website/docs/r/quicksight_refresh_schedule.html.markdown
@@ -93,7 +93,7 @@ The following arguments are optional:
 
 ### schedule_frequency
 
-* `interval` - (Required) The interval between scheduled refreshes. Valid values are `MINUTE15`, `MINUTE30`, `HOURLY`, `DAILY`, `WEEKLY` and `MONTHLY`
+* `interval` - (Required) The interval between scheduled refreshes. Valid values are `MINUTE15`, `MINUTE30`, `HOURLY`, `DAILY`, `WEEKLY` and `MONTHLY`.
 * `time_of_day` - (Optional) The time of day that you want the dataset to refresh. This value is expressed in `HH:MM` format. This field is not required for schedules that refresh hourly.
 * `timezone` - (Optional) The timezone that you want the refresh schedule to use.
 * `refresh_on_day` - (Optional) The [refresh on entity](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_ScheduleRefreshOnEntity.html) configuration for weekly or monthly schedules. See [refresh_on_day](#refresh_on_day).
@@ -101,7 +101,7 @@ The following arguments are optional:
 ### refresh_on_day
 
 * `day_of_month` - (Optional) The day of the month that you want to schedule refresh on.
-* `day_of_week` - (Optional) The day of the week that you want to schedule a refresh on. Valid values are `SUNDAY`, `MONDAY`, `TUESDAY`, `WEDNESDAY`, `THURSDAY`, `FRIDAY` and `SATURDAY`
+* `day_of_week` - (Optional) The day of the week that you want to schedule a refresh on. Valid values are `SUNDAY`, `MONDAY`, `TUESDAY`, `WEDNESDAY`, `THURSDAY`, `FRIDAY` and `SATURDAY`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Description

This PR adds a new `aws_quicksight_refresh_schedule` resource, allowing practitioners to manage scheduled refreshes of Quicksight data sets via Terraform.

### Relations
Closes #30788
Relates To #10990 & #30744

### References

* https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CreateRefreshSchedule.html
* https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DeleteRefreshSchedule.html
* https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DescribeRefreshSchedule.html
* https://docs.aws.amazon.com/quicksight/latest/APIReference/API_ListRefreshSchedules.html
* https://docs.aws.amazon.com/quicksight/latest/APIReference/API_UpdateRefreshSchedule.html


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make testacc PKG=quicksight TESTS=TestAccQuickSightRefreshSchedule_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightRefreshSchedule_'  -timeout 180m
=== RUN   TestAccQuickSightRefreshSchedule_basic
=== PAUSE TestAccQuickSightRefreshSchedule_basic
=== RUN   TestAccQuickSightRefreshSchedule_disappears
=== PAUSE TestAccQuickSightRefreshSchedule_disappears
=== RUN   TestAccQuickSightRefreshSchedule_weeklyRefresh
=== PAUSE TestAccQuickSightRefreshSchedule_weeklyRefresh
=== RUN   TestAccQuickSightRefreshSchedule_monthlyRefresh
=== PAUSE TestAccQuickSightRefreshSchedule_monthlyRefresh
=== CONT  TestAccQuickSightRefreshSchedule_basic
=== CONT  TestAccQuickSightRefreshSchedule_weeklyRefresh
=== CONT  TestAccQuickSightRefreshSchedule_disappears
=== CONT  TestAccQuickSightRefreshSchedule_monthlyRefresh
--- PASS: TestAccQuickSightRefreshSchedule_disappears (27.80s)
--- PASS: TestAccQuickSightRefreshSchedule_weeklyRefresh (29.59s)
--- PASS: TestAccQuickSightRefreshSchedule_basic (30.83s)
--- PASS: TestAccQuickSightRefreshSchedule_monthlyRefresh (31.13s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/quicksight	31.218s
```
