### PR TITLE
r/aws_servicecatalog_provisioned_product: properly set `stack_set_provisioned_preferences`

### DIFF
--- a/internal/service/servicecatalog/provisioned_product.go
+++ b/internal/service/servicecatalog/provisioned_product.go
@@ -657,20 +657,20 @@ func expandProvisioningPreferences(tfMap map[string]interface{}) *servicecatalog
 		apiObject.StackSetAccounts = flex.ExpandStringList(v)
 	}
 
-	if v, ok := tfMap["failure_tolerance_count"].(int64); ok && v != 0 {
-		apiObject.StackSetFailureToleranceCount = aws.Int64(v)
+	if v, ok := tfMap["failure_tolerance_count"].(int); ok && v != 0 {
+		apiObject.StackSetFailureToleranceCount = aws.Int64(int64(v))
 	}
 
-	if v, ok := tfMap["failure_tolerance_percentage"].(int64); ok && v != 0 {
-		apiObject.StackSetFailureTolerancePercentage = aws.Int64(v)
+	if v, ok := tfMap["failure_tolerance_percentage"].(int); ok && v != 0 {
+		apiObject.StackSetFailureTolerancePercentage = aws.Int64(int64(v))
 	}
 
-	if v, ok := tfMap["max_concurrency_count"].(int64); ok && v != 0 {
-		apiObject.StackSetMaxConcurrencyCount = aws.Int64(v)
+	if v, ok := tfMap["max_concurrency_count"].(int); ok && v != 0 {
+		apiObject.StackSetMaxConcurrencyCount = aws.Int64(int64(v))
 	}
 
-	if v, ok := tfMap["max_concurrency_percentage"].(int64); ok && v != 0 {
-		apiObject.StackSetMaxConcurrencyPercentage = aws.Int64(v)
+	if v, ok := tfMap["max_concurrency_percentage"].(int); ok && v != 0 {
+		apiObject.StackSetMaxConcurrencyPercentage = aws.Int64(int64(v))
 	}
 
 	if v, ok := tfMap["regions"].([]interface{}); ok && len(v) > 0 {
@@ -739,20 +739,20 @@ func expandUpdateProvisioningPreferences(tfMap map[string]interface{}) *servicec
 		apiObject.StackSetAccounts = flex.ExpandStringList(v)
 	}
 
-	if v, ok := tfMap["failure_tolerance_count"].(int64); ok && v != 0 {
-		apiObject.StackSetFailureToleranceCount = aws.Int64(v)
+	if v, ok := tfMap["failure_tolerance_count"].(int); ok && v != 0 {
+		apiObject.StackSetFailureToleranceCount = aws.Int64(int64(v))
 	}
 
-	if v, ok := tfMap["failure_tolerance_percentage"].(int64); ok && v != 0 {
-		apiObject.StackSetFailureTolerancePercentage = aws.Int64(v)
+	if v, ok := tfMap["failure_tolerance_percentage"].(int); ok && v != 0 {
+		apiObject.StackSetFailureTolerancePercentage = aws.Int64(int64(v))
 	}
 
-	if v, ok := tfMap["max_concurrency_count"].(int64); ok && v != 0 {
-		apiObject.StackSetMaxConcurrencyCount = aws.Int64(v)
+	if v, ok := tfMap["max_concurrency_count"].(int); ok && v != 0 {
+		apiObject.StackSetMaxConcurrencyCount = aws.Int64(int64(v))
 	}
 
-	if v, ok := tfMap["max_concurrency_percentage"].(int64); ok && v != 0 {
-		apiObject.StackSetMaxConcurrencyPercentage = aws.Int64(v)
+	if v, ok := tfMap["max_concurrency_percentage"].(int); ok && v != 0 {
+		apiObject.StackSetMaxConcurrencyPercentage = aws.Int64(int64(v))
 	}
 
 	if v, ok := tfMap["regions"].([]interface{}); ok && len(v) > 0 {

--- a/internal/service/servicecatalog/provisioned_product_test.go
+++ b/internal/service/servicecatalog/provisioned_product_test.go
@@ -142,6 +142,64 @@ func TestAccServiceCatalogProvisionedProduct_update(t *testing.T) {
 	})
 }
 
+func TestAccServiceCatalogProvisionedProduct_stackSetProvisioningPreferences(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_servicecatalog_provisioned_product.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+	var pprod servicecatalog.ProvisionedProductDetail
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, servicecatalog.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckProvisionedProductDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProvisionedProductConfig_stackSetprovisioningPreferences(rName, domain, acctest.DefaultEmailAddress, "10.1.0.0/16", 1, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProvisionedProductExists(ctx, resourceName, &pprod),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "stack_set_provisioning_preferences.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stack_set_provisioning_preferences.0.failure_tolerance_count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stack_set_provisioning_preferences.0.max_concurrency_count", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"accept_language",
+					"ignore_errors",
+					"provisioning_artifact_name",
+					"provisioning_parameters",
+					"retain_physical_resources",
+					"stack_set_provisioning_preferences",
+				},
+			},
+			{
+				Config: testAccProvisionedProductConfig_stackSetprovisioningPreferences(rName, domain, acctest.DefaultEmailAddress, "10.1.0.0/16", 3, 4),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProvisionedProductExists(ctx, resourceName, &pprod),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "stack_set_provisioning_preferences.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stack_set_provisioning_preferences.0.failure_tolerance_count", "3"),
+					resource.TestCheckResourceAttr(resourceName, "stack_set_provisioning_preferences.0.max_concurrency_count", "4"),
+				),
+			},
+			{
+				Config: testAccProvisionedProductConfig_basic(rName, domain, acctest.DefaultEmailAddress, "10.1.0.0/16"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProvisionedProductExists(ctx, resourceName, &pprod),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "stack_set_provisioning_preferences.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 // NOTE: This test is dependent on a v5.0.0 feature which fixes how
 // products are modified when provisioning_artifact_parameters are
 // changed. Once v5.0.0 is released, this test can be re-enabled.
@@ -723,6 +781,33 @@ resource "aws_servicecatalog_provisioned_product" "test" {
   }
 }
 `, rName, vpcCidr))
+}
+
+func testAccProvisionedProductConfig_stackSetprovisioningPreferences(rName, domain, email, vpcCidr string, failureToleranceCount, maxConcurrencyCount int) string {
+	return acctest.ConfigCompose(testAccProvisionedProductTemplateURLBaseConfig(rName, domain, email),
+		fmt.Sprintf(`
+resource "aws_servicecatalog_provisioned_product" "test" {
+  name                       = %[1]q
+  product_id                 = aws_servicecatalog_product.test.id
+  provisioning_artifact_name = %[1]q
+  path_id                    = data.aws_servicecatalog_launch_paths.test.summaries[0].path_id
+
+  stack_set_provisioning_preferences {
+    failure_tolerance_count = %[3]d
+    max_concurrency_count   = %[4]d
+  }
+
+  provisioning_parameters {
+    key   = "VPCPrimaryCIDR"
+    value = %[2]q
+  }
+
+  provisioning_parameters {
+    key   = "LeaveMeEmpty"
+    value = ""
+  }
+}
+`, rName, vpcCidr, failureToleranceCount, maxConcurrencyCount))
 }
 
 // func testAccProvisionedProductConfig_productName(rName, domain, email, vpcCidr, productName string) string {


### PR DESCRIPTION
### Description
Fixes incorrect type assertions for integer types nested in the `stack_set_provisioned_preferences` attribute. 

### Relations

Closes #29343


### Output from Acceptance Testing

```console
$ make testacc PKG=servicecatalog TESTS=TestAccServiceCatalogProvisionedProduct_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicecatalog/... -v -count 1 -parallel 20 -run='TestAccServiceCatalogProvisionedProduct_'  -timeout 180m

--- PASS: TestAccServiceCatalogProvisionedProduct_errorOnCreate (53.53s)
--- PASS: TestAccServiceCatalogProvisionedProduct_disappears (131.72s)
--- PASS: TestAccServiceCatalogProvisionedProduct_basic (134.96s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags (221.24s)
--- PASS: TestAccServiceCatalogProvisionedProduct_update (222.24s)
--- PASS: TestAccServiceCatalogProvisionedProduct_ProvisioningArtifactName_update (223.63s)
--- PASS: TestAccServiceCatalogProvisionedProduct_computedOutputs (241.03s)
--- PASS: TestAccServiceCatalogProvisionedProduct_errorOnUpdate (262.22s)
--- PASS: TestAccServiceCatalogProvisionedProduct_stackSetProvisioningPreferences (309.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog     312.791s
```
