### PR TITLE
r/aws_servicecatalog_product: provisioning_artifact_parameters changes force replacement

### DIFF
--- a/.changelog/31061.txt
+++ b/.changelog/31061.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_servicecatalog_product: Changes to `provisioning_artifact_parameters` arguments now properly trigger a replacement
+```
+
+```release-note:breaking-change
+resource/aws_servicecatalog_product: Changes to any `provisioning_artifact_parameters` arguments now properly trigger a replacement. This fixes incorrect behavior, but may technically be breaking for configurations expecting non-functional in-place updates.
+```

--- a/internal/service/servicecatalog/product.go
+++ b/internal/service/servicecatalog/product.go
@@ -88,19 +88,23 @@ func ResourceProduct() *schema.Resource {
 						"description": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 						"disable_template_validation": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							ForceNew: true,
 							Default:  false,
 						},
 						"name": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 						"template_physical_id": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 							ExactlyOneOf: []string{
 								"provisioning_artifact_parameters.0.template_url",
 								"provisioning_artifact_parameters.0.template_physical_id",
@@ -109,6 +113,7 @@ func ResourceProduct() *schema.Resource {
 						"template_url": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 							ExactlyOneOf: []string{
 								"provisioning_artifact_parameters.0.template_url",
 								"provisioning_artifact_parameters.0.template_physical_id",
@@ -117,6 +122,7 @@ func ResourceProduct() *schema.Resource {
 						"type": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							ForceNew:     true,
 							ValidateFunc: validation.StringInSlice(servicecatalog.ProvisioningArtifactType_Values(), false),
 						},
 					},

--- a/internal/service/servicecatalog/product_test.go
+++ b/internal/service/servicecatalog/product_test.go
@@ -275,11 +275,6 @@ resource "aws_s3_bucket" "test" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_s3_object" "test" {
   bucket = aws_s3_bucket.test.id
   key    = "%[1]s.json"


### PR DESCRIPTION
### Description
This change will now properly trigger a replacement when any `provisioning_artifact_parameters` arguments are modified.

### Relations
Closes #31049

### Output from Acceptance Testing

```console
$ make testacc PKG=servicecatalog TESTS=TestAccServiceCatalogProduct_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicecatalog/... -v -count 1 -parallel 20 -run='TestAccServiceCatalogProduct_'  -timeout 180m
=== RUN   TestAccServiceCatalogProduct_basic
=== PAUSE TestAccServiceCatalogProduct_basic
=== RUN   TestAccServiceCatalogProduct_disappears
=== PAUSE TestAccServiceCatalogProduct_disappears
=== RUN   TestAccServiceCatalogProduct_update
=== PAUSE TestAccServiceCatalogProduct_update
=== RUN   TestAccServiceCatalogProduct_updateTags
=== PAUSE TestAccServiceCatalogProduct_updateTags
=== RUN   TestAccServiceCatalogProduct_physicalID
=== PAUSE TestAccServiceCatalogProduct_physicalID
=== CONT  TestAccServiceCatalogProduct_basic
=== CONT  TestAccServiceCatalogProduct_updateTags
=== CONT  TestAccServiceCatalogProduct_physicalID
=== CONT  TestAccServiceCatalogProduct_update
=== CONT  TestAccServiceCatalogProduct_disappears
--- PASS: TestAccServiceCatalogProduct_disappears (23.50s)
--- PASS: TestAccServiceCatalogProduct_basic (30.16s)
--- PASS: TestAccServiceCatalogProduct_updateTags (45.56s)
--- PASS: TestAccServiceCatalogProduct_update (45.70s)
--- PASS: TestAccServiceCatalogProduct_physicalID (54.95s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog     58.152s
```
