### PR TITLE
Fix schema type for vlan_id on aws_dx_connection

### DIFF
--- a/.changelog/31480.txt
+++ b/.changelog/31480.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+data-source/aws_dx_connection: Fix the `vlan_id` being returned as null
+```
+
+```release-note:bug
+resource/aws_dx_connection: Fix the `vlan_id` being returned as null
+```

--- a/internal/service/directconnect/connection.go
+++ b/internal/service/directconnect/connection.go
@@ -110,7 +110,7 @@ func ResourceConnection() *schema.Resource {
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vlan_id": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
 		},

--- a/internal/service/directconnect/connection_data_source.go
+++ b/internal/service/directconnect/connection_data_source.go
@@ -54,7 +54,7 @@ func DataSourceConnection() *schema.Resource {
 			},
 			"tags": tftags.TagsSchemaComputed(),
 			"vlan_id": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
 		},

--- a/internal/service/directconnect/connection_test.go
+++ b/internal/service/directconnect/connection_test.go
@@ -41,7 +41,7 @@ func TestAccDirectConnectConnection_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "partner_name", ""),
 					resource.TestCheckResourceAttr(resourceName, "provider_name", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "vlan_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "vlan_id", "0"),
 				),
 			},
 			// Test import.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes the schema type for vlan_id for aws_dx_connection so that null isn't returned.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29165
