### PR TITLE
Tech debt: Reduce `tags` boilerplate code - Generate and use `createTags`

### DIFF
--- a/internal/generate/tags/templates/v1/service_tags_map_body.tmpl
+++ b/internal/generate/tags/templates/v1/service_tags_map_body.tmpl
@@ -28,3 +28,14 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 		inContext.TagsOut = types.Some(KeyValueTags(ctx, tags))
 	}
 }
+
+{{- if ne .CreateTagsFunc "" }}
+// {{ .CreateTagsFunc }} creates {{ .ServicePackage }} service tags for new resources.
+func {{ .CreateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string, tags map[string]*string) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return  {{ .UpdateTagsFunc }}(ctx, conn, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}, nil, tags)
+}
+{{- end }}

--- a/internal/generate/tags/templates/v1/service_tags_slice_body.tmpl
+++ b/internal/generate/tags/templates/v1/service_tags_slice_body.tmpl
@@ -284,3 +284,14 @@ func SetTagsOut(ctx context.Context, tags []*{{ .TagPackage }}.{{ .TagType }}) {
 	}
 }
 {{- end }}
+
+{{- if ne .CreateTagsFunc "" }}
+// {{ .CreateTagsFunc }} creates {{ .ServicePackage }} service tags for new resources.
+func {{ .CreateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string, tags []*{{ .TagPackage }}.{{ .TagType }}) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return  {{ .UpdateTagsFunc }}(ctx, conn, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}, nil, KeyValueTags(ctx, tags))
+}
+{{- end }}

--- a/internal/generate/tags/templates/v1/update_tags_body.tmpl
+++ b/internal/generate/tags/templates/v1/update_tags_body.tmpl
@@ -143,17 +143,6 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 	return nil
 }
 
-{{- if ne .CreateTagsFunc "" }}
-// {{ .CreateTagsFunc }} creates {{ .ServicePackage }} service tags for new resources.
-func {{ .CreateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string, tags []*{{ .TagPackage }}.{{ .TagType }}) error {
-	if len(tags) == 0 {
-		return nil
-	}
-
-	return  {{ .UpdateTagsFunc }}(ctx, conn, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}, nil, KeyValueTags(ctx, tags))
-}
-{{- end }}
-
 // {{ .UpdateTagsFunc }} updates {{ .ServicePackage }} service tags.
 // It is called from outside this package.
 func (p *servicePackage) {{ .UpdateTagsFunc }}(ctx context.Context, meta any, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string, oldTags, newTags any) error {

--- a/internal/generate/tags/templates/v2/service_tags_map_body.tmpl
+++ b/internal/generate/tags/templates/v2/service_tags_map_body.tmpl
@@ -28,3 +28,14 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 		inContext.TagsOut = types.Some(KeyValueTags(ctx, tags))
 	}
 }
+
+{{- if ne .CreateTagsFunc "" }}
+// {{ .CreateTagsFunc }} creates {{ .ServicePackage }} service tags for new resources.
+func {{ .CreateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string, tags map[string]*string) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return  {{ .UpdateTagsFunc }}(ctx, conn, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}, nil, tags)
+}
+{{- end }}

--- a/internal/generate/tags/templates/v2/service_tags_slice_body.tmpl
+++ b/internal/generate/tags/templates/v2/service_tags_slice_body.tmpl
@@ -284,3 +284,14 @@ func SetTagsOut(ctx context.Context, tags []awstypes.{{ .TagType }}) {
 	}
 }
 {{- end }}
+
+{{- if ne .CreateTagsFunc "" }}
+// {{ .CreateTagsFunc }} creates {{ .ServicePackage }} service tags for new resources.
+func {{ .CreateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string, tags []*{{ .TagPackage }}.{{ .TagType }}) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return  {{ .UpdateTagsFunc }}(ctx, conn, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}, nil, KeyValueTags(ctx, tags))
+}
+{{- end }}

--- a/internal/service/devicefarm/device_pool.go
+++ b/internal/service/devicefarm/device_pool.go
@@ -29,6 +29,7 @@ func ResourceDevicePool() *schema.Resource {
 		ReadWithoutTimeout:   resourceDevicePoolRead,
 		UpdateWithoutTimeout: resourceDevicePoolUpdate,
 		DeleteWithoutTimeout: resourceDevicePoolDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -109,20 +110,16 @@ func resourceDevicePoolCreate(ctx context.Context, d *schema.ResourceData, meta 
 		input.MaxDevices = aws.Int64(int64(v.(int)))
 	}
 
-	log.Printf("[DEBUG] Creating DeviceFarm DevicePool: %s", name)
-	out, err := conn.CreateDevicePoolWithContext(ctx, input)
+	output, err := conn.CreateDevicePoolWithContext(ctx, input)
+
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating DeviceFarm DevicePool: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating DeviceFarm Device Pool (%s): %s", name, err)
 	}
 
-	arn := aws.StringValue(out.DevicePool.Arn)
-	log.Printf("[DEBUG] Successsfully Created DeviceFarm DevicePool: %s", arn)
-	d.SetId(arn)
+	d.SetId(aws.StringValue(output.DevicePool.Arn))
 
-	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
-		if err := UpdateTags(ctx, conn, arn, nil, tags); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating DeviceFarm DevicePool (%s) tags: %s", arn, err)
-		}
+	if err := createTags(ctx, conn, d.Id(), GetTagsIn(ctx)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting DeviceFarm Device Pool (%s) tags: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceDevicePoolRead(ctx, d, meta)...)
@@ -135,13 +132,13 @@ func resourceDevicePoolRead(ctx context.Context, d *schema.ResourceData, meta in
 	devicePool, err := FindDevicePoolByARN(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] DeviceFarm DevicePool (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] DeviceFarm Device Pool (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading DeviceFarm DevicePool (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading DeviceFarm Device Pool (%s): %s", d.Id(), err)
 	}
 
 	arn := aws.StringValue(devicePool.Arn)
@@ -193,10 +190,10 @@ func resourceDevicePoolUpdate(ctx context.Context, d *schema.ResourceData, meta 
 			}
 		}
 
-		log.Printf("[DEBUG] Updating DeviceFarm DevicePool: %s", d.Id())
 		_, err := conn.UpdateDevicePoolWithContext(ctx, input)
+
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "Error Updating DeviceFarm DevicePool: %s", err)
+			return sdkdiag.AppendErrorf(diags, "updating DeviceFarm Device Pool (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -207,19 +204,17 @@ func resourceDevicePoolDelete(ctx context.Context, d *schema.ResourceData, meta 
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DeviceFarmConn()
 
-	input := &devicefarm.DeleteDevicePoolInput{
+	log.Printf("[DEBUG] Deleting DeviceFarm Device Pool: %s", d.Id())
+	_, err := conn.DeleteDevicePoolWithContext(ctx, &devicefarm.DeleteDevicePoolInput{
 		Arn: aws.String(d.Id()),
-	}
-
-	log.Printf("[DEBUG] Deleting DeviceFarm DevicePool: %s", d.Id())
-	_, err := conn.DeleteDevicePoolWithContext(ctx, input)
+	})
 
 	if tfawserr.ErrCodeEquals(err, devicefarm.ErrCodeNotFoundException) {
 		return diags
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error deleting DeviceFarm DevicePool: %s", err)
+		return sdkdiag.AppendErrorf(diags, "deleting DeviceFarm Device Pool (%s): %s", err)
 	}
 
 	return diags

--- a/internal/service/devicefarm/device_pool.go
+++ b/internal/service/devicefarm/device_pool.go
@@ -214,7 +214,7 @@ func resourceDevicePoolDelete(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting DeviceFarm Device Pool (%s): %s", err)
+		return sdkdiag.AppendErrorf(diags, "deleting DeviceFarm Device Pool (%s): %s", d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/devicefarm/generate.go
+++ b/internal/service/devicefarm/generate.go
@@ -1,4 +1,4 @@
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags
+//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceARN -ServiceTagsSlice -TagInIDElem=ResourceARN -UpdateTags -CreateTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package devicefarm

--- a/internal/service/devicefarm/project.go
+++ b/internal/service/devicefarm/project.go
@@ -26,6 +26,7 @@ func ResourceProject() *schema.Resource {
 		ReadWithoutTimeout:   resourceProjectRead,
 		UpdateWithoutTimeout: resourceProjectUpdate,
 		DeleteWithoutTimeout: resourceProjectDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -35,19 +36,19 @@ func ResourceProject() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
+			"default_job_timeout_minutes": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringLenBetween(0, 256),
 			},
-			"default_job_timeout_minutes": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
+
 		CustomizeDiff: verify.SetTagsDiff,
 	}
 }
@@ -65,20 +66,16 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.DefaultJobTimeoutMinutes = aws.Int64(int64(v.(int)))
 	}
 
-	log.Printf("[DEBUG] Creating DeviceFarm Project: %s", name)
-	out, err := conn.CreateProjectWithContext(ctx, input)
+	output, err := conn.CreateProjectWithContext(ctx, input)
+
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating DeviceFarm Project: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating DeviceFarm Project (%s): %s", name, err)
 	}
 
-	arn := aws.StringValue(out.Project.Arn)
-	log.Printf("[DEBUG] Successsfully Created DeviceFarm Project: %s", arn)
-	d.SetId(arn)
+	d.SetId(aws.StringValue(output.Project.Arn))
 
-	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
-		if err := UpdateTags(ctx, conn, arn, nil, tags); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating DeviceFarm Project (%s) tags: %s", arn, err)
-		}
+	if err := createTags(ctx, conn, d.Id(), GetTagsIn(ctx)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting DeviceFarm Project (%s) tags: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceProjectRead(ctx, d, meta)...)
@@ -125,10 +122,10 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			input.DefaultJobTimeoutMinutes = aws.Int64(int64(d.Get("default_job_timeout_minutes").(int)))
 		}
 
-		log.Printf("[DEBUG] Updating DeviceFarm Project: %s", d.Id())
 		_, err := conn.UpdateProjectWithContext(ctx, input)
+
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "Error Updating DeviceFarm Project: %s", err)
+			return sdkdiag.AppendErrorf(diags, "updating DeviceFarm Project (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -139,17 +136,17 @@ func resourceProjectDelete(ctx context.Context, d *schema.ResourceData, meta int
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DeviceFarmConn()
 
-	input := &devicefarm.DeleteProjectInput{
+	log.Printf("[DEBUG] Deleting DeviceFarm Project: %s", d.Id())
+	_, err := conn.DeleteProjectWithContext(ctx, &devicefarm.DeleteProjectInput{
 		Arn: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, devicefarm.ErrCodeNotFoundException) {
+		return diags
 	}
 
-	log.Printf("[DEBUG] Deleting DeviceFarm Project: %s", d.Id())
-	_, err := conn.DeleteProjectWithContext(ctx, input)
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, devicefarm.ErrCodeNotFoundException) {
-			return diags
-		}
-		return sdkdiag.AppendErrorf(diags, "Error deleting DeviceFarm Project: %s", err)
+		return sdkdiag.AppendErrorf(diags, "deleting DeviceFarm Project (%s): %s", d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/devicefarm/tags_gen.go
+++ b/internal/service/devicefarm/tags_gen.go
@@ -95,6 +95,15 @@ func SetTagsOut(ctx context.Context, tags []*devicefarm.Tag) {
 	}
 }
 
+// createTags creates devicefarm service tags for new resources.
+func createTags(ctx context.Context, conn devicefarmiface.DeviceFarmAPI, identifier string, tags []*devicefarm.Tag) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return UpdateTags(ctx, conn, identifier, nil, KeyValueTags(ctx, tags))
+}
+
 // UpdateTags updates devicefarm service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.

--- a/internal/service/directconnect/generate.go
+++ b/internal/service/directconnect/generate.go
@@ -1,5 +1,5 @@
 //go:generate go run ../../generate/listpages/main.go -ListOps=DescribeDirectConnectGateways,DescribeDirectConnectGatewayAssociations,DescribeDirectConnectGatewayAssociationProposals
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=DescribeTags -ListTagsInIDElem=ResourceArns -ListTagsInIDNeedSlice=yes -ListTagsOutTagsElem=ResourceTags[0].Tags -ServiceTagsSlice -UpdateTags
+//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=DescribeTags -ListTagsInIDElem=ResourceArns -ListTagsInIDNeedSlice=yes -ListTagsOutTagsElem=ResourceTags[0].Tags -ServiceTagsSlice -UpdateTags -CreateTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package directconnect

--- a/internal/service/directconnect/hosted_private_virtual_interface_accepter.go
+++ b/internal/service/directconnect/hosted_private_virtual_interface_accepter.go
@@ -106,10 +106,8 @@ func resourceHostedPrivateVirtualInterfaceAccepterCreate(ctx context.Context, d 
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
-		if err := UpdateTags(ctx, conn, arn, nil, tags); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Direct Connect hosted private virtual interface (%s) tags: %s", arn, err)
-		}
+	if err := createTags(ctx, conn, arn, GetTagsIn(ctx)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting Direct Connect hosted private virtual interface (%s) tags: %s", arn, err)
 	}
 
 	return append(diags, resourceHostedPrivateVirtualInterfaceAccepterUpdate(ctx, d, meta)...)

--- a/internal/service/directconnect/hosted_public_virtual_interface_accepter.go
+++ b/internal/service/directconnect/hosted_public_virtual_interface_accepter.go
@@ -82,10 +82,8 @@ func resourceHostedPublicVirtualInterfaceAccepterCreate(ctx context.Context, d *
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
-		if err := UpdateTags(ctx, conn, arn, nil, tags); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Direct Connect hosted public virtual interface (%s) tags: %s", arn, err)
-		}
+	if err := createTags(ctx, conn, arn, GetTagsIn(ctx)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting Direct Connect hosted public virtual interface (%s) tags: %s", arn, err)
 	}
 
 	return append(diags, resourceHostedPublicVirtualInterfaceAccepterUpdate(ctx, d, meta)...)

--- a/internal/service/directconnect/hosted_transit_virtual_interface_accepter.go
+++ b/internal/service/directconnect/hosted_transit_virtual_interface_accepter.go
@@ -88,10 +88,8 @@ func resourceHostedTransitVirtualInterfaceAccepterCreate(ctx context.Context, d 
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
-		if err := UpdateTags(ctx, conn, arn, nil, tags); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Direct Connect hosted transit virtual interface (%s) tags: %s", arn, err)
-		}
+	if err := createTags(ctx, conn, arn, GetTagsIn(ctx)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting Direct Connect hosted transit virtual interface (%s) tags: %s", arn, err)
 	}
 
 	return append(diags, resourceHostedTransitVirtualInterfaceAccepterUpdate(ctx, d, meta)...)

--- a/internal/service/directconnect/tags_gen.go
+++ b/internal/service/directconnect/tags_gen.go
@@ -95,6 +95,15 @@ func SetTagsOut(ctx context.Context, tags []*directconnect.Tag) {
 	}
 }
 
+// createTags creates directconnect service tags for new resources.
+func createTags(ctx context.Context, conn directconnectiface.DirectConnectAPI, identifier string, tags []*directconnect.Tag) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return UpdateTags(ctx, conn, identifier, nil, KeyValueTags(ctx, tags))
+}
+
 // UpdateTags updates directconnect service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.

--- a/internal/service/ds/tags_gen.go
+++ b/internal/service/ds/tags_gen.go
@@ -95,6 +95,15 @@ func SetTagsOut(ctx context.Context, tags []*directoryservice.Tag) {
 	}
 }
 
+// createTags creates ds service tags for new resources.
+func createTags(ctx context.Context, conn directoryserviceiface.DirectoryServiceAPI, identifier string, tags []*directoryservice.Tag) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return UpdateTags(ctx, conn, identifier, nil, KeyValueTags(ctx, tags))
+}
+
 // UpdateTags updates ds service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
@@ -133,15 +142,6 @@ func UpdateTags(ctx context.Context, conn directoryserviceiface.DirectoryService
 	}
 
 	return nil
-}
-
-// createTags creates ds service tags for new resources.
-func createTags(ctx context.Context, conn directoryserviceiface.DirectoryServiceAPI, identifier string, tags []*directoryservice.Tag) error {
-	if len(tags) == 0 {
-		return nil
-	}
-
-	return UpdateTags(ctx, conn, identifier, nil, KeyValueTags(ctx, tags))
 }
 
 // UpdateTags updates ds service tags.

--- a/internal/service/ec2/vpc_default_network_acl.go
+++ b/internal/service/ec2/vpc_default_network_acl.go
@@ -122,7 +122,7 @@ func resourceDefaultNetworkACLCreate(ctx context.Context, d *schema.ResourceData
 	// Configure tags.
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 	newTags := KeyValueTags(ctx, GetTagsIn(ctx))
-	oldTags := KeyValueTags(ctx, nacl.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+	oldTags := KeyValueTags(ctx, nacl.Tags).IgnoreSystem(names.EC2).IgnoreConfig(ignoreTagsConfig)
 
 	if !oldTags.Equal(newTags) {
 		if err := UpdateTags(ctx, conn, d.Id(), oldTags, newTags); err != nil {

--- a/internal/service/ec2/vpc_default_security_group.go
+++ b/internal/service/ec2/vpc_default_security_group.go
@@ -112,7 +112,7 @@ func resourceDefaultSecurityGroupCreate(ctx context.Context, d *schema.ResourceD
 
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 	newTags := KeyValueTags(ctx, GetTagsIn(ctx))
-	oldTags := KeyValueTags(ctx, sg.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+	oldTags := KeyValueTags(ctx, sg.Tags).IgnoreSystem(names.EC2).IgnoreConfig(ignoreTagsConfig)
 
 	if !newTags.Equal(oldTags) {
 		if err := UpdateTags(ctx, conn, d.Id(), oldTags, newTags); err != nil {

--- a/internal/service/ec2/vpc_default_subnet.go
+++ b/internal/service/ec2/vpc_default_subnet.go
@@ -239,7 +239,7 @@ func resourceDefaultSubnetCreate(ctx context.Context, d *schema.ResourceData, me
 	// Configure tags.
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 	newTags := KeyValueTags(ctx, GetTagsIn(ctx))
-	oldTags := KeyValueTags(ctx, subnet.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+	oldTags := KeyValueTags(ctx, subnet.Tags).IgnoreSystem(names.EC2).IgnoreConfig(ignoreTagsConfig)
 
 	if !oldTags.Equal(newTags) {
 		if err := UpdateTags(ctx, conn, d.Id(), oldTags, newTags); err != nil {

--- a/internal/service/ec2/vpc_default_vpc.go
+++ b/internal/service/ec2/vpc_default_vpc.go
@@ -304,7 +304,7 @@ func resourceDefaultVPCCreate(ctx context.Context, d *schema.ResourceData, meta 
 	// Configure tags.
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 	newTags := KeyValueTags(ctx, GetTagsIn(ctx))
-	oldTags := KeyValueTags(ctx, vpc.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+	oldTags := KeyValueTags(ctx, vpc.Tags).IgnoreSystem(names.EC2).IgnoreConfig(ignoreTagsConfig)
 
 	if !oldTags.Equal(newTags) {
 		if err := UpdateTags(ctx, conn, d.Id(), oldTags, newTags); err != nil {

--- a/internal/service/ec2/vpc_network_interface.go
+++ b/internal/service/ec2/vpc_network_interface.go
@@ -412,8 +412,7 @@ func resourceNetworkInterfaceCreate(ctx context.Context, d *schema.ResourceData,
 
 	// If IPv4 or IPv6 prefixes are specified, tag after create.
 	// Otherwise "An error occurred (InternalError) when calling the CreateNetworkInterface operation".
-	tags := KeyValueTags(ctx, GetTagsIn(ctx))
-	if len(tags) > 0 && !(ipv4PrefixesSpecified || ipv6PrefixesSpecified) {
+	if !(ipv4PrefixesSpecified || ipv6PrefixesSpecified) {
 		input.TagSpecifications = getTagSpecificationsIn(ctx, ec2.ResourceTypeNetworkInterface)
 	}
 
@@ -450,9 +449,9 @@ func resourceNetworkInterfaceCreate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	if len(tags) > 0 && (ipv4PrefixesSpecified || ipv6PrefixesSpecified) {
-		if err := UpdateTags(ctx, conn, d.Id(), nil, tags); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating EC2 Network Interface (%s) tags: %s", d.Id(), err)
+	if ipv4PrefixesSpecified || ipv6PrefixesSpecified {
+		if err := createTags(ctx, conn, d.Id(), GetTagsIn(ctx)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting EC2 Network Interface (%s) tags: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ec2/vpc_network_interface.go
+++ b/internal/service/ec2/vpc_network_interface.go
@@ -730,8 +730,8 @@ func resourceNetworkInterfaceUpdate(ctx context.Context, d *schema.ResourceData,
 		o, n := d.GetChange("ipv4_prefix_count")
 		ipv4Prefixes := d.Get("ipv4_prefixes").(*schema.Set).List()
 
-		if o != nil && n != nil && n != len(ipv4Prefixes) {
-			if diff := n.(int) - o.(int); diff > 0 {
+		if o, n := o.(int), n.(int); n != len(ipv4Prefixes) {
+			if diff := n - o; diff > 0 {
 				input := &ec2.AssignPrivateIpAddressesInput{
 					NetworkInterfaceId: aws.String(d.Id()),
 					Ipv4PrefixCount:    aws.Int64(int64(diff)),
@@ -964,8 +964,8 @@ func resourceNetworkInterfaceUpdate(ctx context.Context, d *schema.ResourceData,
 		o, n := d.GetChange("ipv6_prefix_count")
 		ipv6Prefixes := d.Get("ipv6_prefixes").(*schema.Set).List()
 
-		if o != nil && n != nil && n != len(ipv6Prefixes) {
-			if diff := n.(int) - o.(int); diff > 0 {
+		if o, n := o.(int), n.(int); n != len(ipv6Prefixes) {
+			if diff := n - o; diff > 0 {
 				input := &ec2.AssignIpv6AddressesInput{
 					NetworkInterfaceId: aws.String(d.Id()),
 					Ipv6PrefixCount:    aws.Int64(int64(diff)),

--- a/internal/service/ec2/vpc_network_interface_test.go
+++ b/internal/service/ec2/vpc_network_interface_test.go
@@ -1125,7 +1125,7 @@ func testAccCheckENIDifferent(iface1 *ec2.NetworkInterface, iface2 *ec2.NetworkI
 	}
 }
 
-func testAccENIIPV4BaseConfig(rName string) string {
+func testAccVPCNetworkInterfaceConfig_baseIPV4(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block           = "172.16.0.0/16"
@@ -1164,7 +1164,7 @@ resource "aws_security_group" "test" {
 `, rName))
 }
 
-func testAccENIIPV6BaseConfig(rName string) string {
+func testAccVPCNetworkInterfaceConfig_baseIPV6(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "172.16.0.0/16"
@@ -1206,7 +1206,7 @@ resource "aws_security_group" "test" {
 }
 
 func testAccVPCNetworkInterfaceConfig_basic(rName string) string {
-	return acctest.ConfigCompose(testAccENIIPV4BaseConfig(rName), `
+	return acctest.ConfigCompose(testAccVPCNetworkInterfaceConfig_baseIPV4(rName), `
 resource "aws_network_interface" "test" {
   subnet_id = aws_subnet.test.id
 }
@@ -1214,7 +1214,7 @@ resource "aws_network_interface" "test" {
 }
 
 func testAccVPCNetworkInterfaceConfig_ipv6(rName string) string {
-	return acctest.ConfigCompose(testAccENIIPV6BaseConfig(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCNetworkInterfaceConfig_baseIPV6(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
   private_ips     = ["172.16.10.100"]
@@ -1229,7 +1229,7 @@ resource "aws_network_interface" "test" {
 }
 
 func testAccVPCNetworkInterfaceConfig_ipv6Multiple(rName string) string {
-	return acctest.ConfigCompose(testAccENIIPV6BaseConfig(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCNetworkInterfaceConfig_baseIPV6(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
   private_ips     = ["172.16.10.100"]
@@ -1244,7 +1244,7 @@ resource "aws_network_interface" "test" {
 }
 
 func testAccVPCNetworkInterfaceConfig_ipv6Count(rName string, ipv6Count int) string {
-	return acctest.ConfigCompose(testAccENIIPV6BaseConfig(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCNetworkInterfaceConfig_baseIPV6(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id          = aws_subnet.test.id
   private_ips        = ["172.16.10.100"]
@@ -1259,7 +1259,7 @@ resource "aws_network_interface" "test" {
 }
 
 func testAccVPCNetworkInterfaceConfig_description(rName, description string) string {
-	return acctest.ConfigCompose(testAccENIIPV4BaseConfig(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCNetworkInterfaceConfig_baseIPV4(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
   private_ips     = ["172.16.10.100"]
@@ -1274,7 +1274,7 @@ resource "aws_network_interface" "test" {
 }
 
 func testAccVPCNetworkInterfaceConfig_sourceDestCheck(rName string, sourceDestCheck bool) string {
-	return acctest.ConfigCompose(testAccENIIPV6BaseConfig(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCNetworkInterfaceConfig_baseIPV6(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id         = aws_subnet.test.id
   source_dest_check = %[2]t
@@ -1291,7 +1291,7 @@ func testAccVPCNetworkInterfaceConfig_attachment(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHVMEBSAMI(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
-		testAccENIIPV4BaseConfig(rName),
+		testAccVPCNetworkInterfaceConfig_baseIPV4(rName),
 		fmt.Sprintf(`
 resource "aws_subnet" "test2" {
   vpc_id            = aws_vpc.test.id
@@ -1336,7 +1336,7 @@ func testAccVPCNetworkInterfaceConfig_externalAttachment(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinuxHVMEBSAMI(),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
-		testAccENIIPV4BaseConfig(rName),
+		testAccVPCNetworkInterfaceConfig_baseIPV4(rName),
 		fmt.Sprintf(`
 resource "aws_subnet" "test2" {
   vpc_id            = aws_vpc.test.id
@@ -1373,7 +1373,7 @@ resource "aws_network_interface" "test" {
 }
 
 func testAccVPCNetworkInterfaceConfig_privateIPsCount(rName string, privateIpsCount int) string {
-	return acctest.ConfigCompose(testAccENIIPV4BaseConfig(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCNetworkInterfaceConfig_baseIPV4(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   private_ips_count = %[2]d
   subnet_id         = aws_subnet.test.id
@@ -1386,7 +1386,7 @@ resource "aws_network_interface" "test" {
 }
 
 func testAccVPCNetworkInterfaceConfig_tags1(rName, tagKey1, tagValue1 string) string {
-	return acctest.ConfigCompose(testAccENIIPV4BaseConfig(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCNetworkInterfaceConfig_baseIPV4(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
   private_ips     = ["172.16.10.100"]
@@ -1400,7 +1400,7 @@ resource "aws_network_interface" "test" {
 }
 
 func testAccVPCNetworkInterfaceConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccENIIPV4BaseConfig(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCNetworkInterfaceConfig_baseIPV4(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
   private_ips     = ["172.16.10.100"]
@@ -1415,7 +1415,7 @@ resource "aws_network_interface" "test" {
 }
 
 func testAccVPCNetworkInterfaceConfig_type(rName, interfaceType string) string {
-	return acctest.ConfigCompose(testAccENIIPV4BaseConfig(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCNetworkInterfaceConfig_baseIPV4(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
   private_ips     = ["172.16.10.100"]
@@ -1430,7 +1430,7 @@ resource "aws_network_interface" "test" {
 }
 
 func testAccVPCNetworkInterfaceConfig_ipv4Prefix(rName string) string {
-	return acctest.ConfigCompose(testAccENIIPV4BaseConfig(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCNetworkInterfaceConfig_baseIPV4(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
   ipv4_prefixes   = ["172.16.10.16/28"]
@@ -1444,7 +1444,7 @@ resource "aws_network_interface" "test" {
 }
 
 func testAccVPCNetworkInterfaceConfig_ipv4PrefixMultiple(rName string) string {
-	return acctest.ConfigCompose(testAccENIIPV4BaseConfig(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCNetworkInterfaceConfig_baseIPV4(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
   ipv4_prefixes   = ["172.16.10.16/28", "172.16.10.32/28"]
@@ -1458,7 +1458,7 @@ resource "aws_network_interface" "test" {
 }
 
 func testAccVPCNetworkInterfaceConfig_ipv4PrefixCount(rName string, ipv4PrefixCount int) string {
-	return acctest.ConfigCompose(testAccENIIPV4BaseConfig(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCNetworkInterfaceConfig_baseIPV4(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id         = aws_subnet.test.id
   ipv4_prefix_count = %[2]d
@@ -1472,7 +1472,7 @@ resource "aws_network_interface" "test" {
 }
 
 func testAccVPCNetworkInterfaceConfig_ipv6Prefix(rName string) string {
-	return acctest.ConfigCompose(testAccENIIPV6BaseConfig(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCNetworkInterfaceConfig_baseIPV6(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
   private_ips     = ["172.16.10.100"]
@@ -1487,7 +1487,7 @@ resource "aws_network_interface" "test" {
 }
 
 func testAccVPCNetworkInterfaceConfig_ipv6PrefixMultiple(rName string) string {
-	return acctest.ConfigCompose(testAccENIIPV6BaseConfig(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCNetworkInterfaceConfig_baseIPV6(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
   private_ips     = ["172.16.10.100"]
@@ -1502,7 +1502,7 @@ resource "aws_network_interface" "test" {
 }
 
 func testAccVPCNetworkInterfaceConfig_ipv6PrefixCount(rName string, ipv6PrefixCount int) string {
-	return acctest.ConfigCompose(testAccENIIPV6BaseConfig(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCNetworkInterfaceConfig_baseIPV6(rName), fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id         = aws_subnet.test.id
   private_ips       = ["172.16.10.100"]
@@ -1518,7 +1518,7 @@ resource "aws_network_interface" "test" {
 
 func testAccVPCNetworkInterfaceConfig_privateIPSet(rName string, privateIPs []string) string {
 	return acctest.ConfigCompose(
-		testAccENIIPV6BaseConfig(rName),
+		testAccVPCNetworkInterfaceConfig_baseIPV6(rName),
 		fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id       = aws_subnet.test.id
@@ -1530,7 +1530,7 @@ resource "aws_network_interface" "test" {
 
 func testAccVPCNetworkInterfaceConfig_privateIPSetCount(rName string, count int) string {
 	return acctest.ConfigCompose(
-		testAccENIIPV6BaseConfig(rName),
+		testAccVPCNetworkInterfaceConfig_baseIPV6(rName),
 		fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id         = aws_subnet.test.id
@@ -1542,7 +1542,7 @@ resource "aws_network_interface" "test" {
 
 func testAccVPCNetworkInterfaceConfig_privateIPList(rName string, privateIPs []string) string {
 	return acctest.ConfigCompose(
-		testAccENIIPV6BaseConfig(rName),
+		testAccVPCNetworkInterfaceConfig_baseIPV6(rName),
 		fmt.Sprintf(`
 resource "aws_network_interface" "test" {
   subnet_id               = aws_subnet.test.id

--- a/internal/service/glacier/generate.go
+++ b/internal/service/glacier/generate.go
@@ -1,4 +1,4 @@
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTagsForVault -ListTagsInIDElem=VaultName -ServiceTagsMap -TagOp=AddTagsToVault -TagInIDElem=VaultName -UntagOp=RemoveTagsFromVault -UpdateTags
+//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTagsForVault -ListTagsInIDElem=VaultName -ServiceTagsMap -TagOp=AddTagsToVault -TagInIDElem=VaultName -UntagOp=RemoveTagsFromVault -UpdateTags -CreateTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package glacier

--- a/internal/service/glacier/tags_gen.go
+++ b/internal/service/glacier/tags_gen.go
@@ -78,6 +78,15 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 	}
 }
 
+// createTags creates glacier service tags for new resources.
+func createTags(ctx context.Context, conn glacieriface.GlacierAPI, identifier string, tags map[string]*string) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return UpdateTags(ctx, conn, identifier, nil, tags)
+}
+
 // UpdateTags updates glacier service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
@@ -116,15 +125,6 @@ func UpdateTags(ctx context.Context, conn glacieriface.GlacierAPI, identifier st
 	}
 
 	return nil
-}
-
-// createTags creates glacier service tags for new resources.
-func createTags(ctx context.Context, conn glacieriface.GlacierAPI, identifier string, tags []*glacier.Tag) error {
-	if len(tags) == 0 {
-		return nil
-	}
-
-	return UpdateTags(ctx, conn, identifier, nil, KeyValueTags(ctx, tags))
 }
 
 // UpdateTags updates glacier service tags.

--- a/internal/service/glacier/tags_gen.go
+++ b/internal/service/glacier/tags_gen.go
@@ -118,6 +118,15 @@ func UpdateTags(ctx context.Context, conn glacieriface.GlacierAPI, identifier st
 	return nil
 }
 
+// createTags creates glacier service tags for new resources.
+func createTags(ctx context.Context, conn glacieriface.GlacierAPI, identifier string, tags []*glacier.Tag) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return UpdateTags(ctx, conn, identifier, nil, KeyValueTags(ctx, tags))
+}
+
 // UpdateTags updates glacier service tags.
 // It is called from outside this package.
 func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {

--- a/internal/service/glacier/vault.go
+++ b/internal/service/glacier/vault.go
@@ -119,10 +119,8 @@ func resourceVaultCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	d.SetId(d.Get("name").(string))
 
-	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
-		if err := UpdateTags(ctx, conn, d.Id(), nil, tags.Map()); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating Glacier Vault (%s) tags: %s", d.Id(), err)
-		}
+	if err := createTags(ctx, conn, d.Id(), GetTagsIn(ctx)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting Glacier Vault (%s) tags: %s", d.Id(), err)
 	}
 
 	if _, ok := d.GetOk("access_policy"); ok {

--- a/internal/service/kinesis/generate.go
+++ b/internal/service/kinesis/generate.go
@@ -1,4 +1,4 @@
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTagsForStream -ListTagsInIDElem=StreamName -ServiceTagsSlice -TagOp=AddTagsToStream -TagOpBatchSize=10 -TagInCustomVal=aws.StringMap(updatedTags.IgnoreAWS().Map()) -TagInIDElem=StreamName -UntagOp=RemoveTagsFromStream -UpdateTags
+//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTagsForStream -ListTagsInIDElem=StreamName -ServiceTagsSlice -TagOp=AddTagsToStream -TagOpBatchSize=10 -TagInCustomVal=aws.StringMap(updatedTags.IgnoreAWS().Map()) -TagInIDElem=StreamName -UntagOp=RemoveTagsFromStream -UpdateTags -CreateTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package kinesis

--- a/internal/service/kinesis/stream.go
+++ b/internal/service/kinesis/stream.go
@@ -241,10 +241,8 @@ func resourceStreamCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 	}
 
-	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
-		if err := UpdateTags(ctx, conn, name, nil, tags); err != nil {
-			return sdkdiag.AppendErrorf(diags, "adding Kinesis Stream (%s) tags: %s", name, err)
-		}
+	if err := createTags(ctx, conn, name, GetTagsIn(ctx)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting Kinesis Stream (%s) tags: %s", name, err)
 	}
 
 	return append(diags, resourceStreamRead(ctx, d, meta)...)

--- a/internal/service/kinesis/tags_gen.go
+++ b/internal/service/kinesis/tags_gen.go
@@ -95,6 +95,15 @@ func SetTagsOut(ctx context.Context, tags []*kinesis.Tag) {
 	}
 }
 
+// createTags creates kinesis service tags for new resources.
+func createTags(ctx context.Context, conn kinesisiface.KinesisAPI, identifier string, tags []*kinesis.Tag) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return UpdateTags(ctx, conn, identifier, nil, KeyValueTags(ctx, tags))
+}
+
 // UpdateTags updates kinesis service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.

--- a/internal/service/logs/destination.go
+++ b/internal/service/logs/destination.go
@@ -91,7 +91,7 @@ func resourceDestinationCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	// Although PutDestinationInput has a Tags field, specifying tags there results in
 	// "InvalidParameterException: Could not deliver test message to specified destination. Check if the destination is valid."
-	if err := UpdateTags(ctx, conn, aws.StringValue(destination.Arn), nil, KeyValueTags(ctx, GetTagsIn(ctx))); err != nil {
+	if err := createTags(ctx, conn, aws.StringValue(destination.Arn), GetTagsIn(ctx)); err != nil {
 		return diag.Errorf("setting CloudWatch Logs Destination (%s) tags: %s", d.Id(), err)
 	}
 

--- a/internal/service/logs/generate.go
+++ b/internal/service/logs/generate.go
@@ -1,5 +1,5 @@
 //go:generate go run ../../generate/listpages/main.go -ListOps=DescribeQueryDefinitions,DescribeResourcePolicies
-//go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags
+//go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags -CreateTags
 //go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTagsLogGroup -ListTagsInIDElem=LogGroupName -ListTagsFunc=ListLogGroupTags -TagOp=TagLogGroup -TagInIDElem=LogGroupName -UntagOp=UntagLogGroup -UntagInTagsElem=Tags -UpdateTags -UpdateTagsFunc=UpdateLogGroupTags -- log_group_tags_gen.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/logs/tags_gen.go
+++ b/internal/service/logs/tags_gen.go
@@ -78,6 +78,15 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 	}
 }
 
+// createTags creates logs service tags for new resources.
+func createTags(ctx context.Context, conn cloudwatchlogsiface.CloudWatchLogsAPI, identifier string, tags map[string]*string) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return UpdateTags(ctx, conn, identifier, nil, tags)
+}
+
 // UpdateTags updates logs service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.

--- a/internal/service/opsworks/generate.go
+++ b/internal/service/opsworks/generate.go
@@ -1,4 +1,4 @@
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTags -ServiceTagsMap -UpdateTags
+//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTags -ServiceTagsMap -UpdateTags -CreateTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package opsworks

--- a/internal/service/opsworks/stack.go
+++ b/internal/service/opsworks/stack.go
@@ -291,18 +291,16 @@ func resourceStackCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	d.SetId(aws.StringValue(outputRaw.(*opsworks.CreateStackOutput).StackId))
 
-	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
-		arn := arn.ARN{
-			Partition: meta.(*conns.AWSClient).Partition,
-			Service:   opsworks.ServiceName,
-			Region:    region,
-			AccountID: meta.(*conns.AWSClient).AccountID,
-			Resource:  fmt.Sprintf("stack/%s/", d.Id()),
-		}.String()
+	arn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   opsworks.ServiceName,
+		Region:    region,
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Resource:  fmt.Sprintf("stack/%s/", d.Id()),
+	}.String()
 
-		if err := UpdateTags(ctx, conn, arn, nil, tags); err != nil {
-			return sdkdiag.AppendErrorf(diags, "adding OpsWorks Stack (%s) tags: %s", arn, err)
-		}
+	if err := createTags(ctx, conn, arn, GetTagsIn(ctx)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting OpsWorks Stack (%s) tags: %s", arn, err)
 	}
 
 	if aws.StringValue(input.VpcId) != "" && aws.BoolValue(input.UseOpsworksSecurityGroups) {

--- a/internal/service/opsworks/tags_gen.go
+++ b/internal/service/opsworks/tags_gen.go
@@ -78,6 +78,15 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 	}
 }
 
+// createTags creates opsworks service tags for new resources.
+func createTags(ctx context.Context, conn opsworksiface.OpsWorksAPI, identifier string, tags map[string]*string) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return UpdateTags(ctx, conn, identifier, nil, tags)
+}
+
 // UpdateTags updates opsworks service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.

--- a/internal/service/route53/generate.go
+++ b/internal/service/route53/generate.go
@@ -1,6 +1,6 @@
 //go:generate go run ../../generate/listpages/main.go -ListOps=ListTrafficPolicies -Paginator=TrafficPolicyIdMarker list_traffic_policies_pages_gen.go
 //go:generate go run ../../generate/listpages/main.go -ListOps=ListTrafficPolicyVersions -Paginator=TrafficPolicyVersionMarker list_traffic_policy_versions_pages_gen.go
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceId -ListTagsOutTagsElem=ResourceTagSet.Tags -ServiceTagsSlice -TagOp=ChangeTagsForResource -TagInIDElem=ResourceId -TagInTagsElem=AddTags -TagResTypeElem=ResourceType -UntagOp=ChangeTagsForResource -UntagInTagsElem=RemoveTagKeys -UpdateTags
+//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceId -ListTagsOutTagsElem=ResourceTagSet.Tags -ServiceTagsSlice -TagOp=ChangeTagsForResource -TagInIDElem=ResourceId -TagInTagsElem=AddTags -TagResTypeElem=ResourceType -UntagOp=ChangeTagsForResource -UntagInTagsElem=RemoveTagKeys -UpdateTags -CreateTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package route53

--- a/internal/service/route53/health_check.go
+++ b/internal/service/route53/health_check.go
@@ -290,7 +290,7 @@ func resourceHealthCheckCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	d.SetId(aws.StringValue(output.HealthCheck.Id))
 
-	if err := UpdateTags(ctx, conn, d.Id(), route53.TagResourceTypeHealthcheck, nil, KeyValueTags(ctx, GetTagsIn(ctx))); err != nil {
+	if err := createTags(ctx, conn, d.Id(), route53.TagResourceTypeHealthcheck, GetTagsIn(ctx)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting Route53 Health Check (%s) tags: %s", d.Id(), err)
 	}
 

--- a/internal/service/route53/tags_gen.go
+++ b/internal/service/route53/tags_gen.go
@@ -96,6 +96,15 @@ func SetTagsOut(ctx context.Context, tags []*route53.Tag) {
 	}
 }
 
+// createTags creates route53 service tags for new resources.
+func createTags(ctx context.Context, conn route53iface.Route53API, identifier, resourceType string, tags []*route53.Tag) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return UpdateTags(ctx, conn, identifier, resourceType, nil, KeyValueTags(ctx, tags))
+}
+
 // UpdateTags updates route53 service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.

--- a/internal/service/route53/zone.go
+++ b/internal/service/route53/zone.go
@@ -162,7 +162,7 @@ func resourceZoneCreate(ctx context.Context, d *schema.ResourceData, meta interf
 		}
 	}
 
-	if err := UpdateTags(ctx, conn, d.Id(), route53.TagResourceTypeHostedzone, nil, KeyValueTags(ctx, GetTagsIn(ctx))); err != nil {
+	if err := createTags(ctx, conn, d.Id(), route53.TagResourceTypeHostedzone, GetTagsIn(ctx)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting Route53 Zone (%s) tags: %s", d.Id(), err)
 	}
 

--- a/internal/service/route53recoveryreadiness/generate.go
+++ b/internal/service/route53recoveryreadiness/generate.go
@@ -1,4 +1,4 @@
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTagsForResources -ServiceTagsMap -UpdateTags
+//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTagsForResources -ServiceTagsMap -UpdateTags -CreateTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package route53recoveryreadiness

--- a/internal/service/route53recoveryreadiness/readiness_check.go
+++ b/internal/service/route53recoveryreadiness/readiness_check.go
@@ -62,23 +62,22 @@ func resourceReadinessCheckCreate(ctx context.Context, d *schema.ResourceData, m
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53RecoveryReadinessConn()
 
+	name := d.Get("readiness_check_name").(string)
 	input := &route53recoveryreadiness.CreateReadinessCheckInput{
-		ReadinessCheckName: aws.String(d.Get("readiness_check_name").(string)),
+		ReadinessCheckName: aws.String(name),
 		ResourceSetName:    aws.String(d.Get("resource_set_name").(string)),
 	}
 
-	resp, err := conn.CreateReadinessCheckWithContext(ctx, input)
+	output, err := conn.CreateReadinessCheckWithContext(ctx, input)
+
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating Route53 Recovery Readiness ReadinessCheck: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Route53 Recovery Readiness Readiness Check (%s): %s", name, err)
 	}
 
-	d.SetId(aws.StringValue(resp.ReadinessCheckName))
+	d.SetId(aws.StringValue(output.ReadinessCheckName))
 
-	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
-		arn := aws.StringValue(resp.ReadinessCheckArn)
-		if err := UpdateTags(ctx, conn, arn, nil, tags); err != nil {
-			return sdkdiag.AppendErrorf(diags, "adding Route53 Recovery Readiness ReadinessCheck (%s) tags: %s", d.Id(), err)
-		}
+	if err := createTags(ctx, conn, aws.StringValue(output.ReadinessCheckArn), GetTagsIn(ctx)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting Route53 Recovery Readiness Readiness Check (%s) tags: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceReadinessCheckRead(ctx, d, meta)...)
@@ -95,13 +94,13 @@ func resourceReadinessCheckRead(ctx context.Context, d *schema.ResourceData, met
 	resp, err := conn.GetReadinessCheckWithContext(ctx, input)
 
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, route53recoveryreadiness.ErrCodeResourceNotFoundException) {
-		log.Printf("[WARN] Route53RecoveryReadiness Readiness Check (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] Route53 Recovery Readiness Readiness Check (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "describing Route53 Recovery Readiness ReadinessCheck: %s", err)
+		return sdkdiag.AppendErrorf(diags, "reading Route53 Recovery Readiness Readiness Check (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", resp.ReadinessCheckArn)
@@ -115,14 +114,17 @@ func resourceReadinessCheckUpdate(ctx context.Context, d *schema.ResourceData, m
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53RecoveryReadinessConn()
 
-	input := &route53recoveryreadiness.UpdateReadinessCheckInput{
-		ReadinessCheckName: aws.String(d.Get("readiness_check_name").(string)),
-		ResourceSetName:    aws.String(d.Get("resource_set_name").(string)),
-	}
+	if d.HasChangesExcept("tags", "tags_all") {
+		input := &route53recoveryreadiness.UpdateReadinessCheckInput{
+			ReadinessCheckName: aws.String(d.Get("readiness_check_name").(string)),
+			ResourceSetName:    aws.String(d.Get("resource_set_name").(string)),
+		}
 
-	_, err := conn.UpdateReadinessCheckWithContext(ctx, input)
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "updating Route53 Recovery Readiness ReadinessCheck: %s", err)
+		_, err := conn.UpdateReadinessCheckWithContext(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating Route53 Recovery Readiness Readiness Check (%s): %s", d.Id(), err)
+		}
 	}
 
 	return append(diags, resourceReadinessCheckRead(ctx, d, meta)...)
@@ -132,15 +134,17 @@ func resourceReadinessCheckDelete(ctx context.Context, d *schema.ResourceData, m
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53RecoveryReadinessConn()
 
-	input := &route53recoveryreadiness.DeleteReadinessCheckInput{
+	log.Printf("[DEBUG] Deleting Route53 Recovery Readiness Readiness Check: %s", d.Id())
+	_, err := conn.DeleteReadinessCheckWithContext(ctx, &route53recoveryreadiness.DeleteReadinessCheckInput{
 		ReadinessCheckName: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, route53recoveryreadiness.ErrCodeResourceNotFoundException) {
+		return diags
 	}
-	_, err := conn.DeleteReadinessCheckWithContext(ctx, input)
+
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, route53recoveryreadiness.ErrCodeResourceNotFoundException) {
-			return diags
-		}
-		return sdkdiag.AppendErrorf(diags, "deleting Route53 Recovery Readiness ReadinessCheck: %s", err)
+		return sdkdiag.AppendErrorf(diags, "deleting Route53 Recovery Readiness Readiness Check (%s): %s", d.Id(), err)
 	}
 
 	gcinput := &route53recoveryreadiness.GetReadinessCheckInput{

--- a/internal/service/route53recoveryreadiness/resource_set.go
+++ b/internal/service/route53recoveryreadiness/resource_set.go
@@ -151,24 +151,23 @@ func resourceResourceSetCreate(ctx context.Context, d *schema.ResourceData, meta
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53RecoveryReadinessConn()
 
+	name := d.Get("resource_set_name").(string)
 	input := &route53recoveryreadiness.CreateResourceSetInput{
-		ResourceSetName: aws.String(d.Get("resource_set_name").(string)),
+		ResourceSetName: aws.String(name),
 		ResourceSetType: aws.String(d.Get("resource_set_type").(string)),
 		Resources:       expandResourceSetResources(d.Get("resources").([]interface{})),
 	}
 
-	resp, err := conn.CreateResourceSetWithContext(ctx, input)
+	output, err := conn.CreateResourceSetWithContext(ctx, input)
+
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating Route53 Recovery Readiness Resource Set: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Route53 Recovery Readiness Resource Set (%s): %s", name, err)
 	}
 
-	d.SetId(aws.StringValue(resp.ResourceSetName))
+	d.SetId(aws.StringValue(output.ResourceSetName))
 
-	if tags := KeyValueTags(ctx, GetTagsIn(ctx)); len(tags) > 0 {
-		arn := aws.StringValue(resp.ResourceSetArn)
-		if err := UpdateTags(ctx, conn, arn, nil, tags); err != nil {
-			return sdkdiag.AppendErrorf(diags, "adding Route53 Recovery Readiness Resource Set (%s) tags: %s", d.Id(), err)
-		}
+	if err := createTags(ctx, conn, aws.StringValue(output.ResourceSetArn), GetTagsIn(ctx)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting Route53 Recovery Readiness Resource Set (%s) tags: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceResourceSetRead(ctx, d, meta)...)
@@ -185,21 +184,20 @@ func resourceResourceSetRead(ctx context.Context, d *schema.ResourceData, meta i
 	resp, err := conn.GetResourceSetWithContext(ctx, input)
 
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, route53recoveryreadiness.ErrCodeResourceNotFoundException) {
-		log.Printf("[WARN] Route53RecoveryReadiness Resource Set (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] Route53 Recovery Readiness Resource Set (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "describing Route53 Recovery Readiness Resource Set: %s", err)
+		return sdkdiag.AppendErrorf(diags, "reading Route53 Recovery Readiness Resource Set (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", resp.ResourceSetArn)
 	d.Set("resource_set_name", resp.ResourceSetName)
 	d.Set("resource_set_type", resp.ResourceSetType)
-
 	if err := d.Set("resources", flattenResourceSetResources(resp.Resources)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting AWS Route53 Recovery Readiness Resource Set resources: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting resources: %s", err)
 	}
 
 	return diags
@@ -209,15 +207,18 @@ func resourceResourceSetUpdate(ctx context.Context, d *schema.ResourceData, meta
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53RecoveryReadinessConn()
 
-	input := &route53recoveryreadiness.UpdateResourceSetInput{
-		ResourceSetName: aws.String(d.Id()),
-		ResourceSetType: aws.String(d.Get("resource_set_type").(string)),
-		Resources:       expandResourceSetResources(d.Get("resources").([]interface{})),
-	}
+	if d.HasChangesExcept("tags", "tags_all") {
+		input := &route53recoveryreadiness.UpdateResourceSetInput{
+			ResourceSetName: aws.String(d.Id()),
+			ResourceSetType: aws.String(d.Get("resource_set_type").(string)),
+			Resources:       expandResourceSetResources(d.Get("resources").([]interface{})),
+		}
 
-	_, err := conn.UpdateResourceSetWithContext(ctx, input)
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "updating Route53 Recovery Readiness Resource Set: %s", err)
+		_, err := conn.UpdateResourceSetWithContext(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating Route53 Recovery Readiness Resource Set (%s): %s", d.Id(), err)
+		}
 	}
 
 	return append(diags, resourceResourceSetRead(ctx, d, meta)...)
@@ -227,15 +228,17 @@ func resourceResourceSetDelete(ctx context.Context, d *schema.ResourceData, meta
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53RecoveryReadinessConn()
 
-	input := &route53recoveryreadiness.DeleteResourceSetInput{
+	log.Printf("[DEBUG] Deleting Route53 Recovery Readiness Resource Set: %s", d.Id())
+	_, err := conn.DeleteResourceSetWithContext(ctx, &route53recoveryreadiness.DeleteResourceSetInput{
 		ResourceSetName: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, route53recoveryreadiness.ErrCodeResourceNotFoundException) {
+		return diags
 	}
-	_, err := conn.DeleteResourceSetWithContext(ctx, input)
+
 	if err != nil {
-		if tfawserr.ErrCodeEquals(err, route53recoveryreadiness.ErrCodeResourceNotFoundException) {
-			return diags
-		}
-		return sdkdiag.AppendErrorf(diags, "deleting Route53 Recovery Readiness Resource Set: %s", err)
+		return sdkdiag.AppendErrorf(diags, "deleting Route53 Recovery Readiness Resource Set (%s): %s", d.Id(), err)
 	}
 
 	gcinput := &route53recoveryreadiness.GetResourceSetInput{

--- a/internal/service/route53recoveryreadiness/tags_gen.go
+++ b/internal/service/route53recoveryreadiness/tags_gen.go
@@ -78,6 +78,15 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 	}
 }
 
+// createTags creates route53recoveryreadiness service tags for new resources.
+func createTags(ctx context.Context, conn route53recoveryreadinessiface.Route53RecoveryReadinessAPI, identifier string, tags map[string]*string) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return UpdateTags(ctx, conn, identifier, nil, tags)
+}
+
 // UpdateTags updates route53recoveryreadiness service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.

--- a/internal/service/ssm/generate.go
+++ b/internal/service/ssm/generate.go
@@ -1,4 +1,4 @@
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceId -ListTagsOutTagsElem=TagList -ServiceTagsSlice -TagOp=AddTagsToResource -TagInIDElem=ResourceId -TagResTypeElem=ResourceType -UntagOp=RemoveTagsFromResource -UpdateTags
+//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsInIDElem=ResourceId -ListTagsOutTagsElem=TagList -ServiceTagsSlice -TagOp=AddTagsToResource -TagInIDElem=ResourceId -TagResTypeElem=ResourceType -UntagOp=RemoveTagsFromResource -UpdateTags  -CreateTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package ssm

--- a/internal/service/ssm/parameter.go
+++ b/internal/service/ssm/parameter.go
@@ -199,8 +199,8 @@ func resourceParameterCreate(ctx context.Context, d *schema.ResourceData, meta i
 	// Tags and Overwrite set to true, we make an additional API call
 	// to Update the resource's tags if necessary
 	if len(tags) > 0 && input.Tags == nil {
-		if err := UpdateTags(ctx, conn, name, ssm.ResourceTypeForTaggingParameter, nil, KeyValueTags(ctx, tags)); err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating SSM Parameter (%s) tags: %s", name, err)
+		if err := createTags(ctx, conn, name, ssm.ResourceTypeForTaggingParameter, tags); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting SSM Parameter (%s) tags: %s", name, err)
 		}
 	}
 

--- a/internal/service/ssm/tags_gen.go
+++ b/internal/service/ssm/tags_gen.go
@@ -138,6 +138,15 @@ func UpdateTags(ctx context.Context, conn ssmiface.SSMAPI, identifier, resourceT
 	return nil
 }
 
+// createTags creates ssm service tags for new resources.
+func createTags(ctx context.Context, conn ssmiface.SSMAPI, identifier, resourceType string, tags []*ssm.Tag) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return UpdateTags(ctx, conn, identifier, resourceType, nil, KeyValueTags(ctx, tags))
+}
+
 // UpdateTags updates ssm service tags.
 // It is called from outside this package.
 func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier, resourceType string, oldTags, newTags any) error {

--- a/internal/service/ssm/tags_gen.go
+++ b/internal/service/ssm/tags_gen.go
@@ -96,6 +96,15 @@ func SetTagsOut(ctx context.Context, tags []*ssm.Tag) {
 	}
 }
 
+// createTags creates ssm service tags for new resources.
+func createTags(ctx context.Context, conn ssmiface.SSMAPI, identifier, resourceType string, tags []*ssm.Tag) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return UpdateTags(ctx, conn, identifier, resourceType, nil, KeyValueTags(ctx, tags))
+}
+
 // UpdateTags updates ssm service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
@@ -136,15 +145,6 @@ func UpdateTags(ctx context.Context, conn ssmiface.SSMAPI, identifier, resourceT
 	}
 
 	return nil
-}
-
-// createTags creates ssm service tags for new resources.
-func createTags(ctx context.Context, conn ssmiface.SSMAPI, identifier, resourceType string, tags []*ssm.Tag) error {
-	if len(tags) == 0 {
-		return nil
-	}
-
-	return UpdateTags(ctx, conn, identifier, resourceType, nil, KeyValueTags(ctx, tags))
 }
 
 // UpdateTags updates ssm service tags.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Generate (and use) a `createTags` function for use by resource whose Create API call does not accept tags so tagging is done as a separate action.

This PR does not include resources where we have conditional logic for the non-Commercial partitions around this functionality.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/29747.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccSSMParameter_Overwrite_tags\|TestAccSSMParameter_tags' PKG=ssm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20  -run=TestAccSSMParameter_Overwrite_tags\|TestAccSSMParameter_tags -timeout 180m
=== RUN   TestAccSSMParameter_Overwrite_tags
=== PAUSE TestAccSSMParameter_Overwrite_tags
=== RUN   TestAccSSMParameter_tags
=== PAUSE TestAccSSMParameter_tags
=== CONT  TestAccSSMParameter_Overwrite_tags
=== CONT  TestAccSSMParameter_tags
--- PASS: TestAccSSMParameter_Overwrite_tags (17.60s)
--- PASS: TestAccSSMParameter_tags (39.32s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	44.682s
% make testacc TESTARGS='-run=TestAccGlacierVault_tags' PKG=glacier
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glacier/... -v -count 1 -parallel 20  -run=TestAccGlacierVault_tags -timeout 180m
=== RUN   TestAccGlacierVault_tags
=== PAUSE TestAccGlacierVault_tags
=== CONT  TestAccGlacierVault_tags
--- PASS: TestAccGlacierVault_tags (39.43s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/glacier	44.678s
% make testacc TESTARGS='-run=TestAccKinesisStream_tags\|TestAccKinesisStream_basic' PKG=kinesis
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kinesis/... -v -count 1 -parallel 20  -run=TestAccKinesisStream_tags\|TestAccKinesisStream_basic -timeout 180m
=== RUN   TestAccKinesisStream_basic
=== PAUSE TestAccKinesisStream_basic
=== RUN   TestAccKinesisStream_tags
=== PAUSE TestAccKinesisStream_tags
=== RUN   TestAccKinesisStream_basicOnDemand
=== PAUSE TestAccKinesisStream_basicOnDemand
=== CONT  TestAccKinesisStream_basic
=== CONT  TestAccKinesisStream_basicOnDemand
=== CONT  TestAccKinesisStream_tags
--- PASS: TestAccKinesisStream_basic (49.74s)
--- PASS: TestAccKinesisStream_basicOnDemand (49.92s)
--- PASS: TestAccKinesisStream_tags (72.01s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesis	77.265s
% make testacc TESTARGS='-run=TestAccVPCNetworkInterface_tags\|TestAccVPCNetworkInterface_ENI_ipv4Prefix\|TestAccVPCNetworkInterface_ENI_ipv6Prefix' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccVPCNetworkInterface_tags\|TestAccVPCNetworkInterface_ENI_ipv4Prefix\|TestAccVPCNetworkInterface_ENI_ipv6Prefix -timeout 180m
=== RUN   TestAccVPCNetworkInterface_tags
=== PAUSE TestAccVPCNetworkInterface_tags
=== RUN   TestAccVPCNetworkInterface_ENI_ipv4Prefix
=== PAUSE TestAccVPCNetworkInterface_ENI_ipv4Prefix
=== RUN   TestAccVPCNetworkInterface_ENI_ipv4PrefixCount
=== PAUSE TestAccVPCNetworkInterface_ENI_ipv4PrefixCount
=== RUN   TestAccVPCNetworkInterface_ENI_ipv6Prefix
=== PAUSE TestAccVPCNetworkInterface_ENI_ipv6Prefix
=== RUN   TestAccVPCNetworkInterface_ENI_ipv6PrefixCount
=== PAUSE TestAccVPCNetworkInterface_ENI_ipv6PrefixCount
=== CONT  TestAccVPCNetworkInterface_tags
=== CONT  TestAccVPCNetworkInterface_ENI_ipv6Prefix
=== CONT  TestAccVPCNetworkInterface_ENI_ipv4PrefixCount
--- PASS: TestAccVPCNetworkInterface_tags (70.80s)
=== CONT  TestAccVPCNetworkInterface_ENI_ipv4Prefix
--- PASS: TestAccVPCNetworkInterface_ENI_ipv6Prefix (79.47s)
=== CONT  TestAccVPCNetworkInterface_ENI_ipv6PrefixCount
--- PASS: TestAccVPCNetworkInterface_ENI_ipv4PrefixCount (88.20s)
--- PASS: TestAccVPCNetworkInterface_ENI_ipv4Prefix (67.16s)
--- PASS: TestAccVPCNetworkInterface_ENI_ipv6PrefixCount (91.62s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	177.727s
% make testacc TESTARGS='-run=TestAccLogsDestination_basic\|TestAccLogsDestination_tags' PKG=logs ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/logs/... -v -count 1 -parallel 3  -run=TestAccLogsDestination_basic\|TestAccLogsDestination_tags -timeout 180m
=== RUN   TestAccLogsDestination_basic
=== PAUSE TestAccLogsDestination_basic
=== RUN   TestAccLogsDestination_tags
=== PAUSE TestAccLogsDestination_tags
=== CONT  TestAccLogsDestination_basic
=== CONT  TestAccLogsDestination_tags
--- PASS: TestAccLogsDestination_basic (60.54s)
--- PASS: TestAccLogsDestination_tags (85.03s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	90.504s
% make testacc TESTARGS='-run=TestAccOpsWorksStack_basic\|TestAccOpsWorksStack_tags' PKG=opsworks ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opsworks/... -v -count 1 -parallel 3  -run=TestAccOpsWorksStack_basic\|TestAccOpsWorksStack_tags -timeout 180m
=== RUN   TestAccOpsWorksStack_basic
=== PAUSE TestAccOpsWorksStack_basic
=== RUN   TestAccOpsWorksStack_tags
=== PAUSE TestAccOpsWorksStack_tags
=== RUN   TestAccOpsWorksStack_tagsAlternateRegion
=== PAUSE TestAccOpsWorksStack_tagsAlternateRegion
=== CONT  TestAccOpsWorksStack_basic
=== CONT  TestAccOpsWorksStack_tagsAlternateRegion
=== CONT  TestAccOpsWorksStack_tags
=== CONT  TestAccOpsWorksStack_tagsAlternateRegion
    acctest.go:834: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccOpsWorksStack_tagsAlternateRegion (0.98s)
--- PASS: TestAccOpsWorksStack_basic (37.45s)
--- PASS: TestAccOpsWorksStack_tags (89.34s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opsworks	94.729s
% make testacc TESTARGS='-run=TestAccRoute53Zone_basic\|TestAccRoute53Zone_tags\|TestAccRoute53HealthCheck_basic\|TestAccRoute53HealthCheck_tags' PKG=route53 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53/... -v -count 1 -parallel 2  -run=TestAccRoute53Zone_basic\|TestAccRoute53Zone_tags\|TestAccRoute53HealthCheck_basic\|TestAccRoute53HealthCheck_tags -timeout 180m
=== RUN   TestAccRoute53HealthCheck_basic
=== PAUSE TestAccRoute53HealthCheck_basic
=== RUN   TestAccRoute53HealthCheck_tags
=== PAUSE TestAccRoute53HealthCheck_tags
=== RUN   TestAccRoute53Zone_basic
=== PAUSE TestAccRoute53Zone_basic
=== RUN   TestAccRoute53Zone_tags
=== PAUSE TestAccRoute53Zone_tags
=== CONT  TestAccRoute53HealthCheck_basic
=== CONT  TestAccRoute53Zone_basic
--- PASS: TestAccRoute53HealthCheck_basic (55.77s)
=== CONT  TestAccRoute53HealthCheck_tags
--- PASS: TestAccRoute53Zone_basic (81.71s)
=== CONT  TestAccRoute53Zone_tags
--- PASS: TestAccRoute53HealthCheck_tags (74.91s)
--- PASS: TestAccRoute53Zone_tags (121.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	220.297s
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=route53recoveryreadiness ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53recoveryreadiness/... -v -count 1 -parallel 2  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccRoute53RecoveryReadinessCell_basic
=== PAUSE TestAccRoute53RecoveryReadinessCell_basic
=== RUN   TestAccRoute53RecoveryReadinessCell_tags
=== PAUSE TestAccRoute53RecoveryReadinessCell_tags
=== RUN   TestAccRoute53RecoveryReadinessReadinessCheck_basic
=== PAUSE TestAccRoute53RecoveryReadinessReadinessCheck_basic
=== RUN   TestAccRoute53RecoveryReadinessReadinessCheck_tags
=== PAUSE TestAccRoute53RecoveryReadinessReadinessCheck_tags
=== RUN   TestAccRoute53RecoveryReadinessRecoveryGroup_basic
=== PAUSE TestAccRoute53RecoveryReadinessRecoveryGroup_basic
=== RUN   TestAccRoute53RecoveryReadinessRecoveryGroup_tags
=== PAUSE TestAccRoute53RecoveryReadinessRecoveryGroup_tags
=== RUN   TestAccRoute53RecoveryReadinessResourceSet_basic
=== PAUSE TestAccRoute53RecoveryReadinessResourceSet_basic
=== RUN   TestAccRoute53RecoveryReadinessResourceSet_tags
=== PAUSE TestAccRoute53RecoveryReadinessResourceSet_tags
=== CONT  TestAccRoute53RecoveryReadinessResourceSet_tags
=== CONT  TestAccRoute53RecoveryReadinessCell_basic
--- PASS: TestAccRoute53RecoveryReadinessCell_basic (40.94s)
=== CONT  TestAccRoute53RecoveryReadinessRecoveryGroup_basic
--- PASS: TestAccRoute53RecoveryReadinessRecoveryGroup_basic (40.81s)
=== CONT  TestAccRoute53RecoveryReadinessResourceSet_basic
--- PASS: TestAccRoute53RecoveryReadinessResourceSet_tags (92.67s)
=== CONT  TestAccRoute53RecoveryReadinessRecoveryGroup_tags
--- PASS: TestAccRoute53RecoveryReadinessResourceSet_basic (31.17s)
=== CONT  TestAccRoute53RecoveryReadinessCell_tags
--- PASS: TestAccRoute53RecoveryReadinessRecoveryGroup_tags (85.17s)
=== CONT  TestAccRoute53RecoveryReadinessReadinessCheck_tags
--- PASS: TestAccRoute53RecoveryReadinessCell_tags (89.36s)
=== CONT  TestAccRoute53RecoveryReadinessReadinessCheck_basic
--- PASS: TestAccRoute53RecoveryReadinessReadinessCheck_basic (43.84s)
--- PASS: TestAccRoute53RecoveryReadinessReadinessCheck_tags (90.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53recoveryreadiness	282.209s
```
```console
% make testacc TESTARGS='-run=_basic$$\|_tags$$' PKG=devicefarm ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/devicefarm/... -v -count 1 -parallel 2  -run=_basic$\|_tags$ -timeout 180m
=== RUN   TestAccDeviceFarmDevicePool_basic
=== PAUSE TestAccDeviceFarmDevicePool_basic
=== RUN   TestAccDeviceFarmDevicePool_tags
=== PAUSE TestAccDeviceFarmDevicePool_tags
=== RUN   TestAccDeviceFarmInstanceProfile_basic
=== PAUSE TestAccDeviceFarmInstanceProfile_basic
=== RUN   TestAccDeviceFarmInstanceProfile_tags
=== PAUSE TestAccDeviceFarmInstanceProfile_tags
=== RUN   TestAccDeviceFarmNetworkProfile_basic
=== PAUSE TestAccDeviceFarmNetworkProfile_basic
=== RUN   TestAccDeviceFarmNetworkProfile_tags
=== PAUSE TestAccDeviceFarmNetworkProfile_tags
=== RUN   TestAccDeviceFarmProject_basic
=== PAUSE TestAccDeviceFarmProject_basic
=== RUN   TestAccDeviceFarmProject_tags
=== PAUSE TestAccDeviceFarmProject_tags
=== RUN   TestAccDeviceFarmTestGridProject_basic
=== PAUSE TestAccDeviceFarmTestGridProject_basic
=== RUN   TestAccDeviceFarmTestGridProject_tags
=== PAUSE TestAccDeviceFarmTestGridProject_tags
=== RUN   TestAccDeviceFarmUpload_basic
=== PAUSE TestAccDeviceFarmUpload_basic
=== CONT  TestAccDeviceFarmDevicePool_basic
=== CONT  TestAccDeviceFarmProject_basic
--- PASS: TestAccDeviceFarmProject_basic (27.78s)
=== CONT  TestAccDeviceFarmTestGridProject_tags
--- PASS: TestAccDeviceFarmDevicePool_basic (36.52s)
=== CONT  TestAccDeviceFarmUpload_basic
--- PASS: TestAccDeviceFarmUpload_basic (27.23s)
=== CONT  TestAccDeviceFarmTestGridProject_basic
--- PASS: TestAccDeviceFarmTestGridProject_tags (37.32s)
=== CONT  TestAccDeviceFarmInstanceProfile_tags
--- PASS: TestAccDeviceFarmTestGridProject_basic (26.57s)
=== CONT  TestAccDeviceFarmNetworkProfile_tags
--- PASS: TestAccDeviceFarmInstanceProfile_tags (37.40s)
=== CONT  TestAccDeviceFarmNetworkProfile_basic
--- PASS: TestAccDeviceFarmNetworkProfile_tags (38.87s)
=== CONT  TestAccDeviceFarmProject_tags
--- PASS: TestAccDeviceFarmNetworkProfile_basic (28.69s)
=== CONT  TestAccDeviceFarmInstanceProfile_basic
--- PASS: TestAccDeviceFarmInstanceProfile_basic (27.41s)
=== CONT  TestAccDeviceFarmDevicePool_tags
--- PASS: TestAccDeviceFarmProject_tags (38.97s)
--- PASS: TestAccDeviceFarmDevicePool_tags (47.08s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/devicefarm	211.173s
```
