### PR TITLE
Correctly fetch overridden actions in the Network Firewall policy data source

### DIFF
--- a/.changelog/31089.txt
+++ b/.changelog/31089.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-data-source/aws_networkfirewall_firewall_policy: Add `firewall_policy.stateful_rule_group_reference.override` attribute
+data-source/aws_networkfirewall_firewall_policy: Add `firewall_policy.stateful_rule_group_reference.override` attribute, fixing `setting firewall_policy: Invalid address to set` error
 ```

--- a/.changelog/31089.txt
+++ b/.changelog/31089.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_networkfirewall_firewall_policy: Fix crash in when a policy has an overridden action on a statefule_rule_group_reference
+```

--- a/.changelog/31089.txt
+++ b/.changelog/31089.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-data-source/aws_networkfirewall_firewall_policy: Fix crash in when a policy has an overridden action on a statefule_rule_group_reference
+data-source/aws_networkfirewall_firewall_policy: Add `firewall_policy.stateful_rule_group_reference.override` attribute
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## 4.65.0 (Unreleased)
+## 4.66.0 (Unreleased)
+## 4.65.0 (April 27, 2023)
 
 NOTES:
 

--- a/internal/service/networkfirewall/firewall_policy_data_source.go
+++ b/internal/service/networkfirewall/firewall_policy_data_source.go
@@ -56,6 +56,18 @@ func DataSourceFirewallPolicy() *schema.Resource {
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"override": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"action": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+											},
+										},
+									},
 									"priority": {
 										Type:     schema.TypeInt,
 										Computed: true,

--- a/internal/service/networkfirewall/firewall_policy_data_source_test.go
+++ b/internal/service/networkfirewall/firewall_policy_data_source_test.go
@@ -103,6 +103,39 @@ func TestAccNetworkFirewallFirewallPolicyDataSource_nameAndARN(t *testing.T) {
 	})
 }
 
+func TestAccNetworkFirewallFirewallPolicyDataSource_withOverriddenManagedRuleGroup(t *testing.T) {
+	ctx := acctest.Context(t)
+	var firewallPolicy networkfirewall.DescribeFirewallPolicyOutput
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	resourceName := "aws_networkfirewall_firewall_policy.test"
+	datasourceName := "data.aws_networkfirewall_firewall_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, networkfirewall.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirewallPolicyDataSourceConfig_withOverriddenManagedRuleGroup(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckFirewallPolicyExists(ctx, resourceName, &firewallPolicy),
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"), resource.TestCheckResourceAttrPair(datasourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(datasourceName, "firewall_policy.#", resourceName, "firewall_policy.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "firewall_policy.0.stateless_fragment_default_actions.#", resourceName, "firewall_policy.0.stateless_fragment_default_actions.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "firewall_policy.0.stateless_fragment_default_actions.0", resourceName, "firewall_policy.0.stateless_fragment_default_actions.0"),
+					resource.TestCheckResourceAttrPair(datasourceName, "firewall_policy.0.stateless_default_actions.#", resourceName, "firewall_policy.0.stateless_default_actions.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "firewall_policy.0.stateless_default_actions.0", resourceName, "firewall_policy.0.stateless_default_actions.0"),
+					resource.TestCheckResourceAttrPair(datasourceName, "firewall_policy.0.stateful_rule_group_reference.#", resourceName, "firewall_policy.0.stateful_rule_group_reference.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "firewall_policy.0.stateful_rule_group_reference.0", resourceName, "firewall_policy.0.stateful_rule_group_reference.0"),
+					resource.TestCheckResourceAttrPair(datasourceName, "firewall_policy.0.stateful_rule_group_reference.override.action", resourceName, "firewall_policy.0.stateful_rule_group_reference.override.action"),
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
+				),
+			},
+		},
+	})
+}
+
 func testAccFirewallPolicyDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_networkfirewall_firewall_policy" "test" {
@@ -141,4 +174,28 @@ data "aws_networkfirewall_firewall_policy" "test" {
   arn  = aws_networkfirewall_firewall_policy.test.arn
   name = aws_networkfirewall_firewall_policy.test.name
 }`)
+}
+
+func testAccFirewallPolicyDataSourceConfig_withOverriddenManagedRuleGroup(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_networkfirewall_firewall_policy" "test" {
+  name = %[1]q
+
+  firewall_policy {
+    stateless_default_actions          = ["aws:forward_to_sfe"]
+    stateless_fragment_default_actions = ["aws:forward_to_sfe"]
+
+    # Managed rule group required for override block
+    stateful_rule_group_reference {
+      resource_arn = "arn:aws:network-firewall:eu-west-1:aws-managed:stateful-rulegroup/MalwareDomainsActionOrder"
+      override {
+        action = "DROP_TO_ALERT"
+      }
+    }
+  }
+}
+
+data "aws_networkfirewall_firewall_policy" "test" {
+  arn = aws_networkfirewall_firewall_policy.test.arn
+}`, rName)
 }


### PR DESCRIPTION
### Description
When an AWS-managed rule is configured in a Network Firewall [with the action overridden](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_firewall_policy#override) Terraform will fail it's plan or apply with `Invalid address to set: []string{"stateful_rule_group_reference", "0", "override"}`

I tried to include an `aws_networkfirewall_rule_group` resource in the test configuration to avoid depending on the referenced rule group existing ahead of time, however override blocks are only available on AWS-managed rule group references.

I was tempted to add a very comprehensive resource configuration for the test to try to pre-empt similar issues, but I couldn't find any cases where that's be done before for data sources. Let me know if that'd be preferable though and I'm happy to update the test.

### Relations

Closes #31088

### References
[The override block documentation in the provider resource docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_firewall_policy#override)

### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccNetworkFirewallFirewallPolicyDataSource PKG=networkfirewall
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkfirewall/... -v -count 1 -parallel 20 -run='TestAccNetworkFirewallFirewallPolicyDataSource'  -timeout 180m
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_arn
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_arn
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_name
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_name
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_nameAndARN
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_nameAndARN
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_withOverriddenManagedRuleGroup
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_withOverriddenManagedRuleGroup
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_arn
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_nameAndARN
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_withOverriddenManagedRuleGroup
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_name
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_name (154.86s)
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_nameAndARN (154.94s)
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_arn (155.13s)
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_withOverriddenManagedRuleGroup (156.32s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall    158.652s
```

EDIT: Updated the test output to include all tests for this data source tests to confirm no regressions.