### PR TITLE
Documentation Update For Issue #30830

### DIFF
--- a/website/docs/d/dynamodb_table_item.html.markdown
+++ b/website/docs/d/dynamodb_table_item.html.markdown
@@ -48,4 +48,4 @@ If no attribute names are specified, then all attributes are returned. If any of
 
 In addition to all arguments above, the following attributes are exported:
 
-* `item` - A map of attribute names to [AttributeValue](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_AttributeValue.html) objects, as specified by ProjectionExpression.
+* `item` - JSON representation of a map of attribute names to [AttributeValue](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_AttributeValue.html) objects, as specified by ProjectionExpression.


### PR DESCRIPTION
### Description

Documentation update for the attributes description "item" mentioned as "map" which has been rectified as " JSON representation of a map" and is inline with Resource block "item" attribut description. 

### Relations

Closes  #30830

### References

DataSource - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/dynamodb_table_item
Resource :- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table_item

### Output from Acceptance Testing
N/A