### PR TITLE
[TechDebt]: QuickSight sweepers

### DIFF
--- a/internal/service/quicksight/data_set.go
+++ b/internal/service/quicksight/data_set.go
@@ -1112,6 +1112,7 @@ func resourceDataSetUpdate(ctx context.Context, d *schema.ResourceData, meta int
 func resourceDataSetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).QuickSightConn()
 
+	log.Printf("[INFO] Deleting QuickSight Data Set %s", d.Id())
 	awsAccountId, dataSetId, err := ParseDataSetID(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
@@ -2701,11 +2702,11 @@ func flattenTagRules(apiObject []*quicksight.RowLevelPermissionTagRule) []interf
 func ParseDataSetID(id string) (string, string, error) {
 	parts := strings.SplitN(id, ",", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("unexpected format of ID (%s), expected AWS_ACCOUNT_ID,DATA_SOURCE_ID", id)
+		return "", "", fmt.Errorf("unexpected format of ID (%s), expected AWS_ACCOUNT_ID,DATA_SET_ID", id)
 	}
 	return parts[0], parts[1], nil
 }
 
-func createDataSetID(awsAccountID, dataSourceID string) string {
-	return fmt.Sprintf("%s,%s", awsAccountID, dataSourceID)
+func createDataSetID(awsAccountID, dataSetID string) string {
+	return fmt.Sprintf("%s,%s", awsAccountID, dataSetID)
 }

--- a/internal/service/quicksight/sweep.go
+++ b/internal/service/quicksight/sweep.go
@@ -16,6 +16,10 @@ import (
 )
 
 func init() {
+	resource.AddTestSweepers("aws_quicksight_data_set", &resource.Sweeper{
+		Name: "aws_quicksight_data_set",
+		F:    sweepDataSets,
+	})
 	resource.AddTestSweepers("aws_quicksight_data_source", &resource.Sweeper{
 		Name: "aws_quicksight_data_source",
 		F:    sweepDataSources,
@@ -24,6 +28,61 @@ func init() {
 		Name: "aws_quicksight_folder",
 		F:    sweepFolders,
 	})
+
+}
+
+func sweepDataSets(region string) error {
+	ctx := sweep.Context(region)
+	client, err := sweep.SharedRegionalSweepClient(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*conns.AWSClient).QuickSightConn()
+	sweepResources := make([]sweep.Sweepable, 0)
+	var errs *multierror.Error
+
+	awsAccountId := client.(*conns.AWSClient).AccountID
+
+	input := &quicksight.ListDataSetsInput{
+		AwsAccountId: aws.String(awsAccountId),
+	}
+
+	err = conn.ListDataSetsPagesWithContext(ctx, input, func(page *quicksight.ListDataSetsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, ds := range page.DataSetSummaries {
+			if ds == nil {
+				continue
+			}
+
+			r := ResourceDataSet()
+			d := r.Data(nil)
+			d.SetId(fmt.Sprintf("%s,%s", awsAccountId, aws.StringValue(ds.DataSetId)))
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("listing QuickSight Data Sets: %w", err))
+	}
+
+	if err := sweep.SweepOrchestratorWithContext(ctx, sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("sweeping QuickSight Data Sets for %s: %w", region, err))
+	}
+
+	if sweep.SkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping QuickSight Data Set sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
 }
 
 func sweepDataSources(region string) error {
@@ -65,11 +124,11 @@ func sweepDataSources(region string) error {
 	})
 
 	if err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error describing QuickSigth Data Sources: %w", err))
+		errs = multierror.Append(errs, fmt.Errorf("listing QuickSight Data Sources: %w", err))
 	}
 
 	if err := sweep.SweepOrchestratorWithContext(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping QuickSight Data Sources for %s: %w", region, err))
+		errs = multierror.Append(errs, fmt.Errorf("sweeping QuickSight Data Sources for %s: %w", region, err))
 	}
 
 	if sweep.SkipSweepError(errs.ErrorOrNil()) {


### PR DESCRIPTION

### Description
Adds sweepers for various QuickSight resources.

### Relations

Relates #10990 


### Output from Acceptance Testing


```
$ make sweep SWEEPARGS=-sweep-run=aws_quicksight
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2,us-east-1,us-east-2 -sweep-run=aws_quicksight -timeout 60m
<snip>

2023/05/11 10:56:53 Completed Sweepers for region (us-east-2) in 1.971284917s
2023/05/11 10:56:53 Sweeper Tests for region (us-east-2) ran successfully:
        - aws_quicksight_folder
        - aws_quicksight_user
        - aws_quicksight_data_set
        - aws_quicksight_template
        - aws_quicksight_data_source
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      11.007s
```
