### PR TITLE
Doc : ACM certificate validation method optional

### DIFF
--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -143,7 +143,7 @@ The following arguments are supported:
 * Creating an Amazon issued certificate
     * `domain_name` - (Required) Domain name for which the certificate should be issued
     * `subject_alternative_names` - (Optional) Set of domains that should be SANs in the issued certificate. To remove all elements of a previously configured list, set this value equal to an empty list (`[]`) or use the [`terraform taint` command](https://www.terraform.io/docs/commands/taint.html) to trigger recreation.
-    * `validation_method` - (Required) Which method to use for validation. `DNS` or `EMAIL` are valid, `NONE` can be used for certificates that were imported into ACM and then into Terraform.
+    * `validation_method` - (Optional) Which method to use for validation. `DNS` or `EMAIL` are valid. This parameter must not be set for certificates that were imported into ACM and then into Terraform.
     * `key_algorithm` - (Optional) Specifies the algorithm of the public and private key pair that your Amazon issued certificate uses to encrypt data. See [ACM Certificate characteristics](https://docs.aws.amazon.com/acm/latest/userguide/acm-certificate.html#algorithms) for more details.
     * `options` - (Optional) Configuration block used to set certificate options. Detailed below.
     * `validation_option` - (Optional) Configuration block used to specify information about the initial validation of each domain name. Detailed below.


### PR DESCRIPTION
### Description

The documentation state that `validation_method` is required in `aws_acm_certificate` resource.
The only method currently validated by the API are `EMAIL` and `DNS`, so people can have issue following the doc recommendation.
As the `validation_method` is currently optional, remove it from the resource fix the issue.

### Relations

Closes #31425

### References

[My answer and test done here](https://github.com/hashicorp/terraform-provider-aws/issues/31425#issuecomment-1551960350)
