### PR TITLE
fix: use correct format for ECS parameters tags in scheduler

### DIFF
--- a/internal/service/scheduler/flex.go
+++ b/internal/service/scheduler/flex.go
@@ -131,15 +131,8 @@ func expandECSParameters(ctx context.Context, tfMap map[string]interface{}) *typ
 		a.ReferenceId = aws.String(v)
 	}
 
-	tags := tftags.New(ctx, tfMap["tags"].(map[string]interface{}))
-
-	if len(tags) > 0 {
-		for k, v := range tags.IgnoreAWS().Map() {
-			a.Tags = append(a.Tags, map[string]string{
-				"key":   k,
-				"value": v,
-			})
-		}
+	if tags := tftags.New(ctx, tfMap["tags"].(map[string]interface{})); len(tags) > 0 {
+		a.Tags = append(a.Tags, tags.IgnoreAWS().Map())
 	}
 
 	if v, ok := tfMap["task_count"].(int); ok {

--- a/website/docs/r/scheduler_schedule.html.markdown
+++ b/website/docs/r/scheduler_schedule.html.markdown
@@ -128,7 +128,7 @@ The following arguments are optional:
 * `platform_version` - (Optional) Specifies the platform version for the task. Specify only the numeric portion of the platform version, such as `1.1.0`.
 * `propagate_tags` - (Optional) Specifies whether to propagate the tags from the task definition to the task. One of: `TASK_DEFINITION`.
 * `reference_id` - (Optional) Reference ID to use for the task.
-* `tags` - (Optional) The metadata that you apply to the task. Each tag consists of a key and an optional value. For more information, see [`RunTask`](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html) in the Amazon ECS API Reference.
+* `tags` - (Optional) Map of tags to apply to the task.
 * `task_count` - (Optional) The number of tasks to create. Ranges from `1` (default) to `10`.
 
 ##### capacity_provider_strategy Configuration Block


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The previous tags format was based on RunTask request syntax [1] which consisted in an array of map with key and an optional value but the schedule format is an array of string to string maps [2].

I did tested that this works with the fix.

[1] https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html
[2] https://docs.aws.amazon.com/scheduler/latest/APIReference/API_EcsParameters.html

