### PR TITLE
r/aws_ecs_capacity_provider: Allow an `instance_warmup_period` of `0`

### DIFF
--- a/.changelog/24005.txt
+++ b/.changelog/24005.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_ecs_capacity_provider: Allow an `instance_warmup_period` of `0` in the `auto_scaling_group_provider.managed_scaling` configuration block
+```

--- a/.changelog/24005.txt
+++ b/.changelog/24005.txt
@@ -1,3 +1,3 @@
-```release-note:breaking-change
+```release-note:bug
 resource/aws_ecs_capacity_provider: Allow an `instance_warmup_period` of `0` in the `auto_scaling_group_provider.managed_scaling` configuration block
 ```

--- a/internal/service/ecs/capacity_provider.go
+++ b/internal/service/ecs/capacity_provider.go
@@ -317,24 +317,24 @@ func expandManagedScaling(configured interface{}) *ecs.ManagedScaling {
 		return nil
 	}
 
-	p := configured.([]interface{})[0].(map[string]interface{})
+	tfMap := configured.([]interface{})[0].(map[string]interface{})
 
 	managedScaling := ecs.ManagedScaling{}
 
-	if val, ok := p["instance_warmup_period"].(int); ok && val != 0 {
-		managedScaling.InstanceWarmupPeriod = aws.Int64(int64(val))
+	if v, ok := tfMap["instance_warmup_period"].(int); ok {
+		managedScaling.InstanceWarmupPeriod = aws.Int64(int64(v))
 	}
-	if val, ok := p["maximum_scaling_step_size"].(int); ok && val != 0 {
-		managedScaling.MaximumScalingStepSize = aws.Int64(int64(val))
+	if v, ok := tfMap["maximum_scaling_step_size"].(int); ok && v != 0 {
+		managedScaling.MaximumScalingStepSize = aws.Int64(int64(v))
 	}
-	if val, ok := p["minimum_scaling_step_size"].(int); ok && val != 0 {
-		managedScaling.MinimumScalingStepSize = aws.Int64(int64(val))
+	if v, ok := tfMap["minimum_scaling_step_size"].(int); ok && v != 0 {
+		managedScaling.MinimumScalingStepSize = aws.Int64(int64(v))
 	}
-	if val, ok := p["status"].(string); ok && len(val) > 0 {
-		managedScaling.Status = aws.String(val)
+	if v, ok := tfMap["status"].(string); ok && len(v) > 0 {
+		managedScaling.Status = aws.String(v)
 	}
-	if val, ok := p["target_capacity"].(int); ok && val != 0 {
-		managedScaling.TargetCapacity = aws.Int64(int64(val))
+	if v, ok := tfMap["target_capacity"].(int); ok && v != 0 {
+		managedScaling.TargetCapacity = aws.Int64(int64(v))
 	}
 
 	return &managedScaling

--- a/internal/service/ecs/capacity_provider.go
+++ b/internal/service/ecs/capacity_provider.go
@@ -66,7 +66,7 @@ func ResourceCapacityProvider() *schema.Resource {
 										Type:         schema.TypeInt,
 										Optional:     true,
 										Computed:     true,
-										ValidateFunc: validation.IntBetween(1, 10000),
+										ValidateFunc: validation.IntBetween(0, 10000),
 									},
 									"maximum_scaling_step_size": {
 										Type:         schema.TypeInt,

--- a/internal/service/ecs/capacity_provider_test.go
+++ b/internal/service/ecs/capacity_provider_test.go
@@ -298,11 +298,11 @@ resource "aws_autoscaling_group" "test" {
     id = aws_launch_template.test.id
   }
 
-  tags = [{
+  tag {
     key                 = "Name"
     value               = %[1]q
     propagate_at_launch = true
-  }]
+  }
 }
 `, rName))
 }

--- a/internal/service/ecs/capacity_provider_test.go
+++ b/internal/service/ecs/capacity_provider_test.go
@@ -303,6 +303,12 @@ resource "aws_autoscaling_group" "test" {
     value               = %[1]q
     propagate_at_launch = true
   }
+
+  lifecycle {
+    ignore_changes = [
+      tag,
+    ]
+  }
 }
 `, rName))
 }

--- a/internal/service/ecs/capacity_provider_test.go
+++ b/internal/service/ecs/capacity_provider_test.go
@@ -124,6 +124,20 @@ func TestAccECSCapacityProvider_managedScaling(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_scaling.0.target_capacity", "100"),
 				),
 			},
+			{
+				Config: testAccCapacityProviderConfig_managedScaling(rName, ecs.ManagedScalingStatusEnabled, 0, 100, 10, 100),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCapacityProviderExists(ctx, resourceName, &provider),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "auto_scaling_group_provider.0.auto_scaling_group_arn", "aws_autoscaling_group.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_termination_protection", "DISABLED"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_scaling.0.instance_warmup_period", "0"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_scaling.0.minimum_scaling_step_size", "10"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_scaling.0.maximum_scaling_step_size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_scaling.0.status", "ENABLED"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling_group_provider.0.managed_scaling.0.target_capacity", "100"),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Allow an `instance_warmup_period` of `0` in the `auto_scaling_group_provider.managed_scaling` configuration block.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/pull/24005.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/24003.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccECSCapacityProvider_managedScaling$$\|TestAccECSCapacityProvider_basic$$' PKG=ecs
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecs/... -v -count 1 -parallel 20  -run=TestAccECSCapacityProvider_managedScaling$\|TestAccECSCapacityProvider_basic$ -timeout 180m
=== RUN   TestAccECSCapacityProvider_basic
=== PAUSE TestAccECSCapacityProvider_basic
=== RUN   TestAccECSCapacityProvider_managedScaling
=== PAUSE TestAccECSCapacityProvider_managedScaling
=== CONT  TestAccECSCapacityProvider_basic
=== CONT  TestAccECSCapacityProvider_managedScaling
--- PASS: TestAccECSCapacityProvider_basic (70.82s)
--- PASS: TestAccECSCapacityProvider_managedScaling (160.56s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	166.296s
```
