### PR TITLE
Bugfix:  `aws_ssm_activation` Fails on nonexistent role

### DIFF
--- a/.changelog/31340.txt
+++ b/.changelog/31340.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ssm_activation: Fix various `ValidationException` errors on resource Create
+```

--- a/internal/service/ssm/activation.go
+++ b/internal/service/ssm/activation.go
@@ -86,7 +86,7 @@ func resourceActivationCreate(ctx context.Context, d *schema.ResourceData, meta 
 	name := d.Get("name").(string)
 	input := &ssm.CreateActivationInput{
 		DefaultInstanceName: aws.String(name),
-		IamRole:             aws.String(d.Get("name").(string)),
+		IamRole:             aws.String(d.Get("iam_role").(string)),
 		Tags:                GetTagsIn(ctx),
 	}
 

--- a/internal/service/ssm/activation_test.go
+++ b/internal/service/ssm/activation_test.go
@@ -20,6 +20,7 @@ func TestAccSSMActivation_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var ssmActivation ssm.Activation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ssm_activation.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -29,7 +30,7 @@ func TestAccSSMActivation_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckActivationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccActivationConfig_basic(rName),
+				Config: testAccActivationConfig_basic(rName, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckActivationExists(ctx, resourceName, &ssmActivation),
 					resource.TestCheckResourceAttrSet(resourceName, "activation_code"),
@@ -53,6 +54,7 @@ func TestAccSSMActivation_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var ssmActivation ssm.Activation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ssm_activation.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -62,7 +64,7 @@ func TestAccSSMActivation_tags(t *testing.T) {
 		CheckDestroy:             testAccCheckActivationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccActivationConfig_tags(rName),
+				Config: testAccActivationConfig_tags(rName, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckActivationExists(ctx, resourceName, &ssmActivation),
 					resource.TestCheckResourceAttrSet(resourceName, "activation_code"),
@@ -87,6 +89,7 @@ func TestAccSSMActivation_expirationDate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var ssmActivation ssm.Activation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	expirationDate := time.Now().Add(48 * time.Hour).UTC().Format(time.RFC3339)
 	resourceName := "aws_ssm_activation.test"
 
@@ -97,7 +100,7 @@ func TestAccSSMActivation_expirationDate(t *testing.T) {
 		CheckDestroy:             testAccCheckActivationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccActivationConfig_expirationDate(rName, expirationDate),
+				Config: testAccActivationConfig_expirationDate(rName, expirationDate, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckActivationExists(ctx, resourceName, &ssmActivation),
 					resource.TestCheckResourceAttr(resourceName, "expiration_date", expirationDate),
@@ -119,6 +122,7 @@ func TestAccSSMActivation_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var ssmActivation ssm.Activation
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	roleName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ssm_activation.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -128,7 +132,7 @@ func TestAccSSMActivation_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckActivationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccActivationConfig_basic(rName),
+				Config: testAccActivationConfig_basic(rName, roleName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckActivationExists(ctx, resourceName, &ssmActivation),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfssm.ResourceActivation(), resourceName),
@@ -190,7 +194,7 @@ func testAccCheckActivationDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccActivationConfig_base(rName string) string {
+func testAccActivationConfig_base(roleName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -218,11 +222,11 @@ resource "aws_iam_role_policy_attachment" "test" {
   role       = aws_iam_role.test.name
   policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
-`, rName)
+`, roleName)
 }
 
-func testAccActivationConfig_basic(rName string) string {
-	return acctest.ConfigCompose(testAccActivationConfig_base(rName), fmt.Sprintf(`
+func testAccActivationConfig_basic(rName string, roleName string) string {
+	return acctest.ConfigCompose(testAccActivationConfig_base(roleName), fmt.Sprintf(`
 resource "aws_ssm_activation" "test" {
   name               = %[1]q
   description        = "Test"
@@ -234,8 +238,8 @@ resource "aws_ssm_activation" "test" {
 `, rName))
 }
 
-func testAccActivationConfig_tags(rName string) string {
-	return acctest.ConfigCompose(testAccActivationConfig_base(rName), fmt.Sprintf(`
+func testAccActivationConfig_tags(rName string, roleName string) string {
+	return acctest.ConfigCompose(testAccActivationConfig_base(roleName), fmt.Sprintf(`
 resource "aws_ssm_activation" "test" {
   name               = %[1]q
   description        = "Test"
@@ -251,8 +255,8 @@ resource "aws_ssm_activation" "test" {
 `, rName))
 }
 
-func testAccActivationConfig_expirationDate(rName, expirationDate string) string {
-	return acctest.ConfigCompose(testAccActivationConfig_base(rName), fmt.Sprintf(`
+func testAccActivationConfig_expirationDate(rName string, expirationDate string, roleName string) string {
+	return acctest.ConfigCompose(testAccActivationConfig_base(roleName), fmt.Sprintf(`
 resource "aws_ssm_activation" "test" {
   name               = %[1]q
   description        = "Test"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This pull request accomplishes the following:

1. Updates the tests for aws_ssm_activation to properly test the `iam_role` field by separating out the resource name and the iam role name.
2. Updates the IamRole in the CreateActivationInput to use the proper schema field. 

I made sure that the tests were failing before the update to code and are now passing with the correct field being passed. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #30441

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccSSMActivation' PKG=ssm 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20  -run=TestAccSSMActivation -timeout 180m
=== RUN   TestAccSSMActivation_basic
=== PAUSE TestAccSSMActivation_basic
=== RUN   TestAccSSMActivation_tags
=== PAUSE TestAccSSMActivation_tags
=== RUN   TestAccSSMActivation_expirationDate
=== PAUSE TestAccSSMActivation_expirationDate
=== RUN   TestAccSSMActivation_disappears
=== PAUSE TestAccSSMActivation_disappears
=== CONT  TestAccSSMActivation_basic
=== CONT  TestAccSSMActivation_expirationDate
=== CONT  TestAccSSMActivation_disappears
=== CONT  TestAccSSMActivation_tags
--- PASS: TestAccSSMActivation_disappears (22.92s)
--- PASS: TestAccSSMActivation_expirationDate (25.55s)
--- PASS: TestAccSSMActivation_tags (33.43s)
--- PASS: TestAccSSMActivation_basic (33.72s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        36.971s

...
```
