### PR TITLE
Documentation correction for aws_s3_object-fix #30770

### DIFF
--- a/website/docs/d/s3_object.html.markdown
+++ b/website/docs/d/s3_object.html.markdown
@@ -44,7 +44,7 @@ data "aws_s3_object" "lambda" {
 }
 
 resource "aws_lambda_function" "test_lambda" {
-  s3_bucket         = data.aws_s3_object.lambda.id
+  s3_bucket         = data.aws_s3_object.lambda.bucket
   s3_key            = data.aws_s3_object.lambda.key
   s3_object_version = data.aws_s3_object.lambda.version_id
   function_name     = "lambda_function_name"


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
In the example usage of the Resource: aws_lambda_function.test_lambda there is this field: s3_bucket = data.aws_s3_object.lambda.id. That id refers to the object id not the bucket id.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #30770
--->

Closes #30770

### References
<!---
documentation containing issue: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_object
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
