### PR TITLE
td/aws_networkmanager_core network_policy-enhancements

### DIFF
--- a/.changelog/30879.txt
+++ b/.changelog/30879.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_networkmanager_core_network: Wait for the network policy to be in the `READY_TO_EXECUTE` state before executing any changes
+```

--- a/internal/service/networkmanager/core_network.go
+++ b/internal/service/networkmanager/core_network.go
@@ -30,9 +30,9 @@ const (
 	// CoreNetwork is in PENDING state before AVAILABLE. No value for PENDING at the moment.
 	coreNetworkStatePending = "PENDING"
 	// Minimum valid policy version id is 1
-	minimumValidPolicyVersionId = 1
+	minimumValidPolicyVersionID = 1
 	// Using the following in the FindCoreNetworkPolicyByID function will default to get the latest policy version
-	latestPolicyVersionId = -1
+	latestPolicyVersionID = -1
 	// Wait time value for core network policy - the default update for the core network policy of 30 minutes is excessive
 	waitCoreNetworkPolicyCreatedTimeInMinutes = 4
 )
@@ -261,7 +261,7 @@ func resourceCoreNetworkRead(ctx context.Context, d *schema.ResourceData, meta i
 	// getting the policy document uses a different API call
 	// policy document is also optional
 	// pass in latestPolicyVersionId to get the latest version id by default
-	coreNetworkPolicy, err := FindCoreNetworkPolicyByID(ctx, conn, d.Id(), latestPolicyVersionId)
+	coreNetworkPolicy, err := FindCoreNetworkPolicyByTwoPartKey(ctx, conn, d.Id(), latestPolicyVersionID)
 
 	if tfresource.NotFound(err) {
 		d.Set("policy_document", nil)
@@ -402,13 +402,12 @@ func FindCoreNetworkByID(ctx context.Context, conn *networkmanager.NetworkManage
 	return output.CoreNetwork, nil
 }
 
-func FindCoreNetworkPolicyByID(ctx context.Context, conn *networkmanager.NetworkManager, id string, policyVersionId int64) (*networkmanager.CoreNetworkPolicy, error) {
+func FindCoreNetworkPolicyByTwoPartKey(ctx context.Context, conn *networkmanager.NetworkManager, coreNetworkID string, policyVersionID int64) (*networkmanager.CoreNetworkPolicy, error) {
 	input := &networkmanager.GetCoreNetworkPolicyInput{
-		CoreNetworkId: aws.String(id),
+		CoreNetworkId: aws.String(coreNetworkID),
 	}
-
-	if policyVersionId >= minimumValidPolicyVersionId {
-		input.PolicyVersionId = aws.Int64(policyVersionId)
+	if policyVersionID >= minimumValidPolicyVersionID {
+		input.PolicyVersionId = aws.Int64(policyVersionID)
 	}
 
 	output, err := conn.GetCoreNetworkPolicyWithContext(ctx, input)
@@ -614,7 +613,7 @@ func PutAndExecuteCoreNetworkPolicy(ctx context.Context, conn *networkmanager.Ne
 
 func statusCoreNetworkPolicyState(ctx context.Context, conn *networkmanager.NetworkManager, coreNetworkId string, policyVersionId int64) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		output, err := FindCoreNetworkPolicyByID(ctx, conn, coreNetworkId, policyVersionId)
+		output, err := FindCoreNetworkPolicyByTwoPartKey(ctx, conn, coreNetworkId, policyVersionId)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil

--- a/internal/service/networkmanager/core_network_policy_attachment.go
+++ b/internal/service/networkmanager/core_network_policy_attachment.go
@@ -89,7 +89,7 @@ func resourceCoreNetworkPolicyAttachmentRead(ctx context.Context, d *schema.Reso
 
 	// getting the policy document uses a different API call
 	// pass in latestPolicyVersionId to get the latest version id by default
-	coreNetworkPolicy, err := FindCoreNetworkPolicyByID(ctx, conn, d.Id(), latestPolicyVersionId)
+	coreNetworkPolicy, err := FindCoreNetworkPolicyByTwoPartKey(ctx, conn, d.Id(), latestPolicyVersionID)
 
 	if tfresource.NotFound(err) {
 		d.Set("policy_document", nil)

--- a/internal/service/networkmanager/core_network_policy_attachment.go
+++ b/internal/service/networkmanager/core_network_policy_attachment.go
@@ -88,7 +88,7 @@ func resourceCoreNetworkPolicyAttachmentRead(ctx context.Context, d *schema.Reso
 	d.Set("state", coreNetwork.State)
 
 	// getting the policy document uses a different API call
-	coreNetworkPolicy, err := FindCoreNetworkPolicyByID(ctx, conn, d.Id())
+	coreNetworkPolicy, err := FindCoreNetworkPolicyByID(ctx, conn, d.Id(), -1)
 
 	if tfresource.NotFound(err) {
 		d.Set("policy_document", nil)

--- a/internal/service/networkmanager/core_network_policy_attachment.go
+++ b/internal/service/networkmanager/core_network_policy_attachment.go
@@ -88,7 +88,8 @@ func resourceCoreNetworkPolicyAttachmentRead(ctx context.Context, d *schema.Reso
 	d.Set("state", coreNetwork.State)
 
 	// getting the policy document uses a different API call
-	coreNetworkPolicy, err := FindCoreNetworkPolicyByID(ctx, conn, d.Id(), -1)
+	// pass in latestPolicyVersionId to get the latest version id by default
+	coreNetworkPolicy, err := FindCoreNetworkPolicyByID(ctx, conn, d.Id(), latestPolicyVersionId)
 
 	if tfresource.NotFound(err) {
 		d.Set("policy_document", nil)

--- a/internal/service/networkmanager/core_network_policy_attachment_test.go
+++ b/internal/service/networkmanager/core_network_policy_attachment_test.go
@@ -169,7 +169,7 @@ func testAccCheckCoreNetworkPolicyAttachmentExists(ctx context.Context, n string
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).NetworkManagerConn()
 
-		_, err := tfnetworkmanager.FindCoreNetworkPolicyByID(ctx, conn, rs.Primary.ID)
+		_, err := tfnetworkmanager.FindCoreNetworkPolicyByID(ctx, conn, rs.Primary.ID, -1)
 
 		return err
 	}

--- a/internal/service/networkmanager/core_network_policy_attachment_test.go
+++ b/internal/service/networkmanager/core_network_policy_attachment_test.go
@@ -171,7 +171,7 @@ func testAccCheckCoreNetworkPolicyAttachmentExists(ctx context.Context, n string
 
 		// pass in latestPolicyVersionId to get the latest version id by default
 		const latestPolicyVersionId = -1
-		_, err := tfnetworkmanager.FindCoreNetworkPolicyByID(ctx, conn, rs.Primary.ID, latestPolicyVersionId)
+		_, err := tfnetworkmanager.FindCoreNetworkPolicyByTwoPartKey(ctx, conn, rs.Primary.ID, latestPolicyVersionId)
 
 		return err
 	}

--- a/internal/service/networkmanager/core_network_policy_attachment_test.go
+++ b/internal/service/networkmanager/core_network_policy_attachment_test.go
@@ -134,6 +134,23 @@ func TestAccNetworkManagerCoreNetworkPolicyAttachment_vpcAttachmentMultiRegion(t
 	})
 }
 
+func TestAccNetworkManagerCoreNetworkPolicyAttachment_expectPolicyErrorInvalidASNRange(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, networkmanager.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCoreNetworkPolicyAttachmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCoreNetworkPolicyAttachmentConfig_expectPolicyError(),
+				ExpectError: regexp.MustCompile("INVALID_ASN_RANGE"),
+			},
+		},
+	})
+}
+
 func testAccCheckCoreNetworkPolicyAttachmentDestroy(ctx context.Context) resource.TestCheckFunc {
 	// policy document will not be reverted to empty if the attachment is deleted
 	return nil
@@ -386,4 +403,33 @@ resource "aws_networkmanager_vpc_attachment" "alternate_region" {
   vpc_arn         = aws_vpc.alternate_region.arn
 }
 `, acctest.Region(), acctest.AlternateRegion()))
+}
+
+func testAccCoreNetworkPolicyAttachmentConfig_expectPolicyError() string {
+	return fmt.Sprintf(`
+resource "aws_networkmanager_global_network" "test" {}
+
+data "aws_networkmanager_core_network_policy_document" "test" {
+  core_network_configuration {
+    asn_ranges = ["65022-65534123"] # not a valid range
+
+    edge_locations {
+      location = %[1]q
+    }
+  }
+
+  segments {
+    name = "test"
+  }
+}
+
+resource "aws_networkmanager_core_network" "test" {
+  global_network_id = aws_networkmanager_global_network.test.id
+}
+
+resource "aws_networkmanager_core_network_policy_attachment" "test" {
+  core_network_id = aws_networkmanager_core_network.test.id
+  policy_document = data.aws_networkmanager_core_network_policy_document.test.json
+}
+`, acctest.Region())
 }

--- a/internal/service/networkmanager/core_network_policy_attachment_test.go
+++ b/internal/service/networkmanager/core_network_policy_attachment_test.go
@@ -169,7 +169,9 @@ func testAccCheckCoreNetworkPolicyAttachmentExists(ctx context.Context, n string
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).NetworkManagerConn()
 
-		_, err := tfnetworkmanager.FindCoreNetworkPolicyByID(ctx, conn, rs.Primary.ID, -1)
+		// pass in latestPolicyVersionId to get the latest version id by default
+		const latestPolicyVersionId = -1
+		_, err := tfnetworkmanager.FindCoreNetworkPolicyByID(ctx, conn, rs.Primary.ID, latestPolicyVersionId)
 
 		return err
 	}

--- a/internal/service/networkmanager/core_network_policy_attachment_test.go
+++ b/internal/service/networkmanager/core_network_policy_attachment_test.go
@@ -144,7 +144,7 @@ func TestAccNetworkManagerCoreNetworkPolicyAttachment_expectPolicyErrorInvalidAS
 		CheckDestroy:             testAccCheckCoreNetworkPolicyAttachmentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCoreNetworkPolicyAttachmentConfig_expectPolicyError(),
+				Config:      testAccCoreNetworkPolicyAttachmentConfig_expectPolicyErrorInvalidASNRange(),
 				ExpectError: regexp.MustCompile("INVALID_ASN_RANGE"),
 			},
 		},
@@ -405,7 +405,7 @@ resource "aws_networkmanager_vpc_attachment" "alternate_region" {
 `, acctest.Region(), acctest.AlternateRegion()))
 }
 
-func testAccCoreNetworkPolicyAttachmentConfig_expectPolicyError() string {
+func testAccCoreNetworkPolicyAttachmentConfig_expectPolicyErrorInvalidASNRange() string {
 	return fmt.Sprintf(`
 resource "aws_networkmanager_global_network" "test" {}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Currently the api `ExecuteCoreNetworkChangeSetWithContext` is called in a `retry` when there is an error of `Incorrect input` which stems from a network policy not being in the correct state. Instead of using a retry, this PR introduces a wait condition to ensure the policy is in the `READY_TO_EXECUTE` state before executing it. The waiter also catches errors when a `FAILED_GENERATION` state is detected.

As part of this waiter, the finder function is refactored to take in a policy version id so that we can accurately wait for the correct policy to finish. For compatibility with the other APIs, we introduce a `-1` check and default to reading the latest policy versions.

Separetely, this PR also adds a test case to check for expected errors should there be an incorrect policy. This helps to test if policy errors can be detected early with an intuitive error message.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #28867

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccNetworkManagerCoreNetwork' PKG=networkmanager
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkmanager/... -v -count 1 -parallel 20  -run=TestAccNetworkManagerCoreNetwork -timeout 180m
=== RUN   TestAccNetworkManagerCoreNetworkPolicyAttachment_basic
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyAttachment_basic
=== RUN   TestAccNetworkManagerCoreNetworkPolicyAttachment_vpcAttachment
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyAttachment_vpcAttachment
=== RUN   TestAccNetworkManagerCoreNetworkPolicyAttachment_vpcAttachmentMultiRegion
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyAttachment_vpcAttachmentMultiRegion
=== RUN   TestAccNetworkManagerCoreNetworkPolicyAttachment_expectPolicyErrorInvalidASNRange
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyAttachment_expectPolicyErrorInvalidASNRange
=== RUN   TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== RUN   TestAccNetworkManagerCoreNetwork_basic
=== PAUSE TestAccNetworkManagerCoreNetwork_basic
=== RUN   TestAccNetworkManagerCoreNetwork_disappears
=== PAUSE TestAccNetworkManagerCoreNetwork_disappears
=== RUN   TestAccNetworkManagerCoreNetwork_tags
=== PAUSE TestAccNetworkManagerCoreNetwork_tags
=== RUN   TestAccNetworkManagerCoreNetwork_description
=== PAUSE TestAccNetworkManagerCoreNetwork_description
=== RUN   TestAccNetworkManagerCoreNetwork_policyDocument
=== PAUSE TestAccNetworkManagerCoreNetwork_policyDocument
=== RUN   TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithoutRegion
=== PAUSE TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithoutRegion
=== RUN   TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithRegion
=== PAUSE TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithRegion
=== RUN   TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithMultiRegion
=== PAUSE TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithMultiRegion
=== RUN   TestAccNetworkManagerCoreNetwork_withoutPolicyDocumentUpdateToCreateBasePolicyDocument
=== PAUSE TestAccNetworkManagerCoreNetwork_withoutPolicyDocumentUpdateToCreateBasePolicyDocument
=== CONT  TestAccNetworkManagerCoreNetworkPolicyAttachment_basic
=== CONT  TestAccNetworkManagerCoreNetwork_tags
=== CONT  TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== CONT  TestAccNetworkManagerCoreNetwork_disappears
=== CONT  TestAccNetworkManagerCoreNetworkPolicyAttachment_vpcAttachmentMultiRegion
=== CONT  TestAccNetworkManagerCoreNetworkPolicyAttachment_expectPolicyErrorInvalidASNRange
=== CONT  TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithRegion
=== CONT  TestAccNetworkManagerCoreNetwork_withoutPolicyDocumentUpdateToCreateBasePolicyDocument
=== CONT  TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithoutRegion
=== CONT  TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithMultiRegion
=== CONT  TestAccNetworkManagerCoreNetwork_policyDocument
=== CONT  TestAccNetworkManagerCoreNetwork_basic
=== CONT  TestAccNetworkManagerCoreNetwork_description
=== CONT  TestAccNetworkManagerCoreNetworkPolicyAttachment_vpcAttachment
--- PASS: TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic (29.47s)
--- PASS: TestAccNetworkManagerCoreNetworkPolicyAttachment_expectPolicyErrorInvalidASNRange (58.66s)
--- PASS: TestAccNetworkManagerCoreNetwork_basic (69.61s)
--- PASS: TestAccNetworkManagerCoreNetwork_disappears (75.73s)
--- PASS: TestAccNetworkManagerCoreNetwork_tags (87.07s)
--- PASS: TestAccNetworkManagerCoreNetwork_description (90.99s)
--- PASS: TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithRegion (551.62s)
--- PASS: TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithoutRegion (560.44s)
--- PASS: TestAccNetworkManagerCoreNetwork_withoutPolicyDocumentUpdateToCreateBasePolicyDocument (571.07s)
--- PASS: TestAccNetworkManagerCoreNetworkPolicyAttachment_basic (710.74s)
--- PASS: TestAccNetworkManagerCoreNetwork_policyDocument (819.73s)
--- PASS: TestAccNetworkManagerCoreNetworkPolicyAttachment_vpcAttachment (1238.58s)
--- PASS: TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithMultiRegion (1511.70s)
--- PASS: TestAccNetworkManagerCoreNetworkPolicyAttachment_vpcAttachmentMultiRegion (2130.35s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager     2130.479s

...
```
