### PR TITLE
fix: Ignore order of client IDs in  iam_openid_connect_provider

### DIFF
--- a/.changelog/31253.txt
+++ b/.changelog/31253.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iam_openid_connect_provider: Ignore changes if only order of client ids has changed
+```

--- a/.changelog/31253.txt
+++ b/.changelog/31253.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_iam_openid_connect_provider: Ignore changes if only order of client ids has changed
+resource/aws_iam_openid_connect_provider: Change `client_id_list` from `TypeList` to `TypeSet` as order is not significant
 ```

--- a/internal/service/iam/diff.go
+++ b/internal/service/iam/diff.go
@@ -21,3 +21,18 @@ func suppressOpenIDURL(k, old, new string, d *schema.ResourceData) bool {
 
 	return oldUrl.String() == newUrl.String()
 }
+
+func suppressOpenIDClientList(k, old, new string, d *schema.ResourceData) bool {
+	if d.GetRawState().IsNull() {
+		return false
+	}
+
+	clientIdList := d.GetRawState().AsValueMap()["client_id_list"].AsValueSlice()
+
+	for _, clientId := range clientIdList {
+		if clientId.AsString() == new {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/service/iam/diff.go
+++ b/internal/service/iam/diff.go
@@ -21,18 +21,3 @@ func suppressOpenIDURL(k, old, new string, d *schema.ResourceData) bool {
 
 	return oldUrl.String() == newUrl.String()
 }
-
-func suppressOpenIDClientList(k, old, new string, d *schema.ResourceData) bool {
-	if d.GetRawState().IsNull() {
-		return false
-	}
-
-	clientIdList := d.GetRawState().AsValueMap()["client_id_list"].AsValueSlice()
-
-	for _, clientId := range clientIdList {
-		if clientId.AsString() == new {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/service/iam/openid_connect_provider.go
+++ b/internal/service/iam/openid_connect_provider.go
@@ -44,6 +44,7 @@ func ResourceOpenIDConnectProvider() *schema.Resource {
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringLenBetween(1, 255),
 				},
+				DiffSuppressFunc: suppressOpenIDClientList,
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),

--- a/internal/service/iam/openid_connect_provider.go
+++ b/internal/service/iam/openid_connect_provider.go
@@ -37,14 +37,13 @@ func ResourceOpenIDConnectProvider() *schema.Resource {
 				Computed: true,
 			},
 			"client_id_list": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Required: true,
 				ForceNew: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringLenBetween(1, 255),
 				},
-				DiffSuppressFunc: suppressOpenIDClientList,
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),

--- a/internal/service/iam/openid_connect_provider.go
+++ b/internal/service/iam/openid_connect_provider.go
@@ -74,7 +74,7 @@ func resourceOpenIDConnectProviderCreate(ctx context.Context, d *schema.Resource
 
 	tags := GetTagsIn(ctx)
 	input := &iam.CreateOpenIDConnectProviderInput{
-		ClientIDList:   flex.ExpandStringList(d.Get("client_id_list").([]interface{})),
+		ClientIDList:   flex.ExpandStringSet(d.Get("client_id_list").(*schema.Set)),
 		Url:            aws.String(d.Get("url").(string)),
 		Tags:           tags,
 		ThumbprintList: flex.ExpandStringList(d.Get("thumbprint_list").([]interface{})),
@@ -121,7 +121,7 @@ func resourceOpenIDConnectProviderRead(ctx context.Context, d *schema.ResourceDa
 	input := &iam.GetOpenIDConnectProviderInput{
 		OpenIDConnectProviderArn: aws.String(d.Id()),
 	}
-	out, err := conn.GetOpenIDConnectProviderWithContext(ctx, input)
+	output, err := conn.GetOpenIDConnectProviderWithContext(ctx, input)
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, iam.ErrCodeNoSuchEntityException) {
 		log.Printf("[WARN] IAM OIDC Provider (%s) not found, removing from state", d.Id())
 		d.SetId("")
@@ -132,11 +132,11 @@ func resourceOpenIDConnectProviderRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	d.Set("arn", d.Id())
-	d.Set("url", out.Url)
-	d.Set("client_id_list", flex.FlattenStringList(out.ClientIDList))
-	d.Set("thumbprint_list", flex.FlattenStringList(out.ThumbprintList))
+	d.Set("url", output.Url)
+	d.Set("client_id_list", aws.StringValueSlice(output.ClientIDList))
+	d.Set("thumbprint_list", aws.StringValueSlice(output.ThumbprintList))
 
-	SetTagsOut(ctx, out.Tags)
+	SetTagsOut(ctx, output.Tags)
 
 	return diags
 }

--- a/internal/service/iam/openid_connect_provider_test.go
+++ b/internal/service/iam/openid_connect_provider_test.go
@@ -133,6 +133,35 @@ func TestAccIAMOpenIDConnectProvider_disappears(t *testing.T) {
 	})
 }
 
+func TestAccIAMOpenIDConnectProvider_clientIdListOrder(t *testing.T) {
+	ctx := acctest.Context(t)
+	rString := sdkacctest.RandString(5)
+	resourceName := "aws_iam_openid_connect_provider.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenIDConnectProviderConfig_clientIdList_first(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOpenIDConnectProvider(ctx, resourceName),
+				),
+			},
+			{
+				Config: testAccOpenIDConnectProviderConfig_clientIdList_second(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOpenIDConnectProvider(ctx, resourceName),
+				),
+				ExpectNonEmptyPlan: false, // Expect an empty plan as only the order has been changed
+				PlanOnly:           true,  // Expect an empty plan as only the order has been changed
+			},
+		},
+	})
+}
+
 func testAccCheckOpenIDConnectProviderDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMConn()
@@ -181,35 +210,6 @@ func testAccCheckOpenIDConnectProvider(ctx context.Context, id string) resource.
 
 		return err
 	}
-}
-
-func TestAccIAMOpenidConnectProvider_clientIdListOrder(t *testing.T) {
-	ctx := acctest.Context(t)
-	rString := sdkacctest.RandString(5)
-	resourceName := "aws_iam_openid_connect_provider.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccOpenIDConnectProviderConfig_clientIdList_first(rString),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOpenIDConnectProvider(ctx, resourceName),
-				),
-			},
-			{
-				Config: testAccOpenIDConnectProviderConfig_clientIdList_second(rString),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOpenIDConnectProvider(ctx, resourceName),
-				),
-				ExpectNonEmptyPlan: false, // Expect an empty plan as only the order has been changed
-				PlanOnly:           true,  // Expect an empty plan as only the order has been changed
-			},
-		},
-	})
 }
 
 func testAccOpenIDConnectProviderConfig_basic(rString string) string {

--- a/internal/service/iam/openid_connect_provider_test.go
+++ b/internal/service/iam/openid_connect_provider_test.go
@@ -283,9 +283,9 @@ resource "aws_iam_openid_connect_provider" "test" {
   url = "https://accounts.testle.com/%s"
 
   client_id_list = [
-	"abc.testle.com",
-	"def.testle.com",
-	"ghi.testle.com",
+    "abc.testle.com",
+    "def.testle.com",
+    "ghi.testle.com",
 	]
 
   thumbprint_list = ["oif8192f189fa2178f-testle.thumbprint.com"]

--- a/internal/service/iam/openid_connect_provider_test.go
+++ b/internal/service/iam/openid_connect_provider_test.go
@@ -286,7 +286,7 @@ resource "aws_iam_openid_connect_provider" "test" {
     "abc.testle.com",
     "def.testle.com",
     "ghi.testle.com",
-	]
+  ]
 
   thumbprint_list = ["oif8192f189fa2178f-testle.thumbprint.com"]
 }

--- a/internal/service/iam/openid_connect_provider_test.go
+++ b/internal/service/iam/openid_connect_provider_test.go
@@ -283,9 +283,9 @@ resource "aws_iam_openid_connect_provider" "test" {
   url = "https://accounts.testle.com/%s"
 
   client_id_list = [
-	  "abc.testle.com",
-	  "def.testle.com",
-	  "ghi.testle.com",
+	"abc.testle.com",
+	"def.testle.com",
+	"ghi.testle.com",
 	]
 
   thumbprint_list = ["oif8192f189fa2178f-testle.thumbprint.com"]
@@ -299,10 +299,10 @@ resource "aws_iam_openid_connect_provider" "test" {
   url = "https://accounts.testle.com/%s"
 
   client_id_list = [
-	  "def.testle.com",
-	  "ghi.testle.com",
-	  "abc.testle.com",
-	]
+    "def.testle.com",
+    "ghi.testle.com",
+    "abc.testle.com",
+  ]
 
   thumbprint_list = ["oif8192f189fa2178f-testle.thumbprint.com"]
 }


### PR DESCRIPTION
### Description

When creating an `aws_iam_openid_connect_provider` today, AWS does not seem to preserve the order of values provided in `client_id_list`. Functionally this is not a problem, but it does lead to #29868 where subsequent applies will lead to non-empty plans, as Terraform attempts to 'correct' the order (unless the order given in your `.tf` file *happens* to match AWS).

This PR addresses that by defining a new `DiffSuppressFunc` for this use case, which suppresses a diff if a 'new' element is found in the list of client_ids present on the current state. As long as your changes only affect the order, there will be no diff and therefore no plan. It should be noted though that once you do change somethign else than the order (i.e. add/remove client ids), the shown diff will still show that Terraform is attempting to change the order.


Should the implementation on AWS side change, this addition will not break (though it will of course be made redundant).

### Relations

Relates to #29868 - please help comment if this should 'close' the issue as well. I originally stumbled on this issue when using the terraform-aws-oidc-github module (see [relevant issue](https://github.com/unfunco/terraform-aws-oidc-github/issues/27)).

### References

N/A

### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccIAMOpenidConnectProvider_clientIdListOrder PKG=iam
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMOpenidConnectProvider_clientIdListOrder'  -timeout 180m
=== RUN   TestAccIAMOpenidConnectProvider_clientIdListOrder
=== PAUSE TestAccIAMOpenidConnectProvider_clientIdListOrder
=== CONT  TestAccIAMOpenidConnectProvider_clientIdListOrder
--- PASS: TestAccIAMOpenidConnectProvider_clientIdListOrder (28.10s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        30.259s


```
