### PR TITLE
rd/aws_autoscaling_group: add missing attributes

### DIFF
--- a/.changelog/31067.txt
+++ b/.changelog/31067.txt
@@ -1,0 +1,35 @@
+```release-note:enhancement
+data-source/aws_autoscaling_group: Add `max_instance_lifetime` attribute
+```
+
+```release-note:enhancement
+data-source/aws_autoscaling_group: Add `mixed_instances_policy` attribute
+```
+
+```release-note:enhancement
+data-source/aws_autoscaling_group: Add `predicted_capacity` attribute
+```
+
+```release-note:enhancement
+resource/aws_autoscaling_group: Add `predicted_capacity` attribute
+```
+
+```release-note:enhancement
+data-source/aws_autoscaling_group: Add `suspended_processes` attribute
+```
+
+```release-note:enhancement
+data-source/aws_autoscaling_group: Add `tag` attribute
+```
+
+```release-note:enhancement
+data-source/aws_autoscaling_group: Add `warm_pool` attribute
+```
+
+```release-note:enhancement
+data-source/aws_autoscaling_group: Add `warm_pool_size` attribute
+```
+
+```release-note:enhancement
+resource/aws_autoscaling_group: Add `warm_pool_size` attribute
+```

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -861,6 +861,10 @@ func ResourceGroup() *schema.Resource {
 					},
 				},
 			},
+			"warm_pool_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 
 		CustomizeDiff: customdiff.Sequence(
@@ -1181,6 +1185,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	} else {
 		d.Set("warm_pool", nil)
 	}
+	d.Set("warm_pool_size", g.WarmPoolSize)
 
 	var tagOk, tagsOk bool
 	var v interface{}

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -700,6 +700,10 @@ func ResourceGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"predicted_capacity": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"protect_from_scale_in": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -1152,6 +1156,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	d.Set("name", g.AutoScalingGroupName)
 	d.Set("name_prefix", create.NamePrefixFromName(aws.StringValue(g.AutoScalingGroupName)))
 	d.Set("placement_group", g.PlacementGroup)
+	d.Set("predicted_capacity", g.PredictedCapacity)
 	d.Set("protect_from_scale_in", g.NewInstancesProtectedFromScaleIn)
 	d.Set("service_linked_role_arn", g.ServiceLinkedRoleARN)
 	d.Set("suspended_processes", flattenSuspendedProcesses(g.SuspendedProcesses))

--- a/internal/service/autoscaling/group_data_source.go
+++ b/internal/service/autoscaling/group_data_source.go
@@ -97,6 +97,326 @@ func DataSourceGroup() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"mixed_instances_policy": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"instances_distribution": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"on_demand_allocation_strategy": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"on_demand_base_capacity": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"on_demand_percentage_above_base_capacity": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"spot_allocation_strategy": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"spot_instance_pools": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"spot_max_price": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"launch_template": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"launch_template_specification": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"launch_template_id": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"launch_template_name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"version": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"override": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"instance_requirements": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"accelerator_count": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"max": {
+																			Type:     schema.TypeInt,
+																			Computed: true,
+																		},
+																		"min": {
+																			Type:     schema.TypeInt,
+																			Computed: true,
+																		},
+																	},
+																},
+															},
+															"accelerator_manufacturers": {
+																Type:     schema.TypeSet,
+																Computed: true,
+																Elem:     &schema.Schema{Type: schema.TypeString},
+															},
+															"accelerator_names": {
+																Type:     schema.TypeSet,
+																Computed: true,
+																Elem:     &schema.Schema{Type: schema.TypeString},
+															},
+															"accelerator_total_memory_mib": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"max": {
+																			Type:     schema.TypeInt,
+																			Computed: true,
+																		},
+																		"min": {
+																			Type:     schema.TypeInt,
+																			Computed: true,
+																		},
+																	},
+																},
+															},
+															"accelerator_types": {
+																Type:     schema.TypeSet,
+																Computed: true,
+																Elem:     &schema.Schema{Type: schema.TypeString},
+															},
+															"allowed_instance_types": {
+																Type:     schema.TypeSet,
+																Computed: true,
+																Elem:     &schema.Schema{Type: schema.TypeString},
+															},
+															"bare_metal": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"baseline_ebs_bandwidth_mbps": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"max": {
+																			Type:     schema.TypeInt,
+																			Computed: true,
+																		},
+																		"min": {
+																			Type:     schema.TypeInt,
+																			Computed: true,
+																		},
+																	},
+																},
+															},
+															"burstable_performance": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"cpu_manufacturers": {
+																Type:     schema.TypeSet,
+																Computed: true,
+																Elem:     &schema.Schema{Type: schema.TypeString},
+															},
+															"excluded_instance_types": {
+																Type:     schema.TypeSet,
+																Computed: true,
+																Elem:     &schema.Schema{Type: schema.TypeString},
+															},
+															"instance_generations": {
+																Type:     schema.TypeSet,
+																Computed: true,
+																Elem:     &schema.Schema{Type: schema.TypeString},
+															},
+															"local_storage": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"local_storage_types": {
+																Type:     schema.TypeSet,
+																Computed: true,
+																Elem:     &schema.Schema{Type: schema.TypeString},
+															},
+															"memory_gib_per_vcpu": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"max": {
+																			Type:     schema.TypeFloat,
+																			Computed: true,
+																		},
+																		"min": {
+																			Type:     schema.TypeFloat,
+																			Computed: true,
+																		},
+																	},
+																},
+															},
+															"memory_mib": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"max": {
+																			Type:     schema.TypeInt,
+																			Computed: true,
+																		},
+																		"min": {
+																			Type:     schema.TypeInt,
+																			Computed: true,
+																		},
+																	},
+																},
+															},
+															"network_bandwidth_gbps": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"max": {
+																			Type:     schema.TypeFloat,
+																			Computed: true,
+																		},
+																		"min": {
+																			Type:     schema.TypeFloat,
+																			Computed: true,
+																		},
+																	},
+																},
+															},
+															"network_interface_count": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"max": {
+																			Type:     schema.TypeInt,
+																			Computed: true,
+																		},
+																		"min": {
+																			Type:     schema.TypeInt,
+																			Computed: true,
+																		},
+																	},
+																},
+															},
+															"on_demand_max_price_percentage_over_lowest_price": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+															"require_hibernate_support": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"spot_max_price_percentage_over_lowest_price": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+															"total_local_storage_gb": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"max": {
+																			Type:     schema.TypeFloat,
+																			Computed: true,
+																		},
+																		"min": {
+																			Type:     schema.TypeFloat,
+																			Computed: true,
+																		},
+																	},
+																},
+															},
+															"vcpu_count": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"max": {
+																			Type:     schema.TypeInt,
+																			Computed: true,
+																		},
+																		"min": {
+																			Type:     schema.TypeInt,
+																			Computed: true,
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+												"instance_type": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"launch_template_specification": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"launch_template_id": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"launch_template_name": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"version": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+														},
+													},
+												},
+												"weighted_capacity": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -171,6 +491,13 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("max_instance_lifetime", group.MaxInstanceLifetime)
 	d.Set("max_size", group.MaxSize)
 	d.Set("min_size", group.MinSize)
+	if group.MixedInstancesPolicy != nil {
+		if err := d.Set("mixed_instances_policy", []interface{}{flattenMixedInstancesPolicy(group.MixedInstancesPolicy)}); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting mixed_instances_policy: %s", err)
+		}
+	} else {
+		d.Set("mixed_instances_policy", nil)
+	}
 	d.Set("name", group.AutoScalingGroupName)
 	d.Set("new_instances_protected_from_scale_in", group.NewInstancesProtectedFromScaleIn)
 	d.Set("placement_group", group.PlacementGroup)

--- a/internal/service/autoscaling/group_data_source.go
+++ b/internal/service/autoscaling/group_data_source.go
@@ -85,6 +85,10 @@ func DataSourceGroup() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"max_instance_lifetime": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"max_size": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -164,6 +168,7 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 		d.Set("launch_template", nil)
 	}
 	d.Set("load_balancers", aws.StringValueSlice(group.LoadBalancerNames))
+	d.Set("max_instance_lifetime", group.MaxInstanceLifetime)
 	d.Set("max_size", group.MaxSize)
 	d.Set("min_size", group.MinSize)
 	d.Set("name", group.AutoScalingGroupName)

--- a/internal/service/autoscaling/group_data_source.go
+++ b/internal/service/autoscaling/group_data_source.go
@@ -446,7 +446,7 @@ func DataSourceGroup() *schema.Resource {
 			},
 			"suspended_processes": {
 				Type:     schema.TypeSet,
-				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"tag": {

--- a/internal/service/autoscaling/group_data_source.go
+++ b/internal/service/autoscaling/group_data_source.go
@@ -464,6 +464,38 @@ func DataSourceGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"warm_pool": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"instance_reuse_policy": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"reuse_on_scale_in": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"max_group_prepared_capacity": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"min_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"pool_state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"warm_pool_size": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -521,6 +553,13 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("target_group_arns", aws.StringValueSlice(group.TargetGroupARNs))
 	d.Set("termination_policies", aws.StringValueSlice(group.TerminationPolicies))
 	d.Set("vpc_zone_identifier", group.VPCZoneIdentifier)
+	if group.WarmPoolConfiguration != nil {
+		if err := d.Set("warm_pool", []interface{}{flattenWarmPoolConfiguration(group.WarmPoolConfiguration)}); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting warm_pool: %s", err)
+		}
+	} else {
+		d.Set("warm_pool", nil)
+	}
 	d.Set("warm_pool_size", group.WarmPoolSize)
 
 	return diags

--- a/internal/service/autoscaling/group_data_source.go
+++ b/internal/service/autoscaling/group_data_source.go
@@ -429,6 +429,10 @@ func DataSourceGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"predicted_capacity": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"service_linked_role_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -436,6 +440,11 @@ func DataSourceGroup() *schema.Resource {
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"suspended_processes": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"target_group_arns": {
 				Type:     schema.TypeSet,
@@ -501,8 +510,10 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("name", group.AutoScalingGroupName)
 	d.Set("new_instances_protected_from_scale_in", group.NewInstancesProtectedFromScaleIn)
 	d.Set("placement_group", group.PlacementGroup)
+	d.Set("predicted_capacity", group.PredictedCapacity)
 	d.Set("service_linked_role_arn", group.ServiceLinkedRoleARN)
 	d.Set("status", group.Status)
+	d.Set("suspended_processes", flattenSuspendedProcesses(group.SuspendedProcesses))
 	d.Set("target_group_arns", aws.StringValueSlice(group.TargetGroupARNs))
 	d.Set("termination_policies", aws.StringValueSlice(group.TerminationPolicies))
 	d.Set("vpc_zone_identifier", group.VPCZoneIdentifier)

--- a/internal/service/autoscaling/group_data_source.go
+++ b/internal/service/autoscaling/group_data_source.go
@@ -464,6 +464,10 @@ func DataSourceGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"warm_pool_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -517,6 +521,7 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("target_group_arns", aws.StringValueSlice(group.TargetGroupARNs))
 	d.Set("termination_policies", aws.StringValueSlice(group.TerminationPolicies))
 	d.Set("vpc_zone_identifier", group.VPCZoneIdentifier)
+	d.Set("warm_pool_size", group.WarmPoolSize)
 
 	return diags
 }

--- a/internal/service/autoscaling/group_data_source_test.go
+++ b/internal/service/autoscaling/group_data_source_test.go
@@ -49,6 +49,7 @@ func TestAccAutoScalingGroupDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "target_group_arns.#", resourceName, "target_group_arns.#"),
 					resource.TestCheckResourceAttr(datasourceName, "termination_policies.#", "1"), // Not set in resource.
 					resource.TestCheckResourceAttr(datasourceName, "vpc_zone_identifier", ""),     // Not set in resource.
+					resource.TestCheckResourceAttrPair(datasourceName, "warm_pool_size", resourceName, "warm_pool_size"),
 				),
 			},
 		},

--- a/internal/service/autoscaling/group_data_source_test.go
+++ b/internal/service/autoscaling/group_data_source_test.go
@@ -49,6 +49,7 @@ func TestAccAutoScalingGroupDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "target_group_arns.#", resourceName, "target_group_arns.#"),
 					resource.TestCheckResourceAttr(datasourceName, "termination_policies.#", "1"), // Not set in resource.
 					resource.TestCheckResourceAttr(datasourceName, "vpc_zone_identifier", ""),     // Not set in resource.
+					resource.TestCheckResourceAttrPair(datasourceName, "warm_pool.#", resourceName, "warm_pool.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "warm_pool_size", resourceName, "warm_pool_size"),
 				),
 			},
@@ -112,6 +113,32 @@ func TestAccAutoScalingGroupDataSource_mixedInstancesPolicy(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.launch_template.0.override.0.weighted_capacity", resourceName, "mixed_instances_policy.0.launch_template.0.override.0.weighted_capacity"),
 					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.launch_template.0.override.1.instance_type", resourceName, "mixed_instances_policy.0.launch_template.0.override.1.instance_type"),
 					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.launch_template.0.override.1.weighted_capacity", resourceName, "mixed_instances_policy.0.launch_template.0.override.1.weighted_capacity"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAutoScalingGroupDataSource_warmPool(t *testing.T) {
+	ctx := acctest.Context(t)
+	datasourceName := "data.aws_autoscaling_group.test"
+	resourceName := "aws_autoscaling_group.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, autoscaling.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGroupDataSourceConfig_launchTemplate(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "warm_pool.#", resourceName, "warm_pool.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "warm_pool.0.instance_reuse_policy.#", resourceName, "warm_pool.0.instance_reuse_policy.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "warm_pool.0.instance_reuse_policy.0.reuse_on_scale_in", resourceName, "warm_pool.0.instance_reuse_policy.0.reuse_on_scale_in"),
+					resource.TestCheckResourceAttrPair(datasourceName, "warm_pool.0.max_group_prepared_capacity", resourceName, "warm_pool.0.max_group_prepared_capacity"),
+					resource.TestCheckResourceAttrPair(datasourceName, "warm_pool.0.min_size", resourceName, "warm_pool.0.min_size"),
+					resource.TestCheckResourceAttrPair(datasourceName, "warm_pool.0.pool_state", resourceName, "warm_pool.0.pool_state"),
 				),
 			},
 		},
@@ -238,6 +265,42 @@ resource "aws_autoscaling_group" "test" {
       }
     }
   }
+}
+
+resource "aws_launch_template" "test" {
+  name          = %[1]q
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+}
+`, rName))
+}
+
+func testAccGroupDataSourceConfig_warmPool(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinuxHVMEBSAMI(),
+		acctest.ConfigAvailableAZsNoOptIn(),
+		acctest.AvailableEC2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t3.micro", "t2.micro"),
+		fmt.Sprintf(`
+data "aws_autoscaling_group" "test" {
+  name = aws_autoscaling_group.test.name
+}
+
+resource "aws_autoscaling_group" "test" {
+  name               = %[1]q
+  availability_zones = [data.aws_availability_zones.available.names[0]]
+  desired_capacity   = 0
+  max_size           = 0
+  min_size           = 0
+
+  warm_pool {
+    pool_state                  = "Stopped"
+    min_size                    = 0
+    max_group_prepared_capacity = 2
+    instance_reuse_policy {
+      reuse_on_scale_in = true
+    }
+  }
+
 }
 
 resource "aws_launch_template" "test" {

--- a/internal/service/autoscaling/group_data_source_test.go
+++ b/internal/service/autoscaling/group_data_source_test.go
@@ -132,7 +132,7 @@ func TestAccAutoScalingGroupDataSource_warmPool(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGroupDataSourceConfig_launchTemplate(rName),
+				Config: testAccGroupDataSourceConfig_warmPool(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "warm_pool.#", resourceName, "warm_pool.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "warm_pool.0.instance_reuse_policy.#", resourceName, "warm_pool.0.instance_reuse_policy.#"),

--- a/internal/service/autoscaling/group_data_source_test.go
+++ b/internal/service/autoscaling/group_data_source_test.go
@@ -38,6 +38,7 @@ func TestAccAutoScalingGroupDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "max_instance_lifetime", resourceName, "max_instance_lifetime"),
 					resource.TestCheckResourceAttrPair(datasourceName, "max_size", resourceName, "max_size"),
 					resource.TestCheckResourceAttrPair(datasourceName, "min_size", resourceName, "min_size"),
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.#", resourceName, "mixed_instances_policy.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttr(datasourceName, "new_instances_protected_from_scale_in", "false"),
 					resource.TestCheckResourceAttrPair(datasourceName, "placement_group", resourceName, "placement_group"),
@@ -70,6 +71,44 @@ func TestAccAutoScalingGroupDataSource_launchTemplate(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "launch_template.0.id", resourceName, "launch_template.0.id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "launch_template.0.name", resourceName, "launch_template.0.name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "launch_template.0.version", resourceName, "launch_template.0.version"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAutoScalingGroupDataSource_mixedInstancesPolicy(t *testing.T) {
+	ctx := acctest.Context(t)
+	datasourceName := "data.aws_autoscaling_group.test"
+	resourceName := "aws_autoscaling_group.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, autoscaling.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGroupDataSourceConfig_mixedInstancesPolicy(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.#", resourceName, "mixed_instances_policy.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.instances_distribution.#", resourceName, "mixed_instances_policy.0.instances_distribution.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.instances_distribution.0.on_demand_allocation_strategy", resourceName, "mixed_instances_policy.0.instances_distribution.0.on_demand_allocation_strategy"),
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.instances_distribution.0.on_demand_base_capacity", resourceName, "mixed_instances_policy.0.instances_distribution.0.on_demand_base_capacity"),
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.instances_distribution.0.on_demand_percentage_above_base_capacity", resourceName, "mixed_instances_policy.0.instances_distribution.0.on_demand_percentage_above_base_capacity"),
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.instances_distribution.0.spot_allocation_strategy", resourceName, "mixed_instances_policy.0.instances_distribution.0.spot_allocation_strategy"),
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.instances_distribution.0.spot_instance_pools", resourceName, "mixed_instances_policy.0.instances_distribution.0.spot_instance_pools"),
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.instances_distribution.0.spot_max_price", resourceName, "mixed_instances_policy.0.instances_distribution.0.spot_max_price"),
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.launch_template.#", resourceName, "mixed_instances_policy.0.launch_template.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.launch_template.0.launch_template_specification.#", resourceName, "mixed_instances_policy.0.launch_template.0.launch_template_specification.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.launch_template.0.launch_template_specification.0.launch_template_id", resourceName, "mixed_instances_policy.0.launch_template.0.launch_template_specification.0.launch_template_id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.launch_template.0.launch_template_specification.0.launch_template_name", resourceName, "mixed_instances_policy.0.launch_template.0.launch_template_specification.0.launch_template_name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.launch_template.0.launch_template_specification.0.version", resourceName, "mixed_instances_policy.0.launch_template.0.launch_template_specification.0.version"),
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.launch_template.0.override.#", resourceName, "mixed_instances_policy.0.launch_template.0.override.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.launch_template.0.override.0.instance_type", resourceName, "mixed_instances_policy.0.launch_template.0.override.0.instance_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.launch_template.0.override.0.weighted_capacity", resourceName, "mixed_instances_policy.0.launch_template.0.override.0.weighted_capacity"),
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.launch_template.0.override.1.instance_type", resourceName, "mixed_instances_policy.0.launch_template.0.override.1.instance_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "mixed_instances_policy.0.launch_template.0.override.1.weighted_capacity", resourceName, "mixed_instances_policy.0.launch_template.0.override.1.weighted_capacity"),
 				),
 			},
 		},
@@ -142,6 +181,59 @@ resource "aws_autoscaling_group" "test" {
   launch_template {
     id      = aws_launch_template.test.id
     version = aws_launch_template.test.default_version
+  }
+}
+
+resource "aws_launch_template" "test" {
+  name          = %[1]q
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+}
+`, rName))
+}
+
+func testAccGroupDataSourceConfig_mixedInstancesPolicy(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinuxHVMEBSAMI(),
+		acctest.ConfigAvailableAZsNoOptIn(),
+		acctest.AvailableEC2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t3.micro", "t2.micro"),
+		fmt.Sprintf(`
+data "aws_autoscaling_group" "test" {
+  name = aws_autoscaling_group.test.name
+}
+
+resource "aws_autoscaling_group" "test" {
+  name               = %[1]q
+  availability_zones = [data.aws_availability_zones.available.names[0]]
+  desired_capacity   = 0
+  max_size           = 0
+  min_size           = 0
+
+  mixed_instances_policy {
+    instances_distribution {
+      on_demand_allocation_strategy            = "prioritized"
+      on_demand_base_capacity                  = 1
+      on_demand_percentage_above_base_capacity = 1
+      spot_allocation_strategy                 = "lowest-price"
+      spot_instance_pools                      = 2
+      spot_max_price                           = "0.50"
+    }
+
+    launch_template {
+      launch_template_specification {
+        launch_template_id = aws_launch_template.test.id
+      }
+
+      override {
+        instance_type     = "t2.micro"
+        weighted_capacity = "1"
+      }
+
+      override {
+        instance_type     = "t3.small"
+        weighted_capacity = "2"
+      }
+    }
   }
 }
 

--- a/internal/service/autoscaling/group_data_source_test.go
+++ b/internal/service/autoscaling/group_data_source_test.go
@@ -35,6 +35,7 @@ func TestAccAutoScalingGroupDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "launch_configuration", resourceName, "launch_configuration"),
 					resource.TestCheckResourceAttrPair(datasourceName, "launch_template.#", resourceName, "launch_template.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "load_balancers.#", resourceName, "load_balancers.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "max_instance_lifetime", resourceName, "max_instance_lifetime"),
 					resource.TestCheckResourceAttrPair(datasourceName, "max_size", resourceName, "max_size"),
 					resource.TestCheckResourceAttrPair(datasourceName, "min_size", resourceName, "min_size"),
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),

--- a/internal/service/autoscaling/group_data_source_test.go
+++ b/internal/service/autoscaling/group_data_source_test.go
@@ -42,8 +42,10 @@ func TestAccAutoScalingGroupDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttr(datasourceName, "new_instances_protected_from_scale_in", "false"),
 					resource.TestCheckResourceAttrPair(datasourceName, "placement_group", resourceName, "placement_group"),
+					resource.TestCheckResourceAttrPair(datasourceName, "predicted_capacity", resourceName, "predicted_capacity"),
 					resource.TestCheckResourceAttrPair(datasourceName, "service_linked_role_arn", resourceName, "service_linked_role_arn"),
 					resource.TestCheckResourceAttr(datasourceName, "status", ""), // Only set when the DeleteAutoScalingGroup operation is in progress.
+					resource.TestCheckResourceAttrPair(datasourceName, "suspended_processes", resourceName, "suspended_processes"),
 					resource.TestCheckResourceAttrPair(datasourceName, "target_group_arns.#", resourceName, "target_group_arns.#"),
 					resource.TestCheckResourceAttr(datasourceName, "termination_policies.#", "1"), // Not set in resource.
 					resource.TestCheckResourceAttr(datasourceName, "vpc_zone_identifier", ""),     // Not set in resource.

--- a/internal/service/autoscaling/group_data_source_test.go
+++ b/internal/service/autoscaling/group_data_source_test.go
@@ -325,6 +325,11 @@ resource "aws_autoscaling_group" "test" {
   max_size           = 0
   min_size           = 0
 
+  launch_template {
+    id      = aws_launch_template.test.id
+    version = aws_launch_template.test.default_version
+  }
+
   warm_pool {
     pool_state                  = "Stopped"
     min_size                    = 0

--- a/internal/service/autoscaling/group_data_source_test.go
+++ b/internal/service/autoscaling/group_data_source_test.go
@@ -45,7 +45,7 @@ func TestAccAutoScalingGroupDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "predicted_capacity", resourceName, "predicted_capacity"),
 					resource.TestCheckResourceAttrPair(datasourceName, "service_linked_role_arn", resourceName, "service_linked_role_arn"),
 					resource.TestCheckResourceAttr(datasourceName, "status", ""), // Only set when the DeleteAutoScalingGroup operation is in progress.
-					resource.TestCheckResourceAttrPair(datasourceName, "suspended_processes", resourceName, "suspended_processes"),
+					resource.TestCheckResourceAttrPair(datasourceName, "suspended_processes.#", resourceName, "suspended_processes.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "tag.#", resourceName, "tag.#"),
 					resource.TestCheckResourceAttrPair(datasourceName, "target_group_arns.#", resourceName, "target_group_arns.#"),
 					resource.TestCheckResourceAttr(datasourceName, "termination_policies.#", "1"), // Not set in resource.

--- a/internal/service/autoscaling/group_test.go
+++ b/internal/service/autoscaling/group_test.go
@@ -102,6 +102,7 @@ func TestAccAutoScalingGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "wait_for_capacity_timeout", "10m"),
 					resource.TestCheckNoResourceAttr(resourceName, "wait_for_elb_capacity"),
 					resource.TestCheckResourceAttr(resourceName, "warm_pool.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "warm_pool_size", "0"),
 				),
 			},
 			testAccGroupImportStep(resourceName),

--- a/internal/service/autoscaling/group_test.go
+++ b/internal/service/autoscaling/group_test.go
@@ -90,6 +90,7 @@ func TestAccAutoScalingGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "name_prefix", ""),
 					resource.TestCheckResourceAttr(resourceName, "placement_group", ""),
+					resource.TestCheckResourceAttr(resourceName, "predicted_capacity", "0"),
 					resource.TestCheckResourceAttr(resourceName, "protect_from_scale_in", "false"),
 					acctest.CheckResourceAttrGlobalARN(resourceName, "service_linked_role_arn", "iam", "role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"),
 					resource.TestCheckResourceAttr(resourceName, "suspended_processes.#", "0"),

--- a/website/docs/d/autoscaling_group.html.markdown
+++ b/website/docs/d/autoscaling_group.html.markdown
@@ -106,8 +106,10 @@ interpolation.
             * `weighted_capacity` - Number of capacity units, which gives the instance type a proportional weight to other instance types.
 * `name` - Name of the Auto Scaling Group.
 * `placement_group` - Name of the placement group into which to launch your instances, if any. For more information, see Placement Groups (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html) in the Amazon Elastic Compute Cloud User Guide.
+* `predicted_capacity` - Predicted capacity of the group.
 * `service_linked_role_arn` - ARN of the service-linked role that the Auto Scaling group uses to call other AWS services on your behalf.
 * `status` - Current state of the group when DeleteAutoScalingGroup is in progress.
+* `suspended_processes` - List of processes suspended processes for the Auto Scaling Group.
 * `target_group_arns` - ARNs of the target groups for your load balancer.
 * `termination_policies` - The termination policies for the group.
 * `vpc_zone_identifier` - VPC ID for the group.

--- a/website/docs/d/autoscaling_group.html.markdown
+++ b/website/docs/d/autoscaling_group.html.markdown
@@ -42,6 +42,7 @@ interpolation.
     * `name` - Name of the launch template.
     * `version` - Template version.
 * `load_balancers` - One or more load balancers associated with the group.
+* `max_instance_lifetime` - Maximum amount of time, in seconds, that an instance can be in service.
 * `max_size` - Maximum size of the group.
 * `min_size` - Minimum size of the group.
 * `name` - Name of the Auto Scaling Group.

--- a/website/docs/d/autoscaling_group.html.markdown
+++ b/website/docs/d/autoscaling_group.html.markdown
@@ -113,4 +113,10 @@ interpolation.
 * `target_group_arns` - ARNs of the target groups for your load balancer.
 * `termination_policies` - The termination policies for the group.
 * `vpc_zone_identifier` - VPC ID for the group.
+* `warm_pool` - List of warm pool configuration objects.
+    * `instance_reuse_policy` - List of instance reuse policy objects.
+        * `reuse_on_scale_in` - Indicates whether instances in the Auto Scaling group can be returned to the warm pool on scale in.
+    * `max_group_prepared_policy` - Total maximum number of instances that are allowed to be in the warm pool or in any state except Terminated for the Auto Scaling group.
+    * `min_size` - Minimum number of instances to maintain in the warm pool.
+    * `pool_state` - Instance state to transition to after the lifecycle actions are complete.
 * `warm_pool_size` - Current size of the warm pool.

--- a/website/docs/d/autoscaling_group.html.markdown
+++ b/website/docs/d/autoscaling_group.html.markdown
@@ -113,3 +113,4 @@ interpolation.
 * `target_group_arns` - ARNs of the target groups for your load balancer.
 * `termination_policies` - The termination policies for the group.
 * `vpc_zone_identifier` - VPC ID for the group.
+* `warm_pool_size` - Current size of the warm pool.

--- a/website/docs/d/autoscaling_group.html.markdown
+++ b/website/docs/d/autoscaling_group.html.markdown
@@ -68,7 +68,7 @@ interpolation.
                 * `accelerator_types` - List of accelerator types.
                 * `allowed_instance_types` - List of instance types to apply the specified attributes against.
                 * `bare_metal` - Indicates whether bare metal instances are included, excluded, or required.
-                * `baseline_ebs_bandwitdh_mbps` - List of objects describing the minimum and maximum baseline EBS bandwidth (Mbps).
+                * `baseline_ebs_bandwidth_mbps` - List of objects describing the minimum and maximum baseline EBS bandwidth (Mbps).
                     * `min` - Minimum.
                     * `max` - Maximum.
                 * `burstable_performance` - Indicates whether burstable performance instance types are included, excluded, or required.
@@ -83,7 +83,7 @@ interpolation.
                 * `memory_mib` - List of objects describing the minimum and maximum amount of memory (MiB).
                     * `min` - Minimum.
                     * `max` - Maximum.
-                * `network_bandwitdh_gbps` - List of objects describing the minimum and maximum amount of network bandwidth (Gbps).
+                * `network_bandwidth_gbps` - List of objects describing the minimum and maximum amount of network bandwidth (Gbps).
                     * `min` - Minimum.
                     * `max`- Maximum.
                 * `network_interface_count` - List of objects describing the minimum and maximum amount of network interfaces.

--- a/website/docs/d/autoscaling_group.html.markdown
+++ b/website/docs/d/autoscaling_group.html.markdown
@@ -37,6 +37,10 @@ interpolation.
 * `health_check_type` - Service to use for the health checks. The valid values are EC2 and ELB.
 * `id` - Name of the Auto Scaling Group.
 * `launch_configuration` - The name of the associated launch configuration.
+* `launch_template` - List of launch templates for the group.
+    * `id` - ID of the launch template.
+    * `name` - Name of the launch template.
+    * `version` - Template version.
 * `load_balancers` - One or more load balancers associated with the group.
 * `max_size` - Maximum size of the group.
 * `min_size` - Minimum size of the group.

--- a/website/docs/d/autoscaling_group.html.markdown
+++ b/website/docs/d/autoscaling_group.html.markdown
@@ -68,7 +68,7 @@ interpolation.
                 * `accelerator_types` - List of accelerator types.
                 * `allowed_instance_types` - List of instance types to apply the specified attributes against.
                 * `bare_metal` - Indicates whether bare metal instances are included, excluded, or required.
-                * `baseline_ebs_bandwith_mbps` - List of objects describing the minimum and maximum baseline EBS bandwidth (Mbps).
+                * `baseline_ebs_bandwitdh_mbps` - List of objects describing the minimum and maximum baseline EBS bandwidth (Mbps).
                     * `min` - Minimum.
                     * `max` - Maximum.
                 * `burstable_performance` - Indicates whether burstable performance instance types are included, excluded, or required.
@@ -83,7 +83,7 @@ interpolation.
                 * `memory_mib` - List of objects describing the minimum and maximum amount of memory (MiB).
                     * `min` - Minimum.
                     * `max` - Maximum.
-                * `network_bandwith_gbps` - List of objects describing the minimum and maximum amount of network bandwidth (Gbps).
+                * `network_bandwitdh_gbps` - List of objects describing the minimum and maximum amount of network bandwidth (Gbps).
                     * `min` - Minimum.
                     * `max`- Maximum.
                 * `network_interface_count` - List of objects describing the minimum and maximum amount of network interfaces.

--- a/website/docs/d/autoscaling_group.html.markdown
+++ b/website/docs/d/autoscaling_group.html.markdown
@@ -110,6 +110,10 @@ interpolation.
 * `service_linked_role_arn` - ARN of the service-linked role that the Auto Scaling group uses to call other AWS services on your behalf.
 * `status` - Current state of the group when DeleteAutoScalingGroup is in progress.
 * `suspended_processes` - List of processes suspended processes for the Auto Scaling Group.
+* `tag` - List of tags for the group.
+    * `key` - Key.
+    * `value` - Value.
+    * `propagate_at_launch` - Whether the tag is propagated to Amazon EC2 instances launched via this ASG.
 * `target_group_arns` - ARNs of the target groups for your load balancer.
 * `termination_policies` - The termination policies for the group.
 * `vpc_zone_identifier` - VPC ID for the group.

--- a/website/docs/d/autoscaling_group.html.markdown
+++ b/website/docs/d/autoscaling_group.html.markdown
@@ -45,6 +45,65 @@ interpolation.
 * `max_instance_lifetime` - Maximum amount of time, in seconds, that an instance can be in service.
 * `max_size` - Maximum size of the group.
 * `min_size` - Minimum size of the group.
+* `mixed_instances_policy` - List of mixed instances policy objects for the group.
+    * `instances_distribution` - List of instances distribution objects.
+        * `on_demand_allocation_strategy` - Strategy used when launching on-demand instances.
+        * `on_demand_base_capacity` -  Absolute minimum amount of desired capacity that must be fulfilled by on-demand instances.
+        * `spot_allocation_strategy` - Strategy used when launching Spot instances.
+        * `spot_instance_pools` - Number of Spot pools per availability zone to allocate capacity.
+        * `spot_max_price` - Maximum price per unit hour that the user is willing to pay for the Spot instances.
+    * `launch_template` - List of launch templates along with the overrides.
+        * `launch_template_specification` - List of launch template specification objects.
+            * `launch_template_id` - ID of the launch template.
+            * `launch_template_name` - Name of the launch template.
+            * `version` - Template version.
+        * `override` - List of properties overriding the same properties in the launch template.
+            * `instance_requirements` - List of instance requirements objects.
+                * `accelerator_count - List of objects describing the minimum and maximum number of accelerators for an instance type.
+                    * `min` - Minimum.
+                    * `max` - Maximum.
+                * `accelerator_manufacturers` - List of accelerator manufacturer names.
+                * `accelerator_names` - List of accelerator names.
+                * `accelerator_total_memory_mib` - List of objects describing the minimum and maximum total memory of the accelerators.
+                * `accelerator_types` - List of accelerator types.
+                * `allowed_instance_types` - List of instance types to apply the specified attributes against.
+                * `bare_metal` - Indicates whether bare metal instances are included, excluded, or required.
+                * `baseline_ebs_bandwith_mbps` - List of objects describing the minimum and maximum baseline EBS bandwidth (Mbps).
+                    * `min` - Minimum.
+                    * `max` - Maximum.
+                * `burstable_performance` - Indicates whether burstable performance instance types are included, excluded, or required.
+                * `cpu_manufacturers` - List of CPU manufacturer names.
+                * `excluded_instance_types` - List of excluded instance types.
+                * `instance_generations` - List of instance generation names.
+                * `local_storage` - Indicates whether instance types with instance store volumes are included, excluded, or required.
+                * `local_storage_types` - List of local storage type names.
+                * `memory_gib_per_vcpu` - List of objects describing the minimum and maximum amount of memory (GiB) per vCPU.
+                    * `min` - Minimum.
+                    * `max` - Maximum.
+                * `memory_mib` - List of objects describing the minimum and maximum amount of memory (MiB).
+                    * `min` - Minimum.
+                    * `max` - Maximum.
+                * `network_bandwith_gbps` - List of objects describing the minimum and maximum amount of network bandwidth (Gbps).
+                    * `min` - Minimum.
+                    * `max`- Maximum.
+                * `network_interface_count` - List of objects describing the minimum and maximum amount of network interfaces.
+                    * `min` - Minimum.
+                    * `max` - Maximum.
+                * `on_demand_max_price_percentage_over_lowest_price` - Price protection threshold for On-Demand Instances.
+                * `require_hibernate_support` - Indicates whether instance types must support On-Demand Instance Hibernation.
+                * `spot_max_price_percentage_over_lowest_price` - Price protection threshold for Spot Instances.
+                * `total_local_storage_gb` - List of objects describing the minimum and maximum total storage (GB).
+                    * `min` - Minimum.
+                    * `max` - Maximum.
+                * `vcpu_count` - List of objects describing the minimum and maximum number of vCPUs.
+                    * `min` - Minimum.
+                    * `max` - Maximum.
+            * `instance_type` - Overriding instance type.
+            * `launch_template_specification` - List of overriding launch template specification objects.
+                * `launch_template_id` - ID of the launch template.
+                * `launch_template_name` - Name of the launch template.
+                * `version` - Template version.
+            * `weighted_capacity` - Number of capacity units, which gives the instance type a proportional weight to other instance types.
 * `name` - Name of the Auto Scaling Group.
 * `placement_group` - Name of the placement group into which to launch your instances, if any. For more information, see Placement Groups (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html) in the Amazon Elastic Compute Cloud User Guide.
 * `service_linked_role_arn` - ARN of the service-linked role that the Auto Scaling group uses to call other AWS services on your behalf.

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -654,10 +654,10 @@ This configuration block supports the following:
 
 This configuration block supports the following:
 
-* `pool_state` - (Optional) Sets the instance state to transition to after the lifecycle hooks finish. Valid values are: Stopped (default), Running or Hibernated.
-* `min_size` - (Optional) Minimum number of instances to maintain in the warm pool. This helps you to ensure that there is always a certain number of warmed instances available to handle traffic spikes. Defaults to 0 if not specified.
 * `instance_reuse_policy` - (Optional) Whether instances in the Auto Scaling group can be returned to the warm pool on scale in. The default is to terminate instances in the Auto Scaling group when the group scales in.
 * `max_group_prepared_capacity` - (Optional) Total maximum number of instances that are allowed to be in the warm pool or in any state except Terminated for the Auto Scaling group.
+* `min_size` - (Optional) Minimum number of instances to maintain in the warm pool. This helps you to ensure that there is always a certain number of warmed instances available to handle traffic spikes. Defaults to 0 if not specified.
+* `pool_state` - (Optional) Sets the instance state to transition to after the lifecycle hooks finish. Valid values are: Stopped (default), Running or Hibernated.
 
 ##### instance_reuse_policy
 

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -683,6 +683,7 @@ In addition to all arguments above, the following attributes are exported:
 * `launch_configuration` - The launch configuration of the Auto Scaling Group
 * `predicted_capacity` - Predicted capacity of the group.
 * `vpc_zone_identifier` (Optional) - The VPC zone identifier
+* `warm_pool_size` - Current size of the warm pool.
 
 ~> **NOTE:** When using `ELB` as the `health_check_type`, `health_check_grace_period` is required.
 

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -535,6 +535,7 @@ This configuration block supports the following:
 * `accelerator_total_memory_mib` - (Optional) Block describing the minimum and maximum total memory of the accelerators. Default is no minimum or maximum.
     * `min` - (Optional) Minimum.
     * `max` - (Optional) Maximum.
+
 * `accelerator_types` - (Optional) List of accelerator types. Default is any accelerator type.
 
     ```

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -681,6 +681,7 @@ In addition to all arguments above, the following attributes are exported:
 * `health_check_type` - "EC2" or "ELB". Controls how health checking is done.
 * `desired_capacity` -The number of Amazon EC2 instances that should be running in the group.
 * `launch_configuration` - The launch configuration of the Auto Scaling Group
+* `predicted_capacity` - Predicted capacity of the group.
 * `vpc_zone_identifier` (Optional) - The VPC zone identifier
 
 ~> **NOTE:** When using `ELB` as the `health_check_type`, `health_check_grace_period` is required.


### PR DESCRIPTION
### Description
This PR adds a handful of missing attributes listed in #20398 to the `aws_autoscaling_group` data source. For every attribute, strived to match the corresponding resource schema.

Attributes:
- `LaunchTemplate` - added documentation (was already implemented)
- `EnabledMetrics` - already done
- `MaxInstanceLifetime` - added to the data source
- `MixedInstancesPolicy` - added to the data source
- `PredictedCapacity` - added to both data source and resource
- `SuspendedProcesses` - added to the data source
- `Tags` - added to the data source (in a way matching the implementation from the resource)
- `TerminationPolicies` - already done
- `WarmPoolConfiguration` - added to the data source
- `WarmPoolSize` - added to both data source and resource

### Relations
Closes #20398.

### References
https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_DescribeAutoScalingGroups.html
https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_AutoScalingGroup.html
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_group

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS="-run=TestAccAutoScalingGroupDataSource_" PKG=autoscaling ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/autoscaling/... -v -count 1 -parallel 2  -run=TestAccAutoScalingGroupDataSource_ -timeout 180m
=== RUN   TestAccAutoScalingGroupDataSource_basic
=== PAUSE TestAccAutoScalingGroupDataSource_basic
=== RUN   TestAccAutoScalingGroupDataSource_launchTemplate
=== PAUSE TestAccAutoScalingGroupDataSource_launchTemplate
=== RUN   TestAccAutoScalingGroupDataSource_mixedInstancesPolicy
=== PAUSE TestAccAutoScalingGroupDataSource_mixedInstancesPolicy
=== RUN   TestAccAutoScalingGroupDataSource_warmPool
=== PAUSE TestAccAutoScalingGroupDataSource_warmPool
=== RUN   TestAccAutoScalingGroupDataSource_tags
=== PAUSE TestAccAutoScalingGroupDataSource_tags
=== CONT  TestAccAutoScalingGroupDataSource_basic
=== CONT  TestAccAutoScalingGroupDataSource_warmPool
--- PASS: TestAccAutoScalingGroupDataSource_basic (46.31s)
=== CONT  TestAccAutoScalingGroupDataSource_tags
--- PASS: TestAccAutoScalingGroupDataSource_tags (45.48s)
=== CONT  TestAccAutoScalingGroupDataSource_mixedInstancesPolicy
--- PASS: TestAccAutoScalingGroupDataSource_mixedInstancesPolicy (36.77s)
=== CONT  TestAccAutoScalingGroupDataSource_launchTemplate
--- PASS: TestAccAutoScalingGroupDataSource_launchTemplate (36.74s)
--- PASS: TestAccAutoScalingGroupDataSource_warmPool (411.40s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling        413.567s
```
```
$ make testacc TESTARGS="-run=TestAccAutoScalingGroup_basic" PKG=autoscaling ACCTEST_PARALLELISM=2          
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/autoscaling/... -v -count 1 -parallel 2  -run=TestAccAutoScalingGroup_basic -timeout 180m
=== RUN   TestAccAutoScalingGroup_basic
=== PAUSE TestAccAutoScalingGroup_basic
=== CONT  TestAccAutoScalingGroup_basic
--- PASS: TestAccAutoScalingGroup_basic (48.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling        50.561s
```