### PR TITLE
r/aws_servicecatalog_provisioned_product: Fix `product_name` update handling

### DIFF
--- a/.changelog/31094.txt
+++ b/.changelog/31094.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_servicecatalog_provisioned_product: Fix `product_name` update handling
+```

--- a/internal/service/servicecatalog/provisioned_product.go
+++ b/internal/service/servicecatalog/provisioned_product.go
@@ -500,10 +500,12 @@ func resourceProvisionedProductUpdate(ctx context.Context, d *schema.ResourceDat
 		input.PathName = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("product_id"); ok {
-		input.ProductId = aws.String(v.(string))
-	} else if v, ok := d.GetOk("product_name"); ok {
+	// check product_name first. product_id is optional/computed and will always be
+	// set by the time update is called
+	if v, ok := d.GetOk("product_name"); ok {
 		input.ProductName = aws.String(v.(string))
+	} else if v, ok := d.GetOk("product_id"); ok {
+		input.ProductId = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("provisioning_artifact_id"); ok {

--- a/internal/service/servicecatalog/provisioned_product_test.go
+++ b/internal/service/servicecatalog/provisioned_product_test.go
@@ -141,6 +141,55 @@ func TestAccServiceCatalogProvisionedProduct_update(t *testing.T) {
 	})
 }
 
+func TestAccServiceCatalogProvisionedProduct_ProductName_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_servicecatalog_provisioned_product.test"
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	productName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	productNameUpdated := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, servicecatalog.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckProvisionedProductDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProvisionedProductConfig_productName(rName, domain, acctest.DefaultEmailAddress, "10.1.0.0/16", productName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProvisionedProductExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "product_name", "aws_servicecatalog_product.test", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "product_id", "aws_servicecatalog_product.test", "id"),
+				),
+			},
+			{
+				// update the product name, but keep provisioned product name as-is to trigger an in-place update
+				Config: testAccProvisionedProductConfig_productName(rName, domain, acctest.DefaultEmailAddress, "10.1.0.0/16", productNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProvisionedProductExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "product_name", "aws_servicecatalog_product.test", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "product_id", "aws_servicecatalog_product.test", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"accept_language",
+					"ignore_errors",
+					"product_name",
+					"provisioning_artifact_name",
+					"provisioning_parameters",
+					"retain_physical_resources",
+				},
+			},
+		},
+	})
+}
+
 func TestAccServiceCatalogProvisionedProduct_computedOutputs(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_provisioned_product.test"
@@ -594,6 +643,28 @@ resource "aws_servicecatalog_provisioned_product" "test" {
   name                       = %[1]q
   product_id                 = aws_servicecatalog_product.test.id
   provisioning_artifact_name = %[1]q
+  path_id                    = data.aws_servicecatalog_launch_paths.test.summaries[0].path_id
+
+  provisioning_parameters {
+    key   = "VPCPrimaryCIDR"
+    value = %[2]q
+  }
+
+  provisioning_parameters {
+    key   = "LeaveMeEmpty"
+    value = ""
+  }
+}
+`, rName, vpcCidr))
+}
+
+func testAccProvisionedProductConfig_productName(rName, domain, email, vpcCidr, productName string) string {
+	return acctest.ConfigCompose(testAccProvisionedProductTemplateURLBaseConfig(productName, domain, email),
+		fmt.Sprintf(`
+resource "aws_servicecatalog_provisioned_product" "test" {
+  name                       = %[1]q
+  product_name               = aws_servicecatalog_product.test.name
+  provisioning_artifact_name = aws_servicecatalog_product.test.provisioning_artifact_parameters[0].name
   path_id                    = data.aws_servicecatalog_launch_paths.test.summaries[0].path_id
 
   provisioning_parameters {


### PR DESCRIPTION
### Description
This fix will allow in-place updates of `product_name` to have the intended effect.


### Relations
Closes #31051 



### Output from Acceptance Testing

```console
$ make testacc PKG=servicecatalog TESTS=TestAccServiceCatalogProvisionedProduct_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicecatalog/... -v -count 1 -parallel 20 -run='TestAccServiceCatalogProvisionedProduct_'  -timeout 180m

--- PASS: TestAccServiceCatalogProvisionedProduct_errorOnCreate (55.03s)
--- PASS: TestAccServiceCatalogProvisionedProduct_basic (136.71s)
--- PASS: TestAccServiceCatalogProvisionedProduct_disappears (141.15s)
--- PASS: TestAccServiceCatalogProvisionedProduct_update (228.62s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags (230.55s)
--- PASS: TestAccServiceCatalogProvisionedProduct_computedOutputs (242.89s)
--- PASS: TestAccServiceCatalogProvisionedProduct_ProductName_update (243.00s)
--- PASS: TestAccServiceCatalogProvisionedProduct_errorOnUpdate (271.77s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog     274.834s
```
