### PR TITLE
Update vpc_peering_connection_options.html.markdown

### DIFF
--- a/website/docs/r/vpc_peering_connection_options.html.markdown
+++ b/website/docs/r/vpc_peering_connection_options.html.markdown
@@ -117,7 +117,7 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
 }
 
 resource "aws_vpc_peering_connection_options" "requester" {
-  provider = aws.requester
+  provider = aws.accepter
 
   # As options can't be set until the connection has been accepted
   # create an explicit dependency on the accepter.

--- a/website/docs/r/vpc_peering_connection_options.html.markdown
+++ b/website/docs/r/vpc_peering_connection_options.html.markdown
@@ -104,6 +104,7 @@ resource "aws_vpc_peering_connection" "peer" {
 }
 
 # Accepter's side of the connection.
+# Also contains the status of the peering.
 resource "aws_vpc_peering_connection_accepter" "peer" {
   provider = aws.accepter
 
@@ -125,6 +126,8 @@ resource "aws_vpc_peering_connection_options" "requester" {
   requester {
     allow_remote_vpc_dns_resolution = true
   }
+  
+  depends_on = [ aws_vpc_peering_connection_options.accepter, aws_vpc_peering_connection_accepter.peer ]
 }
 
 resource "aws_vpc_peering_connection_options" "accepter" {
@@ -135,6 +138,8 @@ resource "aws_vpc_peering_connection_options" "accepter" {
   accepter {
     allow_remote_vpc_dns_resolution = true
   }
+
+  depends_on = [ aws_vpc_peering_connection_accepter.peer ]
 }
 ```
 


### PR DESCRIPTION
Explicitly defined the dependencies for the cross-account usage of the VPC Peering.

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
