### PR TITLE
New Data Source: aws_redshiftserverless_namespace

### DIFF
--- a/.changelog/31250.txt
+++ b/.changelog/31250.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_redshiftserverless_namespace
+```

--- a/internal/service/redshiftserverless/namespace_data_source.go
+++ b/internal/service/redshiftserverless/namespace_data_source.go
@@ -1,0 +1,89 @@
+package redshiftserverless
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+)
+
+// @SDKDataSource("aws_redshiftserverless_namespace")
+func DataSourceNamespace() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceNamespaceRead,
+
+		Schema: map[string]*schema.Schema{
+			"admin_username": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"db_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"default_iam_role_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"iam_roles": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"log_exports": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"namespace_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"namespace_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceNamespaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).RedshiftServerlessConn()
+
+	namespaceName := d.Get("namespace_name").(string)
+
+	resource, err := FindNamespaceByName(ctx, conn, namespaceName)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Redshift Serverless Namespace (%s): %s", namespaceName, err)
+	}
+
+	d.SetId(namespaceName)
+
+	d.Set("admin_username", resource.AdminUsername)
+	d.Set("arn", resource.NamespaceArn)
+	d.Set("db_name", resource.DbName)
+	d.Set("default_iam_role_arn", resource.DefaultIamRoleArn)
+	d.Set("iam_roles", resource.IamRoles)
+	d.Set("kms_key_id", resource.KmsKeyId)
+	d.Set("log_exports", resource.LogExports)
+
+	d.Set("namespace_id", resource.NamespaceId)
+
+	return diags
+}

--- a/internal/service/redshiftserverless/namespace_data_source_test.go
+++ b/internal/service/redshiftserverless/namespace_data_source_test.go
@@ -1,0 +1,191 @@
+package redshiftserverless_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/redshiftserverless"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccRedshiftServerlessNamespaceDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_redshiftserverless_namespace.test"
+	resourceName := "aws_redshiftserverless_namespace.test"
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, redshiftserverless.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNamespaceDataSourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "admin_username", resourceName, "admin_username"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "db_name", resourceName, "db_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "default_iam_role_arn", resourceName, "default_iam_role_arn"),
+					resource.TestCheckResourceAttr(dataSourceName, "iam_roles.#", "0"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "kms_key_id", resourceName, "kms_key_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "log_exports.#", "0"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "namespace_id", resourceName, "namespace_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "namespace_name", resourceName, "namespace_name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRedshiftServerlessNamespaceDataSource_iamRole(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_redshiftserverless_namespace.test"
+	resourceName := "aws_redshiftserverless_namespace.test"
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, redshiftserverless.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNamespaceDataSourceConfig_defaultIAMRole(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "namespace_name", resourceName, "namespace_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "default_iam_role_arn", resourceName, "default_iam_role_arn"),
+					resource.TestCheckResourceAttr(dataSourceName, "iam_roles.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "iam_roles.*", "aws_iam_role.test", "arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRedshiftServerlessNamespaceDataSource_user(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_redshiftserverless_namespace.test"
+	resourceName := "aws_redshiftserverless_namespace.test"
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	username := "admin_user"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, redshiftserverless.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNamespaceDataSourceConfig_user(rName, username),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "namespace_name", resourceName, "namespace_name"),
+					resource.TestCheckResourceAttr(dataSourceName, "admin_username", username),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRedshiftServerlessNamespaceDataSource_logExports(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_redshiftserverless_namespace.test"
+	resourceName := "aws_redshiftserverless_namespace.test"
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	logExport := "userlog"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, redshiftserverless.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNamespaceDataSourceConfig_logExports(rName, logExport),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "namespace_name", resourceName, "namespace_name"),
+					resource.TestCheckResourceAttr(dataSourceName, "log_exports.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "log_exports.0", logExport),
+				),
+			},
+		},
+	})
+}
+
+func testAccNamespaceDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_redshiftserverless_namespace" "test" {
+  namespace_name = %[1]q
+}
+
+data "aws_redshiftserverless_namespace" "test" {
+  namespace_name = aws_redshiftserverless_namespace.test.namespace_name
+}
+`, rName)
+}
+
+func testAccNamespaceDataSourceConfig_defaultIAMRole(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": [
+        "sts:AssumeRole"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_redshiftserverless_namespace" "test" {
+  namespace_name       = %[1]q
+  default_iam_role_arn = aws_iam_role.test.arn
+  iam_roles            = [aws_iam_role.test.arn]
+}
+
+data "aws_redshiftserverless_namespace" "test" {
+  namespace_name = aws_redshiftserverless_namespace.test.namespace_name
+}
+`, rName)
+}
+
+func testAccNamespaceDataSourceConfig_user(rName string, username string) string {
+	return fmt.Sprintf(`
+resource "aws_redshiftserverless_namespace" "test" {
+  namespace_name      = %[1]q
+  admin_username      = %[2]q
+  admin_user_password = "Test_Password_123"
+}
+
+data "aws_redshiftserverless_namespace" "test" {
+  namespace_name = aws_redshiftserverless_namespace.test.namespace_name
+}
+`, rName, username)
+}
+
+func testAccNamespaceDataSourceConfig_logExports(rName string, logExport string) string {
+	return fmt.Sprintf(`
+resource "aws_redshiftserverless_namespace" "test" {
+  namespace_name = %[1]q
+  log_exports = [%[2]q]
+}
+
+data "aws_redshiftserverless_namespace" "test" {
+  namespace_name = aws_redshiftserverless_namespace.test.namespace_name
+}
+`, rName, logExport)
+}

--- a/internal/service/redshiftserverless/namespace_data_source_test.go
+++ b/internal/service/redshiftserverless/namespace_data_source_test.go
@@ -181,7 +181,7 @@ func testAccNamespaceDataSourceConfig_logExports(rName string, logExport string)
 	return fmt.Sprintf(`
 resource "aws_redshiftserverless_namespace" "test" {
   namespace_name = %[1]q
-  log_exports = [%[2]q]
+  log_exports    = [%[2]q]
 }
 
 data "aws_redshiftserverless_namespace" "test" {

--- a/internal/service/redshiftserverless/service_package_gen.go
+++ b/internal/service/redshiftserverless/service_package_gen.go
@@ -26,6 +26,10 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			TypeName: "aws_redshiftserverless_credentials",
 		},
 		{
+			Factory:  DataSourceNamespace,
+			TypeName: "aws_redshiftserverless_namespace",
+		},
+		{
 			Factory:  DataSourceWorkgroup,
 			TypeName: "aws_redshiftserverless_workgroup",
 		},

--- a/website/docs/d/redshiftserverless_namespace.html.markdown
+++ b/website/docs/d/redshiftserverless_namespace.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Redshift Serverless"
 layout: "aws"
 page_title: "AWS: aws_redshiftserverless_namespace"
 description: |-
-Terraform data source for managing an AWS Redshift Serverless Namespace.
+  Terraform data source for managing an AWS Redshift Serverless Namespace.
 ---
 
 # Data Source: aws_redshiftserverless_namespace

--- a/website/docs/d/redshiftserverless_namespace.html.markdown
+++ b/website/docs/d/redshiftserverless_namespace.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "Redshift Serverless"
+layout: "aws"
+page_title: "AWS: aws_redshiftserverless_namespace"
+description: |-
+Terraform data source for managing an AWS Redshift Serverless Namespace.
+---
+
+# Data Source: aws_redshiftserverless_namespace
+
+Terraform data source for managing an AWS Redshift Serverless Namespace.
+
+## Example Usage
+
+```terraform
+data "aws_redshiftserverless_namespace" "example" {
+  namespace_name = "example-namespace"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `namespace_name` - (Required) The name of the namespace.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `admin_username` - The username of the administrator for the first database created in the namespace.
+* `arn` - Amazon Resource Name (ARN) of the Redshift Serverless Namespace.
+* `db_name` - The name of the first database created in the namespace.
+* `default_iam_role_arn` - The Amazon Resource Name (ARN) of the IAM role to set as a default in the namespace. When specifying `default_iam_role_arn`, it also must be part of `iam_roles`.
+* `iam_roles` - A list of IAM roles to associate with the namespace.
+* `kms_key_id` - The ARN of the Amazon Web Services Key Management Service key used to encrypt your data.
+* `log_exports` - The types of logs the namespace can export. Available export types are `userlog`, `connectionlog`, and `useractivitylog`.
+* `namespace_id` - The Redshift Namespace ID.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
New Data Source for `aws_redshiftserverless_namespace`.


### Relations


### References


### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccRedshiftServerlessNamespaceDataSource PKG=redshiftserverless
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/redshiftserverless/... -v -count 1 -parallel 20 -run='TestAccRedshiftServerlessNamespaceDataSource'  -timeout 180m
=== RUN   TestAccRedshiftServerlessNamespaceDataSource_basic
=== PAUSE TestAccRedshiftServerlessNamespaceDataSource_basic
=== RUN   TestAccRedshiftServerlessNamespaceDataSource_iamRole
=== PAUSE TestAccRedshiftServerlessNamespaceDataSource_iamRole
=== RUN   TestAccRedshiftServerlessNamespaceDataSource_user
=== PAUSE TestAccRedshiftServerlessNamespaceDataSource_user
=== RUN   TestAccRedshiftServerlessNamespaceDataSource_logExports
=== PAUSE TestAccRedshiftServerlessNamespaceDataSource_logExports
=== CONT  TestAccRedshiftServerlessNamespaceDataSource_basic
=== CONT  TestAccRedshiftServerlessNamespaceDataSource_user
=== CONT  TestAccRedshiftServerlessNamespaceDataSource_iamRole
=== CONT  TestAccRedshiftServerlessNamespaceDataSource_logExports
--- PASS: TestAccRedshiftServerlessNamespaceDataSource_user (19.88s)
--- PASS: TestAccRedshiftServerlessNamespaceDataSource_logExports (19.99s)
--- PASS: TestAccRedshiftServerlessNamespaceDataSource_basic (20.12s)
--- PASS: TestAccRedshiftServerlessNamespaceDataSource_iamRole (20.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshiftserverless 20.794s

...
```
