### PR TITLE
Enhancement: add configurable timeouts to r/`aws_rds_cluster_role_association`

### DIFF
--- a/.changelog/31015.txt
+++ b/.changelog/31015.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_rds_cluster_role_association: Add configurable Create and Delete timeouts
+```

--- a/internal/service/rds/cluster_role_association.go
+++ b/internal/service/rds/cluster_role_association.go
@@ -3,6 +3,7 @@ package rds
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
@@ -25,6 +26,12 @@ func ResourceClusterRoleAssociation() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -80,7 +87,7 @@ func resourceClusterRoleAssociationCreate(ctx context.Context, d *schema.Resourc
 
 	d.SetId(ClusterRoleAssociationCreateResourceID(dbClusterID, roleARN))
 
-	_, err = waitDBClusterRoleAssociationCreated(ctx, conn, dbClusterID, roleARN)
+	_, err = waitDBClusterRoleAssociationCreated(ctx, conn, dbClusterID, roleARN, d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Cluster (%s) IAM Role (%s) Association to create: %s", dbClusterID, roleARN, err)
@@ -143,7 +150,7 @@ func resourceClusterRoleAssociationDelete(ctx context.Context, d *schema.Resourc
 		return sdkdiag.AppendErrorf(diags, "deleting RDS DB Cluster (%s) IAM Role (%s) Association: %s", dbClusterID, roleARN, err)
 	}
 
-	_, err = waitDBClusterRoleAssociationDeleted(ctx, conn, dbClusterID, roleARN)
+	_, err = waitDBClusterRoleAssociationDeleted(ctx, conn, dbClusterID, roleARN, d.Timeout(schema.TimeoutDelete))
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Cluster (%s) IAM Role (%s) Association to delete: %s", dbClusterID, roleARN, err)

--- a/internal/service/rds/cluster_role_association.go
+++ b/internal/service/rds/cluster_role_association.go
@@ -29,8 +29,8 @@ func ResourceClusterRoleAssociation() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(30 * time.Minute),
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/internal/service/rds/cluster_role_association.go
+++ b/internal/service/rds/cluster_role_association.go
@@ -30,7 +30,6 @@ func ResourceClusterRoleAssociation() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 

--- a/internal/service/rds/cluster_role_association_test.go
+++ b/internal/service/rds/cluster_role_association_test.go
@@ -196,8 +196,6 @@ resource "aws_rds_cluster" "test" {
   database_name           = "mydb"
   master_username         = "foo"
   master_password         = "foobarfoobarfoobar"
-  backup_retention_period = 5
-  preferred_backup_window = "07:00-09:00"
   skip_final_snapshot     = true
 }
 

--- a/internal/service/rds/cluster_role_association_test.go
+++ b/internal/service/rds/cluster_role_association_test.go
@@ -190,13 +190,13 @@ resource "aws_rds_cluster_role_association" "test" {
 }
 
 resource "aws_rds_cluster" "test" {
-  cluster_identifier      = %[1]q
-  engine                  = "aurora-postgresql"
-  availability_zones      = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1], data.aws_availability_zones.available.names[2]]
-  database_name           = "mydb"
-  master_username         = "foo"
-  master_password         = "foobarfoobarfoobar"
-  skip_final_snapshot     = true
+  cluster_identifier  = %[1]q
+  engine              = "aurora-postgresql"
+  availability_zones  = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1], data.aws_availability_zones.available.names[2]]
+  database_name       = "mydb"
+  master_username     = "foo"
+  master_password     = "foobarfoobarfoobar"
+  skip_final_snapshot = true
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/rds/wait.go
+++ b/internal/service/rds/wait.go
@@ -9,11 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 )
 
-const (
-	dbClusterRoleAssociationCreatedTimeout = 10 * time.Minute
-	dbClusterRoleAssociationDeletedTimeout = 10 * time.Minute
-)
-
 func waitEventSubscriptionCreated(ctx context.Context, conn *rds.RDS, id string, timeout time.Duration) (*rds.EventSubscription, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{EventSubscriptionStatusCreating},
@@ -111,12 +106,14 @@ func waitDBProxyEndpointDeleted(ctx context.Context, conn *rds.RDS, id string, t
 	return nil, err
 }
 
-func waitDBClusterRoleAssociationCreated(ctx context.Context, conn *rds.RDS, dbClusterID, roleARN string) (*rds.DBClusterRole, error) {
+func waitDBClusterRoleAssociationCreated(ctx context.Context, conn *rds.RDS, dbClusterID, roleARN string, timeout time.Duration) (*rds.DBClusterRole, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{ClusterRoleStatusPending},
-		Target:  []string{ClusterRoleStatusActive},
-		Refresh: statusDBClusterRole(ctx, conn, dbClusterID, roleARN),
-		Timeout: dbClusterRoleAssociationCreatedTimeout,
+		Pending:    []string{ClusterRoleStatusPending},
+		Target:     []string{ClusterRoleStatusActive},
+		Refresh:    statusDBClusterRole(ctx, conn, dbClusterID, roleARN),
+		Timeout:    timeout,
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
@@ -128,12 +125,14 @@ func waitDBClusterRoleAssociationCreated(ctx context.Context, conn *rds.RDS, dbC
 	return nil, err
 }
 
-func waitDBClusterRoleAssociationDeleted(ctx context.Context, conn *rds.RDS, dbClusterID, roleARN string) (*rds.DBClusterRole, error) {
+func waitDBClusterRoleAssociationDeleted(ctx context.Context, conn *rds.RDS, dbClusterID, roleARN string, timeout time.Duration) (*rds.DBClusterRole, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{ClusterRoleStatusActive, ClusterRoleStatusPending},
-		Target:  []string{},
-		Refresh: statusDBClusterRole(ctx, conn, dbClusterID, roleARN),
-		Timeout: dbClusterRoleAssociationDeletedTimeout,
+		Pending:    []string{ClusterRoleStatusActive, ClusterRoleStatusPending},
+		Target:     []string{},
+		Refresh:    statusDBClusterRole(ctx, conn, dbClusterID, roleARN),
+		Timeout:    timeout,
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)

--- a/website/docs/r/rds_cluster_role_association.html.markdown
+++ b/website/docs/r/rds_cluster_role_association.html.markdown
@@ -42,7 +42,6 @@ In addition to all arguments above, the following attributes are exported:
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
 - `create` - (Default `30m`)
-- `update` - (Default `30m`)
 - `delete` - (Default `30m`)
 
 ## Import

--- a/website/docs/r/rds_cluster_role_association.html.markdown
+++ b/website/docs/r/rds_cluster_role_association.html.markdown
@@ -37,6 +37,14 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - DB Cluster Identifier and IAM Role ARN separated by a comma (`,`)
 
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `create` - (Default `30m`)
+- `update` - (Default `30m`)
+- `delete` - (Default `30m`)
+
 ## Import
 
 `aws_rds_cluster_role_association` can be imported using the DB Cluster Identifier and IAM Role ARN separated by a comma (`,`), e.g.,

--- a/website/docs/r/rds_cluster_role_association.html.markdown
+++ b/website/docs/r/rds_cluster_role_association.html.markdown
@@ -41,8 +41,8 @@ In addition to all arguments above, the following attributes are exported:
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-- `create` - (Default `30m`)
-- `delete` - (Default `30m`)
+- `create` - (Default `10m`)
+- `delete` - (Default `10m`)
 
 ## Import
 


### PR DESCRIPTION
### Description

Added configurable timeouts for the resource `aws_rds_cluster_role_association`.

The default for Create and Delete operations is still 10 minutes (there is no Update operation for the resource).


Also, omitted the `backup_retention_period` and `preferred_backup_window` which caused the acceptance test `TestAccRDSClusterRoleAssociation_basic` to try and delete the associated IAM Role while the cluster was in "backing-up" state:
```
make testacc TESTS='TestAccRDSClusterRoleAssociation_basic' PKG=rds
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSClusterRoleAssociation_basic'  -timeout 180m
=== RUN   TestAccRDSClusterRoleAssociation_basic
=== PAUSE TestAccRDSClusterRoleAssociation_basic
=== CONT  TestAccRDSClusterRoleAssociation_basic
    testing_new.go:82: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting RDS DB Cluster (tf-acc-test-5773960513133025280) IAM Role (arn:aws:iam::531706124245:role/tf-acc-test-5773960513133025280) Association: InvalidDBClusterStateFault: DB Cluster tf-acc-test-5773960513133025280 is not available for IAM role association, disassociation, or updates. Current DB cluster status: backing-up
                status code: 400, request id: 5ccb4373-8b44-4445-b5dc-0ebc1faa9788
        
--- FAIL: TestAccRDSClusterRoleAssociation_basic (107.70s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/rds        107.773s
FAIL
make: *** [GNUmakefile:335: testacc] Error 1
```

Now the cluster resource itself in that particular acceptance test matches the one in the test `testAccClusterConfig_basic` in the file `cluster_test.go`.


### Relations

Closes #30868

### References


### Output from Acceptance Testing

```
make testacc TESTS='TestAccRDSClusterRoleAssociation_basic' PKG=rds
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSClusterRoleAssociation_basic'  -timeout 180m
=== RUN   TestAccRDSClusterRoleAssociation_basic
=== PAUSE TestAccRDSClusterRoleAssociation_basic
=== CONT  TestAccRDSClusterRoleAssociation_basic
--- PASS: TestAccRDSClusterRoleAssociation_basic (209.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        209.607s
```
