### PR TITLE
aws_kendra_index: fix user_group_resolution_configuration model

### DIFF
--- a/.changelog/31274.txt
+++ b/.changelog/31274.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_kendra_index: Fix `user_group_resolution_config` model.
+```

--- a/internal/service/kendra/index.go
+++ b/internal/service/kendra/index.go
@@ -1065,7 +1065,7 @@ func flattenUserGroupResolutionConfiguration(userGroupResolutionConfiguration *t
 	}
 
 	values := map[string]interface{}{
-		"user_group_resolution_configuration": userGroupResolutionConfiguration.UserGroupResolutionMode,
+		"user_group_resolution_mode": userGroupResolutionConfiguration.UserGroupResolutionMode,
 	}
 
 	return []interface{}{values}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Fix model for `aws_kendra_index` to reflect AWS response

AWS returns the following data for a Kendra index:
```
"UserGroupResolutionConfiguration": {
        "UserGroupResolutionMode": "NONE"
    }
```

which makes the plan/apply fail with:
```
│ Error: Invalid address to set: []string{"user_group_resolution_configuration", "0", "user_group_resolution_configuration"}
```

because the current implementation expects:
```
"UserGroupResolutionConfiguration": {
        "UserGroupResolutionConfiguration": "NONE"
    }
```
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
no suitable test environment
