### PR TITLE
aws_lakeformation_permissions lf_tag_policy expression  values supports max 15 fix

### DIFF
--- a/internal/service/lakeformation/permissions.go
+++ b/internal/service/lakeformation/permissions.go
@@ -150,7 +150,6 @@ func ResourcePermissions() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 							MinItems: 1,
-							MaxItems: 1000,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
 								ValidateFunc: validateLFTagValues(),
@@ -199,7 +198,6 @@ func ResourcePermissions() *schema.Resource {
 										Required: true,
 										ForceNew: true,
 										MinItems: 1,
-										MaxItems: 1000,
 										Elem: &schema.Schema{
 											Type:         schema.TypeString,
 											ValidateFunc: validateLFTagValues(),

--- a/internal/service/lakeformation/permissions.go
+++ b/internal/service/lakeformation/permissions.go
@@ -150,7 +150,7 @@ func ResourcePermissions() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 							MinItems: 1,
-							MaxItems: 15,
+							MaxItems: 1000,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
 								ValidateFunc: validateLFTagValues(),
@@ -199,7 +199,7 @@ func ResourcePermissions() *schema.Resource {
 										Required: true,
 										ForceNew: true,
 										MinItems: 1,
-										MaxItems: 15,
+										MaxItems: 1000,
 										Elem: &schema.Schema{
 											Type:         schema.TypeString,
 											ValidateFunc: validateLFTagValues(),

--- a/internal/service/lakeformation/permissions_data_source.go
+++ b/internal/service/lakeformation/permissions_data_source.go
@@ -95,7 +95,6 @@ func DataSourcePermissions() *schema.Resource {
 							Type:     schema.TypeSet,
 							Required: true,
 							MinItems: 1,
-							MaxItems: 15,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
 								ValidateFunc: validateLFTagValues(),
@@ -132,7 +131,6 @@ func DataSourcePermissions() *schema.Resource {
 										Type:     schema.TypeSet,
 										Required: true,
 										MinItems: 1,
-										MaxItems: 15,
 										Elem: &schema.Schema{
 											Type:         schema.TypeString,
 											ValidateFunc: validateLFTagValues(),


### PR DESCRIPTION
```terraform
resource "aws_lakeformation_permissions" "test" {
  principal   = aws_iam_role.sales_role.arn
  permissions = ["CREATE_TABLE", "ALTER", "DROP"]

  lf_tag_policy {
    resource_type = "DATABASE"

    expression {
      key    = "Team"
      values = ["Sales"]
    }
  }
}
```

resource type "aws_lakeformation_permissions" lf_tag_policy.expression.values supports only 15 values. I have added fix for this.