### PR TITLE
Updating basic usage to include updated security group flow

### DIFF
--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -219,14 +219,14 @@ resource "null_resource" "example" {
 
 The following arguments are supported:
 
-- `description` - (Optional, Forces new resource) Security group description. Defaults to `Managed by Terraform`. Cannot be `""`. **NOTE**: This field maps to the AWS `GroupDescription` attribute, for which there is no Update API. If you'd like to classify your security groups in a way that can be updated, use `tags`.
-- `egress` - (Optional, VPC only) Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
-- `ingress` - (Optional) Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
-- `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
-- `name` - (Optional, Forces new resource) Name of the security group. If omitted, Terraform will assign a random, unique name.
-- `revoke_rules_on_delete` - (Optional) Instruct Terraform to revoke all of the Security Groups attached ingress and egress rules before deleting the rule itself. This is normally not needed, however certain AWS services such as Elastic Map Reduce may automatically add required rules to security groups used with the service, and those rules may contain a cyclic dependency that prevent the security groups from being destroyed without removing the dependency first. Default `false`.
-- `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-- `vpc_id` - (Optional, Forces new resource) VPC ID. Defaults to the region's default VPC.
+* `description` - (Optional, Forces new resource) Security group description. Defaults to `Managed by Terraform`. Cannot be `""`. **NOTE**: This field maps to the AWS `GroupDescription` attribute, for which there is no Update API. If you'd like to classify your security groups in a way that can be updated, use `tags`.
+* `egress` - (Optional, VPC only) Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
+* `ingress` - (Optional) Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
+* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
+* `name` - (Optional, Forces new resource) Name of the security group. If omitted, Terraform will assign a random, unique name.
+* `revoke_rules_on_delete` - (Optional) Instruct Terraform to revoke all of the Security Groups attached ingress and egress rules before deleting the rule itself. This is normally not needed, however certain AWS services such as Elastic Map Reduce may automatically add required rules to security groups used with the service, and those rules may contain a cyclic dependency that prevent the security groups from being destroyed without removing the dependency first. Default `false`.
+* `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `vpc_id` - (Optional, Forces new resource) VPC ID. Defaults to the region's default VPC.
 
 ### ingress
 
@@ -234,18 +234,18 @@ This argument is processed in [attribute-as-blocks mode](https://www.terraform.i
 
 The following arguments are required:
 
-- `from_port` - (Required) Start port (or ICMP type number if protocol is `icmp` or `icmpv6`).
-- `to_port` - (Required) End range port (or ICMP code if protocol is `icmp`).
-- `protocol` - (Required) Protocol. If you select a protocol of `-1` (semantically equivalent to `all`, which is not a valid value here), you must specify a `from_port` and `to_port` equal to 0. The supported values are defined in the `IpProtocol` argument on the [IpPermission](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html) API reference. This argument is normalized to a lowercase value to match the AWS API requirement when using with Terraform 0.12.x and above, please make sure that the value of the protocol is specified as lowercase when using with older version of Terraform to avoid an issue during upgrade.
+* `from_port` - (Required) Start port (or ICMP type number if protocol is `icmp` or `icmpv6`).
+* `to_port` - (Required) End range port (or ICMP code if protocol is `icmp`).
+* `protocol` - (Required) Protocol. If you select a protocol of `-1` (semantically equivalent to `all`, which is not a valid value here), you must specify a `from_port` and `to_port` equal to 0. The supported values are defined in the `IpProtocol` argument on the [IpPermission](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html) API reference. This argument is normalized to a lowercase value to match the AWS API requirement when using with Terraform 0.12.x and above, please make sure that the value of the protocol is specified as lowercase when using with older version of Terraform to avoid an issue during upgrade.
 
 The following arguments are optional:
 
-- `cidr_blocks` - (Optional) List of CIDR blocks.
-- `description` - (Optional) Description of this ingress rule.
-- `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
-- `prefix_list_ids` - (Optional) List of Prefix List IDs.
-- `security_groups` - (Optional) List of security groups. A group name can be used relative to the default VPC. Otherwise, group ID.
-- `self` - (Optional) Whether the security group itself will be added as a source to this ingress rule.
+* `cidr_blocks` - (Optional) List of CIDR blocks.
+* `description` - (Optional) Description of this ingress rule.
+* `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
+* `prefix_list_ids` - (Optional) List of Prefix List IDs.
+* `security_groups` - (Optional) List of security groups. A group name can be used relative to the default VPC. Otherwise, group ID.
+* `self` - (Optional) Whether the security group itself will be added as a source to this ingress rule.
 
 ### egress
 
@@ -253,27 +253,27 @@ This argument is processed in [attribute-as-blocks mode](https://www.terraform.i
 
 The following arguments are required:
 
-- `from_port` - (Required) Start port (or ICMP type number if protocol is `icmp`)
-- `to_port` - (Required) End range port (or ICMP code if protocol is `icmp`).
+* `from_port` - (Required) Start port (or ICMP type number if protocol is `icmp`)
+* `to_port` - (Required) End range port (or ICMP code if protocol is `icmp`).
 
 The following arguments are optional:
 
-- `cidr_blocks` - (Optional) List of CIDR blocks.
-- `description` - (Optional) Description of this egress rule.
-- `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
-- `prefix_list_ids` - (Optional) List of Prefix List IDs.
-- `protocol` - (Required) Protocol. If you select a protocol of `-1` (semantically equivalent to `all`, which is not a valid value here), you must specify a `from_port` and `to_port` equal to 0. The supported values are defined in the `IpProtocol` argument in the [IpPermission](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html) API reference. This argument is normalized to a lowercase value to match the AWS API requirement when using Terraform 0.12.x and above. Please make sure that the value of the protocol is specified as lowercase when used with older version of Terraform to avoid issues during upgrade.
-- `security_groups` - (Optional) List of security groups. A group name can be used relative to the default VPC. Otherwise, group ID.
-- `self` - (Optional) Whether the security group itself will be added as a source to this egress rule.
+* `cidr_blocks` - (Optional) List of CIDR blocks.
+* `description` - (Optional) Description of this egress rule.
+* `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
+* `prefix_list_ids` - (Optional) List of Prefix List IDs.
+* `protocol` - (Required) Protocol. If you select a protocol of `-1` (semantically equivalent to `all`, which is not a valid value here), you must specify a `from_port` and `to_port` equal to 0. The supported values are defined in the `IpProtocol` argument in the [IpPermission](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html) API reference. This argument is normalized to a lowercase value to match the AWS API requirement when using Terraform 0.12.x and above. Please make sure that the value of the protocol is specified as lowercase when used with older version of Terraform to avoid issues during upgrade.
+* `security_groups` - (Optional) List of security groups. A group name can be used relative to the default VPC. Otherwise, group ID.
+* `self` - (Optional) Whether the security group itself will be added as a source to this egress rule.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-- `arn` - ARN of the security group.
-- `id` - ID of the security group.
-- `owner_id` - Owner ID.
-- `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+* `arn` - ARN of the security group.
+* `id` - ID of the security group.
+* `owner_id` - Owner ID.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts
 

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -25,29 +25,33 @@ Provides a security group resource.
 ```terraform
 resource "aws_security_group" "allow_tls" {
   name        = "allow_tls"
-  description = "Allow TLS inbound traffic"
+  description = "Allow TLS inbound traffic and all outbound traffic"
   vpc_id      = aws_vpc.main.id
-
-  ingress {
-    description      = "TLS from VPC"
-    from_port        = 443
-    to_port          = 443
-    protocol         = "tcp"
-    cidr_blocks      = [aws_vpc.main.cidr_block]
-    ipv6_cidr_blocks = [aws_vpc.main.ipv6_cidr_block]
-  }
-
-  egress {
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-  }
 
   tags = {
     Name = "allow_tls"
   }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "allow_tls" {
+  security_group_id = aws_security_group.allow_tls.id
+
+  cidr_ipv4   = [aws_vpc.main.cidr_block]
+  cidr_ipv6   = [aws_vpc.main.ipv6_cidr_block]
+  from_port   = 443
+  ip_protocol = "tcp"
+  to_port     = 443
+}
+
+resource "aws_vpc_security_group_egress_rule" "allow_all_traffic" {
+  security_group_id = aws_security_group.allow_tls.id
+
+  cidr_ipv4 = ["0.0.0.0/0"]
+  cidr_piv6 = ["::/0"]
+  # -1 is semantically equivalent to all ports and must be specified for the from_port and to_port if the protocol is "-1"
+  from_port   = -1
+  ip_protocol = "-1"
+  to_port     = -1
 }
 ```
 
@@ -215,14 +219,14 @@ resource "null_resource" "example" {
 
 The following arguments are supported:
 
-* `description` - (Optional, Forces new resource) Security group description. Defaults to `Managed by Terraform`. Cannot be `""`. **NOTE**: This field maps to the AWS `GroupDescription` attribute, for which there is no Update API. If you'd like to classify your security groups in a way that can be updated, use `tags`.
-* `egress` - (Optional, VPC only) Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
-* `ingress` - (Optional) Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
-* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
-* `name` - (Optional, Forces new resource) Name of the security group. If omitted, Terraform will assign a random, unique name.
-* `revoke_rules_on_delete` - (Optional) Instruct Terraform to revoke all of the Security Groups attached ingress and egress rules before deleting the rule itself. This is normally not needed, however certain AWS services such as Elastic Map Reduce may automatically add required rules to security groups used with the service, and those rules may contain a cyclic dependency that prevent the security groups from being destroyed without removing the dependency first. Default `false`.
-* `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `vpc_id` - (Optional, Forces new resource) VPC ID. Defaults to the region's default VPC.
+- `description` - (Optional, Forces new resource) Security group description. Defaults to `Managed by Terraform`. Cannot be `""`. **NOTE**: This field maps to the AWS `GroupDescription` attribute, for which there is no Update API. If you'd like to classify your security groups in a way that can be updated, use `tags`.
+- `egress` - (Optional, VPC only) Configuration block for egress rules. Can be specified multiple times for each egress rule. Each egress block supports fields documented below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
+- `ingress` - (Optional) Configuration block for ingress rules. Can be specified multiple times for each ingress rule. Each ingress block supports fields documented below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html).
+- `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
+- `name` - (Optional, Forces new resource) Name of the security group. If omitted, Terraform will assign a random, unique name.
+- `revoke_rules_on_delete` - (Optional) Instruct Terraform to revoke all of the Security Groups attached ingress and egress rules before deleting the rule itself. This is normally not needed, however certain AWS services such as Elastic Map Reduce may automatically add required rules to security groups used with the service, and those rules may contain a cyclic dependency that prevent the security groups from being destroyed without removing the dependency first. Default `false`.
+- `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+- `vpc_id` - (Optional, Forces new resource) VPC ID. Defaults to the region's default VPC.
 
 ### ingress
 
@@ -230,18 +234,18 @@ This argument is processed in [attribute-as-blocks mode](https://www.terraform.i
 
 The following arguments are required:
 
-* `from_port` - (Required) Start port (or ICMP type number if protocol is `icmp` or `icmpv6`).
-* `to_port` - (Required) End range port (or ICMP code if protocol is `icmp`).
-* `protocol` - (Required) Protocol. If you select a protocol of `-1` (semantically equivalent to `all`, which is not a valid value here), you must specify a `from_port` and `to_port` equal to 0.  The supported values are defined in the `IpProtocol` argument on the [IpPermission](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html) API reference. This argument is normalized to a lowercase value to match the AWS API requirement when using with Terraform 0.12.x and above, please make sure that the value of the protocol is specified as lowercase when using with older version of Terraform to avoid an issue during upgrade.
+- `from_port` - (Required) Start port (or ICMP type number if protocol is `icmp` or `icmpv6`).
+- `to_port` - (Required) End range port (or ICMP code if protocol is `icmp`).
+- `protocol` - (Required) Protocol. If you select a protocol of `-1` (semantically equivalent to `all`, which is not a valid value here), you must specify a `from_port` and `to_port` equal to 0. The supported values are defined in the `IpProtocol` argument on the [IpPermission](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html) API reference. This argument is normalized to a lowercase value to match the AWS API requirement when using with Terraform 0.12.x and above, please make sure that the value of the protocol is specified as lowercase when using with older version of Terraform to avoid an issue during upgrade.
 
 The following arguments are optional:
 
-* `cidr_blocks` - (Optional) List of CIDR blocks.
-* `description` - (Optional) Description of this ingress rule.
-* `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
-* `prefix_list_ids` - (Optional) List of Prefix List IDs.
-* `security_groups` - (Optional) List of security groups. A group name can be used relative to the default VPC. Otherwise, group ID.
-* `self` - (Optional) Whether the security group itself will be added as a source to this ingress rule.
+- `cidr_blocks` - (Optional) List of CIDR blocks.
+- `description` - (Optional) Description of this ingress rule.
+- `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
+- `prefix_list_ids` - (Optional) List of Prefix List IDs.
+- `security_groups` - (Optional) List of security groups. A group name can be used relative to the default VPC. Otherwise, group ID.
+- `self` - (Optional) Whether the security group itself will be added as a source to this ingress rule.
 
 ### egress
 
@@ -249,27 +253,27 @@ This argument is processed in [attribute-as-blocks mode](https://www.terraform.i
 
 The following arguments are required:
 
-* `from_port` - (Required) Start port (or ICMP type number if protocol is `icmp`)
-* `to_port` - (Required) End range port (or ICMP code if protocol is `icmp`).
+- `from_port` - (Required) Start port (or ICMP type number if protocol is `icmp`)
+- `to_port` - (Required) End range port (or ICMP code if protocol is `icmp`).
 
 The following arguments are optional:
 
-* `cidr_blocks` - (Optional) List of CIDR blocks.
-* `description` - (Optional) Description of this egress rule.
-* `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
-* `prefix_list_ids` - (Optional) List of Prefix List IDs.
-* `protocol` - (Required) Protocol. If you select a protocol of `-1` (semantically equivalent to `all`, which is not a valid value here), you must specify a `from_port` and `to_port` equal to 0.  The supported values are defined in the `IpProtocol` argument in the [IpPermission](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html) API reference. This argument is normalized to a lowercase value to match the AWS API requirement when using Terraform 0.12.x and above. Please make sure that the value of the protocol is specified as lowercase when used with older version of Terraform to avoid issues during upgrade.
-* `security_groups` - (Optional) List of security groups. A group name can be used relative to the default VPC. Otherwise, group ID.
-* `self` - (Optional) Whether the security group itself will be added as a source to this egress rule.
+- `cidr_blocks` - (Optional) List of CIDR blocks.
+- `description` - (Optional) Description of this egress rule.
+- `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
+- `prefix_list_ids` - (Optional) List of Prefix List IDs.
+- `protocol` - (Required) Protocol. If you select a protocol of `-1` (semantically equivalent to `all`, which is not a valid value here), you must specify a `from_port` and `to_port` equal to 0. The supported values are defined in the `IpProtocol` argument in the [IpPermission](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html) API reference. This argument is normalized to a lowercase value to match the AWS API requirement when using Terraform 0.12.x and above. Please make sure that the value of the protocol is specified as lowercase when used with older version of Terraform to avoid issues during upgrade.
+- `security_groups` - (Optional) List of security groups. A group name can be used relative to the default VPC. Otherwise, group ID.
+- `self` - (Optional) Whether the security group itself will be added as a source to this egress rule.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - ARN of the security group.
-* `id` - ID of the security group.
-* `owner_id` - Owner ID.
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+- `arn` - ARN of the security group.
+- `id` - ID of the security group.
+- `owner_id` - Owner ID.
+- `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts
 

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -33,14 +33,20 @@ resource "aws_security_group" "allow_tls" {
   }
 }
 
-resource "aws_vpc_security_group_ingress_rule" "allow_tls" {
+resource "aws_vpc_security_group_ingress_rule" "allow_tls_ipv4" {
   security_group_id = aws_security_group.allow_tls.id
+  cidr_ipv4         = aws_vpc.main.cidr_block
+  from_port         = 443
+  ip_protocol       = "tcp"
+  to_port           = 443
+}
 
-  cidr_ipv4   = [aws_vpc.main.cidr_block]
-  cidr_ipv6   = [aws_vpc.main.ipv6_cidr_block]
-  from_port   = 443
-  ip_protocol = "tcp"
-  to_port     = 443
+resource "aws_vpc_security_group_ingress_rule" "allow_tls_ipv6" {
+  security_group_id = aws_security_group.allow_tls.id
+  cidr_ipv6         = aws_vpc.main.ipv6_cidr_block
+  from_port         = 443
+  ip_protocol       = "tcp"
+  to_port           = 443
 }
 
 resource "aws_vpc_security_group_egress_rule" "allow_all_traffic_ipv4" {

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -51,16 +51,14 @@ resource "aws_vpc_security_group_ingress_rule" "allow_tls_ipv6" {
 
 resource "aws_vpc_security_group_egress_rule" "allow_all_traffic_ipv4" {
   security_group_id = aws_security_group.allow_tls.id
-  cidr_ipv4 = "0.0.0.0/0"
-  # -1 is semantically equivalent to all ports
-  ip_protocol = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1" # semantically equivalent to all ports
 }
 
 resource "aws_vpc_security_group_egress_rule" "allow_all_traffic_ipv6" {
   security_group_id = aws_security_group.allow_tls.id
-  cidr_piv6 = "::/0"
-  # -1 is semantically equivalent to all ports
-  ip_protocol = "-1"
+  cidr_ipv6         = "::/0"
+  ip_protocol       = "-1" # semantically equivalent to all ports
 }
 ```
 

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -43,15 +43,18 @@ resource "aws_vpc_security_group_ingress_rule" "allow_tls" {
   to_port     = 443
 }
 
-resource "aws_vpc_security_group_egress_rule" "allow_all_traffic" {
+resource "aws_vpc_security_group_egress_rule" "allow_all_traffic_ipv4" {
   security_group_id = aws_security_group.allow_tls.id
-
-  cidr_ipv4 = ["0.0.0.0/0"]
-  cidr_piv6 = ["::/0"]
-  # -1 is semantically equivalent to all ports and must be specified for the from_port and to_port if the protocol is "-1"
-  from_port   = -1
+  cidr_ipv4 = "0.0.0.0/0"
+  # -1 is semantically equivalent to all ports
   ip_protocol = "-1"
-  to_port     = -1
+}
+
+resource "aws_vpc_security_group_egress_rule" "allow_all_traffic_ipv6" {
+  security_group_id = aws_security_group.allow_tls.id
+  cidr_piv6 = "::/0"
+  # -1 is semantically equivalent to all ports
+  ip_protocol = "-1"
 }
 ```
 


### PR DESCRIPTION
### Description
Documentation change - this PR will update the aws_security_group resource to be more in line with best practices by using the aws_vpc_security_group_ingress_rule and aws_vpc_security_group_egress_rule together. I have modeled my example over the default example provided previously. 

References: AWS Unique ID: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules.html