### PR TITLE
r/aws_servicecatalog_provisioned_product: properly set `stack_set_provisioned_preferences.accounts`

### DIFF
--- a/.changelog/31293.txt
+++ b/.changelog/31293.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_servicecatalog_provisioned_product: Fix to properly send `stack_set_provisioned_preferences.0.accounts` on create and update
+```

--- a/internal/service/servicecatalog/provisioned_product.go
+++ b/internal/service/servicecatalog/provisioned_product.go
@@ -653,7 +653,7 @@ func expandProvisioningPreferences(tfMap map[string]interface{}) *servicecatalog
 
 	apiObject := &servicecatalog.ProvisioningPreferences{}
 
-	if v, ok := tfMap["account"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["accounts"].([]interface{}); ok && len(v) > 0 {
 		apiObject.StackSetAccounts = flex.ExpandStringList(v)
 	}
 
@@ -735,7 +735,7 @@ func expandUpdateProvisioningPreferences(tfMap map[string]interface{}) *servicec
 
 	apiObject := &servicecatalog.UpdateProvisioningPreferences{}
 
-	if v, ok := tfMap["account"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["accounts"].([]interface{}); ok && len(v) > 0 {
 		apiObject.StackSetAccounts = flex.ExpandStringList(v)
 	}
 

--- a/internal/service/servicecatalog/provisioned_product_test.go
+++ b/internal/service/servicecatalog/provisioned_product_test.go
@@ -163,6 +163,8 @@ func TestAccServiceCatalogProvisionedProduct_stackSetProvisioningPreferences(t *
 					resource.TestCheckResourceAttr(resourceName, "stack_set_provisioning_preferences.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stack_set_provisioning_preferences.0.failure_tolerance_count", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stack_set_provisioning_preferences.0.max_concurrency_count", "2"),
+					resource.TestCheckResourceAttr(resourceName, "stack_set_provisioning_preferences.0.accounts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stack_set_provisioning_preferences.0.regions.#", "1"),
 				),
 			},
 			{
@@ -186,6 +188,8 @@ func TestAccServiceCatalogProvisionedProduct_stackSetProvisioningPreferences(t *
 					resource.TestCheckResourceAttr(resourceName, "stack_set_provisioning_preferences.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stack_set_provisioning_preferences.0.failure_tolerance_count", "3"),
 					resource.TestCheckResourceAttr(resourceName, "stack_set_provisioning_preferences.0.max_concurrency_count", "4"),
+					resource.TestCheckResourceAttr(resourceName, "stack_set_provisioning_preferences.0.accounts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stack_set_provisioning_preferences.0.regions.#", "1"),
 				),
 			},
 			{
@@ -786,6 +790,8 @@ resource "aws_servicecatalog_provisioned_product" "test" {
 func testAccProvisionedProductConfig_stackSetprovisioningPreferences(rName, domain, email, vpcCidr string, failureToleranceCount, maxConcurrencyCount int) string {
 	return acctest.ConfigCompose(testAccProvisionedProductTemplateURLBaseConfig(rName, domain, email),
 		fmt.Sprintf(`
+data "aws_region" "current" {}
+
 resource "aws_servicecatalog_provisioned_product" "test" {
   name                       = %[1]q
   product_id                 = aws_servicecatalog_product.test.id
@@ -793,6 +799,8 @@ resource "aws_servicecatalog_provisioned_product" "test" {
   path_id                    = data.aws_servicecatalog_launch_paths.test.summaries[0].path_id
 
   stack_set_provisioning_preferences {
+    accounts                = [data.aws_caller_identity.current.account_id]
+    regions                 = [data.aws_region.current.name]
     failure_tolerance_count = %[3]d
     max_concurrency_count   = %[4]d
   }


### PR DESCRIPTION
### Description
Fixes the `stack_set_provisioned_preferences` expander to properly send the `accounts` attributes on Create/Update.


### Relations

Closes #29343



### Output from Acceptance Testing

```console
$ make testacc PKG=servicecatalog TESTS=TestAccServiceCatalogProvisionedProduct_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicecatalog/... -v -count 1 -parallel 20 -run='TestAccServiceCatalogProvisionedProduct_'  -timeout 180m

--- PASS: TestAccServiceCatalogProvisionedProduct_errorOnCreate (53.31s)
--- PASS: TestAccServiceCatalogProvisionedProduct_disappears (131.60s)
--- PASS: TestAccServiceCatalogProvisionedProduct_basic (135.69s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags (221.81s)
--- PASS: TestAccServiceCatalogProvisionedProduct_update (222.72s)
--- PASS: TestAccServiceCatalogProvisionedProduct_ProvisioningArtifactName_update (225.29s)
--- PASS: TestAccServiceCatalogProvisionedProduct_computedOutputs (242.63s)
--- PASS: TestAccServiceCatalogProvisionedProduct_errorOnUpdate (263.54s)
--- PASS: TestAccServiceCatalogProvisionedProduct_stackSetProvisioningPreferences (310.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog     313.345s
```
