### PR TITLE
Bug #31348 - update regex for single character columns

### DIFF
--- a/internal/service/keyspaces/table.go
+++ b/internal/service/keyspaces/table.go
@@ -204,7 +204,7 @@ func ResourceTable() *schema.Resource {
 										ValidateFunc: validation.All(
 											validation.StringLenBetween(1, 48),
 											validation.StringMatch(
-												regexp.MustCompile(`^[a-z0-9][a-z0-9_]{1,47}$`),
+												regexp.MustCompile(`^[a-z0-9][a-z0-9_]{0,47}$`),
 												"The name must consist of lower case alphanumerics and underscores.",
 											),
 										),


### PR DESCRIPTION
### Description
The regex for the columns on the keyspaces tables were in conflict with the allowed string lengths, this pr brings the two validations into alignment.

### Relations
Closes #31348
