### PR TITLE
Fix aws_quicksight_data_set S3 source upload settings flatten func

### DIFF
--- a/internal/service/quicksight/data_set.go
+++ b/internal/service/quicksight/data_set.go
@@ -2334,7 +2334,7 @@ func flattenUploadSettings(apiObject *quicksight.UploadSettings) []interface{} {
 		tfMap["format"] = aws.StringValue(apiObject.Format)
 	}
 	if apiObject.StartFromRow != nil {
-		tfMap["start_from_row"] = aws.Int64Value(apiObject.StartFromRow)
+		tfMap["start_from_row"] = int(aws.Int64Value(apiObject.StartFromRow))
 	}
 	if apiObject.TextQualifier != nil {
 		tfMap["text_qualifier"] = aws.StringValue(apiObject.TextQualifier)


### PR DESCRIPTION
### Description
When reading data set details from AWS API, the `start_from_row` value `physical_table_map/s3_source/from upload_settings` it is casted as an int64 but it will make the use of `schema.NewSet()` crash as an int is expected in terraform plugin code: https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/schema/serialize.go#L24

You get the following error:

```
Stack trace from the terraform-provider-aws plugin:

panic: interface conversion: interface {} is int64, not int

goroutine 579 [running]:
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.SerializeValueForHash(0xbb7cfa0?, {0xaeb3fa0?, 0x1580c668?}, 0xe?)
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/serialize.go:24 +0x2da
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.SerializeResourceForHash(0xaeb49e0?, {0xbb7cfa0?, 0xc008b66600}, 0x501575?)
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/serialize.go:115 +0x2c8
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.serializeCollectionMemberForHash(0xc0082a8b90?, {0xbb7cfa0, 0xc008b66600}, {0xd663700?, 0xc008b6e460})
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/serialize.go:125 +0xab
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.SerializeValueForHash(0xbb7cfa0?, {0xad5df80, 0xc008b52eb8?}, 0xc008b71b80)
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/serialize.go:33 +0x712
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.SerializeResourceForHash(0x7f8200bea548?, {0xbb7cfa0?, 0xc008b66570}, 0x80?)
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/serialize.go:115 +0x2c8
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.serializeCollectionMemberForHash(0x80?, {0xbb7cfa0, 0xc008b66570}, {0xd663700?, 0xc008b6e540})
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/serialize.go:125 +0xab
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.SerializeValueForHash(0xbb7cfa0?, {0xad5df80, 0xc008b52ed0?}, 0xc008b71cc0)
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/serialize.go:33 +0x712
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.SerializeResourceForHash(0xc0082a8b60?, {0xbb7cfa0?, 0xc008b66540}, 0x473026?)
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/serialize.go:115 +0x2c8
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.HashResource.func1({0xbb7cfa0?, 0xc008b66540?})
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/set.go:33 +0x4b
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Set).hash(0x20?, {0xbb7cfa0?, 0xc008b66540?})
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/set.go:218 +0x2c
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Set).add(0xc008b31840, {0xbb7cfa0?, 0xc008b66540}, 0x0)
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/set.go:198 +0x96
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Set).Add(...)
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/set.go:76
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.NewSet(0xc008b5b9d0, {0xc008b5b9c0, 0x1, 0x9?})
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/set.go:63 +0xa5
github.com/hashicorp/terraform-provider-aws/internal/service/quicksight.flattenPhysicalTableMap(0xc008a52200?, 0xd8cefcc?)
        /home/comtef/go/src/terraform-provider-aws/internal/service/quicksight/data_set.go:2266 +0x366
github.com/hashicorp/terraform-provider-aws/internal/service/quicksight.resourceDataSetRead({0xed1ea40, 0xc008a6cb10}, 0xc008a52200, {0xd859860?, 0xc000402c00?})
        /home/comtef/go/src/terraform-provider-aws/internal/service/quicksight/data_set.go:896 +0xdcd
github.com/hashicorp/terraform-provider-aws/internal/provider.interceptedHandler[...].func1(0x0?, {0xd859860?, 0xc000402c00?})
        /home/comtef/go/src/terraform-provider-aws/internal/provider/intercept.go:96 +0x175
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xed1ea40?, {0xed1ea40?, 0xc008a2b380?}, 0xd?, {0xd859860?, 0xc000402c00?})
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/resource.go:719 +0x87
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc002443dc0, {0xed1ea40, 0xc008a2b380}, 0xc008a42820, {0xd859860, 0xc000402c00})
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/resource.go:1015 +0x585
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadResource(0xc00316f3e0, {0xed1ea40?, 0xc008a2b260?}, 0xc0089cd940)
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema/grpc_provider.go:613 +0x4a5
github.com/hashicorp/terraform-plugin-mux/tf5muxserver.muxServer.ReadResource({0xc004b97a40, 0xc004b97aa0, {0xc002029ae0, 0x2, 0x2}, {0x0, 0x0, 0x0}, {0x0, 0x0, ...}, ...}, ...)
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-mux@v0.10.0/tf5muxserver/mux_server_ReadResource.go:26 +0x102
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadResource(0xc003b4f860, {0xed1ea40?, 0xc008a2a780?}, 0xc008a300c0)
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.15.0/tfprotov5/tf5server/server.go:748 +0x4b1
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadResource_Handler({0xd54aa20?, 0xc003b4f860}, {0xed1ea40, 0xc008a2a780}, 0xc00897d7a0, 0x0)
        /home/comtef/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.15.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:383 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0002001e0, {0xed2eac0, 0xc004e10000}, 0xc008a190e0, 0xc004947e90, 0x1586bc10, 0x0)
        /home/comtef/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:1345 +0xdf0
google.golang.org/grpc.(*Server).handleStream(0xc0002001e0, {0xed2eac0, 0xc004e10000}, 0xc008a190e0, 0x0)
        /home/comtef/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:1722 +0xa2f
google.golang.org/grpc.(*Server).serveStreams.func1.2()
        /home/comtef/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:966 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /home/comtef/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:964 +0x28a

Error: The terraform-provider-aws plugin crashed!
```

### Output from Acceptance Testing
I can't run successfully the acceptance tests for this ressource, I keep getting a diff, is there any known issue about this?


```
make testacc TESTS=TestAccQuickSightDataSet_basic PKG=quicksight
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightDataSet_basic'  -timeout 180m
=== RUN   TestAccQuickSightDataSet_basic
=== PAUSE TestAccQuickSightDataSet_basic
=== CONT  TestAccQuickSightDataSet_basic
    data_set_test.go:27: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # aws_quicksight_data_set.test will be updated in-place
          ~ resource "aws_quicksight_data_set" "test" {
                id             = "725672327308,tf-acc-test-3868098960148927073"
                name           = "tf-acc-test-7406051717992075884"
                # (5 unchanged attributes hidden)

              + physical_table_map {
                  + physical_table_map_id = "tf-acc-test-3868098960148927073"

                  + s3_source {
                      + data_source_arn = "arn:aws:quicksight:eu-central-1:725672327308:datasource/tf-acc-test-3868098960148927073"

                      + input_columns {
                          + name = "Column1"
                          + type = "STRING"
                        }

                      + upload_settings {
                          + contains_header = (known after apply)
                          + delimiter       = (known after apply)
                          + format          = "JSON"
                          + start_from_row  = (known after apply)
                          + text_qualifier  = (known after apply)
                        }
                    }
                }
              - physical_table_map {
                  - physical_table_map_id = "tf-acc-test-3868098960148927073" -> null

                  - s3_source {
                      - data_source_arn = "arn:aws:quicksight:eu-central-1:725672327308:datasource/tf-acc-test-3868098960148927073" -> null

                      - input_columns {
                          - name = "Column1" -> null
                          - type = "STRING" -> null
                        }

                      - upload_settings {
                          - contains_header = true -> null
                          - format          = "JSON" -> null
                          - start_from_row  = 0 -> null
                          - text_qualifier  = "DOUBLE_QUOTE" -> null
                        }
                    }
                }

                # (2 unchanged blocks hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccQuickSightDataSet_basic (28.01s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 28.261s
FAIL
make: *** [GNUmakefile:335: testacc] Error 1
```
