### PR TITLE
Fix requirement of cloudwatch log group arn in opensearch and elasticsearch domain

### DIFF
--- a/internal/service/elasticsearch/domain.go
+++ b/internal/service/elasticsearch/domain.go
@@ -452,7 +452,7 @@ func ResourceDomain() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"cloudwatch_log_group_arn": {
 							Type:         schema.TypeString,
-							Required:     true,
+							Required:     false,
 							ValidateFunc: verify.ValidARN,
 						},
 						"enabled": {

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -736,6 +736,8 @@ func TestAccElasticsearchDomain_LogPublishingOptions_indexSlowLogs(t *testing.T)
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
+	setPublishLogs := true
+	setLogGroup := true
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
@@ -744,7 +746,7 @@ func TestAccElasticsearchDomain_LogPublishingOptions_indexSlowLogs(t *testing.T)
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfig_logPublishingOptions(rName, elasticsearch.LogTypeIndexSlowLogs),
+				Config: testAccDomainConfig_logPublishingOptions(rName, elasticsearch.LogTypeIndexSlowLogs, setPublishLogs, setLogGroup),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(ctx, resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "log_publishing_options.#", "1"),
@@ -772,6 +774,8 @@ func TestAccElasticsearchDomain_LogPublishingOptions_searchSlowLogs(t *testing.T
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
+	setPublishLogs := true
+	setLogGroup := true
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
@@ -780,7 +784,7 @@ func TestAccElasticsearchDomain_LogPublishingOptions_searchSlowLogs(t *testing.T
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfig_logPublishingOptions(rName, elasticsearch.LogTypeSearchSlowLogs),
+				Config: testAccDomainConfig_logPublishingOptions(rName, elasticsearch.LogTypeSearchSlowLogs, setPublishLogs, setLogGroup),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(ctx, resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "log_publishing_options.#", "1"),
@@ -808,6 +812,8 @@ func TestAccElasticsearchDomain_LogPublishingOptions_esApplicationLogs(t *testin
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
+	setPublishLogs := true
+	setLogGroup := true
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
@@ -816,7 +822,7 @@ func TestAccElasticsearchDomain_LogPublishingOptions_esApplicationLogs(t *testin
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfig_logPublishingOptions(rName, elasticsearch.LogTypeEsApplicationLogs),
+				Config: testAccDomainConfig_logPublishingOptions(rName, elasticsearch.LogTypeEsApplicationLogs, setPublishLogs, setLogGroup),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(ctx, resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "log_publishing_options.#", "1"),
@@ -844,6 +850,8 @@ func TestAccElasticsearchDomain_LogPublishingOptions_auditLogs(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
 	rName := testAccRandomDomainName()
 	resourceName := "aws_elasticsearch_domain.test"
+	setPublishLogs := true
+	setLogGroup := true
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
@@ -852,7 +860,47 @@ func TestAccElasticsearchDomain_LogPublishingOptions_auditLogs(t *testing.T) {
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfig_logPublishingOptions(rName, elasticsearch.LogTypeAuditLogs),
+				Config: testAccDomainConfig_logPublishingOptions(rName, elasticsearch.LogTypeAuditLogs, setPublishLogs, setLogGroup),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "log_publishing_options.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_publishing_options.*", map[string]string{
+						"log_type": elasticsearch.LogTypeAuditLogs,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     rName,
+				ImportStateVerify: true,
+				// MasterUserOptions are not returned from DescribeElasticsearchDomainConfig
+				ImportStateVerifyIgnore: []string{"advanced_security_options.0.master_user_options"},
+			},
+		},
+	})
+}
+
+func TestAccElasticsearchDomain_LogPublishingOptions_unsetLogGroup(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var domain elasticsearch.ElasticsearchDomainStatus
+	rName := testAccRandomDomainName()
+	resourceName := "aws_elasticsearch_domain.test"
+	setPublishLogs := true
+	setLogGroup := false
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, elasticsearch.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_logPublishingOptions(rName, elasticsearch.LogTypeAuditLogs, setPublishLogs, setLogGroup),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(ctx, resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "log_publishing_options.#", "1"),
@@ -2900,18 +2948,31 @@ resource "aws_cloudwatch_log_resource_policy" "test" {
 `, rName)
 }
 
-func testAccDomainConfig_logPublishingOptions(rName, logType string) string {
+func testAccDomainConfig_logPublishingOptions(rName, logType string, setPublishLogOpts bool, setLogGroup bool) string {
 	var auditLogsConfig string
+	var logPublishingBaseConfig string
+	var logPublishingOptionsConfig string
+
+	if setPublishLogOpts {
+		logPublishingBaseConfig = testAccDomain_LogPublishingOptions_BaseConfig(rName)
+
+		logPublishingOptionsConfig = fmt.Sprintf(`
+    log_publishing_options {
+      log_type                 = %[1]q
+      cloudwatch_log_group_arn = %[2]t ? aws_cloudwatch_log_group.test.arn : null
+    }`, logType, setLogGroup)
+	}
+
 	if logType == elasticsearch.LogTypeAuditLogs {
 		auditLogsConfig = `
-	  	advanced_security_options {
-			enabled                        = true
-			internal_user_database_enabled = true
-			master_user_options {
-			  master_user_name     = "testmasteruser"
-			  master_user_password = "Barbarbarbar1!"
-			}
-	  	}
+	  advanced_security_options {
+		  enabled                        = true
+		  internal_user_database_enabled = true
+		  master_user_options {
+		    master_user_name     = "testmasteruser"
+		    master_user_password = "Barbarbarbar1!"
+		  }
+	 	}
 	
 		domain_endpoint_options {
 	  		enforce_https       = true
@@ -2926,7 +2987,8 @@ func testAccDomainConfig_logPublishingOptions(rName, logType string) string {
 			enabled = true
 		}`
 	}
-	return acctest.ConfigCompose(testAccDomain_LogPublishingOptions_BaseConfig(rName), fmt.Sprintf(`
+
+	domainResourcesConfig := fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "test" {
   domain_name           = %[1]q
   elasticsearch_version = "7.1" # needed for ESApplication/Audit Log Types
@@ -2936,14 +2998,13 @@ resource "aws_elasticsearch_domain" "test" {
     volume_size = 10
   }
 
-    %[2]s
+  %[2]s
+ 
+  %[3]s
 
-  log_publishing_options {
-    log_type                 = %[3]q
-    cloudwatch_log_group_arn = aws_cloudwatch_log_group.test.arn
-  }
-}
-`, rName, auditLogsConfig, logType))
+}`, rName, auditLogsConfig, logPublishingOptionsConfig)
+
+	return acctest.ConfigCompose(logPublishingBaseConfig, domainResourcesConfig)
 }
 
 func testAccDomainConfig_cognitoOptions(rName string, includeCognitoOptions bool) string {

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -2997,52 +2997,52 @@ func testAccDomainConfig_logPublishingOptions(rName, logType string, setPublishL
 		logPublishingBaseConfig = testAccDomain_LogPublishingOptions_BaseConfig(rName)
 
 		logPublishingOptionsConfig = fmt.Sprintf(`
-    log_publishing_options {
-      log_type                 = %[1]q
-      cloudwatch_log_group_arn = %[2]t ? aws_cloudwatch_log_group.test.arn : null
-    }`, logType, setLogGroup)
+      log_publishing_options {
+        log_type                 = %[1]q
+        cloudwatch_log_group_arn = %[2]t ? aws_cloudwatch_log_group.test.arn : null
+      }`, logType, setLogGroup)
 	}
 
 	if logType == elasticsearch.LogTypeAuditLogs {
 		auditLogsConfig = `
-	  advanced_security_options {
-		  enabled                        = true
-		  internal_user_database_enabled = true
-		  master_user_options {
-		    master_user_name     = "testmasteruser"
-		    master_user_password = "Barbarbarbar1!"
-		  }
-	 	}
-	
-		domain_endpoint_options {
-	  		enforce_https       = true
-	  		tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
-		}
-	
-		encrypt_at_rest {
-			enabled = true
-		}
-	
-		node_to_node_encryption {
-			enabled = true
-		}`
+      advanced_security_options {
+        enabled                        = true
+        internal_user_database_enabled = true
+        master_user_options {
+          master_user_name     = "testmasteruser"
+          master_user_password = "Barbarbarbar1!"
+        }
+      }
+
+      domain_endpoint_options {
+        enforce_https       = true
+        tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+      }
+
+      encrypt_at_rest {
+        enabled = true
+      }
+
+      node_to_node_encryption {
+        enabled = true
+      }`
 	}
 
 	domainResourcesConfig := fmt.Sprintf(`
-resource "aws_elasticsearch_domain" "test" {
-  domain_name           = %[1]q
-  elasticsearch_version = "7.1" # needed for ESApplication/Audit Log Types
+    resource "aws_elasticsearch_domain" "test" {
+      domain_name           = %[1]q
+      elasticsearch_version = "7.1" # needed for ESApplication/Audit Log Types
 
-  ebs_options {
-    ebs_enabled = true
-    volume_size = 10
-  }
+      ebs_options {
+        ebs_enabled = true
+        volume_size = 10
+      }
 
-  %[2]s
- 
-  %[3]s
+      %[2]s
 
-}`, rName, auditLogsConfig, logPublishingOptionsConfig)
+      %[3]s
+
+    }`, rName, auditLogsConfig, logPublishingOptionsConfig)
 
 	return acctest.ConfigCompose(logPublishingBaseConfig, domainResourcesConfig)
 }

--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -466,7 +466,7 @@ func ResourceDomain() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"cloudwatch_log_group_arn": {
 							Type:         schema.TypeString,
-							Required:     true,
+							Required:     false,
 							ValidateFunc: verify.ValidARN,
 						},
 						"enabled": {

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -924,6 +924,44 @@ func TestAccOpenSearchDomain_AdvancedSecurityOptions_disabled(t *testing.T) {
 	})
 }
 
+func TestAccOpenSearchDomain_LogPublishingOptions_CloudWatchLogGroupArn(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var domain opensearchservice.DomainStatus
+	rName := testAccRandomDomainName()
+	resourceName := "aws_opensearch_domain.test"
+	setPublishLogs := true
+	setLogGroup := true
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, opensearchservice.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_logPublishingOptions(rName, opensearchservice.LogTypeIndexSlowLogs, setPublishLogs, setLogGroup),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "log_publishing_options.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_publishing_options.*", map[string]string{
+						"log_type": opensearchservice.LogTypeIndexSlowLogs,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     rName,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccOpenSearchDomain_LogPublishingOptions_indexSlowLogs(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -933,6 +971,8 @@ func TestAccOpenSearchDomain_LogPublishingOptions_indexSlowLogs(t *testing.T) {
 	var domain opensearchservice.DomainStatus
 	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
+	setPublishLogs := true
+	setLogGroup := true
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
@@ -941,7 +981,7 @@ func TestAccOpenSearchDomain_LogPublishingOptions_indexSlowLogs(t *testing.T) {
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfig_logPublishingOptions(rName, opensearchservice.LogTypeIndexSlowLogs),
+				Config: testAccDomainConfig_logPublishingOptions(rName, opensearchservice.LogTypeIndexSlowLogs, setPublishLogs, setLogGroup),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(ctx, resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "log_publishing_options.#", "1"),
@@ -969,6 +1009,8 @@ func TestAccOpenSearchDomain_LogPublishingOptions_searchSlowLogs(t *testing.T) {
 	var domain opensearchservice.DomainStatus
 	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
+	setPublishLogs := true
+	setLogGroup := true
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
@@ -977,7 +1019,7 @@ func TestAccOpenSearchDomain_LogPublishingOptions_searchSlowLogs(t *testing.T) {
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfig_logPublishingOptions(rName, opensearchservice.LogTypeSearchSlowLogs),
+				Config: testAccDomainConfig_logPublishingOptions(rName, opensearchservice.LogTypeSearchSlowLogs, setPublishLogs, setLogGroup),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(ctx, resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "log_publishing_options.#", "1"),
@@ -1005,6 +1047,8 @@ func TestAccOpenSearchDomain_LogPublishingOptions_applicationLogs(t *testing.T) 
 	var domain opensearchservice.DomainStatus
 	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
+	setPublishLogs := true
+	setLogGroup := true
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
@@ -1013,7 +1057,7 @@ func TestAccOpenSearchDomain_LogPublishingOptions_applicationLogs(t *testing.T) 
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfig_logPublishingOptions(rName, opensearchservice.LogTypeEsApplicationLogs),
+				Config: testAccDomainConfig_logPublishingOptions(rName, opensearchservice.LogTypeEsApplicationLogs, setPublishLogs, setLogGroup),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(ctx, resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "log_publishing_options.#", "1"),
@@ -1041,6 +1085,8 @@ func TestAccOpenSearchDomain_LogPublishingOptions_auditLogs(t *testing.T) {
 	var domain opensearchservice.DomainStatus
 	rName := testAccRandomDomainName()
 	resourceName := "aws_opensearch_domain.test"
+	setPublishLogs := true
+	setLogGroup := true
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
@@ -1049,7 +1095,87 @@ func TestAccOpenSearchDomain_LogPublishingOptions_auditLogs(t *testing.T) {
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainConfig_logPublishingOptions(rName, opensearchservice.LogTypeAuditLogs),
+				Config: testAccDomainConfig_logPublishingOptions(rName, opensearchservice.LogTypeAuditLogs, setPublishLogs, setLogGroup),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "log_publishing_options.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_publishing_options.*", map[string]string{
+						"log_type": opensearchservice.LogTypeAuditLogs,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     rName,
+				ImportStateVerify: true,
+				// MasterUserOptions are not returned from DescribeDomainConfig
+				ImportStateVerifyIgnore: []string{"advanced_security_options.0.master_user_options"},
+			},
+		},
+	})
+}
+
+func TestAccOpenSearchDomain_LogPublishingOptions_unsetLogGroup(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var domain opensearchservice.DomainStatus
+	rName := testAccRandomDomainName()
+	resourceName := "aws_opensearch_domain.test"
+	setPublishLogs := true
+	setLogGroup := false
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, opensearchservice.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_logPublishingOptions(rName, opensearchservice.LogTypeAuditLogs, setPublishLogs, setLogGroup),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "log_publishing_options.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_publishing_options.*", map[string]string{
+						"log_type": opensearchservice.LogTypeAuditLogs,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     rName,
+				ImportStateVerify: true,
+				// MasterUserOptions are not returned from DescribeDomainConfig
+				ImportStateVerifyIgnore: []string{"advanced_security_options.0.master_user_options"},
+			},
+		},
+	})
+}
+
+func TestAccOpenSearchDomain_LogPublishingOptions_unsetPublishLog(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var domain opensearchservice.DomainStatus
+	rName := testAccRandomDomainName()
+	resourceName := "aws_opensearch_domain.test"
+	setPublishLogs := false
+	setLogGroup := false
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, opensearchservice.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_logPublishingOptions(rName, opensearchservice.LogTypeAuditLogs, setPublishLogs, setLogGroup),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainExists(ctx, resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "log_publishing_options.#", "1"),
@@ -3211,24 +3337,36 @@ resource "aws_cloudwatch_log_resource_policy" "test" {
       Resource = "arn:${data.aws_partition.current.partition}:logs:*"
     }]
   })
-}
-`, rName)
+}`, rName)
 }
 
-func testAccDomainConfig_logPublishingOptions(rName, logType string) string {
+func testAccDomainConfig_logPublishingOptions(rName, logType string, setPublishLogOpts bool, setLogGroup bool) string {
 	var auditLogsConfig string
+	var logPublishingBaseConfig string
+	var logPublishingOptionsConfig string
+
+	if setPublishLogOpts {
+		logPublishingBaseConfig = testAccDomain_logPublishingOptionsBase(rName)
+
+		logPublishingOptionsConfig = fmt.Sprintf(`
+    log_publishing_options {
+      log_type                 = %[1]q
+      cloudwatch_log_group_arn = %[2]t ? aws_cloudwatch_log_group.test.arn : null
+    }`, logType, setLogGroup)
+	}
+
 	if logType == opensearchservice.LogTypeAuditLogs {
 		auditLogsConfig = `
-	  	advanced_security_options {
-			enabled                        = true
-			internal_user_database_enabled = true
-			master_user_options {
-			  master_user_name     = "testmasteruser"
-			  master_user_password = "Barbarbarbar1!"
-			}
-	  	}
+	  advanced_security_options {
+		  enabled                        = true
+		  internal_user_database_enabled = true
+		  master_user_options {
+		    master_user_name     = "testmasteruser"
+		    master_user_password = "Barbarbarbar1!"
+		  }
+	  }
 	
-		domain_endpoint_options {
+    domain_endpoint_op:tions {
 	  		enforce_https       = true
 	  		tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
 		}
@@ -3239,9 +3377,11 @@ func testAccDomainConfig_logPublishingOptions(rName, logType string) string {
 	
 		node_to_node_encryption {
 			enabled = true
-		}`
+		}
+    `
 	}
-	return acctest.ConfigCompose(testAccDomain_logPublishingOptionsBase(rName), fmt.Sprintf(`
+
+	domainResourcesConfig := fmt.Sprintf(`
 resource "aws_opensearch_domain" "test" {
   domain_name    = %[1]q
   engine_version = "Elasticsearch_7.1" # needed for ESApplication/Audit Log Types
@@ -3251,14 +3391,13 @@ resource "aws_opensearch_domain" "test" {
     volume_size = 10
   }
 
-    %[2]s
+  %[2]s
 
-  log_publishing_options {
-    log_type                 = %[3]q
-    cloudwatch_log_group_arn = aws_cloudwatch_log_group.test.arn
-  }
-}
-`, rName, auditLogsConfig, logType))
+  %[3]s
+
+ }`, rName, auditLogsConfig, logPublishingOptionsConfig)
+
+	return acctest.ConfigCompose(logPublishingBaseConfig, domainResourcesConfig)
 }
 
 func testAccDomainConfig_cognitoOptions(rName string, includeCognitoOptions bool) string {

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -3311,53 +3311,52 @@ func testAccDomainConfig_logPublishingOptions(rName, logType string, setPublishL
 		logPublishingBaseConfig = testAccDomain_logPublishingOptionsBase(rName)
 
 		logPublishingOptionsConfig = fmt.Sprintf(`
-    log_publishing_options {
-      log_type                 = %[1]q
-      cloudwatch_log_group_arn = %[2]t ? aws_cloudwatch_log_group.test.arn : null
-    }`, logType, setLogGroup)
+      log_publishing_options {
+        log_type                 = %[1]q
+        cloudwatch_log_group_arn = %[2]t ? aws_cloudwatch_log_group.test.arn : null
+      }`, logType, setLogGroup)
 	}
 
 	if logType == opensearchservice.LogTypeAuditLogs {
 		auditLogsConfig = `
-	  advanced_security_options {
-		  enabled                        = true
-		  internal_user_database_enabled = true
-		  master_user_options {
-		    master_user_name     = "testmasteruser"
-		    master_user_password = "Barbarbarbar1!"
-		  }
-	  }
-	
-    domain_endpoint_op:tions {
-	  		enforce_https       = true
-	  		tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
-		}
-	
-		encrypt_at_rest {
-			enabled = true
-		}
-	
-		node_to_node_encryption {
-			enabled = true
-		}
-    `
+      advanced_security_options {
+        enabled                        = true
+        internal_user_database_enabled = true
+        master_user_options {
+          master_user_name     = "testmasteruser"
+          master_user_password = "Barbarbarbar1!"
+        }
+      }
+
+      domain_endpoint_options {
+        enforce_https       = true
+        tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+      }
+
+      encrypt_at_rest {
+        enabled = true
+      }
+
+      node_to_node_encryption {
+        enabled = true
+      }`
 	}
 
 	domainResourcesConfig := fmt.Sprintf(`
-resource "aws_opensearch_domain" "test" {
-  domain_name    = %[1]q
-  engine_version = "Elasticsearch_7.1" # needed for ESApplication/Audit Log Types
+    resource "aws_opensearch_domain" "test" {
+      domain_name    = %[1]q
+      engine_version = "Elasticsearch_7.1" # needed for ESApplication/Audit Log Types
 
-  ebs_options {
-    ebs_enabled = true
-    volume_size = 10
-  }
+      ebs_options {
+        ebs_enabled = true
+        volume_size = 10
+      }
 
-  %[2]s
+      %[2]s
 
-  %[3]s
+      %[3]s
 
- }`, rName, auditLogsConfig, logPublishingOptionsConfig)
+  }`, rName, auditLogsConfig, logPublishingOptionsConfig)
 
 	return acctest.ConfigCompose(logPublishingBaseConfig, domainResourcesConfig)
 }

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -924,44 +924,6 @@ func TestAccOpenSearchDomain_AdvancedSecurityOptions_disabled(t *testing.T) {
 	})
 }
 
-func TestAccOpenSearchDomain_LogPublishingOptions_CloudWatchLogGroupArn(t *testing.T) {
-	ctx := acctest.Context(t)
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
-	var domain opensearchservice.DomainStatus
-	rName := testAccRandomDomainName()
-	resourceName := "aws_opensearch_domain.test"
-	setPublishLogs := true
-	setLogGroup := true
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIAMServiceLinkedRole(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, opensearchservice.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDomainDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDomainConfig_logPublishingOptions(rName, opensearchservice.LogTypeIndexSlowLogs, setPublishLogs, setLogGroup),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainExists(ctx, resourceName, &domain),
-					resource.TestCheckResourceAttr(resourceName, "log_publishing_options.#", "1"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "log_publishing_options.*", map[string]string{
-						"log_type": opensearchservice.LogTypeIndexSlowLogs,
-					}),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateId:     rName,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccOpenSearchDomain_LogPublishingOptions_indexSlowLogs(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -307,7 +307,7 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 
 ### log_publishing_options
 
-* `cloudwatch_log_group_arn` - (Required) ARN of the Cloudwatch log group to which log needs to be published.
+* `cloudwatch_log_group_arn` - (Optional) ARN of the Cloudwatch log group to which log needs to be published.
 * `enabled` - (Optional, Default: true) Whether given log publishing option is enabled or not.
 * `log_type` - (Required) Type of Elasticsearch log. Valid values: `INDEX_SLOW_LOGS`, `SEARCH_SLOW_LOGS`, `ES_APPLICATION_LOGS`, `AUDIT_LOGS`.
 

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -419,7 +419,7 @@ AWS documentation: [Amazon Cognito Authentication for Dashboard](https://docs.aw
 
 ### log_publishing_options
 
-* `cloudwatch_log_group_arn` - (Required) ARN of the Cloudwatch log group to which log needs to be published.
+* `cloudwatch_log_group_arn` - (Optional) ARN of the Cloudwatch log group to which log needs to be published.
 * `enabled` - (Optional, Default: true) Whether given log publishing option is enabled or not.
 * `log_type` - (Required) Type of OpenSearch log. Valid values: `INDEX_SLOW_LOGS`, `SEARCH_SLOW_LOGS`, `ES_APPLICATION_LOGS`, `AUDIT_LOGS`.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Maybe Closes #25506

### References
https://docs.aws.amazon.com/opensearch-service/latest/APIReference/API_LogPublishingOption.html
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-logpublishingoption.html#cfn-elasticsearch-domain-logpublishingoption-cloudwatchlogsloggrouparn

### Output from Acceptance Testing
I can't execute the acceptance tests