### PR TITLE
elasticache/rep_group: Remove availability zones and other deprecated parameters

### DIFF
--- a/.changelog/31008.txt
+++ b/.changelog/31008.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+resource/aws_elasticache_replication_group: Removed `availability_zones` argument -- use `preferred_cache_cluster_azs` instead
+```
+
+```release-note:note
+resource/aws_elasticache_replication_group: Update configurations to use the `preferred_cache_cluster_azs` instead of the `availability_zones` argument
+```

--- a/.changelog/31008.txt
+++ b/.changelog/31008.txt
@@ -1,7 +1,35 @@
 ```release-note:breaking-change
-resource/aws_elasticache_replication_group: Removed `availability_zones` argument -- use `preferred_cache_cluster_azs` instead
+resource/aws_elasticache_replication_group: Remove `availability_zones`, `number_cache_clusters`, `replication_group_description` arguments -- use `preferred_cache_cluster_azs`, `num_cache_clusters`, and `description`, respectively, instead
+```
+
+```release-note:breaking-change
+resource/aws_elasticache_replication_group: Remove `cluster_mode` configuration block -- use top-level `num_node_groups` and `replicas_per_node_group` instead
 ```
 
 ```release-note:note
-resource/aws_elasticache_replication_group: Update configurations to use the `preferred_cache_cluster_azs` instead of the `availability_zones` argument
+resource/aws_elasticache_replication_group: Update configurations to use `preferred_cache_cluster_azs` instead of the `availability_zones` argument
+```
+
+```release-note:note
+resource/aws_elasticache_replication_group: Update configurations to use `num_cache_clusters` instead of the `number_cache_clusters` argument
+```
+
+```release-note:note
+resource/aws_elasticache_replication_group: Update configurations to use `description` instead of the `replication_group_description` argument
+```
+
+```release-note:note
+resource/aws_elasticache_replication_group: Update configurations to use top-level `num_node_groups` and `replicas_per_node_group` instead of `cluster_mode.0.num_node_groups` and `cluster_mode.0.replicas_per_node_group`, respectively
+```
+
+```release-note:breaking-change
+data-source/aws_elasticache_replication_group: Remove `number_cache_clusters`, `replication_group_description` arguments -- use `num_cache_clusters`, and `description`, respectively, instead
+```
+
+```release-note:note
+data-source/aws_elasticache_replication_group: Update configurations to use `num_cache_clusters` instead of the `number_cache_clusters` argument
+```
+
+```release-note:note
+data-source/aws_elasticache_replication_group: Update configurations to use `description` instead of the `replication_group_description` argument
 ```

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -954,18 +954,6 @@ func deleteReplicationGroup(ctx context.Context, replicationGroupID string, conn
 	return err
 }
 
-func flattenNodeGroupsToClusterMode(nodeGroups []*elasticache.NodeGroup) []map[string]interface{} {
-	if len(nodeGroups) == 0 {
-		return []map[string]interface{}{}
-	}
-
-	m := map[string]interface{}{
-		"num_node_groups":         len(nodeGroups),
-		"replicas_per_node_group": (len(nodeGroups[0].NodeGroupMembers) - 1),
-	}
-	return []map[string]interface{}{m}
-}
-
 func modifyReplicationGroupShardConfiguration(ctx context.Context, conn *elasticache.ElastiCache, d *schema.ResourceData) error {
 	if d.HasChange("num_node_groups") {
 		err := modifyReplicationGroupShardConfigurationNumNodeGroups(ctx, conn, d, "num_node_groups")

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -74,14 +74,6 @@ func ResourceReplicationGroup() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
-			"availability_zones": {
-				Type:          schema.TypeSet,
-				Optional:      true,
-				ForceNew:      true,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				Set:           schema.HashString,
-				ConflictsWith: []string{"preferred_cache_cluster_azs"},
-			},
 			"cluster_enabled": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -264,10 +256,9 @@ func ResourceReplicationGroup() *schema.Resource {
 				},
 			},
 			"preferred_cache_cluster_azs": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				ConflictsWith: []string{"availability_zones"},
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"primary_endpoint_address": {
 				Type:     schema.TypeString,
@@ -452,9 +443,6 @@ func resourceReplicationGroupCreate(ctx context.Context, d *schema.ResourceData,
 
 	if preferredAZs, ok := d.GetOk("preferred_cache_cluster_azs"); ok {
 		input.PreferredCacheClusterAZs = flex.ExpandStringList(preferredAZs.([]interface{}))
-	}
-	if availabilityZones := d.Get("availability_zones").(*schema.Set); availabilityZones.Len() > 0 {
-		input.PreferredCacheClusterAZs = flex.ExpandStringSet(availabilityZones)
 	}
 
 	if v, ok := d.GetOk("parameter_group_name"); ok {

--- a/internal/service/elasticache/replication_group_data_source.go
+++ b/internal/service/elasticache/replication_group_data_source.go
@@ -24,11 +24,6 @@ func DataSourceReplicationGroup() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validateReplicationGroupID,
 			},
-			"replication_group_description": {
-				Type:       schema.TypeString,
-				Computed:   true,
-				Deprecated: "Use description instead",
-			},
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -68,11 +63,6 @@ func DataSourceReplicationGroup() *schema.Resource {
 			"num_node_groups": {
 				Type:     schema.TypeInt,
 				Computed: true,
-			},
-			"number_cache_clusters": {
-				Type:       schema.TypeInt,
-				Computed:   true,
-				Deprecated: "Use num_cache_clusters instead",
 			},
 			"member_clusters": {
 				Type:     schema.TypeSet,
@@ -140,7 +130,6 @@ func dataSourceReplicationGroupRead(ctx context.Context, d *schema.ResourceData,
 
 	d.SetId(aws.StringValue(rg.ReplicationGroupId))
 	d.Set("description", rg.Description)
-	d.Set("replication_group_description", rg.Description)
 	d.Set("arn", rg.ARN)
 	d.Set("auth_token_enabled", rg.AuthTokenEnabled)
 
@@ -178,7 +167,6 @@ func dataSourceReplicationGroupRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	d.Set("num_cache_clusters", len(rg.MemberClusters))
-	d.Set("number_cache_clusters", len(rg.MemberClusters))
 	if err := d.Set("member_clusters", flex.FlattenStringList(rg.MemberClusters)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting member_clusters: %s", err)
 	}

--- a/internal/service/elasticache/replication_group_data_source_test.go
+++ b/internal/service/elasticache/replication_group_data_source_test.go
@@ -157,14 +157,14 @@ func TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfig
 func testAccReplicationGroupDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigAvailableAZsNoOptIn() + fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id       = %[1]q
-  description                = "test description"
-  node_type                  = "cache.t3.small"
-  num_cache_clusters         = 2
-  port                       = 6379
-  availability_zones         = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
-  automatic_failover_enabled = true
-  snapshot_window            = "01:00-02:00"
+  replication_group_id        = %[1]q
+  description                 = "test description"
+  node_type                   = "cache.t3.small"
+  num_cache_clusters          = 2
+  port                        = 6379
+  preferred_cache_cluster_azs = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
+  automatic_failover_enabled  = true
+  snapshot_window             = "01:00-02:00"
 }
 
 data "aws_elasticache_replication_group" "test" {

--- a/internal/service/elasticache/replication_group_data_source_test.go
+++ b/internal/service/elasticache/replication_group_data_source_test.go
@@ -35,13 +35,11 @@ func TestAccElastiCacheReplicationGroupDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "multi_az_enabled", resourceName, "multi_az_enabled"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "member_clusters.#", resourceName, "member_clusters.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "node_type", resourceName, "node_type"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "num_cache_clusters", resourceName, "number_cache_clusters"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "number_cache_clusters", resourceName, "number_cache_clusters"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "num_cache_clusters", resourceName, "num_cache_clusters"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "port", resourceName, "port"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "primary_endpoint_address", resourceName, "primary_endpoint_address"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "reader_endpoint_address", resourceName, "reader_endpoint_address"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "replication_group_description"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "replication_group_description", resourceName, "replication_group_description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "replication_group_id", resourceName, "replication_group_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "snapshot_window", resourceName, "snapshot_window"),
 				),
@@ -76,7 +74,7 @@ func TestAccElastiCacheReplicationGroupDataSource_clusterMode(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "num_node_groups", resourceName, "cluster_mode.0.num_node_groups"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "port", resourceName, "port"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "replicas_per_node_group", resourceName, "cluster_mode.0.replicas_per_node_group"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "replication_group_description", resourceName, "replication_group_description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "replication_group_id", resourceName, "replication_group_id"),
 				),
 			},
@@ -159,14 +157,14 @@ func TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfig
 func testAccReplicationGroupDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigAvailableAZsNoOptIn() + fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t3.small"
-  number_cache_clusters         = 2
-  port                          = 6379
-  availability_zones            = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
-  automatic_failover_enabled    = true
-  snapshot_window               = "01:00-02:00"
+  replication_group_id       = %[1]q
+  description                = "test description"
+  node_type                  = "cache.t3.small"
+  num_cache_clusters         = 2
+  port                       = 6379
+  availability_zones         = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
+  automatic_failover_enabled = true
+  snapshot_window            = "01:00-02:00"
 }
 
 data "aws_elasticache_replication_group" "test" {
@@ -178,11 +176,11 @@ data "aws_elasticache_replication_group" "test" {
 func testAccReplicationGroupDataSourceConfig_clusterMode(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t3.small"
-  port                          = 6379
-  automatic_failover_enabled    = true
+  replication_group_id       = %[1]q
+  description                = "test description"
+  node_type                  = "cache.t3.small"
+  port                       = 6379
+  automatic_failover_enabled = true
 
   cluster_mode {
     replicas_per_node_group = 1
@@ -199,12 +197,12 @@ data "aws_elasticache_replication_group" "test" {
 func testAccReplicationGroupDataSourceConfig_multiAZ(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t3.small"
-  number_cache_clusters         = 2
-  automatic_failover_enabled    = true
-  multi_az_enabled              = true
+  replication_group_id       = %[1]q
+  description                = "test description"
+  node_type                  = "cache.t3.small"
+  num_cache_clusters         = 2
+  automatic_failover_enabled = true
+  multi_az_enabled           = true
 }
 
 data "aws_elasticache_replication_group" "test" {

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -554,40 +554,6 @@ func TestAccElastiCacheReplicationGroup_vpc(t *testing.T) {
 	})
 }
 
-func TestAccElastiCacheReplicationGroup_depecatedAvailabilityZones_vpc(t *testing.T) {
-	ctx := acctest.Context(t)
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
-	var rg elasticache.ReplicationGroup
-	resourceName := "aws_elasticache_replication_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, elasticache.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccReplicationGroupConfig_inVPCDeprecatedAvailabilityZones(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "1"),
-					resource.TestCheckResourceAttr(resourceName, "availability_zones.#", "1"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately", "availability_zones"},
-			},
-		},
-	})
-}
-
 func TestAccElastiCacheReplicationGroup_multiAzNotInVPC(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -614,7 +580,6 @@ func TestAccElastiCacheReplicationGroup_multiAzNotInVPC(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "preferred_cache_cluster_azs.#", "2"),
 					resource.TestCheckResourceAttrPair(resourceName, "preferred_cache_cluster_azs.0", "data.aws_availability_zones.available", "names.0"),
 					resource.TestCheckResourceAttrPair(resourceName, "preferred_cache_cluster_azs.1", "data.aws_availability_zones.available", "names.1"),
-					resource.TestCheckResourceAttr(resourceName, "availability_zones.#", "0"),
 				),
 			},
 			{
@@ -655,7 +620,6 @@ func TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "preferred_cache_cluster_azs.1", "data.aws_availability_zones.available", "names.1"),
 					resource.TestCheckResourceAttrPair(resourceName, "preferred_cache_cluster_azs.2", "data.aws_availability_zones.available", "names.0"),
 					resource.TestCheckResourceAttrPair(resourceName, "preferred_cache_cluster_azs.3", "data.aws_availability_zones.available", "names.1"),
-					resource.TestCheckResourceAttr(resourceName, "availability_zones.#", "0"),
 				),
 			},
 			{
@@ -663,61 +627,6 @@ func TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"apply_immediately", "preferred_cache_cluster_azs"},
-			},
-		},
-	})
-}
-
-func TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzNotInVPC(t *testing.T) {
-	ctx := acctest.Context(t)
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
-	var rg1, rg2 elasticache.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_elasticache_replication_group.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, elasticache.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccReplicationGroupConfig_multiAZNotInVPCBasic(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg1),
-					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
-					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "true"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately"},
-			},
-			{
-				Config: testAccReplicationGroupConfig_multiAZNotInVPCDeprecatedAvailabilityZones(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg2),
-					testAccCheckReplicationGroupRecreated(&rg1, &rg2),
-					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
-					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "availability_zones.#", "2"),
-					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.0", "data.aws_availability_zones.available", "names.0"),
-					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.1", "data.aws_availability_zones.available", "names.1"),
-					resource.TestCheckResourceAttr(resourceName, "preferred_cache_cluster_azs.#", "0"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately", "availability_zones"},
 			},
 		},
 	})
@@ -762,7 +671,7 @@ func TestAccElastiCacheReplicationGroup_multiAzInVPC(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately", "availability_zones"},
+				ImportStateVerifyIgnore: []string{"apply_immediately", "preferred_cache_cluster_azs"},
 			},
 		},
 	})
@@ -807,7 +716,7 @@ func TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately", "availability_zones"},
+				ImportStateVerifyIgnore: []string{"apply_immediately", "preferred_cache_cluster_azs"},
 			},
 		},
 	})
@@ -1296,7 +1205,7 @@ func TestAccElastiCacheReplicationGroup_enableAuthTokenTransitEncryption(t *test
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately", "auth_token", "availability_zones"},
+				ImportStateVerifyIgnore: []string{"apply_immediately", "auth_token", "preferred_cache_cluster_azs"},
 			},
 		},
 	})
@@ -2992,42 +2901,6 @@ resource "aws_security_group" "test" {
 	)
 }
 
-func testAccReplicationGroupConfig_inVPCDeprecatedAvailabilityZones(rName string) string {
-	return acctest.ConfigCompose(
-		acctest.ConfigVPCWithSubnets(rName, 1),
-		fmt.Sprintf(`
-resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t3.small"
-  number_cache_clusters         = 1
-  port                          = 6379
-  subnet_group_name             = aws_elasticache_subnet_group.test.name
-  security_group_ids            = [aws_security_group.test.id]
-  availability_zones            = [data.aws_availability_zones.available.names[0]]
-}
-
-resource "aws_elasticache_subnet_group" "test" {
-  name       = %[1]q
-  subnet_ids = aws_subnet.test[*].id
-}
-
-resource "aws_security_group" "test" {
-  name        = %[1]q
-  description = "tf-test-security-group-descr"
-  vpc_id      = aws_vpc.test.id
-
-  ingress {
-    from_port   = -1
-    to_port     = -1
-    protocol    = "icmp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-`, rName),
-	)
-}
-
 func testAccReplicationGroupConfig_multiAZNotInVPCBasic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
@@ -3086,7 +2959,7 @@ resource "aws_elasticache_replication_group" "test" {
   node_type                     = "cache.t3.small"
   automatic_failover_enabled    = true
   multi_az_enabled              = true
-  availability_zones            = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
+  preferred_cache_cluster_azs   = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 }
 `, rName),
 	)
@@ -3104,7 +2977,7 @@ resource "aws_elasticache_replication_group" "test" {
   port                          = 6379
   subnet_group_name             = aws_elasticache_subnet_group.test.name
   security_group_ids            = [aws_security_group.test.id]
-  availability_zones            = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
+  preferred_cache_cluster_azs   = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
   automatic_failover_enabled    = true
   multi_az_enabled              = true
   snapshot_window               = "02:00-03:00"

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -43,13 +43,12 @@ func TestAccElastiCacheReplicationGroup_basic(t *testing.T) {
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "elasticache", fmt.Sprintf("replicationgroup:%s", rName)),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "1"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "1"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "0"),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "1"),
+					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "0"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "false"),
 					testCheckEngineStuffDefault(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "true"),
@@ -287,8 +286,8 @@ func TestAccElastiCacheReplicationGroup_updateDescription(t *testing.T) {
 				Config: testAccReplicationGroupConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "1"),
-					resource.TestCheckResourceAttr(resourceName, "replication_group_description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "1"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
 				),
 			},
 			{
@@ -301,8 +300,8 @@ func TestAccElastiCacheReplicationGroup_updateDescription(t *testing.T) {
 				Config: testAccReplicationGroupConfig_updatedDescription(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "1"),
-					resource.TestCheckResourceAttr(resourceName, "replication_group_description", "updated description"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "1"),
+					resource.TestCheckResourceAttr(resourceName, "description", "updated description"),
 				),
 			},
 		},
@@ -413,7 +412,7 @@ func TestAccElastiCacheReplicationGroup_updateNodeSize(t *testing.T) {
 				Config: testAccReplicationGroupConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "1"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "1"),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "cache.t3.small"),
 				),
 			},
@@ -427,7 +426,7 @@ func TestAccElastiCacheReplicationGroup_updateNodeSize(t *testing.T) {
 				Config: testAccReplicationGroupConfig_updatedNodeSize(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "1"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "1"),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "cache.t3.medium"),
 				),
 			},
@@ -540,7 +539,7 @@ func TestAccElastiCacheReplicationGroup_vpc(t *testing.T) {
 				Config: testAccReplicationGroupConfig_inVPC(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "1"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "1"),
 					resource.TestCheckResourceAttr(resourceName, "preferred_cache_cluster_azs.#", "1"),
 				),
 			},
@@ -652,7 +651,7 @@ func TestAccElastiCacheReplicationGroup_multiAzInVPC(t *testing.T) {
 				Config: testAccReplicationGroupConfig_multiAZInVPC(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "2"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_window", "02:00-03:00"),
@@ -697,7 +696,7 @@ func TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
 				Config: testAccReplicationGroupConfig_multiAZInVPC(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "2"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_window", "02:00-03:00"),
@@ -761,14 +760,13 @@ func TestAccElastiCacheReplicationGroup_ClusterMode_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "2"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "1"),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
+					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "1"),
 					resource.TestCheckResourceAttr(resourceName, "port", "6379"),
 					resource.TestCheckResourceAttrSet(resourceName, "configuration_endpoint_address"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "4"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "4"),
 					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
 				),
@@ -805,12 +803,11 @@ func TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup(t
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.redis6.x"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "1"),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "1"),
+					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "1"),
 					resource.TestMatchResourceAttr(resourceName, "primary_endpoint_address", regexp.MustCompile(fmt.Sprintf("%s\\..+\\.%s", rName, acctest.PartitionDNSSuffix()))),
 					resource.TestCheckNoResourceAttr(resourceName, "configuration_endpoint_address"),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "2"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "2"),
 				),
 			},
@@ -848,11 +845,10 @@ func TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp(t
 				Config: testAccReplicationGroupConfig_nativeRedisCluster(rName, 2, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "4"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "2"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "1"),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
+					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "1"),
 					testAccReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 4, []kvp{
 						{"key", "value"},
 					}),
@@ -864,10 +860,9 @@ func TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp(t
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "3"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "1"),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "6"),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "3"),
+					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "1"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "6"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "6"),
 					testAccReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 6, []kvp{
 						{"key", "value"},
@@ -900,10 +895,9 @@ func TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "3"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "1"),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "6"),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "3"),
+					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "1"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "6"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "6"),
 					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
 				),
@@ -913,10 +907,9 @@ func TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "2"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "1"),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "4"),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
+					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "1"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "4"),
 					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
 				),
@@ -946,10 +939,9 @@ func TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup(t
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "2"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "1"),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "4"),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
+					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "1"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "4"),
 					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
 				),
@@ -959,10 +951,9 @@ func TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup(t
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "2"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "3"),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "8"),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
+					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "3"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "8"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "8"),
 					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
 				),
@@ -972,10 +963,9 @@ func TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup(t
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "2"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "2"),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "6"),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
+					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "2"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "6"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "6"),
 					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
 				),
@@ -1005,10 +995,9 @@ func TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplica
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "2"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "1"),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "4"),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
+					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "1"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "4"),
 					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
 				),
@@ -1018,10 +1007,9 @@ func TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplica
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "3"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "2"),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "9"),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "3"),
+					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "2"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "9"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "9"),
 					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
 				),
@@ -1051,10 +1039,9 @@ func TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplica
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "3"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "2"),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "9"),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "3"),
+					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "2"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "9"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "9"),
 					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
 				),
@@ -1064,10 +1051,9 @@ func TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplica
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "2"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "1"),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "4"),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
+					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "1"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "4"),
 					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
 				),
@@ -1098,12 +1084,11 @@ func TestAccElastiCacheReplicationGroup_ClusterMode_singleNode(t *testing.T) {
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.redis6.x.cluster.on"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "0"),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "1"),
+					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "0"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "1"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "1"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "1"),
 				),
 			},
@@ -1132,7 +1117,7 @@ func TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError(t *te
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccReplicationGroupConfig_nativeRedisClusterError(rName),
-				ExpectError: regexp.MustCompile(`"cluster_mode.0.num_node_groups": conflicts with number_cache_clusters`),
+				ExpectError: regexp.MustCompile(`"num_node_groups": conflicts with num_cache_clusters`),
 			},
 		},
 	})
@@ -1293,7 +1278,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic(t *testing.T) 
 					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "2"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "2"),
 					testAccReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 2, []kvp{
 						{"key", "value"},
@@ -1312,7 +1297,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic(t *testing.T) 
 					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "4"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "4"),
 					testAccReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 4, []kvp{
 						{"key", "value"},
@@ -1325,7 +1310,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic(t *testing.T) 
 					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "2"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "2"),
 					testAccReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 2, []kvp{
 						{"key", "value"},
@@ -1361,7 +1346,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailover
 					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", strconv.FormatBool(autoFailoverEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", strconv.FormatBool(multiAZEnabled)),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "3"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "3"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "3"),
 				),
 			},
@@ -1386,7 +1371,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailover
 					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", strconv.FormatBool(autoFailoverEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", strconv.FormatBool(multiAZEnabled)),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "2"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "2"),
 				),
 			},
@@ -1419,7 +1404,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailover
 					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", strconv.FormatBool(autoFailoverEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", strconv.FormatBool(multiAZEnabled)),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "3"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "3"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "3"),
 				),
 			},
@@ -1449,7 +1434,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersFailover_autoFailover
 					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", strconv.FormatBool(autoFailoverEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", strconv.FormatBool(multiAZEnabled)),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "2"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "2"),
 				),
 			},
@@ -1482,7 +1467,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled(t *te
 					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", strconv.FormatBool(autoFailoverEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", strconv.FormatBool(multiAZEnabled)),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "3"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "3"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "3"),
 				),
 			},
@@ -1512,7 +1497,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled(t *te
 					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", strconv.FormatBool(autoFailoverEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", strconv.FormatBool(multiAZEnabled)),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "2"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "2"),
 				),
 			},
@@ -1540,7 +1525,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 3),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "3"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "3"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "3"),
 				),
 			},
@@ -1563,7 +1548,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 3),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "3"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "3"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "3"),
 				),
 			},
@@ -1591,7 +1576,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 3),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "3"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "3"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "3"),
 				),
 			},
@@ -1614,7 +1599,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 4),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "4"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "4"),
 				),
 			},
@@ -1642,7 +1627,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 3),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "3"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "3"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "3"),
 				),
 			},
@@ -1665,7 +1650,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "2"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "2"),
 				),
 			},
@@ -1693,7 +1678,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 4),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "4"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "4"),
 				),
 			},
@@ -1716,7 +1701,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "2"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "2"),
 				),
 			},
@@ -1969,8 +1954,8 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic(t *testin
 					resource.TestCheckResourceAttrPair(resourceName, "engine", primaryGroupResourceName, "engine"),
 					resource.TestCheckResourceAttrPair(resourceName, "engine_version", primaryGroupResourceName, "engine_version"),
 					resource.TestMatchResourceAttr(resourceName, "parameter_group_name", regexp.MustCompile(fmt.Sprintf("^global-datastore-%s-", rName))),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", "1"),
-					resource.TestCheckResourceAttr(primaryGroupResourceName, "number_cache_clusters", "2"),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "1"),
+					resource.TestCheckResourceAttr(primaryGroupResourceName, "num_cache_clusters", "2"),
 				),
 			},
 			{
@@ -2023,7 +2008,7 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full(t *testing
 					resource.TestCheckResourceAttrPair(resourceName, "engine_version", primaryGroupResourceName, "engine_version"),
 					resource.TestMatchResourceAttr(resourceName, "parameter_group_name", regexp.MustCompile(fmt.Sprintf("^global-datastore-%s-", rName))),
 
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", strconv.Itoa(initialNumCacheClusters)),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", strconv.Itoa(initialNumCacheClusters)),
 					resource.TestCheckResourceAttrPair(resourceName, "multi_az_enabled", primaryGroupResourceName, "multi_az_enabled"),
 					resource.TestCheckResourceAttrPair(resourceName, "automatic_failover_enabled", primaryGroupResourceName, "automatic_failover_enabled"),
 
@@ -2045,7 +2030,7 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full(t *testing
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg2),
 					testAccCheckReplicationGroupParameterGroup(ctx, &rg2, &pg2),
-					resource.TestCheckResourceAttr(resourceName, "number_cache_clusters", strconv.Itoa(updatedNumCacheClusters)),
+					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", strconv.Itoa(updatedNumCacheClusters)),
 				),
 			},
 		},
@@ -2115,15 +2100,13 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basi
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg1),
 					testAccCheckReplicationGroupParameterGroup(ctx, &rg1, &pg1),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "2"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "1"),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
+					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "1"),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceName, "parameter_group_name", regexp.MustCompile(fmt.Sprintf("^global-datastore-%s-", rName))),
 
-					resource.TestCheckResourceAttr(primaryGroupResourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(primaryGroupResourceName, "cluster_mode.0.num_node_groups", "2"),
-					resource.TestCheckResourceAttr(primaryGroupResourceName, "cluster_mode.0.replicas_per_node_group", "2"),
+					resource.TestCheckResourceAttr(primaryGroupResourceName, "num_node_groups", "2"),
+					resource.TestCheckResourceAttr(primaryGroupResourceName, "replicas_per_node_group", "2"),
 				),
 			},
 			{
@@ -2138,13 +2121,11 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basi
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg2),
 					testAccCheckReplicationGroupParameterGroup(ctx, &rg2, &pg2),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.num_node_groups", "2"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.0.replicas_per_node_group", "3"),
+					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
+					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "3"),
 
-					resource.TestCheckResourceAttr(primaryGroupResourceName, "cluster_mode.#", "1"),
-					resource.TestCheckResourceAttr(primaryGroupResourceName, "cluster_mode.0.num_node_groups", "2"),
-					resource.TestCheckResourceAttr(primaryGroupResourceName, "cluster_mode.0.replicas_per_node_group", "1"),
+					resource.TestCheckResourceAttr(primaryGroupResourceName, "num_node_groups", "2"),
+					resource.TestCheckResourceAttr(primaryGroupResourceName, "replicas_per_node_group", "1"),
 				),
 			},
 		},
@@ -2170,7 +2151,7 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValid
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccReplicationGroupConfig_globalIDClusterModeNumNodeOnSecondary(rName),
-				ExpectError: regexp.MustCompile(`"global_replication_group_id": conflicts with cluster_mode.0.num_node_groups`),
+				ExpectError: regexp.MustCompile(`"global_replication_group_id": conflicts with num_node_groups`),
 			},
 		},
 	})
@@ -2340,7 +2321,6 @@ func TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_C
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.redis6.x.cluster.on"),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination", rName),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination_type", "cloudwatch-logs"),
@@ -2367,7 +2347,6 @@ func TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_C
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.redis6.x.cluster.on"),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination", rName),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination_type", "cloudwatch-logs"),
@@ -2385,7 +2364,6 @@ func TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_C
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", "default.redis6.x.cluster.on"),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination", rName),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination_type", "kinesis-firehose"),
@@ -2403,7 +2381,6 @@ func TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_C
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "engine", "redis"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "cluster_mode.#", "1"),
 					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configuration.0.destination"),
 					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configuration.0.destination_type"),
 					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configuration.0.log_format"),
@@ -2689,13 +2666,13 @@ func testAccCheckResourceTags(resourceName string, kvs []kvp) []resource.TestChe
 func testAccReplicationGroupConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t3.small"
-  port                          = 6379
-  apply_immediately             = true
-  maintenance_window            = "tue:06:30-tue:07:30"
-  snapshot_window               = "01:00-02:00"
+  replication_group_id = %[1]q
+  description          = "test description"
+  node_type            = "cache.t3.small"
+  port                 = 6379
+  apply_immediately    = true
+  maintenance_window   = "tue:06:30-tue:07:30"
+  snapshot_window      = "01:00-02:00"
 }
 `, rName)
 }
@@ -2703,10 +2680,10 @@ resource "aws_elasticache_replication_group" "test" {
 func testAccReplicationGroupConfig_v5(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t3.small"
-  engine_version                = "5.0.6"
+  replication_group_id = %[1]q
+  description          = "test description"
+  node_type            = "cache.t3.small"
+  engine_version       = "5.0.6"
 }
 `, rName)
 }
@@ -2716,12 +2693,12 @@ func testAccReplicationGroupConfig_uppercase(rName string) string {
 		acctest.ConfigVPCWithSubnets(rName, 2),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  node_type                     = "cache.t2.micro"
-  number_cache_clusters         = 1
-  port                          = 6379
-  replication_group_description = "test description"
-  replication_group_id          = %[1]q
-  subnet_group_name             = aws_elasticache_subnet_group.test.name
+  node_type            = "cache.t2.micro"
+  num_cache_clusters   = 1
+  port                 = 6379
+  description          = "test description"
+  replication_group_id = %[1]q
+  subnet_group_name    = aws_elasticache_subnet_group.test.name
 }
 
 resource "aws_elasticache_subnet_group" "test" {
@@ -2735,16 +2712,14 @@ resource "aws_elasticache_subnet_group" "test" {
 func testAccReplicationGroupConfig_engineVersion(rName, engineVersion string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-
-  node_type             = "cache.t3.small"
-  number_cache_clusters = 2
-
-  engine_version     = %[2]q
-  apply_immediately  = true
-  maintenance_window = "tue:06:30-tue:07:30"
-  snapshot_window    = "01:00-02:00"
+  replication_group_id = %[1]q
+  description          = "test description"
+  node_type            = "cache.t3.small"
+  num_cache_clusters   = 2
+  engine_version       = %[2]q
+  apply_immediately    = true
+  maintenance_window   = "tue:06:30-tue:07:30"
+  snapshot_window      = "01:00-02:00"
 }
 `, rName, engineVersion)
 }
@@ -2752,14 +2727,14 @@ resource "aws_elasticache_replication_group" "test" {
 func testAccReplicationGroupConfig_enableSnapshotting(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t3.small"
-  port                          = 6379
-  apply_immediately             = true
-  maintenance_window            = "tue:06:30-tue:07:30"
-  snapshot_window               = "01:00-02:00"
-  snapshot_retention_limit      = 2
+  replication_group_id     = %[1]q
+  description              = "test description"
+  node_type                = "cache.t3.small"
+  port                     = 6379
+  apply_immediately        = true
+  maintenance_window       = "tue:06:30-tue:07:30"
+  snapshot_window          = "01:00-02:00"
+  snapshot_retention_limit = 2
 }
 `, rName)
 }
@@ -2782,13 +2757,13 @@ resource "aws_elasticache_parameter_group" "test" {
 }
 
 resource "aws_elasticache_replication_group" "test" {
-  apply_immediately             = true
-  node_type                     = "cache.t3.small"
-  number_cache_clusters         = 2
-  engine_version                = "6.x"
-  parameter_group_name          = aws_elasticache_parameter_group.test[%[2]d].name
-  replication_group_description = "test description"
-  replication_group_id          = %[1]q
+  apply_immediately    = true
+  node_type            = "cache.t3.small"
+  num_cache_clusters   = 2
+  engine_version       = "6.x"
+  parameter_group_name = aws_elasticache_parameter_group.test[%[2]d].name
+  description          = "test description"
+  replication_group_id = %[1]q
 }
 `, rName, parameterGroupNameIndex)
 }
@@ -2796,11 +2771,11 @@ resource "aws_elasticache_replication_group" "test" {
 func testAccReplicationGroupConfig_updatedDescription(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "updated description"
-  node_type                     = "cache.t3.small"
-  port                          = 6379
-  apply_immediately             = true
+  replication_group_id = %[1]q
+  description          = "updated description"
+  node_type            = "cache.t3.small"
+  port                 = 6379
+  apply_immediately    = true
 }
 `, rName)
 }
@@ -2808,13 +2783,13 @@ resource "aws_elasticache_replication_group" "test" {
 func testAccReplicationGroupConfig_updatedMaintenanceWindow(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "updated description"
-  node_type                     = "cache.t3.small"
-  port                          = 6379
-  apply_immediately             = true
-  maintenance_window            = "wed:03:00-wed:06:00"
-  snapshot_window               = "01:00-02:00"
+  replication_group_id = %[1]q
+  description          = "updated description"
+  node_type            = "cache.t3.small"
+  port                 = 6379
+  apply_immediately    = true
+  maintenance_window   = "wed:03:00-wed:06:00"
+  snapshot_window      = "01:00-02:00"
 }
 `, rName)
 }
@@ -2822,11 +2797,11 @@ resource "aws_elasticache_replication_group" "test" {
 func testAccReplicationGroupConfig_updatedNodeSize(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "updated description"
-  node_type                     = "cache.t3.medium"
-  port                          = 6379
-  apply_immediately             = true
+  replication_group_id = %[1]q
+  description          = "updated description"
+  node_type            = "cache.t3.medium"
+  port                 = 6379
+  apply_immediately    = true
 }
 `, rName)
 }
@@ -2852,15 +2827,15 @@ resource "aws_elasticache_user_group" "test" {
 }
 
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t3.small"
-  port                          = 6379
-  apply_immediately             = true
-  maintenance_window            = "tue:06:30-tue:07:30"
-  snapshot_window               = "01:00-02:00"
-  transit_encryption_enabled    = true
-  user_group_ids                = [aws_elasticache_user_group.test[%[3]d].id]
+  replication_group_id       = %[1]q
+  description                = "test description"
+  node_type                  = "cache.t3.small"
+  port                       = 6379
+  apply_immediately          = true
+  maintenance_window         = "tue:06:30-tue:07:30"
+  snapshot_window            = "01:00-02:00"
+  transit_encryption_enabled = true
+  user_group_ids             = [aws_elasticache_user_group.test[%[3]d].id]
 }
 `, rName, userGroup, flag)
 }
@@ -2870,14 +2845,14 @@ func testAccReplicationGroupConfig_inVPC(rName string) string {
 		acctest.ConfigVPCWithSubnets(rName, 1),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t3.small"
-  number_cache_clusters         = 1
-  port                          = 6379
-  subnet_group_name             = aws_elasticache_subnet_group.test.name
-  security_group_ids            = [aws_security_group.test.id]
-  preferred_cache_cluster_azs   = [data.aws_availability_zones.available.names[0]]
+  replication_group_id        = %[1]q
+  description                 = "test description"
+  node_type                   = "cache.t3.small"
+  num_cache_clusters          = 1
+  port                        = 6379
+  subnet_group_name           = aws_elasticache_subnet_group.test.name
+  security_group_ids          = [aws_security_group.test.id]
+  preferred_cache_cluster_azs = [data.aws_availability_zones.available.names[0]]
 }
 
 resource "aws_elasticache_subnet_group" "test" {
@@ -2899,19 +2874,6 @@ resource "aws_security_group" "test" {
 }
 `, rName),
 	)
-}
-
-func testAccReplicationGroupConfig_multiAZNotInVPCBasic(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  number_cache_clusters         = 2
-  node_type                     = "cache.t3.small"
-  automatic_failover_enabled    = true
-  multi_az_enabled              = true
-}
-`, rName)
 }
 
 func testAccReplicationGroupConfig_multiAZNotInVPCPreferredCacheClusterAZsNotRepeated(rName string) string {
@@ -2948,40 +2910,23 @@ resource "aws_elasticache_replication_group" "test" {
 	)
 }
 
-func testAccReplicationGroupConfig_multiAZNotInVPCDeprecatedAvailabilityZones(rName string) string {
-	return acctest.ConfigCompose(
-		acctest.ConfigAvailableAZsNoOptIn(),
-		fmt.Sprintf(`
-resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  number_cache_clusters         = 2
-  node_type                     = "cache.t3.small"
-  automatic_failover_enabled    = true
-  multi_az_enabled              = true
-  preferred_cache_cluster_azs   = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
-}
-`, rName),
-	)
-}
-
 func testAccReplicationGroupConfig_multiAZInVPC(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigVPCWithSubnets(rName, 2),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t3.small"
-  number_cache_clusters         = 2
-  port                          = 6379
-  subnet_group_name             = aws_elasticache_subnet_group.test.name
-  security_group_ids            = [aws_security_group.test.id]
-  preferred_cache_cluster_azs   = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
-  automatic_failover_enabled    = true
-  multi_az_enabled              = true
-  snapshot_window               = "02:00-03:00"
-  snapshot_retention_limit      = 7
+  replication_group_id        = %[1]q
+  description                 = "test description"
+  node_type                   = "cache.t3.small"
+  num_cache_clusters          = 2
+  port                        = 6379
+  subnet_group_name           = aws_elasticache_subnet_group.test.name
+  security_group_ids          = [aws_security_group.test.id]
+  preferred_cache_cluster_azs = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
+  automatic_failover_enabled  = true
+  multi_az_enabled            = true
+  snapshot_window             = "02:00-03:00"
+  snapshot_retention_limit    = 7
 }
 
 resource "aws_elasticache_subnet_group" "test" {
@@ -3008,12 +2953,12 @@ resource "aws_security_group" "test" {
 func testAccReplicationGroupConfig_multiAZNoAutomaticFailover(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  number_cache_clusters         = 1
-  node_type                     = "cache.t3.small"
-  automatic_failover_enabled    = false
-  multi_az_enabled              = true
+  replication_group_id       = %[1]q
+  description                = "test description"
+  num_cache_clusters         = 1
+  node_type                  = "cache.t3.small"
+  automatic_failover_enabled = false
+  multi_az_enabled           = true
 }
 `, rName)
 }
@@ -3023,20 +2968,16 @@ func testAccReplicationGroupConfig_nativeRedisClusterError(rName string) string 
 		acctest.ConfigVPCWithSubnets(rName, 2),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t2.micro"
-  port                          = 6379
-  subnet_group_name             = aws_elasticache_subnet_group.test.name
-  security_group_ids            = [aws_security_group.test.id]
-  automatic_failover_enabled    = true
-
-  cluster_mode {
-    replicas_per_node_group = 1
-    num_node_groups         = 2
-  }
-
-  number_cache_clusters = 3
+  replication_group_id       = %[1]q
+  description                = "test description"
+  node_type                  = "cache.t2.micro"
+  port                       = 6379
+  subnet_group_name          = aws_elasticache_subnet_group.test.name
+  security_group_ids         = [aws_security_group.test.id]
+  automatic_failover_enabled = true
+  replicas_per_node_group    = 1
+  num_node_groups            = 2
+  num_cache_clusters         = 3
 }
 
 resource "aws_elasticache_subnet_group" "test" {
@@ -3117,18 +3058,15 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t2.micro"
-  port                          = 6379
-  subnet_group_name             = aws_elasticache_subnet_group.test.name
-  security_group_ids            = [aws_security_group.test.id]
-  automatic_failover_enabled    = true
-
-  cluster_mode {
-    num_node_groups         = %[2]d
-    replicas_per_node_group = %[3]d
-  }
+  replication_group_id       = %[1]q
+  description                = "test description"
+  node_type                  = "cache.t2.micro"
+  port                       = 6379
+  subnet_group_name          = aws_elasticache_subnet_group.test.name
+  security_group_ids         = [aws_security_group.test.id]
+  automatic_failover_enabled = true
+  num_node_groups            = %[2]d
+  replicas_per_node_group    = %[3]d
 
   tags = {
     key = "value"
@@ -3143,17 +3081,14 @@ func testAccReplicationGroupConfig_nativeRedisClusterNonClusteredParameter(rName
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t2.medium"
-  automatic_failover_enabled    = false
-
-  engine_version       = "6.x"
-  parameter_group_name = "default.redis6.x"
-  cluster_mode {
-    num_node_groups         = 1
-    replicas_per_node_group = 1
-  }
+  replication_group_id       = %[1]q
+  description                = "test description"
+  node_type                  = "cache.t2.medium"
+  automatic_failover_enabled = false
+  engine_version             = "6.x"
+  parameter_group_name       = "default.redis6.x"
+  num_node_groups            = 1
+  replicas_per_node_group    = 1
 }
 `, rName),
 	)
@@ -3164,17 +3099,14 @@ func testAccReplicationGroupConfig_nativeRedisClusterSingleNode(rName string) st
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t2.medium"
-  automatic_failover_enabled    = true
-
-  engine_version       = "6.x"
-  parameter_group_name = "default.redis6.x.cluster.on"
-  cluster_mode {
-    num_node_groups         = 1
-    replicas_per_node_group = 0
-  }
+  replication_group_id       = %[1]q
+  description                = "test description"
+  node_type                  = "cache.t2.medium"
+  automatic_failover_enabled = true
+  engine_version             = "6.x"
+  parameter_group_name       = "default.redis6.x.cluster.on"
+  num_node_groups            = 1
+  replicas_per_node_group    = 0
 }
 `, rName),
 	)
@@ -3185,17 +3117,17 @@ func testAccReplicationGroupConfig_useCMKKMSKeyID(rName string) string {
 		acctest.ConfigVPCWithSubnets(rName, 1),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t2.micro"
-  number_cache_clusters         = "1"
-  port                          = 6379
-  subnet_group_name             = aws_elasticache_subnet_group.test.name
-  security_group_ids            = [aws_security_group.test.id]
-  parameter_group_name          = "default.redis3.2"
-  engine_version                = "3.2.6"
-  at_rest_encryption_enabled    = true
-  kms_key_id                    = aws_kms_key.test.arn
+  replication_group_id       = %[1]q
+  description                = "test description"
+  node_type                  = "cache.t2.micro"
+  num_cache_clusters         = "1"
+  port                       = 6379
+  subnet_group_name          = aws_elasticache_subnet_group.test.name
+  security_group_ids         = [aws_security_group.test.id]
+  parameter_group_name       = "default.redis3.2"
+  engine_version             = "3.2.6"
+  at_rest_encryption_enabled = true
+  kms_key_id                 = aws_kms_key.test.arn
 }
 
 resource "aws_elasticache_subnet_group" "test" {
@@ -3228,16 +3160,16 @@ func testAccReplicationGroupConfig_enableAtRestEncryption(rName string) string {
 		acctest.ConfigVPCWithSubnets(rName, 1),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t2.micro"
-  number_cache_clusters         = "1"
-  port                          = 6379
-  subnet_group_name             = aws_elasticache_subnet_group.test.name
-  security_group_ids            = [aws_security_group.test.id]
-  parameter_group_name          = "default.redis3.2"
-  engine_version                = "3.2.6"
-  at_rest_encryption_enabled    = true
+  replication_group_id       = %[1]q
+  description                = "test description"
+  node_type                  = "cache.t2.micro"
+  num_cache_clusters         = "1"
+  port                       = 6379
+  subnet_group_name          = aws_elasticache_subnet_group.test.name
+  security_group_ids         = [aws_security_group.test.id]
+  parameter_group_name       = "default.redis3.2"
+  engine_version             = "3.2.6"
+  at_rest_encryption_enabled = true
 }
 
 resource "aws_elasticache_subnet_group" "test" {
@@ -3266,17 +3198,17 @@ func testAccReplicationGroupConfig_enableAuthTokenTransitEncryption(rName string
 		acctest.ConfigVPCWithSubnets(rName, 1),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t2.micro"
-  number_cache_clusters         = "1"
-  port                          = 6379
-  subnet_group_name             = aws_elasticache_subnet_group.test.name
-  security_group_ids            = [aws_security_group.test.id]
-  parameter_group_name          = "default.redis5.0"
-  engine_version                = "5.0.6"
-  transit_encryption_enabled    = true
-  auth_token                    = "%[2]s"
+  replication_group_id       = %[1]q
+  description                = "test description"
+  node_type                  = "cache.t2.micro"
+  num_cache_clusters         = "1"
+  port                       = 6379
+  subnet_group_name          = aws_elasticache_subnet_group.test.name
+  security_group_ids         = [aws_security_group.test.id]
+  parameter_group_name       = "default.redis5.0"
+  engine_version             = "5.0.6"
+  transit_encryption_enabled = true
+  auth_token                 = "%[2]s"
 }
 
 resource "aws_elasticache_subnet_group" "test" {
@@ -3306,11 +3238,11 @@ func testAccReplicationGroupConfig_numberCacheClusters(rName string, numberCache
 		testAccReplicationGroupClusterData(numberCacheClusters),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  node_type                     = "cache.t2.micro"
-  number_cache_clusters         = %[2]d
-  replication_group_id          = %[1]q
-  replication_group_description = "Terraform Acceptance Testing - number_cache_clusters"
-  subnet_group_name             = aws_elasticache_subnet_group.test.name
+  node_type            = "cache.t2.micro"
+  num_cache_clusters   = %[2]d
+  replication_group_id = %[1]q
+  description          = "Terraform Acceptance Testing - num_cache_clusters"
+  subnet_group_name    = aws_elasticache_subnet_group.test.name
 
   tags = {
     key = "value"
@@ -3331,13 +3263,13 @@ func testAccReplicationGroupConfig_failoverMultiAZ(rName string, numberCacheClus
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
   # InvalidParameterCombination: Automatic failover is not supported for T1 and T2 cache node types.
-  automatic_failover_enabled    = %[3]t
-  multi_az_enabled              = %[4]t
-  node_type                     = "cache.t3.medium"
-  number_cache_clusters         = %[2]d
-  replication_group_id          = %[1]q
-  replication_group_description = "Terraform Acceptance Testing - number_cache_clusters"
-  subnet_group_name             = aws_elasticache_subnet_group.test.name
+  automatic_failover_enabled = %[3]t
+  multi_az_enabled           = %[4]t
+  node_type                  = "cache.t3.medium"
+  num_cache_clusters         = %[2]d
+  replication_group_id       = %[1]q
+  description                = "Terraform Acceptance Testing - num_cache_clusters"
+  subnet_group_name          = aws_elasticache_subnet_group.test.name
 }
 
 resource "aws_elasticache_subnet_group" "test" {
@@ -3354,14 +3286,14 @@ func testAccReplicationGroupConfig_tags1(rName, tagKey1, tagValue1 string) strin
 		testAccReplicationGroupClusterData(clusterCount),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t3.small"
-  number_cache_clusters         = %[2]d
-  port                          = 6379
-  apply_immediately             = true
-  maintenance_window            = "tue:06:30-tue:07:30"
-  snapshot_window               = "01:00-02:00"
+  replication_group_id = %[1]q
+  description          = "test description"
+  node_type            = "cache.t3.small"
+  num_cache_clusters   = %[2]d
+  port                 = 6379
+  apply_immediately    = true
+  maintenance_window   = "tue:06:30-tue:07:30"
+  snapshot_window      = "01:00-02:00"
 
   tags = {
     %[3]q = %[4]q
@@ -3377,14 +3309,14 @@ func testAccReplicationGroupConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tag
 		testAccReplicationGroupClusterData(clusterCount),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t3.small"
-  number_cache_clusters         = %[2]d
-  port                          = 6379
-  apply_immediately             = true
-  maintenance_window            = "tue:06:30-tue:07:30"
-  snapshot_window               = "01:00-02:00"
+  replication_group_id = %[1]q
+  description          = "test description"
+  node_type            = "cache.t3.small"
+  num_cache_clusters   = %[2]d
+  port                 = 6379
+  apply_immediately    = true
+  maintenance_window   = "tue:06:30-tue:07:30"
+  snapshot_window      = "01:00-02:00"
 
   tags = {
     %[3]q = %[4]q
@@ -3401,12 +3333,12 @@ func testAccReplicationGroupConfig_versionAndTag(rName, version, tagKey1, tagVal
 		testAccReplicationGroupClusterData(clusterCount),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t3.small"
-  number_cache_clusters         = %[2]d
-  apply_immediately             = true
-  engine_version                = %[3]q
+  replication_group_id = %[1]q
+  description          = "test description"
+  node_type            = "cache.t3.small"
+  num_cache_clusters   = %[2]d
+  apply_immediately    = true
+  engine_version       = %[3]q
 
   tags = {
     %[4]q = %[5]q
@@ -3429,10 +3361,10 @@ data "aws_elasticache_cluster" "test" {
 func testAccReplicationGroupConfig_finalSnapshot(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t3.small"
-  number_cache_clusters         = 1
+  replication_group_id = %[1]q
+  description          = "test description"
+  node_type            = "cache.t3.small"
+  num_cache_clusters   = 1
 
   final_snapshot_identifier = %[1]q
 }
@@ -3442,10 +3374,9 @@ resource "aws_elasticache_replication_group" "test" {
 func testAccReplicationGroupConfig_autoMinorVersionUpgrade(rName string, enable bool) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.t3.small"
-
+  replication_group_id       = %[1]q
+  description                = "test description"
+  node_type                  = "cache.t3.small"
   auto_minor_version_upgrade = %[2]t
 }
 `, rName, enable)
@@ -3454,9 +3385,9 @@ resource "aws_elasticache_replication_group" "test" {
 func testAccReplicationGroupConfig_validationNoNodeType(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  number_cache_clusters         = 1
+  replication_group_id = %[1]q
+  description          = "test description"
+  num_cache_clusters   = 1
 }
 `, rName)
 }
@@ -3470,15 +3401,12 @@ func testAccReplicationGroupConfig_validationGlobalIdAndNodeType(rName string) s
 resource "aws_elasticache_replication_group" "test" {
   provider = aws
 
-  replication_group_id          = "%[1]s-s"
-  replication_group_description = "secondary"
-  global_replication_group_id   = aws_elasticache_global_replication_group.test.global_replication_group_id
-
-  subnet_group_name = aws_elasticache_subnet_group.test.name
-
-  node_type = "cache.m5.large"
-
-  number_cache_clusters = 1
+  replication_group_id        = "%[1]s-s"
+  description                 = "secondary"
+  global_replication_group_id = aws_elasticache_global_replication_group.test.global_replication_group_id
+  subnet_group_name           = aws_elasticache_subnet_group.test.name
+  node_type                   = "cache.m5.large"
+  num_cache_clusters          = 1
 }
 
 resource "aws_elasticache_global_replication_group" "test" {
@@ -3491,16 +3419,13 @@ resource "aws_elasticache_global_replication_group" "test" {
 resource "aws_elasticache_replication_group" "primary" {
   provider = awsalternate
 
-  replication_group_id          = "%[1]s-p"
-  replication_group_description = "primary"
-
-  subnet_group_name = aws_elasticache_subnet_group.primary.name
-
-  node_type = "cache.m5.large"
-
-  engine                = "redis"
-  engine_version        = "5.0.6"
-  number_cache_clusters = 1
+  replication_group_id = "%[1]s-p"
+  description          = "primary"
+  subnet_group_name    = aws_elasticache_subnet_group.primary.name
+  node_type            = "cache.m5.large"
+  engine               = "redis"
+  engine_version       = "5.0.6"
+  num_cache_clusters   = 1
 }
 `, rName),
 	)
@@ -3513,11 +3438,10 @@ func testAccReplicationGroupConfig_globalIDBasic(rName string) string {
 		testAccVPCBaseWithProvider(rName, "primary", acctest.ProviderNameAlternate, 1),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = "%[1]s-s"
-  replication_group_description = "secondary"
-  global_replication_group_id   = aws_elasticache_global_replication_group.test.global_replication_group_id
-
-  subnet_group_name = aws_elasticache_subnet_group.test.name
+  replication_group_id        = "%[1]s-s"
+  description                 = "secondary"
+  global_replication_group_id = aws_elasticache_global_replication_group.test.global_replication_group_id
+  subnet_group_name           = aws_elasticache_subnet_group.test.name
 }
 
 resource "aws_elasticache_global_replication_group" "test" {
@@ -3530,16 +3454,13 @@ resource "aws_elasticache_global_replication_group" "test" {
 resource "aws_elasticache_replication_group" "primary" {
   provider = awsalternate
 
-  replication_group_id          = "%[1]s-p"
-  replication_group_description = "primary"
-
-  subnet_group_name = aws_elasticache_subnet_group.primary.name
-
-  node_type = "cache.m5.large"
-
-  engine                = "redis"
-  engine_version        = "5.0.6"
-  number_cache_clusters = 2
+  replication_group_id = "%[1]s-p"
+  description          = "primary"
+  subnet_group_name    = aws_elasticache_subnet_group.primary.name
+  node_type            = "cache.m5.large"
+  engine               = "redis"
+  engine_version       = "5.0.6"
+  num_cache_clusters   = 2
 }
 `, rName),
 	)
@@ -3552,17 +3473,14 @@ func testAccReplicationGroupConfig_globalIDFull(rName string, numCacheClusters i
 		testAccVPCBaseWithProvider(rName, "primary", acctest.ProviderNameAlternate, 2),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = "%[1]s-s"
-  replication_group_description = "secondary"
-  global_replication_group_id   = aws_elasticache_global_replication_group.test.global_replication_group_id
-
-  subnet_group_name = aws_elasticache_subnet_group.test.name
-
-  number_cache_clusters      = %[2]d
-  automatic_failover_enabled = true
-  multi_az_enabled           = true
-
-  port = 16379
+  replication_group_id        = "%[1]s-s"
+  description                 = "secondary"
+  global_replication_group_id = aws_elasticache_global_replication_group.test.global_replication_group_id
+  subnet_group_name           = aws_elasticache_subnet_group.test.name
+  num_cache_clusters          = %[2]d
+  automatic_failover_enabled  = true
+  multi_az_enabled            = true
+  port                        = 16379
 }
 
 resource "aws_elasticache_global_replication_group" "test" {
@@ -3575,16 +3493,13 @@ resource "aws_elasticache_global_replication_group" "test" {
 resource "aws_elasticache_replication_group" "primary" {
   provider = awsalternate
 
-  replication_group_id          = "%[1]s-p"
-  replication_group_description = "primary"
-
-  subnet_group_name = aws_elasticache_subnet_group.primary.name
-
-  node_type = "cache.m5.large"
-
+  replication_group_id       = "%[1]s-p"
+  description                = "primary"
+  subnet_group_name          = aws_elasticache_subnet_group.primary.name
+  node_type                  = "cache.m5.large"
   engine                     = "redis"
   engine_version             = "5.0.6"
-  number_cache_clusters      = 2
+  num_cache_clusters         = 2
   automatic_failover_enabled = true
   multi_az_enabled           = true
 
@@ -3604,16 +3519,12 @@ func testAccReplicationGroupConfig_globalIDClusterMode(rName string, primaryRepl
 		testAccVPCBaseWithProvider(rName, "primary", acctest.ProviderNameAlternate, 2),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = "%[1]s-s"
-  replication_group_description = "secondary"
-  global_replication_group_id   = aws_elasticache_global_replication_group.test.global_replication_group_id
-
-  subnet_group_name = aws_elasticache_subnet_group.test.name
-
-  automatic_failover_enabled = true
-  cluster_mode {
-    replicas_per_node_group = %[3]d
-  }
+  replication_group_id        = "%[1]s-s"
+  description                 = "secondary"
+  global_replication_group_id = aws_elasticache_global_replication_group.test.global_replication_group_id
+  subnet_group_name           = aws_elasticache_subnet_group.test.name
+  automatic_failover_enabled  = true
+  replicas_per_node_group     = %[3]d
 }
 
 resource "aws_elasticache_global_replication_group" "test" {
@@ -3626,22 +3537,16 @@ resource "aws_elasticache_global_replication_group" "test" {
 resource "aws_elasticache_replication_group" "primary" {
   provider = awsalternate
 
-  replication_group_id          = "%[1]s-p"
-  replication_group_description = "primary"
-
-  subnet_group_name = aws_elasticache_subnet_group.primary.name
-
-  engine         = "redis"
-  engine_version = "6.2"
-  node_type      = "cache.m5.large"
-
-  parameter_group_name = "default.redis6.x.cluster.on"
-
+  replication_group_id       = "%[1]s-p"
+  description                = "primary"
+  subnet_group_name          = aws_elasticache_subnet_group.primary.name
+  engine                     = "redis"
+  engine_version             = "6.2"
+  node_type                  = "cache.m5.large"
+  parameter_group_name       = "default.redis6.x.cluster.on"
   automatic_failover_enabled = true
-  cluster_mode {
-    num_node_groups         = 2
-    replicas_per_node_group = %[2]d
-  }
+  num_node_groups            = 2
+  replicas_per_node_group    = %[2]d
 }
 `, rName, primaryReplicaCount, secondaryReplicaCount),
 	)
@@ -3654,17 +3559,13 @@ func testAccReplicationGroupConfig_globalIDClusterModeNumNodeOnSecondary(rName s
 		testAccVPCBaseWithProvider(rName, "primary", acctest.ProviderNameAlternate, 2),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = "%[1]s-s"
-  replication_group_description = "secondary"
-  global_replication_group_id   = aws_elasticache_global_replication_group.test.global_replication_group_id
-
-  subnet_group_name = aws_elasticache_subnet_group.test.name
-
-  automatic_failover_enabled = true
-  cluster_mode {
-    num_node_groups         = 2
-    replicas_per_node_group = 1
-  }
+  replication_group_id        = "%[1]s-s"
+  description                 = "secondary"
+  global_replication_group_id = aws_elasticache_global_replication_group.test.global_replication_group_id
+  subnet_group_name           = aws_elasticache_subnet_group.test.name
+  automatic_failover_enabled  = true
+  num_node_groups             = 2
+  replicas_per_node_group     = 1
 }
 
 resource "aws_elasticache_global_replication_group" "test" {
@@ -3677,22 +3578,16 @@ resource "aws_elasticache_global_replication_group" "test" {
 resource "aws_elasticache_replication_group" "primary" {
   provider = awsalternate
 
-  replication_group_id          = "%[1]s-p"
-  replication_group_description = "primary"
-
-  subnet_group_name = aws_elasticache_subnet_group.primary.name
-
-  engine         = "redis"
-  engine_version = "6.2"
-  node_type      = "cache.m5.large"
-
-  parameter_group_name = "default.redis6.x.cluster.on"
-
+  replication_group_id       = "%[1]s-p"
+  description                = "primary"
+  subnet_group_name          = aws_elasticache_subnet_group.primary.name
+  engine                     = "redis"
+  engine_version             = "6.2"
+  node_type                  = "cache.m5.large"
+  parameter_group_name       = "default.redis6.x.cluster.on"
   automatic_failover_enabled = true
-  cluster_mode {
-    num_node_groups         = 2
-    replicas_per_node_group = 1
-  }
+  num_node_groups            = 2
+  replicas_per_node_group    = 1
 }
 `, rName),
 	)
@@ -3703,13 +3598,13 @@ func testAccReplicationGroupConfig_dataTiering(rName string) string {
 		acctest.ConfigVPCWithSubnets(rName, 1),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = %[1]q
-  replication_group_description = "test description"
-  node_type                     = "cache.r6gd.xlarge"
-  data_tiering_enabled          = true
-  port                          = 6379
-  subnet_group_name             = aws_elasticache_subnet_group.test.name
-  security_group_ids            = [aws_security_group.test.id]
+  replication_group_id = %[1]q
+  description          = "test description"
+  node_type            = "cache.r6gd.xlarge"
+  data_tiering_enabled = true
+  port                 = 6379
+  subnet_group_name    = aws_elasticache_subnet_group.test.name
+  security_group_ids   = [aws_security_group.test.id]
 }
 
 resource "aws_elasticache_subnet_group" "test" {
@@ -3818,23 +3713,19 @@ resource "aws_kinesis_firehose_delivery_stream" "ds" {
 }
 
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id          = "%[1]s"
-  replication_group_description = "test description"
-  node_type                     = "cache.t3.small"
-  port                          = 6379
-  apply_immediately             = true
-  maintenance_window            = "tue:06:30-tue:07:30"
-  snapshot_window               = "01:00-02:00"
-  engine_version                = "6.x"
-  parameter_group_name          = tobool("%[2]t") ? "default.redis6.x.cluster.on" : "default.redis6.x"
-  automatic_failover_enabled    = tobool("%[2]t")
-  dynamic "cluster_mode" {
-    for_each = tobool("%[2]t") ? [""] : []
-    content {
-      num_node_groups         = 1
-      replicas_per_node_group = 0
-    }
-  }
+  replication_group_id       = "%[1]s"
+  description                = "test description"
+  node_type                  = "cache.t3.small"
+  port                       = 6379
+  apply_immediately          = true
+  maintenance_window         = "tue:06:30-tue:07:30"
+  snapshot_window            = "01:00-02:00"
+  engine_version             = "6.x"
+  parameter_group_name       = tobool("%[2]t") ? "default.redis6.x.cluster.on" : "default.redis6.x"
+  automatic_failover_enabled = tobool("%[2]t")
+  num_node_groups            = tobool("%[2]t") ? 1 : null
+  replicas_per_node_group    = tobool("%[2]t") ? 0 : null
+
   dynamic "log_delivery_configuration" {
     for_each = tobool("%[3]t") ? [""] : []
     content {

--- a/website/docs/d/elasticache_replication_group.html.markdown
+++ b/website/docs/d/elasticache_replication_group.html.markdown
@@ -35,11 +35,9 @@ In addition to all arguments above, the following attributes are exported:
 * `node_type` – The cluster node type.
 * `num_cache_clusters` – The number of cache clusters that the replication group has.
 * `num_node_groups` - Number of node groups (shards) for the replication group.
-* `number_cache_clusters` – (**Deprecated** use `num_cache_clusters` instead) Number of cache clusters that the replication group has.
 * `member_clusters` - Identifiers of all the nodes that are part of this replication group.
 * `multi_az_enabled` - Whether Multi-AZ Support is enabled for the replication group.
 * `replicas_per_node_group` - Number of replica nodes in each node group.
-* `replication_group_description` - (**Deprecated** use `description` instead) Description of the replication group.
 * `log_delivery_configuration` - Redis [SLOWLOG](https://redis.io/commands/slowlog) or Redis [Engine Log](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Log_Delivery.html#Log_contents-engine-log) delivery settings.
 * `snapshot_window` - Daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of your node group (shard).
 * `snapshot_retention_limit` - The number of days for which ElastiCache retains automatic cache cluster snapshots before deleting them.

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -179,7 +179,6 @@ The following arguments are optional:
   Only supported for engine type `"redis"` and if the engine version is 6 or higher.
   Defaults to `true`.
 * `automatic_failover_enabled` - (Optional) Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. If enabled, `num_cache_clusters` must be greater than 1. Must be enabled for Redis (cluster mode enabled) replication groups. Defaults to `false`.
-* `availability_zones` - (Optional, **Deprecated** use `preferred_cache_cluster_azs` instead) List of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not considered.
 * `cluster_mode` - (Optional, **Deprecated** use root-level `num_node_groups` and `replicas_per_node_group` instead) Create a native Redis cluster. `automatic_failover_enabled` must be set to true. Cluster Mode documented below. Only 1 `cluster_mode` block is allowed. Note that configuring this block does not enable cluster mode, i.e., data sharding, this requires using a parameter group that has the parameter `cluster-enabled` set to true.
 * `data_tiering_enabled` - (Optional) Enables data tiering. Data tiering is only supported for replication groups using the r6gd node type. This parameter must be set to `true` when using r6gd nodes.
 * `engine` - (Optional) Name of the cache engine to be used for the clusters in this replication group. The only valid value is `redis`.

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -168,7 +168,6 @@ The following arguments are required:
 
 * `description` – (Required) User-created description for the replication group. Must not be empty.
 * `replication_group_id` – (Required) Replication group identifier. This parameter is stored as a lowercase string.
-* `replication_group_description` – (**Deprecated** use `description` instead) User-created description for the replication group. Must not be empty.
 
 The following arguments are optional:
 
@@ -179,7 +178,6 @@ The following arguments are optional:
   Only supported for engine type `"redis"` and if the engine version is 6 or higher.
   Defaults to `true`.
 * `automatic_failover_enabled` - (Optional) Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. If enabled, `num_cache_clusters` must be greater than 1. Must be enabled for Redis (cluster mode enabled) replication groups. Defaults to `false`.
-* `cluster_mode` - (Optional, **Deprecated** use root-level `num_node_groups` and `replicas_per_node_group` instead) Create a native Redis cluster. `automatic_failover_enabled` must be set to true. Cluster Mode documented below. Only 1 `cluster_mode` block is allowed. Note that configuring this block does not enable cluster mode, i.e., data sharding, this requires using a parameter group that has the parameter `cluster-enabled` set to true.
 * `data_tiering_enabled` - (Optional) Enables data tiering. Data tiering is only supported for replication groups using the r6gd node type. This parameter must be set to `true` when using r6gd nodes.
 * `engine` - (Optional) Name of the cache engine to be used for the clusters in this replication group. The only valid value is `redis`.
 * `engine_version` - (Optional) Version number of the cache engine to be used for the cache clusters in this replication group.
@@ -188,15 +186,14 @@ The following arguments are optional:
   Otherwise, specify the full version desired, e.g., `5.0.6`.
   The actual engine version used is returned in the attribute `engine_version_actual`, see [Attributes Reference](#attributes-reference) below.
 * `final_snapshot_identifier` - (Optional) The name of your final node group (shard) snapshot. ElastiCache creates the snapshot from the primary node in the cluster. If omitted, no final snapshot will be made.
-* `global_replication_group_id` - (Optional) The ID of the global replication group to which this replication group should belong. If this parameter is specified, the replication group is added to the specified global replication group as a secondary replication group; otherwise, the replication group is not part of any global replication group. If `global_replication_group_id` is set, the `num_node_groups` parameter (or the `num_node_groups` parameter of the deprecated `cluster_mode` block) cannot be set.
+* `global_replication_group_id` - (Optional) The ID of the global replication group to which this replication group should belong. If this parameter is specified, the replication group is added to the specified global replication group as a secondary replication group; otherwise, the replication group is not part of any global replication group. If `global_replication_group_id` is set, the `num_node_groups` parameter cannot be set.
 * `kms_key_id` - (Optional) The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if `at_rest_encryption_enabled = true`.
 * `log_delivery_configuration` - (Optional, Redis only) Specifies the destination and format of Redis [SLOWLOG](https://redis.io/commands/slowlog) or Redis [Engine Log](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Log_Delivery.html#Log_contents-engine-log). See the documentation on [Amazon ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Log_Delivery.html#Log_contents-engine-log). See [Log Delivery Configuration](#log-delivery-configuration) below for more details.
 * `maintenance_window` – (Optional) Specifies the weekly time range for when maintenance on the cache cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H Clock UTC). The minimum maintenance window is a 60 minute period. Example: `sun:05:00-sun:09:00`
 * `multi_az_enabled` - (Optional) Specifies whether to enable Multi-AZ Support for the replication group. If `true`, `automatic_failover_enabled` must also be enabled. Defaults to `false`.
 * `node_type` - (Optional) Instance class to be used. See AWS documentation for information on [supported node types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html) and [guidance on selecting node types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/nodes-select-size.html). Required unless `global_replication_group_id` is set. Cannot be set if `global_replication_group_id` is set.
 * `notification_topic_arn` – (Optional) ARN of an SNS topic to send ElastiCache notifications to. Example: `arn:aws:sns:us-east-1:012345678999:my_sns_topic`
-* `number_cache_clusters` - (Optional, **Deprecated** use `num_cache_clusters` instead) Number of cache clusters (primary and replicas) this replication group will have. If Multi-AZ is enabled, the value of this parameter must be at least 2. Updates will occur before other modifications. Conflicts with `num_cache_clusters`, `num_node_groups`, or the deprecated `cluster_mode`. Defaults to `1`.
-* `num_cache_clusters` - (Optional) Number of cache clusters (primary and replicas) this replication group will have. If Multi-AZ is enabled, the value of this parameter must be at least 2. Updates will occur before other modifications. Conflicts with `num_node_groups`, the deprecated`number_cache_clusters`, or the deprecated `cluster_mode`. Defaults to `1`.
+* `num_cache_clusters` - (Optional) Number of cache clusters (primary and replicas) this replication group will have. If Multi-AZ is enabled, the value of this parameter must be at least 2. Updates will occur before other modifications. Conflicts with `num_node_groups`. Defaults to `1`.
 * `num_node_groups` - (Optional) Number of node groups (shards) for this Redis replication group.
   Changing this number will trigger a resizing operation before other settings modifications.
 * `parameter_group_name` - (Optional) Name of the parameter group to associate with this replication group. If this argument is omitted, the default cache parameter group for the specified engine is used. To enable "cluster mode", i.e., data sharding, use a parameter group that has the parameter `cluster-enabled` set to true.
@@ -215,11 +212,6 @@ The following arguments are optional:
 * `tags` - (Optional) Map of tags to assign to the resource. Adding tags to this resource will add or overwrite any existing tags on the clusters in the replication group and not to the group itself. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `transit_encryption_enabled` - (Optional) Whether to enable encryption in transit.
 * `user_group_ids` - (Optional) User Group ID to associate with the replication group. Only a maximum of one (1) user group ID is valid. **NOTE:** This argument _is_ a set because the AWS specification allows for multiple IDs. However, in practice, AWS only allows a maximum size of one.
-
-### cluster_mode (**DEPRECATED**)
-
-* `num_node_groups` - (Optional, **Deprecated** use root-level `num_node_groups` instead) Number of node groups (shards) for this Redis replication group. Changing this number will trigger an online resizing operation before other settings modifications. Required unless `global_replication_group_id` is set.
-* `replicas_per_node_group` - (Optional, Required with `cluster_mode` `num_node_groups`, **Deprecated** use root-level `replicas_per_node_group` instead) Number of replica nodes in each node group. Valid values are 0 to 5. Changing this number will trigger an online resizing operation before other settings modifications.
 
 ### Log Delivery Configuration
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #18439
Closes #18441

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Failure unrelated to these changes

```console
% make t T='TestAccElastiCacheReplicationGroup_ClusterMode_basic|TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup|TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown|TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp|TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown|TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp|TestAccElastiCacheReplicationGroup_enableAtRestEncryption|TestAccElastiCacheReplicationGroup_enableAuthTokenTransitEncryption|TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic|TestAccElastiCacheReplicationGroup_tagWithOtherModification|TestAccElastiCacheReplicationGroup_updateAuthToken|TestAccElastiCacheReplicationGroup_useCMKKMSKeyID' K=elasticache P=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 3 -run='TestAccElastiCacheReplicationGroup_ClusterMode_basic|TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup|TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown|TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp|TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown|TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp|TestAccElastiCacheReplicationGroup_enableAtRestEncryption|TestAccElastiCacheReplicationGroup_enableAuthTokenTransitEncryption|TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic|TestAccElastiCacheReplicationGroup_tagWithOtherModification|TestAccElastiCacheReplicationGroup_updateAuthToken|TestAccElastiCacheReplicationGroup_useCMKKMSKeyID'  -timeout 180m
=== RUN   TestAccElastiCacheReplicationGroup_updateAuthToken
=== PAUSE TestAccElastiCacheReplicationGroup_updateAuthToken
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_basic
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_basic
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
=== RUN   TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp
=== RUN   TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown
=== PAUSE TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown
=== RUN   TestAccElastiCacheReplicationGroup_enableAuthTokenTransitEncryption
=== PAUSE TestAccElastiCacheReplicationGroup_enableAuthTokenTransitEncryption
=== RUN   TestAccElastiCacheReplicationGroup_enableAtRestEncryption
=== PAUSE TestAccElastiCacheReplicationGroup_enableAtRestEncryption
=== RUN   TestAccElastiCacheReplicationGroup_useCMKKMSKeyID
=== PAUSE TestAccElastiCacheReplicationGroup_useCMKKMSKeyID
=== RUN   TestAccElastiCacheReplicationGroup_tagWithOtherModification
=== PAUSE TestAccElastiCacheReplicationGroup_tagWithOtherModification
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
=== CONT  TestAccElastiCacheReplicationGroup_updateAuthToken
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown
--- PASS: TestAccElastiCacheReplicationGroup_updateAuthToken (1039.85s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown (2188.47s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown (2521.79s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp (2655.21s)
=== CONT  TestAccElastiCacheReplicationGroup_useCMKKMSKeyID
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup (2171.31s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp (2179.21s)
=== CONT  TestAccElastiCacheReplicationGroup_tagWithOtherModification
--- PASS: TestAccElastiCacheReplicationGroup_useCMKKMSKeyID (792.83s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_basic (1049.49s)
=== CONT  TestAccElastiCacheReplicationGroup_enableAtRestEncryption
--- PASS: TestAccElastiCacheReplicationGroup_enableAtRestEncryption (837.54s)
=== CONT  TestAccElastiCacheReplicationGroup_enableAuthTokenTransitEncryption
--- PASS: TestAccElastiCacheReplicationGroup_enableAuthTokenTransitEncryption (2189.62s)
=== NAME  TestAccElastiCacheReplicationGroup_tagWithOtherModification
    replication_group_test.go:1793: Step 2/2 error: Error running apply: exit status 1
        
        Error: updating ElastiCache Replication Group (tf-acc-test-8460758980054193126): InvalidReplicationGroupState: Replication group must be in available state to modify.
        	status code: 400, request id: fe639b9f-13ee-452a-a606-18c74ac55a79
        
          with aws_elasticache_replication_group.test,
          on terraform_plugin_test.tf line 8, in resource "aws_elasticache_replication_group" "test":
           8: resource "aws_elasticache_replication_group" "test" {
        
--- FAIL: TestAccElastiCacheReplicationGroup_tagWithOtherModification (914.19s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic (3798.17s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	3831.602s
```
