### PR TITLE
Add 'context' field to EC2 spot fleet request

### DIFF
--- a/.changelog/30918.txt
+++ b/.changelog/30918.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_spot_fleet_request: Add 'aws_spot_fleet_request.context' argument
+```

--- a/internal/service/ec2/ec2_spot_fleet_request.go
+++ b/internal/service/ec2/ec2_spot_fleet_request.go
@@ -885,6 +885,10 @@ func resourceSpotFleetRequestCreate(ctx context.Context, d *schema.ResourceData,
 		Type:                             aws.String(d.Get("fleet_type").(string)),
 	}
 
+	if v, ok := d.GetOk("context"); ok {
+		spotFleetConfig.Context = aws.String(v.(string))
+	}
+
 	if launchSpecificationOk {
 		launchSpecs, err := buildSpotFleetLaunchSpecifications(ctx, d, meta)
 		if err != nil {
@@ -1038,6 +1042,7 @@ func resourceSpotFleetRequestRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("allocation_strategy", config.AllocationStrategy)
 	d.Set("instance_pools_to_use_count", config.InstancePoolsToUseCount)
 	d.Set("client_token", config.ClientToken)
+	d.Set("context", config.Context)
 	d.Set("excess_capacity_termination_policy", config.ExcessCapacityTerminationPolicy)
 	d.Set("iam_fleet_role", config.IamFleetRole)
 	d.Set("spot_maintenance_strategies", flattenSpotMaintenanceStrategies(config.SpotMaintenanceStrategies))

--- a/internal/service/ec2/ec2_spot_fleet_request.go
+++ b/internal/service/ec2/ec2_spot_fleet_request.go
@@ -64,6 +64,12 @@ func ResourceSpotFleetRequest() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"context": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+			},
 			// Provided constants do not have the correct casing so going with hard-coded values.
 			"excess_capacity_termination_policy": {
 				Type:     schema.TypeString,

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -198,6 +198,7 @@ Most of these arguments directly correspond to the
   Spot instances on your behalf when you cancel its Spot fleet request using
 CancelSpotFleetRequests or when the Spot fleet request expires, if you set
 terminateInstancesWithExpiration.
+* `context` - (Optional) Reserved.
 * `replace_unhealthy_instances` - (Optional) Indicates whether Spot fleet should replace unhealthy instances. Default `false`.
 * `launch_specification` - (Optional) Used to define the launch configuration of the
   spot-fleet request. Can be specified multiple times to define different bids


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add the `context` field to `aws_spot_fleet_request`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=ec2 TESTS=TestAccEC2SpotFleetRequest_context
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2SpotFleetRequest_context'  -timeout 180m
=== RUN   TestAccEC2SpotFleetRequest_context
=== PAUSE TestAccEC2SpotFleetRequest_context
=== CONT  TestAccEC2SpotFleetRequest_context
--- PASS: TestAccEC2SpotFleetRequest_context (22.72s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        22.375s
```
