### PR TITLE
Add aws_elasticache_user customizable timeouts

### DIFF
--- a/.changelog/31076.txt
+++ b/.changelog/31076.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_elasticache_user: Add support for defining custom timeouts
+```

--- a/internal/service/elasticache/user.go
+++ b/internal/service/elasticache/user.go
@@ -30,9 +30,11 @@ func ResourceUser() *schema.Resource {
 		ReadWithoutTimeout:   resourceUserRead,
 		UpdateWithoutTimeout: resourceUserUpdate,
 		DeleteWithoutTimeout: resourceUserDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+
 		CustomizeDiff: verify.SetTagsDiff,
 
 		Timeouts: &schema.ResourceTimeout{
@@ -332,7 +334,6 @@ const (
 )
 
 func waitUserCreated(ctx context.Context, conn *elasticache.ElastiCache, id string, timeout time.Duration) (*elasticache.User, error) {
-
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{userStatusCreating},
 		Target:  []string{userStatusActive},
@@ -350,7 +351,6 @@ func waitUserCreated(ctx context.Context, conn *elasticache.ElastiCache, id stri
 }
 
 func waitUserUpdated(ctx context.Context, conn *elasticache.ElastiCache, id string, timeout time.Duration) (*elasticache.User, error) {
-
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{userStatusModifying},
 		Target:  []string{userStatusActive},
@@ -368,7 +368,6 @@ func waitUserUpdated(ctx context.Context, conn *elasticache.ElastiCache, id stri
 }
 
 func waitUserDeleted(ctx context.Context, conn *elasticache.ElastiCache, id string, timeout time.Duration) (*elasticache.User, error) {
-
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{userStatusDeleting},
 		Target:  []string{},

--- a/internal/service/elasticache/user_test.go
+++ b/internal/service/elasticache/user_test.go
@@ -359,12 +359,6 @@ resource "aws_elasticache_user" "test" {
   access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
   engine        = "REDIS"
   passwords     = ["password123456789"]
-
-  timeouts {
-	create = "10m"
-	delete = "10m"
-	update = "10m"
-  }
 }
 `, rName)
 }

--- a/internal/service/elasticache/user_test.go
+++ b/internal/service/elasticache/user_test.go
@@ -359,6 +359,12 @@ resource "aws_elasticache_user" "test" {
   access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
   engine        = "REDIS"
   passwords     = ["password123456789"]
+
+  timeouts {
+	create = "10m"
+	delete = "10m"
+	update = "10m"
+  }
 }
 `, rName)
 }

--- a/website/docs/r/elasticache_user.html.markdown
+++ b/website/docs/r/elasticache_user.html.markdown
@@ -79,6 +79,14 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The ARN of the created ElastiCache User.
 
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `create` - (Default `5m`)
+- `update` - (Default `5m`)
+- `delete` - (Default `5m`)
+
 ## Import
 
 ElastiCache users can be imported using the `user_id`, e.g.,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This change allows users to change the timeout for the user creation, default time is 5 minutes

```
  resource "aws_elasticache_user" "test" {
    user_name     = "username1"
    ...
    timeouts {
      create = "60m"
    }
  }
  
```
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #30921

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS='TestAccElastiCacheUser_basic' PKG=elasticache
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheUser_basic'  -timeout 180m
=== RUN   TestAccElastiCacheUser_basic
=== PAUSE TestAccElastiCacheUser_basic
=== CONT  TestAccElastiCacheUser_basic
--- PASS: TestAccElastiCacheUser_basic (35.63s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        59.948s
```
