### PR TITLE
Formatting fix: Require blank line after headings in markdown files

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -26,9 +26,6 @@ line-length: false
 # MD014
 commands-show-output: false
 
-# MD022
-blanks-around-headings: false
-
 # MD024
 no-duplicate-heading: false
 

--- a/docs/add-a-new-datasource.md
+++ b/docs/add-a-new-datasource.md
@@ -50,6 +50,7 @@ func DataSourceExample() *schema.Resource {
 ```
 
 ### Write Passing Acceptance Tests
+
 In order to adequately test the data source we will need to write a complete set of Acceptance Tests. You will need an AWS account for this which allows the provider to read to state of the associated resource. See [Writing Acceptance Tests](running-and-writing-acceptance-tests.md) for a detailed guide on how to approach these.
 
 You will need at minimum:

--- a/docs/add-a-new-resource.md
+++ b/docs/add-a-new-resource.md
@@ -31,6 +31,7 @@ Typically you will add arguments to represent the values that are under control 
 Attribute names are to specified in `camel_case` as opposed to the AWS API which is `CamelCase`
 
 ### Implement CRUD handlers
+
 These will map planned Terraform state to the AWS API call, or an AWS API response to an applied Terraform state. You will also need to handle different response types (including errors correctly). For complex attributes you will need to implement Flattener or Expander functions. The [Data Handling and Conversion Guide](data-handling-and-conversion.md) covers everything you need to know for mapping AWS API responses to Terraform State and vice-versa. The [Error Handling Guide](error-handling.md) covers everything you need to know about handling AWS API responses consistently.
 
 ### Register Resource to the provider
@@ -51,6 +52,7 @@ func ResourceExample() *schema.Resource {
 ```
 
 ### Write passing Acceptance Tests
+
 In order to adequately test the resource we will need to write a complete set of Acceptance Tests. You will need an AWS account for this which allows the creation of that resource. See [Writing Acceptance Tests](running-and-writing-acceptance-tests.md) for a detailed guide on how to approach these.
 
 You will need at minimum:

--- a/website/docs/d/backup_framework.html.markdown
+++ b/website/docs/d/backup_framework.html.markdown
@@ -38,6 +38,7 @@ In addition to the arguments above, the following attributes are exported:
 * `tags` - Metadata that helps organize the frameworks you create.
 
 ### Control Attributes
+
 For **control** the following attributes are supported:
 
 * `input_parameter` - One or more input parameter blocks. An example of a control with two parameters is: "backup plan frequency is at least daily and the retention period is at least 1 year". The first parameter is daily. The second parameter is 1 year. Detailed below.
@@ -45,12 +46,14 @@ For **control** the following attributes are supported:
 * `scope` - Scope of a control. The control scope defines what the control will evaluate. Three examples of control scopes are: a specific backup plan, all backup plans with a specific tag, or all backup plans. Detailed below.
 
 ### Input Parameter Attributes
+
 For **input_parameter** the following attributes are supported:
 
 * `name` - Name of a parameter, for example, BackupPlanFrequency.
 * `value` - Value of parameter, for example, hourly.
 
 ### Scope Attributes
+
 For **scope** the following attributes are supported:
 
 * `compliance_resource_ids` - The ID of the only AWS resource that you want your control scope to contain.

--- a/website/docs/d/backup_report_plan.html.markdown
+++ b/website/docs/d/backup_report_plan.html.markdown
@@ -38,6 +38,7 @@ In addition to the arguments above, the following attributes are exported:
 * `tags` - Metadata that you can assign to help organize the report plans you create.
 
 ### Report Delivery Channel Attributes
+
 For **report_delivery_channel** the following attributes are supported:
 
 * `formats` - List of the format of your reports: CSV, JSON, or both.
@@ -45,6 +46,7 @@ For **report_delivery_channel** the following attributes are supported:
 * `s3_key_prefix` - Prefix for where Backup Audit Manager delivers your reports to Amazon S3. The prefix is this part of the following path: s3://your-bucket-name/prefix/Backup/us-west-2/year/month/day/report-name.
 
 ### Report Setting Attributes
+
 For **report_setting** the following attributes are supported:
 
 * `framework_arns` - ARNs of the frameworks a report covers.

--- a/website/docs/d/connect_contact_flow.html.markdown
+++ b/website/docs/d/connect_contact_flow.html.markdown
@@ -11,6 +11,7 @@ description: |-
 Provides details about a specific Amazon Connect Contact Flow.
 
 ## Example Usage
+
 By name
 
 ```hcl

--- a/website/docs/d/connect_hours_of_operation.html.markdown
+++ b/website/docs/d/connect_hours_of_operation.html.markdown
@@ -11,6 +11,7 @@ description: |-
 Provides details about a specific Amazon Connect Hours of Operation.
 
 ## Example Usage
+
 By `name`
 
 ```hcl

--- a/website/docs/d/connect_instance.html.markdown
+++ b/website/docs/d/connect_instance.html.markdown
@@ -11,6 +11,7 @@ description: |-
 Provides details about a specific Amazon Connect Instance.
 
 ## Example Usage
+
 By instance_alias
 
 ```hcl

--- a/website/docs/d/networkfirewall_firewall_policy.html.markdown
+++ b/website/docs/d/networkfirewall_firewall_policy.html.markdown
@@ -42,6 +42,7 @@ AWS Network Firewall does not allow multiple firewall policies with the same nam
 ~> **Note:** If there are multiple firewall policies in an account with the same `name`, and `arn` is not specified, the default behavior will return the firewall policy with `name` that was created in the account.
 
 ## Argument Reference
+
 One or more of the following arguments are required:
 
 * `arn` - ARN of the firewall policy.

--- a/website/docs/d/organizations_organizational_unit_child_accounts.html.markdown
+++ b/website/docs/d/organizations_organizational_unit_child_accounts.html.markdown
@@ -7,6 +7,7 @@ description: |-
 ---
 
 # Data Source: aws_organizations_organizational_unit_child_accounts
+
 Get all direct child accounts under a parent organizational unit. This only provides immediate children, not all children.
 
 ## Example Usage

--- a/website/docs/d/organizations_organizational_unit_descendant_accounts.html.markdown
+++ b/website/docs/d/organizations_organizational_unit_descendant_accounts.html.markdown
@@ -7,6 +7,7 @@ description: |-
 ---
 
 # Data Source: aws_organizations_organizational_unit_descendant_accounts
+
 Get all direct child accounts under a parent organizational unit. This provides all children.
 
 ## Example Usage

--- a/website/docs/d/organizations_organizational_units.html.markdown
+++ b/website/docs/d/organizations_organizational_units.html.markdown
@@ -7,6 +7,7 @@ description: |-
 ---
 
 # Data Source: aws_organizations_organizational_units
+
 Get all direct child organizational units under a parent organizational unit. This only provides immediate children, not all children.
 
 ## Example Usage

--- a/website/docs/d/organizations_resource_tags.html.markdown
+++ b/website/docs/d/organizations_resource_tags.html.markdown
@@ -7,6 +7,7 @@ description: |-
 ---
 
 # Data Source: aws_organizations_resource_tags
+
 Get tags attached to the specified AWS Organizations resource.
 
 ## Example Usage

--- a/website/docs/d/waf_ipset.html.markdown
+++ b/website/docs/d/waf_ipset.html.markdown
@@ -25,6 +25,7 @@ The following arguments are supported:
 * `name` - (Required) Name of the WAF IP set.
 
 ## Attributes Reference
+
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the WAF IP set.

--- a/website/docs/d/waf_rate_based_rule.html.markdown
+++ b/website/docs/d/waf_rate_based_rule.html.markdown
@@ -26,6 +26,7 @@ The following arguments are supported:
 * `name` - (Required) Name of the WAF rate based rule.
 
 ## Attributes Reference
+
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the WAF rate based rule.

--- a/website/docs/d/waf_rule.html.markdown
+++ b/website/docs/d/waf_rule.html.markdown
@@ -26,6 +26,7 @@ The following arguments are supported:
 * `name` - (Required) Name of the WAF rule.
 
 ## Attributes Reference
+
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the WAF rule.

--- a/website/docs/d/waf_web_acl.html.markdown
+++ b/website/docs/d/waf_web_acl.html.markdown
@@ -25,6 +25,7 @@ The following arguments are supported:
 * `name` - (Required) Name of the WAF Web ACL.
 
 ## Attributes Reference
+
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the WAF Web ACL.

--- a/website/docs/d/wafregional_ipset.html.markdown
+++ b/website/docs/d/wafregional_ipset.html.markdown
@@ -25,6 +25,7 @@ The following arguments are supported:
 * `name` - (Required) Name of the WAF Regional IP set.
 
 ## Attributes Reference
+
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the WAF Regional IP set.

--- a/website/docs/d/wafregional_rate_based_rule.html.markdown
+++ b/website/docs/d/wafregional_rate_based_rule.html.markdown
@@ -25,6 +25,7 @@ The following arguments are supported:
 * `name` - (Required) Name of the WAF Regional rate based rule.
 
 ## Attributes Reference
+
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the WAF Regional rate based rule.

--- a/website/docs/d/wafregional_rule.html.markdown
+++ b/website/docs/d/wafregional_rule.html.markdown
@@ -25,6 +25,7 @@ The following arguments are supported:
 * `name` - (Required) Name of the WAF Regional rule.
 
 ## Attributes Reference
+
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the WAF Regional rule.

--- a/website/docs/d/wafregional_web_acl.html.markdown
+++ b/website/docs/d/wafregional_web_acl.html.markdown
@@ -25,6 +25,7 @@ The following arguments are supported:
 * `name` - (Required) Name of the WAF Regional Web ACL.
 
 ## Attributes Reference
+
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the WAF Regional Web ACL.

--- a/website/docs/r/api_gateway_rest_api.html.markdown
+++ b/website/docs/r/api_gateway_rest_api.html.markdown
@@ -69,6 +69,7 @@ resource "aws_api_gateway_stage" "example" {
 ```
 
 ### OpenAPI Specification with Private Endpoints
+
 Using `put_rest_api_mode` = `merge` when importing the OpenAPI Specification, the AWS control plane will not delete all existing literal properties that are not explicitly set in the OpenAPI definition. Impacted API Gateway properties: ApiKeySourceType, BinaryMediaTypes, Description, EndpointConfiguration, MinimumCompressionSize, Name, Policy).
 
 ```terraform

--- a/website/docs/r/backup_framework.html.markdown
+++ b/website/docs/r/backup_framework.html.markdown
@@ -121,6 +121,7 @@ The following arguments are supported:
 * `tags` - (Optional) Metadata that you can assign to help organize the frameworks you create. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Control Arguments
+
 For **control** the following attributes are supported:
 
 * `input_parameter` - (Optional) One or more input parameter blocks. An example of a control with two parameters is: "backup plan frequency is at least daily and the retention period is at least 1 year". The first parameter is daily. The second parameter is 1 year. Detailed below.
@@ -128,12 +129,14 @@ For **control** the following attributes are supported:
 * `scope` - (Optional) The scope of a control. The control scope defines what the control will evaluate. Three examples of control scopes are: a specific backup plan, all backup plans with a specific tag, or all backup plans. Detailed below.
 
 ### Input Parameter Arguments
+
 For **input_parameter** the following attributes are supported:
 
 * `name` - (Optional) The name of a parameter, for example, BackupPlanFrequency.
 * `value` - (Optional) The value of parameter, for example, hourly.
 
 ### Scope Arguments
+
 For **scope** the following attributes are supported:
 
 * `compliance_resource_ids` - (Optional) The ID of the only AWS resource that you want your control scope to contain. Minimum number of 1 item. Maximum number of 100 items.

--- a/website/docs/r/backup_plan.html.markdown
+++ b/website/docs/r/backup_plan.html.markdown
@@ -45,6 +45,7 @@ The following arguments are supported:
 * `tags` - (Optional) Metadata that you can assign to help organize the plans you create. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Rule Arguments
+
 For **rule** the following attributes are supported:
 
 * `rule_name` - (Required) An display name for a backup rule.
@@ -58,18 +59,21 @@ For **rule** the following attributes are supported:
 * `copy_action` - (Optional) Configuration block(s) with copy operation settings. Detailed below.
 
 ### Lifecycle Arguments
+
 For **lifecycle** the following attributes are supported:
 
 * `cold_storage_after` - (Optional) Specifies the number of days after creation that a recovery point is moved to cold storage.
 * `delete_after` - (Optional) Specifies the number of days after creation that a recovery point is deleted. Must be 90 days greater than `cold_storage_after`.
 
 ### Copy Action Arguments
+
 For **copy_action** the following attributes are supported:
 
 * `lifecycle` - (Optional) The lifecycle defines when a protected resource is copied over to a backup vault and when it expires.  Fields documented above.
 * `destination_vault_arn` - (Required) An Amazon Resource Name (ARN) that uniquely identifies the destination backup vault for the copied backup.
 
 ### Advanced Backup Setting Arguments
+
 For `advanced_backup_setting` the following attibutes are supported:
 
 * `backup_options` - (Required) Specifies the backup option for a selected resource. This option is only available for Windows VSS backup jobs. Set to `{ WindowsVSS = "enabled" }` to enable Windows VSS backup option and create a VSS Windows backup.

--- a/website/docs/r/backup_report_plan.html.markdown
+++ b/website/docs/r/backup_report_plan.html.markdown
@@ -46,6 +46,7 @@ The following arguments are supported:
 * `tags` - (Optional) Metadata that you can assign to help organize the report plans you create. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Report Delivery Channel Arguments
+
 For **report_delivery_channel** the following attributes are supported:
 
 * `formats` - (Optional) A list of the format of your reports: CSV, JSON, or both. If not specified, the default format is CSV.
@@ -53,6 +54,7 @@ For **report_delivery_channel** the following attributes are supported:
 * `s3_key_prefix` - (Optional) The prefix for where Backup Audit Manager delivers your reports to Amazon S3. The prefix is this part of the following path: s3://your-bucket-name/prefix/Backup/us-west-2/year/month/day/report-name. If not specified, there is no prefix.
 
 ### Report Setting Arguments
+
 For **report_setting** the following attributes are supported:
 
 * `framework_arns` - (Optional) Specifies the Amazon Resource Names (ARNs) of the frameworks a report covers.

--- a/website/docs/r/codegurureviewer_repository_association.html.markdown
+++ b/website/docs/r/codegurureviewer_repository_association.html.markdown
@@ -51,6 +51,7 @@ The following arguments are optional:
 * `kms_key_details` - (Optional) An object describing the KMS key to asssociate. Block is documented below.
 
 ## repository
+
 This configuration block supports the following:
 
 ### bitbucket
@@ -75,6 +76,7 @@ This configuration block supports the following:
 * `name` - (Required) The name of the repository in the S3 bucket.
 
 ## kms_key_details
+
 This configuration block supports the following:
 
 * `encryption_option` - (Optional) The encryption option for a repository association. It is either owned by AWS Key Management Service (KMS) (`AWS_OWNED_CMK`) or customer managed (`CUSTOMER_MANAGED_CMK`).

--- a/website/docs/r/directory_service_radius_settings.html.markdown
+++ b/website/docs/r/directory_service_radius_settings.html.markdown
@@ -9,6 +9,7 @@ description: |-
 # Resource: aws_directory_service_radius_settings
 
 Manages a directory's multi-factor authentication (MFA) using a Remote Authentication Dial In User Service (RADIUS) server.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/dms_replication_instance.html.markdown
+++ b/website/docs/r/dms_replication_instance.html.markdown
@@ -11,6 +11,7 @@ description: |-
 Provides a DMS (Data Migration Service) replication instance resource. DMS replication instances can be created, updated, deleted, and imported.
 
 ## Example Usage
+
 Create required roles and then create a DMS instance, setting the depends_on to the required role policy attachments.
 
 ```terraform

--- a/website/docs/r/dx_connection.html.markdown
+++ b/website/docs/r/dx_connection.html.markdown
@@ -34,6 +34,7 @@ resource "aws_dx_connection" "example" {
 ```
 
 ### Configure encryption mode for MACsec-capable connections
+
 -> **NOTE:** You can only specify the `encryption_mode` argument once the connection is in an `Available` state.
 
 ```terraform

--- a/website/docs/r/efs_backup_policy.html.markdown
+++ b/website/docs/r/efs_backup_policy.html.markdown
@@ -35,6 +35,7 @@ The following arguments are supported:
 * `backup_policy` - (Required) A backup_policy object (documented below).
 
 ### Backup Policy Arguments
+
 For **backup_policy** the following attributes are supported:
 
 * `status` - (Required) A status of the backup policy. Valid values: `ENABLED`, `DISABLED`.

--- a/website/docs/r/efs_file_system.html.markdown
+++ b/website/docs/r/efs_file_system.html.markdown
@@ -54,6 +54,7 @@ user guide for more information.
 * `throughput_mode` - (Optional) Throughput mode for the file system. Defaults to `bursting`. Valid values: `bursting`, `provisioned`, or `elastic`. When using `provisioned`, also set `provisioned_throughput_in_mibps`.
 
 ### Lifecycle Policy Arguments
+
 For **lifecycle_policy** the following attributes are supported:
 
 * `transition_to_ia` - (Optional) Indicates how long it takes to transition files to the IA storage class. Valid values: `AFTER_1_DAY`, `AFTER_7_DAYS`, `AFTER_14_DAYS`, `AFTER_30_DAYS`, `AFTER_60_DAYS`, or `AFTER_90_DAYS`.

--- a/website/docs/r/eks_addon.html.markdown
+++ b/website/docs/r/eks_addon.html.markdown
@@ -25,6 +25,7 @@ resource "aws_eks_addon" "example" {
 ```
 
 ## Example Update add-on usage with resolve_conflicts and PRESERVE
+
 `resolve_conflicts` with `PRESERVE` can be used to retain the config changes applied to the add-on with kubectl while upgrading to a newer version of the add-on.
 
 ~> **Note:** `resolve_conflicts` with `PRESERVE` can only be used for upgrading the add-ons but not during the creation of add-on.
@@ -39,6 +40,7 @@ resource "aws_eks_addon" "example" {
 ```
 
 ## Example add-on usage with custom configuration_values
+
 Custom add-on configuration can be passed using `configuration_values` as a single JSON string while creating or updating the add-on.
 
 ~> **Note:** `configuration_values` is a single JSON string should match the valid JSON schema for each add-on with specific version.

--- a/website/docs/r/fsx_file_cache.html.markdown
+++ b/website/docs/r/fsx_file_cache.html.markdown
@@ -10,6 +10,7 @@ description: |-
 
 Terraform resource for managing an Amazon File Cache cache.
 See the [Create File Cache](https://docs.aws.amazon.com/fsx/latest/APIReference/API_CreateFileCache.html) for more information.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/guardduty_detector.html.markdown
+++ b/website/docs/r/guardduty_detector.html.markdown
@@ -80,18 +80,21 @@ The `audit_logs` block supports the following:
   Defaults to `true`.
 
 ### Malware Protection
+
 `malware_protection` block supports the following:
 
 * `scan_ec2_instance_with_findings` - (Required) Configure whether [Malware Protection](https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection.html) is enabled as data source for EC2 instances with findings for the detector.
   See [Scan EC2 instance with findings](#scan-ec2-instance-with-findings) below for more details.
 
 #### Scan EC2 instance with findings
+
 The `scan_ec2_instance_with_findings` block supports the following:
 
 * `ebs_volumes` - (Required) Configure whether scanning EBS volumes is enabled as data source for the detector for instances with findings.
   See [EBS volumes](#ebs-volumes) below for more details.
 
 #### EBS volumes
+
 The `ebs_volumes` block supports the following:
 
 * `enable` - (Required) If true, enables [Malware Protection](https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection.html) as data source for the detector.

--- a/website/docs/r/guardduty_organization_configuration.html.markdown
+++ b/website/docs/r/guardduty_organization_configuration.html.markdown
@@ -64,6 +64,7 @@ The following arguments are supported:
 * `auto_enable` - (Optional) Set to `true` if you want S3 data event logs to be automatically enabled for new members of the organization. Default: `false`
 
 ### Kubernetes
+
 `kubernetes` block supports the following:
 
 * `audit_logs` - (Required) Enable Kubernetes Audit Logs Monitoring automatically for new member accounts. [Kubernetes protection](https://docs.aws.amazon.com/guardduty/latest/ug/kubernetes-protection.html).
@@ -77,18 +78,21 @@ The `audit_logs` block supports the following:
   Defaults to `true`.
 
 ### Malware Protection
+
 `malware_protection` block supports the following:
 
 * `scan_ec2_instance_with_findings` - (Required) Configure whether [Malware Protection](https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection.html) for EC2 instances with findings should be auto-enabled for new members joining the organization.
    See [Scan EC2 instance with findings](#scan-ec2-instance-with-findings) below for more details.
 
 #### Scan EC2 instance with findings
+
 The `scan_ec2_instance_with_findings` block supports the following:
 
 * `ebs_volumes` - (Required) Configure whether scanning EBS volumes should be auto-enabled for new members joining the organization
   See [EBS volumes](#ebs-volumes) below for more details.
 
 #### EBS volumes
+
 The `ebs_volumes` block supports the following:
 
 * `auto_enable` - (Required) If true, enables [Malware Protection](https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection.html) for all new accounts joining the organization.

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -95,6 +95,7 @@ resource "aws_lambda_function" "lambda_processor" {
 ```
 
 ### Extended S3 Destination with dynamic partitioning
+
 These examples use built-in Firehose functionality, rather than requiring a lambda.
 
 ```terraform

--- a/website/docs/r/kms_key.html.markdown
+++ b/website/docs/r/kms_key.html.markdown
@@ -13,6 +13,7 @@ Manages a single-Region or multi-Region primary KMS key.
 ~> **NOTE on KMS Key Policy:** KMS Key Policy can be configured in either the standalone resource [`aws_kms_key_policy`](kms_key_policy.html)
 or with the parameter `policy` in this resource.
 Configuring with both will cause inconsistencies and may overwrite configuration.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -123,6 +123,7 @@ The following arguments are supported:
 * `type` - (Required) The type of sticky sessions. The only current possible values are `lb_cookie`, `app_cookie` for ALBs, `source_ip` for NLBs, and `source_ip_dest_ip`, `source_ip_dest_ip_proto` for GWLBs.
 
 ### target_failover
+
 ~> **NOTE:** This block is only applicable for a Gateway Load Balancer (GWLB). The two attributes `on_deregistration` and `on_unhealthy` cannot be set independently. The value you set for both attributes must be the same.
 
 * `on_deregistration` - (Optional) Indicates how the GWLB handles existing flows when a target is deregistered. Possible values are `rebalance` and `no_rebalance`. Must match the attribute value set for `on_unhealthy`. Default: `no_rebalance`.

--- a/website/docs/r/lightsail_instance.html.markdown
+++ b/website/docs/r/lightsail_instance.html.markdown
@@ -90,6 +90,7 @@ Defines the add on configuration for the instance. The `add_on` configuration bl
 * `status` - (Required) The status of the add on. Valid Values: `Enabled`, `Disabled`.
 
 ## Availability Zones
+
 Lightsail currently supports the following Availability Zones (e.g., `us-east-1a`):
 
 - `ap-northeast-1{a,c,d}`

--- a/website/docs/r/networkfirewall_firewall_policy.html.markdown
+++ b/website/docs/r/networkfirewall_firewall_policy.html.markdown
@@ -98,6 +98,7 @@ In addition, you can specify custom actions that are compatible with your standa
 * `stateless_rule_group_reference` - (Optional) Set of configuration blocks containing references to the stateless rule groups that are used in the policy. See [Stateless Rule Group Reference](#stateless-rule-group-reference) below for details.
 
 ### Stateful Engine Options
+
 The `stateful_engine_options` block supports the following argument:
 
 ~> **NOTE:** If the `STRICT_ORDER` rule order is specified, this firewall policy can only reference stateful rule groups that utilize `STRICT_ORDER`.

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -11,6 +11,7 @@ description: |-
 Provides a Step Function State Machine resource
 
 ## Example Usage
+
 ### Basic (Standard Workflow)
 
 ```terraform

--- a/website/docs/r/transfer_access.html.markdown
+++ b/website/docs/r/transfer_access.html.markdown
@@ -63,6 +63,7 @@ The following arguments are supported:
 * `secondary_gids` - (Optional) The secondary POSIX group IDs used for all EFS operations by this user.
 
 ## Attributes Reference
+
 In addition to all arguments above, the following attributes are exported:
 
 * `id`  - The ID of the resource

--- a/website/docs/r/transfer_server.html.markdown
+++ b/website/docs/r/transfer_server.html.markdown
@@ -139,6 +139,7 @@ The following arguments are supported:
 * `workflow_id` - (Required)  A unique identifier for the workflow.
 
 ## Attributes Reference
+
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - Amazon Resource Name (ARN) of Transfer Server

--- a/website/docs/r/transfer_user.html.markdown
+++ b/website/docs/r/transfer_user.html.markdown
@@ -102,6 +102,7 @@ home_directory_mappings {
 * `secondary_gids` - (Optional) The secondary POSIX group IDs used for all EFS operations by this user.
 
 ## Attributes Reference
+
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - Amazon Resource Name (ARN) of Transfer User

--- a/website/docs/r/vpclattice_listener.html.markdown
+++ b/website/docs/r/vpclattice_listener.html.markdown
@@ -125,6 +125,7 @@ The following arguments are supported:
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Default Action
+
 Default action blocks (for `default_action`) must include at least one of the following argument blocks:
 
 * `fixed-response` - (Optional) Configuration block for returning a fixed response. See Fixed Response blocks below.
@@ -133,16 +134,19 @@ Default action blocks (for `default_action`) must include at least one of the fo
 -> **NOTE:** You must specify exactly one of the following argument blocks: `fixed_response` or `forward`.
 
 ### Fixed Response
+
 Fixed response blocks (for `fixed-response`) must include the following argument:
 
 * `status_code` - (Required) Custom HTTP status code to return, e.g. a 404 response code. See [Listeners](https://docs.aws.amazon.com/vpc-lattice/latest/ug/listeners.html) in the AWS documentation for a list of supported codes.
 
 ### Forward
+
 Forward blocks (for `forward`) must include the following arguments:
 
 * `target_groups` - (Required) One or more target group blocks.
 
 ### Target Groups
+
 Target group blocks (for `target_group`) must include the following arguments:
 
 * `target_group_identifier` - (Required) ID or Amazon Resource Name (ARN) of the target group.

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -153,6 +153,7 @@ resource "aws_wafv2_web_acl" "atp-example" {
 ```
 
 ### Rate Based
+
 Rate-limit US and NL-based clients to 10,000 requests for every 5 minutes.
 
 ```terraform


### PR DESCRIPTION
### Description

Requires a blank line after headings in markdown files and removes linter exclusion
