### PR TITLE
Added new delete-precheck status for RDS

### DIFF
--- a/.changelog/31047.txt
+++ b/.changelog/31047.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
-resource/aws_db_instance: Add delete-precheck status
+resource/aws_db_instance: Consider `delete-precheck` a valid pending state for resource deletion
+```
+
+```release-note:bug
+resource/aws_rds_cluster_instance: Consider `delete-precheck` a valid pending state for resource deletion
 ```

--- a/.changelog/31047.txt
+++ b/.changelog/31047.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_instance: Add delete-precheck status
+```

--- a/internal/service/rds/consts.go
+++ b/internal/service/rds/consts.go
@@ -64,6 +64,7 @@ const (
 	InstanceStatusConfiguringLogExports                        = "configuring-log-exports"
 	InstanceStatusConvertingToVPC                              = "converting-to-vpc"
 	InstanceStatusCreating                                     = "creating"
+	InstanceStatusDeletePrecheck                               = "delete-precheck"
 	InstanceStatusDeleting                                     = "deleting"
 	InstanceStatusFailed                                       = "failed"
 	InstanceStatusInaccessibleEncryptionCredentials            = "inaccessible-encryption-credentials"

--- a/internal/service/rds/consts.go
+++ b/internal/service/rds/consts.go
@@ -64,7 +64,7 @@ const (
 	InstanceStatusConfiguringLogExports                        = "configuring-log-exports"
 	InstanceStatusConvertingToVPC                              = "converting-to-vpc"
 	InstanceStatusCreating                                     = "creating"
-	InstanceStatusDeletePrecheck                               = "delete-precheck"
+	InstanceStatusDeletePreCheck                               = "delete-precheck"
 	InstanceStatusDeleting                                     = "deleting"
 	InstanceStatusFailed                                       = "failed"
 	InstanceStatusInaccessibleEncryptionCredentials            = "inaccessible-encryption-credentials"

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -2487,7 +2487,7 @@ func waitDBInstanceDeleted(ctx context.Context, conn *rds.RDS, id string, timeou
 			InstanceStatusConfiguringEnhancedMonitoring,
 			InstanceStatusConfiguringLogExports,
 			InstanceStatusCreating,
-			InstanceStatusDeletePrecheck,
+			InstanceStatusDeletePreCheck,
 			InstanceStatusDeleting,
 			InstanceStatusIncompatibleParameters,
 			InstanceStatusIncompatibleRestore,

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -2487,6 +2487,7 @@ func waitDBInstanceDeleted(ctx context.Context, conn *rds.RDS, id string, timeou
 			InstanceStatusConfiguringEnhancedMonitoring,
 			InstanceStatusConfiguringLogExports,
 			InstanceStatusCreating,
+			InstanceStatusDeletePrecheck,
 			InstanceStatusDeleting,
 			InstanceStatusIncompatibleParameters,
 			InstanceStatusIncompatibleRestore,

--- a/internal/service/rds/wait.go
+++ b/internal/service/rds/wait.go
@@ -215,6 +215,7 @@ func waitDBClusterInstanceDeleted(ctx context.Context, conn *rds.RDS, id string,
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{
 			InstanceStatusConfiguringLogExports,
+			InstanceStatusDeletePrecheck,
 			InstanceStatusDeleting,
 			InstanceStatusModifying,
 		},

--- a/internal/service/rds/wait.go
+++ b/internal/service/rds/wait.go
@@ -215,7 +215,7 @@ func waitDBClusterInstanceDeleted(ctx context.Context, conn *rds.RDS, id string,
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{
 			InstanceStatusConfiguringLogExports,
-			InstanceStatusDeletePrecheck,
+			InstanceStatusDeletePreCheck,
 			InstanceStatusDeleting,
 			InstanceStatusModifying,
 		},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
New `delete-precheck` status for RDS Custom.

```
module.vpc.aws_route_table_association.private["private/us-west-2a"]: Destroying... [id=rtbassoc-0656aa92a09e88bdb]
module.vpc.aws_route_table_association.private["private/us-west-2b"]: Destroying... [id=rtbassoc-0ca867f749dc899ce]
module.vpc.aws_route_table_association.private["private/us-west-2c"]: Destroying... [id=rtbassoc-05c492e63cffdbdc6]
aws_db_instance.test-replica[0]: Destroying... [id=ee-replica]
module.vpc.aws_route_table_association.private["private/us-west-2c"]: Destruction complete after 2s
module.vpc.aws_route_table_association.private["private/us-west-2b"]: Destruction complete after 2s
module.vpc.aws_route_table_association.private["private/us-west-2a"]: Destruction complete after 2s
aws_db_instance.test-replica[0]: Still destroying... [id=ee-replica, 10s elapsed]
aws_db_instance.test-replica[0]: Still destroying... [id=ee-replica, 20s elapsed]
aws_db_instance.test-replica[0]: Still destroying... [id=ee-replica, 30s elapsed]
aws_db_instance.test-replica[0]: Still destroying... [id=ee-replica, 40s elapsed]
aws_db_instance.test-replica[0]: Still destroying... [id=ee-replica, 50s elapsed]
aws_db_instance.test-replica[0]: Still destroying... [id=ee-replica, 1m0s elapsed]
2023-04-27T14:47:40.577-0400 [ERROR] provider.terraform-provider-aws_v4.62.0_x5: Response contains error diagnostic: diagnostic_summary="waiting for RDS DB Instance (ee-replica) delete: unexpected state 'delete-precheck', wanted target ''. last error: %!s(<nil>)" tf_provider_addr=registry.terraform.io/hashicorp/aws tf_proto_version=5.3 tf_req_id=711d48d6-0bdd-76f6-6a0d-7b80d44032d4 @caller=github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov5/internal/diag/diagnostics.go:55 @module=sdk.proto diagnostic_detail= diagnostic_severity=ERROR tf_resource_type=aws_db_instance tf_rpc=ApplyResourceChange timestamp=2023-04-27T14:47:40.576-0400
2023-04-27T14:47:40.600-0400 [ERROR] vertex "aws_db_instance.test-replica[0] (destroy)" error: waiting for RDS DB Instance (ee-replica) delete: unexpected state 'delete-precheck', wanted target ''. last error: %!s(<nil>)
╷
│ Error: waiting for RDS DB Instance (ee-replica) delete: unexpected state 'delete-precheck', wanted target ''. last error: %!s(<nil>)
│ 
│ 
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
ake testacc PKG=rds TESTS=TestAccRDSInstance_basic                                    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstance_basic'  -timeout 180m
=== RUN   TestAccRDSInstance_basic
=== PAUSE TestAccRDSInstance_basic
=== CONT  TestAccRDSInstance_basic
--- PASS: TestAccRDSInstance_basic (500.56s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	505.897s

...
```
