### PR TITLE
r/aws_servicecatalog_provisioning_artifact: add `provisioning_artifact_id` attribute

### DIFF
--- a/.changelog/31086.txt
+++ b/.changelog/31086.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_servicecatalog_provisioning_artifact: Add `provisioning_artifact_id` attribute
+```

--- a/internal/service/servicecatalog/provisioning_artifact.go
+++ b/internal/service/servicecatalog/provisioning_artifact.go
@@ -78,6 +78,10 @@ func ResourceProvisioningArtifact() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"provisioning_artifact_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"template_physical_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -209,6 +213,7 @@ func resourceProvisioningArtifactRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("guidance", pad.Guidance)
 	d.Set("name", pad.Name)
 	d.Set("product_id", productID)
+	d.Set("provisioning_artifact_id", artifactID)
 	d.Set("type", pad.Type)
 
 	return diags

--- a/internal/service/servicecatalog/provisioning_artifact_test.go
+++ b/internal/service/servicecatalog/provisioning_artifact_test.go
@@ -42,6 +42,7 @@ func TestAccServiceCatalogProvisioningArtifact_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "guidance", servicecatalog.ProvisioningArtifactGuidanceDefault),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s-2", rName)),
 					resource.TestCheckResourceAttrPair(resourceName, "product_id", "aws_servicecatalog_product.test", "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "provisioning_artifact_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "template_url"),
 					resource.TestCheckResourceAttr(resourceName, "type", servicecatalog.ProductTypeCloudFormationTemplate),
 					acctest.CheckResourceAttrRFC3339(resourceName, "created_time"),
@@ -252,11 +253,6 @@ func testAccProvisioningArtifactTemplateURLBaseConfig(rName, domain string) stri
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
   force_destroy = true
-}
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
 }
 
 resource "aws_s3_object" "test" {

--- a/website/docs/r/servicecatalog_provisioning_artifact.html.markdown
+++ b/website/docs/r/servicecatalog_provisioning_artifact.html.markdown
@@ -52,7 +52,8 @@ The following arguments are optional:
 In addition to all arguments above, the following attributes are exported:
 
 * `created_time` - Time when the provisioning artifact was created.
-* `id` - Provisioning Artifact identifier and product identifier separated by a colon.
+* `id` - Provisioning artifact identifier and product identifier separated by a colon.
+* `provisioning_artifact_id` - Provisioning artifact identifier.
 * `status` - Status of the provisioning artifact.
 
 ## Timeouts


### PR DESCRIPTION
### Description
Adds a computed `provisioning_artifact_id` for use with downstream resources accepting artifact IDs as inputs.

### Relations
Closes #31053 

### Output from Acceptance Testing

```console
$ make testacc PKG=servicecatalog TESTS=TestAccServiceCatalogProvisioningArtifact_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicecatalog/... -v -count 1 -parallel 20 -run='TestAccServiceCatalogProvisioningArtifact_'  -timeout 180m
=== RUN   TestAccServiceCatalogProvisioningArtifact_basic
=== PAUSE TestAccServiceCatalogProvisioningArtifact_basic
=== RUN   TestAccServiceCatalogProvisioningArtifact_disappears
=== PAUSE TestAccServiceCatalogProvisioningArtifact_disappears
=== RUN   TestAccServiceCatalogProvisioningArtifact_update
=== PAUSE TestAccServiceCatalogProvisioningArtifact_update
=== RUN   TestAccServiceCatalogProvisioningArtifact_physicalID
=== PAUSE TestAccServiceCatalogProvisioningArtifact_physicalID
=== CONT  TestAccServiceCatalogProvisioningArtifact_basic
=== CONT  TestAccServiceCatalogProvisioningArtifact_update
=== CONT  TestAccServiceCatalogProvisioningArtifact_physicalID
=== CONT  TestAccServiceCatalogProvisioningArtifact_disappears
--- PASS: TestAccServiceCatalogProvisioningArtifact_disappears (30.80s)
--- PASS: TestAccServiceCatalogProvisioningArtifact_basic (37.26s)
--- PASS: TestAccServiceCatalogProvisioningArtifact_update (60.91s)
--- PASS: TestAccServiceCatalogProvisioningArtifact_physicalID (61.72s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog     64.774s
```
