### PR TITLE
Fixes S3 bucket policy for CloudTrail acceptance tests

### DIFF
--- a/internal/service/cloudtrail/cloudtrail_test.go
+++ b/internal/service/cloudtrail/cloudtrail_test.go
@@ -895,7 +895,11 @@ func testAccCheckLoadTags(ctx context.Context, trail *cloudtrail.Trail, tags *[]
 
 func testAccBaseConfig(rName string) string {
 	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
 data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
 
 resource "aws_s3_bucket" "test" {
   bucket        = %[1]q
@@ -910,19 +914,29 @@ resource "aws_s3_bucket_policy" "test" {
       {
         Sid       = "AWSCloudTrailAclCheck"
         Effect    = "Allow"
-        Principal = "*"
+        Principal = {
+          Service = "cloudtrail.amazonaws.com"
+        }
         Action    = "s3:GetBucketAcl"
         Resource  = "arn:${data.aws_partition.current.partition}:s3:::%[1]s"
+		Condition = {
+		  StringEquals = {
+			"aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/%[1]s"
+		  }
+		}
       },
       {
         Sid       = "AWSCloudTrailWrite"
         Effect    = "Allow"
-        Principal = "*"
+        Principal = {
+          Service = "cloudtrail.amazonaws.com"
+        }
         Action    = "s3:PutObject"
         Resource  = "arn:${data.aws_partition.current.partition}:s3:::%[1]s/*"
         Condition = {
           StringEquals = {
             "s3:x-amz-acl" = "bucket-owner-full-control"
+			"aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/%[1]s"
           }
         }
       }
@@ -1497,13 +1511,13 @@ resource "aws_cloudtrail" "test" {
 }
 
 func testAccCloudTrailConfig_advancedEventSelector(rName string) string {
-	return fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccBaseConfig(rName), fmt.Sprintf(`
 resource "aws_cloudtrail" "test" {
   # Must have bucket policy attached first
   depends_on = [aws_s3_bucket_policy.test]
 
   name           = %[1]q
-  s3_bucket_name = aws_s3_bucket.test1.id
+  s3_bucket_name = aws_s3_bucket.test.id
 
   advanced_event_selector {
     name = "s3Custom"
@@ -1593,46 +1607,9 @@ resource "aws_cloudtrail" "test" {
   }
 }
 
-data "aws_partition" "current" {}
-
-resource "aws_s3_bucket" "test1" {
-  bucket        = "%[1]s-1"
-  force_destroy = true
-}
-
-resource "aws_s3_bucket_policy" "test" {
-  bucket = aws_s3_bucket.test1.id
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AWSCloudTrailAclCheck",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:GetBucketAcl",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::%[1]s-1"
-    },
-    {
-      "Sid": "AWSCloudTrailWrite",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "s3:PutObject",
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::%[1]s-1/*",
-      "Condition": {
-        "StringEquals": {
-          "s3:x-amz-acl": "bucket-owner-full-control"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
-
 resource "aws_s3_bucket" "test2" {
   bucket        = "%[1]s-2"
   force_destroy = true
 }
-`, rName)
+`, rName))
 }

--- a/internal/service/cloudtrail/cloudtrail_test.go
+++ b/internal/service/cloudtrail/cloudtrail_test.go
@@ -912,31 +912,31 @@ resource "aws_s3_bucket_policy" "test" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid       = "AWSCloudTrailAclCheck"
-        Effect    = "Allow"
+        Sid    = "AWSCloudTrailAclCheck"
+        Effect = "Allow"
         Principal = {
           Service = "cloudtrail.amazonaws.com"
         }
-        Action    = "s3:GetBucketAcl"
-        Resource  = "arn:${data.aws_partition.current.partition}:s3:::%[1]s"
-		Condition = {
-		  StringEquals = {
-			"aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/%[1]s"
-		  }
-		}
-      },
-      {
-        Sid       = "AWSCloudTrailWrite"
-        Effect    = "Allow"
-        Principal = {
-          Service = "cloudtrail.amazonaws.com"
-        }
-        Action    = "s3:PutObject"
-        Resource  = "arn:${data.aws_partition.current.partition}:s3:::%[1]s/*"
+        Action   = "s3:GetBucketAcl"
+        Resource = "arn:${data.aws_partition.current.partition}:s3:::%[1]s"
         Condition = {
           StringEquals = {
-            "s3:x-amz-acl" = "bucket-owner-full-control"
-			"aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/%[1]s"
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/%[1]s"
+          }
+        }
+      },
+      {
+        Sid    = "AWSCloudTrailWrite"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudtrail.amazonaws.com"
+        }
+        Action   = "s3:PutObject"
+        Resource = "arn:${data.aws_partition.current.partition}:s3:::%[1]s/*"
+        Condition = {
+          StringEquals = {
+            "s3:x-amz-acl"  = "bucket-owner-full-control"
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/%[1]s"
           }
         }
       }

--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -22,19 +22,19 @@ Enable CloudTrail to capture all compatible management events in region.
 For capturing events from services like IAM, `include_global_service_events` must be enabled.
 
 ```terraform
-resource "aws_cloudtrail" "foobar" {
-  name                          = "tf-trail-foobar"
-  s3_bucket_name                = aws_s3_bucket.foo.id
+resource "aws_cloudtrail" "example" {
+  name                          = "example"
+  s3_bucket_name                = aws_s3_bucket.example.id
   s3_key_prefix                 = "prefix"
   include_global_service_events = false
 }
 
-resource "aws_s3_bucket" "foo" {
+resource "aws_s3_bucket" "example" {
   bucket        = "tf-test-trail"
   force_destroy = true
 }
 
-data "aws_iam_policy_document" "foo" {
+data "aws_iam_policy_document" "example" {
   statement {
     sid    = "AWSCloudTrailAclCheck"
     effect = "Allow"
@@ -45,11 +45,11 @@ data "aws_iam_policy_document" "foo" {
     }
 
     actions   = ["s3:GetBucketAcl"]
-    resources = [aws_s3_bucket.foo.arn]
+    resources = [aws_s3_bucket.example.arn]
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"
-      values   = ["arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/tf-trail-foobar"]
+      values   = ["arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/example"]
     }
   }
 
@@ -63,7 +63,7 @@ data "aws_iam_policy_document" "foo" {
     }
 
     actions   = ["s3:PutObject"]
-    resources = ["${aws_s3_bucket.foo.arn}/prefix/AWSLogs/${data.aws_caller_identity.current.account_id}/*"]
+    resources = ["${aws_s3_bucket.example.arn}/prefix/AWSLogs/${data.aws_caller_identity.current.account_id}/*"]
 
     condition {
       test     = "StringEquals"
@@ -73,13 +73,13 @@ data "aws_iam_policy_document" "foo" {
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"
-      values   = ["arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/tf-trail-foobar"]
+      values   = ["arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/example"]
     }
   }
 }
-resource "aws_s3_bucket_policy" "foo" {
-  bucket = aws_s3_bucket.foo.id
-  policy = data.aws_iam_policy_document.foo.json
+resource "aws_s3_bucket_policy" "example" {
+  bucket = aws_s3_bucket.example.id
+  policy = data.aws_iam_policy_document.example.json
 }
 
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
### Description

With the recent bucket ownership control updates from AWS, current policies in the acceptance tests and documentation for CloutTrail were no longer valid

### Relations

Relates #31021

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=cloudtrail TESTS=TestAccCloudTrail_serial

--- PASS: TestAccCloudTrail_serial (425.16s)
    --- PASS: TestAccCloudTrail_serial/Trail (425.16s)
        --- PASS: TestAccCloudTrail_serial/Trail/insightSelector (48.00s)
        --- PASS: TestAccCloudTrail_serial/Trail/disappears (14.41s)
        --- SKIP: TestAccCloudTrail_serial/Trail/enableLogging (20.63s)
        --- PASS: TestAccCloudTrail_serial/Trail/multiRegion (36.11s)
        --- PASS: TestAccCloudTrail_serial/Trail/eventSelectorDynamoDB (21.64s)
        --- PASS: TestAccCloudTrail_serial/Trail/cloudwatch (46.59s)
        --- PASS: TestAccCloudTrail_serial/Trail/globalServiceEvents (15.86s)
        --- PASS: TestAccCloudTrail_serial/Trail/logValidation (25.77s)
        --- PASS: TestAccCloudTrail_serial/Trail/eventSelector (60.02s)
        --- PASS: TestAccCloudTrail_serial/Trail/eventSelectorExclude (37.15s)
        --- PASS: TestAccCloudTrail_serial/Trail/advancedEventSelector (16.30s)
        --- SKIP: TestAccCloudTrail_serial/Trail/organization (0.48s)
        --- PASS: TestAccCloudTrail_serial/Trail/kmsKey (18.83s)
        --- PASS: TestAccCloudTrail_serial/Trail/tags (36.18s)
        --- PASS: TestAccCloudTrail_serial/Trail/basic (27.18s)
```
