### PR TITLE
Fix inconsistent read after create for vpc_endpoint_route_table_association

### DIFF
--- a/.changelog/30994.txt
+++ b/.changelog/30994.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpc_endpoint_route_table_association: Retry resource Create for EC2 eventual consistency
+```

--- a/internal/service/ec2/vpc_endpoint_route_table_association.go
+++ b/internal/service/ec2/vpc_endpoint_route_table_association.go
@@ -57,7 +57,6 @@ func resourceVPCEndpointRouteTableAssociationCreate(ctx context.Context, d *sche
 
 	log.Printf("[DEBUG] Creating VPC Endpoint Route Table Association: %s", input)
 	_, err := conn.ModifyVpcEndpointWithContext(ctx, input)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating VPC Endpoint Route Table Association (%s): %s", id, err)
 	}
@@ -82,7 +81,9 @@ func resourceVPCEndpointRouteTableAssociationRead(ctx context.Context, d *schema
 	// Human friendly ID for error messages since d.Id() is non-descriptive
 	id := fmt.Sprintf("%s/%s", endpointID, routeTableID)
 
-	err := FindVPCEndpointRouteTableAssociationExists(ctx, conn, endpointID, routeTableID)
+	_, err := tfresource.RetryWhenNewResourceNotFound(ctx, RouteTableAssociationPropagationTimeout, func() (interface{}, error) {
+		return nil, FindVPCEndpointRouteTableAssociationExists(ctx, conn, endpointID, routeTableID)
+	}, d.IsNewResource())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] VPC Endpoint Route Table Association (%s) not found, removing from state", id)


### PR DESCRIPTION
This fixes read after newly created **vpc_endpoint_route_table_association** that can fail because of AWS API eventual consistency https://docs.aws.amazon.com/AWSEC2/latest/APIReference/query-api-troubleshooting.html


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Fixes #30993

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
