### PR TITLE
fix: Update CUR documentation

### DIFF
--- a/website/docs/r/cur_report_definition.html.markdown
+++ b/website/docs/r/cur_report_definition.html.markdown
@@ -12,8 +12,6 @@ Manages Cost and Usage Report Definitions.
 
 ~> *NOTE:* The AWS Cost and Usage Report service is only available in `us-east-1` currently.
 
-~> *NOTE:* If AWS Organizations is enabled, only the master account can use this resource.
-
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
### Description
Updated Cost and Usage Report (CUR) documentation because it is available for the Linked accounts.

### References
https://aws.amazon.com/about-aws/whats-new/2020/12/cost-and-usage-report-now-available-to-member-linked-accounts/

