### PR TITLE
Add resource "aws_redshiftdata_batch_statement"

### DIFF
--- a/.changelog/2023-5-5-temp0.txt
+++ b/.changelog/2023-5-5-temp0.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_redshiftdata_batch_statement
+```

--- a/internal/service/redshiftdata/batch_statement.go
+++ b/internal/service/redshiftdata/batch_statement.go
@@ -1,0 +1,176 @@
+package redshiftdata
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/redshiftdataapiservice"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+// @SDKResource("aws_redshiftdata_batch_statement")
+func ResourceBatchStatement() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceBatchStatementCreate,
+		ReadWithoutTimeout:   resourceBatchStatementRead,
+		DeleteWithoutTimeout: schema.NoopContext,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"cluster_identifier": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"database": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"db_user": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"secret_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"sqls": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"statement_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"with_event": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+			"workgroup_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceBatchStatementCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).RedshiftDataConn()
+
+	input := &redshiftdataapiservice.BatchExecuteStatementInput{
+		Database:  aws.String(d.Get("database").(string)),
+		WithEvent: aws.Bool(d.Get("with_event").(bool)),
+	}
+
+	if v, ok := d.GetOk("cluster_identifier"); ok {
+		input.ClusterIdentifier = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("db_user"); ok {
+		input.DbUser = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("sqls"); ok && len(v.([]interface{})) > 0 {
+		input.Sqls = flex.ExpandStringList(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("secret_arn"); ok {
+		input.SecretArn = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("statement_name"); ok {
+		input.StatementName = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("workgroup_name"); ok {
+		input.WorkgroupName = aws.String(v.(string))
+	}
+
+	output, err := conn.BatchExecuteStatementWithContext(ctx, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "executing Redshift Data Batch Statement: %s", err)
+	}
+
+	d.SetId(aws.StringValue(output.Id))
+
+	if _, err := waitStatementFinished(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for Redshift Data Statement (%s) to finish: %s", d.Id(), err)
+	}
+
+	return append(diags, resourceBatchStatementRead(ctx, d, meta)...)
+}
+
+func resourceBatchStatementRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).RedshiftDataConn()
+
+	sub, err := FindStatementByID(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Redshift Data Batch Statement (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Redshift Batch Data Statement (%s): %s", d.Id(), err)
+	}
+
+	d.Set("cluster_identifier", sub.ClusterIdentifier)
+	d.Set("database", d.Get("database").(string))
+	d.Set("db_user", d.Get("db_user").(string))
+	f := flattenSqlStatements(sub.SubStatements)
+	d.Set("sqls", f)
+	d.Set("secret_arn", sub.SecretArn)
+	d.Set("workgroup_name", sub.WorkgroupName)
+
+	return diags
+}
+
+func flattenSqlStatements(apiObjects []*redshiftdataapiservice.SubStatementData) []string {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	// tfMap := map[string]interface{}{}
+	var tfStrings []string
+
+	for _, apiObject := range apiObjects {
+		if apiObject == nil {
+			continue
+		}
+
+		if v := apiObject.QueryString; v != nil {
+			// tfMap["query_string"] = aws.StringValue(v)
+			tfStrings = append(tfStrings, aws.StringValue(v))
+		}
+	}
+
+	return tfStrings
+}

--- a/internal/service/redshiftdata/batch_statement_test.go
+++ b/internal/service/redshiftdata/batch_statement_test.go
@@ -1,0 +1,146 @@
+package redshiftdata_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/redshiftdataapiservice"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfredshiftdata "github.com/hashicorp/terraform-provider-aws/internal/service/redshiftdata"
+)
+
+func TestAccRedshiftDataBatchStatement_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v redshiftdataapiservice.DescribeStatementOutput
+	resourceName := "aws_redshiftdata_batch_statement.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, redshiftdataapiservice.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBatchStatementConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchStatementExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "cluster_identifier", "aws_redshift_cluster.test", "cluster_identifier"),
+					resource.TestCheckResourceAttr(resourceName, "sqls.0", "CREATE GROUP group_name;"),
+					resource.TestCheckResourceAttr(resourceName, "sqls.1", "CREATE GROUP group_name2;"),
+					resource.TestCheckResourceAttr(resourceName, "workgroup_name", ""),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"database", "db_user"},
+			},
+		},
+	})
+}
+
+func TestAccRedshiftDataBatchStatement_workgroup(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v redshiftdataapiservice.DescribeStatementOutput
+	resourceName := "aws_redshiftdata_batch_statement.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, redshiftdataapiservice.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBatchStatementConfig_workgroup(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBatchStatementExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "cluster_identifier", ""),
+					resource.TestCheckResourceAttr(resourceName, "sqls.0", "CREATE GROUP group_name;"),
+					resource.TestCheckResourceAttr(resourceName, "sqls.1", "CREATE GROUP group_name2;"),
+					resource.TestCheckResourceAttrPair(resourceName, "workgroup_name", "aws_redshiftserverless_workgroup.test", "workgroup_name"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"database", "db_user"},
+			},
+		},
+	})
+}
+
+func testAccCheckBatchStatementExists(ctx context.Context, n string, v *redshiftdataapiservice.DescribeStatementOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Redshift Data Statement ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftDataConn()
+
+		output, err := tfredshiftdata.FindStatementByID(ctx, conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		*v = *output
+
+		return nil
+	}
+}
+
+func testAccBatchStatementConfig_basic(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+resource "aws_redshift_cluster" "test" {
+  cluster_identifier                  = %[1]q
+  availability_zone                   = data.aws_availability_zones.available.names[0]
+  database_name                       = "mydb"
+  master_username                     = "foo_test"
+  master_password                     = "Mustbe8characters"
+  node_type                           = "dc2.large"
+  automated_snapshot_retention_period = 0
+  allow_version_upgrade               = false
+  skip_final_snapshot                 = true
+}
+
+resource "aws_redshiftdata_batch_statement" "test" {
+  cluster_identifier = aws_redshift_cluster.test.cluster_identifier
+  database           = aws_redshift_cluster.test.database_name
+  db_user            = aws_redshift_cluster.test.master_username
+  sqls                = ["CREATE GROUP group_name;","CREATE GROUP group_name2;"]
+}
+`, rName))
+}
+
+func testAccBatchStatementConfig_workgroup(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_redshiftserverless_namespace" "test" {
+  namespace_name = %[1]q
+}
+
+resource "aws_redshiftserverless_workgroup" "test" {
+  namespace_name = aws_redshiftserverless_namespace.test.namespace_name
+  workgroup_name = %[1]q
+}
+
+resource "aws_redshiftdata_batch_statement" "test" {
+  workgroup_name = aws_redshiftserverless_workgroup.test.workgroup_name
+  database       = "dev"
+  sqls            = ["CREATE GROUP group_name;"]
+}
+`, rName)
+}

--- a/internal/service/redshiftdata/service_package_gen.go
+++ b/internal/service/redshiftdata/service_package_gen.go
@@ -26,6 +26,10 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
 		{
+			Factory:  ResourceBatchStatement,
+			TypeName: "aws_redshiftdata_batch_statement",
+		},
+		{
 			Factory:  ResourceStatement,
 			TypeName: "aws_redshiftdata_statement",
 		},

--- a/website/docs/r/redshiftdata_batch_statement.html.markdown
+++ b/website/docs/r/redshiftdata_batch_statement.html.markdown
@@ -1,0 +1,64 @@
+---
+subcategory: "Redshift Data"
+layout: "aws"
+page_title: "AWS: aws_redshiftdata_batch_statement"
+description: |-
+  Provides a Redshift Data Batch Statement execution resource.
+---
+
+# Resource: aws_redshiftdata_batch_statement
+
+Executes a batch of SQL statements using Redshift Data..
+
+## Example Usage
+
+### cluster_identifier
+
+```terraform
+resource "aws_redshiftdata_batch_statement" "example" {
+  cluster_identifier = aws_redshift_cluster.example.cluster_identifier
+  database           = aws_redshift_cluster.example.database_name
+  db_user            = aws_redshift_cluster.example.master_username
+  sqls                = ["CREATE GROUP group_name;"]
+}
+```
+
+### workgroup_name
+
+```terraform
+resource "aws_redshiftdata_batch_statement" "example" {
+  workgroup_name = aws_redshiftserverless_workgroup.example.workgroup_name
+  database       = "dev"
+  sqls            = ["CREATE GROUP group_name;"]
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `database` - (Required) The name of the database.
+* `sqls` - (Required) The SQL statements list to run.
+
+The following arguments are optional:
+
+* `cluster_identifier` - (Optional) The cluster identifier. This parameter is required when connecting to a cluster and authenticating using either Secrets Manager or temporary credentials.
+* `db_user` - (Optional) The database user name.
+* `secret_arn` - (Optional) The name or ARN of the secret that enables access to the database.
+* `statement_name` - (Optional) The name of the SQL statement. You can name the SQL statement when you create it to identify the query.
+* `with_event` - (Optional) A value that indicates whether to send an event to the Amazon EventBridge event bus after the SQL statement runs.
+* `workgroup_name` - (Optional) The serverless workgroup name. This parameter is required when connecting to a serverless workgroup and authenticating using either Secrets Manager or temporary credentials.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The Redshift Data Statement ID.
+
+## Import
+
+Redshift Data Statements can be imported using the `id`, e.g.,
+
+```
+$ terraform import aws_redshiftdata_batch_statement.example example
+```


### PR DESCRIPTION
## Description
New resource "aws_redshiftdata_batch_statement". It complements the resource "aws_redshiftdata_statement" that executes a single SQL statement whereas "aws_redshiftdata_batch_statement" executes multiple in a single transaction.

### References
https://awscli.amazonaws.com/v2/documentation/api/latest/reference/redshift-data/batch-execute-statement.html

### Output from Acceptance Testing
```
$ make testacc ACCTEST_PARALLELISM=1 ACCTEST_TIMEOUT=20m TESTS=TestAccRedshiftDataBatchStatement_basic PKG=redshiftdata
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/redshiftdata/... -v -count 1 -parallel 1 -run='TestAccRedshiftDataBatchStatement_basic'  -timeout 20m
=== RUN   TestAccRedshiftDataBatchStatement_basic
=== PAUSE TestAccRedshiftDataBatchStatement_basic
=== CONT  TestAccRedshiftDataBatchStatement_basic
--- PASS: TestAccRedshiftDataBatchStatement_basic (292.53s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshiftdata       292.633s
```

```
$ make testacc ACCTEST_PARALLELISM=1 ACCTEST_TIMEOUT=20m TESTS=TestAccRedshiftDataBatchStatement_workgroup PKG=redshiftdata
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/redshiftdata/... -v -count 1 -parallel 1 -run='TestAccRedshiftDataBatchStatement_workgroup'  -timeout 20m
=== RUN   TestAccRedshiftDataBatchStatement_workgroup
=== PAUSE TestAccRedshiftDataBatchStatement_workgroup
=== CONT  TestAccRedshiftDataBatchStatement_workgroup

--- PASS: TestAccRedshiftDataBatchStatement_workgroup (655.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshiftdata       655.722s
```