### PR TITLE
tags: duplicate and computed tags on framework

### DIFF
--- a/internal/framework/base.go
+++ b/internal/framework/base.go
@@ -90,7 +90,7 @@ func (r *ResourceWithConfigure) SetTagsAll(ctx context.Context, request resource
 	}
 
 	if !planTags.IsUnknown() {
-		if !HasUnknownElements(planTags) {
+		if !mapHasUnknownElements(planTags) {
 			resourceTags := tftags.New(ctx, planTags)
 
 			allTags := defaultTagsConfig.MergeTags(resourceTags).IgnoreConfig(ignoreTagsConfig)
@@ -209,7 +209,7 @@ func (w *WithTimeouts) DeleteTimeout(ctx context.Context, timeouts timeouts.Valu
 	return timeout
 }
 
-func HasUnknownElements(m types.Map) bool {
+func mapHasUnknownElements(m types.Map) bool {
 	for _, v := range m.Elements() {
 		if v.IsUnknown() {
 			return true

--- a/internal/framework/base.go
+++ b/internal/framework/base.go
@@ -90,17 +90,15 @@ func (r *ResourceWithConfigure) SetTagsAll(ctx context.Context, request resource
 	}
 
 	if !planTags.IsUnknown() {
-		resourceTags := tftags.New(ctx, planTags)
+		if !HasUnknownElements(planTags) {
+			resourceTags := tftags.New(ctx, planTags)
 
-		if defaultTagsConfig.TagsEqual(resourceTags) {
-			response.Diagnostics.AddError(
-				`"tags" are identical to those in the "default_tags" configuration block of the provider`,
-				"please de-duplicate and try again")
+			allTags := defaultTagsConfig.MergeTags(resourceTags).IgnoreConfig(ignoreTagsConfig)
+
+			response.Diagnostics.Append(response.Plan.SetAttribute(ctx, path.Root("tags_all"), flex.FlattenFrameworkStringValueMapLegacy(ctx, allTags.Map()))...)
+		} else {
+			response.Diagnostics.Append(response.Plan.SetAttribute(ctx, path.Root("tags_all"), tftags.Unknown)...)
 		}
-
-		allTags := defaultTagsConfig.MergeTags(resourceTags).IgnoreConfig(ignoreTagsConfig)
-
-		response.Diagnostics.Append(response.Plan.SetAttribute(ctx, path.Root("tags_all"), flex.FlattenFrameworkStringValueMapLegacy(ctx, allTags.Map()))...)
 	} else {
 		response.Diagnostics.Append(response.Plan.SetAttribute(ctx, path.Root("tags_all"), tftags.Unknown)...)
 	}
@@ -209,4 +207,14 @@ func (w *WithTimeouts) DeleteTimeout(ctx context.Context, timeouts timeouts.Valu
 	}
 
 	return timeout
+}
+
+func HasUnknownElements(m types.Map) bool {
+	for _, v := range m.Elements() {
+		if v.IsUnknown() {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/provider/fwprovider/intercept.go
+++ b/internal/provider/fwprovider/intercept.go
@@ -410,7 +410,7 @@ func (r tagsInterceptor) read(ctx context.Context, request resource.ReadRequest,
 		stateTags := tftags.Null
 		// Remove any provider configured ignore_tags and system tags from those returned from the service API.
 		// The resource's configured tags do not include any provider configured default_tags.
-		if v := apiTags.IgnoreSystem(inContext.ServicePackageName).IgnoreConfig(tagsInContext.IgnoreConfig).RemoveDefaultConfig(tagsInContext.DefaultConfig).Map(); len(v) > 0 {
+		if v := apiTags.IgnoreSystem(inContext.ServicePackageName).IgnoreConfig(tagsInContext.IgnoreConfig).ResolveDuplicatesFramework(ctx, tagsInContext.DefaultConfig, tagsInContext.IgnoreConfig, response, diags).Map(); len(v) > 0 {
 			stateTags = flex.FlattenFrameworkStringValueMapLegacy(ctx, v)
 		}
 		diags.Append(response.State.SetAttribute(ctx, path.Root(names.AttrTags), &stateTags)...)

--- a/internal/provider/intercept.go
+++ b/internal/provider/intercept.go
@@ -348,7 +348,7 @@ func (r tagsInterceptor) run(ctx context.Context, d schemaResourceData, meta any
 			tags := tagsInContext.TagsOut.UnwrapOrDefault().IgnoreSystem(inContext.ServicePackageName).IgnoreConfig(tagsInContext.IgnoreConfig)
 
 			// The resource's configured tags can now include duplicate tags that have been configured on the provider.
-			if err := d.Set(names.AttrTags, tags.ResolveDuplicates(ctx, tagsInContext.DefaultConfig, d).Map()); err != nil {
+			if err := d.Set(names.AttrTags, tags.ResolveDuplicates(ctx, tagsInContext.DefaultConfig, tagsInContext.IgnoreConfig, d).Map()); err != nil {
 				return ctx, sdkdiag.AppendErrorf(diags, "setting %s: %s", names.AttrTags, err)
 			}
 

--- a/internal/provider/tags_interceptor.go
+++ b/internal/provider/tags_interceptor.go
@@ -142,7 +142,7 @@ func tagsReadFunc(ctx context.Context, d schemaResourceData, sp conns.ServicePac
 	toAdd := tagsInContext.TagsOut.UnwrapOrDefault().IgnoreSystem(inContext.ServicePackageName).IgnoreConfig(tagsInContext.IgnoreConfig)
 
 	// The resource's configured tags can now include duplicate tags that have been configured on the provider.
-	if err := d.Set(names.AttrTags, toAdd.ResolveDuplicates(ctx, tagsInContext.DefaultConfig, d).Map()); err != nil {
+	if err := d.Set(names.AttrTags, toAdd.ResolveDuplicates(ctx, tagsInContext.DefaultConfig, tagsInContext.IgnoreConfig, d).Map()); err != nil {
 		return ctx, sdkdiag.AppendErrorf(diags, "setting %s: %s", names.AttrTags, err)
 	}
 

--- a/internal/service/ec2/vpc_security_group_ingress_rule_test.go
+++ b/internal/service/ec2/vpc_security_group_ingress_rule_test.go
@@ -188,6 +188,30 @@ func TestAccVPCSecurityGroupIngressRule_tags(t *testing.T) {
 	})
 }
 
+func TestAccVPCSecurityGroupIngressRule_tags_computed(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v ec2.SecurityGroupRule
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_vpc_security_group_ingress_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSecurityGroupIngressRuleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCSecurityGroupIngressRuleConfig_computed(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecurityGroupIngressRuleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "tags.eip"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccVPCSecurityGroupIngressRule_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ec2.SecurityGroupRule
@@ -1087,6 +1111,27 @@ resource "aws_vpc_security_group_ingress_rule" "test" {
   }
 }
 `, tagKey1, tagValue1))
+}
+
+func testAccVPCSecurityGroupIngressRuleConfig_computed(rName string) string {
+	return acctest.ConfigCompose(testAccVPCSecurityGroupRuleConfig_base(rName), `
+resource "aws_eip" "test" {
+  vpc = true
+}
+
+resource "aws_vpc_security_group_ingress_rule" "test" {
+  security_group_id = aws_security_group.test.id
+
+  cidr_ipv4   = "10.0.0.0/8"
+  from_port   = 80
+  ip_protocol = "tcp"
+  to_port     = 8080
+
+  tags = {
+    eip = aws_eip.test.public_ip
+  }
+}
+`)
 }
 
 func testAccVPCSecurityGroupIngressRuleConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {

--- a/internal/service/ec2/vpc_security_group_ingress_rule_test.go
+++ b/internal/service/ec2/vpc_security_group_ingress_rule_test.go
@@ -461,6 +461,8 @@ func TestAccVPCSecurityGroupIngressRule_DefaultTagsProviderAndResource_overlappi
 func TestAccVPCSecurityGroupIngressRule_DefaultTagsProviderAndResource_duplicateTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	var v ec2.SecurityGroupRule
+	resourceName := "aws_vpc_security_group_ingress_rule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -473,8 +475,11 @@ func TestAccVPCSecurityGroupIngressRule_DefaultTagsProviderAndResource_duplicate
 					acctest.ConfigDefaultTags_Tags1("overlapkey", "overlapvalue"),
 					testAccVPCSecurityGroupIngressRuleConfig_tags1(rName, "overlapkey", "overlapvalue"),
 				),
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`"tags" are identical to those in the "default_tags" configuration block`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecurityGroupIngressRuleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags_all.%", "1"),
+				),
 			},
 		},
 	})

--- a/internal/tags/key_value_tags.go
+++ b/internal/tags/key_value_tags.go
@@ -745,7 +745,7 @@ type schemaResourceData interface {
 	GetRawState() cty.Value
 }
 
-func (tags KeyValueTags) ResolveDuplicates(ctx context.Context, defaultConfig *DefaultConfig, d schemaResourceData) KeyValueTags {
+func (tags KeyValueTags) ResolveDuplicates(ctx context.Context, defaultConfig *DefaultConfig, ignoreConfig *IgnoreConfig, d schemaResourceData) KeyValueTags {
 	// remove default config.
 	t := tags.RemoveDefaultConfig(defaultConfig)
 
@@ -803,7 +803,7 @@ func (tags KeyValueTags) ResolveDuplicates(ctx context.Context, defaultConfig *D
 		}
 	}
 
-	return New(ctx, result)
+	return New(ctx, result).IgnoreConfig(ignoreConfig)
 }
 
 // ToSnakeCase converts a string to snake case.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

- Allow duplicate `tags` on framework resources
- properly sets `ignore_config` on SDK and Framework resources

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Relates #29747
Relates #19583
Relates #19204
Relates #18311

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

#### SDK

```console
$ make testacc TESTARGS='-run=TestAccVPC_ -short' PKG=vpc

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPC_ -short -timeout 180m
    vpc_test.go:942: skipping long-running test in short mode
--- SKIP: TestAccVPC_IPAMIPv4BasicNetmask (0.00s)
    vpc_test.go:969: skipping long-running test in short mode
--- SKIP: TestAccVPC_IPAMIPv4BasicExplicitCIDR (0.00s)
    vpc_test.go:997: skipping long-running test in short mode
--- SKIP: TestAccVPC_IPAMIPv6 (0.00s)
=== NAME  TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup
    ec2_availability_zone_data_source_test.go:211: skipping since no Local Zones are available
--- SKIP: TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup (0.79s)
--- PASS: TestAccVPC_disappears (24.10s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_duplicateTag (26.79s)
--- PASS: TestAccVPC_tags_computed (30.59s)
--- PASS: TestAccVPC_basic (33.86s)
--- PASS: TestAccVPC_bothDNSOptionsSet (41.41s)
--- PASS: TestAccVPC_enableNetworkAddressUsageMetrics (41.61s)
--- PASS: TestAccVPC_DefaultTags_updateToResourceOnly (44.95s)
--- PASS: TestAccVPC_DefaultTags_updateToProviderOnly (48.31s)
--- PASS: TestAccVPC_DynamicResourceTags_ignoreChanges (48.40s)
--- PASS: TestAccVPC_DynamicResourceTagsMergedWithLocals_ignoreChanges (48.80s)
--- PASS: TestAccVPC_ignoreTags (50.52s)
--- PASS: TestAccVPC_defaultAndIgnoreTags (51.33s)
--- PASS: TestAccVPC_DefaultTags_zeroValue (54.30s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_overlappingTag (54.46s)
--- PASS: TestAccVPC_updateDNSHostnames (55.16s)
--- PASS: TestAccVPC_disabledDNSSupport (33.35s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_nonOverlappingTag (58.05s)
--- PASS: TestAccVPC_DefaultTags_providerOnlyTestAccVPC_DefaultTags_providerOnly (58.08s)
--- PASS: TestAccVPC_tags (62.43s)
--- PASS: TestAccVPC_tenancy (64.32s)
--- PASS: TestAccVPC_assignGeneratedIPv6CIDRBlock (87.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	90.181s
...
```

#### Framework

```console
$ make testacc TESTARGS='-run=TestAccVPCSecurityGroupIngressRule_' PKG=vpc

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPCSecurityGroupIngressRule_ -timeout 180m
--- PASS: TestAccVPCSecurityGroupIngressRule_DefaultTagsProviderAndResource_duplicateTag (31.91s)
--- PASS: TestAccVPCSecurityGroupIngressRule_disappears (37.61s)
--- PASS: TestAccVPCSecurityGroupIngressRule_tags_computed (38.09s)
--- PASS: TestAccVPCSecurityGroupIngressRule_basic (41.36s)
--- PASS: TestAccVPCSecurityGroupIngressRule_ReferencedSecurityGroupID_peerVPC (50.09s)
--- PASS: TestAccVPCSecurityGroupIngressRule_DefaultTags_updateToProviderOnly (56.44s)
--- PASS: TestAccVPCSecurityGroupIngressRule_DefaultTags_updateToResourceOnly (57.47s)
--- PASS: TestAccVPCSecurityGroupIngressRule_referencedSecurityGroupID (60.08s)
--- PASS: TestAccVPCSecurityGroupIngressRule_description (60.16s)
--- PASS: TestAccVPCSecurityGroupIngressRule_cidrIPv6 (60.17s)
--- PASS: TestAccVPCSecurityGroupIngressRule_cidrIPv4 (60.17s)
--- PASS: TestAccVPCSecurityGroupIngressRule_updateSourceType (61.45s)
--- PASS: TestAccVPCSecurityGroupIngressRule_defaultAndIgnoreTags (62.26s)
--- PASS: TestAccVPCSecurityGroupIngressRule_ignoreTags (63.06s)
--- PASS: TestAccVPCSecurityGroupIngressRule_DefaultTagsProviderAndResource_nonOverlappingTag (65.21s)
--- PASS: TestAccVPCSecurityGroupIngressRule_prefixListID (66.34s)
--- PASS: TestAccVPCSecurityGroupIngressRule_DefaultTagsProviderAndResource_overlappingTag (67.40s)
--- PASS: TestAccVPCSecurityGroupIngressRule_DefaultTags_providerOnly (67.89s)
--- PASS: TestAccVPCSecurityGroupIngressRule_updateTagsKnownAtApply (67.89s)
--- PASS: TestAccVPCSecurityGroupIngressRule_tags (72.75s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	75.916s
```
