### PR TITLE
aws_nat_gateway: guarantee that all attributes are set when the NAT Gateway is associated with a single address

### DIFF
--- a/.changelog/31118.txt
+++ b/.changelog/31118.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_nat_gateway: Guarantee that all attributes are set when the NAT Gateway is associated with a single address
+```
+
+```release-note:bug
+data-source/aws_nat_gateway: Guarantee that all attributes are set when the NAT Gateway is associated with a single address
+```

--- a/internal/service/ec2/vpc_nat_gateway.go
+++ b/internal/service/ec2/vpc_nat_gateway.go
@@ -131,12 +131,14 @@ func resourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	for _, address := range ng.NatGatewayAddresses {
-		if aws.BoolValue(address.IsPrimary) {
+		// Length check guarantees the attributes are always set (#30865).
+		if len(ng.NatGatewayAddresses) == 1 || aws.BoolValue(address.IsPrimary) {
 			d.Set("allocation_id", address.AllocationId)
 			d.Set("association_id", address.AssociationId)
 			d.Set("network_interface_id", address.NetworkInterfaceId)
 			d.Set("private_ip", address.PrivateIp)
 			d.Set("public_ip", address.PublicIp)
+			break
 		}
 	}
 

--- a/internal/service/ec2/vpc_nat_gateway_data_source.go
+++ b/internal/service/ec2/vpc_nat_gateway_data_source.go
@@ -118,7 +118,8 @@ func dataSourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("vpc_id", ngw.VpcId)
 
 	for _, address := range ngw.NatGatewayAddresses {
-		if aws.BoolValue(address.IsPrimary) {
+		// Length check guarantees the attributes are always set (#30865).
+		if len(ngw.NatGatewayAddresses) == 1 || aws.BoolValue(address.IsPrimary) {
 			d.Set("allocation_id", address.AllocationId)
 			d.Set("association_id", address.AssociationId)
 			d.Set("network_interface_id", address.NetworkInterfaceId)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Speculatively fixes https://github.com/hashicorp/terraform-provider-aws/issues/30865 -- I wasn't able to reproduce the original bug report (see issue comments).

When a NAT Gateway is associated with a single address, consider it the primary. Otherwise find an address that has the `IsPrimary` attribute present and set to true.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/30865

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccVPCNATGateway PKG=ec2 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 2 -run='TestAccVPCNATGateway'  -timeout 180m
=== RUN   TestAccVPCNATGatewayDataSource_basic
=== PAUSE TestAccVPCNATGatewayDataSource_basic
=== RUN   TestAccVPCNATGateway_basic
=== PAUSE TestAccVPCNATGateway_basic
=== RUN   TestAccVPCNATGateway_disappears
=== PAUSE TestAccVPCNATGateway_disappears
=== RUN   TestAccVPCNATGateway_ConnectivityType_private
=== PAUSE TestAccVPCNATGateway_ConnectivityType_private
=== RUN   TestAccVPCNATGateway_privateIP
=== PAUSE TestAccVPCNATGateway_privateIP
=== RUN   TestAccVPCNATGateway_tags
=== PAUSE TestAccVPCNATGateway_tags
=== RUN   TestAccVPCNATGatewaysDataSource_basic
=== PAUSE TestAccVPCNATGatewaysDataSource_basic
=== CONT  TestAccVPCNATGatewayDataSource_basic
=== CONT  TestAccVPCNATGateway_privateIP
--- PASS: TestAccVPCNATGatewayDataSource_basic (168.62s)
=== CONT  TestAccVPCNATGateway_tags
--- PASS: TestAccVPCNATGateway_privateIP (170.33s)
=== CONT  TestAccVPCNATGatewaysDataSource_basic
--- PASS: TestAccVPCNATGatewaysDataSource_basic (197.24s)
=== CONT  TestAccVPCNATGateway_basic
--- PASS: TestAccVPCNATGateway_tags (205.70s)
=== CONT  TestAccVPCNATGateway_disappears
--- PASS: TestAccVPCNATGateway_disappears (146.88s)
=== CONT  TestAccVPCNATGateway_ConnectivityType_private
--- PASS: TestAccVPCNATGateway_basic (189.13s)
--- PASS: TestAccVPCNATGateway_ConnectivityType_private (168.89s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        692.291s
```
