### PR TITLE
datasource/aws_iam_policy_document: Add test for multiple condition keys

### DIFF
--- a/internal/service/iam/policy_document_data_source_test.go
+++ b/internal/service/iam/policy_document_data_source_test.go
@@ -52,6 +52,25 @@ func TestAccIAMPolicyDocumentDataSource_singleConditionValue(t *testing.T) {
 	})
 }
 
+func TestAccIAMPolicyDocumentDataSource_multipleConditionKeys(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_iam_policy_document.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyDocumentDataSourceConfig_multipleConditionKeys,
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrEquivalentJSON(dataSourceName, "json", testAccPolicyDocumentConfig_multipleConditionKeys_ExpectedJSON),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIAMPolicyDocumentDataSource_conditionWithBoolValue(t *testing.T) {
 	ctx := acctest.Context(t)
 	resource.ParallelTest(t, resource.TestCase{
@@ -639,6 +658,58 @@ const testAccPolicyDocumentConfig_SingleConditionValue_ExpectedJSON = `{
     }
   ]
 }`
+
+const testAccPolicyDocumentDataSourceConfig_multipleConditionKeys = `
+data "aws_iam_policy_document" "test" {
+  statement {
+    sid = "AWSCloudTrailWrite20150319"
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    actions = ["s3:PutObject"]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = ["some-other-value"]
+    }
+  }
+}
+`
+
+var testAccPolicyDocumentConfig_multipleConditionKeys_ExpectedJSON = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AWSCloudTrailWrite20150319",
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+      "Resource": "*",
+      "Principal": {
+        "Service": "cloudtrail.amazonaws.com"
+      },
+      "Condition": {
+        "StringEquals": {
+          "s3:x-amz-acl": "bucket-owner-full-control",
+          "aws:SourceArn": "some-other-value"
+        }
+      }
+    }
+  ]
+}
+`
 
 var testAccPolicyDocumentDataSourceConfig_deprecated = `
 data "aws_partition" "current" {}


### PR DESCRIPTION
### Description

Adds test for multiple condition keys for same operator in policy document

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=iam TESTS=TestAccIAMPolicyDocumentDataSource_

--- PASS: TestAccIAMPolicyDocumentDataSource_sourceListConflicting (7.48s)
--- PASS: TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_stringAndSlice (37.54s)
--- PASS: TestAccIAMPolicyDocumentDataSource_noStatementOverride (38.87s)
--- PASS: TestAccIAMPolicyDocumentDataSource_conditionWithBoolValue (38.98s)
--- PASS: TestAccIAMPolicyDocumentDataSource_singleConditionValue (39.14s)
--- PASS: TestAccIAMPolicyDocumentDataSource_StatementPrincipalIdentifiers_multiplePrincipals (39.26s)
--- PASS: TestAccIAMPolicyDocumentDataSource_multipleConditionKeys (39.33s)
--- PASS: TestAccIAMPolicyDocumentDataSource_override (40.02s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceConflicting (40.04s)
--- PASS: TestAccIAMPolicyDocumentDataSource_noStatementMerge (40.20s)
--- PASS: TestAccIAMPolicyDocumentDataSource_basic (40.21s)
--- PASS: TestAccIAMPolicyDocumentDataSource_overrideList (40.39s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceList (40.41s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourcePolicyValidJSON (40.68s)
--- PASS: TestAccIAMPolicyDocumentDataSource_overridePolicyDocumentValidJSON (41.04s)
--- PASS: TestAccIAMPolicyDocumentDataSource_overrideJSONValidJSON (41.04s)
--- PASS: TestAccIAMPolicyDocumentDataSource_duplicateSid (40.55s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceJSONValidJSON (41.24s)
--- PASS: TestAccIAMPolicyDocumentDataSource_version20081017 (44.89s)
--- PASS: TestAccIAMPolicyDocumentDataSource_source (47.80s)
```
