### PR TITLE
Tech debt: Migrate `accessanalyzer` resources to AWS SDK for Go v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.255
 	github.com/aws/aws-sdk-go-v2 v1.18.0
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.3
+	github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.19.11
 	github.com/aws/aws-sdk-go-v2/service/account v1.10.5
 	github.com/aws/aws-sdk-go-v2/service/auditmanager v1.24.6
 	github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.27 h1:vFQlirhuM8lLlpI7im
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.27/go.mod h1:UrHnn3QV/d0pBZ6QBAEQcqFLf8FAzLmoUfPVIueOvoM=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.29 h1:J4xhFd6zHhdF9jPP0FQJ6WknzBboGMBNjKOv4iTuw4A=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.29/go.mod h1:TwuqRBGzxjQJIwH16/fOZodwXt2Zxa9/cwJC5ke4j7s=
+github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.19.11 h1:xKLlNhEQlfGpYdm5Ko7Mmylfk3vq4MN20TNGARj66ZM=
+github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.19.11/go.mod h1:05NIzmwCjR1k1Hhx3RPSkKFRdO9AyHuEJCEgTZG8Ta4=
 github.com/aws/aws-sdk-go-v2/service/account v1.10.5 h1:K+Od2Oz2nhQJx3e3Q+ziU11avIlINB0ngfsdc7O2X3M=
 github.com/aws/aws-sdk-go-v2/service/account v1.10.5/go.mod h1:sxLUXrqYXCfOBPBBk0azv+UOoFsnrQ9G1ZcICrb9O+0=
 github.com/aws/aws-sdk-go-v2/service/auditmanager v1.24.6 h1:UNaqp6XOs26fmBNASN9SF23H3DytHaaRQ/hF/BJNnes=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -4,6 +4,7 @@ package conns
 import (
 	"net/http"
 
+	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
 	"github.com/aws/aws-sdk-go-v2/service/account"
 	"github.com/aws/aws-sdk-go-v2/service/auditmanager"
 	"github.com/aws/aws-sdk-go-v2/service/cleanrooms"
@@ -40,7 +41,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/transcribe"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/accessanalyzer"
 	"github.com/aws/aws-sdk-go/service/acm"
 	"github.com/aws/aws-sdk-go/service/acmpca"
 	"github.com/aws/aws-sdk-go/service/alexaforbusiness"
@@ -360,7 +360,7 @@ type AWSClient struct {
 	apigatewayConn                   *apigateway.APIGateway
 	apigatewaymanagementapiConn      *apigatewaymanagementapi.ApiGatewayManagementApi
 	apigatewayv2Conn                 *apigatewayv2.ApiGatewayV2
-	accessanalyzerConn               *accessanalyzer.AccessAnalyzer
+	accessanalyzerClient             *accessanalyzer.Client
 	accountClient                    *account.Client
 	alexaforbusinessConn             *alexaforbusiness.AlexaForBusiness
 	amplifyConn                      *amplify.Amplify
@@ -698,8 +698,8 @@ func (client *AWSClient) APIGatewayV2Conn() *apigatewayv2.ApiGatewayV2 {
 	return client.apigatewayv2Conn
 }
 
-func (client *AWSClient) AccessAnalyzerConn() *accessanalyzer.AccessAnalyzer {
-	return client.accessanalyzerConn
+func (client *AWSClient) AccessAnalyzerClient() *accessanalyzer.Client {
+	return client.accessanalyzerClient
 }
 
 func (client *AWSClient) AccountClient() *account.Client {

--- a/internal/conns/config_gen.go
+++ b/internal/conns/config_gen.go
@@ -3,6 +3,7 @@ package conns
 
 import (
 	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
 	"github.com/aws/aws-sdk-go-v2/service/account"
 	"github.com/aws/aws-sdk-go-v2/service/auditmanager"
 	"github.com/aws/aws-sdk-go-v2/service/cleanrooms"
@@ -39,7 +40,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/accessanalyzer"
 	"github.com/aws/aws-sdk-go/service/acm"
 	"github.com/aws/aws-sdk-go/service/acmpca"
 	"github.com/aws/aws-sdk-go/service/alexaforbusiness"
@@ -331,7 +331,6 @@ func (c *Config) sdkv1Conns(client *AWSClient, sess *session.Session) {
 	client.apigatewayConn = apigateway.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.APIGateway])}))
 	client.apigatewaymanagementapiConn = apigatewaymanagementapi.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.APIGatewayManagementAPI])}))
 	client.apigatewayv2Conn = apigatewayv2.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.APIGatewayV2])}))
-	client.accessanalyzerConn = accessanalyzer.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AccessAnalyzer])}))
 	client.alexaforbusinessConn = alexaforbusiness.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AlexaForBusiness])}))
 	client.amplifyConn = amplify.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.Amplify])}))
 	client.amplifybackendConn = amplifybackend.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.AmplifyBackend])}))
@@ -610,6 +609,11 @@ func (c *Config) sdkv1Conns(client *AWSClient, sess *session.Session) {
 
 // sdkv2Conns initializes AWS SDK for Go v2 clients.
 func (c *Config) sdkv2Conns(client *AWSClient, cfg aws_sdkv2.Config) {
+	client.accessanalyzerClient = accessanalyzer.NewFromConfig(cfg, func(o *accessanalyzer.Options) {
+		if endpoint := c.Endpoints[names.AccessAnalyzer]; endpoint != "" {
+			o.EndpointResolver = accessanalyzer.EndpointResolverFromURL(endpoint)
+		}
+	})
 	client.accountClient = account.NewFromConfig(cfg, func(o *account.Options) {
 		if endpoint := c.Endpoints[names.Account]; endpoint != "" {
 			o.EndpointResolver = account.EndpointResolverFromURL(endpoint)

--- a/internal/service/accessanalyzer/accessanalyzer_test.go
+++ b/internal/service/accessanalyzer/accessanalyzer_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/accessanalyzer"
+	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 )
@@ -31,11 +31,11 @@ func TestAccAccessAnalyzer_serial(t *testing.T) {
 }
 
 func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerConn()
+	conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerClient()
 
 	input := &accessanalyzer.ListAnalyzersInput{}
 
-	_, err := conn.ListAnalyzersWithContext(ctx, input)
+	_, err := conn.ListAnalyzers(ctx, input)
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)

--- a/internal/service/accessanalyzer/analyzer.go
+++ b/internal/service/accessanalyzer/analyzer.go
@@ -6,15 +6,17 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/accessanalyzer"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
+	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -32,12 +34,13 @@ const (
 
 // @SDKResource("aws_accessanalyzer_analyzer", name="Analyzer")
 // @Tags(identifierAttribute="arn")
-func ResourceAnalyzer() *schema.Resource {
+func resourceAnalyzer() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAnalyzerCreate,
 		ReadWithoutTimeout:   resourceAnalyzerRead,
 		UpdateWithoutTimeout: resourceAnalyzerUpdate,
 		DeleteWithoutTimeout: resourceAnalyzerDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -59,14 +62,11 @@ func ResourceAnalyzer() *schema.Resource {
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  accessanalyzer.TypeAccount,
-				ValidateFunc: validation.StringInSlice([]string{
-					accessanalyzer.TypeAccount,
-					accessanalyzer.TypeOrganization,
-				}, false),
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Default:          types.TypeAccount,
+				ValidateDiagFunc: enum.Validate[types.Type](),
 			},
 		},
 
@@ -76,37 +76,32 @@ func ResourceAnalyzer() *schema.Resource {
 
 func resourceAnalyzerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).AccessAnalyzerConn()
+	conn := meta.(*conns.AWSClient).AccessAnalyzerClient()
 
 	analyzerName := d.Get("analyzer_name").(string)
 	input := &accessanalyzer.CreateAnalyzerInput{
 		AnalyzerName: aws.String(analyzerName),
 		ClientToken:  aws.String(id.UniqueId()),
 		Tags:         GetTagsIn(ctx),
-		Type:         aws.String(d.Get("type").(string)),
+		Type:         types.Type(d.Get("type").(string)),
 	}
 
-	// Handle Organizations eventual consistency
-	err := retry.RetryContext(ctx, organizationCreationTimeout, func() *retry.RetryError {
-		_, err := conn.CreateAnalyzerWithContext(ctx, input)
+	// Handle Organizations eventual consistency.
+	_, err := tfresource.RetryWhen(ctx, organizationCreationTimeout,
+		func() (interface{}, error) {
+			return conn.CreateAnalyzer(ctx, input)
+		},
+		func(err error) (bool, error) {
+			if errs.IsAErrorMessageContains[*types.ValidationException](err, "You must create an organization") {
+				return true, err
+			}
 
-		if tfawserr.ErrMessageContains(err, accessanalyzer.ErrCodeValidationException, "You must create an organization") {
-			return retry.RetryableError(err)
-		}
-
-		if err != nil {
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
-	})
-
-	if tfresource.TimedOut(err) {
-		_, err = conn.CreateAnalyzerWithContext(ctx, input)
-	}
+			return false, err
+		},
+	)
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating Access Analyzer Analyzer (%s): %s", analyzerName, err)
+		return sdkdiag.AppendErrorf(diags, "creating IAM Access Analyzer Analyzer (%s): %s", analyzerName, err)
 	}
 
 	d.SetId(analyzerName)
@@ -116,34 +111,25 @@ func resourceAnalyzerCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 func resourceAnalyzerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).AccessAnalyzerConn()
+	conn := meta.(*conns.AWSClient).AccessAnalyzerClient()
 
-	input := &accessanalyzer.GetAnalyzerInput{
-		AnalyzerName: aws.String(d.Id()),
-	}
+	analyzer, err := findAnalyzerByName(ctx, conn, d.Id())
 
-	output, err := conn.GetAnalyzerWithContext(ctx, input)
-
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, accessanalyzer.ErrCodeResourceNotFoundException) {
-		log.Printf("[WARN] Access Analyzer Analyzer (%s) not found, removing from state", d.Id())
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] IAM Access Analyzer Analyzer (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "getting Access Analyzer Analyzer (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading IAM Access Analyzer Analyzer (%s): %s", d.Id(), err)
 	}
 
-	if output == nil || output.Analyzer == nil {
-		return sdkdiag.AppendErrorf(diags, "getting Access Analyzer Analyzer (%s): empty response", d.Id())
-	}
+	d.Set("analyzer_name", analyzer.Name)
+	d.Set("arn", analyzer.Arn)
+	d.Set("type", analyzer.Type)
 
-	d.Set("analyzer_name", output.Analyzer.Name)
-	d.Set("arn", output.Analyzer.Arn)
-
-	SetTagsOut(ctx, output.Analyzer.Tags)
-
-	d.Set("type", output.Analyzer.Type)
+	SetTagsOut(ctx, analyzer.Tags)
 
 	return diags
 }
@@ -158,21 +144,46 @@ func resourceAnalyzerUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 func resourceAnalyzerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).AccessAnalyzerConn()
+	conn := meta.(*conns.AWSClient).AccessAnalyzerClient()
 
-	log.Printf("[DEBUG] Deleting Access Analyzer Analyzer: (%s)", d.Id())
-	_, err := conn.DeleteAnalyzerWithContext(ctx, &accessanalyzer.DeleteAnalyzerInput{
+	log.Printf("[DEBUG] Deleting IAM Access Analyzer Analyzer: %s", d.Id())
+	_, err := conn.DeleteAnalyzer(ctx, &accessanalyzer.DeleteAnalyzerInput{
 		AnalyzerName: aws.String(d.Id()),
 		ClientToken:  aws.String(id.UniqueId()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, accessanalyzer.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting Access Analyzer Analyzer (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting IAM Access Analyzer Analyzer (%s): %s", d.Id(), err)
 	}
 
 	return diags
+}
+
+func findAnalyzerByName(ctx context.Context, conn *accessanalyzer.Client, name string) (*types.AnalyzerSummary, error) {
+	input := &accessanalyzer.GetAnalyzerInput{
+		AnalyzerName: aws.String(name),
+	}
+
+	output, err := conn.GetAnalyzer(ctx, input)
+
+	if errs.IsA[*types.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Analyzer == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.Analyzer, nil
 }

--- a/internal/service/accessanalyzer/analyzer_test.go
+++ b/internal/service/accessanalyzer/analyzer_test.go
@@ -5,26 +5,27 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/accessanalyzer"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfaccessanalyzer "github.com/hashicorp/terraform-provider-aws/internal/service/accessanalyzer"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func testAccAnalyzer_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var analyzer accessanalyzer.AnalyzerSummary
+	var analyzer types.AnalyzerSummary
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_accessanalyzer_analyzer.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, accessanalyzer.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -35,7 +36,7 @@ func testAccAnalyzer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "analyzer_name", rName),
 					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "access-analyzer", fmt.Sprintf("analyzer/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "type", accessanalyzer.TypeAccount),
+					resource.TestCheckResourceAttr(resourceName, "type", string(types.TypeAccount)),
 				),
 			},
 			{
@@ -49,14 +50,14 @@ func testAccAnalyzer_basic(t *testing.T) {
 
 func testAccAnalyzer_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var analyzer accessanalyzer.AnalyzerSummary
+	var analyzer types.AnalyzerSummary
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_accessanalyzer_analyzer.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, accessanalyzer.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -64,7 +65,7 @@ func testAccAnalyzer_disappears(t *testing.T) {
 				Config: testAccAnalyzerConfig_name(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAnalyzerExists(ctx, resourceName, &analyzer),
-					testAccCheckAnalyzerDisappears(ctx, &analyzer),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfaccessanalyzer.ResourceAnalyzer(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -74,14 +75,14 @@ func testAccAnalyzer_disappears(t *testing.T) {
 
 func testAccAnalyzer_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var analyzer accessanalyzer.AnalyzerSummary
+	var analyzer types.AnalyzerSummary
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_accessanalyzer_analyzer.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, accessanalyzer.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -121,7 +122,7 @@ func testAccAnalyzer_tags(t *testing.T) {
 
 func testAccAnalyzer_Type_Organization(t *testing.T) {
 	ctx := acctest.Context(t)
-	var analyzer accessanalyzer.AnalyzerSummary
+	var analyzer types.AnalyzerSummary
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_accessanalyzer_analyzer.test"
@@ -132,7 +133,7 @@ func testAccAnalyzer_Type_Organization(t *testing.T) {
 			testAccPreCheck(ctx, t)
 			acctest.PreCheckOrganizationsAccount(ctx, t)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, accessanalyzer.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.AccessAnalyzerEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckAnalyzerDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -140,7 +141,7 @@ func testAccAnalyzer_Type_Organization(t *testing.T) {
 				Config: testAccAnalyzerConfig_typeOrganization(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAnalyzerExists(ctx, resourceName, &analyzer),
-					resource.TestCheckResourceAttr(resourceName, "type", accessanalyzer.TypeOrganization),
+					resource.TestCheckResourceAttr(resourceName, "type", string(types.TypeOrganization)),
 				),
 			},
 			{
@@ -154,20 +155,16 @@ func testAccAnalyzer_Type_Organization(t *testing.T) {
 
 func testAccCheckAnalyzerDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerConn()
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerClient()
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_accessanalyzer_analyzer" {
 				continue
 			}
 
-			input := &accessanalyzer.GetAnalyzerInput{
-				AnalyzerName: aws.String(rs.Primary.ID),
-			}
+			_, err := tfaccessanalyzer.FindAnalyzerByName(ctx, conn, rs.Primary.ID)
 
-			output, err := conn.GetAnalyzerWithContext(ctx, input)
-
-			if tfawserr.ErrCodeEquals(err, accessanalyzer.ErrCodeResourceNotFoundException) {
+			if tfresource.NotFound(err) {
 				continue
 			}
 
@@ -175,53 +172,33 @@ func testAccCheckAnalyzerDestroy(ctx context.Context) resource.TestCheckFunc {
 				return err
 			}
 
-			if output != nil {
-				return fmt.Errorf("Access Analyzer Analyzer (%s) still exists", rs.Primary.ID)
-			}
+			return fmt.Errorf("IAM Access Analyzer Analyzer %s still exists", rs.Primary.ID)
 		}
 
 		return nil
 	}
 }
 
-func testAccCheckAnalyzerDisappears(ctx context.Context, analyzer *accessanalyzer.AnalyzerSummary) resource.TestCheckFunc {
+func testAccCheckAnalyzerExists(ctx context.Context, n string, v *types.AnalyzerSummary) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerConn()
-
-		input := &accessanalyzer.DeleteAnalyzerInput{
-			AnalyzerName: analyzer.Name,
-		}
-
-		_, err := conn.DeleteAnalyzerWithContext(ctx, input)
-
-		return err
-	}
-}
-
-func testAccCheckAnalyzerExists(ctx context.Context, resourceName string, analyzer *accessanalyzer.AnalyzerSummary) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceName]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("resource not found: %s", resourceName)
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("resource (%s) ID not set", resourceName)
+			return fmt.Errorf("No IAM Access Analyzer Analyzer ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerConn()
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerClient()
 
-		input := &accessanalyzer.GetAnalyzerInput{
-			AnalyzerName: aws.String(rs.Primary.ID),
-		}
-
-		output, err := conn.GetAnalyzerWithContext(ctx, input)
+		output, err := tfaccessanalyzer.FindAnalyzerByName(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
 		}
 
-		*analyzer = *output.Analyzer
+		*v = *output
 
 		return nil
 	}

--- a/internal/service/accessanalyzer/archive_rule.go
+++ b/internal/service/accessanalyzer/archive_rule.go
@@ -8,20 +8,21 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go/service/accessanalyzer"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
+	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	sdkid "github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/experimental/nullable"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 // @SDKResource("aws_accessanalyzer_archive_rule")
-func ResourceArchiveRule() *schema.Resource {
+func resourceArchiveRule() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceArchiveRuleCreate,
 		ReadWithoutTimeout:   resourceArchiveRuleRead,
@@ -84,124 +85,127 @@ func ResourceArchiveRule() *schema.Resource {
 }
 
 func resourceArchiveRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).AccessAnalyzerConn()
+	conn := meta.(*conns.AWSClient).AccessAnalyzerClient()
 
 	analyzerName := d.Get("analyzer_name").(string)
 	ruleName := d.Get("rule_name").(string)
-
-	in := &accessanalyzer.CreateArchiveRuleInput{
+	id := archiveRuleCreateResourceID(analyzerName, ruleName)
+	input := &accessanalyzer.CreateArchiveRuleInput{
 		AnalyzerName: aws.String(analyzerName),
-		ClientToken:  aws.String(id.UniqueId()),
+		ClientToken:  aws.String(sdkid.UniqueId()),
 		RuleName:     aws.String(ruleName),
 	}
 
 	if v, ok := d.GetOk("filter"); ok {
-		in.Filter = expandFilter(v.(*schema.Set))
+		input.Filter = expandFilter(v.(*schema.Set))
 	}
 
-	_, err := conn.CreateArchiveRuleWithContext(ctx, in)
+	_, err := conn.CreateArchiveRule(ctx, input)
+
 	if err != nil {
-		return diag.Errorf("creating AWS IAM Access Analyzer ArchiveRule (%s): %s", d.Get("rule_name").(string), err)
+		return diag.Errorf("creating IAM Access Analyzer Archive Rule (%s): %s", id, err)
 	}
 
-	id := EncodeRuleID(analyzerName, ruleName)
 	d.SetId(id)
 
 	return resourceArchiveRuleRead(ctx, d, meta)
 }
 
 func resourceArchiveRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).AccessAnalyzerConn()
+	conn := meta.(*conns.AWSClient).AccessAnalyzerClient()
 
-	analyzerName, ruleName, err := DecodeRuleID(d.Id())
+	analyzerName, ruleName, err := archiveRuleParseResourceID(d.Id())
+
 	if err != nil {
-		return diag.Errorf("unable to decode AccessAnalyzer ArchiveRule ID (%s): %s", d.Id(), err)
+		return diag.FromErr(err)
 	}
 
-	out, err := FindArchiveRule(ctx, conn, analyzerName, ruleName)
+	archiveRule, err := findArchiveRuleByTwoPartKey(ctx, conn, analyzerName, ruleName)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] AccessAnalyzer ArchiveRule (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] IAM Access Analyzer Archive Rule (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		return diag.Errorf("reading AccessAnalyzer ArchiveRule (%s): %s", d.Id(), err)
+		return diag.Errorf("reading IAM Access Analyzer Archive Rule (%s): %s", d.Id(), err)
 	}
 
 	d.Set("analyzer_name", analyzerName)
-	d.Set("filter", flattenFilter(out.Filter))
-	d.Set("rule_name", out.RuleName)
+	d.Set("filter", flattenFilter(archiveRule.Filter))
+	d.Set("rule_name", archiveRule.RuleName)
 
 	return nil
 }
 
 func resourceArchiveRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).AccessAnalyzerConn()
+	conn := meta.(*conns.AWSClient).AccessAnalyzerClient()
 
-	analyzerName, ruleName, err := DecodeRuleID(d.Id())
+	analyzerName, ruleName, err := archiveRuleParseResourceID(d.Id())
+
 	if err != nil {
-		return diag.Errorf("unable to decode AccessAnalyzer ArchiveRule ID (%s): %s", d.Id(), err)
+		return diag.FromErr(err)
 	}
 
-	in := &accessanalyzer.UpdateArchiveRuleInput{
+	input := &accessanalyzer.UpdateArchiveRuleInput{
 		AnalyzerName: aws.String(analyzerName),
-		ClientToken:  aws.String(id.UniqueId()),
+		ClientToken:  aws.String(sdkid.UniqueId()),
 		RuleName:     aws.String(ruleName),
 	}
 
 	if d.HasChanges("filter") {
-		in.Filter = expandFilter(d.Get("filter").(*schema.Set))
+		input.Filter = expandFilter(d.Get("filter").(*schema.Set))
 	}
 
-	log.Printf("[DEBUG] Updating AccessAnalyzer ArchiveRule (%s): %#v", d.Id(), in)
-	_, err = conn.UpdateArchiveRuleWithContext(ctx, in)
+	_, err = conn.UpdateArchiveRule(ctx, input)
+
 	if err != nil {
-		return diag.Errorf("updating AccessAnalyzer ArchiveRule (%s): %s", d.Id(), err)
+		return diag.Errorf("updating AWS IAM Access Analyzer Archive Rule (%s): %s", d.Id(), err)
 	}
 
 	return resourceArchiveRuleRead(ctx, d, meta)
 }
 
 func resourceArchiveRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).AccessAnalyzerConn()
+	conn := meta.(*conns.AWSClient).AccessAnalyzerClient()
 
-	log.Printf("[INFO] Deleting AccessAnalyzer ArchiveRule %s", d.Id())
+	analyzerName, ruleName, err := archiveRuleParseResourceID(d.Id())
 
-	analyzerName, ruleName, err := DecodeRuleID(d.Id())
 	if err != nil {
-		return diag.Errorf("unable to decode AccessAnalyzer ArchiveRule ID (%s): %s", d.Id(), err)
+		return diag.FromErr(err)
 	}
 
-	_, err = conn.DeleteArchiveRuleWithContext(ctx, &accessanalyzer.DeleteArchiveRuleInput{
+	log.Printf("[INFO] Deleting IAM Access Analyzer Archive Rule: %s", d.Id())
+	_, err = conn.DeleteArchiveRule(ctx, &accessanalyzer.DeleteArchiveRuleInput{
 		AnalyzerName: aws.String(analyzerName),
-		ClientToken:  aws.String(id.UniqueId()),
+		ClientToken:  aws.String(sdkid.UniqueId()),
 		RuleName:     aws.String(ruleName),
 	})
 
-	if tfawserr.ErrCodeEquals(err, accessanalyzer.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting AccessAnalyzer ArchiveRule (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting IAM Access Analyzer Archive Rule (%s): %s", d.Id(), err)
 	}
 
 	return nil
 }
 
-func FindArchiveRule(ctx context.Context, conn *accessanalyzer.AccessAnalyzer, analyzerName, ruleName string) (*accessanalyzer.ArchiveRuleSummary, error) {
-	in := &accessanalyzer.GetArchiveRuleInput{
+func findArchiveRuleByTwoPartKey(ctx context.Context, conn *accessanalyzer.Client, analyzerName, ruleName string) (*types.ArchiveRuleSummary, error) {
+	input := &accessanalyzer.GetArchiveRuleInput{
 		AnalyzerName: aws.String(analyzerName),
 		RuleName:     aws.String(ruleName),
 	}
 
-	out, err := conn.GetArchiveRuleWithContext(ctx, in)
-	if tfawserr.ErrCodeEquals(err, accessanalyzer.ErrCodeResourceNotFoundException) {
+	output, err := conn.GetArchiveRule(ctx, input)
+
+	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
-			LastRequest: in,
+			LastRequest: input,
 		}
 	}
 
@@ -209,14 +213,14 @@ func FindArchiveRule(ctx context.Context, conn *accessanalyzer.AccessAnalyzer, a
 		return nil, err
 	}
 
-	if out == nil || out.ArchiveRule == nil {
-		return nil, tfresource.NewEmptyResultError(in)
+	if output == nil || output.ArchiveRule == nil {
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	return out.ArchiveRule, nil
+	return output.ArchiveRule, nil
 }
 
-func flattenFilter(filter map[string]*accessanalyzer.Criterion) []interface{} {
+func flattenFilter(filter map[string]types.Criterion) []interface{} {
 	if filter == nil {
 		return nil
 	}
@@ -226,14 +230,14 @@ func flattenFilter(filter map[string]*accessanalyzer.Criterion) []interface{} {
 	for key, value := range filter {
 		val := make(map[string]interface{})
 		val["criteria"] = key
-		val["contains"] = aws.ToStringSlice(value.Contains)
-		val["eq"] = aws.ToStringSlice(value.Eq)
+		val["contains"] = value.Contains
+		val["eq"] = value.Eq
 
 		if value.Exists != nil {
 			val["exists"] = strconv.FormatBool(aws.ToBool(value.Exists))
 		}
 
-		val["neq"] = aws.ToStringSlice(value.Neq)
+		val["neq"] = value.Neq
 
 		l = append(l, val)
 	}
@@ -241,28 +245,28 @@ func flattenFilter(filter map[string]*accessanalyzer.Criterion) []interface{} {
 	return l
 }
 
-func expandFilter(l *schema.Set) map[string]*accessanalyzer.Criterion {
+func expandFilter(l *schema.Set) map[string]types.Criterion {
 	if len(l.List()) == 0 || l.List()[0] == nil {
 		return nil
 	}
 
-	a := make(map[string]*accessanalyzer.Criterion)
+	a := make(map[string]types.Criterion)
 
 	for _, value := range l.List() {
-		c := &accessanalyzer.Criterion{}
+		c := types.Criterion{}
 		if v, ok := value.(map[string]interface{})["contains"]; ok {
 			if len(v.([]interface{})) > 0 {
-				c.Contains = flex.ExpandStringList(v.([]interface{}))
+				c.Contains = flex.ExpandStringValueList(v.([]interface{}))
 			}
 		}
 		if v, ok := value.(map[string]interface{})["eq"]; ok {
 			if len(v.([]interface{})) > 0 {
-				c.Eq = flex.ExpandStringList(v.([]interface{}))
+				c.Eq = flex.ExpandStringValueList(v.([]interface{}))
 			}
 		}
 		if v, ok := value.(map[string]interface{})["neq"]; ok {
 			if len(v.([]interface{})) > 0 {
-				c.Neq = flex.ExpandStringList(v.([]interface{}))
+				c.Neq = flex.ExpandStringValueList(v.([]interface{}))
 			}
 		}
 		if v, ok := value.(map[string]interface{})["exists"]; ok {
@@ -277,15 +281,20 @@ func expandFilter(l *schema.Set) map[string]*accessanalyzer.Criterion {
 	return a
 }
 
-func EncodeRuleID(analyzerName, ruleName string) string {
-	return fmt.Sprintf("%s/%s", analyzerName, ruleName)
+const archiveRuleResourceIDSeparator = "/"
+
+func archiveRuleCreateResourceID(analyzerName, ruleName string) string {
+	parts := []string{analyzerName, ruleName}
+	id := strings.Join(parts, archiveRuleResourceIDSeparator)
+
+	return id
 }
 
-func DecodeRuleID(id string) (string, string, error) {
-	idParts := strings.Split(id, "/")
-	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
-		return "", "", fmt.Errorf("expected ID to be the form analyzer_name/rule_name, given: %s", id)
+func archiveRuleParseResourceID(id string) (string, string, error) {
+	parts := strings.Split(id, archiveRuleResourceIDSeparator)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("unexpected format for ID (%[1]s), expected AnalyzerName%[2]sRuleName", id, archiveRuleResourceIDSeparator)
 	}
 
-	return idParts[0], idParts[1], nil
+	return parts[0], parts[1], nil
 }

--- a/internal/service/accessanalyzer/exports_test.go
+++ b/internal/service/accessanalyzer/exports_test.go
@@ -1,0 +1,11 @@
+package accessanalyzer
+
+// Exports for use in tests only.
+var (
+	ArchiveRuleParseResourceID  = archiveRuleParseResourceID
+	FindAnalyzerByName          = findAnalyzerByName
+	FindArchiveRuleByTwoPartKey = findArchiveRuleByTwoPartKey
+
+	ResourceAnalyzer    = resourceAnalyzer
+	ResourceArchiveRule = resourceArchiveRule
+)

--- a/internal/service/accessanalyzer/generate.go
+++ b/internal/service/accessanalyzer/generate.go
@@ -1,4 +1,4 @@
-//go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ListTags -ServiceTagsMap -UpdateTags -KVTValues -SkipTypesImp
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package accessanalyzer

--- a/internal/service/accessanalyzer/service_package_gen.go
+++ b/internal/service/accessanalyzer/service_package_gen.go
@@ -26,7 +26,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
 		{
-			Factory:  ResourceAnalyzer,
+			Factory:  resourceAnalyzer,
 			TypeName: "aws_accessanalyzer_analyzer",
 			Name:     "Analyzer",
 			Tags: &types.ServicePackageResourceTags{
@@ -34,7 +34,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceArchiveRule,
+			Factory:  resourceArchiveRule,
 			TypeName: "aws_accessanalyzer_archive_rule",
 		},
 	}

--- a/internal/service/accessanalyzer/sweep.go
+++ b/internal/service/accessanalyzer/sweep.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/accessanalyzer"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
@@ -27,33 +27,30 @@ func sweepAnalyzers(region string) error {
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
 	}
-	conn := client.(*conns.AWSClient).AccessAnalyzerConn()
+	conn := client.(*conns.AWSClient).AccessAnalyzerClient()
 	input := &accessanalyzer.ListAnalyzersInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	err = conn.ListAnalyzersPagesWithContext(ctx, input, func(page *accessanalyzer.ListAnalyzersOutput, lastPage bool) bool {
-		if page == nil {
-			return !lastPage
+	pages := accessanalyzer.NewListAnalyzersPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if sweep.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping IAM Access Analyzer Analyzer sweep for %s: %s", region, err)
+			return nil
 		}
 
-		for _, analyzer := range page.Analyzers {
+		if err != nil {
+			return fmt.Errorf("error listing IAM Access Analyzer Analyzers (%s): %w", region, err)
+		}
+
+		for _, v := range page.Analyzers {
 			r := resourceAnalyzer()
 			d := r.Data(nil)
-			d.SetId(aws.StringValue(analyzer.Name))
+			d.SetId(aws.ToString(v.Name))
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
-
-		return !lastPage
-	})
-
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping IAM Access Analyzer Analyzer sweep for %s: %s", region, err)
-		return nil
-	}
-
-	if err != nil {
-		return fmt.Errorf("error listing IAM Access Analyzer Analyzers (%s): %w", region, err)
 	}
 
 	err = sweep.SweepOrchestratorWithContext(ctx, sweepResources)

--- a/internal/service/accessanalyzer/sweep.go
+++ b/internal/service/accessanalyzer/sweep.go
@@ -37,7 +37,7 @@ func sweepAnalyzers(region string) error {
 		}
 
 		for _, analyzer := range page.Analyzers {
-			r := ResourceAnalyzer()
+			r := resourceAnalyzer()
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(analyzer.Name))
 
@@ -48,18 +48,18 @@ func sweepAnalyzers(region string) error {
 	})
 
 	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping Access Analyzer Analyzer sweep for %s: %s", region, err)
+		log.Printf("[WARN] Skipping IAM Access Analyzer Analyzer sweep for %s: %s", region, err)
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("error listing Access Analyzer Analyzers (%s): %w", region, err)
+		return fmt.Errorf("error listing IAM Access Analyzer Analyzers (%s): %w", region, err)
 	}
 
 	err = sweep.SweepOrchestratorWithContext(ctx, sweepResources)
 
 	if err != nil {
-		return fmt.Errorf("error sweeping Access Analyzer Analyzers (%s): %w", region, err)
+		return fmt.Errorf("error sweeping IAM Access Analyzer Analyzers (%s): %w", region, err)
 	}
 
 	return nil

--- a/internal/service/accessanalyzer/tags_gen.go
+++ b/internal/service/accessanalyzer/tags_gen.go
@@ -5,9 +5,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/accessanalyzer"
-	"github.com/aws/aws-sdk-go/service/accessanalyzer/accessanalyzeriface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
@@ -17,12 +16,12 @@ import (
 // ListTags lists accessanalyzer service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func ListTags(ctx context.Context, conn accessanalyzeriface.AccessAnalyzerAPI, identifier string) (tftags.KeyValueTags, error) {
+func ListTags(ctx context.Context, conn *accessanalyzer.Client, identifier string) (tftags.KeyValueTags, error) {
 	input := &accessanalyzer.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResourceWithContext(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -34,7 +33,7 @@ func ListTags(ctx context.Context, conn accessanalyzeriface.AccessAnalyzerAPI, i
 // ListTags lists accessanalyzer service tags and set them in Context.
 // It is called from outside this package.
 func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier string) error {
-	tags, err := ListTags(ctx, meta.(*conns.AWSClient).AccessAnalyzerConn(), identifier)
+	tags, err := ListTags(ctx, meta.(*conns.AWSClient).AccessAnalyzerClient(), identifier)
 
 	if err != nil {
 		return err
@@ -47,21 +46,21 @@ func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier stri
 	return nil
 }
 
-// map[string]*string handling
+// map[string]string handling
 
 // Tags returns accessanalyzer service tags.
-func Tags(tags tftags.KeyValueTags) map[string]*string {
-	return aws.StringMap(tags.Map())
+func Tags(tags tftags.KeyValueTags) map[string]string {
+	return tags.Map()
 }
 
 // KeyValueTags creates KeyValueTags from accessanalyzer service tags.
-func KeyValueTags(ctx context.Context, tags map[string]*string) tftags.KeyValueTags {
+func KeyValueTags(ctx context.Context, tags map[string]string) tftags.KeyValueTags {
 	return tftags.New(ctx, tags)
 }
 
 // GetTagsIn returns accessanalyzer service tags from Context.
 // nil is returned if there are no input tags.
-func GetTagsIn(ctx context.Context) map[string]*string {
+func GetTagsIn(ctx context.Context) map[string]string {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		if tags := Tags(inContext.TagsIn.UnwrapOrDefault()); len(tags) > 0 {
 			return tags
@@ -72,7 +71,7 @@ func GetTagsIn(ctx context.Context) map[string]*string {
 }
 
 // SetTagsOut sets accessanalyzer service tags in Context.
-func SetTagsOut(ctx context.Context, tags map[string]*string) {
+func SetTagsOut(ctx context.Context, tags map[string]string) {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		inContext.TagsOut = types.Some(KeyValueTags(ctx, tags))
 	}
@@ -81,7 +80,7 @@ func SetTagsOut(ctx context.Context, tags map[string]*string) {
 // UpdateTags updates accessanalyzer service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func UpdateTags(ctx context.Context, conn accessanalyzeriface.AccessAnalyzerAPI, identifier string, oldTagsMap, newTagsMap any) error {
+func UpdateTags(ctx context.Context, conn *accessanalyzer.Client, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -90,10 +89,10 @@ func UpdateTags(ctx context.Context, conn accessanalyzeriface.AccessAnalyzerAPI,
 	if len(removedTags) > 0 {
 		input := &accessanalyzer.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.Keys()),
+			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResourceWithContext(ctx, input)
+		_, err := conn.UntagResource(ctx, input)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -108,7 +107,7 @@ func UpdateTags(ctx context.Context, conn accessanalyzeriface.AccessAnalyzerAPI,
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResourceWithContext(ctx, input)
+		_, err := conn.TagResource(ctx, input)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)
@@ -121,5 +120,5 @@ func UpdateTags(ctx context.Context, conn accessanalyzeriface.AccessAnalyzerAPI,
 // UpdateTags updates accessanalyzer service tags.
 // It is called from outside this package.
 func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
-	return UpdateTags(ctx, meta.(*conns.AWSClient).AccessAnalyzerConn(), identifier, oldTags, newTags)
+	return UpdateTags(ctx, meta.(*conns.AWSClient).AccessAnalyzerClient(), identifier, oldTags, newTags)
 }

--- a/names/names.go
+++ b/names/names.go
@@ -22,7 +22,7 @@ import (
 
 // This "should" be defined by the AWS Go SDK v2, but currently isn't.
 const (
-	AccessAnalyzerEndpointID             = "accessanalyzer"
+	AccessAnalyzerEndpointID             = "access-analyzer"
 	AccountEndpointID                    = "account"
 	AuditManagerEndpointID               = "auditmanager"
 	CloudWatchLogsEndpointID             = "logs"

--- a/names/names.go
+++ b/names/names.go
@@ -22,6 +22,7 @@ import (
 
 // This "should" be defined by the AWS Go SDK v2, but currently isn't.
 const (
+	AccessAnalyzerEndpointID             = "accessanalyzer"
 	AccountEndpointID                    = "account"
 	AuditManagerEndpointID               = "auditmanager"
 	CloudWatchLogsEndpointID             = "logs"

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -1,4 +1,5 @@
 AWSCLIV2Command,AWSCLIV2CommandNoDashes,GoV1Package,GoV2Package,ProviderPackageActual,ProviderPackageCorrect,SplitPackageRealPackage,Aliases,ProviderNameUpper,GoV1ClientTypeName,SkipClientGenerate,ClientSDKV1,ClientSDKV2,ResourcePrefixActual,ResourcePrefixCorrect,FilePrefix,DocPrefix,HumanFriendly,Brand,Exclude,AllowedSubcategory,DeprecatedEnvVar,EnvVar,Note
+accessanalyzer,accessanalyzer,accessanalyzer,accessanalyzer,,accessanalyzer,,,AccessAnalyzer,AccessAnalyzer,,,2,,aws_accessanalyzer_,,accessanalyzer_,IAM Access Analyzer,AWS,,,,,
 account,account,account,account,,account,,,Account,Account,,,2,,aws_account_,,account_,Account Management,AWS,,,,,
 acm,acm,acm,acm,,acm,,,ACM,ACM,,1,,,aws_acm_,,acm_,ACM (Certificate Manager),AWS,,,,,
 acm-pca,acmpca,acmpca,acmpca,,acmpca,,,ACMPCA,ACMPCA,,1,,,aws_acmpca_,,acmpca_,ACM PCA (Certificate Manager Private Certificate Authority),AWS,,,,,
@@ -171,7 +172,6 @@ health,health,health,health,,health,,,Health,Health,,1,,,aws_health_,,health_,He
 healthlake,healthlake,healthlake,healthlake,,healthlake,,,HealthLake,HealthLake,,,2,,aws_healthlake_,,healthlake_,HealthLake,Amazon,,,,,
 honeycode,honeycode,honeycode,honeycode,,honeycode,,,Honeycode,Honeycode,,1,,,aws_honeycode_,,honeycode_,Honeycode,Amazon,,,,,
 iam,iam,iam,iam,,iam,,,IAM,IAM,,1,,,aws_iam_,,iam_,IAM (Identity & Access Management),AWS,,,AWS_IAM_ENDPOINT,TF_AWS_IAM_ENDPOINT,
-accessanalyzer,accessanalyzer,accessanalyzer,accessanalyzer,,accessanalyzer,,,AccessAnalyzer,AccessAnalyzer,,1,,,aws_accessanalyzer_,,accessanalyzer_,IAM Access Analyzer,AWS,,,,,
 inspector,inspector,inspector,inspector,,inspector,,,Inspector,Inspector,,1,,,aws_inspector_,,inspector_,Inspector Classic,Amazon,,,,,
 inspector2,inspector2,inspector2,inspector2,,inspector2,,inspectorv2,Inspector2,Inspector2,,,2,,aws_inspector2_,,inspector2_,Inspector,Amazon,,,,,
 iot1click-devices,iot1clickdevices,iot1clickdevicesservice,iot1clickdevicesservice,,iot1clickdevices,,iot1clickdevicesservice,IoT1ClickDevices,IoT1ClickDevicesService,,1,,,aws_iot1clickdevices_,,iot1clickdevices_,IoT 1-Click Devices,AWS,,,,,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Ibid.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccAccessAnalyzer_serial' PKG=accessanalyzer
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/accessanalyzer/... -v -count 1 -parallel 20  -run=TestAccAccessAnalyzer_serial -timeout 180m
=== RUN   TestAccAccessAnalyzer_serial
=== PAUSE TestAccAccessAnalyzer_serial
=== CONT  TestAccAccessAnalyzer_serial
=== RUN   TestAccAccessAnalyzer_serial/Analyzer
=== RUN   TestAccAccessAnalyzer_serial/Analyzer/tags
=== RUN   TestAccAccessAnalyzer_serial/Analyzer/Type_Organization
    acctest.go:895: skipping tests; this AWS account must not be an existing member of an AWS Organization
=== RUN   TestAccAccessAnalyzer_serial/Analyzer/basic
=== RUN   TestAccAccessAnalyzer_serial/Analyzer/disappears
=== RUN   TestAccAccessAnalyzer_serial/ArchiveRule
=== RUN   TestAccAccessAnalyzer_serial/ArchiveRule/update_filters
=== RUN   TestAccAccessAnalyzer_serial/ArchiveRule/basic
=== RUN   TestAccAccessAnalyzer_serial/ArchiveRule/disappears
--- PASS: TestAccAccessAnalyzer_serial (126.32s)
    --- PASS: TestAccAccessAnalyzer_serial/Analyzer (63.52s)
        --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags (36.53s)
        --- SKIP: TestAccAccessAnalyzer_serial/Analyzer/Type_Organization (0.31s)
        --- PASS: TestAccAccessAnalyzer_serial/Analyzer/basic (15.29s)
        --- PASS: TestAccAccessAnalyzer_serial/Analyzer/disappears (11.38s)
    --- PASS: TestAccAccessAnalyzer_serial/ArchiveRule (62.80s)
        --- PASS: TestAccAccessAnalyzer_serial/ArchiveRule/update_filters (34.43s)
        --- PASS: TestAccAccessAnalyzer_serial/ArchiveRule/basic (15.54s)
        --- PASS: TestAccAccessAnalyzer_serial/ArchiveRule/disappears (12.83s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/accessanalyzer	131.595s
```