### PR TITLE
r/aws_rbin_rule: Fix multiple resource tag panic

### DIFF
--- a/.changelog/31393.txt
+++ b/.changelog/31393.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rbin_rule: Fix crash when multiple `resource_tags` blocks are configured
+```

--- a/internal/service/rbin/rule.go
+++ b/internal/service/rbin/rule.go
@@ -244,7 +244,7 @@ func resourceRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if d.HasChanges("resource_tags") {
-		in.ResourceTags = expandResourceTags(d.Get("resource_tags").([]interface{}))
+		in.ResourceTags = expandResourceTags(d.Get("resource_tags").(*schema.Set).List())
 		update = true
 	}
 

--- a/internal/service/rbin/rule_test.go
+++ b/internal/service/rbin/rule_test.go
@@ -35,7 +35,7 @@ func TestAccRBinRule_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRuleConfig_basic(description, resourceType),
+				Config: testAccRuleConfig_basic1(description, resourceType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuleExists(resourceName, &rule),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
@@ -45,8 +45,8 @@ func TestAccRBinRule_basic(t *testing.T) {
 						"retention_period_unit":  "DAYS",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "resource_tags.*", map[string]string{
-						"resource_tag_key":   "some_tag",
-						"resource_tag_value": "",
+						"resource_tag_key":   "some_tag1",
+						"resource_tag_value": "some_value1",
 					}),
 				),
 			},
@@ -54,6 +54,26 @@ func TestAccRBinRule_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRuleConfig_basic2(description, resourceType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuleExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "resource_type", resourceType),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "retention_period.*", map[string]string{
+						"retention_period_value": "10",
+						"retention_period_unit":  "DAYS",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "resource_tags.*", map[string]string{
+						"resource_tag_key":   "some_tag3",
+						"resource_tag_value": "some_value3",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "resource_tags.*", map[string]string{
+						"resource_tag_key":   "some_tag4",
+						"resource_tag_value": "some_value4",
+					}),
+				),
 			},
 		},
 	})
@@ -76,7 +96,7 @@ func TestAccRBinRule_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRuleConfig_basic(description, resourceType),
+				Config: testAccRuleConfig_basic1(description, resourceType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuleExists(resourceName, &rbinrule),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfrbin.ResourceRule(), resourceName),
@@ -218,15 +238,39 @@ func testAccCheckRuleExists(name string, rbinrule *rbin.GetRuleOutput) resource.
 	}
 }
 
-func testAccRuleConfig_basic(description, resourceType string) string {
+func testAccRuleConfig_basic1(description, resourceType string) string {
 	return fmt.Sprintf(`
 resource "aws_rbin_rule" "test" {
   description   = %[1]q
   resource_type = %[2]q
 
   resource_tags {
-    resource_tag_key   = "some_tag"
-    resource_tag_value = ""
+    resource_tag_key   = "some_tag1"
+    resource_tag_value = "some_value1"
+  }
+
+  retention_period {
+    retention_period_value = 10
+    retention_period_unit  = "DAYS"
+  }
+}
+`, description, resourceType)
+}
+
+func testAccRuleConfig_basic2(description, resourceType string) string {
+	return fmt.Sprintf(`
+resource "aws_rbin_rule" "test" {
+  description   = %[1]q
+  resource_type = %[2]q
+
+  resource_tags {
+    resource_tag_key   = "some_tag3"
+    resource_tag_value = "some_value3"
+  }
+
+  resource_tags {
+    resource_tag_key   = "some_tag4"
+    resource_tag_value = "some_value4"
   }
 
   retention_period {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

aws-rbin_rule update crashes with multiple resource tags.

```go
panic: interface conversion: interface {} is *schema.Set, not []interface {}
```

Steps to re-produce the panic.

```terraform
resource "aws_rbin_rule" "example" {
  description   = "example_rule"
  resource_type = "EBS_SNAPSHOT"

  resource_tags {
    resource_tag_key   = "tag_key1"
    resource_tag_value = "tag_value1"
  }

  retention_period {
    retention_period_value = 10
    retention_period_unit  = "DAYS"
  }

  tags = {
    "test_tag_key" = "test_tag_value"
  }
}
```
Update the resource with two tags

```terraform
resource "aws_rbin_rule" "example" {
  description   = "example_rule"
  resource_type = "EBS_SNAPSHOT"

  resource_tags {
    resource_tag_key   = "tag_key1"
    resource_tag_value = "tag_value1"
  }

  resource_tags {
    resource_tag_key   = "tag_key2"
    resource_tag_value = "tag_value2"
  }

  retention_period {
    retention_period_value = 10
    retention_period_unit  = "DAYS"
  }

  tags = {
    "test_tag_key" = "test_tag_value"
  }
}
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=rbin TESTS=TestAccRBinRule_basic
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rbin/... -v -count 1 -parallel 20 -run='TestAccRBinRule_basic'  -timeout 180m
=== RUN   TestAccRBinRule_basic
=== PAUSE TestAccRBinRule_basic
=== CONT  TestAccRBinRule_basic
--- PASS: TestAccRBinRule_basic (52.93s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rbin	56.441s
$ make testacc PKG=rbin TESTS=TestAccRBinRule_disappears
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rbin/... -v -count 1 -parallel 20 -run='TestAccRBinRule_disappears'  -timeout 180m
=== RUN   TestAccRBinRule_disappears
=== PAUSE TestAccRBinRule_disappears
=== CONT  TestAccRBinRule_disappears
--- PASS: TestAccRBinRule_disappears (22.45s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rbin	25.872s
$ make testacc PKG=rbin TESTS=TestAccRBinRule_tags
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rbin/... -v -count 1 -parallel 20 -run='TestAccRBinRule_tags'  -timeout 180m
=== RUN   TestAccRBinRule_tags
=== PAUSE TestAccRBinRule_tags
=== CONT  TestAccRBinRule_tags
--- PASS: TestAccRBinRule_tags (70.86s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rbin	74.132s
$ make testacc PKG=rbin TESTS=TestAccRBinRule_lock_config
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rbin/... -v -count 1 -parallel 20 -run='TestAccRBinRule_lock_config'  -timeout 180m
=== RUN   TestAccRBinRule_lock_config
=== PAUSE TestAccRBinRule_lock_config
=== CONT  TestAccRBinRule_lock_config
--- PASS: TestAccRBinRule_lock_config (27.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rbin	31.107s
```