### PR TITLE
aws_elasticsearch_domain - update service linked role documentation

### DIFF
--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -151,7 +151,7 @@ resource "aws_security_group" "es" {
 }
 
 resource "aws_iam_service_linked_role" "es" {
-  aws_service_name = "es.amazonaws.com"
+  aws_service_name = "opensearchservice.amazonaws.com"
 }
 
 resource "aws_elasticsearch_domain" "es" {


### PR DESCRIPTION
Since the introduction of AWS OpenSearch, the service linked role that ElasticSearch/OpenSearch requires has changed.

It used to be a role named:

```AWSServiceRoleForAmazonElasticsearchService```

but is now a role named:

```AWSServiceRoleForAmazonOpenSearchService```

which is created and linked with:

```
resource "aws_iam_service_linked_role" "es" {
  aws_service_name = "opensearchservice.amazonaws.com"
}
```

This role is required for both ElasticSearch and OpenSearch.

This PR updates the documentation to this effect.
