### PR TITLE
New Resource: `aws_quicksight_template_alias`

### DIFF
--- a/.changelog/31310.txt
+++ b/.changelog/31310.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_quicksight_template_alias
+```

--- a/internal/service/quicksight/exports_test.go
+++ b/internal/service/quicksight/exports_test.go
@@ -7,4 +7,5 @@ var (
 	ResourceIngestion           = newResourceIngestion
 	ResourceNamespace           = newResourceNamespace
 	ResourceRefreshSchedule     = newResourceRefreshSchedule
+	ResourceTemplateAlias       = newResourceTemplateAlias
 )

--- a/internal/service/quicksight/service_package_gen.go
+++ b/internal/service/quicksight/service_package_gen.go
@@ -40,6 +40,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Factory: newResourceRefreshSchedule,
 			Name:    "Refresh Schedule",
 		},
+		{
+			Factory: newResourceTemplateAlias,
+			Name:    "Template Alias",
+		},
 	}
 }
 

--- a/internal/service/quicksight/template_alias.go
+++ b/internal/service/quicksight/template_alias.go
@@ -1,0 +1,283 @@
+package quicksight
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/quicksight"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource(name="Template Alias")
+func newResourceTemplateAlias(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceTemplateAlias{}, nil
+}
+
+const (
+	ResNameTemplateAlias = "Template Alias"
+)
+
+type resourceTemplateAlias struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceTemplateAlias) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_quicksight_template_alias"
+}
+
+func (r *resourceTemplateAlias) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"alias_name": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"arn": framework.ARNAttributeComputedOnly(),
+			"aws_account_id": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"id": framework.IDAttribute(),
+			"template_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"template_version_number": schema.Int64Attribute{
+				Required: true,
+			},
+		},
+	}
+}
+
+func (r *resourceTemplateAlias) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().QuickSightConn()
+
+	var plan resourceTemplateAliasData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if plan.AWSAccountID.IsUnknown() || plan.AWSAccountID.IsNull() {
+		plan.AWSAccountID = types.StringValue(r.Meta().AccountID)
+	}
+	plan.ID = types.StringValue(
+		createTemplateAliasID(plan.AWSAccountID.ValueString(), plan.TemplateID.ValueString(), plan.AliasName.ValueString()))
+
+	in := &quicksight.CreateTemplateAliasInput{
+		AliasName:             aws.String(plan.AliasName.ValueString()),
+		AwsAccountId:          aws.String(plan.AWSAccountID.ValueString()),
+		TemplateId:            aws.String(plan.TemplateID.ValueString()),
+		TemplateVersionNumber: aws.Int64(plan.TemplateVersionNumber.ValueInt64()),
+	}
+
+	out, err := conn.CreateTemplateAliasWithContext(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QuickSight, create.ErrActionCreating, ResNameTemplateAlias, plan.AliasName.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil || out.TemplateAlias == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QuickSight, create.ErrActionCreating, ResNameTemplateAlias, plan.AliasName.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	plan.ARN = flex.StringToFramework(ctx, out.TemplateAlias.Arn)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceTemplateAlias) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().QuickSightConn()
+
+	var state resourceTemplateAliasData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := FindTemplateAliasByID(ctx, conn, state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QuickSight, create.ErrActionSetting, ResNameTemplateAlias, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.ARN = flex.StringToFramework(ctx, out.Arn)
+	state.AliasName = flex.StringToFramework(ctx, out.AliasName)
+	state.TemplateVersionNumber = flex.Int64ToFramework(ctx, out.TemplateVersionNumber)
+
+	// To support import, parse the ID for the component keys and set
+	// individual values in state
+	awsAccountID, templateID, _, err := ParseTemplateAliasID(state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QuickSight, create.ErrActionSetting, ResNameTemplateAlias, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.AWSAccountID = flex.StringValueToFramework(ctx, awsAccountID)
+	state.TemplateID = flex.StringValueToFramework(ctx, templateID)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceTemplateAlias) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().QuickSightConn()
+
+	var plan, state resourceTemplateAliasData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.TemplateVersionNumber.Equal(state.TemplateVersionNumber) {
+		in := &quicksight.UpdateTemplateAliasInput{
+			AliasName:             aws.String(plan.AliasName.ValueString()),
+			AwsAccountId:          aws.String(plan.AWSAccountID.ValueString()),
+			TemplateId:            aws.String(plan.TemplateID.ValueString()),
+			TemplateVersionNumber: aws.Int64(plan.TemplateVersionNumber.ValueInt64()),
+		}
+
+		out, err := conn.UpdateTemplateAliasWithContext(ctx, in)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.QuickSight, create.ErrActionUpdating, ResNameTemplateAlias, plan.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		if out == nil || out.TemplateAlias == nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.QuickSight, create.ErrActionUpdating, ResNameTemplateAlias, plan.ID.String(), nil),
+				errors.New("empty output").Error(),
+			)
+			return
+		}
+
+		plan.ARN = flex.StringToFramework(ctx, out.TemplateAlias.Arn)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceTemplateAlias) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().QuickSightConn()
+
+	var state resourceTemplateAliasData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &quicksight.DeleteTemplateAliasInput{
+		AliasName:    aws.String(state.AliasName.ValueString()),
+		AwsAccountId: aws.String(state.AWSAccountID.ValueString()),
+		TemplateId:   aws.String(state.TemplateID.ValueString()),
+	}
+
+	_, err := conn.DeleteTemplateAliasWithContext(ctx, in)
+	if err != nil {
+		if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QuickSight, create.ErrActionDeleting, ResNameTemplateAlias, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceTemplateAlias) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func FindTemplateAliasByID(ctx context.Context, conn *quicksight.QuickSight, id string) (*quicksight.TemplateAlias, error) {
+	awsAccountID, templateID, aliasName, err := ParseTemplateAliasID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	in := &quicksight.DescribeTemplateAliasInput{
+		AliasName:    aws.String(aliasName),
+		AwsAccountId: aws.String(awsAccountID),
+		TemplateId:   aws.String(templateID),
+	}
+
+	out, err := conn.DescribeTemplateAliasWithContext(ctx, in)
+	if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil || out.TemplateAlias == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out.TemplateAlias, nil
+}
+
+func ParseTemplateAliasID(id string) (string, string, string, error) {
+	parts := strings.SplitN(id, ",", 3)
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", "", "", fmt.Errorf("unexpected format of ID (%s), expected AWS_ACCOUNT_ID,TEMPLATE_ID,ALIAS_NAME", id)
+	}
+	return parts[0], parts[1], parts[2], nil
+}
+
+func createTemplateAliasID(awsAccountID, templateID, aliasName string) string {
+	return strings.Join([]string{awsAccountID, templateID, aliasName}, ",")
+}
+
+type resourceTemplateAliasData struct {
+	AliasName             types.String `tfsdk:"alias_name"`
+	ARN                   types.String `tfsdk:"arn"`
+	AWSAccountID          types.String `tfsdk:"aws_account_id"`
+	ID                    types.String `tfsdk:"id"`
+	TemplateID            types.String `tfsdk:"template_id"`
+	TemplateVersionNumber types.Int64  `tfsdk:"template_version_number"`
+}

--- a/internal/service/quicksight/template_alias_test.go
+++ b/internal/service/quicksight/template_alias_test.go
@@ -1,0 +1,144 @@
+package quicksight_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/quicksight"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfquicksight "github.com/hashicorp/terraform-provider-aws/internal/service/quicksight"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccQuickSightTemplateAlias_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var templateAlias quicksight.TemplateAlias
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	aliasName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_quicksight_template_alias.test"
+	resourceTemplateName := "aws_quicksight_template.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, quicksight.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, quicksight.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTemplateAliasDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTemplateAliasConfig_basic(rId, rName, aliasName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTemplateAliasExists(ctx, resourceName, &templateAlias),
+					resource.TestCheckResourceAttr(resourceName, "alias_name", aliasName),
+					resource.TestCheckResourceAttrPair(resourceName, "template_id", resourceTemplateName, "template_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "template_version_number", resourceTemplateName, "version_number"),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "quicksight", fmt.Sprintf("template/%[1]s/alias/%[2]s", rId, aliasName)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccQuickSightTemplateAlias_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	var templateAlias quicksight.TemplateAlias
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	aliasName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_quicksight_template_alias.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, quicksight.EndpointsID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, quicksight.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTemplateAliasDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTemplateAliasConfig_basic(rId, rName, aliasName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTemplateAliasExists(ctx, resourceName, &templateAlias),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfquicksight.ResourceTemplateAlias, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckTemplateAliasDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).QuickSightConn()
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_quicksight_template_alias" {
+				continue
+			}
+
+			_, err := tfquicksight.FindTemplateAliasByID(ctx, conn, rs.Primary.ID)
+			if err != nil {
+				if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
+					return nil
+				}
+				return err
+			}
+
+			return create.Error(names.QuickSight, create.ErrActionCheckingDestroyed, tfquicksight.ResNameTemplateAlias, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTemplateAliasExists(ctx context.Context, name string, templateAlias *quicksight.TemplateAlias) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.QuickSight, create.ErrActionCheckingExistence, tfquicksight.ResNameTemplateAlias, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.QuickSight, create.ErrActionCheckingExistence, tfquicksight.ResNameTemplateAlias, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).QuickSightConn()
+		resp, err := tfquicksight.FindTemplateAliasByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.QuickSight, create.ErrActionCheckingExistence, tfquicksight.ResNameTemplateAlias, rs.Primary.ID, err)
+		}
+
+		*templateAlias = *resp
+
+		return nil
+	}
+}
+
+func testAccTemplateAliasConfig_basic(rId, rName, aliasName string) string {
+	return acctest.ConfigCompose(
+		testAccTemplateConfig_basic(rId, rName),
+		fmt.Sprintf(`
+resource "aws_quicksight_template_alias" "test" {
+  alias_name              = %[1]q
+  template_id             = aws_quicksight_template.test.template_id
+  template_version_number = aws_quicksight_template.test.version_number
+}
+`, aliasName))
+}

--- a/website/docs/r/quicksight_template_alias.html.markdown
+++ b/website/docs/r/quicksight_template_alias.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "QuickSight"
+layout: "aws"
+page_title: "AWS: aws_quicksight_template_alias"
+description: |-
+  Terraform resource for managing an AWS QuickSight Template Alias.
+---
+
+# Resource: aws_quicksight_template_alias
+
+Terraform resource for managing an AWS QuickSight Template Alias.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_quicksight_template_alias" "example" {
+  alias_name              = "example-alias"
+  template_id             = aws_quicksight_template.test.template_id
+  template_version_number = aws_quicksight_template.test.version_number
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `alias_name` - (Required, Forces new resource) Display name of the template alias.
+* `template_id` - (Required, Forces new resource) ID of the template.
+* `template_version_number` - (Required) Version number of the template.
+
+The following arguments are optional:
+
+* `aws_account_id` - (Optional, Forces new resource) AWS account ID.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Amazon Resource Name (ARN) of the template alias.
+* `id` - A comma-delimited string joining AWS account ID, template ID, and alias name.
+
+## Import
+
+QuickSight Template Alias can be imported using the AWS account ID, template ID, and alias name separated by a comma (`,`) e.g.,
+
+```
+$ terraform import aws_quicksight_template_alias.example 123456789012,example-id,example-alias
+```


### PR DESCRIPTION

### Description
This resource will allow practitioners to manager QuickSight template aliases via Terraform.


### Relations

Relates #10990
Closes #11836 

### References
- https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CreateTemplateAlias.html
- https://docs.aws.amazon.com/quicksight/latest/APIReference/API_UpdateTemplateAlias.html
- https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DescribeTemplateAlias.html
- https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DeleteTemplateAlias.html


### Output from Acceptance Testing

```console
$ make testacc PKG=quicksight TESTS=TestAccQuickSightTemplateAlias_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightTemplateAlias_'  -timeout 180m
?       github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema  [no test files]
=== RUN   TestAccQuickSightTemplateAlias_basic
=== PAUSE TestAccQuickSightTemplateAlias_basic
=== RUN   TestAccQuickSightTemplateAlias_disappears
=== PAUSE TestAccQuickSightTemplateAlias_disappears
=== CONT  TestAccQuickSightTemplateAlias_basic
=== CONT  TestAccQuickSightTemplateAlias_disappears
--- PASS: TestAccQuickSightTemplateAlias_disappears (33.35s)
--- PASS: TestAccQuickSightTemplateAlias_basic (35.57s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 38.878s
```
