### PR TITLE
New Resource: `aws_quicksight_folder_membership`

### DIFF
--- a/.changelog/30871.txt
+++ b/.changelog/30871.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_quicksight_folder_membership
+```

--- a/internal/service/quicksight/exports_test.go
+++ b/internal/service/quicksight/exports_test.go
@@ -2,6 +2,7 @@ package quicksight
 
 // Exports for use in tests only.
 var (
+	ResourceFolderMembership    = newResourceFolderMembership
 	ResourceIAMPolicyAssignment = newResourceIAMPolicyAssignment
 	ResourceIngestion           = newResourceIngestion
 	ResourceNamespace           = newResourceNamespace

--- a/internal/service/quicksight/folder_membership.go
+++ b/internal/service/quicksight/folder_membership.go
@@ -1,0 +1,263 @@
+package quicksight
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/quicksight"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
+// @FrameworkResource(name="Folder Membership")
+func newResourceFolderMembership(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceFolderMembership{}, nil
+}
+
+const (
+	ResNameFolderMembership = "Folder Membership"
+)
+
+type resourceFolderMembership struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceFolderMembership) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_quicksight_folder_membership"
+}
+
+func (r *resourceFolderMembership) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"aws_account_id": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"id": framework.IDAttribute(),
+			"folder_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"member_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"member_type": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.OneOf(quicksight.MemberType_Values()...),
+				},
+			},
+		},
+	}
+}
+
+func (r *resourceFolderMembership) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().QuickSightConn()
+
+	var plan resourceFolderMembershipData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if plan.AWSAccountID.IsUnknown() || plan.AWSAccountID.IsNull() {
+		plan.AWSAccountID = types.StringValue(r.Meta().AccountID)
+	}
+	plan.ID = types.StringValue(createFolderMembershipID(
+		plan.AWSAccountID.ValueString(), plan.FolderID.ValueString(),
+		plan.MemberType.ValueString(), plan.MemberID.ValueString(),
+	))
+
+	in := &quicksight.CreateFolderMembershipInput{
+		AwsAccountId: aws.String(plan.AWSAccountID.ValueString()),
+		FolderId:     aws.String(plan.FolderID.ValueString()),
+		MemberId:     aws.String(plan.MemberID.ValueString()),
+		MemberType:   aws.String(plan.MemberType.ValueString()),
+	}
+
+	out, err := conn.CreateFolderMembershipWithContext(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QuickSight, create.ErrActionCreating, ResNameFolderMembership, plan.MemberID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil || out.FolderMember == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QuickSight, create.ErrActionCreating, ResNameFolderMembership, plan.MemberID.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceFolderMembership) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().QuickSightConn()
+
+	var state resourceFolderMembershipData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := FindFolderMembershipByID(ctx, conn, state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QuickSight, create.ErrActionSetting, ResNameFolderMembership, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.MemberID = flex.StringToFramework(ctx, out.MemberId)
+
+	// To support import, parse the ID for the component keys and set
+	// individual values in state
+	awsAccountID, folderID, memberType, _, err := ParseFolderMembershipID(state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QuickSight, create.ErrActionSetting, ResNameIngestion, state.ID.String(), nil),
+			err.Error(),
+		)
+		return
+	}
+	state.AWSAccountID = flex.StringValueToFramework(ctx, awsAccountID)
+	state.FolderID = flex.StringValueToFramework(ctx, folderID)
+	state.MemberType = flex.StringValueToFramework(ctx, memberType)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// There is no update API, so this method is a no-op
+func (r *resourceFolderMembership) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+}
+
+func (r *resourceFolderMembership) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().QuickSightConn()
+
+	var state resourceFolderMembershipData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &quicksight.DeleteFolderMembershipInput{
+		AwsAccountId: aws.String(state.AWSAccountID.ValueString()),
+		FolderId:     aws.String(state.FolderID.ValueString()),
+		MemberId:     aws.String(state.MemberID.ValueString()),
+		MemberType:   aws.String(state.MemberType.ValueString()),
+	}
+
+	_, err := conn.DeleteFolderMembershipWithContext(ctx, in)
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QuickSight, create.ErrActionDeleting, ResNameFolderMembership, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceFolderMembership) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func FindFolderMembershipByID(ctx context.Context, conn *quicksight.QuickSight, id string) (*quicksight.MemberIdArnPair, error) {
+	awsAccountID, folderID, _, memberID, err := ParseFolderMembershipID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	in := &quicksight.ListFolderMembersInput{
+		AwsAccountId: aws.String(awsAccountID),
+		FolderId:     aws.String(folderID),
+	}
+
+	// There is no Get/Describe API for a single folder member, so utilize the
+	// ListFolderMembers API to get all members and check for the presence of the
+	// configured member ID
+	out, err := conn.ListFolderMembersWithContext(ctx, in)
+	if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	for _, member := range out.FolderMemberList {
+		if aws.StringValue(member.MemberId) == memberID {
+			return member, nil
+		}
+	}
+
+	return nil, &retry.NotFoundError{
+		LastError:   errors.New("member ID not found in folder"),
+		LastRequest: in,
+	}
+}
+
+func ParseFolderMembershipID(id string) (string, string, string, string, error) {
+	parts := strings.SplitN(id, ",", 4)
+	if len(parts) != 4 || parts[0] == "" || parts[1] == "" || parts[2] == "" || parts[3] == "" {
+		return "", "", "", "", fmt.Errorf("unexpected format of ID (%s), expected AWS_ACCOUNT_ID,FOLDER_ID,MEMBER_TYPE,MEMBER_ID", id)
+	}
+	return parts[0], parts[1], parts[2], parts[3], nil
+}
+
+func createFolderMembershipID(awsAccountID, folderID, memberType, memberID string) string {
+	return strings.Join([]string{awsAccountID, folderID, memberType, memberID}, ",")
+}
+
+type resourceFolderMembershipData struct {
+	AWSAccountID types.String `tfsdk:"aws_account_id"`
+	FolderID     types.String `tfsdk:"folder_id"`
+	ID           types.String `tfsdk:"id"`
+	MemberID     types.String `tfsdk:"member_id"`
+	MemberType   types.String `tfsdk:"member_type"`
+}

--- a/internal/service/quicksight/folder_membership_test.go
+++ b/internal/service/quicksight/folder_membership_test.go
@@ -1,0 +1,133 @@
+package quicksight_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/quicksight"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfquicksight "github.com/hashicorp/terraform-provider-aws/internal/service/quicksight"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccQuickSightFolderMembership_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var folderMember quicksight.MemberIdArnPair
+	resourceName := "aws_quicksight_folder_membership.test"
+	folderResourceName := "aws_quicksight_folder.test"
+	dataSetResourceName := "aws_quicksight_data_set.test"
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, quicksight.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFolderMembershipDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFolderMembershipConfig_basic(rId, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFolderMembershipExists(ctx, resourceName, &folderMember),
+					resource.TestCheckResourceAttrPair(resourceName, "folder_id", folderResourceName, "folder_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "member_id", dataSetResourceName, "data_set_id"),
+					resource.TestCheckResourceAttr(resourceName, "member_type", quicksight.MemberTypeDataset),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccQuickSightFolderMembership_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	var folderMember quicksight.MemberIdArnPair
+	resourceName := "aws_quicksight_folder_membership.test"
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, quicksight.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFolderMembershipDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFolderMembershipConfig_basic(rId, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFolderMembershipExists(ctx, resourceName, &folderMember),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfquicksight.ResourceFolderMembership, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckFolderMembershipExists(ctx context.Context, resourceName string, folderMember *quicksight.MemberIdArnPair) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).QuickSightConn()
+		output, err := tfquicksight.FindFolderMembershipByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.QuickSight, create.ErrActionCheckingExistence, tfquicksight.ResNameFolderMembership, rs.Primary.ID, err)
+		}
+
+		*folderMember = *output
+
+		return nil
+	}
+}
+
+func testAccCheckFolderMembershipDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).QuickSightConn()
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_quicksight_folder_membership" {
+				continue
+			}
+
+			output, err := tfquicksight.FindFolderMembershipByID(ctx, conn, rs.Primary.ID)
+			if err != nil {
+				if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
+					return nil
+				}
+				return err
+			}
+
+			if output != nil {
+				return create.Error(names.QuickSight, create.ErrActionCheckingDestroyed, tfquicksight.ResNameFolderMembership, rs.Primary.ID, err)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccFolderMembershipConfig_basic(rId, rName string) string {
+	return acctest.ConfigCompose(
+		testAccDataSetConfigBasic(rId, rName),
+		testAccFolderConfig_basic(rId, rName),
+		`
+resource "aws_quicksight_folder_membership" "test" {
+  folder_id   = aws_quicksight_folder.test.folder_id
+  member_type = "DATASET"
+  member_id   = aws_quicksight_data_set.test.data_set_id
+}
+`)
+}

--- a/internal/service/quicksight/service_package_gen.go
+++ b/internal/service/quicksight/service_package_gen.go
@@ -18,6 +18,10 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
 	return []*types.ServicePackageFrameworkResource{
 		{
+			Factory: newResourceFolderMembership,
+			Name:    "Folder Membership",
+		},
+		{
 			Factory: newResourceIAMPolicyAssignment,
 			Name:    "IAM Policy Assignment",
 		},

--- a/website/docs/r/quicksight_folder_membership.html.markdown
+++ b/website/docs/r/quicksight_folder_membership.html.markdown
@@ -1,0 +1,49 @@
+---
+subcategory: "QuickSight"
+layout: "aws"
+page_title: "AWS: aws_quicksight_folder_membership"
+description: |-
+  Terraform resource for managing an AWS QuickSight Folder Membership.
+---
+
+# Resource: aws_quicksight_folder_membership
+
+Terraform resource for managing an AWS QuickSight Folder Membership.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_quicksight_folder_membership" "example" {
+  folder_id   = aws_quicksight_folder.example.folder_id
+  member_type = "DATASET"
+  member_id   = aws_quicksight_data_set.example.data_set_id
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `folder_id` - (Required, Forces new resource) Identifier for the folder.
+* `member_id` - (Required, Forces new resource) ID of the asset (the dashboard, analysis, or dataset).
+* `member_type` - (Required, Forces new resource) Type of the member. Valid values are `ANALYSIS`, `DASHBOARD`, and `DATASET`.
+
+The following arguments are optional:
+
+* `aws_account_id` - (Optional, Forces new resource) AWS account ID.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A comma-delimited string joining AWS account ID, folder ID, member type, and member ID.
+
+## Import
+
+QuickSight Folder Membership can be imported using the AWS account ID, folder ID, member type, and member ID separated by commas (`,`) e.g.,
+
+```
+$ terraform import aws_quicksight_folder_membership.example 123456789012,example-folder,DATASET,example-dataset
+```


### PR DESCRIPTION
### Description
This PR will allow practitioners to manage QuickSight folder memberships via Terraform.

### Relations
Relates #10990 
Closes #30851 

### References
- https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CreateFolderMembership.html
- https://docs.aws.amazon.com/quicksight/latest/APIReference/API_ListFolderMembers.html
- https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DeleteFolderMembership.html

### Output from Acceptance Testing

```console
$ make testacc PKG=quicksight TESTS=TestAccQuickSightFolderMembership_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightFolderMembership_'  -timeout 180m
=== RUN   TestAccQuickSightFolderMembership_basic
=== PAUSE TestAccQuickSightFolderMembership_basic
=== RUN   TestAccQuickSightFolderMembership_disappears
=== PAUSE TestAccQuickSightFolderMembership_disappears
=== CONT  TestAccQuickSightFolderMembership_basic
=== CONT  TestAccQuickSightFolderMembership_disappears
--- PASS: TestAccQuickSightFolderMembership_disappears (27.93s)
--- PASS: TestAccQuickSightFolderMembership_basic (29.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 33.088s
```
