### PR TITLE
fix: dms-vpc-role missing

### DIFF
--- a/internal/service/dms/replication_task_test.go
+++ b/internal/service/dms/replication_task_test.go
@@ -398,6 +398,31 @@ resource "aws_dms_replication_instance" "test" {
   preferred_maintenance_window = "sun:00:30-sun:02:30"
   publicly_accessible          = false
   replication_subnet_group_id  = aws_dms_replication_subnet_group.test.replication_subnet_group_id
+
+  depends_on = [
+    aws_iam_role_policy_attachment.allow_dms_to_manage_vpc_settings
+  ]
+}
+
+data "aws_iam_policy_document" "dms_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      identifiers = ["dms.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_iam_role" "allow_dms_to_manage_vpc_settings" {
+  assume_role_policy = data.aws_iam_policy_document.dms_assume_role.json
+  name               = "dms-vpc-role"
+}
+
+resource "aws_iam_role_policy_attachment" "allow_dms_to_manage_vpc_settings" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonDMSVPCManagementRole"
+  role       = aws_iam_role.allow_dms_to_manage_vpc_settings.name
 }
 `, rName))
 }
@@ -629,6 +654,10 @@ resource "aws_dms_replication_instance" "test" {
   publicly_accessible          = false
   replication_subnet_group_id  = aws_dms_replication_subnet_group.test.replication_subnet_group_id
   vpc_security_group_ids       = [aws_security_group.test.id]
+
+  depends_on = [
+    aws_iam_role_policy_attachment.allow_dms_to_manage_vpc_settings
+  ]
 }
 
 resource "aws_dms_replication_task" "test" {
@@ -648,6 +677,27 @@ resource "aws_dms_replication_task" "test" {
   target_endpoint_arn = aws_dms_endpoint.target.endpoint_arn
 
   depends_on = [aws_rds_cluster_instance.test1, aws_rds_cluster_instance.test2]
+}
+
+data "aws_iam_policy_document" "dms_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      identifiers = ["dms.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_iam_role" "allow_dms_to_manage_vpc_settings" {
+  assume_role_policy = data.aws_iam_policy_document.dms_assume_role.json
+  name               = "dms-vpc-role"
+}
+
+resource "aws_iam_role_policy_attachment" "allow_dms_to_manage_vpc_settings" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonDMSVPCManagementRole"
+  role       = aws_iam_role.allow_dms_to_manage_vpc_settings.name
 }
 `, rName, startTask, ruleName))
 }
@@ -814,6 +864,10 @@ resource "aws_dms_replication_instance" "test" {
   publicly_accessible          = false
   replication_subnet_group_id  = aws_dms_replication_subnet_group.test.replication_subnet_group_id
   vpc_security_group_ids       = [aws_security_group.test.id]
+
+  depends_on = [
+    aws_iam_role_policy_attachment.allow_dms_to_manage_vpc_settings
+  ]
 }
 
 resource "aws_dms_replication_task" "test" {
@@ -831,6 +885,27 @@ resource "aws_dms_replication_task" "test" {
   target_endpoint_arn = aws_dms_endpoint.target.endpoint_arn
 
   depends_on = [aws_rds_cluster_instance.test]
+}
+
+data "aws_iam_policy_document" "dms_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      identifiers = ["dms.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_iam_role" "allow_dms_to_manage_vpc_settings" {
+  assume_role_policy = data.aws_iam_policy_document.dms_assume_role.json
+  name               = "dms-vpc-role"
+}
+
+resource "aws_iam_role_policy_attachment" "allow_dms_to_manage_vpc_settings" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonDMSVPCManagementRole"
+  role       = aws_iam_role.allow_dms_to_manage_vpc_settings.name
 }
 `, rName))
 }

--- a/internal/service/dms/replication_task_test.go
+++ b/internal/service/dms/replication_task_test.go
@@ -327,6 +327,7 @@ func testAccCheckReplicationTaskDestroy(ctx context.Context) resource.TestCheckF
 }
 
 func replicationTaskConfigBase(rName string) string {
+	// lintignore:AWSAT005
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -488,6 +489,7 @@ resource "aws_dms_replication_task" "test" {
 }
 
 func testAccReplicationTaskConfig_start(rName string, startTask bool, ruleName string) string {
+	// lintignore:AWSAT005
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
@@ -703,6 +705,7 @@ resource "aws_iam_role_policy_attachment" "allow_dms_to_manage_vpc_settings" {
 }
 
 func testAccReplicationTaskConfig_s3ToRDS(rName string) string {
+	// lintignore:AWSAT005
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),
 		testAccS3EndpointConfig_base(rName),


### PR DESCRIPTION
### Description
This Pull Request create IAM role "dms-vpc-role" as a test acceptance dependency. 

### Relations
Closes #30882
Related #19883

### Output from Acceptance Testing
```
make testacc TESTS=TestAccDMSReplicationTask_basic PKG=dms
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dms/... -v -count 1 -parallel 20 -run='TestAccDMSReplicationTask_basic'  -timeout 180m
=== RUN   TestAccDMSReplicationTask_basic
=== PAUSE TestAccDMSReplicationTask_basic
=== CONT  TestAccDMSReplicationTask_basic
    replication_task_test.go:33: Step 1/4 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_dms_replication_task.test will be updated in-place
          ~ resource "aws_dms_replication_task" "test" {
                id                        = "tf-acc-test-483941223990513909"
              ~ replication_task_settings = jsonencode(
                  ~ {
                      ~ Logging                             = {
                          - EnableLogContext = false
                            # (2 unchanged attributes hidden)
                        }
                        # (13 unchanged attributes hidden)
                    }
                )
                tags                      = {
                    "Name"   = "tf-acc-test-483941223990513909"
                    "Remove" = "to-remove"
                    "Update" = "to-update"
                }
                # (10 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccDMSReplicationTask_basic (1136.78s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/dms        1136.892s
FAIL
make: *** [GNUmakefile:324: testacc] Error 1
```
Facing the same issue than #19883, I'll open another PR to fix it.