### PR TITLE
r/aws_account_alternate_contact: Simplify retries

### DIFF
--- a/internal/service/account/retry/wrappers.go
+++ b/internal/service/account/retry/wrappers.go
@@ -9,31 +9,54 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-// If retries an operation until the timeout elapses or predicate indicates otherwise.
-func If[T any](ctx context.Context, timeout time.Duration, op func() (T, error), predicate func(T, error) (bool, error)) (T, error) {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+type Op[T any] interface {
+	Invoke(context.Context) (T, error)
+}
 
-	for r := Begin(); r.Continue(ctx); {
-		t, err := op()
-		if retry, err := predicate(t, err); !retry {
-			return t, err
-		}
-	}
+type OpFunc[T any] func(context.Context) (T, error)
 
-	var t T
-	return t, ctx.Err()
+func (f OpFunc[T]) Invoke(ctx context.Context) (T, error) {
+	return f(ctx)
+}
+
+type Predicate[T any] interface {
+	Invoke(T, error) (bool, error)
+}
+
+type PredicateFunc[T any] func(T, error) (bool, error)
+
+func (f PredicateFunc[T]) Invoke(t T, err error) (bool, error) {
+	return f(t, err)
+}
+
+// defaultPredicate short-circuits a retry loop if the operation returns any error.
+func defaultPredicate[T any](t T, err error) (bool, error) {
+	return err != nil, err
+}
+
+type operation[T any] struct {
+	op        Op[T]
+	predicate Predicate[T]
+}
+
+// Operation returns a new wrapper on top of the specified function.
+func Operation[T any](op OpFunc[T]) operation[T] {
+	return operation[T]{op: op, predicate: PredicateFunc[T](defaultPredicate[T])}
+}
+
+func (o operation[T]) If(predicate PredicateFunc[T]) operation[T] {
+	return operation[T]{op: o.op, predicate: predicate}
 }
 
 // UntilFoundN retries an operation if it returns a retry.NotFoundError.
-func UntilFoundN[T any](ctx context.Context, timeout time.Duration, op func() (T, error), continuousTargetOccurence int) (T, error) {
+func (o operation[T]) UntilFoundN(continuousTargetOccurence int) operation[T] {
 	if continuousTargetOccurence < 1 {
 		continuousTargetOccurence = 1
 	}
 
 	targetOccurence := 0
 
-	t, err := If(ctx, timeout, op, func(_ T, err error) (bool, error) {
+	predicate := func(_ T, err error) (bool, error) {
 		if err == nil {
 			targetOccurence++
 
@@ -51,14 +74,41 @@ func UntilFoundN[T any](ctx context.Context, timeout time.Duration, op func() (T
 		}
 
 		return false, err
-	})
+	}
 
-	return t, err
+	return operation[T]{op: o.op, predicate: PredicateFunc[T](predicate)}
 }
 
-// UntilNotFound retries an operation until it returns a retry.NotFoundError.
-func UntilNotFound[T any](ctx context.Context, timeout time.Duration, op func() (T, error)) (T, error) {
-	t, err := If(ctx, timeout, op, func(_ T, err error) (bool, error) {
+// Run retries an operation until the timeout elapses or predicate indicates otherwise.
+func (o operation[T]) Run(ctx context.Context, timeout time.Duration) (T, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for r := Begin(); r.Continue(ctx); {
+		t, err := o.op.Invoke(ctx)
+
+		if retry, err := o.predicate.Invoke(t, err); !retry {
+			return t, err
+		}
+	}
+
+	var t T
+	return t, ctx.Err()
+}
+
+type transformErrorOperation[T any] struct {
+	inner     operation[T]
+	transform func(error) error
+}
+
+func (o transformErrorOperation[T]) Run(ctx context.Context, timeout time.Duration) (T, error) {
+	t, err := o.inner.Run(ctx, timeout)
+
+	return t, o.transform(err)
+}
+
+func (o operation[T]) UntilNotFound() transformErrorOperation[T] {
+	predicate := func(_ T, err error) (bool, error) {
 		if err == nil {
 			return true, nil
 		}
@@ -68,11 +118,15 @@ func UntilNotFound[T any](ctx context.Context, timeout time.Duration, op func() 
 		}
 
 		return false, err
-	})
-
-	if errors.Is(err, context.DeadlineExceeded) {
-		return t, fmt.Errorf("found resource: %w", err)
 	}
 
-	return t, err
+	transform := func(err error) error {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("found resource: %w", err)
+		}
+
+		return err
+	}
+
+	return transformErrorOperation[T]{inner: operation[T]{op: o.op, predicate: PredicateFunc[T](predicate)}, transform: transform}
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Ibid.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/26123.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccAccount_serial/AlternateContact' PKG=account
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/account/... -v -count 1 -parallel 20  -run=TestAccAccount_serial/AlternateContact -timeout 180m
=== RUN   TestAccAccount_serial
=== PAUSE TestAccAccount_serial
=== CONT  TestAccAccount_serial
=== RUN   TestAccAccount_serial/AlternateContact
=== RUN   TestAccAccount_serial/AlternateContact/basic
=== RUN   TestAccAccount_serial/AlternateContact/disappears
=== RUN   TestAccAccount_serial/AlternateContact/AccountID
--- PASS: TestAccAccount_serial (81.41s)
    --- PASS: TestAccAccount_serial/AlternateContact (81.41s)
        --- PASS: TestAccAccount_serial/AlternateContact/basic (28.06s)
        --- PASS: TestAccAccount_serial/AlternateContact/disappears (12.56s)
        --- PASS: TestAccAccount_serial/AlternateContact/AccountID (40.79s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/account	87.359s
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/account/retry	0.849s [no tests to run]
```
