### PR TITLE
`r/aws_autoscaling_group`: Remove deprecated `tags` attribute

### DIFF
--- a/.changelog/30842.txt
+++ b/.changelog/30842.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_autoscaling_group: Remove deprecated `tags` attribute
+```

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -744,52 +744,6 @@ func ResourceGroup() *schema.Resource {
 
 					return create.StringHashcode(buf.String())
 				},
-				ConflictsWith: []string{"tags"},
-			},
-			"tags": {
-				Deprecated: "Use tag instead",
-				Type:       schema.TypeSet,
-				Optional:   true,
-				Elem: &schema.Schema{
-					Type: schema.TypeMap,
-					Elem: &schema.Schema{Type: schema.TypeString},
-				},
-				// Terraform 0.11 and earlier can provide incorrect type
-				// information during difference handling, in which boolean
-				// values are represented as "0" and "1". This Set function
-				// normalizes these hashing variations, while the Terraform
-				// Plugin SDK automatically suppresses the boolean/string
-				// difference in the value itself.
-				Set: func(v interface{}) int {
-					var buf bytes.Buffer
-
-					m, ok := v.(map[string]interface{})
-
-					if !ok {
-						return 0
-					}
-
-					if v, ok := m["key"].(string); ok {
-						buf.WriteString(fmt.Sprintf("%s-", v))
-					}
-
-					if v, ok := m["value"].(string); ok {
-						buf.WriteString(fmt.Sprintf("%s-", v))
-					}
-
-					if v, ok := m["propagate_at_launch"].(bool); ok {
-						buf.WriteString(fmt.Sprintf("%t-", v))
-					} else if v, ok := m["propagate_at_launch"].(string); ok {
-						if b, err := strconv.ParseBool(v); err == nil {
-							buf.WriteString(fmt.Sprintf("%t-", b))
-						} else {
-							buf.WriteString(fmt.Sprintf("%s-", v))
-						}
-					}
-
-					return create.StringHashcode(buf.String())
-				},
-				ConflictsWith: []string{"tag"},
 			},
 			"target_group_arns": {
 				Type:     schema.TypeSet,
@@ -974,10 +928,6 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if v, ok := d.GetOk("tag"); ok {
-		createInput.Tags = Tags(KeyValueTags(ctx, v, asgName, TagResourceTypeGroup).IgnoreAWS())
-	}
-
-	if v, ok := d.GetOk("tags"); ok {
 		createInput.Tags = Tags(KeyValueTags(ctx, v, asgName, TagResourceTypeGroup).IgnoreAWS())
 	}
 
@@ -1177,31 +1127,8 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		d.Set("warm_pool", nil)
 	}
 
-	var tagOk, tagsOk bool
-	var v interface{}
-
-	// Deprecated: In a future major version, this should always set all tags except those ignored.
-	//             Remove d.GetOk() and Only() handling.
-	if v, tagOk = d.GetOk("tag"); tagOk {
-		proposedStateTags := KeyValueTags(ctx, v, d.Id(), TagResourceTypeGroup)
-
-		if err := d.Set("tag", ListOfMap(KeyValueTags(ctx, g.Tags, d.Id(), TagResourceTypeGroup).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Only(proposedStateTags))); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting tag: %s", err)
-		}
-	}
-
-	if v, tagsOk = d.GetOk("tags"); tagsOk {
-		proposedStateTags := KeyValueTags(ctx, v, d.Id(), TagResourceTypeGroup)
-
-		if err := d.Set("tags", ListOfStringMap(KeyValueTags(ctx, g.Tags, d.Id(), TagResourceTypeGroup).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Only(proposedStateTags))); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-		}
-	}
-
-	if !tagOk && !tagsOk {
-		if err := d.Set("tag", ListOfMap(KeyValueTags(ctx, g.Tags, d.Id(), TagResourceTypeGroup).IgnoreAWS().IgnoreConfig(ignoreTagsConfig))); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting tag: %s", err)
-		}
+	if err := d.Set("tag", ListOfMap(KeyValueTags(ctx, g.Tags, d.Id(), TagResourceTypeGroup).IgnoreAWS().IgnoreConfig(ignoreTagsConfig))); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting tag: %s", err)
 	}
 
 	return diags
@@ -1219,7 +1146,6 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		"load_balancers",
 		"suspended_processes",
 		"tag",
-		"tags",
 		"target_group_arns",
 		"warm_pool",
 	) {
@@ -1339,17 +1265,11 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 	}
 
-	if d.HasChanges("tag", "tags") {
+	if d.HasChanges("tag") {
 		oTagRaw, nTagRaw := d.GetChange("tag")
-		oTagsRaw, nTagsRaw := d.GetChange("tags")
 
-		oTag := KeyValueTags(ctx, oTagRaw, d.Id(), TagResourceTypeGroup)
-		oTags := KeyValueTags(ctx, oTagsRaw, d.Id(), TagResourceTypeGroup)
-		oldTags := Tags(oTag.Merge(oTags))
-
-		nTag := KeyValueTags(ctx, nTagRaw, d.Id(), TagResourceTypeGroup)
-		nTags := KeyValueTags(ctx, nTagsRaw, d.Id(), TagResourceTypeGroup)
-		newTags := Tags(nTag.Merge(nTags))
+		oldTags := Tags(KeyValueTags(ctx, oTagRaw, d.Id(), TagResourceTypeGroup))
+		newTags := Tags(KeyValueTags(ctx, nTagRaw, d.Id(), TagResourceTypeGroup))
 
 		if err := UpdateTags(ctx, conn, d.Id(), TagResourceTypeGroup, oldTags, newTags); err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating tags for Auto Scaling Group (%s): %s", d.Id(), err)
@@ -1499,12 +1419,6 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 					if v := v.(string); v != "" {
 						triggers = append(triggers, v)
 					}
-				}
-
-				if v.Contains("tag") && !v.Contains("tags") {
-					triggers = append(triggers, "tags") // nozero
-				} else if !v.Contains("tag") && v.Contains("tags") {
-					triggers = append(triggers, "tag") // nozero
 				}
 
 				shouldRefreshInstances = d.HasChanges(triggers...)

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -258,6 +258,53 @@ resource "aws_autoscaling_group" "example" {
 }
 ```
 
+### Dynamic tagging
+
+```terraform
+variable "extra_tags" {
+  default = [
+    {
+      key                 = "Foo"
+      value               = "Bar"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "Baz"
+      value               = "Bam"
+      propagate_at_launch = true
+    },
+  ]
+}
+
+resource "aws_autoscaling_group" "test" {
+  name                 = "foobar3-terraform-test"
+  max_size             = 5
+  min_size             = 2
+  launch_configuration = aws_launch_configuration.foobar.name
+  vpc_zone_identifier  = [aws_subnet.example1.id, aws_subnet.example2.id]
+
+  tag {
+    key                 = "explicit1"
+    value               = "value1"
+    propagate_at_launch = true
+  }
+  tag {
+    key                 = "explicit2"
+    value               = "value2"
+    propagate_at_launch = true
+  }
+
+  dynamic "tag" {
+    for_each = var.extra_tags
+    content {
+      key                 = tag.value.key
+      propagate_at_launch = tag.value.propagate_at_launch
+      value               = tag.value.value
+    }
+  }
+}
+```
+
 ### Automatically refresh all instances after the group is updated
 
 ```terraform

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -258,49 +258,6 @@ resource "aws_autoscaling_group" "example" {
 }
 ```
 
-### Interpolated tags
-
-```terraform
-variable "extra_tags" {
-  default = [
-    {
-      key                 = "Foo"
-      value               = "Bar"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "Baz"
-      value               = "Bam"
-      propagate_at_launch = true
-    },
-  ]
-}
-
-resource "aws_autoscaling_group" "bar" {
-  name                 = "foobar3-terraform-test"
-  max_size             = 5
-  min_size             = 2
-  launch_configuration = aws_launch_configuration.foobar.name
-  vpc_zone_identifier  = [aws_subnet.example1.id, aws_subnet.example2.id]
-
-  tags = concat(
-    [
-      {
-        "key"                 = "interpolation1"
-        "value"               = "value3"
-        "propagate_at_launch" = true
-      },
-      {
-        "key"                 = "interpolation2"
-        "value"               = "value4"
-        "propagate_at_launch" = true
-      },
-    ],
-    var.extra_tags,
-  )
-}
-```
-
 ### Automatically refresh all instances after the group is updated
 
 ```terraform
@@ -416,8 +373,7 @@ The following arguments are supported:
 * `termination_policies` (Optional) List of policies to decide how the instances in the Auto Scaling Group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `OldestLaunchTemplate`, `AllocationStrategy`, `Default`. Additionally, the ARN of a Lambda function can be specified for custom termination policies.
 * `suspended_processes` - (Optional) List of processes to suspend for the Auto Scaling Group. The allowed values are `Launch`, `Terminate`, `HealthCheck`, `ReplaceUnhealthy`, `AZRebalance`, `AlarmNotification`, `ScheduledActions`, `AddToLoadBalancer`, `InstanceRefresh`.
 Note that if you suspend either the `Launch` or `Terminate` process types, it can prevent your Auto Scaling Group from functioning properly.
-* `tag` (Optional) Configuration block(s) containing resource tags. Conflicts with `tags`. See [Tag](#tag-and-tags) below for more details.
-* `tags` (Optional, **Deprecated** use `tag` instead) Set of maps containing resource tags. Conflicts with `tag`. See [Tags](#tag-and-tags) below for more details.
+* `tag` (Optional) Configuration block(s) containing resource tags. See [Tag](#tag) below for more details.
 * `placement_group` (Optional) Name of the placement group into which you'll launch your instances, if any.
 * `metrics_granularity` - (Optional) Granularity to associate with the metrics to collect. The only valid value is `1Minute`. Default is `1Minute`.
 * `enabled_metrics` - (Optional) List of metrics to collect. The allowed values are defined by the [underlying AWS API](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_EnableMetricsCollection.html).
@@ -611,7 +567,7 @@ This configuration block supports the following:
     * `min` - (Required) Minimum.
     * `max` - (Optional) Maximum.
 
-### tag and tags
+### tag
 
 The `tag` attribute accepts exactly one tag declaration with the following fields:
 
@@ -620,10 +576,7 @@ The `tag` attribute accepts exactly one tag declaration with the following field
 * `propagate_at_launch` - (Required) Enables propagation of the tag to
    Amazon EC2 instances launched via this ASG
 
-To declare multiple tags additional `tag` blocks can be specified.
-Alternatively the `tags` attributes can be used, which accepts a list of maps containing the above field names as keys and their respective values.
-This allows the construction of dynamic lists of tags which is not possible using the single `tag` attribute.
-`tag` and `tags` are mutually exclusive, only one of them can be specified.
+To declare multiple tags, additional `tag` blocks can be specified.
 
 ~> **NOTE:** Other AWS APIs may automatically add special tags to their associated Auto Scaling Group for management purposes, such as ECS Capacity Providers adding the `AmazonECSManaged` tag. These generally should be included in the configuration so Terraform does not attempt to remove them and so if the `min_size` was greater than zero on creation, that these tag(s) are applied to any initial EC2 Instances in the Auto Scaling Group. If these tag(s) were missing in the Auto Scaling Group configuration on creation, affected EC2 Instances missing the tags may require manual intervention of adding the tags to ensure they work properly with the other AWS service.
 


### PR DESCRIPTION
### Description
Removes the deprecated `tags` attribute from the `aws_autoscaling_group` resource. Documentation and acceptance test updates are also included.

### Relations
Closes #7655
Closes #22905


### Output from Acceptance Testing

```console
$ make testacc PKG=autoscaling TESTS=TestAccAutoScalingGroup_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/autoscaling/... -v -count 1 -parallel 20 -run='TestAccAutoScalingGroup_'  -timeout 180m

--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_spotMaxPricePercentageOverLowestPrice (68.41s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicy_capacityRebalance
--- PASS: TestAccAutoScalingGroup_basic (68.74s)
=== CONT  TestAccAutoScalingGroup_mixedInstancesPolicy
--- PASS: TestAccAutoScalingGroup_serviceLinkedRoleARN (74.96s)
=== CONT  TestAccAutoScalingGroup_Destroy_whenProtectedFromScaleIn
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandAllocationStrategy (82.71s)
=== CONT  TestAccAutoScalingGroup_launchTempPartitionNum
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTypes (89.40s)
=== CONT  TestAccAutoScalingGroup_warmPool
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_instanceGenerations (95.16s)
=== CONT  TestAccAutoScalingGroup_ALBTargetGroups_elbCapacity
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_excludedInstanceTypes (99.92s)
=== CONT  TestAccAutoScalingGroup_targetGroups
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryGiBPerVCPU (112.69s)
=== CONT  TestAccAutoScalingGroup_loadBalancers
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_allowedInstanceTypes (113.43s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_version
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorManufacturers (117.52s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorCount
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_cpuManufacturers (117.82s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryMiBAndVCPUCount
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicy_capacityRebalance (59.32s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity_withELB
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandBaseCapacity (130.40s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorage (162.78s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceTypeWithLaunchTemplateSpecification
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceType
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_version (50.91s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryMiBAndVCPUCount (52.25s)
=== CONT  TestAccAutoScalingGroup_withLoadBalancer
--- PASS: TestAccAutoScalingGroup_launchTempPartitionNum (91.13s)
=== CONT  TestAccAutoScalingGroup_suspendingProcesses
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorNames (181.46s)
=== CONT  TestAccAutoScalingGroup_withMetrics
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceTypeWithLaunchTemplateSpecification (32.36s)
=== CONT  TestAccAutoScalingGroup_enablingMetrics
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorCount (84.57s)
=== CONT  TestAccAutoScalingGroup_withNoScalingActivityErrorCorrectInstanceArchitecture
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceType (65.83s)
=== CONT  TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture
--- PASS: TestAccAutoScalingGroup_withMetrics (58.76s)
=== CONT  TestAccAutoScalingGroup_withScalingActivityErrorPlacementGroupNotSupportedOnInstanceType
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_bareMetal (246.76s)
=== CONT  TestAccAutoScalingGroup_withPlacementGroup
--- PASS: TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture (20.15s)
=== CONT  TestAccAutoScalingGroup_WithLoadBalancer_toTargetGroup
--- PASS: TestAccAutoScalingGroup_enablingMetrics (56.76s)
=== CONT  TestAccAutoScalingGroup_tags
--- PASS: TestAccAutoScalingGroup_withScalingActivityErrorPlacementGroupNotSupportedOnInstanceType (26.96s)
=== CONT  TestAccAutoScalingGroup_vpcUpdates
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity (137.54s)
=== CONT  TestAccAutoScalingGroup_terminationPolicies
--- PASS: TestAccAutoScalingGroup_Destroy_whenProtectedFromScaleIn (197.74s)
=== CONT  TestAccAutoScalingGroup_simple
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_baselineEBSBandwidthMbps (282.17s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotInstancePools
--- PASS: TestAccAutoScalingGroup_targetGroups (191.06s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName (36.62s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotMaxPrice
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotInstancePools (49.04s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandPercentageAboveBaseCapacity
--- PASS: TestAccAutoScalingGroup_withNoScalingActivityErrorCorrectInstanceArchitecture (143.23s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotAllocationStrategy
--- PASS: TestAccAutoScalingGroup_tags (93.73s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_updateToZeroOnDemandBaseCapacity
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity_withELB (220.00s)
=== CONT  TestAccAutoScalingGroup_nameGenerated
--- PASS: TestAccAutoScalingGroup_vpcUpdates (82.98s)
=== CONT  TestAccAutoScalingGroup_namePrefix
--- PASS: TestAccAutoScalingGroup_ALBTargetGroups_elbCapacity (273.56s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeUnits
--- PASS: TestAccAutoScalingGroup_suspendingProcesses (205.63s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeVCPU
--- PASS: TestAccAutoScalingGroup_loadBalancers (267.30s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_totalLocalStorageGB
--- PASS: TestAccAutoScalingGroup_terminationPolicies (115.65s)
=== CONT  TestAccAutoScalingGroup_defaultInstanceWarmup
--- PASS: TestAccAutoScalingGroup_withLoadBalancer (214.27s)
=== CONT  TestAccAutoScalingGroup_LaunchTemplate_update
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTotalMemoryMiB (390.58s)
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_start
--- PASS: TestAccAutoScalingGroup_namePrefix (42.86s)
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_basic
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_updateToZeroOnDemandBaseCapacity (56.85s)
=== CONT  TestAccAutoScalingGroup_largeDesiredCapacity
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotAllocationStrategy (62.84s)
=== CONT  TestAccAutoScalingGroup_initialLifecycleHook
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotMaxPrice (83.90s)
=== CONT  TestAccAutoScalingGroup_launchTemplate
--- PASS: TestAccAutoScalingGroup_nameGenerated (90.10s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkInterfaceCount
--- PASS: TestAccAutoScalingGroup_launchTemplate (32.36s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandPercentageAboveBaseCapacity (133.62s)
=== CONT  TestAccAutoScalingGroup_disappears
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_burstablePerformance (469.18s)
=== CONT  TestAccAutoScalingGroup_maxInstanceLifetime
--- PASS: TestAccAutoScalingGroup_mixedInstancesPolicy (412.13s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkBandwidthGbps
--- PASS: TestAccAutoScalingGroup_defaultInstanceWarmup (97.45s)
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_triggers
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorageTypes (485.65s)
--- PASS: TestAccAutoScalingGroup_disappears (37.51s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice (71.23s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_requireHibernateSupport (521.68s)
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_start (152.14s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkBandwidthGbps (67.08s)
--- PASS: TestAccAutoScalingGroup_maxInstanceLifetime (80.88s)
--- PASS: TestAccAutoScalingGroup_LaunchTemplate_update (174.17s)
--- PASS: TestAccAutoScalingGroup_simple (286.50s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkInterfaceCount (121.99s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeVCPU (181.26s)
--- PASS: TestAccAutoScalingGroup_warmPool (505.60s)
--- PASS: TestAccAutoScalingGroup_largeDesiredCapacity (197.97s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeUnits (235.65s)
--- PASS: TestAccAutoScalingGroup_WithLoadBalancer_toTargetGroup (371.94s)
--- PASS: TestAccAutoScalingGroup_initialLifecycleHook (215.16s)
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_triggers (145.24s)
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_basic (269.90s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_totalLocalStorageGB (288.48s)
--- PASS: TestAccAutoScalingGroup_withPlacementGroup (553.35s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling        803.349s
```
