### PR TITLE
Update permissive ECR policy docs to better demonstrate best practices

### DIFF
--- a/website/docs/r/ecr_repository_policy.html.markdown
+++ b/website/docs/r/ecr_repository_policy.html.markdown
@@ -25,8 +25,8 @@ data "aws_iam_policy_document" "foopolicy" {
     effect = "Allow"
 
     principals {
-      type        = "*"
-      identifiers = ["*"]
+      type        = "AWS"
+      identifiers = ["123456789012"]
     }
 
     actions = [

--- a/website/docs/r/ecrpublic_repository_policy.html.markdown
+++ b/website/docs/r/ecrpublic_repository_policy.html.markdown
@@ -27,8 +27,8 @@ data "aws_iam_policy_document" "example" {
     effect = "Allow"
 
     principals {
-      type        = "*"
-      identifiers = ["*"]
+      type        = "AWS"
+      identifiers = ["123456789012"]
     }
 
     actions = [


### PR DESCRIPTION
### Description

The documentation for ECR Repository policies is permissive. This is a minor update to documentation that better demonstrates best practices of explicitly setting the type and identifier in the policy.

### References

Policy example in AWS docs can be found [here](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policy-examples.html) and [here](https://docs.aws.amazon.com/AmazonECR/latest/public/public-repository-policies.html).
