### PR TITLE
configservice/remediation_configuration: parameters TypeSet -> TypeList

### DIFF
--- a/.changelog/31315.txt
+++ b/.changelog/31315.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_config_remediation_configuration: Change `parameter` attribute to `TypeList` for better diff calculation
+```

--- a/internal/service/configservice/configservice_test.go
+++ b/internal/service/configservice/configservice_test.go
@@ -92,12 +92,13 @@ func TestAccConfigService_serial(t *testing.T) {
 			"TagValueScope":             testAccOrganizationManagedRule_TagValueScope,
 		},
 		"RemediationConfiguration": {
-			"basic":         testAccRemediationConfiguration_basic,
-			"basicBackward": testAccRemediationConfiguration_basicBackwardCompatible,
-			"disappears":    testAccRemediationConfiguration_disappears,
-			"recreates":     testAccRemediationConfiguration_recreates,
-			"updates":       testAccRemediationConfiguration_updates,
-			"values":        testAccRemediationConfiguration_values,
+			"basic":             testAccRemediationConfiguration_basic,
+			"basicBackward":     testAccRemediationConfiguration_basicBackwardCompatible,
+			"disappears":        testAccRemediationConfiguration_disappears,
+			"migrateParameters": testAccRemediationConfiguration_migrateParameters,
+			"recreates":         testAccRemediationConfiguration_recreates,
+			"updates":           testAccRemediationConfiguration_updates,
+			"values":            testAccRemediationConfiguration_values,
 		},
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #31319

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccConfigService_serial/RemediationConfiguration' PKG=configservice

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/configservice/... -v -count 1 -parallel 20  -run=TestAccConfigService_serial/RemediationConfiguration -timeout 180m
=== RUN   TestAccConfigService_serial
=== PAUSE TestAccConfigService_serial
=== CONT  TestAccConfigService_serial
=== RUN   TestAccConfigService_serial/RemediationConfiguration
=== RUN   TestAccConfigService_serial/RemediationConfiguration/disappears
=== RUN   TestAccConfigService_serial/RemediationConfiguration/migrateParameters
=== RUN   TestAccConfigService_serial/RemediationConfiguration/recreates
=== RUN   TestAccConfigService_serial/RemediationConfiguration/updates
=== RUN   TestAccConfigService_serial/RemediationConfiguration/values
=== RUN   TestAccConfigService_serial/RemediationConfiguration/basic
=== RUN   TestAccConfigService_serial/RemediationConfiguration/basicBackward
--- PASS: TestAccConfigService_serial (609.31s)
    --- PASS: TestAccConfigService_serial/RemediationConfiguration (609.31s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/disappears (78.54s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/migrateParameters (104.69s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/recreates (92.84s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/updates (89.80s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/values (81.52s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/basic (81.20s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/basicBackward (80.73s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/configservice	612.605s
```
