### PR TITLE
rd/aws_imagebuilder_image: add `containers` attribute to the `output_resources` block

### DIFF
--- a/.changelog/30899.txt
+++ b/.changelog/30899.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_imagebuilder_image: Add `containers` attribute to the `output_resources` block
+```
+
+```release-note:enhancement
+data-source/aws_imagebuilder_image: Add `containers` attribute to the `output_resources` block
+```

--- a/internal/service/imagebuilder/image.go
+++ b/internal/service/imagebuilder/image.go
@@ -141,6 +141,23 @@ func ResourceImage() *schema.Resource {
 								},
 							},
 						},
+						"containers": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"image_uris": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"region": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -319,6 +336,10 @@ func flattenOutputResources(apiObject *imagebuilder.OutputResources) map[string]
 		tfMap["amis"] = flattenAMIs(v)
 	}
 
+	if v := apiObject.Containers; v != nil {
+		tfMap["containers"] = flattenContainers(v)
+	}
+
 	return tfMap
 }
 
@@ -365,6 +386,42 @@ func flattenAMIs(apiObjects []*imagebuilder.Ami) []interface{} {
 		}
 
 		tfList = append(tfList, flattenAMI(apiObject))
+	}
+
+	return tfList
+}
+
+func flattenContainer(apiObject *imagebuilder.Container) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.ImageUris; v != nil {
+		tfMap["image_uris"] = aws.StringValueSlice(v)
+	}
+
+	if v := apiObject.Region; v != nil {
+		tfMap["region"] = aws.StringValue(v)
+	}
+
+	return tfMap
+}
+
+func flattenContainers(apiObjects []*imagebuilder.Container) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		tfList = append(tfList, flattenContainer(apiObject))
 	}
 
 	return tfList

--- a/internal/service/imagebuilder/image_data_source.go
+++ b/internal/service/imagebuilder/image_data_source.go
@@ -109,6 +109,23 @@ func DataSourceImage() *schema.Resource {
 								},
 							},
 						},
+						"containers": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"image_uris": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"region": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/internal/service/imagebuilder/image_data_source_test.go
+++ b/internal/service/imagebuilder/image_data_source_test.go
@@ -28,7 +28,7 @@ func TestAccImageBuilderImageDataSource_ARN_aws(t *testing.T) { // nosemgrep:ci.
 					acctest.MatchResourceAttrRegionalARNAccountID(dataSourceName, "build_version_arn", "imagebuilder", "aws", regexp.MustCompile(`image/amazon-linux-2-x86/\d+\.\d+\.\d+/\d+`)),
 					acctest.CheckResourceAttrRFC3339(dataSourceName, "date_created"),
 					resource.TestCheckNoResourceAttr(dataSourceName, "distribution_configuration_arn"),
-					resource.TestCheckResourceAttr(dataSourceName, "enhanced_image_metadata_enabled", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "enhanced_image_metadata_enabled", "false"),
 					resource.TestCheckNoResourceAttr(dataSourceName, "image_recipe_arn"),
 					resource.TestCheckResourceAttr(dataSourceName, "image_tests_configuration.#", "0"),
 					resource.TestCheckNoResourceAttr(dataSourceName, "infrastructure_configuration_arn"),

--- a/internal/service/imagebuilder/image_data_source_test.go
+++ b/internal/service/imagebuilder/image_data_source_test.go
@@ -80,7 +80,7 @@ func TestAccImageBuilderImageDataSource_ARN_self(t *testing.T) {
 	})
 }
 
-func TestAccImageBuilderImageDataSource_ARN_containerRecipeARN(t *testing.T) {
+func TestAccImageBuilderImageDataSource_ARN_containerRecipe(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_imagebuilder_image.test"
@@ -93,10 +93,14 @@ func TestAccImageBuilderImageDataSource_ARN_containerRecipeARN(t *testing.T) {
 		CheckDestroy:             testAccCheckImageDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImageDataSourceConfig_arnContainerRecipeARN(rName),
+				Config: testAccImageDataSourceConfig_arnContainerRecipe(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "container_recipe_arn", resourceName, "container_recipe_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "output_resources.#", resourceName, "output_resources.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "output_resources.0.containers.#", resourceName, "output_resources.0.containers.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "output_resources.0.containers.0.image_uris.#", resourceName, "output_resources.0.containers.0.image_uris.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "output_resources.0.containers.0.region", resourceName, "output_resources.0.containers.0.region"),
 				),
 			},
 		},
@@ -231,7 +235,7 @@ data "aws_imagebuilder_image" "test" {
 `, rName)
 }
 
-func testAccImageDataSourceConfig_arnContainerRecipeARN(rName string) string {
+func testAccImageDataSourceConfig_arnContainerRecipe(rName string) string {
 	return fmt.Sprintf(`
 data "aws_region" "current" {}
 
@@ -314,7 +318,8 @@ resource "aws_iam_instance_profile" "test" {
 }
 
 resource "aws_ecr_repository" "test" {
-  name = %[1]q
+  name         = %[1]q
+  force_delete = true
 }
 
 data "aws_imagebuilder_component" "update-linux" {

--- a/website/docs/d/imagebuilder_image.html.markdown
+++ b/website/docs/d/imagebuilder_image.html.markdown
@@ -48,5 +48,8 @@ In addition to all arguments above, the following attributes are exported:
         * `image` - Identifier of the AMI.
         * `name` - Name of the AMI.
         * `region` - Region of the AMI.
+    * `containers` - Set of objects with each container image created and stored in the output repository.
+        * `image_uris` - Set of URIs for created containers.
+        * `region` - Region of the container image.
 * `tags` - Key-value map of resource tags for the image.
 * `version` - Version of the image.

--- a/website/docs/r/imagebuilder_image.html.markdown
+++ b/website/docs/r/imagebuilder_image.html.markdown
@@ -57,6 +57,9 @@ In addition to all arguments above, the following attributes are exported:
         * `image` - Identifier of the AMI.
         * `name` - Name of the AMI.
         * `region` - Region of the AMI.
+    * `containers` - Set of objects with each container image created and stored in the output repository.
+        * `image_uris` - Set of URIs for created containers.
+        * `region` - Region of the container image.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `version` - Version of the image.
 


### PR DESCRIPTION
### Description
This PR adds the `containers` attribute to the `output_resources` block of `aws_imagebuilder_image` resource and data-source.

### Relations
Closes #30840.

### References
https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_OutputResources.html


### Output from Acceptance Testing
```
$ make testacc TESTARGS="-run=TestAccImageBuilderImage_outputResources_containers" PKG=imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20  -run=TestAccImageBuilderImage_outputResources_containers -timeout 180m
=== RUN   TestAccImageBuilderImage_outputResources_containers
=== PAUSE TestAccImageBuilderImage_outputResources_containers
=== CONT  TestAccImageBuilderImage_outputResources_containers
--- PASS: TestAccImageBuilderImage_outputResources_containers (497.17s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       499.308s
```
```
$ make testacc TESTARGS="-run=TestAccImageBuilderImageDataSource_ARN_containerRecipe" PKG=imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/imagebuilder/... -v -count 1 -parallel 20  -run=TestAccImageBuilderImageDataSource_ARN_containerRecipe -timeout 180m
=== RUN   TestAccImageBuilderImageDataSource_ARN_containerRecipe
=== PAUSE TestAccImageBuilderImageDataSource_ARN_containerRecipe
=== CONT  TestAccImageBuilderImageDataSource_ARN_containerRecipe
--- PASS: TestAccImageBuilderImageDataSource_ARN_containerRecipe (611.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       613.421s
```
