### PR TITLE
r/aws_apigateway_rest_api: add put_rest_api_mode to ImportStateVerifyIgnore

### DIFF
--- a/internal/service/apigateway/rest_api_test.go
+++ b/internal/service/apigateway/rest_api_test.go
@@ -1218,7 +1218,7 @@ func TestAccAPIGatewayRestAPI_FailOnWarnings(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"body"},
+				ImportStateVerifyIgnore: []string{"body", "put_rest_api_mode"},
 			},
 			// Verify invalid body fails update, when fail_on_warnings is true
 			{


### PR DESCRIPTION
### Description
Fixes failing acceptance test due to missing `put_rest_api_mode` in the `ImportStateVerifyIgnore` list.

```console
$ make testacc PKG=apigateway TESTS=TestAccAPIGatewayRestAPI_FailOnWarnings
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayRestAPI_FailOnWarnings'  -timeout 180m
=== RUN   TestAccAPIGatewayRestAPI_FailOnWarnings
=== PAUSE TestAccAPIGatewayRestAPI_FailOnWarnings
=== CONT  TestAccAPIGatewayRestAPI_FailOnWarnings
    rest_api_test.go:1197: Step 3/5 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.

          map[string]string{
        +       "put_rest_api_mode": "overwrite",
          }
--- FAIL: TestAccAPIGatewayRestAPI_FailOnWarnings (43.59s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/apigateway 46.702s
FAIL
make: *** [testacc] Error 1
```

### Output from Acceptance Testing

```console
$ make testacc PKG=apigateway TESTS=TestAccAPIGatewayRestAPI_FailOnWarnings
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayRestAPI_FailOnWarnings'  -timeout 180m
=== RUN   TestAccAPIGatewayRestAPI_FailOnWarnings
=== PAUSE TestAccAPIGatewayRestAPI_FailOnWarnings
=== CONT  TestAccAPIGatewayRestAPI_FailOnWarnings
--- PASS: TestAccAPIGatewayRestAPI_FailOnWarnings (42.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigateway 45.763s
```
