### PR TITLE
Add configurable timeouts to aws_sfn_state_machine

### DIFF
--- a/.changelog/31097.txt
+++ b/.changelog/31097.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sfn_state_machine: Add configurable timeouts
+```

--- a/internal/service/sfn/state_machine.go
+++ b/internal/service/sfn/state_machine.go
@@ -36,6 +36,12 @@ func ResourceStateMachine() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(1 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
@@ -159,7 +165,7 @@ func resourceStateMachineCreate(ctx context.Context, d *schema.ResourceData, met
 	// Note: the instance may be in a deleting mode, hence the retry
 	// when creating the step function. This can happen when we are
 	// updating the resource (since there is no update API call).
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, stateMachineCreatedTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
 		return conn.CreateStateMachineWithContext(ctx, input)
 	}, sfn.ErrCodeStateMachineDeleting, "AccessDeniedException")
 
@@ -247,7 +253,7 @@ func resourceStateMachineUpdate(ctx context.Context, d *schema.ResourceData, met
 		}
 
 		// Handle eventual consistency after update.
-		err = retry.RetryContext(ctx, stateMachineUpdatedTimeout, func() *retry.RetryError { // nosemgrep:ci.helper-schema-retry-RetryContext-without-TimeoutError-check
+		err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutUpdate), func() *retry.RetryError { // nosemgrep:ci.helper-schema-retry-RetryContext-without-TimeoutError-check
 			output, err := FindStateMachineByARN(ctx, conn, d.Id())
 
 			if err != nil {
@@ -285,7 +291,7 @@ func resourceStateMachineDelete(ctx context.Context, d *schema.ResourceData, met
 		return diag.Errorf("deleting Step Functions State Machine (%s): %s", d.Id(), err)
 	}
 
-	if _, err := waitStateMachineDeleted(ctx, conn, d.Id()); err != nil {
+	if _, err := waitStateMachineDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 		return diag.Errorf("waiting for Step Functions State Machine (%s) delete: %s", d.Id(), err)
 	}
 
@@ -333,18 +339,12 @@ func statusStateMachine(ctx context.Context, conn *sfn.SFN, stateMachineArn stri
 	}
 }
 
-const (
-	stateMachineCreatedTimeout = 5 * time.Minute
-	stateMachineDeletedTimeout = 5 * time.Minute
-	stateMachineUpdatedTimeout = 1 * time.Minute
-)
-
-func waitStateMachineDeleted(ctx context.Context, conn *sfn.SFN, stateMachineArn string) (*sfn.DescribeStateMachineOutput, error) {
+func waitStateMachineDeleted(ctx context.Context, conn *sfn.SFN, stateMachineArn string, timeout time.Duration) (*sfn.DescribeStateMachineOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{sfn.StateMachineStatusActive, sfn.StateMachineStatusDeleting},
 		Target:  []string{},
 		Refresh: statusStateMachine(ctx, conn, stateMachineArn),
-		Timeout: stateMachineDeletedTimeout,
+		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -129,6 +129,14 @@ In addition to all arguments above, the following attributes are exported:
 * `status` - The current status of the state machine. Either `ACTIVE` or `DELETING`.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `5m`)
+* `update` - (Default `1m`)
+* `delete` - (Default `5m`)
+
 ## Import
 
 State Machines can be imported using the `arn`, e.g.,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Add configurable timeouts for `create`, `update`, and `delete` to the `aws_sfn_state_machine` resource

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes [#27673](https://github.com/hashicorp/terraform-provider-aws/issues/27673).
Closes [#29206](https://github.com/hashicorp/terraform-provider-aws/issues/29206).


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccSFNStateMachine_' PKG=sfn ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/sfn/... -v -count 1 -parallel 3  -run=TestAccSFNStateMachine_ -timeout 180m
=== RUN   TestAccSFNStateMachine_createUpdate
=== PAUSE TestAccSFNStateMachine_createUpdate
=== RUN   TestAccSFNStateMachine_expressUpdate
=== PAUSE TestAccSFNStateMachine_expressUpdate
=== RUN   TestAccSFNStateMachine_standardUpdate
=== PAUSE TestAccSFNStateMachine_standardUpdate
=== RUN   TestAccSFNStateMachine_nameGenerated
=== PAUSE TestAccSFNStateMachine_nameGenerated
=== RUN   TestAccSFNStateMachine_namePrefix
=== PAUSE TestAccSFNStateMachine_namePrefix
=== RUN   TestAccSFNStateMachine_tags
=== PAUSE TestAccSFNStateMachine_tags
=== RUN   TestAccSFNStateMachine_tracing
=== PAUSE TestAccSFNStateMachine_tracing
=== RUN   TestAccSFNStateMachine_disappears
=== PAUSE TestAccSFNStateMachine_disappears
=== RUN   TestAccSFNStateMachine_expressLogging
=== PAUSE TestAccSFNStateMachine_expressLogging
=== CONT  TestAccSFNStateMachine_createUpdate
=== CONT  TestAccSFNStateMachine_tags
=== CONT  TestAccSFNStateMachine_nameGenerated
=== CONT  TestAccSFNStateMachine_standardUpdate
--- PASS: TestAccSFNStateMachine_createUpdate (152.44s)
=== CONT  TestAccSFNStateMachine_expressUpdate
--- PASS: TestAccSFNStateMachine_tags (202.20s)
--- PASS: TestAccSFNStateMachine_standardUpdate (126.66s)
=== CONT  TestAccSFNStateMachine_disappears
--- PASS: TestAccSFNStateMachine_nameGenerated (328.99s)
=== CONT  TestAccSFNStateMachine_expressLogging
--- PASS: TestAccSFNStateMachine_disappears (167.72s)
=== CONT  TestAccSFNStateMachine_namePrefix
--- PASS: TestAccSFNStateMachine_expressUpdate (297.72s)
=== CONT  TestAccSFNStateMachine_tracing
--- PASS: TestAccSFNStateMachine_expressLogging (171.26s)
--- PASS: TestAccSFNStateMachine_namePrefix (241.96s)
--- PASS: TestAccSFNStateMachine_tracing (240.25s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sfn        740.339s
```
