### PR TITLE
Minor `skaff` self-registration annotation updates

### DIFF
--- a/docs/add-a-new-datasource.md
+++ b/docs/add-a-new-datasource.md
@@ -41,7 +41,7 @@ package something
 
 import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-// @SDKDataSource("aws_something_example")
+// @SDKDataSource("aws_something_example", name="Example")
 func DataSourceExample() *schema.Resource {
 	return &schema.Resource{
 	    // some configuration

--- a/docs/add-a-new-resource.md
+++ b/docs/add-a-new-resource.md
@@ -42,7 +42,7 @@ package something
 
 import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-// @SDKResource("aws_something_example")
+// @SDKResource("aws_something_example", name="Example)
 func ResourceExample() *schema.Resource {
 	return &schema.Resource{
 	    // some configuration

--- a/internal/conns/conns.go
+++ b/internal/conns/conns.go
@@ -32,11 +32,22 @@ var (
 
 // InContext represents the resource information kept in Context.
 type InContext struct {
+	IsDataSource       bool   // Data source?
 	ResourceName       string // Friendly resource name, e.g. "Subnet"
 	ServicePackageName string // Canonical name defined as a constant in names package
 }
 
-func NewContext(ctx context.Context, servicePackageName, resourceName string) context.Context {
+func NewDataSourceContext(ctx context.Context, servicePackageName, resourceName string) context.Context {
+	v := InContext{
+		IsDataSource:       true,
+		ResourceName:       resourceName,
+		ServicePackageName: servicePackageName,
+	}
+
+	return context.WithValue(ctx, contextKey, &v)
+}
+
+func NewResourceContext(ctx context.Context, servicePackageName, resourceName string) context.Context {
 	v := InContext{
 		ResourceName:       resourceName,
 		ServicePackageName: servicePackageName,

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -318,7 +318,7 @@ func (p *fwprovider) DataSources(ctx context.Context) []func() datasource.DataSo
 
 			// bootstrapContext is run on all wrapped methods before any interceptors.
 			bootstrapContext := func(ctx context.Context, meta *conns.AWSClient) context.Context {
-				ctx = conns.NewContext(ctx, servicePackageName, v.Name)
+				ctx = conns.NewDataSourceContext(ctx, servicePackageName, v.Name)
 				if meta != nil {
 					ctx = tftags.NewContext(ctx, meta.DefaultTagsConfig, meta.IgnoreTagsConfig)
 				}
@@ -362,7 +362,7 @@ func (p *fwprovider) Resources(ctx context.Context) []func() resource.Resource {
 
 			// bootstrapContext is run on all wrapped methods before any interceptors.
 			bootstrapContext := func(ctx context.Context, meta *conns.AWSClient) context.Context {
-				ctx = conns.NewContext(ctx, servicePackageName, v.Name)
+				ctx = conns.NewResourceContext(ctx, servicePackageName, v.Name)
 				if meta != nil {
 					ctx = tftags.NewContext(ctx, meta.DefaultTagsConfig, meta.IgnoreTagsConfig)
 				}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -279,7 +279,7 @@ func New(ctx context.Context) (*schema.Provider, error) {
 
 			// bootstrapContext is run on all wrapped methods before any interceptors.
 			bootstrapContext := func(ctx context.Context, meta any) context.Context {
-				ctx = conns.NewContext(ctx, servicePackageName, v.Name)
+				ctx = conns.NewDataSourceContext(ctx, servicePackageName, v.Name)
 				if v, ok := meta.(*conns.AWSClient); ok {
 					ctx = tftags.NewContext(ctx, v.DefaultTagsConfig, v.IgnoreTagsConfig)
 				}
@@ -330,7 +330,7 @@ func New(ctx context.Context) (*schema.Provider, error) {
 
 			// bootstrapContext is run on all wrapped methods before any interceptors.
 			bootstrapContext := func(ctx context.Context, meta any) context.Context {
-				ctx = conns.NewContext(ctx, servicePackageName, v.Name)
+				ctx = conns.NewResourceContext(ctx, servicePackageName, v.Name)
 				if v, ok := meta.(*conns.AWSClient); ok {
 					ctx = tftags.NewContext(ctx, v.DefaultTagsConfig, v.IgnoreTagsConfig)
 				}

--- a/skaff/datasource/datasource.tmpl
+++ b/skaff/datasource/datasource.tmpl
@@ -82,7 +82,7 @@ import (
 {{- end }}
 
 // Function annotations are used for datasource registration to the Provider. DO NOT EDIT.
-// @SDKDataSource("{{ .ProviderResourceName }}")
+// @SDKDataSource("{{ .ProviderResourceName }}", name="{{ .HumanDataSourceName }}")
 func DataSource{{ .DataSource }}() *schema.Resource {
 	return &schema.Resource{
 		{{- if .IncludeComments }}

--- a/skaff/resource/resource.tmpl
+++ b/skaff/resource/resource.tmpl
@@ -82,7 +82,7 @@ import (
 {{- end }}
 
 // Function annotations are used for resource registration to the Provider. DO NOT EDIT.
-// @SDKResource("{{ .ProviderResourceName }}")
+// @SDKResource("{{ .ProviderResourceName }}", name="{{ .HumanResourceName }}")
 func Resource{{ .Resource }}() *schema.Resource {
 	return &schema.Resource{
 		{{- if .IncludeComments }}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds `name="<human friendly name>"` to the resource/data source self registration annotations generated by `skaff`.
Also adds an `IsDataSource` flag to the `InContext` structure than can be used for various purposes.