### PR TITLE
Bug: Missing shared directory resources on read

### DIFF
--- a/.changelog/30914.txt
+++ b/.changelog/30914.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ds_shared_directory: Properly handle paged response objects on read
+```

--- a/internal/service/ds/find.go
+++ b/internal/service/ds/find.go
@@ -196,7 +196,21 @@ func FindSharedDirectory(ctx context.Context, conn *directoryservice.DirectorySe
 		SharedDirectoryIds: aws.StringSlice([]string{sharedDirectoryID}),
 	}
 
-	output, err := conn.DescribeSharedDirectoriesWithContext(ctx, input)
+	var output []*directoryservice.SharedDirectory
+
+	err := conn.DescribeSharedDirectoriesPagesWithContext(ctx, input, func(page *directoryservice.DescribeSharedDirectoriesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, v := range page.SharedDirectories {
+			if v != nil {
+				output = append(output, v)
+			}
+		}
+
+		return !lastPage
+	})
 
 	if tfawserr.ErrCodeEquals(err, directoryservice.ErrCodeEntityDoesNotExistException) {
 		return nil, &retry.NotFoundError{
@@ -209,15 +223,15 @@ func FindSharedDirectory(ctx context.Context, conn *directoryservice.DirectorySe
 		return nil, err
 	}
 
-	if output == nil || len(output.SharedDirectories) == 0 || output.SharedDirectories[0] == nil {
+	if len(output) == 0 {
 		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	if count := len(output.SharedDirectories); count > 1 {
+	if count := len(output); count > 1 {
 		return nil, tfresource.NewTooManyResultsError(count, input)
 	}
 
-	sharedDirectory := output.SharedDirectories[0]
+	sharedDirectory := output[0]
 
 	if status := aws.StringValue(sharedDirectory.ShareStatus); status == directoryservice.ShareStatusDeleted {
 		return nil, &retry.NotFoundError{


### PR DESCRIPTION
### Description
Change this method to page results like the others, it's possible the API returns a non-null `NextToken` while the `SharedDirectories` array is empty. Paging is consistent with the AWS CLI and allows us to find the required shared directory.

Not paging means for directories with large numbers of shares the provider believes the resource has been deleted outside of terraform and attempts to recreate the resources, which fails.
