### PR TITLE
Fix: Principal allowed returned multiple when expecting one

### DIFF
--- a/.changelog/30974.txt
+++ b/.changelog/30974.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpc_endpoint_service_allowed_principal: Fix `too many results` error
+```

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -3354,7 +3354,15 @@ func FindVPCEndpointServicePermissionsByServiceID(ctx context.Context, conn *ec2
 }
 
 func FindVPCEndpointServicePermission(ctx context.Context, conn *ec2.EC2, serviceID, principalARN string) (*ec2.AllowedPrincipal, error) {
-	allowedPrincipals, err := FindVPCEndpointServicePermissionsByServiceID(ctx, conn, serviceID)
+	input := &ec2.DescribeVpcEndpointServicePermissionsInput{
+		ServiceId: aws.String(serviceID),
+		Filters: BuildAttributeFilterList(map[string]string{
+			"principal": principalARN,
+		}),
+	}
+
+	allowedPrincipals, err := FindVPCEndpointServicePermissions(ctx, conn, input)
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -3355,10 +3355,10 @@ func FindVPCEndpointServicePermissionsByServiceID(ctx context.Context, conn *ec2
 
 func FindVPCEndpointServicePermission(ctx context.Context, conn *ec2.EC2, serviceID, principalARN string) (*ec2.AllowedPrincipal, error) {
 	input := &ec2.DescribeVpcEndpointServicePermissionsInput{
-		ServiceId: aws.String(serviceID),
 		Filters: BuildAttributeFilterList(map[string]string{
 			"principal": principalARN,
 		}),
+		ServiceId: aws.String(serviceID),
 	}
 
 	allowedPrincipals, err := FindVPCEndpointServicePermissions(ctx, conn, input)

--- a/internal/service/ec2/vpc_endpoint_service_allowed_principal_test.go
+++ b/internal/service/ec2/vpc_endpoint_service_allowed_principal_test.go
@@ -212,7 +212,7 @@ func testAccCheckVPCEndpointServiceAllowedPrincipalExists(ctx context.Context, n
 }
 
 func testAccVPCEndpointServiceAllowedPrincipalConfig_basic(rName string) string {
-	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_baseNetworkLoadBalancer(rName, 1), `
+	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_baseNetworkLoadBalancer(rName, 1), fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_session_context" "current" {
@@ -222,6 +222,10 @@ data "aws_iam_session_context" "current" {
 resource "aws_vpc_endpoint_service" "test" {
   acceptance_required        = false
   network_load_balancer_arns = aws_lb.test[*].arn
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_vpc_endpoint_service_allowed_principal" "test" {
@@ -229,11 +233,11 @@ resource "aws_vpc_endpoint_service_allowed_principal" "test" {
 
   principal_arn = data.aws_iam_session_context.current.issuer_arn
 }
-`)
+`, rName))
 }
 
 func testAccVPCEndpointServiceAllowedPrincipalConfig_Multiple(rName string) string {
-	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_baseNetworkLoadBalancer(rName, 1), `
+	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_baseNetworkLoadBalancer(rName, 1), fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
@@ -245,6 +249,10 @@ resource "aws_vpc_endpoint_service" "test" {
   acceptance_required        = false
   network_load_balancer_arns = aws_lb.test[*].arn
   allowed_principals         = ["arn:${data.aws_partition.current.partition}:iam::123456789012:root"]
+
+  tags = {
+    Name = %[1]q
+  }
 
   lifecycle {
     ignore_changes = [
@@ -258,7 +266,7 @@ resource "aws_vpc_endpoint_service_allowed_principal" "test" {
 
   principal_arn = data.aws_iam_session_context.current.issuer_arn
 }
-`)
+`, rName))
 }
 
 func testAccVPCEndpointServiceAllowedPrincipalConfig_tag(rName string) string {

--- a/internal/service/ec2/vpc_endpoint_service_allowed_principal_test.go
+++ b/internal/service/ec2/vpc_endpoint_service_allowed_principal_test.go
@@ -212,8 +212,7 @@ func testAccCheckVPCEndpointServiceAllowedPrincipalExists(ctx context.Context, n
 }
 
 func testAccVPCEndpointServiceAllowedPrincipalConfig_basic(rName string) string {
-	return acctest.ConfigCompose(
-		testAccVPCEndpointServiceConfig_networkLoadBalancerBase(rName, 1), `
+	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_baseNetworkLoadBalancer(rName, 1), `
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_session_context" "current" {
@@ -234,9 +233,9 @@ resource "aws_vpc_endpoint_service_allowed_principal" "test" {
 }
 
 func testAccVPCEndpointServiceAllowedPrincipalConfig_Multiple(rName string) string {
-	return acctest.ConfigCompose(
-		testAccVPCEndpointServiceConfig_networkLoadBalancerBase(rName, 1), `
+	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_baseNetworkLoadBalancer(rName, 1), `
 data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
 
 data "aws_iam_session_context" "current" {
   arn = data.aws_caller_identity.current.arn
@@ -245,7 +244,7 @@ data "aws_iam_session_context" "current" {
 resource "aws_vpc_endpoint_service" "test" {
   acceptance_required        = false
   network_load_balancer_arns = aws_lb.test[*].arn
-  allowed_principals         = ["arn:aws:iam::123456789012:root"]
+  allowed_principals         = ["arn:${data.aws_partition.current.partition}:iam::123456789012:root"]
 
   lifecycle {
     ignore_changes = [
@@ -263,9 +262,7 @@ resource "aws_vpc_endpoint_service_allowed_principal" "test" {
 }
 
 func testAccVPCEndpointServiceAllowedPrincipalConfig_tag(rName string) string {
-	return acctest.ConfigCompose(
-		testAccVPCEndpointServiceAllowedPrincipalConfig_basic(rName),
-		fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCEndpointServiceAllowedPrincipalConfig_basic(rName), fmt.Sprintf(`
 resource "aws_ec2_tag" "test" {
   resource_id = aws_vpc_endpoint_service_allowed_principal.test.id
 

--- a/internal/service/ec2/vpc_endpoint_service_allowed_principal_test.go
+++ b/internal/service/ec2/vpc_endpoint_service_allowed_principal_test.go
@@ -245,12 +245,12 @@ data "aws_iam_session_context" "current" {
 resource "aws_vpc_endpoint_service" "test" {
   acceptance_required        = false
   network_load_balancer_arns = aws_lb.test[*].arn
-  allowed_principals = ["arn:aws:iam::123456789012:root"]
+  allowed_principals         = ["arn:aws:iam::123456789012:root"]
 
   lifecycle {
-	ignore_changes = [
-		allowed_principals
-	]
+    ignore_changes = [
+      allowed_principals
+    ]
   }
 }
 

--- a/internal/service/ec2/vpc_endpoint_service_data_source_test.go
+++ b/internal/service/ec2/vpc_endpoint_service_data_source_test.go
@@ -238,7 +238,7 @@ data "aws_vpc_endpoint_service" "test" {
 }
 
 func testAccVPCEndpointServiceDataSourceConfig_customBase(rName string) string {
-	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_networkLoadBalancerBase(rName, 1), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_baseNetworkLoadBalancer(rName, 1), fmt.Sprintf(`
 resource "aws_vpc_endpoint_service" "test" {
   acceptance_required        = false
   network_load_balancer_arns = aws_lb.test[*].arn

--- a/internal/service/ec2/vpc_endpoint_service_test.go
+++ b/internal/service/ec2/vpc_endpoint_service_test.go
@@ -444,25 +444,7 @@ resource "aws_vpc_endpoint_service" "test" {
 }
 
 func testAccVPCEndpointServiceConfig_gatewayLoadBalancerARNs(rName string, count int) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block = "10.10.10.0/25"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_subnet" "test" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 2, 0)
-  vpc_id            = aws_vpc.test.id
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
 resource "aws_lb" "test" {
   count = %[2]d
 
@@ -470,7 +452,7 @@ resource "aws_lb" "test" {
   name               = "%[1]s-${count.index}"
 
   subnet_mapping {
-    subnet_id = aws_subnet.test.id
+    subnet_id = aws_subnet.test[0].id
   }
 }
 

--- a/internal/service/ec2/vpc_endpoint_service_test.go
+++ b/internal/service/ec2/vpc_endpoint_service_test.go
@@ -370,28 +370,8 @@ func testAccCheckVPCEndpointServiceExists(ctx context.Context, n string, v *ec2.
 	}
 }
 
-func testAccVPCEndpointServiceConfig_networkLoadBalancerBase(rName string, count int) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block = "10.0.0.0/16"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_subnet" "test" {
-  count = 2
-
-  vpc_id            = aws_vpc.test.id
-  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
-  availability_zone = data.aws_availability_zones.available.names[count.index]
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
+func testAccVPCEndpointServiceConfig_baseNetworkLoadBalancer(rName string, count int) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
 resource "aws_lb" "test" {
   count = %[2]d
 
@@ -411,7 +391,7 @@ resource "aws_lb" "test" {
 `, rName, count))
 }
 
-func testAccVPCEndpointServiceConfig_supportedIPAddressTypesBase(rName string) string {
+func testAccVPCEndpointServiceConfig_baseSupportedIPAddressTypes(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block                       = "10.0.0.0/16"
@@ -455,7 +435,7 @@ resource "aws_lb" "test" {
 }
 
 func testAccVPCEndpointServiceConfig_basic(rName string) string {
-	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_networkLoadBalancerBase(rName, 1), `
+	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_baseNetworkLoadBalancer(rName, 1), `
 resource "aws_vpc_endpoint_service" "test" {
   acceptance_required        = false
   network_load_balancer_arns = aws_lb.test[*].arn
@@ -506,7 +486,7 @@ resource "aws_vpc_endpoint_service" "test" {
 }
 
 func testAccVPCEndpointServiceConfig_networkLoadBalancerARNs(rName string, count int) string {
-	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_networkLoadBalancerBase(rName, count), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_baseNetworkLoadBalancer(rName, count), fmt.Sprintf(`
 resource "aws_vpc_endpoint_service" "test" {
   acceptance_required        = false
   network_load_balancer_arns = aws_lb.test[*].arn
@@ -519,7 +499,7 @@ resource "aws_vpc_endpoint_service" "test" {
 }
 
 func testAccVPCEndpointServiceConfig_supportedIPAddressTypesIPv4(rName string) string {
-	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_supportedIPAddressTypesBase(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_baseSupportedIPAddressTypes(rName), fmt.Sprintf(`
 resource "aws_vpc_endpoint_service" "test" {
   acceptance_required        = false
   network_load_balancer_arns = aws_lb.test[*].arn
@@ -533,7 +513,7 @@ resource "aws_vpc_endpoint_service" "test" {
 }
 
 func testAccVPCEndpointServiceConfig_supportedIPAddressTypesIPv4AndIPv6(rName string) string {
-	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_supportedIPAddressTypesBase(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_baseSupportedIPAddressTypes(rName), fmt.Sprintf(`
 resource "aws_vpc_endpoint_service" "test" {
   acceptance_required        = false
   network_load_balancer_arns = aws_lb.test[*].arn
@@ -547,7 +527,7 @@ resource "aws_vpc_endpoint_service" "test" {
 }
 
 func testAccVPCEndpointServiceConfig_allowedPrincipals(rName string, count int) string {
-	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_networkLoadBalancerBase(rName, 1), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_baseNetworkLoadBalancer(rName, 1), fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_session_context" "current" {
@@ -568,7 +548,7 @@ resource "aws_vpc_endpoint_service" "test" {
 }
 
 func testAccVPCEndpointServiceConfig_tags1(rName, tagKey1, tagValue1 string) string {
-	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_networkLoadBalancerBase(rName, 1), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_baseNetworkLoadBalancer(rName, 1), fmt.Sprintf(`
 resource "aws_vpc_endpoint_service" "test" {
   acceptance_required        = false
   network_load_balancer_arns = aws_lb.test[*].arn
@@ -581,7 +561,7 @@ resource "aws_vpc_endpoint_service" "test" {
 }
 
 func testAccVPCEndpointServiceConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_networkLoadBalancerBase(rName, 1), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_baseNetworkLoadBalancer(rName, 1), fmt.Sprintf(`
 resource "aws_vpc_endpoint_service" "test" {
   acceptance_required        = false
   network_load_balancer_arns = aws_lb.test[*].arn
@@ -595,7 +575,7 @@ resource "aws_vpc_endpoint_service" "test" {
 }
 
 func testAccVPCEndpointServiceConfig_privateDNSName(rName, dnsName string) string {
-	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_networkLoadBalancerBase(rName, 1), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_baseNetworkLoadBalancer(rName, 1), fmt.Sprintf(`
 resource "aws_vpc_endpoint_service" "test" {
   acceptance_required        = false
   network_load_balancer_arns = aws_lb.test[*].arn

--- a/internal/service/ec2/vpc_endpoint_test.go
+++ b/internal/service/ec2/vpc_endpoint_test.go
@@ -695,7 +695,7 @@ resource "aws_vpc_endpoint" "test" {
 }
 
 func testAccVPCEndpointConfig_ipAddressType(rName, addressType string) string {
-	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_supportedIPAddressTypesBase(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccVPCEndpointServiceConfig_baseSupportedIPAddressTypes(rName), fmt.Sprintf(`
 resource "aws_vpc_endpoint_service" "test" {
   acceptance_required        = false
   network_load_balancer_arns = aws_lb.test[*].arn


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
A change was made to `vpc_endpoint_service_allowed` #27640 which introduced `tfresource.AssertSingleResult` however the results returned from the call to `FindVPCEndpointServicePermissions` didn't filter the result & anything above 1 allowed principal resulted in an error. I've also added an additional test which adds two service principals to be allowed access to the endpoint.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates 
or 
Closes #0000
--->

Closes #30873.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/27640.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccVPCEndpointServiceAllowedPrincipal_multiple PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCEndpointServiceAllowedPrincipal_multiple'  -timeout 180m
=== RUN   TestAccVPCEndpointServiceAllowedPrincipal_multiple
=== PAUSE TestAccVPCEndpointServiceAllowedPrincipal_multiple
=== CONT  TestAccVPCEndpointServiceAllowedPrincipal_multiple
--- PASS: TestAccVPCEndpointServiceAllowedPrincipal_multiple (270.01s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        274.270s

...
```
