### PR TITLE
resource/aws_inspector2_enabler: Fix various errors

### DIFF
--- a/.changelog/31038.txt
+++ b/.changelog/31038.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/aws_inspector2_enabler: Correctly supports `LAMBDA` resource scanning
+```
+
+```release-note:bug
+resource/aws_inspector2_enabler: No longer calls `Disable` API for status checking
+```
+
+```release-note:bug
+resource/aws_inspector2_enabler: Correctly supports multiple accounts
+```

--- a/docs/acc-test-environment-variables.md
+++ b/docs/acc-test-environment-variables.md
@@ -58,6 +58,10 @@ Environment variables (beyond standard AWS Go SDK ones) used by acceptance testi
 | `AWS_LAMBDA_IMAGE_LATEST_ID` | ECR repository image URI (tagged as `latest`) for Lambda container image acceptance tests.
 | `AWS_LAMBDA_IMAGE_V1_ID` | ECR repository image URI (tagged as `v1`) for Lambda container image acceptance tests.
 | `AWS_LAMBDA_IMAGE_V2_ID` | ECR repository image URI (tagged as `v2`) for Lambda container image acceptance tests.
+| `AWS_THIRD_ACCESS_KEY_ID` | AWS access key ID with access to a third AWS account for tests requiring multiple accounts. Requires `AWS_THIRD_SECRET_ACCESS_KEY`. Conflicts with `AWS_THIRD_PROFILE`. |
+| `AWS_THIRD_SECRET_ACCESS_KEY` | AWS secret access key with access to a third AWS account for tests requiring multiple accounts. Requires `AWS_THIRD_ACCESS_KEY_ID`. Conflicts with `AWS_THIRD_PROFILE`. |
+| `AWS_THIRD_PROFILE` | AWS profile with access to a third AWS account for tests requiring multiple accounts. Conflicts with `AWS_THIRD_ACCESS_KEY_ID` and `AWS_THIRD_SECRET_ACCESS_KEY`. |
+| `AWS_THIRD_REGION` | Third AWS region for tests requiring multiple regions. Defaults to `us-east-2`. |
 | `DX_CONNECTION_ID` | Identifier for Direct Connect Connection testing. |
 | `DX_VIRTUAL_INTERFACE_ID` | Identifier for Direct Connect Virtual Interface testing. |
 | `EC2_SECURITY_GROUP_RULES_PER_GROUP_LIMIT` | EC2 Quota for Rules per Security Group. Defaults to 50. **DEPRECATED:** Can be augmented or replaced with Service Quotas lookup. |

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -252,8 +252,8 @@ func PreCheck(ctx context.Context, t *testing.T) {
 	})
 }
 
-// providerAccountID returns the account ID of an AWS provider
-func providerAccountID(provo *schema.Provider) string {
+// ProviderAccountID returns the account ID of an AWS provider
+func ProviderAccountID(provo *schema.Provider) string {
 	if provo == nil {
 		log.Print("[DEBUG] Unable to read account ID from test provider: empty provider")
 		return ""
@@ -717,7 +717,7 @@ func PrimaryInstanceState(s *terraform.State, name string) (*terraform.InstanceS
 // AccountID returns the account ID of Provider
 // Must be used within a resource.TestCheckFunc
 func AccountID() string {
-	return providerAccountID(Provider)
+	return ProviderAccountID(Provider)
 }
 
 func Region() string {

--- a/internal/envvar/envvar.go
+++ b/internal/envvar/envvar.go
@@ -45,8 +45,17 @@ const (
 	// For tests using an alternate AWS account, the equivalent of AWS_SECRET_ACCESS_KEY for that account
 	AlternateSecretAccessKey = "AWS_ALTERNATE_SECRET_ACCESS_KEY"
 
+	// For tests using a third AWS account, the equivalent of AWS_ACCESS_KEY_ID for that account
+	ThirdAccessKeyId = "AWS_THIRD_ACCESS_KEY_ID"
+
+	// For tests using a third AWS account, the equivalent of AWS_PROFILE for that account
+	ThirdProfile = "AWS_THIRD_PROFILE"
+
 	// For tests using a third AWS region, the equivalent of AWS_DEFAULT_REGION for that region
 	ThirdRegion = "AWS_THIRD_REGION"
+
+	// For tests using a third AWS account, the equivalent of AWS_SECRET_ACCESS_KEY for that account
+	ThirdSecretAccessKey = "AWS_THIRD_SECRET_ACCESS_KEY"
 
 	// For tests requiring GitHub permissions
 	GithubToken = "GITHUB_TOKEN"

--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -54,7 +54,7 @@ func FlattenStringList(list []*string) []interface{} {
 	return vs
 }
 
-// Takes list of pointers to strings. Expand to an array
+// Takes list of strings. Expand to an array
 // of raw strings and returns a []interface{}
 // to keep compatibility w/ schema.NewSetschema.NewSet
 func FlattenStringValueList(list []string) []interface{} {

--- a/internal/service/inspector2/acc_test.go
+++ b/internal/service/inspector2/acc_test.go
@@ -1,0 +1,26 @@
+package inspector2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/inspector2"
+	"github.com/aws/aws-sdk-go-v2/service/inspector2/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+)
+
+func testAccPreCheck(ctx context.Context, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).Inspector2Client()
+
+	_, err := conn.ListDelegatedAdminAccounts(ctx, &inspector2.ListDelegatedAdminAccountsInput{})
+
+	if errs.IsA[*types.AccessDeniedException](err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}

--- a/internal/service/inspector2/delegated_admin_account_test.go
+++ b/internal/service/inspector2/delegated_admin_account_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/service/inspector2"
 	"github.com/aws/aws-sdk-go-v2/service/inspector2/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -142,20 +141,6 @@ func testAccCheckDelegatedAdminAccountExists(ctx context.Context, name string) r
 		}
 
 		return nil
-	}
-}
-
-func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).Inspector2Client()
-
-	_, err := conn.ListDelegatedAdminAccounts(ctx, &inspector2.ListDelegatedAdminAccountsInput{})
-
-	if errs.IsA[*types.AccessDeniedException](err) {
-		t.Skipf("skipping acceptance testing: %s", err)
-	}
-
-	if err != nil {
-		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 

--- a/internal/service/inspector2/enabler.go
+++ b/internal/service/inspector2/enabler.go
@@ -38,9 +38,9 @@ func ResourceEnabler() *schema.Resource {
 		DeleteWithoutTimeout: resourceEnablerDelete,
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(15 * time.Minute),
-			Update: schema.DefaultTimeout(15 * time.Minute),
-			Delete: schema.DefaultTimeout(15 * time.Minute),
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/internal/service/inspector2/enabler.go
+++ b/internal/service/inspector2/enabler.go
@@ -211,15 +211,6 @@ func statusEnablerAccount(ctx context.Context, conn *inspector2.Client, id strin
 	}
 }
 
-func All[T any](s []T, f tfslices.FilterFunc[T]) bool {
-	for _, e := range s {
-		if !f(e) {
-			return false
-		}
-	}
-	return true
-}
-
 func statusEnable(ctx context.Context, conn *inspector2.Client, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		st, err := FindAccountStatuses(ctx, conn, id)

--- a/internal/service/inspector2/enabler.go
+++ b/internal/service/inspector2/enabler.go
@@ -72,6 +72,7 @@ const (
 )
 
 func resourceEnablerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Inspector2Client()
 
 	in := &inspector2.EnableInput{
@@ -84,20 +85,20 @@ func resourceEnablerCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	out, err := conn.Enable(ctx, in)
 	if err != nil {
-		return create.DiagError(names.Inspector2, create.ErrActionCreating, ResNameEnabler, id, err)
+		return append(diags, create.DiagError(names.Inspector2, create.ErrActionCreating, ResNameEnabler, id, err)...)
 	}
 
 	if out == nil {
-		return create.DiagError(names.Inspector2, create.ErrActionCreating, ResNameEnabler, id, errors.New("empty output"))
+		return append(diags, create.DiagError(names.Inspector2, create.ErrActionCreating, ResNameEnabler, id, errors.New("empty output"))...)
 	}
 
 	d.SetId(id)
 
 	if err := waitEnabled(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.Inspector2, create.ErrActionWaitingForCreation, ResNameEnabler, d.Id(), err)
+		return append(diags, create.DiagError(names.Inspector2, create.ErrActionWaitingForCreation, ResNameEnabler, d.Id(), err)...)
 	}
 
-	return resourceEnablerRead(ctx, d, meta)
+	return append(diags, resourceEnablerRead(ctx, d, meta)...)
 }
 
 func resourceEnablerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -139,10 +140,11 @@ func resourceEnablerRead(ctx context.Context, d *schema.ResourceData, meta inter
 		return append(diags, create.DiagError(names.Inspector2, create.ErrActionReading, ResNameEnabler, d.Id(), err)...)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceEnablerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Inspector2Client()
 
 	var enable, disable []types.ResourceScanType
@@ -166,11 +168,11 @@ func resourceEnablerUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		_, err := conn.Enable(ctx, in)
 		if err != nil {
-			return create.DiagError(names.Inspector2, create.ErrActionUpdating, ResNameEnabler, id, err)
+			return append(diags, create.DiagError(names.Inspector2, create.ErrActionUpdating, ResNameEnabler, id, err)...)
 		}
 
 		if err := waitEnabled(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-			return create.DiagError(names.Inspector2, create.ErrActionWaitingForUpdate, ResNameEnabler, d.Id(), err)
+			return append(diags, create.DiagError(names.Inspector2, create.ErrActionWaitingForUpdate, ResNameEnabler, d.Id(), err)...)
 		}
 	}
 
@@ -181,20 +183,21 @@ func resourceEnablerUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 		_, err := conn.Disable(ctx, in)
 		if err != nil {
-			return create.DiagError(names.Inspector2, create.ErrActionUpdating, ResNameEnabler, id, err)
+			return append(diags, create.DiagError(names.Inspector2, create.ErrActionUpdating, ResNameEnabler, id, err)...)
 		}
 	}
 
 	d.SetId(id)
 
 	if err := waitEnabled(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.Inspector2, create.ErrActionWaitingForUpdate, ResNameEnabler, d.Id(), err)
+		return append(diags, create.DiagError(names.Inspector2, create.ErrActionWaitingForUpdate, ResNameEnabler, d.Id(), err)...)
 	}
 
-	return resourceEnablerRead(ctx, d, meta)
+	return append(diags, resourceEnablerRead(ctx, d, meta)...)
 }
 
 func resourceEnablerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Inspector2Client()
 
 	in := &inspector2.DisableInput{
@@ -204,14 +207,14 @@ func resourceEnablerDelete(ctx context.Context, d *schema.ResourceData, meta int
 
 	_, err := conn.Disable(ctx, in)
 	if err != nil {
-		return create.DiagError(names.Inspector2, create.ErrActionDeleting, ResNameEnabler, d.Id(), err)
+		return append(diags, create.DiagError(names.Inspector2, create.ErrActionDeleting, ResNameEnabler, d.Id(), err)...)
 	}
 
 	if err := waitDisabled(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.Inspector2, create.ErrActionWaitingForDeletion, ResNameEnabler, d.Id(), err)
+		return append(diags, create.DiagError(names.Inspector2, create.ErrActionWaitingForDeletion, ResNameEnabler, d.Id(), err)...)
 	}
 
-	return nil
+	return diags
 }
 
 const (

--- a/internal/service/inspector2/enabler.go
+++ b/internal/service/inspector2/enabler.go
@@ -73,7 +73,7 @@ func ResourceEnabler() *schema.Resource {
 					client := meta.(*conns.AWSClient)
 
 					if slices.Contains(accountIDs, client.AccountID) {
-						return fmt.Errorf(`"account_ids" can contain either the administrator account or one or more member accounts. Contains the administrator account and %d other accounts`, l-1)
+						return fmt.Errorf(`"account_ids" can contain either the administrator account or one or more member accounts. Contains %v`, accountIDs)
 					}
 				}
 				return nil

--- a/internal/service/inspector2/enabler_test.go
+++ b/internal/service/inspector2/enabler_test.go
@@ -34,12 +34,12 @@ func testAccEnabler_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEnablerConfig_basic([]string{"ECR"}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEnablerExists(ctx, []string{"ECR"}),
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.*", "data.aws_caller_identity.current", "account_id"),
 					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_types.0", "ECR"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", "ECR"),
 				),
 			},
 		},
@@ -63,10 +63,10 @@ func testAccEnabler_accountID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEnablerConfig_basic([]string{"EC2", "ECR"}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEnablerExists(ctx, []string{"EC2", "ECR"}),
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
 					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "resource_types.0", "EC2"),
 					resource.TestCheckResourceAttr(resourceName, "resource_types.1", "ECR"),
@@ -93,7 +93,7 @@ func testAccEnabler_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEnablerConfig_basic([]string{"ECR"}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEnablerExists(ctx, []string{"ECR"}),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfinspector2.ResourceEnabler(), resourceName),
 				),
@@ -120,20 +120,20 @@ func testAccEnabler_updateResourceTypes(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEnablerConfig_basic([]string{"EC2"}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEnablerExists(ctx, []string{"EC2"}),
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
 					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "resource_types.0", "EC2"),
 				),
 			},
 			{
 				Config: testAccEnablerConfig_basic([]string{"ECR"}),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEnablerExists(ctx, []string{"ECR"}),
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
 					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "resource_types.0", "ECR"),
 				),

--- a/internal/service/inspector2/enabler_test.go
+++ b/internal/service/inspector2/enabler_test.go
@@ -76,8 +76,8 @@ func testAccEnabler_accountID(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
 					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "resource_types.0", "EC2"),
-					resource.TestCheckResourceAttr(resourceName, "resource_types.1", "ECR"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", "EC2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", "ECR"),
 				),
 			},
 		},
@@ -118,6 +118,63 @@ func testAccEnabler_updateResourceTypes(t *testing.T) {
 
 	resourceName := "aws_inspector2_enabler.test"
 	originalResourceTypes := []types.ResourceScanType{"EC2"}
+	update1ResourceTypes := []types.ResourceScanType{"EC2", "ECR"}
+	update2ResourceTypes := []types.ResourceScanType{"ECR"}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Inspector2EndpointID)
+			testAccPreCheck(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnablerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnablerConfig_basic(originalResourceTypes),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEnablerExists(ctx, originalResourceTypes),
+					testAccCheckEnablerID(resourceName, originalResourceTypes),
+					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", "EC2"),
+				),
+			},
+			{
+				Config: testAccEnablerConfig_basic(update1ResourceTypes),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEnablerExists(ctx, update1ResourceTypes),
+					testAccCheckEnablerID(resourceName, update1ResourceTypes),
+					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", "EC2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", "ECR"),
+				),
+			},
+			{
+				Config: testAccEnablerConfig_basic(update2ResourceTypes),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEnablerExists(ctx, update2ResourceTypes),
+					testAccCheckEnablerID(resourceName, update2ResourceTypes),
+					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", "ECR"),
+				),
+			},
+		},
+	})
+}
+
+func testAccEnabler_updateResourceTypes_disjoint(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_inspector2_enabler.test"
+	originalResourceTypes := []types.ResourceScanType{"EC2"}
 	updatedResourceTypes := []types.ResourceScanType{"ECR"}
 
 	resource.Test(t, resource.TestCase{
@@ -139,7 +196,7 @@ func testAccEnabler_updateResourceTypes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
 					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_types.0", "EC2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", "EC2"),
 				),
 			},
 			{
@@ -150,7 +207,7 @@ func testAccEnabler_updateResourceTypes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
 					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_types.0", "ECR"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", "ECR"),
 				),
 			},
 		},

--- a/internal/service/inspector2/enabler_test.go
+++ b/internal/service/inspector2/enabler_test.go
@@ -103,6 +103,45 @@ func testAccEnabler_disappears(t *testing.T) {
 	})
 }
 
+func testAccEnabler_updateResourceTypes(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_inspector2_enabler.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Inspector2EndpointID)
+			testAccPreCheck(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnablerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnablerConfig_basic([]string{"EC2"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnablerExists(ctx, []string{"EC2"}),
+					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.0", "EC2"),
+				),
+			},
+			{
+				Config: testAccEnablerConfig_basic([]string{"ECR"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnablerExists(ctx, []string{"ECR"}),
+					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.0", "ECR"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckEnablerDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		id := ""

--- a/internal/service/inspector2/enabler_test.go
+++ b/internal/service/inspector2/enabler_test.go
@@ -41,7 +41,7 @@ func testAccEnabler_basic(t *testing.T) {
 			{
 				Config: testAccEnablerConfig_basic(resourceTypes),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckEnablerExists(ctx, resourceTypes),
+					testAccCheckEnablerExists(ctx, resourceName, resourceTypes),
 					testAccCheckEnablerID(resourceName, resourceTypes),
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.*", "data.aws_caller_identity.current", "account_id"),
@@ -73,7 +73,7 @@ func testAccEnabler_accountID(t *testing.T) {
 			{
 				Config: testAccEnablerConfig_basic(resourceTypes),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckEnablerExists(ctx, resourceTypes),
+					testAccCheckEnablerExists(ctx, resourceName, resourceTypes),
 					testAccCheckEnablerID(resourceName, resourceTypes),
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
@@ -106,7 +106,7 @@ func testAccEnabler_disappears(t *testing.T) {
 			{
 				Config: testAccEnablerConfig_basic(resourceTypes),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckEnablerExists(ctx, resourceTypes),
+					testAccCheckEnablerExists(ctx, resourceName, resourceTypes),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfinspector2.ResourceEnabler(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -137,7 +137,7 @@ func testAccEnabler_updateResourceTypes(t *testing.T) {
 			{
 				Config: testAccEnablerConfig_basic(originalResourceTypes),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckEnablerExists(ctx, originalResourceTypes),
+					testAccCheckEnablerExists(ctx, resourceName, originalResourceTypes),
 					testAccCheckEnablerID(resourceName, originalResourceTypes),
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
@@ -148,7 +148,7 @@ func testAccEnabler_updateResourceTypes(t *testing.T) {
 			{
 				Config: testAccEnablerConfig_basic(update1ResourceTypes),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckEnablerExists(ctx, update1ResourceTypes),
+					testAccCheckEnablerExists(ctx, resourceName, update1ResourceTypes),
 					testAccCheckEnablerID(resourceName, update1ResourceTypes),
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
@@ -160,7 +160,7 @@ func testAccEnabler_updateResourceTypes(t *testing.T) {
 			{
 				Config: testAccEnablerConfig_basic(update2ResourceTypes),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckEnablerExists(ctx, update2ResourceTypes),
+					testAccCheckEnablerExists(ctx, resourceName, update2ResourceTypes),
 					testAccCheckEnablerID(resourceName, update2ResourceTypes),
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
@@ -193,7 +193,7 @@ func testAccEnabler_updateResourceTypes_disjoint(t *testing.T) {
 			{
 				Config: testAccEnablerConfig_basic(originalResourceTypes),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckEnablerExists(ctx, originalResourceTypes),
+					testAccCheckEnablerExists(ctx, resourceName, originalResourceTypes),
 					testAccCheckEnablerID(resourceName, originalResourceTypes),
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
@@ -204,7 +204,7 @@ func testAccEnabler_updateResourceTypes_disjoint(t *testing.T) {
 			{
 				Config: testAccEnablerConfig_basic(updatedResourceTypes),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckEnablerExists(ctx, updatedResourceTypes),
+					testAccCheckEnablerExists(ctx, resourceName, updatedResourceTypes),
 					testAccCheckEnablerID(resourceName, updatedResourceTypes),
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
@@ -236,7 +236,7 @@ func testAccEnabler_lambda(t *testing.T) {
 			{
 				Config: testAccEnablerConfig_basic(resourceTypes),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckEnablerExists(ctx, resourceTypes),
+					testAccCheckEnablerExists(ctx, resourceName, resourceTypes),
 					testAccCheckEnablerID(resourceName, resourceTypes),
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.*", "data.aws_caller_identity.current", "account_id"),
@@ -271,7 +271,7 @@ func testAccEnabler_memberAccount_basic(t *testing.T) {
 			{
 				Config: testAccEnablerConfig_MemberAccount(resourceTypes),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckEnablerExistsProvider(ctx, resourceTypes, acctest.NamedProviderFunc(acctest.ProviderNameAlternate, providers)),
+					testAccCheckEnablerExists(ctx, resourceName, resourceTypes),
 					testAccCheckEnablerIDProvider(resourceName, resourceTypes, acctest.NamedProviderFunc(acctest.ProviderNameAlternate, providers)),
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.*", "data.aws_caller_identity.member", "account_id"),
@@ -307,7 +307,7 @@ func testAccEnabler_memberAccount_multiple(t *testing.T) {
 			{
 				Config: testAccEnablerConfig_MemberAccount_Multiple(t, resourceTypes),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckEnablerExistsProvider(ctx, resourceTypes, acctest.NamedProviderFunc(acctest.ProviderNameAlternate, providers)),
+					testAccCheckEnablerExists(ctx, resourceName, resourceTypes),
 					testAccCheckEnablerIDProvider(resourceName, resourceTypes,
 						acctest.NamedProviderFunc(acctest.ProviderNameAlternate, providers),
 						acctest.NamedProviderFunc(acctest.ProviderNameThird, providers),
@@ -364,22 +364,28 @@ func testAccCheckEnablerDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckEnablerExists(ctx context.Context, t []types.ResourceScanType) resource.TestCheckFunc {
-	return testAccCheckEnablerExistsProvider(ctx, t, func() *schema.Provider { return acctest.Provider })
-}
-
-func testAccCheckEnablerExistsProvider(ctx context.Context, t []types.ResourceScanType, providerF func() *schema.Provider) resource.TestCheckFunc {
+func testAccCheckEnablerExists(ctx context.Context, name string, t []types.ResourceScanType) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		// This is using `acctest.Provider`, as the resource is created in the primary account,
-		// using the account ID of the secondary account
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.Inspector2, create.ErrActionCheckingExistence, tfinspector2.ResNameEnabler, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.Inspector2, create.ErrActionCheckingExistence, tfinspector2.ResNameEnabler, name, errors.New("not set"))
+		}
+
 		conn := acctest.Provider.Meta().(*conns.AWSClient).Inspector2Client()
 
-		accountID := acctest.ProviderAccountID(providerF())
-		accountIDs := []string{accountID}
+		accountIDs, _, err := tfinspector2.ParseEnablerID(rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.Inspector2, create.ErrActionCheckingExistence, tfinspector2.ResNameEnabler, name, err)
+		}
+
 		id := tfinspector2.EnablerID(accountIDs, t)
 		st, err := tfinspector2.AccountStatuses(ctx, conn, accountIDs)
 		if err != nil {
-			return create.Error(names.Inspector2, create.ErrActionCheckingExistence, tfinspector2.ResNameEnabler, id, err)
+			return create.Error(names.Inspector2, create.ErrActionCheckingExistence, tfinspector2.ResNameEnabler, name, err)
 		}
 
 		for k, s := range st {

--- a/internal/service/inspector2/enabler_test.go
+++ b/internal/service/inspector2/enabler_test.go
@@ -23,7 +23,7 @@ func testAccEnabler_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName := "aws_inspector2_enabler.test"
-	resourceTypes := []types.ResourceScanType{"ECR"}
+	resourceTypes := []types.ResourceScanType{types.ResourceScanTypeEcr}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -44,7 +44,7 @@ func testAccEnabler_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.*", "data.aws_caller_identity.current", "account_id"),
 					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", "ECR"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeEcr)),
 				),
 			},
 		},
@@ -55,7 +55,7 @@ func testAccEnabler_accountID(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName := "aws_inspector2_enabler.test"
-	resourceTypes := []types.ResourceScanType{"EC2", "ECR"}
+	resourceTypes := []types.ResourceScanType{types.ResourceScanTypeEc2, types.ResourceScanTypeEcr}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -76,8 +76,8 @@ func testAccEnabler_accountID(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
 					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "2"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", "EC2"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", "ECR"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeEc2)),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeEcr)),
 				),
 			},
 		},
@@ -88,7 +88,7 @@ func testAccEnabler_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName := "aws_inspector2_enabler.test"
-	resourceTypes := []types.ResourceScanType{"ECR"}
+	resourceTypes := []types.ResourceScanType{types.ResourceScanTypeEcr}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -117,9 +117,9 @@ func testAccEnabler_updateResourceTypes(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName := "aws_inspector2_enabler.test"
-	originalResourceTypes := []types.ResourceScanType{"EC2"}
-	update1ResourceTypes := []types.ResourceScanType{"EC2", "ECR"}
-	update2ResourceTypes := []types.ResourceScanType{"ECR"}
+	originalResourceTypes := []types.ResourceScanType{types.ResourceScanTypeEc2}
+	update1ResourceTypes := []types.ResourceScanType{types.ResourceScanTypeEc2, types.ResourceScanTypeLambda}
+	update2ResourceTypes := []types.ResourceScanType{types.ResourceScanTypeLambda}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -140,7 +140,7 @@ func testAccEnabler_updateResourceTypes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
 					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", "EC2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeEc2)),
 				),
 			},
 			{
@@ -151,8 +151,8 @@ func testAccEnabler_updateResourceTypes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
 					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "2"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", "EC2"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", "ECR"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeEc2)),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeLambda)),
 				),
 			},
 			{
@@ -163,7 +163,7 @@ func testAccEnabler_updateResourceTypes(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
 					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", "ECR"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeLambda)),
 				),
 			},
 		},
@@ -174,8 +174,8 @@ func testAccEnabler_updateResourceTypes_disjoint(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName := "aws_inspector2_enabler.test"
-	originalResourceTypes := []types.ResourceScanType{"EC2"}
-	updatedResourceTypes := []types.ResourceScanType{"ECR"}
+	originalResourceTypes := []types.ResourceScanType{types.ResourceScanTypeEc2}
+	updatedResourceTypes := []types.ResourceScanType{types.ResourceScanTypeEcr}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -196,7 +196,7 @@ func testAccEnabler_updateResourceTypes_disjoint(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
 					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", "EC2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeEc2)),
 				),
 			},
 			{
@@ -207,7 +207,39 @@ func testAccEnabler_updateResourceTypes_disjoint(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.0", "data.aws_caller_identity.current", "account_id"),
 					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", "ECR"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeEcr)),
+				),
+			},
+		},
+	})
+}
+
+func testAccEnabler_lambda(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_inspector2_enabler.test"
+	resourceTypes := []types.ResourceScanType{types.ResourceScanTypeLambda}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Inspector2EndpointID)
+			testAccPreCheck(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnablerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnablerConfig_basic(resourceTypes),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEnablerExists(ctx, resourceTypes),
+					testAccCheckEnablerID(resourceName, resourceTypes),
+					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.*", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeLambda)),
 				),
 			},
 		},

--- a/internal/service/inspector2/enabler_test.go
+++ b/internal/service/inspector2/enabler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	tfinspector2 "github.com/hashicorp/terraform-provider-aws/internal/service/inspector2"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -283,6 +284,38 @@ func testAccEnabler_memberAccount_basic(t *testing.T) {
 	})
 }
 
+func testAccEnabler_memberAccount_disappearsMemberAssociation(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_inspector2_enabler.member"
+	resourceTypes := []types.ResourceScanType{types.ResourceScanTypeEcr}
+
+	providers := make(map[string]*schema.Provider)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Inspector2EndpointID)
+			testAccPreCheck(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesNamedAlternate(ctx, t, providers),
+		CheckDestroy:             testAccCheckEnablerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnablerConfig_MemberAccount(resourceTypes),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEnablerExists(ctx, resourceName, resourceTypes),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfinspector2.ResourceMemberAssociation(), "aws_inspector2_member_association.member"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccEnabler_memberAccount_multiple(t *testing.T) {
 	ctx := acctest.Context(t)
 
@@ -323,44 +356,176 @@ func testAccEnabler_memberAccount_multiple(t *testing.T) {
 	})
 }
 
+func testAccEnabler_memberAccount_updateMemberAccounts(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_inspector2_enabler.members"
+	resourceTypes := []types.ResourceScanType{types.ResourceScanTypeEcr}
+
+	providers := make(map[string]*schema.Provider)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Inspector2EndpointID)
+			testAccPreCheck(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+			acctest.PreCheckThirdAccount(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesNamed(ctx, t, providers, acctest.ProviderName, acctest.ProviderNameAlternate, acctest.ProviderNameThird),
+		CheckDestroy:             testAccCheckEnablerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnablerConfig_MemberAccount_UpdateMemberAccountsAlternate(t, resourceTypes),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEnablerExists(ctx, resourceName, resourceTypes),
+					testAccCheckEnablerIDProvider(resourceName, resourceTypes,
+						acctest.NamedProviderFunc(acctest.ProviderNameAlternate, providers),
+					),
+					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.*", "data.aws_caller_identity.alternate", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeEcr)),
+				),
+			},
+			{
+				Config: testAccEnablerConfig_MemberAccount_UpdateMemberAccountsMultiple(t, resourceTypes),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEnablerExists(ctx, resourceName, resourceTypes),
+					testAccCheckEnablerIDProvider(resourceName, resourceTypes,
+						acctest.NamedProviderFunc(acctest.ProviderNameAlternate, providers),
+						acctest.NamedProviderFunc(acctest.ProviderNameThird, providers),
+					),
+					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "2"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.*", "data.aws_caller_identity.alternate", "account_id"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.*", "data.aws_caller_identity.third", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeEcr)),
+				),
+			},
+			{
+				Config: testAccEnablerConfig_MemberAccount_UpdateMemberAccountsThird(t, resourceTypes),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEnablerExists(ctx, resourceName, resourceTypes),
+					testAccCheckEnablerIDProvider(resourceName, resourceTypes,
+						acctest.NamedProviderFunc(acctest.ProviderNameThird, providers),
+					),
+					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.*", "data.aws_caller_identity.third", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeEcr)),
+				),
+			},
+		},
+	})
+}
+
+func testAccEnabler_memberAccount_updateMemberAccountsAndScanTypes(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_inspector2_enabler.members"
+	originalResourceTypes := []types.ResourceScanType{types.ResourceScanTypeEc2}
+	update1ResourceTypes := []types.ResourceScanType{types.ResourceScanTypeEc2, types.ResourceScanTypeLambda}
+	update2ResourceTypes := []types.ResourceScanType{types.ResourceScanTypeLambda}
+
+	providers := make(map[string]*schema.Provider)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.Inspector2EndpointID)
+			testAccPreCheck(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+			acctest.PreCheckThirdAccount(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2EndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesNamed(ctx, t, providers, acctest.ProviderName, acctest.ProviderNameAlternate, acctest.ProviderNameThird),
+		CheckDestroy:             testAccCheckEnablerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnablerConfig_MemberAccount_UpdateMemberAccountsAlternate(t, originalResourceTypes),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEnablerExists(ctx, resourceName, originalResourceTypes),
+					testAccCheckEnablerIDProvider(resourceName, originalResourceTypes,
+						acctest.NamedProviderFunc(acctest.ProviderNameAlternate, providers),
+					),
+					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.*", "data.aws_caller_identity.alternate", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeEc2)),
+				),
+			},
+			{
+				Config: testAccEnablerConfig_MemberAccount_UpdateMemberAccountsMultiple(t, update1ResourceTypes),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEnablerExists(ctx, resourceName, update1ResourceTypes),
+					testAccCheckEnablerIDProvider(resourceName, update1ResourceTypes,
+						acctest.NamedProviderFunc(acctest.ProviderNameAlternate, providers),
+						acctest.NamedProviderFunc(acctest.ProviderNameThird, providers),
+					),
+					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "2"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.*", "data.aws_caller_identity.alternate", "account_id"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.*", "data.aws_caller_identity.third", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeEc2)),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeLambda)),
+				),
+			},
+			{
+				Config: testAccEnablerConfig_MemberAccount_UpdateMemberAccountsThird(t, update2ResourceTypes),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckEnablerExists(ctx, resourceName, update2ResourceTypes),
+					testAccCheckEnablerIDProvider(resourceName, update2ResourceTypes,
+						acctest.NamedProviderFunc(acctest.ProviderNameThird, providers),
+					),
+					resource.TestCheckResourceAttr(resourceName, "account_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "account_ids.*", "data.aws_caller_identity.third", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "resource_types.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "resource_types.*", string(types.ResourceScanTypeLambda)),
+				),
+				// PlanOnly: true,
+			},
+		},
+	})
+}
+
 func testAccCheckEnablerDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		id := ""
+		conn := acctest.Provider.Meta().(*conns.AWSClient).Inspector2Client()
+
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_inspector2_enabler" {
 				continue
 			}
 
-			id = rs.Primary.ID
-			break
-		}
+			accountIDs, _, err := tfinspector2.ParseEnablerID(rs.Primary.ID)
+			if err != nil {
+				return create.Error(names.Inspector2, create.ErrActionCheckingDestroyed, tfinspector2.ResNameEnabler, rs.Primary.ID, err)
+			}
 
-		if id == "" {
-			return create.Error(names.Inspector2, create.ErrActionCheckingDestroyed, tfinspector2.ResNameEnabler, id, errors.New("not in state"))
-		}
+			st, err := tfinspector2.AccountStatuses(ctx, conn, accountIDs)
+			if tfresource.NotFound(err) {
+				continue
+			}
+			if err != nil {
+				return create.Error(names.Inspector2, create.ErrActionCheckingDestroyed, tfinspector2.ResNameEnabler, rs.Primary.ID, err)
+			}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).Inspector2Client()
-
-		accountIDs, _, err := tfinspector2.ParseEnablerID(id)
-		if err != nil {
-			return create.Error(names.Inspector2, create.ErrActionCheckingDestroyed, tfinspector2.ResNameEnabler, id, err)
-		}
-
-		st, err := tfinspector2.AccountStatuses(ctx, conn, accountIDs)
-		if err != nil {
-			return create.Error(names.Inspector2, create.ErrActionCheckingDestroyed, tfinspector2.ResNameEnabler, id, err)
-		}
-
-		for k, v := range st {
-			if v.Status != types.StatusDisabled {
-				err = multierror.Append(err,
-					create.Error(names.Inspector2, create.ErrActionCheckingDestroyed, tfinspector2.ResNameEnabler, id,
-						fmt.Errorf("after destroy, expected DISABLED for account %s, got: %s", k, v),
-					),
-				)
+			for k, v := range st {
+				if v.Status != types.StatusDisabled {
+					err = multierror.Append(err,
+						create.Error(names.Inspector2, create.ErrActionCheckingDestroyed, tfinspector2.ResNameEnabler, rs.Primary.ID,
+							fmt.Errorf("after destroy, expected DISABLED for account %s, got: %s", k, v),
+						),
+					)
+				}
 			}
 		}
-		return err
+
+		return nil
 	}
 }
 
@@ -473,6 +638,125 @@ data "aws_caller_identity" "third" {
 locals {
   member_account_ids = [
     data.aws_caller_identity.alternate.account_id,
+    data.aws_caller_identity.third.account_id,
+  ]
+}
+
+resource "aws_inspector2_enabler" "members" {
+  account_ids    = local.member_account_ids
+  resource_types = ["%[1]s"]
+
+  depends_on = [aws_inspector2_member_association.members]
+}
+
+resource "aws_inspector2_member_association" "members" {
+  count = length(local.member_account_ids)
+
+  account_id = local.member_account_ids[count.index]
+
+  depends_on = [aws_inspector2_delegated_admin_account.test]
+}
+
+resource "aws_inspector2_delegated_admin_account" "test" {
+  account_id = data.aws_caller_identity.current.account_id
+}
+`, strings.Join(enum.Slice(types...), `", "`)),
+	)
+}
+
+func testAccEnablerConfig_MemberAccount_UpdateMemberAccountsAlternate(t *testing.T, types []types.ResourceScanType) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleAccountProvider(t, 3),
+		fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_caller_identity" "alternate" {
+  provider = "awsalternate"
+}
+
+locals {
+  member_account_ids = [
+    data.aws_caller_identity.alternate.account_id,
+  ]
+}
+
+resource "aws_inspector2_enabler" "members" {
+  account_ids    = local.member_account_ids
+  resource_types = ["%[1]s"]
+
+  depends_on = [aws_inspector2_member_association.members]
+}
+
+resource "aws_inspector2_member_association" "members" {
+  count = length(local.member_account_ids)
+
+  account_id = local.member_account_ids[count.index]
+
+  depends_on = [aws_inspector2_delegated_admin_account.test]
+}
+
+resource "aws_inspector2_delegated_admin_account" "test" {
+  account_id = data.aws_caller_identity.current.account_id
+}
+`, strings.Join(enum.Slice(types...), `", "`)),
+	)
+}
+
+func testAccEnablerConfig_MemberAccount_UpdateMemberAccountsMultiple(t *testing.T, types []types.ResourceScanType) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleAccountProvider(t, 3),
+		fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_caller_identity" "alternate" {
+  provider = "awsalternate"
+}
+
+data "aws_caller_identity" "third" {
+  provider = "awsthird"
+}
+
+locals {
+  member_account_ids = [
+    data.aws_caller_identity.alternate.account_id,
+    data.aws_caller_identity.third.account_id,
+  ]
+}
+
+resource "aws_inspector2_enabler" "members" {
+  account_ids    = local.member_account_ids
+  resource_types = ["%[1]s"]
+
+  depends_on = [aws_inspector2_member_association.members]
+}
+
+resource "aws_inspector2_member_association" "members" {
+  count = length(local.member_account_ids)
+
+  account_id = local.member_account_ids[count.index]
+
+  depends_on = [aws_inspector2_delegated_admin_account.test]
+}
+
+resource "aws_inspector2_delegated_admin_account" "test" {
+  account_id = data.aws_caller_identity.current.account_id
+}
+`, strings.Join(enum.Slice(types...), `", "`)),
+	)
+}
+
+func testAccEnablerConfig_MemberAccount_UpdateMemberAccountsThird(t *testing.T, types []types.ResourceScanType) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleAccountProvider(t, 3),
+		fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_caller_identity" "third" {
+  provider = "awsthird"
+}
+
+locals {
+  member_account_ids = [
     data.aws_caller_identity.third.account_id,
   ]
 }

--- a/internal/service/inspector2/exports_test.go
+++ b/internal/service/inspector2/exports_test.go
@@ -1,0 +1,7 @@
+package inspector2
+
+// Exports for use in tests only.
+var (
+	EnablerID      = enablerID
+	ParseEnablerID = parseEnablerID
+)

--- a/internal/service/inspector2/inspector2_test.go
+++ b/internal/service/inspector2/inspector2_test.go
@@ -11,9 +11,10 @@ func TestAccInspector2_serial(t *testing.T) {
 
 	testCases := map[string]map[string]func(t *testing.T){
 		"Enabler": {
-			"basic":      testAccEnabler_basic,
-			"accountID":  testAccEnabler_accountID,
-			"disappears": testAccEnabler_disappears,
+			"basic":               testAccEnabler_basic,
+			"accountID":           testAccEnabler_accountID,
+			"disappears":          testAccEnabler_disappears,
+			"updateResourceTypes": testAccEnabler_updateResourceTypes,
 		},
 		"DelegatedAdminAccount": {
 			"basic":      testAccDelegatedAdminAccount_basic,

--- a/internal/service/inspector2/inspector2_test.go
+++ b/internal/service/inspector2/inspector2_test.go
@@ -11,14 +11,17 @@ func TestAccInspector2_serial(t *testing.T) {
 
 	testCases := map[string]map[string]func(t *testing.T){
 		"Enabler": {
-			"basic":                        testAccEnabler_basic,
-			"accountID":                    testAccEnabler_accountID,
-			"disappears":                   testAccEnabler_disappears,
-			"lambda":                       testAccEnabler_lambda,
-			"updateResourceTypes":          testAccEnabler_updateResourceTypes,
-			"updateResourceTypes_disjoint": testAccEnabler_updateResourceTypes_disjoint,
-			"memberAccount_basic":          testAccEnabler_memberAccount_basic,
-			"memberAccount_multiple":       testAccEnabler_memberAccount_multiple,
+			"basic":                              testAccEnabler_basic,
+			"accountID":                          testAccEnabler_accountID,
+			"disappears":                         testAccEnabler_disappears,
+			"lambda":                             testAccEnabler_lambda,
+			"updateResourceTypes":                testAccEnabler_updateResourceTypes,
+			"updateResourceTypes_disjoint":       testAccEnabler_updateResourceTypes_disjoint,
+			"memberAccount_basic":                testAccEnabler_memberAccount_basic,
+			"memberAccount_multiple":             testAccEnabler_memberAccount_multiple,
+			"memberAccount_updateMemberAccounts": testAccEnabler_memberAccount_updateMemberAccounts,
+			"memberAccount_updateMemberAccountsAndScanTypes": testAccEnabler_memberAccount_updateMemberAccountsAndScanTypes,
+			"memberAccount_disappearsMemberAssociation":      testAccEnabler_memberAccount_disappearsMemberAssociation,
 		},
 		"DelegatedAdminAccount": {
 			"basic":      testAccDelegatedAdminAccount_basic,

--- a/internal/service/inspector2/inspector2_test.go
+++ b/internal/service/inspector2/inspector2_test.go
@@ -14,6 +14,7 @@ func TestAccInspector2_serial(t *testing.T) {
 			"basic":                        testAccEnabler_basic,
 			"accountID":                    testAccEnabler_accountID,
 			"disappears":                   testAccEnabler_disappears,
+			"lambda":                       testAccEnabler_lambda,
 			"updateResourceTypes":          testAccEnabler_updateResourceTypes,
 			"updateResourceTypes_disjoint": testAccEnabler_updateResourceTypes_disjoint,
 		},

--- a/internal/service/inspector2/inspector2_test.go
+++ b/internal/service/inspector2/inspector2_test.go
@@ -11,10 +11,11 @@ func TestAccInspector2_serial(t *testing.T) {
 
 	testCases := map[string]map[string]func(t *testing.T){
 		"Enabler": {
-			"basic":               testAccEnabler_basic,
-			"accountID":           testAccEnabler_accountID,
-			"disappears":          testAccEnabler_disappears,
-			"updateResourceTypes": testAccEnabler_updateResourceTypes,
+			"basic":                        testAccEnabler_basic,
+			"accountID":                    testAccEnabler_accountID,
+			"disappears":                   testAccEnabler_disappears,
+			"updateResourceTypes":          testAccEnabler_updateResourceTypes,
+			"updateResourceTypes_disjoint": testAccEnabler_updateResourceTypes_disjoint,
 		},
 		"DelegatedAdminAccount": {
 			"basic":      testAccDelegatedAdminAccount_basic,

--- a/internal/service/inspector2/inspector2_test.go
+++ b/internal/service/inspector2/inspector2_test.go
@@ -17,7 +17,8 @@ func TestAccInspector2_serial(t *testing.T) {
 			"lambda":                       testAccEnabler_lambda,
 			"updateResourceTypes":          testAccEnabler_updateResourceTypes,
 			"updateResourceTypes_disjoint": testAccEnabler_updateResourceTypes_disjoint,
-			"multiAccount_basic":           testAccEnabler_multiAccount_basic,
+			// "multiAccount_NonMember": testAccEnabler_multiAccount_NonMember,
+			"memberAccount_basic": testAccEnabler_memberAccount_basic,
 		},
 		"DelegatedAdminAccount": {
 			"basic":      testAccDelegatedAdminAccount_basic,

--- a/internal/service/inspector2/inspector2_test.go
+++ b/internal/service/inspector2/inspector2_test.go
@@ -17,6 +17,7 @@ func TestAccInspector2_serial(t *testing.T) {
 			"lambda":                       testAccEnabler_lambda,
 			"updateResourceTypes":          testAccEnabler_updateResourceTypes,
 			"updateResourceTypes_disjoint": testAccEnabler_updateResourceTypes_disjoint,
+			"multiAccount_basic":           testAccEnabler_multiAccount_basic,
 		},
 		"DelegatedAdminAccount": {
 			"basic":      testAccDelegatedAdminAccount_basic,

--- a/internal/service/inspector2/inspector2_test.go
+++ b/internal/service/inspector2/inspector2_test.go
@@ -17,8 +17,8 @@ func TestAccInspector2_serial(t *testing.T) {
 			"lambda":                       testAccEnabler_lambda,
 			"updateResourceTypes":          testAccEnabler_updateResourceTypes,
 			"updateResourceTypes_disjoint": testAccEnabler_updateResourceTypes_disjoint,
-			// "multiAccount_NonMember": testAccEnabler_multiAccount_NonMember,
-			"memberAccount_basic": testAccEnabler_memberAccount_basic,
+			"memberAccount_basic":          testAccEnabler_memberAccount_basic,
+			"memberAccount_multiple":       testAccEnabler_memberAccount_multiple,
 		},
 		"DelegatedAdminAccount": {
 			"basic":      testAccDelegatedAdminAccount_basic,

--- a/internal/service/inspector2/member_association.go
+++ b/internal/service/inspector2/member_association.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -69,10 +70,14 @@ func resourceMemberAssociationCreate(ctx context.Context, d *schema.ResourceData
 	_, err := conn.AssociateMember(ctx, input)
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating Inspector2 Member Association (%s): %s", accountID, err)
+		return sdkdiag.AppendErrorf(diags, "creating Amazon Inspector Member Association (%s): %s", accountID, err)
 	}
 
 	d.SetId(accountID)
+
+	if err := waitMemberAssociationCreated(ctx, conn, accountID, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating Amazon Inspector Member Association (%s): waiting for completion: %s", accountID, err)
+	}
 
 	return append(diags, resourceMemberAssociationRead(ctx, d, meta)...)
 }
@@ -84,13 +89,13 @@ func resourceMemberAssociationRead(ctx context.Context, d *schema.ResourceData, 
 	member, err := FindMemberByAccountID(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] Inspector2 Member Association (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] Amazon Inspector Member Association (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading Inspector2 Member Association (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Amazon Inspector Member Association (%s): %s", d.Id(), err)
 	}
 
 	d.Set("account_id", member.AccountId)
@@ -105,9 +110,11 @@ func resourceMemberAssociationDelete(ctx context.Context, d *schema.ResourceData
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Inspector2Client()
 
-	log.Printf("[DEBUG] Deleting Inspector2 Member Association: %s", d.Id())
+	log.Printf("[DEBUG] Deleting Amazon Inspector Member Association: %s", d.Id())
+
+	accountID := d.Get("account_id").(string)
 	_, err := conn.DisassociateMember(ctx, &inspector2.DisassociateMemberInput{
-		AccountId: aws.String(d.Get("account_id").(string)),
+		AccountId: aws.String(accountID),
 	})
 
 	// An error occurred (ValidationException) when calling the DisassociateMember operation: The request is rejected because the current account cannot disassociate the given member account ID since the latter is not yet associated to it.
@@ -116,7 +123,11 @@ func resourceMemberAssociationDelete(ctx context.Context, d *schema.ResourceData
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting Inspector2 Member Association (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Amazon Inspector Member Association (%s): %s", d.Id(), err)
+	}
+
+	if err := waitMemberAssociationDeleted(ctx, conn, accountID, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "deleting Amazon Inspector Member Association (%s): waiting for completion: %s", accountID, err)
 	}
 
 	return diags
@@ -152,4 +163,42 @@ func FindMemberByAccountID(ctx context.Context, conn *inspector2.Client, id stri
 	}
 
 	return output.Member, nil
+}
+
+func waitMemberAssociationCreated(ctx context.Context, conn *inspector2.Client, id string, timeout time.Duration) error {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(types.RelationshipStatusCreated),
+		Target:  enum.Slice(types.RelationshipStatusEnabled),
+		Refresh: statusMemberAssociation(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func waitMemberAssociationDeleted(ctx context.Context, conn *inspector2.Client, id string, timeout time.Duration) error {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(types.RelationshipStatusCreated, types.RelationshipStatusEnabled),
+		Target:  []string{},
+		Refresh: statusMemberAssociation(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func statusMemberAssociation(ctx context.Context, conn *inspector2.Client, id string) retry.StateRefreshFunc {
+	return func() (any, string, error) {
+		member, err := FindMemberByAccountID(ctx, conn, id)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+		if err != nil {
+			return nil, "", err
+		}
+
+		return member, string(member.RelationshipStatus), nil
+	}
 }

--- a/internal/service/inspector2/member_association.go
+++ b/internal/service/inspector2/member_association.go
@@ -41,6 +41,18 @@ func ResourceMemberAssociation() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: verify.ValidAccountID,
 			},
+			"delegated_admin_account_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"relationship_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -82,6 +94,9 @@ func resourceMemberAssociationRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	d.Set("account_id", member.AccountId)
+	d.Set("delegated_admin_account_id", member.DelegatedAdminAccountId)
+	d.Set("relationship_status", member.RelationshipStatus)
+	d.Set("updated_at", aws.ToTime(member.UpdatedAt).Format(time.RFC3339))
 
 	return diags
 }

--- a/internal/service/inspector2/member_association_test.go
+++ b/internal/service/inspector2/member_association_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/service/inspector2/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -34,6 +35,10 @@ func testAccMemberAssociation_basic(t *testing.T) {
 				Config: testAccMemberAssociationConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMemberAssociationExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "account_id", "data.aws_caller_identity.member", "account_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "delegated_admin_account_id", "data.aws_caller_identity.current", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "relationship_status", string(types.RelationshipStatusCreated)),
+					acctest.CheckResourceAttrRFC3339(resourceName, "updated_at"),
 				),
 			},
 			{

--- a/internal/service/inspector2/member_association_test.go
+++ b/internal/service/inspector2/member_association_test.go
@@ -37,7 +37,7 @@ func testAccMemberAssociation_basic(t *testing.T) {
 					testAccCheckMemberAssociationExists(ctx, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "account_id", "data.aws_caller_identity.member", "account_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "delegated_admin_account_id", "data.aws_caller_identity.current", "account_id"),
-					resource.TestCheckResourceAttr(resourceName, "relationship_status", string(types.RelationshipStatusCreated)),
+					resource.TestCheckResourceAttr(resourceName, "relationship_status", string(types.RelationshipStatusEnabled)),
 					acctest.CheckResourceAttrRFC3339(resourceName, "updated_at"),
 				),
 			},

--- a/internal/service/licensemanager/grant_accepter_test.go
+++ b/internal/service/licensemanager/grant_accepter_test.go
@@ -34,7 +34,7 @@ func testAccGrantAccepter_basic(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, licensemanager.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesNamed(ctx, t, providers),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesNamedAlternate(ctx, t, providers),
 		CheckDestroy:             acctest.CheckWithNamedProviders(testAccCheckGrantAccepterDestroyWithProvider(ctx), providers),
 		Steps: []resource.TestStep{
 			{
@@ -77,7 +77,7 @@ func testAccGrantAccepter_disappears(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, licensemanager.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesNamed(ctx, t, providers),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesNamedAlternate(ctx, t, providers),
 		CheckDestroy:             acctest.CheckWithNamedProviders(testAccCheckGrantAccepterDestroyWithProvider(ctx), providers),
 		Steps: []resource.TestStep{
 			{

--- a/internal/slices/filters.go
+++ b/internal/slices/filters.go
@@ -1,0 +1,7 @@
+package slices
+
+func FilterEquals[T comparable](v T) FilterFunc[T] {
+	return func(x T) bool {
+		return x == v
+	}
+}

--- a/internal/slices/slices.go
+++ b/internal/slices/slices.go
@@ -53,6 +53,16 @@ func Filter[T any](s []T, f FilterFunc[T]) []T {
 	return slices.Clip(v)
 }
 
+// All returns `true` if the filter function `f` retruns `true` for all items
+func All[T any](s []T, f FilterFunc[T]) bool {
+	for _, e := range s {
+		if !f(e) {
+			return false
+		}
+	}
+	return true
+}
+
 // Chunks returns a slice of S, each of the specified size (or less).
 func Chunks[S ~[]E, E any](s S, size int) []S {
 	chunks := make([]S, 0)

--- a/internal/slices/slices.go
+++ b/internal/slices/slices.go
@@ -63,6 +63,16 @@ func All[T any](s []T, f FilterFunc[T]) bool {
 	return true
 }
 
+// Any returns `true` if the filter function `f` retruns `true` for any item
+func Any[T any](s []T, f FilterFunc[T]) bool {
+	for _, e := range s {
+		if f(e) {
+			return true
+		}
+	}
+	return false
+}
+
 // Chunks returns a slice of S, each of the specified size (or less).
 func Chunks[S ~[]E, E any](s S, size int) []S {
 	chunks := make([]S, 0)

--- a/website/docs/r/inspector2_enabler.html.markdown
+++ b/website/docs/r/inspector2_enabler.html.markdown
@@ -49,6 +49,6 @@ No additional attributes are exported.
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-* `create` - (Default `15m`)
-* `update` - (Default `15m`)
-* `delete` - (Default `15m`)
+* `create` - (Default `5m`)
+* `update` - (Default `5m`)
+* `delete` - (Default `5m`)

--- a/website/docs/r/inspector2_enabler.html.markdown
+++ b/website/docs/r/inspector2_enabler.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Terraform resource for enabling Amazon Inspector resource scans.
 
-~> **NOTE:** Due to testing limitations, we provide this resource as best effort. If you use it or have the ability to test it, and notice problems, please consider reaching out to us on [GitHub](https://github.com/hashicorp/terraform-provider-aws/issues/new/choose).
+This resource must be created in the Organization's Administrator Account.
 
 ## Example Usage
 
@@ -18,7 +18,7 @@ Terraform resource for enabling Amazon Inspector resource scans.
 
 ```terraform
 resource "aws_inspector2_enabler" "example" {
-  account_ids    = ["012345678901"]
+  account_ids    = ["123456789012"]
   resource_types = ["EC2"]
 }
 ```
@@ -39,7 +39,10 @@ resource "aws_inspector2_enabler" "test" {
 The following arguments are required:
 
 * `account_ids` - (Required) Set of account IDs.
-* `resource_types` - (Required) Type of resources to scan. Valid values are `EC2`, `ECR`, and `LAMBDA`. If you only use one type, Terraform will ignore the status of the other type.
+  Can contain one of: the Organization's Administrator Account, or one or more Member Accounts.
+* `resource_types` - (Required) Type of resources to scan.
+  Valid values are `EC2`, `ECR`, and `LAMBDA`.
+  At least one item is required.
 
 ## Attributes Reference
 

--- a/website/docs/r/inspector2_member_association.html.markdown
+++ b/website/docs/r/inspector2_member_association.html.markdown
@@ -22,10 +22,22 @@ resource "aws_inspector2_member_association" "example" {
 
 ## Argument Reference
 
-The following arguments are required:
+The following argument is required:
 
 * `account_id` - (Required) ID of the account to associate
 
 ## Attributes Reference
 
-No additional attributes are exported.
+In addition to all arguments above, the following attributes are exported:
+
+* `delegated_admin_account_id` - Account ID of the delegated administrator account
+* `relationship_status` - Status of the member relationship
+* `updated_at` - Date and time of the last update of the relationship
+
+## Import
+
+Amazon Inspector Member Association can be imported using the `account_id`, e.g.,
+
+```
+$ terraform import aws_inspector2_member_association.example 123456789012
+```


### PR DESCRIPTION
### Description

Enabling scanning for Lambda resources using `aws_inspector2_enabler` did not work, though the parameter was accepted.

Additionally, the resource used the `Disable` API call rather than `BatchGetAccountStatus`, which sometimes timed out, and also possibly ran into permissions problems if the user did not have authorization to disable Inspector.

Lastly, the `Enable` API call can either be called for the Organization Administrator account or a set of Member accounts.

### Relations

Closes #30776
Closes #30144
Closes #27644
Closes #27639

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ AWS_PROFILE=<org admin account> AWS_ALTERNATE_PROFILE=<member account> AWS_THIRD_PROFILE=<another member account> make testacc PKG=inspector2

--- PASS: TestAccInspector2_serial (1877.80s)
    --- PASS: TestAccInspector2_serial/DelegatedAdminAccount (42.24s)
        --- PASS: TestAccInspector2_serial/DelegatedAdminAccount/basic (25.77s)
        --- PASS: TestAccInspector2_serial/DelegatedAdminAccount/disappears (16.47s)
    --- PASS: TestAccInspector2_serial/MemberAssociation (46.15s)
        --- PASS: TestAccInspector2_serial/MemberAssociation/disappears (21.92s)
        --- PASS: TestAccInspector2_serial/MemberAssociation/basic (24.23s)
    --- PASS: TestAccInspector2_serial/OrganizationConfiguration (138.25s)
        --- PASS: TestAccInspector2_serial/OrganizationConfiguration/basic (27.09s)
        --- PASS: TestAccInspector2_serial/OrganizationConfiguration/disappears (41.23s)
        --- PASS: TestAccInspector2_serial/OrganizationConfiguration/ec2ECR (35.62s)
        --- PASS: TestAccInspector2_serial/OrganizationConfiguration/lambda (34.31s)
    --- PASS: TestAccInspector2_serial/Enabler (1651.16s)
        --- PASS: TestAccInspector2_serial/Enabler/accountID (317.36s)
        --- PASS: TestAccInspector2_serial/Enabler/lambda (175.16s)
        --- PASS: TestAccInspector2_serial/Enabler/updateResourceTypes (183.78s)
        --- PASS: TestAccInspector2_serial/Enabler/memberAccount_disappearsMemberAssociation (121.99s)
        --- PASS: TestAccInspector2_serial/Enabler/basic (137.99s)
        --- PASS: TestAccInspector2_serial/Enabler/disappears (48.68s)
        --- PASS: TestAccInspector2_serial/Enabler/updateResourceTypes_disjoint (98.55s)
        --- PASS: TestAccInspector2_serial/Enabler/memberAccount_basic (51.72s)
        --- PASS: TestAccInspector2_serial/Enabler/memberAccount_multiple (101.96s)
        --- PASS: TestAccInspector2_serial/Enabler/memberAccount_updateMemberAccounts (133.84s)
        --- PASS: TestAccInspector2_serial/Enabler/memberAccount_updateMemberAccountsAndScanTypes (280.11s)
```
