### PR TITLE
r/aws_kinesis_firehose_delivery_stream: deprecate root `s3_configuration`

### DIFF
--- a/.changelog/31138.txt
+++ b/.changelog/31138.txt
@@ -1,0 +1,11 @@
+```release-note:breaking-change
+resource/aws_kinesis_firehose_delivery_stream: Remove `s3` as an option for `destination`. Use `extended_s3` instead
+```
+
+```release-note:breaking-change
+resource/aws_kinesis_firehose_delivery_stream: Remove `s3_configuration` attribute from the root of the resource. `s3_configuration` is now a part of the following blocks: `elasticsearch_configuration`, `opensearch_configuration`, `redshift_configuration`, `splunk_configuration`, and `http_endpoint_configuration`
+```
+
+```release-note:enhancement
+resource/aws_kinesis_firehose_delivery_stream: Add `s3_configuration` to `elasticsearch_configuration`, `opensearch_configuration`, `redshift_configuration`, `splunk_configuration`, and `http_endpoint_configuration`
+```

--- a/internal/service/firehose/delivery_stream.go
+++ b/internal/service/firehose/delivery_stream.go
@@ -1641,6 +1641,13 @@ func ResourceDeliveryStream() *schema.Resource {
 							Required: true,
 						},
 
+						"retry_duration": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      3600,
+							ValidateFunc: validation.IntBetween(0, 7200),
+						},
+
 						"s3_backup_mode": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -1652,13 +1659,6 @@ func ResourceDeliveryStream() *schema.Resource {
 						},
 
 						"s3_configuration": s3ConfigurationSchema(),
-
-						"retry_duration": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Default:      3600,
-							ValidateFunc: validation.IntBetween(0, 7200),
-						},
 
 						"cloudwatch_logging_options": cloudWatchLoggingOptionsSchema(),
 
@@ -1697,6 +1697,13 @@ func ResourceDeliveryStream() *schema.Resource {
 							Sensitive:    true,
 						},
 
+						"retry_duration": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      300,
+							ValidateFunc: validation.IntBetween(0, 7200),
+						},
+
 						"role_arn": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -1711,13 +1718,6 @@ func ResourceDeliveryStream() *schema.Resource {
 						},
 
 						"s3_configuration": s3ConfigurationSchema(),
-
-						"retry_duration": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Default:      300,
-							ValidateFunc: validation.IntBetween(0, 7200),
-						},
 
 						"buffering_interval": {
 							Type:         schema.TypeInt,

--- a/internal/service/firehose/delivery_stream.go
+++ b/internal/service/firehose/delivery_stream.go
@@ -261,6 +261,7 @@ func flattenElasticsearchConfiguration(description *firehose.ElasticsearchDestin
 		"type_name":                  aws.StringValue(description.TypeName),
 		"index_name":                 aws.StringValue(description.IndexName),
 		"s3_backup_mode":             aws.StringValue(description.S3BackupMode),
+		"s3_configuration":           flattenS3Configuration(description.S3DestinationDescription),
 		"index_rotation_period":      aws.StringValue(description.IndexRotationPeriod),
 		"vpc_config":                 flattenVPCConfiguration(description.VpcConfigurationDescription),
 		"processing_configuration":   flattenProcessingConfiguration(description.ProcessingConfiguration, aws.StringValue(description.RoleARN)),
@@ -297,6 +298,7 @@ func flattenOpensearchConfiguration(description *firehose.Amazonopensearchservic
 		"type_name":                  aws.StringValue(description.TypeName),
 		"index_name":                 aws.StringValue(description.IndexName),
 		"s3_backup_mode":             aws.StringValue(description.S3BackupMode),
+		"s3_configuration":           flattenS3Configuration(description.S3DestinationDescription),
 		"index_rotation_period":      aws.StringValue(description.IndexRotationPeriod),
 		"vpc_config":                 flattenVPCConfiguration(description.VpcConfigurationDescription),
 		"processing_configuration":   flattenProcessingConfiguration(description.ProcessingConfiguration, aws.StringValue(description.RoleARN)),
@@ -381,6 +383,7 @@ func flattenRedshiftConfiguration(description *firehose.RedshiftDestinationDescr
 		"role_arn":                   aws.StringValue(description.RoleARN),
 		"s3_backup_configuration":    flattenS3Configuration(description.S3BackupDescription),
 		"s3_backup_mode":             aws.StringValue(description.S3BackupMode),
+		"s3_configuration":           flattenS3Configuration(description.S3DestinationDescription),
 		"username":                   aws.StringValue(description.Username),
 	}
 
@@ -409,6 +412,7 @@ func flattenSplunkConfiguration(description *firehose.SplunkDestinationDescripti
 		"hec_token":                  aws.StringValue(description.HECToken),
 		"processing_configuration":   flattenProcessingConfiguration(description.ProcessingConfiguration, ""),
 		"s3_backup_mode":             aws.StringValue(description.S3BackupMode),
+		"s3_configuration":           flattenS3Configuration(description.S3DestinationDescription),
 	}
 
 	if description.RetryOptions != nil {
@@ -808,46 +812,26 @@ func flattenDeliveryStream(d *schema.ResourceData, s *firehose.DeliveryStreamDes
 			if err := d.Set("redshift_configuration", flattenRedshiftConfiguration(destination.RedshiftDestinationDescription, configuredPassword)); err != nil {
 				return fmt.Errorf("setting redshift_configuration: %s", err)
 			}
-			if err := d.Set("s3_configuration", flattenS3Configuration(destination.RedshiftDestinationDescription.S3DestinationDescription)); err != nil {
-				return fmt.Errorf("setting s3_configuration: %s", err)
-			}
 		} else if destination.ElasticsearchDestinationDescription != nil {
 			d.Set("destination", destinationTypeElasticsearch)
 			if err := d.Set("elasticsearch_configuration", flattenElasticsearchConfiguration(destination.ElasticsearchDestinationDescription)); err != nil {
 				return fmt.Errorf("setting elasticsearch_configuration: %s", err)
-			}
-			if err := d.Set("s3_configuration", flattenS3Configuration(destination.ElasticsearchDestinationDescription.S3DestinationDescription)); err != nil {
-				return fmt.Errorf("setting s3_configuration: %s", err)
 			}
 		} else if destination.AmazonopensearchserviceDestinationDescription != nil {
 			d.Set("destination", destinationTypeOpensearch)
 			if err := d.Set("opensearch_configuration", flattenOpensearchConfiguration(destination.AmazonopensearchserviceDestinationDescription)); err != nil {
 				return fmt.Errorf("setting opensearch_configuration: %s", err)
 			}
-			if err := d.Set("s3_configuration", flattenS3Configuration(destination.AmazonopensearchserviceDestinationDescription.S3DestinationDescription)); err != nil {
-				return fmt.Errorf("setting s3_configuration: %s", err)
-			}
 		} else if destination.SplunkDestinationDescription != nil {
 			d.Set("destination", destinationTypeSplunk)
 			if err := d.Set("splunk_configuration", flattenSplunkConfiguration(destination.SplunkDestinationDescription)); err != nil {
 				return fmt.Errorf("setting splunk_configuration: %s", err)
-			}
-			if err := d.Set("s3_configuration", flattenS3Configuration(destination.SplunkDestinationDescription.S3DestinationDescription)); err != nil {
-				return fmt.Errorf("setting s3_configuration: %s", err)
 			}
 		} else if destination.HttpEndpointDestinationDescription != nil {
 			d.Set("destination", destinationTypeHTTPEndpoint)
 			configuredAccessKey := d.Get("http_endpoint_configuration.0.access_key").(string)
 			if err := d.Set("http_endpoint_configuration", flattenHTTPEndpointConfiguration(destination.HttpEndpointDestinationDescription, configuredAccessKey)); err != nil {
 				return fmt.Errorf("setting http_endpoint_configuration: %s", err)
-			}
-			if err := d.Set("s3_configuration", flattenS3Configuration(destination.HttpEndpointDestinationDescription.S3DestinationDescription)); err != nil {
-				return fmt.Errorf("setting s3_configuration: %s", err)
-			}
-		} else if d.Get("destination").(string) == destinationTypeS3 {
-			d.Set("destination", destinationTypeS3)
-			if err := d.Set("s3_configuration", flattenS3Configuration(destination.S3DestinationDescription)); err != nil {
-				return fmt.Errorf("setting s3_configuration: %s", err)
 			}
 		} else {
 			d.Set("destination", destinationTypeExtendedS3)
@@ -871,6 +855,7 @@ func flattenHTTPEndpointConfiguration(description *firehose.HttpEndpointDestinat
 		"name":                       aws.StringValue(description.EndpointConfiguration.Name),
 		"role_arn":                   aws.StringValue(description.RoleARN),
 		"s3_backup_mode":             aws.StringValue(description.S3BackupMode),
+		"s3_configuration":           flattenS3Configuration(description.S3DestinationDescription),
 		"request_configuration":      flattenRequestConfiguration(description.RequestConfiguration),
 		"cloudwatch_logging_options": flattenCloudWatchLoggingOptions(description.CloudWatchLoggingOptions),
 		"processing_configuration":   flattenProcessingConfiguration(description.ProcessingConfiguration, aws.StringValue(description.RoleARN)),

--- a/internal/service/firehose/delivery_stream.go
+++ b/internal/service/firehose/delivery_stream.go
@@ -1319,12 +1319,24 @@ func ResourceDeliveryStream() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"cloudwatch_logging_options": cloudWatchLoggingOptionsSchema(),
+
 						"cluster_jdbcurl": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
 
-						"username": {
+						"copy_options": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"data_table_columns": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"data_table_name": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
@@ -1336,6 +1348,13 @@ func ResourceDeliveryStream() *schema.Resource {
 						},
 
 						"processing_configuration": processingConfigurationSchema(),
+
+						"retry_duration": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      3600,
+							ValidateFunc: validation.IntBetween(0, 7200),
+						},
 
 						"role_arn": {
 							Type:         schema.TypeString,
@@ -1354,29 +1373,10 @@ func ResourceDeliveryStream() *schema.Resource {
 
 						"s3_configuration": s3ConfigurationSchema(),
 
-						"retry_duration": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Default:      3600,
-							ValidateFunc: validation.IntBetween(0, 7200),
-						},
-
-						"copy_options": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-
-						"data_table_columns": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-
-						"data_table_name": {
+						"username": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-
-						"cloudwatch_logging_options": cloudWatchLoggingOptionsSchema(),
 					},
 				},
 			},
@@ -1401,6 +1401,14 @@ func ResourceDeliveryStream() *schema.Resource {
 							ValidateFunc: validation.IntBetween(1, 100),
 						},
 
+						"cloudwatch_logging_options": cloudWatchLoggingOptionsSchema(),
+
+						"cluster_endpoint": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							ConflictsWith: []string{"elasticsearch_configuration.0.domain_arn"},
+						},
+
 						"domain_arn": {
 							Type:          schema.TypeString,
 							Optional:      true,
@@ -1419,6 +1427,8 @@ func ResourceDeliveryStream() *schema.Resource {
 							Default:      firehose.ElasticsearchIndexRotationPeriodOneDay,
 							ValidateFunc: validation.StringInSlice(firehose.ElasticsearchIndexRotationPeriod_Values(), false),
 						},
+
+						"processing_configuration": processingConfigurationSchema(),
 
 						"retry_duration": {
 							Type:         schema.TypeInt,
@@ -1480,15 +1490,6 @@ func ResourceDeliveryStream() *schema.Resource {
 									},
 								},
 							},
-						},
-
-						"cloudwatch_logging_options": cloudWatchLoggingOptionsSchema(),
-
-						"processing_configuration": processingConfigurationSchema(),
-						"cluster_endpoint": {
-							Type:          schema.TypeString,
-							Optional:      true,
-							ConflictsWith: []string{"elasticsearch_configuration.0.domain_arn"},
 						},
 					},
 				},

--- a/internal/service/firehose/delivery_stream.go
+++ b/internal/service/firehose/delivery_stream.go
@@ -996,10 +996,9 @@ func ResourceDeliveryStream() *schema.Resource {
 			},
 
 			"extended_s3_configuration": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				ConflictsWith: []string{"s3_configuration"},
-				MaxItems:      1,
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"bucket_arn": {

--- a/internal/service/firehose/delivery_stream.go
+++ b/internal/service/firehose/delivery_stream.go
@@ -26,7 +26,6 @@ import (
 )
 
 const (
-	destinationTypeS3            = "s3"
 	destinationTypeExtendedS3    = "extended_s3"
 	destinationTypeElasticsearch = "elasticsearch"
 	destinationTypeOpensearch    = "opensearch"

--- a/internal/service/firehose/delivery_stream_test.go
+++ b/internal/service/firehose/delivery_stream_test.go
@@ -956,8 +956,8 @@ func TestAccFirehoseDeliveryStream_Splunk_ErrorOutputPrefix(t *testing.T) {
 				Config: testAccDeliveryStreamConfig_splunkErrorOutputPrefix(rName, "prefix1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.error_output_prefix", "prefix1"),
+					resource.TestCheckResourceAttr(resourceName, "splunk_configuration.0.s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "splunk_configuration.0.s3_configuration.0.error_output_prefix", "prefix1"),
 				),
 			},
 			{
@@ -969,8 +969,8 @@ func TestAccFirehoseDeliveryStream_Splunk_ErrorOutputPrefix(t *testing.T) {
 				Config: testAccDeliveryStreamConfig_splunkErrorOutputPrefix(rName, "prefix2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.error_output_prefix", "prefix2"),
+					resource.TestCheckResourceAttr(resourceName, "splunk_configuration.0.s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "splunk_configuration.0.s3_configuration.0.error_output_prefix", "prefix2"),
 				),
 			},
 			{
@@ -982,8 +982,8 @@ func TestAccFirehoseDeliveryStream_Splunk_ErrorOutputPrefix(t *testing.T) {
 				Config: testAccDeliveryStreamConfig_splunkErrorOutputPrefix(rName, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.error_output_prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "splunk_configuration.0.s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "splunk_configuration.0.s3_configuration.0.error_output_prefix", ""),
 				),
 			},
 		},
@@ -1063,8 +1063,8 @@ func TestAccFirehoseDeliveryStream_HTTPEndpoint_ErrorOutputPrefix(t *testing.T) 
 				Config: testAccDeliveryStreamConfig_httpEndpointErrorOutputPrefix(rName, "prefix1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.error_output_prefix", "prefix1"),
+					resource.TestCheckResourceAttr(resourceName, "http_endpoint_configuration.0.s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "http_endpoint_configuration.0.s3_configuration.0.error_output_prefix", "prefix1"),
 				),
 			},
 			{
@@ -1076,8 +1076,8 @@ func TestAccFirehoseDeliveryStream_HTTPEndpoint_ErrorOutputPrefix(t *testing.T) 
 				Config: testAccDeliveryStreamConfig_httpEndpointErrorOutputPrefix(rName, "prefix2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.error_output_prefix", "prefix2"),
+					resource.TestCheckResourceAttr(resourceName, "http_endpoint_configuration.0.s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "http_endpoint_configuration.0.s3_configuration.0.error_output_prefix", "prefix2"),
 				),
 			},
 			{
@@ -1089,8 +1089,8 @@ func TestAccFirehoseDeliveryStream_HTTPEndpoint_ErrorOutputPrefix(t *testing.T) 
 				Config: testAccDeliveryStreamConfig_httpEndpointErrorOutputPrefix(rName, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.error_output_prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "http_endpoint_configuration.0.s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "http_endpoint_configuration.0.s3_configuration.0.error_output_prefix", ""),
 				),
 			},
 		},
@@ -1321,8 +1321,8 @@ func TestAccFirehoseDeliveryStream_Elasticsearch_ErrorOutputPrefix(t *testing.T)
 				Config: testAccDeliveryStreamConfig_elasticsearchErrorOutputPrefix(rName, "prefix1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.error_output_prefix", "prefix1"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch_configuration.0.s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch_configuration.0.s3_configuration.0.error_output_prefix", "prefix1"),
 				),
 			},
 			{
@@ -1334,8 +1334,8 @@ func TestAccFirehoseDeliveryStream_Elasticsearch_ErrorOutputPrefix(t *testing.T)
 				Config: testAccDeliveryStreamConfig_elasticsearchErrorOutputPrefix(rName, "prefix2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.error_output_prefix", "prefix2"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch_configuration.0.s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch_configuration.0.s3_configuration.0.error_output_prefix", "prefix2"),
 				),
 			},
 			{
@@ -1347,8 +1347,8 @@ func TestAccFirehoseDeliveryStream_Elasticsearch_ErrorOutputPrefix(t *testing.T)
 				Config: testAccDeliveryStreamConfig_elasticsearchErrorOutputPrefix(rName, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.error_output_prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch_configuration.0.s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch_configuration.0.s3_configuration.0.error_output_prefix", ""),
 				),
 			},
 		},
@@ -1558,8 +1558,8 @@ func TestAccFirehoseDeliveryStream_Opensearch_ErrorOutputPrefix(t *testing.T) {
 				Config: testAccDeliveryStreamConfig_opensearchErrorOutputPrefix(rName, "prefix1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.error_output_prefix", "prefix1"),
+					resource.TestCheckResourceAttr(resourceName, "opensearch_configuration.0.s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "opensearch_configuration.0.s3_configuration.0.error_output_prefix", "prefix1"),
 				),
 			},
 			{
@@ -1571,8 +1571,8 @@ func TestAccFirehoseDeliveryStream_Opensearch_ErrorOutputPrefix(t *testing.T) {
 				Config: testAccDeliveryStreamConfig_opensearchErrorOutputPrefix(rName, "prefix2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.error_output_prefix", "prefix2"),
+					resource.TestCheckResourceAttr(resourceName, "opensearch_configuration.0.s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "opensearch_configuration.0.s3_configuration.0.error_output_prefix", "prefix2"),
 				),
 			},
 			{
@@ -1584,8 +1584,8 @@ func TestAccFirehoseDeliveryStream_Opensearch_ErrorOutputPrefix(t *testing.T) {
 				Config: testAccDeliveryStreamConfig_opensearchErrorOutputPrefix(rName, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.error_output_prefix", ""),
+					resource.TestCheckResourceAttr(resourceName, "opensearch_configuration.0.s3_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "opensearch_configuration.0.s3_configuration.0.error_output_prefix", ""),
 				),
 			},
 		},
@@ -3346,16 +3346,16 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "elasticsearch"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
   elasticsearch_configuration {
     domain_arn = aws_elasticsearch_domain.test_cluster.arn
     role_arn   = aws_iam_role.firehose.arn
     index_name = "test"
     type_name  = "test"
+
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
+  }
   }
 }
 `, rName))
@@ -3369,17 +3369,17 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "elasticsearch"
 
-  s3_configuration {
-    role_arn            = aws_iam_role.firehose.arn
-    bucket_arn          = aws_s3_bucket.bucket.arn
-    error_output_prefix = %[2]q
-  }
-
   elasticsearch_configuration {
     domain_arn = aws_elasticsearch_domain.test_cluster.arn
     role_arn   = aws_iam_role.firehose.arn
     index_name = "test"
     type_name  = "test"
+
+  s3_configuration {
+    role_arn            = aws_iam_role.firehose.arn
+    bucket_arn          = aws_s3_bucket.bucket.arn
+    error_output_prefix = %[2]q
+  }
   }
 }
 `, rName, errorOutputPrefix))
@@ -3393,16 +3393,16 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "elasticsearch"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
   elasticsearch_configuration {
     domain_arn = aws_elasticsearch_domain.test_cluster.arn
     role_arn   = aws_iam_role.firehose.arn
     index_name = "test"
     type_name  = "test"
+
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
+  }
 
     vpc_config {
       subnet_ids         = aws_subnet.test[*].id
@@ -3425,17 +3425,17 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "elasticsearch"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
   elasticsearch_configuration {
     domain_arn         = aws_elasticsearch_domain.test_cluster.arn
     role_arn           = aws_iam_role.firehose.arn
     index_name         = "test"
     type_name          = "test"
     buffering_interval = 500
+
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
+  }
 
     processing_configuration {
       enabled = false
@@ -3473,17 +3473,17 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "elasticsearch"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
   elasticsearch_configuration {
     domain_arn         = aws_elasticsearch_domain.test_cluster.arn
     role_arn           = aws_iam_role.firehose.arn
     index_name         = "test"
     type_name          = "test"
     buffering_interval = 500
+
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
+  }
 
     vpc_config {
       subnet_ids         = aws_subnet.test[*].id
@@ -3521,16 +3521,16 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "elasticsearch"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
   elasticsearch_configuration {
     cluster_endpoint = "https://${aws_elasticsearch_domain.test_cluster.endpoint}"
     role_arn         = aws_iam_role.firehose.arn
     index_name       = "test"
     type_name        = "test"
+
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
+  }
   }
 }`, rName))
 }
@@ -3546,17 +3546,17 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "elasticsearch"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
   elasticsearch_configuration {
     cluster_endpoint   = "https://${aws_elasticsearch_domain.test_cluster.endpoint}"
     role_arn           = aws_iam_role.firehose.arn
     index_name         = "test"
     type_name          = "test"
     buffering_interval = 500
+
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
+  }
 
     processing_configuration {
       enabled = false
@@ -3706,15 +3706,15 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "opensearch"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
   opensearch_configuration {
     domain_arn = aws_opensearch_domain.test_cluster.arn
     role_arn   = aws_iam_role.firehose.arn
     index_name = "test"
+
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
+  }
   }
 }
 `, rName))
@@ -3728,15 +3728,15 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "opensearch"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
   opensearch_configuration {
     cluster_endpoint = "https://${aws_opensearch_domain.test_cluster.endpoint}"
     role_arn         = aws_iam_role.firehose.arn
     index_name       = "test"
+
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
+  }
   }
 }`, rName))
 }
@@ -3752,16 +3752,16 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "opensearch"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
   opensearch_configuration {
     cluster_endpoint   = "https://${aws_opensearch_domain.test_cluster.endpoint}"
     role_arn           = aws_iam_role.firehose.arn
     index_name         = "test"
     buffering_interval = 500
+
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
+  }
 
     processing_configuration {
       enabled = false
@@ -3795,16 +3795,16 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "opensearch"
 
+  opensearch_configuration {
+    domain_arn = aws_opensearch_domain.test_cluster.arn
+    role_arn   = aws_iam_role.firehose.arn
+    index_name = "test"
+
   s3_configuration {
     role_arn            = aws_iam_role.firehose.arn
     bucket_arn          = aws_s3_bucket.bucket.arn
     error_output_prefix = %[2]q
   }
-
-  opensearch_configuration {
-    domain_arn = aws_opensearch_domain.test_cluster.arn
-    role_arn   = aws_iam_role.firehose.arn
-    index_name = "test"
   }
 }
 `, rName, errorOutputPrefix))
@@ -3818,15 +3818,15 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "opensearch"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
   opensearch_configuration {
     domain_arn = aws_opensearch_domain.test_cluster.arn
     role_arn   = aws_iam_role.firehose.arn
     index_name = "test"
+
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
+  }
 
     vpc_config {
       subnet_ids         = aws_subnet.test[*].id
@@ -3849,16 +3849,16 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "opensearch"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
   opensearch_configuration {
     domain_arn         = aws_opensearch_domain.test_cluster.arn
     role_arn           = aws_iam_role.firehose.arn
     index_name         = "test"
     buffering_interval = 500
+
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
+  }
 
     processing_configuration {
       enabled = false
@@ -3896,16 +3896,16 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "opensearch"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
   opensearch_configuration {
     domain_arn         = aws_opensearch_domain.test_cluster.arn
     role_arn           = aws_iam_role.firehose.arn
     index_name         = "test"
     buffering_interval = 500
+
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.bucket.arn
+  }
 
     vpc_config {
       subnet_ids         = aws_subnet.test[*].id

--- a/internal/service/firehose/delivery_stream_test.go
+++ b/internal/service/firehose/delivery_stream_test.go
@@ -3352,10 +3352,10 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     index_name = "test"
     type_name  = "test"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = aws_s3_bucket.bucket.arn
+    }
   }
 }
 `, rName))
@@ -3375,11 +3375,11 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     index_name = "test"
     type_name  = "test"
 
-  s3_configuration {
-    role_arn            = aws_iam_role.firehose.arn
-    bucket_arn          = aws_s3_bucket.bucket.arn
-    error_output_prefix = %[2]q
-  }
+    s3_configuration {
+      role_arn            = aws_iam_role.firehose.arn
+      bucket_arn          = aws_s3_bucket.bucket.arn
+      error_output_prefix = %[2]q
+    }
   }
 }
 `, rName, errorOutputPrefix))
@@ -3399,10 +3399,10 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     index_name = "test"
     type_name  = "test"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = aws_s3_bucket.bucket.arn
+    }
 
     vpc_config {
       subnet_ids         = aws_subnet.test[*].id
@@ -3432,10 +3432,10 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     type_name          = "test"
     buffering_interval = 500
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = aws_s3_bucket.bucket.arn
+    }
 
     processing_configuration {
       enabled = false
@@ -3480,10 +3480,10 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     type_name          = "test"
     buffering_interval = 500
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = aws_s3_bucket.bucket.arn
+    }
 
     vpc_config {
       subnet_ids         = aws_subnet.test[*].id
@@ -3527,10 +3527,10 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     index_name       = "test"
     type_name        = "test"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = aws_s3_bucket.bucket.arn
+    }
   }
 }`, rName))
 }
@@ -3553,10 +3553,10 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     type_name          = "test"
     buffering_interval = 500
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = aws_s3_bucket.bucket.arn
+    }
 
     processing_configuration {
       enabled = false
@@ -3711,10 +3711,10 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     role_arn   = aws_iam_role.firehose.arn
     index_name = "test"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = aws_s3_bucket.bucket.arn
+    }
   }
 }
 `, rName))
@@ -3733,10 +3733,10 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     role_arn         = aws_iam_role.firehose.arn
     index_name       = "test"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = aws_s3_bucket.bucket.arn
+    }
   }
 }`, rName))
 }
@@ -3758,10 +3758,10 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     index_name         = "test"
     buffering_interval = 500
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = aws_s3_bucket.bucket.arn
+    }
 
     processing_configuration {
       enabled = false
@@ -3800,11 +3800,11 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     role_arn   = aws_iam_role.firehose.arn
     index_name = "test"
 
-  s3_configuration {
-    role_arn            = aws_iam_role.firehose.arn
-    bucket_arn          = aws_s3_bucket.bucket.arn
-    error_output_prefix = %[2]q
-  }
+    s3_configuration {
+      role_arn            = aws_iam_role.firehose.arn
+      bucket_arn          = aws_s3_bucket.bucket.arn
+      error_output_prefix = %[2]q
+    }
   }
 }
 `, rName, errorOutputPrefix))
@@ -3823,10 +3823,10 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     role_arn   = aws_iam_role.firehose.arn
     index_name = "test"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = aws_s3_bucket.bucket.arn
+    }
 
     vpc_config {
       subnet_ids         = aws_subnet.test[*].id
@@ -3855,10 +3855,10 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     index_name         = "test"
     buffering_interval = 500
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = aws_s3_bucket.bucket.arn
+    }
 
     processing_configuration {
       enabled = false
@@ -3902,10 +3902,10 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     index_name         = "test"
     buffering_interval = 500
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = aws_s3_bucket.bucket.arn
+    }
 
     vpc_config {
       subnet_ids         = aws_subnet.test[*].id

--- a/internal/service/firehose/delivery_stream_test.go
+++ b/internal/service/firehose/delivery_stream_test.go
@@ -1279,7 +1279,7 @@ func TestAccFirehoseDeliveryStream_elasticSearchWithVPCUpdates(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
 					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
-					resource.TestCheckResourceAttrPair(resourceName, "elasticsearch_configuration.0.vpc_config.0.vpc_id", "aws_vpc.elasticsearch_in_vpc", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "elasticsearch_configuration.0.vpc_config.0.vpc_id", "aws_vpc.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "elasticsearch_configuration.0.vpc_config.0.subnet_ids.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "elasticsearch_configuration.0.vpc_config.0.security_group_ids.#", "2"),
 					resource.TestCheckResourceAttrPair(resourceName, "elasticsearch_configuration.0.vpc_config.0.role_arn", "aws_iam_role.firehose", "arn"),
@@ -1295,7 +1295,7 @@ func TestAccFirehoseDeliveryStream_elasticSearchWithVPCUpdates(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
 					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, updatedElasticsearchConfig, nil, nil, nil),
-					resource.TestCheckResourceAttrPair(resourceName, "elasticsearch_configuration.0.vpc_config.0.vpc_id", "aws_vpc.elasticsearch_in_vpc", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "elasticsearch_configuration.0.vpc_config.0.vpc_id", "aws_vpc.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "elasticsearch_configuration.0.vpc_config.0.subnet_ids.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "elasticsearch_configuration.0.vpc_config.0.security_group_ids.#", "2"),
 					resource.TestCheckResourceAttrPair(resourceName, "elasticsearch_configuration.0.vpc_config.0.role_arn", "aws_iam_role.firehose", "arn"),

--- a/internal/service/firehose/delivery_stream_test.go
+++ b/internal/service/firehose/delivery_stream_test.go
@@ -125,249 +125,6 @@ func TestAccFirehoseDeliveryStream_tags(t *testing.T) {
 	})
 }
 
-func TestAccFirehoseDeliveryStream_s3basic(t *testing.T) {
-	ctx := acctest.Context(t)
-	var stream firehose.DeliveryStreamDescription
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_kinesis_firehose_delivery_stream.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, firehose.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeliveryStreamDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDeliveryStreamConfig_s3basic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
-				),
-			},
-		},
-	})
-}
-
-func TestAccFirehoseDeliveryStream_s3basicWithPrefixes(t *testing.T) {
-	ctx := acctest.Context(t)
-	var stream firehose.DeliveryStreamDescription
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_kinesis_firehose_delivery_stream.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, firehose.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeliveryStreamDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDeliveryStreamConfig_s3basicPrefixes(rName, "logs/", ""),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.prefix", "logs/"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.error_output_prefix", ""),
-				),
-			},
-			{
-				Config: testAccDeliveryStreamConfig_s3basicPrefixes(rName, "logs/", "errors/"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.prefix", "logs/"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.error_output_prefix", "errors/"),
-				),
-			},
-			{
-				Config: testAccDeliveryStreamConfig_s3basicPrefixes(rName, "logs/{timestamp:yyyy-MM-dd}/", "errors/{timestamp:yyyy-MM-dd}/"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.prefix", "logs/{timestamp:yyyy-MM-dd}/"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.error_output_prefix", "errors/{timestamp:yyyy-MM-dd}/"),
-				),
-			},
-			{
-				Config: testAccDeliveryStreamConfig_s3basicPrefixes(rName, "", ""),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.prefix", ""),
-					resource.TestCheckResourceAttr(resourceName, "s3_configuration.0.error_output_prefix", ""),
-				),
-			},
-		},
-	})
-}
-
-func TestAccFirehoseDeliveryStream_s3basicWithSSE(t *testing.T) {
-	ctx := acctest.Context(t)
-	var stream firehose.DeliveryStreamDescription
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_kinesis_firehose_delivery_stream.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, firehose.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeliveryStreamDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDeliveryStreamConfig_s3basicSSE(rName, true),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.key_type", "AWS_OWNED_CMK"),
-				),
-			},
-			{
-				Config: testAccDeliveryStreamConfig_s3basicSSE(rName, false),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "false"),
-				),
-			},
-			{
-				Config:   testAccDeliveryStreamConfig_s3basic(rName),
-				PlanOnly: true,
-			},
-			{
-				Config: testAccDeliveryStreamConfig_s3basicSSE(rName, true),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.key_type", "AWS_OWNED_CMK"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccFirehoseDeliveryStream_s3basicWithSSEAndKeyARN(t *testing.T) {
-	ctx := acctest.Context(t)
-	var stream firehose.DeliveryStreamDescription
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_kinesis_firehose_delivery_stream.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, firehose.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeliveryStreamDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDeliveryStreamConfig_s3BasicSSEAndKeyARN(rName, true),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.key_type", firehose.KeyTypeCustomerManagedCmk),
-					resource.TestCheckResourceAttrPair(resourceName, "server_side_encryption.0.key_arn", "aws_kms_key.test", "arn"),
-				),
-			},
-			{
-				Config: testAccDeliveryStreamConfig_s3basicSSE(rName, false),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "false"),
-				),
-			},
-			{
-				Config: testAccDeliveryStreamConfig_s3BasicSSEAndKeyARN(rName, true),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.key_type", firehose.KeyTypeCustomerManagedCmk),
-					resource.TestCheckResourceAttrPair(resourceName, "server_side_encryption.0.key_arn", "aws_kms_key.test", "arn"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccFirehoseDeliveryStream_s3basicWithSSEAndKeyType(t *testing.T) {
-	ctx := acctest.Context(t)
-	var stream firehose.DeliveryStreamDescription
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_kinesis_firehose_delivery_stream.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, firehose.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeliveryStreamDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDeliveryStreamConfig_s3basicSSEAndKeyType(rName, true, firehose.KeyTypeAwsOwnedCmk),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.key_type", firehose.KeyTypeAwsOwnedCmk),
-				),
-			},
-			{
-				Config: testAccDeliveryStreamConfig_s3basicSSE(rName, false),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "false"),
-				),
-			},
-			{
-				Config: testAccDeliveryStreamConfig_s3basicSSEAndKeyType(rName, true, firehose.KeyTypeAwsOwnedCmk),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.key_type", firehose.KeyTypeAwsOwnedCmk),
-				),
-			},
-		},
-	})
-}
-
-func TestAccFirehoseDeliveryStream_s3KinesisStreamSource(t *testing.T) {
-	ctx := acctest.Context(t)
-	var stream firehose.DeliveryStreamDescription
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_kinesis_firehose_delivery_stream.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, firehose.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeliveryStreamDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDeliveryStreamConfig_s3Source(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
-				),
-			},
-		},
-	})
-}
-
 func TestAccFirehoseDeliveryStream_s3WithCloudWatchLogging(t *testing.T) {
 	ctx := acctest.Context(t)
 	var stream firehose.DeliveryStreamDescription
@@ -385,43 +142,6 @@ func TestAccFirehoseDeliveryStream_s3WithCloudWatchLogging(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
 					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
-				),
-			},
-		},
-	})
-}
-
-func TestAccFirehoseDeliveryStream_s3Updates(t *testing.T) {
-	ctx := acctest.Context(t)
-	var stream firehose.DeliveryStreamDescription
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_kinesis_firehose_delivery_stream.test"
-
-	updatedS3DestinationConfig := &firehose.S3DestinationDescription{
-		BufferingHints: &firehose.BufferingHints{
-			IntervalInSeconds: aws.Int64(400),
-			SizeInMBs:         aws.Int64(10),
-		},
-	}
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, firehose.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeliveryStreamDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDeliveryStreamConfig_s3basic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, nil, nil, nil, nil, nil, nil, nil),
-				),
-			},
-			{
-				Config: testAccDeliveryStreamConfig_s3Updates(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryStreamExists(ctx, resourceName, &stream),
-					testAccCheckDeliveryStreamAttributes(&stream, updatedS3DestinationConfig, nil, nil, nil, nil, nil, nil),
 				),
 			},
 		},
@@ -2471,9 +2191,9 @@ resource "aws_cloudwatch_log_stream" "test" {
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
   name        = %[1]q
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.firehose.arn
     bucket_arn = aws_s3_bucket.bucket.arn
 
@@ -2487,111 +2207,14 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 `, rName)
 }
 
-func testAccDeliveryStreamConfig_s3basic(rName string) string {
-	return acctest.ConfigCompose(testAccDeliveryStreamConfig_base(rName), fmt.Sprintf(`
-resource "aws_kinesis_firehose_delivery_stream" "test" {
-  depends_on  = [aws_iam_role_policy.firehose]
-  name        = %[1]q
-  destination = "s3"
-
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-}
-`, rName))
-}
-
-func testAccDeliveryStreamConfig_s3basicPrefixes(rName, prefix, errorOutputPrefix string) string {
-	return acctest.ConfigCompose(testAccDeliveryStreamConfig_base(rName), fmt.Sprintf(`
-resource "aws_kinesis_firehose_delivery_stream" "test" {
-  depends_on  = ["aws_iam_role_policy.firehose"]
-  name        = %[1]q
-  destination = "s3"
-
-  s3_configuration {
-    role_arn            = aws_iam_role.firehose.arn
-    bucket_arn          = aws_s3_bucket.bucket.arn
-    prefix              = %[2]q
-    error_output_prefix = %[3]q
-  }
-}
-`, rName, prefix, errorOutputPrefix))
-}
-
-func testAccDeliveryStreamConfig_s3basicSSE(rName string, sseEnabled bool) string {
-	return acctest.ConfigCompose(testAccDeliveryStreamConfig_base(rName), fmt.Sprintf(`
-resource "aws_kinesis_firehose_delivery_stream" "test" {
-  depends_on  = [aws_iam_role_policy.firehose]
-  name        = %[1]q
-  destination = "s3"
-
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
-  server_side_encryption {
-    enabled = %[2]t
-  }
-}
-`, rName, sseEnabled))
-}
-
-func testAccDeliveryStreamConfig_s3BasicSSEAndKeyARN(rName string, sseEnabled bool) string {
-	return acctest.ConfigCompose(testAccDeliveryStreamConfig_base(rName), fmt.Sprintf(`
-resource "aws_kms_key" "test" {
-  deletion_window_in_days = 7
-  description             = %[1]q
-}
-
-resource "aws_kinesis_firehose_delivery_stream" "test" {
-  depends_on  = [aws_iam_role_policy.firehose]
-  name        = %[1]q
-  destination = "s3"
-
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
-  server_side_encryption {
-    enabled  = %[2]t
-    key_arn  = aws_kms_key.test.arn
-    key_type = "CUSTOMER_MANAGED_CMK"
-  }
-}
-`, rName, sseEnabled))
-}
-
-func testAccDeliveryStreamConfig_s3basicSSEAndKeyType(rName string, sseEnabled bool, keyType string) string {
-	return acctest.ConfigCompose(testAccDeliveryStreamConfig_base(rName), fmt.Sprintf(`
-resource "aws_kinesis_firehose_delivery_stream" "test" {
-  depends_on  = [aws_iam_role_policy.firehose]
-  name        = %[1]q
-  destination = "s3"
-
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
-  server_side_encryption {
-    enabled  = %[2]t
-    key_type = %[3]q
-  }
-}
-`, rName, sseEnabled, keyType))
-}
-
 func testAccDeliveryStreamConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccDeliveryStreamConfig_base(rName), fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
   name        = %[1]q
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.firehose.arn
     bucket_arn = aws_s3_bucket.bucket.arn
   }
@@ -2608,9 +2231,9 @@ func testAccDeliveryStreamConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagVa
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
   name        = %[1]q
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.firehose.arn
     bucket_arn = aws_s3_bucket.bucket.arn
   }
@@ -2621,48 +2244,6 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
-}
-
-func testAccDeliveryStreamConfig_s3Source(rName string) string {
-	return acctest.ConfigCompose(
-		testAccDeliveryStreamConfig_base(rName),
-		testAccDeliveryStreamConfig_baseKinesisStreamSource(rName),
-		fmt.Sprintf(`
-resource "aws_kinesis_firehose_delivery_stream" "test" {
-  depends_on = [aws_iam_role_policy.firehose, aws_iam_role_policy.kinesis_source]
-  name       = %[1]q
-
-  kinesis_source_configuration {
-    kinesis_stream_arn = aws_kinesis_stream.source.arn
-    role_arn           = aws_iam_role.kinesis_source.arn
-  }
-
-  destination = "s3"
-
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-}
-`, rName))
-}
-
-func testAccDeliveryStreamConfig_s3Updates(rName string) string {
-	return acctest.ConfigCompose(testAccDeliveryStreamConfig_base(rName), fmt.Sprintf(`
-resource "aws_kinesis_firehose_delivery_stream" "test" {
-  depends_on  = [aws_iam_role_policy.firehose]
-  name        = %[1]q
-  destination = "s3"
-
-  s3_configuration {
-    role_arn           = aws_iam_role.firehose.arn
-    bucket_arn         = aws_s3_bucket.bucket.arn
-    buffering_size     = 10
-    buffering_interval = 400
-    compression_format = "GZIP"
-  }
-}
-`, rName))
 }
 
 func testAccDeliveryStreamConfig_extendedS3basic(rName string) string {
@@ -3351,17 +2932,17 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "redshift"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
   redshift_configuration {
     role_arn        = aws_iam_role.firehose.arn
     cluster_jdbcurl = "jdbc:redshift://${aws_redshift_cluster.test.endpoint}/${aws_redshift_cluster.test.database_name}"
     username        = "testuser"
     password        = "T3stPass"
     data_table_name = "test-table"
+
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = aws_s3_bucket.bucket.arn
+    }
   }
 }
 `, rName))
@@ -3376,14 +2957,6 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "redshift"
 
-  s3_configuration {
-    role_arn           = aws_iam_role.firehose.arn
-    bucket_arn         = aws_s3_bucket.bucket.arn
-    buffering_size     = 10
-    buffering_interval = 400
-    compression_format = "GZIP"
-  }
-
   redshift_configuration {
     role_arn        = aws_iam_role.firehose.arn
     cluster_jdbcurl = "jdbc:redshift://${aws_redshift_cluster.test.endpoint}/${aws_redshift_cluster.test.database_name}"
@@ -3395,6 +2968,15 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
       role_arn   = aws_iam_role.firehose.arn
       bucket_arn = aws_s3_bucket.bucket.arn
     }
+
+    s3_configuration {
+      role_arn           = aws_iam_role.firehose.arn
+      bucket_arn         = aws_s3_bucket.bucket.arn
+      buffering_size        = 10
+      buffering_interval    = 400
+      compression_format = "GZIP"
+    }
+
 
     data_table_name    = "test-table"
     copy_options       = "GZIP"
@@ -3432,14 +3014,14 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "splunk"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
   splunk_configuration {
     hec_endpoint = "https://input-test.com:443"
     hec_token    = "51D4DA16-C61B-4F5F-8EC7-ED4301342A4A"
+
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = aws_s3_bucket.bucket.arn
+    }
   }
 }
 `, rName))
@@ -3455,20 +3037,20 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "splunk"
 
-  s3_configuration {
-    role_arn           = aws_iam_role.firehose.arn
-    bucket_arn         = aws_s3_bucket.bucket.arn
-    buffering_size     = 10
-    buffering_interval = 400
-    compression_format = "GZIP"
-  }
-
   splunk_configuration {
     hec_endpoint               = "https://input-test.com:443"
     hec_token                  = "51D4DA16-C61B-4F5F-8EC7-ED4301342A4A"
     hec_acknowledgment_timeout = 600
     hec_endpoint_type          = "Event"
     s3_backup_mode             = "FailedEventsOnly"
+
+    s3_configuration {
+      role_arn           = aws_iam_role.firehose.arn
+      bucket_arn         = aws_s3_bucket.bucket.arn
+      buffering_size        = 10
+      buffering_interval    = 400
+      compression_format = "GZIP"
+    }
 
     processing_configuration {
       enabled = true
@@ -3509,15 +3091,15 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "splunk"
 
-  s3_configuration {
-    role_arn            = aws_iam_role.firehose.arn
-    bucket_arn          = aws_s3_bucket.bucket.arn
-    error_output_prefix = %[2]q
-  }
-
   splunk_configuration {
     hec_endpoint = "https://input-test.com:443"
     hec_token    = "51D4DA16-C61B-4F5F-8EC7-ED4301342A4A"
+
+    s3_configuration {
+      role_arn            = aws_iam_role.firehose.arn
+      bucket_arn          = aws_s3_bucket.bucket.arn
+      error_output_prefix = %[2]q
+    }
   }
 }
 `, rName, errorOutputPrefix))
@@ -3530,15 +3112,15 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "http_endpoint"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
   http_endpoint_configuration {
     url      = "https://input-test.com:443"
     name     = "HTTP_test"
     role_arn = aws_iam_role.firehose.arn
+
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = aws_s3_bucket.bucket.arn
+    }
   }
 }
 `, rName))
@@ -3551,16 +3133,16 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "http_endpoint"
 
-  s3_configuration {
-    role_arn            = aws_iam_role.firehose.arn
-    bucket_arn          = aws_s3_bucket.bucket.arn
-    error_output_prefix = %[2]q
-  }
-
   http_endpoint_configuration {
     url      = "https://input-test.com:443"
     name     = "HTTP_test"
     role_arn = aws_iam_role.firehose.arn
+
+    s3_configuration {
+      role_arn            = aws_iam_role.firehose.arn
+      bucket_arn          = aws_s3_bucket.bucket.arn
+      error_output_prefix = %[2]q
+    }
   }
 }
 `, rName, errorOutputPrefix))
@@ -3573,16 +3155,16 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "http_endpoint"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-
   http_endpoint_configuration {
     url            = "https://input-test.com:443"
     name           = "HTTP_test"
     retry_duration = %[2]d
     role_arn       = aws_iam_role.firehose.arn
+
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = aws_s3_bucket.bucket.arn
+    }
   }
 }
 `, rName, retryDuration))
@@ -3598,20 +3180,20 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[1]q
   destination = "http_endpoint"
 
-  s3_configuration {
-    role_arn           = aws_iam_role.firehose.arn
-    bucket_arn         = aws_s3_bucket.bucket.arn
-    buffering_size     = 10
-    buffering_interval = 400
-    compression_format = "GZIP"
-  }
-
   http_endpoint_configuration {
     url            = "https://input-test.com:443"
     name           = "HTTP_test"
     access_key     = "test_key"
     role_arn       = aws_iam_role.firehose.arn
     s3_backup_mode = "FailedDataOnly"
+
+    s3_configuration {
+      role_arn           = aws_iam_role.firehose.arn
+      bucket_arn         = aws_s3_bucket.bucket.arn
+      buffering_size        = 10
+      buffering_interval    = 400
+      compression_format = "GZIP"
+    }
 
     processing_configuration {
       enabled = true

--- a/internal/service/firehose/delivery_stream_test.go
+++ b/internal/service/firehose/delivery_stream_test.go
@@ -2972,8 +2972,8 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     s3_configuration {
       role_arn           = aws_iam_role.firehose.arn
       bucket_arn         = aws_s3_bucket.bucket.arn
-      buffering_size        = 10
-      buffering_interval    = 400
+      buffering_size     = 10
+      buffering_interval = 400
       compression_format = "GZIP"
     }
 
@@ -3047,8 +3047,8 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     s3_configuration {
       role_arn           = aws_iam_role.firehose.arn
       bucket_arn         = aws_s3_bucket.bucket.arn
-      buffering_size        = 10
-      buffering_interval    = 400
+      buffering_size     = 10
+      buffering_interval = 400
       compression_format = "GZIP"
     }
 
@@ -3190,8 +3190,8 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
     s3_configuration {
       role_arn           = aws_iam_role.firehose.arn
       bucket_arn         = aws_s3_bucket.bucket.arn
-      buffering_size        = 10
-      buffering_interval    = 400
+      buffering_size     = 10
+      buffering_interval = 400
       compression_format = "GZIP"
     }
 

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -185,7 +185,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
       buffering_interval = 400
       compression_format = "GZIP"
     }
-    
+
     s3_backup_configuration {
       role_arn           = aws_iam_role.firehose_role.arn
       bucket_arn         = aws_s3_bucket.bucket.arn
@@ -221,7 +221,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
       buffering_interval = 400
       compression_format = "GZIP"
     }
-    
+
     processing_configuration {
       enabled = "true"
 
@@ -312,7 +312,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
       role_arn   = aws_iam_role.firehose.arn
       bucket_arn = aws_s3_bucket.bucket.arn
     }
-    
+
     vpc_config {
       subnet_ids         = [aws_subnet.first.id, aws_subnet.second.id]
       security_group_ids = [aws_security_group.first.id]
@@ -345,7 +345,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
       buffering_interval = 400
       compression_format = "GZIP"
     }
-    
+
     processing_configuration {
       enabled = "true"
 
@@ -438,7 +438,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
       role_arn   = aws_iam_role.firehose.arn
       bucket_arn = aws_s3_bucket.bucket.arn
     }
-    
+
     vpc_config {
       subnet_ids         = [aws_subnet.first.id, aws_subnet.second.id]
       security_group_ids = [aws_security_group.first.id]
@@ -496,7 +496,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
       buffering_interval = 400
       compression_format = "GZIP"
     }
-    
+
     request_configuration {
       content_encoding = "GZIP"
 

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -545,7 +545,7 @@ The `server_side_encryption` object supports the following:
 * `key_type`- (Optional) Type of encryption key. Default is `AWS_OWNED_CMK`. Valid values are `AWS_OWNED_CMK` and `CUSTOMER_MANAGED_CMK`
 * `key_arn` - (Optional) Amazon Resource Name (ARN) of the encryption key. Required when `key_type` is `CUSTOMER_MANAGED_CMK`.
 
-The `extended_s3_configuration` object supports the same fields from [s3_configuration](#s3configuration) as well as the following:
+The `extended_s3_configuration` object supports the same fields from [s3_configuration](#s3-configuration) as well as the following:
 
 * `data_format_conversion_configuration` - (Optional) Nested argument for the serializer, deserializer, and schema for converting data from the JSON format to the Parquet or ORC format before writing it to Amazon S3. More details given below.
 * `processing_configuration` - (Optional) The data processing configuration.  More details are given below.
@@ -560,7 +560,7 @@ The `redshift_configuration` object supports the following:
 * `password` - (Required) The password for the username above.
 * `retry_duration` - (Optional) The length of time during which Firehose retries delivery after a failure, starting from the initial request and including the first attempt. The default value is 3600 seconds (60 minutes). Firehose does not retry if the value of DurationInSeconds is 0 (zero) or if the first delivery attempt takes longer than the current value.
 * `role_arn` - (Required) The arn of the role the stream assumes.
-* `s3_configuration` - (Required) The S3 Configuration. See [s3_configuration](#s3configuration) for more details.
+* `s3_configuration` - (Required) The S3 Configuration. See [s3_configuration](#s3-configuration) for more details.
 * `s3_backup_mode` - (Optional) The Amazon S3 backup mode.  Valid values are `Disabled` and `Enabled`.  Default value is `Disabled`.
 * `s3_backup_configuration` - (Optional) The configuration for backup in Amazon S3. Required if `s3_backup_mode` is `Enabled`. Supports the same fields as `s3_configuration` object.
 * `data_table_name` - (Required) The name of the table in the redshift cluster that the s3 bucket will copy to.
@@ -579,7 +579,7 @@ The `elasticsearch_configuration` object supports the following:
 * `index_rotation_period` - (Optional) The Elasticsearch index rotation period.  Index rotation appends a timestamp to the IndexName to facilitate expiration of old data.  Valid values are `NoRotation`, `OneHour`, `OneDay`, `OneWeek`, and `OneMonth`.  The default value is `OneDay`.
 * `retry_duration` - (Optional) After an initial failure to deliver to Amazon Elasticsearch, the total amount of time, in seconds between 0 to 7200, during which Firehose re-attempts delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 300s.  There will be no retry if the value is 0.
 * `role_arn` - (Required) The ARN of the IAM role to be assumed by Firehose for calling the Amazon ES Configuration API and for indexing documents.  The IAM role must have permission for `DescribeElasticsearchDomain`, `DescribeElasticsearchDomains`, and `DescribeElasticsearchDomainConfig`.  The pattern needs to be `arn:.*`.
-* `s3_configuration` - (Required) The S3 Configuration. See [s3_configuration](#s3configuration) for more details.
+* `s3_configuration` - (Required) The S3 Configuration. See [s3_configuration](#s3-configuration) for more details.
 * `s3_backup_mode` - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDocumentsOnly` and `AllDocuments`.  Default value is `FailedDocumentsOnly`.
 * `type_name` - (Optional) The Elasticsearch type name with maximum length of 100 characters.
 * `cloudwatch_logging_options` - (Optional) The CloudWatch Logging Options for the delivery stream. More details are given below
@@ -596,7 +596,7 @@ The `opensearch_configuration` object supports the following:
 * `index_rotation_period` - (Optional) The Opensearch index rotation period.  Index rotation appends a timestamp to the IndexName to facilitate expiration of old data.  Valid values are `NoRotation`, `OneHour`, `OneDay`, `OneWeek`, and `OneMonth`.  The default value is `OneDay`.
 * `retry_duration` - (Optional) After an initial failure to deliver to Amazon OpenSearch, the total amount of time, in seconds between 0 to 7200, during which Firehose re-attempts delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 300s.  There will be no retry if the value is 0.
 * `role_arn` - (Required) The ARN of the IAM role to be assumed by Firehose for calling the Amazon ES Configuration API and for indexing documents.  The IAM role must have permission for `DescribeDomain`, `DescribeDomains`, and `DescribeDomainConfig`.  The pattern needs to be `arn:.*`.
-* `s3_configuration` - (Required) The S3 Configuration. See [s3_configuration](#s3configuration) for more details.
+* `s3_configuration` - (Required) The S3 Configuration. See [s3_configuration](#s3-configuration) for more details.
 * `s3_backup_mode` - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDocumentsOnly` and `AllDocuments`.  Default value is `FailedDocumentsOnly`.
 * `type_name` - (Optional) The Elasticsearch type name with maximum length of 100 characters. Types are deprecated in OpenSearch_1.1. TypeName must be empty.
 * `cloudwatch_logging_options` - (Optional) The CloudWatch Logging Options for the delivery stream. More details are given below
@@ -609,7 +609,7 @@ The `splunk_configuration` objects supports the following:
 * `hec_endpoint` - (Required) The HTTP Event Collector (HEC) endpoint to which Kinesis Firehose sends your data.
 * `hec_endpoint_type` - (Optional) The HEC endpoint type. Valid values are `Raw` or `Event`. The default value is `Raw`.
 * `hec_token` - (Required) The GUID that you obtain from your Splunk cluster when you create a new HEC endpoint.
-* `s3_configuration` - (Required) The S3 Configuration. See [s3_configuration](#s3configuration) for more details.
+* `s3_configuration` - (Required) The S3 Configuration. See [s3_configuration](#s3-configuration) for more details.
 * `s3_backup_mode` - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedEventsOnly` and `AllEvents`.  Default value is `FailedEventsOnly`.
 * `retry_duration` - (Optional) After an initial failure to deliver to Splunk, the total amount of time, in seconds between 0 to 7200, during which Firehose re-attempts delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 300s.  There will be no retry if the value is 0.
 * `cloudwatch_logging_options` - (Optional) The CloudWatch Logging Options for the delivery stream. More details are given below.
@@ -621,7 +621,7 @@ The `http_endpoint_configuration` objects supports the following:
 * `name` - (Optional) The HTTP endpoint name.
 * `access_key` - (Optional) The access key required for Kinesis Firehose to authenticate with the HTTP endpoint selected as the destination.
 * `role_arn` - (Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`.
-* `s3_configuration` - (Required) The S3 Configuration. See [s3_configuration](#s3configuration) for more details.
+* `s3_configuration` - (Required) The S3 Configuration. See [s3_configuration](#s3-configuration) for more details.
 * `s3_backup_mode` - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDataOnly` and `AllData`.  Default value is `FailedDataOnly`.
 * `buffering_size` - (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
 * `buffering_interval` - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).
@@ -711,7 +711,7 @@ resource "aws_kinesis_firehose_delivery_stream" "example" {
 * `schema_configuration` - (Required) Nested argument that specifies the AWS Glue Data Catalog table that contains the column information. More details below.
 * `enabled` - (Optional) Defaults to `true`. Set it to `false` if you want to disable format conversion while preserving the configuration details.
 
-#### s3_configuration
+#### S3 Configuration
 
 * `role_arn` - (Required) The ARN of the AWS credentials.
 * `bucket_arn` - (Required) The ARN of the S3 bucket

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -152,47 +152,6 @@ resource "aws_kinesis_firehose_delivery_stream" "extended_s3_stream" {
 }
 ```
 
-### S3 Destination (deprecated)
-
-```terraform
-resource "aws_s3_bucket" "bucket" {
-  bucket = "tf-test-bucket"
-}
-
-resource "aws_s3_bucket_acl" "bucket_acl" {
-  bucket = aws_s3_bucket.bucket.id
-  acl    = "private"
-}
-
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    effect = "Allow"
-
-    principals {
-      type        = "Service"
-      identifiers = ["firehose.amazonaws.com"]
-    }
-
-    actions = ["sts:AssumeRole"]
-  }
-}
-
-resource "aws_iam_role" "firehose_role" {
-  name               = "firehose_test_role"
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
-}
-
-resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
-  name        = "terraform-kinesis-firehose-test-stream"
-  destination = "s3"
-
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose_role.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
-}
-```
-
 ### Redshift Destination
 
 ```terraform
@@ -209,14 +168,6 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   name        = "terraform-kinesis-firehose-test-stream"
   destination = "redshift"
 
-  s3_configuration {
-    role_arn           = aws_iam_role.firehose_role.arn
-    bucket_arn         = aws_s3_bucket.bucket.arn
-    buffering_size     = 10
-    buffering_interval = 400
-    compression_format = "GZIP"
-  }
-
   redshift_configuration {
     role_arn           = aws_iam_role.firehose_role.arn
     cluster_jdbcurl    = "jdbc:redshift://${aws_redshift_cluster.test_cluster.endpoint}/${aws_redshift_cluster.test_cluster.database_name}"
@@ -227,6 +178,14 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
     data_table_columns = "test-col"
     s3_backup_mode     = "Enabled"
 
+    s3_configuration {
+      role_arn           = aws_iam_role.firehose_role.arn
+      bucket_arn         = aws_s3_bucket.bucket.arn
+      buffering_size     = 10
+      buffering_interval = 400
+      compression_format = "GZIP"
+    }
+    
     s3_backup_configuration {
       role_arn           = aws_iam_role.firehose_role.arn
       bucket_arn         = aws_s3_bucket.bucket.arn
@@ -249,20 +208,20 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   name        = "terraform-kinesis-firehose-test-stream"
   destination = "elasticsearch"
 
-  s3_configuration {
-    role_arn           = aws_iam_role.firehose_role.arn
-    bucket_arn         = aws_s3_bucket.bucket.arn
-    buffering_size     = 10
-    buffering_interval = 400
-    compression_format = "GZIP"
-  }
-
   elasticsearch_configuration {
     domain_arn = aws_elasticsearch_domain.test_cluster.arn
     role_arn   = aws_iam_role.firehose_role.arn
     index_name = "test"
     type_name  = "test"
 
+    s3_configuration {
+      role_arn           = aws_iam_role.firehose_role.arn
+      bucket_arn         = aws_s3_bucket.bucket.arn
+      buffering_size     = 10
+      buffering_interval = 400
+      compression_format = "GZIP"
+    }
+    
     processing_configuration {
       enabled = "true"
 
@@ -342,16 +301,18 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
   name        = "terraform-kinesis-firehose-es"
   destination = "elasticsearch"
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
+
   elasticsearch_configuration {
     domain_arn = aws_elasticsearch_domain.test_cluster.arn
     role_arn   = aws_iam_role.firehose.arn
     index_name = "test"
     type_name  = "test"
 
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = aws_s3_bucket.bucket.arn
+    }
+    
     vpc_config {
       subnet_ids         = [aws_subnet.first.id, aws_subnet.second.id]
       security_group_ids = [aws_security_group.first.id]
@@ -372,19 +333,19 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   name        = "terraform-kinesis-firehose-test-stream"
   destination = "opensearch"
 
-  s3_configuration {
-    role_arn           = aws_iam_role.firehose_role.arn
-    bucket_arn         = aws_s3_bucket.bucket.arn
-    buffering_size     = 10
-    buffering_interval = 400
-    compression_format = "GZIP"
-  }
-
   opensearch_configuration {
     domain_arn = aws_opensearch_domain.test_cluster.arn
     role_arn   = aws_iam_role.firehose_role.arn
     index_name = "test"
 
+    s3_configuration {
+      role_arn           = aws_iam_role.firehose_role.arn
+      bucket_arn         = aws_s3_bucket.bucket.arn
+      buffering_size     = 10
+      buffering_interval = 400
+      compression_format = "GZIP"
+    }
+    
     processing_configuration {
       enabled = "true"
 
@@ -467,15 +428,17 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 
   name        = "terraform-kinesis-firehose-os"
   destination = "opensearch"
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose.arn
-    bucket_arn = aws_s3_bucket.bucket.arn
-  }
+
   opensearch_configuration {
     domain_arn = aws_opensearch_domain.test_cluster.arn
     role_arn   = aws_iam_role.firehose.arn
     index_name = "test"
 
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose.arn
+      bucket_arn = aws_s3_bucket.bucket.arn
+    }
+    
     vpc_config {
       subnet_ids         = [aws_subnet.first.id, aws_subnet.second.id]
       security_group_ids = [aws_security_group.first.id]
@@ -492,20 +455,20 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   name        = "terraform-kinesis-firehose-test-stream"
   destination = "splunk"
 
-  s3_configuration {
-    role_arn           = aws_iam_role.firehose.arn
-    bucket_arn         = aws_s3_bucket.bucket.arn
-    buffering_size     = 10
-    buffering_interval = 400
-    compression_format = "GZIP"
-  }
-
   splunk_configuration {
     hec_endpoint               = "https://http-inputs-mydomain.splunkcloud.com:443"
     hec_token                  = "51D4DA16-C61B-4F5F-8EC7-ED4301342A4A"
     hec_acknowledgment_timeout = 600
     hec_endpoint_type          = "Event"
     s3_backup_mode             = "FailedEventsOnly"
+
+    s3_configuration {
+      role_arn           = aws_iam_role.firehose.arn
+      bucket_arn         = aws_s3_bucket.bucket.arn
+      buffering_size     = 10
+      buffering_interval = 400
+      compression_format = "GZIP"
+    }
   }
 }
 ```
@@ -517,14 +480,6 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   name        = "terraform-kinesis-firehose-test-stream"
   destination = "http_endpoint"
 
-  s3_configuration {
-    role_arn           = aws_iam_role.firehose.arn
-    bucket_arn         = aws_s3_bucket.bucket.arn
-    buffering_size     = 10
-    buffering_interval = 400
-    compression_format = "GZIP"
-  }
-
   http_endpoint_configuration {
     url                = "https://aws-api.newrelic.com/firehose/v1"
     name               = "New Relic"
@@ -534,6 +489,14 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
     role_arn           = aws_iam_role.firehose.arn
     s3_backup_mode     = "FailedDataOnly"
 
+    s3_configuration {
+      role_arn           = aws_iam_role.firehose.arn
+      bucket_arn         = aws_s3_bucket.bucket.arn
+      buffering_size     = 10
+      buffering_interval = 400
+      compression_format = "GZIP"
+    }
+    
     request_configuration {
       content_encoding = "GZIP"
 
@@ -561,7 +524,6 @@ The following arguments are supported:
 * `server_side_encryption` - (Optional) Encrypt at rest options.
 Server-side encryption should not be enabled when a kinesis stream is configured as the source of the firehose delivery stream.
 * `destination` – (Required) This is the destination to where the data is delivered. The only options are `s3` (Deprecated, use `extended_s3` instead), `extended_s3`, `redshift`, `elasticsearch`, `splunk`, `http_endpoint` and `opensearch`.
-* `s3_configuration` - (Optional) Required for non-S3 destinations. For S3 destination, use `extended_s3_configuration` instead. Configuration options for the s3 destination (or the intermediate bucket if the destination
 is redshift). More details are given below.
 * `extended_s3_configuration` - (Optional, only Required when `destination` is `extended_s3`) Enhanced configuration options for the s3 destination. More details are given below.
 * `redshift_configuration` - (Optional) Configuration options if redshift is the destination.
@@ -583,23 +545,7 @@ The `server_side_encryption` object supports the following:
 * `key_type`- (Optional) Type of encryption key. Default is `AWS_OWNED_CMK`. Valid values are `AWS_OWNED_CMK` and `CUSTOMER_MANAGED_CMK`
 * `key_arn` - (Optional) Amazon Resource Name (ARN) of the encryption key. Required when `key_type` is `CUSTOMER_MANAGED_CMK`.
 
-The `s3_configuration` object supports the following:
-
-~> **NOTE:** This configuration block is deprecated for the `s3` destination.
-
-* `role_arn` - (Required) The ARN of the AWS credentials.
-* `bucket_arn` - (Required) The ARN of the S3 bucket
-* `prefix` - (Optional) The "YYYY/MM/DD/HH" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket
-* `buffering_size` - (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
-                                We recommend setting SizeInMBs to a value greater than the amount of data you typically ingest into the delivery stream in 10 seconds. For example, if you typically ingest data at 1 MB/sec set SizeInMBs to be 10 MB or higher.
-* `buffering_interval` - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
-* `compression_format` - (Optional) The compression format. If no value is specified, the default is `UNCOMPRESSED`. Other supported values are `GZIP`, `ZIP`, `Snappy`, & `HADOOP_SNAPPY`.
-* `error_output_prefix` - (Optional) Prefix added to failed records before writing them to S3. Not currently supported for `redshift` destination. This prefix appears immediately following the bucket name. For information about how to specify this prefix, see [Custom Prefixes for Amazon S3 Objects](https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html).
-* `kms_key_arn` - (Optional) Specifies the KMS key ARN the stream will use to encrypt data. If not set, no encryption will
-be used.
-* `cloudwatch_logging_options` - (Optional) The CloudWatch Logging Options for the delivery stream. More details are given below
-
-The `extended_s3_configuration` object supports the same fields from `s3_configuration` as well as the following:
+The `extended_s3_configuration` object supports the same fields from [s3_configuration](#s3configuration) as well as the following:
 
 * `data_format_conversion_configuration` - (Optional) Nested argument for the serializer, deserializer, and schema for converting data from the JSON format to the Parquet or ORC format before writing it to Amazon S3. More details given below.
 * `processing_configuration` - (Optional) The data processing configuration.  More details are given below.
@@ -614,6 +560,7 @@ The `redshift_configuration` object supports the following:
 * `password` - (Required) The password for the username above.
 * `retry_duration` - (Optional) The length of time during which Firehose retries delivery after a failure, starting from the initial request and including the first attempt. The default value is 3600 seconds (60 minutes). Firehose does not retry if the value of DurationInSeconds is 0 (zero) or if the first delivery attempt takes longer than the current value.
 * `role_arn` - (Required) The arn of the role the stream assumes.
+* `s3_configuration` - (Required) The S3 Configuration. See [s3_configuration](#s3configuration) for more details.
 * `s3_backup_mode` - (Optional) The Amazon S3 backup mode.  Valid values are `Disabled` and `Enabled`.  Default value is `Disabled`.
 * `s3_backup_configuration` - (Optional) The configuration for backup in Amazon S3. Required if `s3_backup_mode` is `Enabled`. Supports the same fields as `s3_configuration` object.
 * `data_table_name` - (Required) The name of the table in the redshift cluster that the s3 bucket will copy to.
@@ -632,6 +579,7 @@ The `elasticsearch_configuration` object supports the following:
 * `index_rotation_period` - (Optional) The Elasticsearch index rotation period.  Index rotation appends a timestamp to the IndexName to facilitate expiration of old data.  Valid values are `NoRotation`, `OneHour`, `OneDay`, `OneWeek`, and `OneMonth`.  The default value is `OneDay`.
 * `retry_duration` - (Optional) After an initial failure to deliver to Amazon Elasticsearch, the total amount of time, in seconds between 0 to 7200, during which Firehose re-attempts delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 300s.  There will be no retry if the value is 0.
 * `role_arn` - (Required) The ARN of the IAM role to be assumed by Firehose for calling the Amazon ES Configuration API and for indexing documents.  The IAM role must have permission for `DescribeElasticsearchDomain`, `DescribeElasticsearchDomains`, and `DescribeElasticsearchDomainConfig`.  The pattern needs to be `arn:.*`.
+* `s3_configuration` - (Required) The S3 Configuration. See [s3_configuration](#s3configuration) for more details.
 * `s3_backup_mode` - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDocumentsOnly` and `AllDocuments`.  Default value is `FailedDocumentsOnly`.
 * `type_name` - (Optional) The Elasticsearch type name with maximum length of 100 characters.
 * `cloudwatch_logging_options` - (Optional) The CloudWatch Logging Options for the delivery stream. More details are given below
@@ -648,6 +596,7 @@ The `opensearch_configuration` object supports the following:
 * `index_rotation_period` - (Optional) The Opensearch index rotation period.  Index rotation appends a timestamp to the IndexName to facilitate expiration of old data.  Valid values are `NoRotation`, `OneHour`, `OneDay`, `OneWeek`, and `OneMonth`.  The default value is `OneDay`.
 * `retry_duration` - (Optional) After an initial failure to deliver to Amazon OpenSearch, the total amount of time, in seconds between 0 to 7200, during which Firehose re-attempts delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 300s.  There will be no retry if the value is 0.
 * `role_arn` - (Required) The ARN of the IAM role to be assumed by Firehose for calling the Amazon ES Configuration API and for indexing documents.  The IAM role must have permission for `DescribeDomain`, `DescribeDomains`, and `DescribeDomainConfig`.  The pattern needs to be `arn:.*`.
+* `s3_configuration` - (Required) The S3 Configuration. See [s3_configuration](#s3configuration) for more details.
 * `s3_backup_mode` - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDocumentsOnly` and `AllDocuments`.  Default value is `FailedDocumentsOnly`.
 * `type_name` - (Optional) The Elasticsearch type name with maximum length of 100 characters. Types are deprecated in OpenSearch_1.1. TypeName must be empty.
 * `cloudwatch_logging_options` - (Optional) The CloudWatch Logging Options for the delivery stream. More details are given below
@@ -660,6 +609,7 @@ The `splunk_configuration` objects supports the following:
 * `hec_endpoint` - (Required) The HTTP Event Collector (HEC) endpoint to which Kinesis Firehose sends your data.
 * `hec_endpoint_type` - (Optional) The HEC endpoint type. Valid values are `Raw` or `Event`. The default value is `Raw`.
 * `hec_token` - (Required) The GUID that you obtain from your Splunk cluster when you create a new HEC endpoint.
+* `s3_configuration` - (Required) The S3 Configuration. See [s3_configuration](#s3configuration) for more details.
 * `s3_backup_mode` - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedEventsOnly` and `AllEvents`.  Default value is `FailedEventsOnly`.
 * `retry_duration` - (Optional) After an initial failure to deliver to Splunk, the total amount of time, in seconds between 0 to 7200, during which Firehose re-attempts delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 300s.  There will be no retry if the value is 0.
 * `cloudwatch_logging_options` - (Optional) The CloudWatch Logging Options for the delivery stream. More details are given below.
@@ -671,6 +621,7 @@ The `http_endpoint_configuration` objects supports the following:
 * `name` - (Optional) The HTTP endpoint name.
 * `access_key` - (Optional) The access key required for Kinesis Firehose to authenticate with the HTTP endpoint selected as the destination.
 * `role_arn` - (Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`.
+* `s3_configuration` - (Required) The S3 Configuration. See [s3_configuration](#s3configuration) for more details.
 * `s3_backup_mode` - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDataOnly` and `AllData`.  Default value is `FailedDataOnly`.
 * `buffering_size` - (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
 * `buffering_interval` - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).
@@ -759,6 +710,20 @@ resource "aws_kinesis_firehose_delivery_stream" "example" {
 * `output_format_configuration` - (Required) Nested argument that specifies the serializer that you want Kinesis Data Firehose to use to convert the format of your data to the Parquet or ORC format. More details below.
 * `schema_configuration` - (Required) Nested argument that specifies the AWS Glue Data Catalog table that contains the column information. More details below.
 * `enabled` - (Optional) Defaults to `true`. Set it to `false` if you want to disable format conversion while preserving the configuration details.
+
+#### s3_configuration
+
+* `role_arn` - (Required) The ARN of the AWS credentials.
+* `bucket_arn` - (Required) The ARN of the S3 bucket
+* `prefix` - (Optional) The "YYYY/MM/DD/HH" time format prefix is automatically used for delivered S3 files. You can specify an extra prefix to be added in front of the time format prefix. Note that if the prefix ends with a slash, it appears as a folder in the S3 bucket
+* `buffering_size` - (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
+  We recommend setting SizeInMBs to a value greater than the amount of data you typically ingest into the delivery stream in 10 seconds. For example, if you typically ingest data at 1 MB/sec set SizeInMBs to be 10 MB or higher.
+* `buffering_interval` - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
+* `compression_format` - (Optional) The compression format. If no value is specified, the default is `UNCOMPRESSED`. Other supported values are `GZIP`, `ZIP`, `Snappy`, & `HADOOP_SNAPPY`.
+* `error_output_prefix` - (Optional) Prefix added to failed records before writing them to S3. Not currently supported for `redshift` destination. This prefix appears immediately following the bucket name. For information about how to specify this prefix, see [Custom Prefixes for Amazon S3 Objects](https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html).
+* `kms_key_arn` - (Optional) Specifies the KMS key ARN the stream will use to encrypt data. If not set, no encryption will
+  be used.
+* `cloudwatch_logging_options` - (Optional) The CloudWatch Logging Options for the delivery stream. More details are given below
 
 #### input_format_configuration
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

- [x] remove root `s3_configuration` attribute
- [x]  add `s3_configuration` to the following:
- - [x] `elasticsearch_configuration`
- - [x] `opensearch_configuration`
- - [x] `splunk_configuration`
- - [x] `redshift_configuration`
- - [x] `http_endpoint_configuration`


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:
--->

Closes #22309

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console 
$ make testacc TESTARGS='-run=TestAccFirehoseDeliveryStream_' PKG=firehose

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/firehose/... -v -count 1 -parallel 20  -run=TestAccFirehoseDeliveryStream_ -timeout 180m
--- PASS: TestAccFirehoseDeliveryStream_extendedS3basic (284.78s)
--- PASS: TestAccFirehoseDeliveryStream_basic (309.18s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionHiveJSONSerDe_empty (313.75s)
--- PASS: TestAccFirehoseDeliveryStream_missingProcessing (323.59s)
--- PASS: TestAccFirehoseDeliveryStream_s3WithCloudWatchLogging (326.91s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionOpenXJSONSerDe_empty (333.31s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3_S3BackupConfiguration_ErrorOutputPrefix (350.32s)
--- PASS: TestAccFirehoseDeliveryStream_tags (358.36s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionDeserializer_update (369.15s)
--- PASS: TestAccFirehoseDeliveryStream_disappears (378.45s)
--- PASS: TestAccFirehoseDeliveryStream_Splunk_ErrorOutputPrefix (396.01s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversion_enabled (445.47s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionParquetSerDe_empty (199.23s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3_errorOutputPrefix (265.46s)
--- PASS: TestAccFirehoseDeliveryStream_extendedS3DynamicPartitioning (181.99s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3Processing_empty (200.16s)
--- PASS: TestAccFirehoseDeliveryStream_httpEndpoint (232.99s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionOrcSerDe_empty (261.95s)
--- PASS: TestAccFirehoseDeliveryStream_extendedS3KMSKeyARN (285.70s)
--- PASS: TestAccFirehoseDeliveryStream_HTTPEndpoint_ErrorOutputPrefix (271.30s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3DataFormatConversionSerializer_update (325.54s)
--- PASS: TestAccFirehoseDeliveryStream_HTTPEndpoint_retryDuration (311.90s)
--- PASS: TestAccFirehoseDeliveryStream_extendedS3DynamicPartitioningUpdate (639.03s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3_kinesisStreamSource (154.08s)
--- PASS: TestAccFirehoseDeliveryStream_extendedS3Updates (188.18s)
--- PASS: TestAccFirehoseDeliveryStream_ExtendedS3_externalUpdate (183.13s)
--- PASS: TestAccFirehoseDeliveryStream_splunkUpdates (229.21s)
--- PASS: TestAccFirehoseDeliveryStream_redshiftUpdates (560.60s)
--- PASS: TestAccFirehoseDeliveryStream_elasticSearchUpdates (1453.28s)
--- PASS: TestAccFirehoseDeliveryStream_elasticSearchEndpointUpdates (1599.33s)
--- PASS: TestAccFirehoseDeliveryStream_Elasticsearch_ErrorOutputPrefix (1615.67s)
--- PASS: TestAccFirehoseDeliveryStream_Opensearch_ErrorOutputPrefix (1682.39s)
--- PASS: TestAccFirehoseDeliveryStream_openSearchUpdates (1723.14s)
--- PASS: TestAccFirehoseDeliveryStream_openSearchEndpointUpdates (2085.22s)
--- PASS: TestAccFirehoseDeliveryStream_elasticSearchWithVPCUpdates (2435.51s)
--- PASS: TestAccFirehoseDeliveryStream_openSearchWithVPCUpdates (2551.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/firehose	2868.183s
...
```
