### PR TITLE
r/aws_fsx_ontap_file_system - allow updating route table ids + 4096 throughput_capacity support 

### DIFF
--- a/.changelog/31251.txt
+++ b/.changelog/31251.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_fsx_ontap_file_system: Allow updating route_table_ids
+```
+
+```release-note:enhancement
+resource/aws_fsx_ontap_file_system: Support setting throughput_capacity to 4096 
+```

--- a/.changelog/31251.txt
+++ b/.changelog/31251.txt
@@ -1,7 +1,7 @@
 ```release-note:enhancement
-resource/aws_fsx_ontap_file_system: Allow updating route_table_ids
+resource/aws_fsx_ontap_file_system: Allow in-place update of `route_table_ids`
 ```
 
 ```release-note:enhancement
-resource/aws_fsx_ontap_file_system: Support setting throughput_capacity to 4096 
+resource/aws_fsx_ontap_file_system: Support setting `throughput_capacity` to `4096`
 ```

--- a/internal/service/fsx/ontap_file_system.go
+++ b/internal/service/fsx/ontap_file_system.go
@@ -411,7 +411,6 @@ func resourceOntapFileSystemUpdate(ctx context.Context, d *schema.ResourceData, 
 			if removed.Len() > 0 {
 				input.OntapConfiguration.RemoveRouteTableIds = flex.ExpandStringSet(removed)
 			}
-
 		}
 
 		_, err := conn.UpdateFileSystemWithContext(ctx, input)

--- a/internal/service/fsx/ontap_file_system.go
+++ b/internal/service/fsx/ontap_file_system.go
@@ -181,7 +181,6 @@ func ResourceOntapFileSystem() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 				MaxItems: 50,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
@@ -210,7 +209,7 @@ func ResourceOntapFileSystem() *schema.Resource {
 			"throughput_capacity": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntInSlice([]int{128, 256, 512, 1024, 2048}),
+				ValidateFunc: validation.IntInSlice([]int{128, 256, 512, 1024, 2048, 4096}),
 			},
 			"vpc_id": {
 				Type:     schema.TypeString,
@@ -396,6 +395,23 @@ func resourceOntapFileSystemUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		if d.HasChange("disk_iops_configuration") {
 			input.OntapConfiguration.DiskIopsConfiguration = expandOntapFileDiskIopsConfiguration(d.Get("disk_iops_configuration").([]interface{}))
+		}
+
+		if d.HasChange("route_table_ids") {
+			o, n := d.GetChange("route_table_ids")
+			ns := n.(*schema.Set)
+			os := o.(*schema.Set)
+			added := ns.Difference(os)
+			removed := os.Difference(ns)
+
+			if added.Len() > 0 {
+				input.OntapConfiguration.AddRouteTableIds = flex.ExpandStringSet(added)
+			}
+
+			if removed.Len() > 0 {
+				input.OntapConfiguration.RemoveRouteTableIds = flex.ExpandStringSet(removed)
+			}
+
 		}
 
 		_, err := conn.UpdateFileSystemWithContext(ctx, input)

--- a/internal/service/fsx/ontap_file_system_test.go
+++ b/internal/service/fsx/ontap_file_system_test.go
@@ -284,11 +284,11 @@ func TestAccFSxOntapFileSystem_routeTableIDs(t *testing.T) {
 		CheckDestroy:             testAccCheckOntapFileSystemDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccONTAPFileSystemConfig_routeTable(rName),
+				Config: testAccONTAPFileSystemConfig_routeTable(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOntapFileSystemExists(ctx, resourceName, &filesystem1),
 					resource.TestCheckResourceAttr(resourceName, "route_table_ids.#", "1"),
-					resource.TestCheckTypeSetElemAttrPair(resourceName, "route_table_ids.*", "aws_route_table.test", "id"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "route_table_ids.*", "aws_route_table.test[0]", "id"),
 				),
 			},
 			{
@@ -296,6 +296,23 @@ func TestAccFSxOntapFileSystem_routeTableIDs(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"security_group_ids"},
+			},
+			{
+				Config: testAccONTAPFileSystemConfig_routeTable(rName, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOntapFileSystemExists(ctx, resourceName, &filesystem1),
+					resource.TestCheckResourceAttr(resourceName, "route_table_ids.#", "2"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "route_table_ids.*", "aws_route_table.test[0]", "id"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "route_table_ids.*", "aws_route_table.test[1]", "id"),
+				),
+			},
+			{
+				Config: testAccONTAPFileSystemConfig_routeTable(rName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOntapFileSystemExists(ctx, resourceName, &filesystem1),
+					resource.TestCheckResourceAttr(resourceName, "route_table_ids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "route_table_ids.*", "aws_route_table.test[0]", "id"),
+				),
 			},
 		},
 	})
@@ -750,7 +767,7 @@ resource "aws_fsx_ontap_file_system" "test" {
 `, rName, iops))
 }
 
-func testAccONTAPFileSystemConfig_routeTable(rName string) string {
+func testAccONTAPFileSystemConfig_routeTable(rName string, cnt int) string {
 	return acctest.ConfigCompose(testAccOntapFileSystemBaseConfig(rName), fmt.Sprintf(`
 resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
@@ -761,6 +778,8 @@ resource "aws_internet_gateway" "test" {
 }
 
 resource "aws_route_table" "test" {
+  count = %[2]d
+
   vpc_id = aws_vpc.test.id
 
   route {
@@ -779,13 +798,13 @@ resource "aws_fsx_ontap_file_system" "test" {
   deployment_type     = "MULTI_AZ_1"
   throughput_capacity = 128
   preferred_subnet_id = aws_subnet.test1.id
-  route_table_ids     = [aws_route_table.test.id]
+  route_table_ids     = aws_route_table.test[*].id
 
   tags = {
     Name = %[1]q
   }
 }
-`, rName))
+`, rName, cnt))
 }
 
 func testAccONTAPFileSystemConfig_securityGroupIDs1(rName string) string {

--- a/internal/service/fsx/ontap_file_system_test.go
+++ b/internal/service/fsx/ontap_file_system_test.go
@@ -311,7 +311,7 @@ func TestAccFSxOntapFileSystem_routeTableIDs(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOntapFileSystemExists(ctx, resourceName, &filesystem1),
 					resource.TestCheckResourceAttr(resourceName, "route_table_ids.#", "1"),
-					resource.TestCheckTypeSetElemAttrPair(resourceName, "route_table_ids.*", "aws_route_table.test[0]", "id"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "route_table_ids.*", "aws_route_table.test.0", "id"),
 				),
 			},
 		},

--- a/internal/service/fsx/ontap_file_system_test.go
+++ b/internal/service/fsx/ontap_file_system_test.go
@@ -288,7 +288,7 @@ func TestAccFSxOntapFileSystem_routeTableIDs(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOntapFileSystemExists(ctx, resourceName, &filesystem1),
 					resource.TestCheckResourceAttr(resourceName, "route_table_ids.#", "1"),
-					resource.TestCheckTypeSetElemAttrPair(resourceName, "route_table_ids.*", "aws_route_table.test[0]", "id"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "route_table_ids.*", "aws_route_table.test.0", "id"),
 				),
 			},
 			{
@@ -302,8 +302,8 @@ func TestAccFSxOntapFileSystem_routeTableIDs(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOntapFileSystemExists(ctx, resourceName, &filesystem1),
 					resource.TestCheckResourceAttr(resourceName, "route_table_ids.#", "2"),
-					resource.TestCheckTypeSetElemAttrPair(resourceName, "route_table_ids.*", "aws_route_table.test[0]", "id"),
-					resource.TestCheckTypeSetElemAttrPair(resourceName, "route_table_ids.*", "aws_route_table.test[1]", "id"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "route_table_ids.*", "aws_route_table.test.0", "id"),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "route_table_ids.*", "aws_route_table.test.1", "id"),
 				),
 			},
 			{

--- a/website/docs/r/fsx_ontap_file_system.html.markdown
+++ b/website/docs/r/fsx_ontap_file_system.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 * `fsx_admin_password` - (Optional) The ONTAP administrative password for the fsxadmin user that you can use to administer your file system using the ONTAP CLI and REST API.
 * `route_table_ids` - (Optional) Specifies the VPC route tables in which your file system's endpoints will be created. You should specify all VPC route tables associated with the subnets in which your clients are located. By default, Amazon FSx selects your VPC's default route table.
 * `tags` - (Optional) A map of tags to assign to the file system. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `throughput_capacity` - (Required) Sets the throughput capacity (in MBps) for the file system that you're creating. Valid values are `128`, `256`, `512`, `1024`, and `2048`.
+* `throughput_capacity` - (Required) Sets the throughput capacity (in MBps) for the file system that you're creating. Valid values are `128`, `256`, `512`, `1024`, `2048`, and `4096`.
 
 ### Disk Iops Configuration
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29301
Closes #29128

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccFSxOntapFileSystem_routeTableIDs  PKG=fsx

--- PASS: TestAccFSxOntapFileSystem_routeTableIDs (2803.90s)

```
