### PR TITLE
rds/instance: NEW ID configuration

### DIFF
--- a/.changelog/31232.txt
+++ b/.changelog/31232.txt
@@ -1,0 +1,35 @@
+```release-note:breaking-change
+resource/aws_db_instance: Remove `name` - use `db_name` instead
+```
+
+```release-note:enhancement
+resource/aws_db_instance: Updates to `identifier` and `identifier_prefix` will no longer cause the database instance to be destroyed and recreated
+```
+
+```release-note:breaking-change
+resource/aws_db_instance: `id` is no longer the AWS database `identifier` - `id` is now the `dbi-resource-id`. Refer to `identifier` instead of `id` to use the database's identifier
+```
+
+```release-note:note
+resource/aws_db_instance: The change of what `id` is, namely, a DBI Resource ID now versus DB Identifier previously, has far-reaching consequences. Configurations that refer to, for example, `aws_db_instance.example.id` will now have errors and must be changed to use `identifier` instead, for example, `aws_db_instance.example.identifier`
+```
+
+```release-note:note
+resource/aws_db_snapshot: Configurations that define `db_instance_identifier` using the `id` attribute of `aws_db_instance` must be updated to use `identifier` instead - for example, `db_instance_identifier = aws_db_instance.example.id` must be updated to `db_instance_identifier = aws_db_instance.example.identifier`
+```
+
+```release-note:note
+resource/aws_db_instance: Configurations that define `replicate_source_db` using the `id` attribute of `aws_db_instance` must be updated to use `identifier` instead - for example, `replicate_source_db = aws_db_instance.example.id` must be updated to `replicate_source_db = aws_db_instance.example.identifier`
+```
+
+```release-note:note
+resource/aws_db_instance_role_association: Configurations that define `db_instance_identifier` using the `id` attribute of `aws_db_instance` must be updated to use `identifier` instead - for example, `db_instance_identifier = aws_db_instance.example.id` must be updated to `db_instance_identifier = aws_db_instance.example.identifier`
+```
+
+```release-note:note
+resource/aws_db_proxy_target: Configurations that define `db_instance_identifier` using the `id` attribute of `aws_db_instance` must be updated to use `identifier` instead - for example, `db_instance_identifier = aws_db_instance.example.id` must be updated to `db_instance_identifier = aws_db_instance.example.identifier`
+```
+
+```release-note:note
+resource/aws_db_event_subscription: Configurations that define `source_ids` using the `id` attribute of `aws_db_instance` must be updated to use `identifier` instead - for example, `source_ids = [aws_db_instance.example.id]` must be updated to `source_ids = [aws_db_instance.example.identifier]`
+```

--- a/examples/rds/main.tf
+++ b/examples/rds/main.tf
@@ -13,7 +13,7 @@ resource "aws_db_instance" "default" {
   engine                 = var.engine
   engine_version         = var.engine_version[var.engine]
   instance_class         = var.instance_class
-  name                   = var.db_name
+  db_name                = var.db_name
   username               = var.username
   password               = var.password
   vpc_security_group_ids = [aws_security_group.default.id]

--- a/examples/rds/outputs.tf
+++ b/examples/rds/outputs.tf
@@ -3,7 +3,7 @@ output "subnet_group" {
 }
 
 output "db_instance_id" {
-  value = aws_db_instance.default.id
+  value = aws_db_instance.default.identifier
 }
 
 output "db_instance_address" {

--- a/internal/service/rds/blue_green.go
+++ b/internal/service/rds/blue_green.go
@@ -113,7 +113,7 @@ func (h *instanceHandler) precondition(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if needsPreConditions {
-		err := dbInstanceModify(ctx, h.conn, input, d.Timeout(schema.TimeoutUpdate))
+		err := dbInstanceModify(ctx, h.conn, d.Id(), input, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return fmt.Errorf("setting pre-conditions: %s", err)
 		}
@@ -148,7 +148,7 @@ func (h *instanceHandler) modifyTarget(ctx context.Context, identifier string, d
 	if needsModify {
 		log.Printf("[DEBUG] %s: Updating Green environment", operation)
 
-		err := dbInstanceModify(ctx, h.conn, modifyInput, timeout)
+		err := dbInstanceModify(ctx, h.conn, d.Id(), modifyInput, timeout)
 		if err != nil {
 			return fmt.Errorf("updating Green environment: %s", err)
 		}

--- a/internal/service/rds/blue_green.go
+++ b/internal/service/rds/blue_green.go
@@ -97,7 +97,7 @@ func (h *instanceHandler) precondition(ctx context.Context, d *schema.ResourceDa
 	needsPreConditions := false
 	input := &rds_sdkv2.ModifyDBInstanceInput{
 		ApplyImmediately:     true,
-		DBInstanceIdentifier: aws.String(d.Id()),
+		DBInstanceIdentifier: aws.String(d.Get("identifier").(string)),
 	}
 
 	// Backups must be enabled for Blue/Green Deployments. Enable them first.
@@ -123,7 +123,7 @@ func (h *instanceHandler) precondition(ctx context.Context, d *schema.ResourceDa
 
 func (h *instanceHandler) createBlueGreenInput(d *schema.ResourceData) *rds_sdkv2.CreateBlueGreenDeploymentInput {
 	input := &rds_sdkv2.CreateBlueGreenDeploymentInput{
-		BlueGreenDeploymentName: aws.String(d.Id()),
+		BlueGreenDeploymentName: aws.String(d.Get("identifier").(string)),
 		Source:                  aws.String(d.Get("arn").(string)),
 	}
 

--- a/internal/service/rds/export_task_test.go
+++ b/internal/service/rds/export_task_test.go
@@ -253,7 +253,7 @@ resource "aws_db_instance" "test" {
 }
 
 resource "aws_db_snapshot" "test" {
-  db_instance_identifier = aws_db_instance.test.id
+  db_instance_identifier = aws_db_instance.test.identifier
   db_snapshot_identifier = %[1]q
 }
 `, rName)

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -34,6 +34,17 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+// NOTE ON "ID", "IDENTIFIER":
+// ID is overloaded and potentially confusing. Hopefully this clears it up.
+// * ID, as in d.Id(), d.SetId(), is:
+//    - the same as AWS calls the "dbi-resource-id" a/k/a "database instance resource ID"
+//    - unchangeable/immutable
+//    - called either "id" or "resource_id" in schema/state (previously was only "resource_id")
+// * "identifier" is:
+//    - user-defined identifier which AWS calls "identifier"
+//    - can be updated
+//    - called "identifier" in the schema/state (previously was also "id")
+
 // @SDKResource("aws_db_instance", name="DB Instance")
 // @Tags(identifierAttribute="arn")
 func ResourceInstance() *schema.Resource {
@@ -47,12 +58,17 @@ func ResourceInstance() *schema.Resource {
 			StateContext: resourceInstanceImport,
 		},
 
-		SchemaVersion: 1,
+		SchemaVersion: 2,
 		StateUpgraders: []schema.StateUpgrader{
 			{
 				Type:    resourceInstanceResourceV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: InstanceStateUpgradeV0,
 				Version: 0,
+			},
+			{
+				Type:    resourceInstanceResourceV1().CoreConfigSchema().ImpliedType(),
+				Upgrade: InstanceStateUpgradeV1,
+				Version: 1,
 			},
 		},
 
@@ -177,7 +193,6 @@ func ResourceInstance() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 				ConflictsWith: []string{
-					"name",
 					"replicate_source_db",
 				},
 			},
@@ -256,7 +271,6 @@ func ResourceInstance() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{"identifier_prefix"},
 				ValidateFunc:  validIdentifier,
 			},
@@ -264,7 +278,6 @@ func ResourceInstance() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{"identifier"},
 				ValidateFunc:  validIdentifierPrefix,
 			},
@@ -383,17 +396,6 @@ func ResourceInstance() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Computed: true,
-			},
-			"name": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Computed:   true,
-				Deprecated: "Use db_name instead",
-				ForceNew:   true,
-				ConflictsWith: []string{
-					"db_name",
-					"replicate_source_db",
-				},
 			},
 			"nchar_character_set_name": {
 				Type:     schema.TypeString,
@@ -645,7 +647,10 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	// we expect everything to be in sync before returning completion.
 	var requiresRebootDbInstance bool
 
+	// See discussion of IDs at the top of file - this is NOT d.Id()
 	identifier := create.Name(d.Get("identifier").(string), d.Get("identifier_prefix").(string))
+
+	var resourceID string // will be assigned depending on how it is created
 
 	if v, ok := d.GetOk("replicate_source_db"); ok {
 		sourceDBInstanceID := v.(string)
@@ -664,7 +669,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			// RDS doesn't allow modifying the storage of a replica within the first 6h of creation.
 			// allocated_storage is inherited from the primary so only the same value or no value is correct; a different value would fail the creation.
 			// A different value is possible, granted: the value is higher than the current, there has been 6h between
-			diags = sdkdiag.AppendWarningf(diags, `"allocated_storage" was ignored for DB Instance (%s) because a replica inherits the primary's allocated_storage and cannot be changed at creation.`, d.Id())
+			diags = sdkdiag.AppendWarningf(diags, `"allocated_storage" was ignored for DB Instance (%s) because a replica inherits the primary's allocated_storage and cannot be changed at creation.`, identifier)
 		}
 
 		if v, ok := d.GetOk("availability_zone"); ok {
@@ -762,6 +767,8 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 		output := outputRaw.(*rds.CreateDBInstanceReadReplicaOutput)
 
+		resourceID = aws.StringValue(output.DBInstance.DbiResourceId)
+
 		if v, ok := d.GetOk("allow_major_version_upgrade"); ok {
 			// Having allowing_major_version_upgrade by itself should not trigger ModifyDBInstance
 			// "InvalidParameterCombination: No modifications were requested".
@@ -827,11 +834,6 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			requiresModifyDbInstance = true
 		}
 	} else if v, ok := d.GetOk("s3_import"); ok {
-		dbName := d.Get("db_name").(string)
-		if dbName == "" {
-			dbName = d.Get("name").(string)
-		}
-
 		if _, ok := d.GetOk("allocated_storage"); !ok {
 			diags = sdkdiag.AppendErrorf(diags, `"allocated_storage": required field is not set`)
 		}
@@ -859,7 +861,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			CopyTagsToSnapshot:      aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
 			DBInstanceClass:         aws.String(d.Get("instance_class").(string)),
 			DBInstanceIdentifier:    aws.String(identifier),
-			DBName:                  aws.String(dbName),
+			DBName:                  aws.String(d.Get("db_name").(string)),
 			DeletionProtection:      aws.Bool(d.Get("deletion_protection").(bool)),
 			Engine:                  aws.String(d.Get("engine").(string)),
 			EngineVersion:           aws.String(d.Get("engine_version").(string)),
@@ -970,7 +972,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			input.VpcSecurityGroupIds = flex.ExpandStringSet(v.(*schema.Set))
 		}
 
-		_, err := tfresource.RetryWhen(ctx, propagationTimeout,
+		outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return conn.RestoreDBInstanceFromS3WithContext(ctx, input)
 			},
@@ -995,6 +997,10 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating RDS DB Instance (restore from S3) (%s): %s", identifier, err)
 		}
+
+		output := outputRaw.(*rds.RestoreDBInstanceFromS3Output)
+
+		resourceID = aws.StringValue(output.DBInstance.DbiResourceId)
 	} else if v, ok := d.GetOk("snapshot_identifier"); ok {
 		input := &rds.RestoreDBInstanceFromDBSnapshotInput{
 			AutoMinorVersionUpgrade: aws.Bool(d.Get("auto_minor_version_upgrade").(bool)),
@@ -1009,15 +1015,6 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 		engine := strings.ToLower(d.Get("engine").(string))
 		if v, ok := d.GetOk("db_name"); ok {
-			// "Note: This parameter [DBName] doesn't apply to the MySQL, PostgreSQL, or MariaDB engines."
-			// https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_RestoreDBInstanceFromDBSnapshot.html
-			switch engine {
-			case InstanceEngineMySQL, InstanceEnginePostgres, InstanceEngineMariaDB:
-				// skip
-			default:
-				input.DBName = aws.String(v.(string))
-			}
-		} else if v, ok := d.GetOk("name"); ok {
 			// "Note: This parameter [DBName] doesn't apply to the MySQL, PostgreSQL, or MariaDB engines."
 			// https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_RestoreDBInstanceFromDBSnapshot.html
 			switch engine {
@@ -1186,7 +1183,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			input.VpcSecurityGroupIds = flex.ExpandStringSet(v)
 		}
 
-		_, err := tfresource.RetryWhen(ctx, propagationTimeout,
+		outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return conn.RestoreDBInstanceFromDBSnapshotWithContext(ctx, input)
 			},
@@ -1198,6 +1195,10 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 				return false, err
 			},
 		)
+
+		output := outputRaw.(*rds.RestoreDBInstanceFromDBSnapshotOutput)
+
+		resourceID = aws.StringValue(output.DBInstance.DbiResourceId)
 
 		// When using SQL Server engine with MultiAZ enabled, its not
 		// possible to immediately enable mirroring since
@@ -1265,8 +1266,6 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if v, ok := d.GetOk("db_name"); ok {
-			input.DBName = aws.String(v.(string))
-		} else if v, ok := d.GetOk("name"); ok {
 			input.DBName = aws.String(v.(string))
 		}
 
@@ -1348,7 +1347,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			input.VpcSecurityGroupIds = flex.ExpandStringSet(v.(*schema.Set))
 		}
 
-		_, err := tfresource.RetryWhen(ctx, propagationTimeout,
+		outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 			func() (interface{}, error) {
 				return conn.RestoreDBInstanceToPointInTimeWithContext(ctx, input)
 			},
@@ -1363,12 +1362,11 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating RDS DB Instance (restore to point-in-time) (%s): %s", identifier, err)
 		}
-	} else {
-		dbName := d.Get("db_name").(string)
-		if dbName == "" {
-			dbName = d.Get("name").(string)
-		}
 
+		output := outputRaw.(*rds.RestoreDBInstanceToPointInTimeOutput)
+
+		resourceID = aws.StringValue(output.DBInstance.DbiResourceId)
+	} else {
 		if _, ok := d.GetOk("allocated_storage"); !ok {
 			diags = sdkdiag.AppendErrorf(diags, `"allocated_storage": required field is not set`)
 		}
@@ -1389,7 +1387,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			CopyTagsToSnapshot:      aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
 			DBInstanceClass:         aws.String(d.Get("instance_class").(string)),
 			DBInstanceIdentifier:    aws.String(identifier),
-			DBName:                  aws.String(dbName),
+			DBName:                  aws.String(d.Get("db_name").(string)),
 			DeletionProtection:      aws.Bool(d.Get("deletion_protection").(bool)),
 			Engine:                  aws.String(d.Get("engine").(string)),
 			EngineVersion:           aws.String(d.Get("engine_version").(string)),
@@ -1552,6 +1550,8 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 		output := outputRaw.(*rds.CreateDBInstanceOutput)
 
+		resourceID = aws.StringValue(output.DBInstance.DbiResourceId)
+
 		// This is added here to avoid unnecessary modification when ca_cert_identifier is the default one
 		if v, ok := d.GetOk("ca_cert_identifier"); ok && v.(string) != aws.StringValue(output.DBInstance.CACertificateIdentifier) {
 			modifyDbInstanceInput.CACertificateIdentifier = aws.String(v.(string))
@@ -1559,35 +1559,35 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 	}
 
-	d.SetId(identifier)
+	d.SetId(resourceID)
 
 	if _, err := waitDBInstanceAvailableSDKv1(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Instance (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Instance (%s) create: %s", identifier, err)
 	}
 
 	if requiresModifyDbInstance {
-		modifyDbInstanceInput.DBInstanceIdentifier = aws.String(d.Id())
+		modifyDbInstanceInput.DBInstanceIdentifier = aws.String(identifier)
 
 		_, err := conn.ModifyDBInstanceWithContext(ctx, modifyDbInstanceInput)
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", identifier, err)
 		}
 
 		if _, err := waitDBInstanceAvailableSDKv1(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Instance (%s) update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Instance (%s) update: %s", identifier, err)
 		}
 	}
 
 	if requiresRebootDbInstance {
 		_, err := conn.RebootDBInstanceWithContext(ctx, &rds.RebootDBInstanceInput{
-			DBInstanceIdentifier: aws.String(d.Id()),
+			DBInstanceIdentifier: aws.String(identifier),
 		})
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "rebooting RDS DB Instance (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "rebooting RDS DB Instance (%s): %s", identifier, err)
 		}
 
 		if _, err := waitDBInstanceAvailableSDKv1(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Instance (%s) update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Instance (%s) update: %s", identifier, err)
 		}
 	}
 
@@ -1600,18 +1600,17 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	v, err := findDBInstanceByIDSDKv1(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] RDS DB Instance (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] RDS DB Instance (%s) not found, removing from state", d.Get("identifier").(string))
 		d.SetId("")
 		return nil
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading RDS DB Instance (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading RDS DB Instance (%s): %s", d.Get("identifier").(string), err)
 	}
 
 	d.Set("allocated_storage", v.AllocatedStorage)
-	arn := aws.StringValue(v.DBInstanceArn)
-	d.Set("arn", arn)
+	d.Set("arn", v.DBInstanceArn)
 	d.Set("auto_minor_version_upgrade", v.AutoMinorVersionUpgrade)
 	d.Set("availability_zone", v.AvailabilityZone)
 	d.Set("backup_retention_period", v.BackupRetentionPeriod)
@@ -1671,7 +1670,6 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("monitoring_interval", v.MonitoringInterval)
 	d.Set("monitoring_role_arn", v.MonitoringRoleArn)
 	d.Set("multi_az", v.MultiAZ)
-	d.Set("name", v.DBName)
 	d.Set("nchar_character_set_name", v.NcharCharacterSetName)
 	d.Set("network_type", v.NetworkType)
 	if len(v.OptionGroupMemberships) > 0 && v.OptionGroupMemberships[0] != nil {
@@ -1734,7 +1732,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		if d.Get("replicate_source_db").(string) == "" {
 			input := &rds_sdkv2.PromoteReadReplicaInput{
 				BackupRetentionPeriod: aws.Int32(int32(d.Get("backup_retention_period").(int))),
-				DBInstanceIdentifier:  aws.String(d.Id()),
+				DBInstanceIdentifier:  aws.String(d.Get("identifier").(string)),
 			}
 
 			if attr, ok := d.GetOk("backup_window"); ok {
@@ -1743,11 +1741,11 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 			_, err := conn.PromoteReadReplica(ctx, input)
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "promoting RDS DB Instance (%s): %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "promoting RDS DB Instance (%s): %s", d.Get("identifier").(string), err)
 			}
 
 			if _, err := waitDBInstanceAvailableSDKv2(ctx, conn, d.Id(), deadline.Remaining()); err != nil {
-				return sdkdiag.AppendErrorf(diags, "promoting RDS DB Instance (%s): waiting for completion: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "promoting RDS DB Instance (%s): waiting for completion: %s", d.Get("identifier").(string), err)
 			}
 		} else {
 			return sdkdiag.AppendErrorf(diags, "cannot elect new source database for replication")
@@ -1785,23 +1783,23 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 			err := handler.precondition(ctx, d)
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", d.Get("identifier").(string), err)
 			}
 
 			createIn := handler.createBlueGreenInput(d)
 
-			log.Printf("[DEBUG] Updating RDS DB Instance (%s): Creating Blue/Green Deployment", d.Id())
+			log.Printf("[DEBUG] Updating RDS DB Instance (%s): Creating Blue/Green Deployment", d.Get("identifier").(string))
 
 			dep, err := orchestrator.createDeployment(ctx, createIn)
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", d.Get("identifier").(string), err)
 			}
 			deploymentIdentifier := dep.BlueGreenDeploymentIdentifier
 			defer func() {
-				log.Printf("[DEBUG] Updating RDS DB Instance (%s): Deleting Blue/Green Deployment", d.Id())
+				log.Printf("[DEBUG] Updating RDS DB Instance (%s): Deleting Blue/Green Deployment", d.Get("identifier").(string))
 
 				if dep == nil {
-					log.Printf("[DEBUG] Updating RDS DB Instance (%s): Deleting Blue/Green Deployment: deployment disappeared", d.Id())
+					log.Printf("[DEBUG] Updating RDS DB Instance (%s): Deleting Blue/Green Deployment: deployment disappeared", d.Get("identifier").(string))
 					return
 				}
 
@@ -1814,49 +1812,49 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 				}
 				_, err = conn.DeleteBlueGreenDeployment(ctx, input)
 				if err != nil {
-					diags = sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): deleting Blue/Green Deployment: %s", d.Id(), err)
+					diags = sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): deleting Blue/Green Deployment: %s", d.Get("identifier").(string), err)
 					return
 				}
 
 				cleaupWaiters = append(cleaupWaiters, func(optFns ...tfresource.OptionsFunc) {
 					_, err = waitBlueGreenDeploymentDeleted(ctx, conn, aws.StringValue(deploymentIdentifier), deadline.Remaining(), optFns...)
 					if err != nil {
-						diags = sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): deleting Blue/Green Deployment: waiting for completion: %s", d.Id(), err)
+						diags = sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): deleting Blue/Green Deployment: waiting for completion: %s", d.Get("identifier").(string), err)
 					}
 				})
 			}()
 
 			dep, err = orchestrator.waitForDeploymentAvailable(ctx, aws.StringValue(dep.BlueGreenDeploymentIdentifier), deadline.Remaining())
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", d.Get("identifier").(string), err)
 			}
 
 			targetARN, err := parseDBInstanceARN(aws.StringValue(dep.Target))
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): creating Blue/Green Deployment: waiting for Green environment: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): creating Blue/Green Deployment: waiting for Green environment: %s", d.Get("identifier").(string), err)
 			}
 			_, err = waitDBInstanceAvailableSDKv2(ctx, conn, targetARN.Identifier, deadline.Remaining())
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): creating Blue/Green Deployment: waiting for Green environment: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): creating Blue/Green Deployment: waiting for Green environment: %s", d.Get("identifier").(string), err)
 			}
 
-			err = handler.modifyTarget(ctx, targetARN.Identifier, d, deadline.Remaining(), fmt.Sprintf("Updating RDS DB Instance (%s)", d.Id()))
+			err = handler.modifyTarget(ctx, targetARN.Identifier, d, deadline.Remaining(), fmt.Sprintf("Updating RDS DB Instance (%s)", d.Get("identifier").(string)))
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", d.Get("identifier").(string), err)
 			}
 
-			log.Printf("[DEBUG] Updating RDS DB Instance (%s): Switching over Blue/Green Deployment", d.Id())
+			log.Printf("[DEBUG] Updating RDS DB Instance (%s): Switching over Blue/Green Deployment", d.Get("identifier").(string))
 
 			dep, err = orchestrator.switchover(ctx, aws.StringValue(dep.BlueGreenDeploymentIdentifier), deadline.Remaining())
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", d.Get("identifier").(string), err)
 			}
 
-			log.Printf("[DEBUG] Updating RDS DB Instance (%s): Deleting Blue/Green Deployment source", d.Id())
+			log.Printf("[DEBUG] Updating RDS DB Instance (%s): Deleting Blue/Green Deployment source", d.Get("identifier").(string))
 
 			sourceARN, err := parseDBInstanceARN(aws.StringValue(dep.Source))
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): deleting Blue/Green Deployment source: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): deleting Blue/Green Deployment source: %s", d.Get("identifier").(string), err)
 			}
 			if d.Get("deletion_protection").(bool) {
 				input := &rds_sdkv2.ModifyDBInstanceInput{
@@ -1864,9 +1862,9 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 					DBInstanceIdentifier: aws.String(sourceARN.Identifier),
 					DeletionProtection:   aws.Bool(false),
 				}
-				err := dbInstanceModify(ctx, conn, input, deadline.Remaining())
+				err := dbInstanceModify(ctx, conn, d.Id(), input, deadline.Remaining())
 				if err != nil {
-					return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): deleting Blue/Green Deployment source: disabling deletion protection: %s", d.Id(), err)
+					return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): deleting Blue/Green Deployment source: disabling deletion protection: %s", d.Get("identifier").(string), err)
 				}
 			}
 			deleteInput := &rds_sdkv2.DeleteDBInstanceInput{
@@ -1892,13 +1890,13 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 				},
 			)
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): deleting Blue/Green Deployment source: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): deleting Blue/Green Deployment source: %s", d.Get("identifier").(string), err)
 			}
 
 			cleaupWaiters = append(cleaupWaiters, func(optFns ...tfresource.OptionsFunc) {
 				_, err = waitDBInstanceDeleted(ctx, meta.(*conns.AWSClient).RDSConn(), sourceARN.Identifier, deadline.Remaining(), optFns...)
 				if err != nil {
-					diags = sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): deleting Blue/Green Deployment source: waiting for completion: %s", d.Id(), err)
+					diags = sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): deleting Blue/Green Deployment source: waiting for completion: %s", d.Get("identifier").(string), err)
 				}
 			})
 
@@ -1906,9 +1904,14 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 				return
 			}
 		} else {
+			oldID := d.Get("identifier").(string)
+			if d.HasChange("identifier") {
+				o, _ := d.GetChange("identifier")
+				oldID = o.(string)
+			}
 			input := &rds_sdkv2.ModifyDBInstanceInput{
 				ApplyImmediately:     d.Get("apply_immediately").(bool),
-				DBInstanceIdentifier: aws.String(d.Id()),
+				DBInstanceIdentifier: aws.String(oldID),
 			}
 
 			if !input.ApplyImmediately {
@@ -1929,9 +1932,9 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 				input.DBParameterGroupName = aws.String(d.Get("parameter_group_name").(string))
 			}
 
-			err := dbInstanceModify(ctx, conn, input, deadline.Remaining())
+			err := dbInstanceModify(ctx, conn, d.Id(), input, deadline.Remaining())
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", d.Get("identifier").(string), err)
 			}
 		}
 	}
@@ -2017,6 +2020,11 @@ func dbInstancePopulateModify(input *rds_sdkv2.ModifyDBInstanceInput, d *schema.
 	if d.HasChange("iam_database_authentication_enabled") {
 		needsModify = true
 		input.EnableIAMDatabaseAuthentication = aws.Bool(d.Get("iam_database_authentication_enabled").(bool))
+	}
+
+	if d.HasChange("identifier") {
+		needsModify = true
+		input.NewDBInstanceIdentifier = aws.String(d.Get("identifier").(string))
 	}
 
 	if d.HasChange("instance_class") {
@@ -2147,7 +2155,7 @@ func dbInstancePopulateModify(input *rds_sdkv2.ModifyDBInstanceInput, d *schema.
 	return needsModify
 }
 
-func dbInstanceModify(ctx context.Context, conn *rds_sdkv2.Client, input *rds_sdkv2.ModifyDBInstanceInput, timeout time.Duration) error {
+func dbInstanceModify(ctx context.Context, conn *rds_sdkv2.Client, resourceID string, input *rds_sdkv2.ModifyDBInstanceInput, timeout time.Duration) error {
 	_, err := tfresource.RetryWhen(ctx, timeout,
 		func() (interface{}, error) {
 			return conn.ModifyDBInstance(ctx, input)
@@ -2170,7 +2178,7 @@ func dbInstanceModify(ctx context.Context, conn *rds_sdkv2.Client, input *rds_sd
 		return err
 	}
 
-	if _, err := waitDBInstanceAvailableSDKv2(ctx, conn, aws.StringValue(input.DBInstanceIdentifier), timeout); err != nil {
+	if _, err := waitDBInstanceAvailableSDKv2(ctx, conn, resourceID, timeout); err != nil {
 		return fmt.Errorf("waiting for completion: %w", err)
 	}
 	return nil
@@ -2180,7 +2188,7 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 	conn := meta.(*conns.AWSClient).RDSConn()
 
 	input := &rds.DeleteDBInstanceInput{
-		DBInstanceIdentifier:   aws.String(d.Id()),
+		DBInstanceIdentifier:   aws.String(d.Get("identifier").(string)),
 		DeleteAutomatedBackups: aws.Bool(d.Get("delete_automated_backups").(bool)),
 	}
 
@@ -2196,7 +2204,7 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 		}
 	}
 
-	log.Printf("[DEBUG] Deleting RDS DB Instance: %s", d.Id())
+	log.Printf("[DEBUG] Deleting RDS DB Instance: %s", d.Get("identifier").(string))
 	_, err := conn.DeleteDBInstanceWithContext(ctx, input)
 
 	if tfawserr.ErrMessageContains(err, errCodeInvalidParameterCombination, "disable deletion pro") {
@@ -2205,7 +2213,7 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 				func() (interface{}, error) {
 					return conn.ModifyDBInstanceWithContext(ctx, &rds.ModifyDBInstanceInput{
 						ApplyImmediately:     aws.Bool(true),
-						DBInstanceIdentifier: aws.String(d.Id()),
+						DBInstanceIdentifier: aws.String(d.Get("identifier").(string)),
 						DeletionProtection:   aws.Bool(false),
 					})
 				},
@@ -2225,11 +2233,11 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 			)
 
 			if ierr != nil {
-				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating RDS DB Instance (%s): %s", d.Get("identifier").(string), err)
 			}
 
 			if _, ierr := waitDBInstanceAvailableSDKv1(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); ierr != nil {
-				return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Instance (%s) update: %s", d.Id(), ierr)
+				return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Instance (%s) update: %s", d.Get("identifier").(string), ierr)
 			}
 
 			_, err = conn.DeleteDBInstanceWithContext(ctx, input)
@@ -2241,11 +2249,11 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if err != nil && !tfawserr.ErrMessageContains(err, rds.ErrCodeInvalidDBInstanceStateFault, "is already being deleted") {
-		return sdkdiag.AppendErrorf(diags, "deleting RDS DB Instance (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting RDS DB Instance (%s): %s", d.Get("identifier").(string), err)
 	}
 
 	if _, err := waitDBInstanceDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Instance (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Instance (%s) delete: %s", d.Get("identifier").(string), err)
 	}
 
 	return nil
@@ -2313,7 +2321,12 @@ func parseDBInstanceARN(s string) (dbInstanceARN, error) {
 
 func findDBInstanceByIDSDKv1(ctx context.Context, conn *rds.RDS, id string) (*rds.DBInstance, error) {
 	input := &rds.DescribeDBInstancesInput{
-		DBInstanceIdentifier: aws.String(id),
+		Filters: []*rds.Filter{
+			{
+				Name:   aws.String("dbi-resource-id"),
+				Values: aws.StringSlice([]string{id}),
+			},
+		},
 	}
 
 	output, err := conn.DescribeDBInstancesWithContext(ctx, input)
@@ -2338,7 +2351,12 @@ func findDBInstanceByIDSDKv1(ctx context.Context, conn *rds.RDS, id string) (*rd
 
 func findDBInstanceByIDSDKv2(ctx context.Context, conn *rds_sdkv2.Client, id string) (*types.DBInstance, error) {
 	input := &rds_sdkv2.DescribeDBInstancesInput{
-		DBInstanceIdentifier: aws.String(id),
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("dbi-resource-id"),
+				Values: []string{id},
+			},
+		},
 	}
 
 	output, err := conn.DescribeDBInstances(ctx, input)

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -2502,7 +2502,7 @@ func waitDBInstanceAvailableSDKv1(ctx context.Context, conn *rds.RDS, id string,
 	return nil, err
 }
 
-func waitDBInstanceAvailableSDKv2(ctx context.Context, conn *rds_sdkv2.Client, id string, timeout time.Duration, optFns ...tfresource.OptionsFunc) (*rds.DBInstance, error) {
+func waitDBInstanceAvailableSDKv2(ctx context.Context, conn *rds_sdkv2.Client, id string, timeout time.Duration, optFns ...tfresource.OptionsFunc) (*rds.DBInstance, error) { //nolint:unparam
 	options := tfresource.Options{
 		PollInterval:              10 * time.Second,
 		Delay:                     1 * time.Minute,

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -2459,7 +2459,7 @@ func statusDBInstanceSDKv2(ctx context.Context, conn *rds_sdkv2.Client, id strin
 	}
 }
 
-func waitDBInstanceAvailableSDKv1(ctx context.Context, conn *rds.RDS, id string, timeout time.Duration, optFns ...tfresource.OptionsFunc) (*rds.DBInstance, error) { //nolint:unparam
+func waitDBInstanceAvailableSDKv1(ctx context.Context, conn *rds.RDS, id string, timeout time.Duration, optFns ...tfresource.OptionsFunc) (*rds.DBInstance, error) {
 	options := tfresource.Options{
 		PollInterval:              10 * time.Second,
 		Delay:                     1 * time.Minute,
@@ -2502,7 +2502,7 @@ func waitDBInstanceAvailableSDKv1(ctx context.Context, conn *rds.RDS, id string,
 	return nil, err
 }
 
-func waitDBInstanceAvailableSDKv2(ctx context.Context, conn *rds_sdkv2.Client, id string, timeout time.Duration, optFns ...tfresource.OptionsFunc) (*rds.DBInstance, error) { //nolint:unparam
+func waitDBInstanceAvailableSDKv2(ctx context.Context, conn *rds_sdkv2.Client, id string, timeout time.Duration, optFns ...tfresource.OptionsFunc) (*rds.DBInstance, error) {
 	options := tfresource.Options{
 		PollInterval:              10 * time.Second,
 		Delay:                     1 * time.Minute,

--- a/internal/service/rds/instance_automated_backups_replication_test.go
+++ b/internal/service/rds/instance_automated_backups_replication_test.go
@@ -171,7 +171,7 @@ resource "aws_db_instance" "test" {
   engine                  = "postgres"
   engine_version          = "13.4"
   instance_class          = "db.t3.micro"
-  name                    = "mydb"
+  db_name                 = "mydb"
   username                = "masterusername"
   password                = "mustbeeightcharacters"
   backup_retention_period = 7

--- a/internal/service/rds/instance_data_source_test.go
+++ b/internal/service/rds/instance_data_source_test.go
@@ -113,7 +113,7 @@ resource "aws_db_instance" "test" {
   engine_version          = data.aws_rds_engine_version.default.version
   identifier              = %[1]q
   instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
-  name                    = "test"
+  db_name                 = "test"
   password                = "avoid-plaintext-passwords"
   skip_final_snapshot     = true
   username                = "tfacctest"
@@ -148,7 +148,7 @@ resource "aws_db_instance" "test" {
   identifier                  = %[1]q
   instance_class              = data.aws_rds_orderable_db_instance.test.instance_class
   manage_master_user_password = true
-  name                        = "test"
+  db_name                     = "test"
   skip_final_snapshot         = true
   username                    = "tfacctest"
 

--- a/internal/service/rds/instance_migrate.go
+++ b/internal/service/rds/instance_migrate.go
@@ -2,9 +2,17 @@ package rds
 
 import (
 	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
 
+	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func resourceInstanceResourceV0() *schema.Resource {
@@ -386,6 +394,542 @@ func InstanceStateUpgradeV0(_ context.Context, rawState map[string]interface{}, 
 	}
 
 	rawState["delete_automated_backups"] = true
+
+	return rawState, nil
+}
+
+func resourceInstanceResourceV1() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"allocated_storage": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					mas := d.Get("max_allocated_storage").(int)
+
+					newInt, err := strconv.Atoi(new)
+					if err != nil {
+						return false
+					}
+
+					oldInt, err := strconv.Atoi(old)
+					if err != nil {
+						return false
+					}
+
+					// Allocated is higher than the configuration
+					// and autoscaling is enabled
+					if oldInt > newInt && mas > newInt {
+						return true
+					}
+
+					return false
+				},
+			},
+			"allow_major_version_upgrade": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			// apply_immediately is used to determine when the update modifications
+			// take place.
+			// See http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html
+			"apply_immediately": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"auto_minor_version_upgrade": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"backup_retention_period": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(0, 35),
+			},
+			"backup_window": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: verify.ValidOnceADayWindowFormat,
+			},
+			"blue_green_update": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"ca_cert_identifier": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"character_set_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"copy_tags_to_snapshot": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"custom_iam_instance_profile": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^AWSRDSCustom.*$`), "must begin with AWSRDSCustom"),
+			},
+			"customer_owned_ip_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"db_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				ConflictsWith: []string{
+					"replicate_source_db",
+				},
+			},
+			"db_subnet_group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"delete_automated_backups": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"deletion_protection": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"domain_iam_role_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enabled_cloudwatch_logs_exports": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice(InstanceExportableLogType_Values(), false),
+				},
+			},
+			"endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				StateFunc: func(v interface{}) string {
+					value := v.(string)
+					return strings.ToLower(value)
+				},
+			},
+			"engine_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"engine_version_actual": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"final_snapshot_identifier": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`^[A-Za-z]`), "must begin with alphabetic character"),
+					validation.StringMatch(regexp.MustCompile(`^[0-9A-Za-z-]+$`), "must only contain alphanumeric characters and hyphens"),
+					validation.StringDoesNotMatch(regexp.MustCompile(`--`), "cannot contain two consecutive hyphens"),
+					validation.StringDoesNotMatch(regexp.MustCompile(`-$`), "cannot end in a hyphen"),
+				),
+			},
+			"hosted_zone_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"iam_database_authentication_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"identifier": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"identifier_prefix"},
+				ValidateFunc:  validIdentifier,
+			},
+			"identifier_prefix": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"identifier"},
+				ValidateFunc:  validIdentifierPrefix,
+			},
+			"instance_class": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"iops": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"kms_key_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"latest_restorable_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"license_model": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"listener_endpoint": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"hosted_zone_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"maintenance_window": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				StateFunc: func(v interface{}) string {
+					if v != nil {
+						value := v.(string)
+						return strings.ToLower(value)
+					}
+					return ""
+				},
+				ValidateFunc: verify.ValidOnceAWeekWindowFormat,
+			},
+			"manage_master_user_password": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				ConflictsWith: []string{"password"},
+			},
+			"master_user_secret": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kms_key_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"secret_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"secret_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"master_user_secret_kms_key_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: verify.ValidKMSKeyID,
+			},
+			"max_allocated_storage": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if old == "0" && new == fmt.Sprintf("%d", d.Get("allocated_storage").(int)) {
+						return true
+					}
+					return false
+				},
+			},
+			"monitoring_interval": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      0,
+				ValidateFunc: validation.IntInSlice([]int{0, 1, 5, 10, 15, 30, 60}),
+			},
+			"monitoring_role_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"multi_az": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"nchar_character_set_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"network_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(NetworkType_Values(), false),
+			},
+			"option_group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"parameter_group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"password": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Sensitive:     true,
+				ConflictsWith: []string{"manage_master_user_password"},
+			},
+			"performance_insights_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"performance_insights_kms_key_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"performance_insights_retention_period": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"port": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"publicly_accessible": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"replica_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(rds.ReplicaMode_Values(), false),
+			},
+			"replicas": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"replicate_source_db": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"restore_to_point_in_time": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				ForceNew: true,
+				ConflictsWith: []string{
+					"s3_import",
+					"snapshot_identifier",
+					"replicate_source_db",
+				},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"restore_time": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							ValidateFunc:  verify.ValidUTCTimestamp,
+							ConflictsWith: []string{"restore_to_point_in_time.0.use_latest_restorable_time"},
+						},
+						"source_db_instance_automated_backups_arn": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"source_db_instance_identifier": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"source_dbi_resource_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"use_latest_restorable_time": {
+							Type:          schema.TypeBool,
+							Optional:      true,
+							ConflictsWith: []string{"restore_to_point_in_time.0.restore_time"},
+						},
+					},
+				},
+			},
+			"s3_import": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				ConflictsWith: []string{
+					"snapshot_identifier",
+					"replicate_source_db",
+				},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bucket_name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"bucket_prefix": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"ingestion_role": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"source_engine": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"source_engine_version": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			"skip_final_snapshot": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"snapshot_identifier": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"storage_encrypted": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+			"storage_throughput": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"storage_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(StorageType_Values(), false),
+			},
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			"timezone": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"username": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"replicate_source_db"},
+			},
+			"vpc_security_group_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func InstanceStateUpgradeV1(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	if rawState == nil {
+		return nil, nil
+	}
+
+	rawState["id"] = rawState["resource_id"]
 
 	return rawState, nil
 }

--- a/internal/service/rds/instance_migrate_test.go
+++ b/internal/service/rds/instance_migrate_test.go
@@ -62,3 +62,61 @@ func TestInstanceStateUpgradeV0(t *testing.T) {
 		})
 	}
 }
+
+func TestInstanceStateUpgradeV1(t *testing.T) {
+	ctx := acctest.Context(t)
+	t.Parallel()
+
+	testCases := []struct {
+		Description   string
+		InputState    map[string]interface{}
+		ExpectedState map[string]interface{}
+	}{
+		{
+			Description:   "missing state",
+			InputState:    nil,
+			ExpectedState: nil,
+		},
+		{
+			Description: "change id to resource id",
+			InputState: map[string]interface{}{
+				"allocated_storage": 10,
+				"engine":            "mariadb",
+				"id":                "my-test-instance",
+				"identifier":        "my-test-instance",
+				"instance_class":    "db.t2.micro",
+				"password":          "avoid-plaintext-passwords",
+				"resource_id":       "db-cnuap2ilnbmok4eunzklfvwjca",
+				"tags":              map[string]interface{}{"key1": "value1"},
+				"username":          "tfacctest",
+			},
+			ExpectedState: map[string]interface{}{
+				"allocated_storage": 10,
+				"engine":            "mariadb",
+				"id":                "db-cnuap2ilnbmok4eunzklfvwjca",
+				"identifier":        "my-test-instance",
+				"instance_class":    "db.t2.micro",
+				"password":          "avoid-plaintext-passwords",
+				"resource_id":       "db-cnuap2ilnbmok4eunzklfvwjca",
+				"tags":              map[string]interface{}{"key1": "value1"},
+				"username":          "tfacctest",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.Description, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tfrds.InstanceStateUpgradeV1(ctx, testCase.InputState, nil)
+			if err != nil {
+				t.Fatalf("error migrating state: %s", err)
+			}
+
+			if !reflect.DeepEqual(testCase.ExpectedState, got) {
+				t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", testCase.ExpectedState, got)
+			}
+		})
+	}
+}

--- a/internal/service/rds/instance_role_association_test.go
+++ b/internal/service/rds/instance_role_association_test.go
@@ -167,7 +167,7 @@ func testAccCheckInstanceRoleAssociationDisappears(ctx context.Context, dbInstan
 func testAccInstanceRoleAssociationConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_db_instance_role_association" "test" {
-  db_instance_identifier = aws_db_instance.test.id
+  db_instance_identifier = aws_db_instance.test.identifier
   feature_name           = "S3_INTEGRATION"
   role_arn               = aws_iam_role.test.arn
 }

--- a/internal/service/rds/instance_role_association_test.go
+++ b/internal/service/rds/instance_role_association_test.go
@@ -38,7 +38,7 @@ func TestAccRDSInstanceRoleAssociation_basic(t *testing.T) {
 				Config: testAccInstanceRoleAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceRoleAssociationExists(ctx, resourceName, &dbInstanceRole1),
-					resource.TestCheckResourceAttrPair(resourceName, "db_instance_identifier", dbInstanceResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "db_instance_identifier", dbInstanceResourceName, "identifier"),
 					resource.TestCheckResourceAttr(resourceName, "feature_name", "S3_INTEGRATION"),
 					resource.TestCheckResourceAttrPair(resourceName, "role_arn", iamRoleResourceName, "arn"),
 				),

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -5656,13 +5656,15 @@ func testAccCheckInstanceExists(ctx context.Context, n string, v *rds.DBInstance
 			return fmt.Errorf("Not found: %s", n)
 		}
 
+		fmt.Printf("identifier: %s, id: %s\n", rs.Primary.Attributes["identifier"], rs.Primary.ID)
+
 		if rs.Primary.Attributes["identifier"] == "" {
 			return fmt.Errorf("No RDS DB Instance ID is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).RDSConn()
 
-		output, err := tfrds.FindDBInstanceByID(ctx, conn, rs.Primary.Attributes["identifier"])
+		output, err := tfrds.FindDBInstanceByID(ctx, conn, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -10220,7 +10222,7 @@ data "aws_rds_orderable_db_instance" "test" {
 
 data "aws_rds_engine_version" "initial" {
   engine             = "mysql"
-  preferred_versions = ["8.0.32", "8.0.31", "8.0.30"]
+  preferred_versions = ["8.0.31", "8.0.30", "8.0.28"]
 }
 
 data "aws_rds_engine_version" "updated" {

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -4887,11 +4887,12 @@ func TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica(t *testing.T
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"apply_immediately",
+					"blue_green_update",
+					"delete_automated_backups",
 					"final_snapshot_identifier",
+					"latest_restorable_time",
 					"password",
 					"skip_final_snapshot",
-					"delete_automated_backups",
-					"blue_green_update",
 				},
 			},
 		},
@@ -5655,8 +5656,6 @@ func testAccCheckInstanceExists(ctx context.Context, n string, v *rds.DBInstance
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
-
-		fmt.Printf("identifier: %s, id: %s\n", rs.Primary.Attributes["identifier"], rs.Primary.ID)
 
 		if rs.Primary.Attributes["identifier"] == "" {
 			return fmt.Errorf("No RDS DB Instance ID is set")

--- a/internal/service/rds/option_group_test.go
+++ b/internal/service/rds/option_group_test.go
@@ -673,7 +673,7 @@ resource "aws_db_instance" "test" {
   engine            = data.aws_rds_orderable_db_instance.test.engine
   engine_version    = data.aws_rds_orderable_db_instance.test.engine_version
   instance_class    = data.aws_rds_orderable_db_instance.test.instance_class
-  name              = "baz"
+  db_name           = "baz"
   password          = "barbarbarbar"
   username          = "foo"
 

--- a/internal/service/rds/proxy_target_test.go
+++ b/internal/service/rds/proxy_target_test.go
@@ -330,7 +330,7 @@ resource "aws_db_instance" "test" {
 }
 
 resource "aws_db_proxy_target" "test" {
-  db_instance_identifier = aws_db_instance.test.id
+  db_instance_identifier = aws_db_instance.test.identifier
   db_proxy_name          = aws_db_proxy.test.name
   target_group_name      = "default"
 }

--- a/internal/service/rds/proxy_target_test.go
+++ b/internal/service/rds/proxy_target_test.go
@@ -303,7 +303,7 @@ func testAccProxyTargetConfig_instance(rName string) string {
 	return acctest.ConfigCompose(testAccProxyTargetBaseConfig(rName), fmt.Sprintf(`
 data "aws_rds_engine_version" "test" {
   engine             = "mysql"
-  preferred_versions = ["5.7.31", "5.7.30"]
+  preferred_versions = ["8.0.33", "8.0.32", "8.0.31"]
 }
 
 data "aws_rds_orderable_db_instance" "test" {

--- a/internal/service/rds/snapshot_copy_test.go
+++ b/internal/service/rds/snapshot_copy_test.go
@@ -202,7 +202,7 @@ resource "aws_db_instance" "test" {
 }
 
 resource "aws_db_snapshot" "test" {
-  db_instance_identifier = aws_db_instance.test.id
+  db_instance_identifier = aws_db_instance.test.identifier
   db_snapshot_identifier = "%[1]s-source"
 }`, rName)
 }

--- a/internal/service/rds/snapshot_copy_test.go
+++ b/internal/service/rds/snapshot_copy_test.go
@@ -191,7 +191,7 @@ resource "aws_db_instance" "test" {
   engine                  = data.aws_rds_engine_version.default.engine
   engine_version          = data.aws_rds_engine_version.default.version
   instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
-  name                    = "test"
+  db_name                 = "test"
   identifier              = %[1]q
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"

--- a/internal/service/rds/snapshot_data_source_test.go
+++ b/internal/service/rds/snapshot_data_source_test.go
@@ -85,7 +85,7 @@ data "aws_db_snapshot" "snapshot" {
 }
 
 resource "aws_db_snapshot" "test" {
-  db_instance_identifier = aws_db_instance.bar.id
+  db_instance_identifier = aws_db_instance.bar.identifier
   db_snapshot_identifier = "testsnapshot%[2]d"
 }
 `, mySQLPreferredInstanceClasses, rInt)

--- a/internal/service/rds/snapshot_data_source_test.go
+++ b/internal/service/rds/snapshot_data_source_test.go
@@ -64,7 +64,7 @@ resource "aws_db_instance" "bar" {
   engine              = data.aws_rds_engine_version.default.engine
   engine_version      = data.aws_rds_engine_version.default.version
   instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
-  name                = "baz"
+  db_name             = "baz"
   password            = "barbarbarbar"
   username            = "foo"
   skip_final_snapshot = true

--- a/internal/service/rds/snapshot_test.go
+++ b/internal/service/rds/snapshot_test.go
@@ -249,7 +249,7 @@ resource "aws_db_instance" "test" {
 func testAccSnapshotConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccSnapshotConfig_base(rName), fmt.Sprintf(`
 resource "aws_db_snapshot" "test" {
-  db_instance_identifier = aws_db_instance.test.id
+  db_instance_identifier = aws_db_instance.test.identifier
   db_snapshot_identifier = %[1]q
 }
 `, rName))
@@ -258,7 +258,7 @@ resource "aws_db_snapshot" "test" {
 func testAccSnapshotConfig_tags1(rName, tag1Key, tag1Value string) string {
 	return acctest.ConfigCompose(testAccSnapshotConfig_base(rName), fmt.Sprintf(`
 resource "aws_db_snapshot" "test" {
-  db_instance_identifier = aws_db_instance.test.id
+  db_instance_identifier = aws_db_instance.test.identifier
   db_snapshot_identifier = %[1]q
 
   tags = {
@@ -271,7 +271,7 @@ resource "aws_db_snapshot" "test" {
 func testAccSnapshotConfig_tags2(rName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
 	return acctest.ConfigCompose(testAccSnapshotConfig_base(rName), fmt.Sprintf(`
 resource "aws_db_snapshot" "test" {
-  db_instance_identifier = aws_db_instance.test.id
+  db_instance_identifier = aws_db_instance.test.identifier
   db_snapshot_identifier = %[1]q
 
   tags = {
@@ -285,7 +285,7 @@ resource "aws_db_snapshot" "test" {
 func testAccSnapshotConfig_share(rName string) string {
 	return acctest.ConfigCompose(testAccSnapshotConfig_base(rName), fmt.Sprintf(`
 resource "aws_db_snapshot" "test" {
-  db_instance_identifier = aws_db_instance.test.id
+  db_instance_identifier = aws_db_instance.test.identifier
   db_snapshot_identifier = %[1]q
   shared_accounts        = ["all"]
 }

--- a/internal/service/rds/snapshot_test.go
+++ b/internal/service/rds/snapshot_test.go
@@ -235,7 +235,7 @@ resource "aws_db_instance" "test" {
   engine                  = data.aws_rds_engine_version.default.engine
   engine_version          = data.aws_rds_engine_version.default.version
   instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
-  name                    = "test"
+  db_name                 = "test"
   identifier              = %[1]q
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"

--- a/internal/service/rds/sweep.go
+++ b/internal/service/rds/sweep.go
@@ -379,10 +379,11 @@ func sweepInstances(region string) error {
 		for _, v := range page.DBInstances {
 			r := ResourceInstance()
 			d := r.Data(nil)
-			d.SetId(aws.StringValue(v.DBInstanceIdentifier))
+			d.SetId(aws.StringValue(v.DbiResourceId))
 			d.Set("apply_immediately", true)
 			d.Set("delete_automated_backups", true)
 			d.Set("deletion_protection", false)
+			d.Set("identifier", v.DBInstanceIdentifier)
 			d.Set("skip_final_snapshot", true)
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))

--- a/website/docs/d/db_snapshot.html.markdown
+++ b/website/docs/d/db_snapshot.html.markdown
@@ -29,7 +29,7 @@ resource "aws_db_instance" "prod" {
 }
 
 data "aws_db_snapshot" "latest_prod_snapshot" {
-  db_instance_identifier = aws_db_instance.prod.id
+  db_instance_identifier = aws_db_instance.prod.identifier
   most_recent            = true
 }
 

--- a/website/docs/d/db_snapshot.html.markdown
+++ b/website/docs/d/db_snapshot.html.markdown
@@ -21,7 +21,7 @@ resource "aws_db_instance" "prod" {
   engine               = "mysql"
   engine_version       = "5.6.17"
   instance_class       = "db.t2.micro"
-  name                 = "mydb"
+  db_name              = "mydb"
   username             = "foo"
   password             = "bar"
   db_subnet_group_name = "my_database_subnet_group"
@@ -36,7 +36,7 @@ data "aws_db_snapshot" "latest_prod_snapshot" {
 # Use the latest production snapshot to create a dev instance.
 resource "aws_db_instance" "dev" {
   instance_class      = "db.t2.micro"
-  name                = "mydbdev"
+  db_name             = "mydbdev"
   snapshot_identifier = data.aws_db_snapshot.latest_prod_snapshot.id
 
   lifecycle {

--- a/website/docs/r/db_event_subscription.html.markdown
+++ b/website/docs/r/db_event_subscription.html.markdown
@@ -34,7 +34,7 @@ resource "aws_db_event_subscription" "default" {
   sns_topic = aws_sns_topic.default.arn
 
   source_type = "db-instance"
-  source_ids  = [aws_db_instance.default.id]
+  source_ids  = [aws_db_instance.default.identifier]
 
   event_categories = [
     "availability",

--- a/website/docs/r/db_event_subscription.html.markdown
+++ b/website/docs/r/db_event_subscription.html.markdown
@@ -18,7 +18,7 @@ resource "aws_db_instance" "default" {
   engine               = "mysql"
   engine_version       = "5.6.17"
   instance_class       = "db.t2.micro"
-  name                 = "mydb"
+  db_name              = "mydb"
   username             = "foo"
   password             = "bar"
   db_subnet_group_name = "my_database_subnet_group"

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -401,7 +401,7 @@ DB instance.
 * `engine_version_actual` - The running version of the database.
 * `hosted_zone_id` - The canonical hosted zone ID of the DB instance (to be used
 in a Route 53 Alias record).
-* `id` - The RDS instance ID.
+* `id` - RDS DBI resource ID.
 * `instance_class`- The RDS instance class.
 * `latest_restorable_time` - The latest time, in UTC [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8), to which a database can be restored with point-in-time restore.
 * `listener_endpoint` - Specifies the listener connection endpoint for SQL Server Always On. See [endpoint](#endpoint) below.

--- a/website/docs/r/db_instance_automated_backups_replication.markdown
+++ b/website/docs/r/db_instance_automated_backups_replication.markdown
@@ -50,7 +50,7 @@ resource "aws_db_instance" "default" {
   engine                  = "postgres"
   engine_version          = "13.4"
   instance_class          = "db.t3.micro"
-  name                    = "mydb"
+  db_name                 = "mydb"
   username                = "masterusername"
   password                = "mustbeeightcharacters"
   backup_retention_period = 7

--- a/website/docs/r/db_instance_role_association.html.markdown
+++ b/website/docs/r/db_instance_role_association.html.markdown
@@ -19,7 +19,7 @@ Manages an RDS DB Instance association with an IAM Role. Example use cases:
 
 ```terraform
 resource "aws_db_instance_role_association" "example" {
-  db_instance_identifier = aws_db_instance.example.id
+  db_instance_identifier = aws_db_instance.example.identifier
   feature_name           = "S3_INTEGRATION"
   role_arn               = aws_iam_role.example.arn
 }

--- a/website/docs/r/db_proxy_target.html.markdown
+++ b/website/docs/r/db_proxy_target.html.markdown
@@ -49,7 +49,7 @@ resource "aws_db_proxy_default_target_group" "example" {
 }
 
 resource "aws_db_proxy_target" "example" {
-  db_instance_identifier = aws_db_instance.example.id
+  db_instance_identifier = aws_db_instance.example.identifier
   db_proxy_name          = aws_db_proxy.example.name
   target_group_name      = aws_db_proxy_default_target_group.example.name
 }

--- a/website/docs/r/db_snapshot.html.markdown
+++ b/website/docs/r/db_snapshot.html.markdown
@@ -28,7 +28,7 @@ resource "aws_db_instance" "bar" {
 }
 
 resource "aws_db_snapshot" "test" {
-  db_instance_identifier = aws_db_instance.bar.id
+  db_instance_identifier = aws_db_instance.bar.identifier
   db_snapshot_identifier = "testsnapshot1234"
 }
 ```

--- a/website/docs/r/db_snapshot.html.markdown
+++ b/website/docs/r/db_snapshot.html.markdown
@@ -18,7 +18,7 @@ resource "aws_db_instance" "bar" {
   engine            = "mysql"
   engine_version    = "5.6.21"
   instance_class    = "db.t2.micro"
-  name              = "baz"
+  db_name           = "baz"
   password          = "barbarbarbar"
   username          = "foo"
 

--- a/website/docs/r/db_snapshot_copy.html.markdown
+++ b/website/docs/r/db_snapshot_copy.html.markdown
@@ -18,7 +18,7 @@ resource "aws_db_instance" "example" {
   engine            = "mysql"
   engine_version    = "5.6.21"
   instance_class    = "db.t2.micro"
-  name              = "baz"
+  db_name           = "baz"
   password          = "barbarbarbar"
   username          = "foo"
 

--- a/website/docs/r/db_snapshot_copy.html.markdown
+++ b/website/docs/r/db_snapshot_copy.html.markdown
@@ -28,7 +28,7 @@ resource "aws_db_instance" "example" {
 }
 
 resource "aws_db_snapshot" "example" {
-  db_instance_identifier = aws_db_instance.example.id
+  db_instance_identifier = aws_db_instance.example.identifier
   db_snapshot_identifier = "testsnapshot1234"
 }
 

--- a/website/docs/r/rds_export_task.html.markdown
+++ b/website/docs/r/rds_export_task.html.markdown
@@ -113,7 +113,7 @@ resource "aws_db_instance" "example" {
 }
 
 resource "aws_db_snapshot" "example" {
-  db_instance_identifier = aws_db_instance.example.id
+  db_instance_identifier = aws_db_instance.example.identifier
   db_snapshot_identifier = "example"
 }
 

--- a/website/docs/r/ssm_parameter.html.markdown
+++ b/website/docs/r/ssm_parameter.html.markdown
@@ -33,7 +33,7 @@ resource "aws_db_instance" "default" {
   engine               = "mysql"
   engine_version       = "5.7.16"
   instance_class       = "db.t2.micro"
-  name                 = "mydb"
+  db_name              = "mydb"
   username             = "foo"
   password             = var.database_master_password
   db_subnet_group_name = "my_database_subnet_group"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #16782
Closes #507

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

(Failures unrelated to these changes.)

```console
% make t T=TestAccRDSInstance_ K=rds P=5 ACCTEST_TIMEOUT=780m
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 5 -run='TestAccRDSInstance_'  -timeout 780m
=== RUN   TestAccRDSInstance_basic
=== PAUSE TestAccRDSInstance_basic
=== RUN   TestAccRDSInstance_manage_password
=== PAUSE TestAccRDSInstance_manage_password
=== RUN   TestAccRDSInstance_identifierPrefix
=== PAUSE TestAccRDSInstance_identifierPrefix
=== RUN   TestAccRDSInstance_identifierGenerated
=== PAUSE TestAccRDSInstance_identifierGenerated
=== RUN   TestAccRDSInstance_disappears
=== PAUSE TestAccRDSInstance_disappears
=== RUN   TestAccRDSInstance_tags
=== PAUSE TestAccRDSInstance_tags
=== RUN   TestAccRDSInstance_onlyMajorVersion
=== PAUSE TestAccRDSInstance_onlyMajorVersion
=== RUN   TestAccRDSInstance_kmsKey
=== PAUSE TestAccRDSInstance_kmsKey
=== RUN   TestAccRDSInstance_customIAMInstanceProfile
=== PAUSE TestAccRDSInstance_customIAMInstanceProfile
=== RUN   TestAccRDSInstance_subnetGroup
=== PAUSE TestAccRDSInstance_subnetGroup
=== RUN   TestAccRDSInstance_networkType
=== PAUSE TestAccRDSInstance_networkType
=== RUN   TestAccRDSInstance_optionGroup
=== PAUSE TestAccRDSInstance_optionGroup
=== RUN   TestAccRDSInstance_iamAuth
=== PAUSE TestAccRDSInstance_iamAuth
=== RUN   TestAccRDSInstance_allowMajorVersionUpgrade
=== PAUSE TestAccRDSInstance_allowMajorVersionUpgrade
=== RUN   TestAccRDSInstance_dbSubnetGroupName
=== PAUSE TestAccRDSInstance_dbSubnetGroupName
=== RUN   TestAccRDSInstance_DBSubnetGroupName_ramShared
=== PAUSE TestAccRDSInstance_DBSubnetGroupName_ramShared
=== RUN   TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs
=== PAUSE TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs
=== RUN   TestAccRDSInstance_deletionProtection
=== PAUSE TestAccRDSInstance_deletionProtection
=== RUN   TestAccRDSInstance_finalSnapshotIdentifier
=== PAUSE TestAccRDSInstance_finalSnapshotIdentifier
=== RUN   TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot
=== PAUSE TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot
=== RUN   TestAccRDSInstance_isAlreadyBeingDeleted
=== PAUSE TestAccRDSInstance_isAlreadyBeingDeleted
=== RUN   TestAccRDSInstance_maxAllocatedStorage
=== PAUSE TestAccRDSInstance_maxAllocatedStorage
=== RUN   TestAccRDSInstance_password
=== PAUSE TestAccRDSInstance_password
=== RUN   TestAccRDSInstance_ManagedMasterPassword_managed
=== PAUSE TestAccRDSInstance_ManagedMasterPassword_managed
=== RUN   TestAccRDSInstance_ManagedMasterPassword_managedSpecificKMSKey
=== PAUSE TestAccRDSInstance_ManagedMasterPassword_managedSpecificKMSKey
=== RUN   TestAccRDSInstance_ManagedMasterPassword_convertToManaged
=== PAUSE TestAccRDSInstance_ManagedMasterPassword_convertToManaged
=== RUN   TestAccRDSInstance_ReplicateSourceDB_basic
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_basic
=== RUN   TestAccRDSInstance_ReplicateSourceDB_namePrefix
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_namePrefix
=== RUN   TestAccRDSInstance_ReplicateSourceDB_nameGenerated
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_nameGenerated
=== RUN   TestAccRDSInstance_ReplicateSourceDB_addLater
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_addLater
=== RUN   TestAccRDSInstance_ReplicateSourceDB_allocatedStorage
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_allocatedStorage
=== RUN   TestAccRDSInstance_ReplicateSourceDB_iops
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_iops
=== RUN   TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops
=== RUN   TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade
=== RUN   TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade
=== RUN   TestAccRDSInstance_ReplicateSourceDB_availabilityZone
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_availabilityZone
=== RUN   TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod
=== RUN   TestAccRDSInstance_ReplicateSourceDB_backupWindow
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_backupWindow
=== RUN   TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName
=== RUN   TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_ramShared
=== PAUSE TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_ramShared
=== RUN   TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_vpcSecurityGroupIDs
=== PAUSE TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_vpcSecurityGroupIDs
=== RUN   TestAccRDSInstance_ReplicateSourceDB_deletionProtection
    acctest.go:78: CreateDBInstanceReadReplica API currently ignores DeletionProtection=true with SourceDBInstanceIdentifier set
--- SKIP: TestAccRDSInstance_ReplicateSourceDB_deletionProtection (0.00s)
=== RUN   TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled
=== RUN   TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow
=== RUN   TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage
=== RUN   TestAccRDSInstance_ReplicateSourceDB_monitoring
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_monitoring
=== RUN   TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists
=== RUN   TestAccRDSInstance_ReplicateSourceDB_multiAZ
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_multiAZ
=== RUN   TestAccRDSInstance_ReplicateSourceDB_networkType
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_networkType
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSameSetOnBoth
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSameSetOnBoth
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica
=== RUN   TestAccRDSInstance_ReplicateSourceDB_port
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_port
=== RUN   TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs
=== RUN   TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier
=== RUN   TestAccRDSInstance_ReplicateSourceDB_replicaMode
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_replicaMode
=== RUN   TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep
=== RUN   TestAccRDSInstance_S3Import_basic
    acctest.go:78: RestoreDBInstanceFromS3 cannot restore from MySQL version 5.6
--- SKIP: TestAccRDSInstance_S3Import_basic (0.00s)
=== RUN   TestAccRDSInstance_SnapshotIdentifier_basic
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_basic
=== RUN   TestAccRDSInstance_SnapshotIdentifier_namePrefix
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_namePrefix
=== RUN   TestAccRDSInstance_SnapshotIdentifier_nameGenerated
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_nameGenerated
=== RUN   TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved
=== RUN   TestAccRDSInstance_SnapshotIdentifier_allocatedStorage
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_allocatedStorage
=== RUN   TestAccRDSInstance_SnapshotIdentifier_io1Storage
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_io1Storage
=== RUN   TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade
=== RUN   TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade
=== RUN   TestAccRDSInstance_SnapshotIdentifier_availabilityZone
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_availabilityZone
=== RUN   TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride
=== RUN   TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset
=== RUN   TestAccRDSInstance_SnapshotIdentifier_backupWindow
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_backupWindow
=== RUN   TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName
=== RUN   TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameRAMShared
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameRAMShared
=== RUN   TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs
=== RUN   TestAccRDSInstance_SnapshotIdentifier_deletionProtection
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_deletionProtection
=== RUN   TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled
=== RUN   TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow
=== RUN   TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage
=== RUN   TestAccRDSInstance_SnapshotIdentifier_monitoring
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_monitoring
=== RUN   TestAccRDSInstance_SnapshotIdentifier_multiAZ
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_multiAZ
=== RUN   TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer
=== RUN   TestAccRDSInstance_SnapshotIdentifier_parameterGroupName
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_parameterGroupName
=== RUN   TestAccRDSInstance_SnapshotIdentifier_port
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_port
=== RUN   TestAccRDSInstance_SnapshotIdentifier_tags
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_tags
=== RUN   TestAccRDSInstance_SnapshotIdentifier_tagsRemove
    acctest.go:78: To be fixed: https://github.com/hashicorp/terraform-provider-aws/issues/26808
--- SKIP: TestAccRDSInstance_SnapshotIdentifier_tagsRemove (0.00s)
=== RUN   TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs
=== RUN   TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags
=== RUN   TestAccRDSInstance_monitoringInterval
=== PAUSE TestAccRDSInstance_monitoringInterval
=== RUN   TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled
=== PAUSE TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled
=== RUN   TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved
=== PAUSE TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved
=== RUN   TestAccRDSInstance_MonitoringRoleARN_removedToEnabled
=== PAUSE TestAccRDSInstance_MonitoringRoleARN_removedToEnabled
=== RUN   TestAccRDSInstance_separateIopsUpdate
=== PAUSE TestAccRDSInstance_separateIopsUpdate
=== RUN   TestAccRDSInstance_portUpdate
=== PAUSE TestAccRDSInstance_portUpdate
=== RUN   TestAccRDSInstance_MSSQL_tz
=== PAUSE TestAccRDSInstance_MSSQL_tz
=== RUN   TestAccRDSInstance_MSSQL_domain
=== PAUSE TestAccRDSInstance_MSSQL_domain
=== RUN   TestAccRDSInstance_MSSQL_domainSnapshotRestore
=== PAUSE TestAccRDSInstance_MSSQL_domainSnapshotRestore
=== RUN   TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion
=== PAUSE TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion
=== RUN   TestAccRDSInstance_minorVersion
=== PAUSE TestAccRDSInstance_minorVersion
=== RUN   TestAccRDSInstance_cloudWatchLogsExport
=== PAUSE TestAccRDSInstance_cloudWatchLogsExport
=== RUN   TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL
=== PAUSE TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL
=== RUN   TestAccRDSInstance_EnabledCloudWatchLogsExports_msSQL
=== PAUSE TestAccRDSInstance_EnabledCloudWatchLogsExports_msSQL
=== RUN   TestAccRDSInstance_EnabledCloudWatchLogsExports_oracle
=== PAUSE TestAccRDSInstance_EnabledCloudWatchLogsExports_oracle
=== RUN   TestAccRDSInstance_EnabledCloudWatchLogsExports_postgresql
=== PAUSE TestAccRDSInstance_EnabledCloudWatchLogsExports_postgresql
=== RUN   TestAccRDSInstance_noDeleteAutomatedBackups
=== PAUSE TestAccRDSInstance_noDeleteAutomatedBackups
=== RUN   TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled
=== PAUSE TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled
=== RUN   TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled
=== PAUSE TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled
=== RUN   TestAccRDSInstance_performanceInsightsKMSKeyID
=== PAUSE TestAccRDSInstance_performanceInsightsKMSKeyID
=== RUN   TestAccRDSInstance_performanceInsightsRetentionPeriod
=== PAUSE TestAccRDSInstance_performanceInsightsRetentionPeriod
=== RUN   TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled
=== RUN   TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled
=== PAUSE TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled
=== RUN   TestAccRDSInstance_caCertificateIdentifier
=== PAUSE TestAccRDSInstance_caCertificateIdentifier
=== RUN   TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier
=== PAUSE TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier
=== RUN   TestAccRDSInstance_RestoreToPointInTime_sourceResourceID
=== PAUSE TestAccRDSInstance_RestoreToPointInTime_sourceResourceID
=== RUN   TestAccRDSInstance_RestoreToPointInTime_monitoring
=== PAUSE TestAccRDSInstance_RestoreToPointInTime_monitoring
=== RUN   TestAccRDSInstance_NationalCharacterSet_oracle
=== PAUSE TestAccRDSInstance_NationalCharacterSet_oracle
=== RUN   TestAccRDSInstance_NoNationalCharacterSet_oracle
=== PAUSE TestAccRDSInstance_NoNationalCharacterSet_oracle
=== RUN   TestAccRDSInstance_coIPEnabled
=== PAUSE TestAccRDSInstance_coIPEnabled
=== RUN   TestAccRDSInstance_CoIPEnabled_disabledToEnabled
=== PAUSE TestAccRDSInstance_CoIPEnabled_disabledToEnabled
=== RUN   TestAccRDSInstance_CoIPEnabled_enabledToDisabled
=== PAUSE TestAccRDSInstance_CoIPEnabled_enabledToDisabled
=== RUN   TestAccRDSInstance_CoIPEnabled_restoreToPointInTime
=== PAUSE TestAccRDSInstance_CoIPEnabled_restoreToPointInTime
=== RUN   TestAccRDSInstance_CoIPEnabled_snapshotIdentifier
=== PAUSE TestAccRDSInstance_CoIPEnabled_snapshotIdentifier
=== RUN   TestAccRDSInstance_license
=== PAUSE TestAccRDSInstance_license
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup
=== RUN   TestAccRDSInstance_BlueGreenDeployment_tags
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_tags
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups
=== RUN   TestAccRDSInstance_BlueGreenDeployment_deletionProtection
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_deletionProtection
=== RUN   TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection
=== PAUSE TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection
=== RUN   TestAccRDSInstance_gp3MySQL
=== PAUSE TestAccRDSInstance_gp3MySQL
=== RUN   TestAccRDSInstance_gp3Postgres
=== PAUSE TestAccRDSInstance_gp3Postgres
=== RUN   TestAccRDSInstance_gp3SQLServer
=== PAUSE TestAccRDSInstance_gp3SQLServer
=== RUN   TestAccRDSInstance_storageThroughput
=== PAUSE TestAccRDSInstance_storageThroughput
=== RUN   TestAccRDSInstance_storageTypePostgres
=== PAUSE TestAccRDSInstance_storageTypePostgres
=== RUN   TestAccRDSInstance_newIdentifier
=== PAUSE TestAccRDSInstance_newIdentifier
=== CONT  TestAccRDSInstance_basic
=== CONT  TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion
=== CONT  TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameRAMShared
=== CONT  TestAccRDSInstance_ReplicateSourceDB_networkType
=== CONT  TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName
--- PASS: TestAccRDSInstance_basic (371.82s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_backupWindow
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName (1065.38s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameRAMShared (1162.27s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride
--- PASS: TestAccRDSInstance_ReplicateSourceDB_networkType (1619.36s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_availabilityZone
--- PASS: TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion (1686.82s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupWindow (1425.51s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset (1530.22s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_io1Storage
--- PASS: TestAccRDSInstance_SnapshotIdentifier_availabilityZone (1191.85s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_allocatedStorage
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride (1694.64s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved
--- PASS: TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade (1215.14s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_nameGenerated
--- PASS: TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade (1681.76s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_namePrefix
--- PASS: TestAccRDSInstance_SnapshotIdentifier_nameGenerated (937.29s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_basic
--- PASS: TestAccRDSInstance_SnapshotIdentifier_namePrefix (1071.35s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep
--- PASS: TestAccRDSInstance_SnapshotIdentifier_io1Storage (1488.58s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_replicaMode
--- PASS: TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved (1278.65s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier
    instance_test.go:2092: Step 1/1 error: Error running pre-apply refresh: exit status 1
        
        Error: multiple RDS Certificates match the criteria; try changing search query
        
          with data.aws_rds_certificate.latest,
          on terraform_plugin_test.tf line 15, in data "aws_rds_certificate" "latest":
          15: data "aws_rds_certificate" "latest" {
        
--- FAIL: TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier (6.98s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs
--- PASS: TestAccRDSInstance_SnapshotIdentifier_allocatedStorage (1891.62s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth
--- PASS: TestAccRDSInstance_SnapshotIdentifier_basic (1247.07s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSameSetOnBoth
--- PASS: TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs (1509.04s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_port
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth (1619.87s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica
--- PASS: TestAccRDSInstance_ReplicateSourceDB_replicaMode (2563.71s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSameSetOnBoth (1627.13s)
=== CONT  TestAccRDSInstance_MSSQL_domainSnapshotRestore
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep (2812.37s)
=== CONT  TestAccRDSInstance_MSSQL_domain
--- PASS: TestAccRDSInstance_ReplicateSourceDB_port (1372.31s)
=== CONT  TestAccRDSInstance_MSSQL_tz
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica (1714.85s)
=== CONT  TestAccRDSInstance_portUpdate
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs (1107.50s)
=== CONT  TestAccRDSInstance_separateIopsUpdate
--- PASS: TestAccRDSInstance_portUpdate (710.70s)
=== CONT  TestAccRDSInstance_MonitoringRoleARN_removedToEnabled
--- PASS: TestAccRDSInstance_separateIopsUpdate (671.61s)
=== CONT  TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved
--- PASS: TestAccRDSInstance_MSSQL_tz (1650.61s)
=== CONT  TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled
--- PASS: TestAccRDSInstance_MonitoringRoleARN_removedToEnabled (617.71s)
=== CONT  TestAccRDSInstance_monitoringInterval
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved (822.08s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled (855.51s)
=== CONT  TestAccRDSInstance_ManagedMasterPassword_managedSpecificKMSKey
--- PASS: TestAccRDSInstance_MSSQL_domainSnapshotRestore (3112.06s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_multiAZ
--- PASS: TestAccRDSInstance_ManagedMasterPassword_managedSpecificKMSKey (523.83s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists
--- PASS: TestAccRDSInstance_MSSQL_domain (3416.11s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_monitoring
--- PASS: TestAccRDSInstance_monitoringInterval (1384.79s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags (1113.84s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage (1318.68s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists (1660.14s)
=== CONT  TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_vpcSecurityGroupIDs
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring (1574.05s)
=== CONT  TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_ramShared
--- PASS: TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_ramShared (2072.48s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow (1390.53s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_backupWindow
--- PASS: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName (1865.93s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod
--- PASS: TestAccRDSInstance_ReplicateSourceDB_multiAZ (2073.20s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_availabilityZone
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled (1433.87s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade
--- PASS: TestAccRDSInstance_ReplicateSourceDB_backupWindow (1451.46s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue
--- PASS: TestAccRDSInstance_ReplicateSourceDB_availabilityZone (1640.43s)
=== CONT  TestAccRDSInstance_coIPEnabled
    acctest.go:1061: skipping since no Outposts found
--- SKIP: TestAccRDSInstance_coIPEnabled (0.51s)
=== CONT  TestAccRDSInstance_newIdentifier
--- PASS: TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod (1877.37s)
=== CONT  TestAccRDSInstance_storageTypePostgres
--- PASS: TestAccRDSInstance_ReplicateSourceDBDBSubnetGroupName_vpcSecurityGroupIDs (1994.46s)
=== CONT  TestAccRDSInstance_storageThroughput
--- PASS: TestAccRDSInstance_newIdentifier (662.72s)
=== CONT  TestAccRDSInstance_gp3SQLServer
--- PASS: TestAccRDSInstance_storageTypePostgres (732.22s)
=== CONT  TestAccRDSInstance_gp3Postgres
--- PASS: TestAccRDSInstance_storageThroughput (778.30s)
=== CONT  TestAccRDSInstance_gp3MySQL
--- PASS: TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade (1540.94s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue (1668.97s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_deletionProtection
--- PASS: TestAccRDSInstance_gp3Postgres (755.75s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups
--- PASS: TestAccRDSInstance_gp3SQLServer (1024.08s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica
--- PASS: TestAccRDSInstance_gp3MySQL (809.37s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass
--- PASS: TestAccRDSInstance_BlueGreenDeployment_deletionProtection (2055.43s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_tags
--- PASS: TestAccRDSInstance_BlueGreenDeployment_tags (697.16s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass (2394.89s)
=== CONT  TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups (2597.85s)
=== CONT  TestAccRDSInstance_license
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica (3442.94s)
=== CONT  TestAccRDSInstance_CoIPEnabled_snapshotIdentifier
    acctest.go:1061: skipping since no Outposts found
--- SKIP: TestAccRDSInstance_CoIPEnabled_snapshotIdentifier (0.50s)
=== CONT  TestAccRDSInstance_CoIPEnabled_restoreToPointInTime
    acctest.go:1061: skipping since no Outposts found
--- SKIP: TestAccRDSInstance_CoIPEnabled_restoreToPointInTime (0.18s)
=== CONT  TestAccRDSInstance_CoIPEnabled_enabledToDisabled
    acctest.go:1061: skipping since no Outposts found
--- SKIP: TestAccRDSInstance_CoIPEnabled_enabledToDisabled (0.20s)
=== CONT  TestAccRDSInstance_CoIPEnabled_disabledToEnabled
    acctest.go:1061: skipping since no Outposts found
--- SKIP: TestAccRDSInstance_CoIPEnabled_disabledToEnabled (0.18s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_addLater
--- PASS: TestAccRDSInstance_license (977.50s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup (2228.41s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion (2250.31s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_iops
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection (4159.42s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_allocatedStorage
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade (1359.58s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_namePrefix
--- PASS: TestAccRDSInstance_ReplicateSourceDB_addLater (1468.47s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_nameGenerated
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allocatedStorage (1413.93s)
=== CONT  TestAccRDSInstance_iamAuth
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops (1703.36s)
=== CONT  TestAccRDSInstance_ManagedMasterPassword_managed
--- PASS: TestAccRDSInstance_ReplicateSourceDB_nameGenerated (1566.68s)
=== CONT  TestAccRDSInstance_password
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iops (1795.41s)
=== CONT  TestAccRDSInstance_maxAllocatedStorage
--- PASS: TestAccRDSInstance_ReplicateSourceDB_namePrefix (1692.10s)
=== CONT  TestAccRDSInstance_isAlreadyBeingDeleted
--- PASS: TestAccRDSInstance_iamAuth (482.42s)
=== CONT  TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot
--- PASS: TestAccRDSInstance_ManagedMasterPassword_managed (480.53s)
=== CONT  TestAccRDSInstance_finalSnapshotIdentifier
--- PASS: TestAccRDSInstance_isAlreadyBeingDeleted (488.84s)
=== CONT  TestAccRDSInstance_deletionProtection
--- PASS: TestAccRDSInstance_password (588.08s)
=== CONT  TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs
--- PASS: TestAccRDSInstance_maxAllocatedStorage (817.15s)
=== CONT  TestAccRDSInstance_DBSubnetGroupName_ramShared
--- PASS: TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot (671.82s)
=== CONT  TestAccRDSInstance_dbSubnetGroupName
--- PASS: TestAccRDSInstance_deletionProtection (479.81s)
=== CONT  TestAccRDSInstance_allowMajorVersionUpgrade
--- PASS: TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs (527.36s)
=== CONT  TestAccRDSInstance_onlyMajorVersion
--- PASS: TestAccRDSInstance_finalSnapshotIdentifier (947.37s)
=== CONT  TestAccRDSInstance_optionGroup
--- PASS: TestAccRDSInstance_DBSubnetGroupName_ramShared (543.58s)
=== CONT  TestAccRDSInstance_networkType
--- PASS: TestAccRDSInstance_dbSubnetGroupName (510.89s)
=== CONT  TestAccRDSInstance_subnetGroup
--- PASS: TestAccRDSInstance_allowMajorVersionUpgrade (550.77s)
=== CONT  TestAccRDSInstance_customIAMInstanceProfile
--- PASS: TestAccRDSInstance_onlyMajorVersion (508.93s)
=== CONT  TestAccRDSInstance_kmsKey
--- PASS: TestAccRDSInstance_optionGroup (493.29s)
=== CONT  TestAccRDSInstance_performanceInsightsKMSKeyID
--- PASS: TestAccRDSInstance_kmsKey (536.16s)
=== CONT  TestAccRDSInstance_NoNationalCharacterSet_oracle
--- PASS: TestAccRDSInstance_subnetGroup (924.62s)
=== CONT  TestAccRDSInstance_NationalCharacterSet_oracle
--- PASS: TestAccRDSInstance_networkType (1086.73s)
=== CONT  TestAccRDSInstance_RestoreToPointInTime_monitoring
--- PASS: TestAccRDSInstance_NoNationalCharacterSet_oracle (853.83s)
=== CONT  TestAccRDSInstance_RestoreToPointInTime_sourceResourceID
--- PASS: TestAccRDSInstance_performanceInsightsKMSKeyID (1191.92s)
=== CONT  TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier
--- PASS: TestAccRDSInstance_NationalCharacterSet_oracle (965.48s)
=== CONT  TestAccRDSInstance_caCertificateIdentifier
    instance_test.go:4213: Step 1/1 error: Error running pre-apply refresh: exit status 1
        
        Error: multiple RDS Certificates match the criteria; try changing search query
        
          with data.aws_rds_certificate.latest,
          on terraform_plugin_test.tf line 15, in data "aws_rds_certificate" "latest":
          15: data "aws_rds_certificate" "latest" {
        
--- FAIL: TestAccRDSInstance_caCertificateIdentifier (6.74s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled
--- PASS: TestAccRDSInstance_RestoreToPointInTime_monitoring (1624.10s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier (1352.85s)
=== CONT  TestAccRDSInstance_performanceInsightsRetentionPeriod
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceResourceID (1421.22s)
=== CONT  TestAccRDSInstance_ReplicateSourceDB_basic
--- PASS: TestAccRDSInstance_customIAMInstanceProfile (2897.54s)
=== CONT  TestAccRDSInstance_manage_password
--- PASS: TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled (1412.78s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_monitoring
--- PASS: TestAccRDSInstance_manage_password (517.03s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_tags
--- PASS: TestAccRDSInstance_performanceInsightsRetentionPeriod (1126.92s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_port
--- PASS: TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled (1713.55s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_parameterGroupName
--- PASS: TestAccRDSInstance_ReplicateSourceDB_basic (1671.35s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer
--- PASS: TestAccRDSInstance_SnapshotIdentifier_tags (1162.16s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_multiAZ
--- PASS: TestAccRDSInstance_SnapshotIdentifier_monitoring (1631.65s)
=== CONT  TestAccRDSInstance_ManagedMasterPassword_convertToManaged
--- PASS: TestAccRDSInstance_SnapshotIdentifier_port (964.22s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled
--- PASS: TestAccRDSInstance_ManagedMasterPassword_convertToManaged (629.16s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage
--- PASS: TestAccRDSInstance_SnapshotIdentifier_parameterGroupName (1271.59s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow
--- PASS: TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled (1106.16s)
=== CONT  TestAccRDSInstance_tags
--- PASS: TestAccRDSInstance_SnapshotIdentifier_multiAZ (1882.81s)
=== CONT  TestAccRDSInstance_EnabledCloudWatchLogsExports_oracle
--- PASS: TestAccRDSInstance_tags (584.05s)
=== CONT  TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow (1225.46s)
=== CONT  TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage (1333.55s)
=== CONT  TestAccRDSInstance_noDeleteAutomatedBackups
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_oracle (961.15s)
=== CONT  TestAccRDSInstance_EnabledCloudWatchLogsExports_postgresql
--- PASS: TestAccRDSInstance_PerformanceInsightsEnabled_disabledToEnabled (756.53s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs
--- PASS: TestAccRDSInstance_noDeleteAutomatedBackups (769.28s)
=== CONT  TestAccRDSInstance_SnapshotIdentifier_deletionProtection
--- PASS: TestAccRDSInstance_PerformanceInsightsEnabled_enabledToDisabled (932.92s)
=== CONT  TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_postgresql (571.11s)
=== CONT  TestAccRDSInstance_EnabledCloudWatchLogsExports_msSQL
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_mySQL (1053.45s)
=== CONT  TestAccRDSInstance_identifierPrefix
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs (1231.67s)
=== CONT  TestAccRDSInstance_cloudWatchLogsExport
--- PASS: TestAccRDSInstance_EnabledCloudWatchLogsExports_msSQL (797.84s)
=== CONT  TestAccRDSInstance_minorVersion
--- PASS: TestAccRDSInstance_SnapshotIdentifier_deletionProtection (1308.47s)
=== CONT  TestAccRDSInstance_identifierGenerated
--- PASS: TestAccRDSInstance_identifierPrefix (573.97s)
=== CONT  TestAccRDSInstance_disappears
--- PASS: TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer (4720.36s)
--- PASS: TestAccRDSInstance_minorVersion (491.35s)
--- PASS: TestAccRDSInstance_identifierGenerated (503.87s)
--- PASS: TestAccRDSInstance_cloudWatchLogsExport (612.58s)
--- PASS: TestAccRDSInstance_disappears (494.04s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/rds	32914.575s
% make t T=TestAccRDSInstanceRoleAssociation_ K=rds
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstanceRoleAssociation_'  -timeout 180m
=== RUN   TestAccRDSInstanceRoleAssociation_basic
=== PAUSE TestAccRDSInstanceRoleAssociation_basic
=== RUN   TestAccRDSInstanceRoleAssociation_disappears
=== PAUSE TestAccRDSInstanceRoleAssociation_disappears
=== CONT  TestAccRDSInstanceRoleAssociation_basic
=== CONT  TestAccRDSInstanceRoleAssociation_disappears
--- PASS: TestAccRDSInstanceRoleAssociation_disappears (941.00s)
--- PASS: TestAccRDSInstanceRoleAssociation_basic (1006.89s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	1008.628s
% make t T='TestAccRDSEventSubscription_|TestAccRDSProxyTarget_' K=rds 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSEventSubscription_|TestAccRDSProxyTarget_'  -timeout 180m
=== RUN   TestAccRDSEventSubscription_basic
=== PAUSE TestAccRDSEventSubscription_basic
=== RUN   TestAccRDSEventSubscription_disappears
=== PAUSE TestAccRDSEventSubscription_disappears
=== RUN   TestAccRDSEventSubscription_Name_generated
=== PAUSE TestAccRDSEventSubscription_Name_generated
=== RUN   TestAccRDSEventSubscription_namePrefix
=== PAUSE TestAccRDSEventSubscription_namePrefix
=== RUN   TestAccRDSEventSubscription_tags
=== PAUSE TestAccRDSEventSubscription_tags
=== RUN   TestAccRDSEventSubscription_categories
=== PAUSE TestAccRDSEventSubscription_categories
=== RUN   TestAccRDSEventSubscription_sourceIDs
=== PAUSE TestAccRDSEventSubscription_sourceIDs
=== RUN   TestAccRDSProxyTarget_instance
=== PAUSE TestAccRDSProxyTarget_instance
=== RUN   TestAccRDSProxyTarget_cluster
=== PAUSE TestAccRDSProxyTarget_cluster
=== RUN   TestAccRDSProxyTarget_disappears
=== PAUSE TestAccRDSProxyTarget_disappears
=== CONT  TestAccRDSEventSubscription_basic
=== CONT  TestAccRDSEventSubscription_categories
=== CONT  TestAccRDSEventSubscription_namePrefix
=== CONT  TestAccRDSEventSubscription_tags
=== CONT  TestAccRDSEventSubscription_Name_generated
=== CONT  TestAccRDSEventSubscription_disappears
=== CONT  TestAccRDSProxyTarget_disappears
=== CONT  TestAccRDSProxyTarget_cluster
=== CONT  TestAccRDSProxyTarget_instance
=== CONT  TestAccRDSEventSubscription_sourceIDs
--- PASS: TestAccRDSProxyTarget_instance (701.41s)
--- PASS: TestAccRDSProxyTarget_disappears (704.68s)
--- PASS: TestAccRDSEventSubscription_disappears (82.97s)
--- PASS: TestAccRDSEventSubscription_basic (89.38s)
--- PASS: TestAccRDSEventSubscription_Name_generated (89.44s)
--- PASS: TestAccRDSEventSubscription_namePrefix (89.60s)
--- PASS: TestAccRDSEventSubscription_sourceIDs (101.99s)
--- PASS: TestAccRDSEventSubscription_tags (117.02s)
--- PASS: TestAccRDSEventSubscription_categories (196.79s)
--- PASS: TestAccRDSProxyTarget_cluster (509.80s)
```
