### PR TITLE
r/aws_connect_hours_of_operation: Remove `hours_of_operation_arn`

### DIFF
--- a/.changelog/#####.txt
+++ b/.changelog/#####.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_connect_hours_of_operation: The `hours_of_operation_arn` attribute has been removed
+```

--- a/.changelog/#####.txt
+++ b/.changelog/#####.txt
@@ -1,3 +1,7 @@
 ```release-note:breaking-change
 resource/aws_connect_hours_of_operation: The `hours_of_operation_arn` attribute has been removed
 ```
+
+```release-note:breaking-change
+data-source/aws_connect_hours_of_operation: The `hours_of_operation_arn` attribute has been removed
+```

--- a/internal/service/connect/hours_of_operation.go
+++ b/internal/service/connect/hours_of_operation.go
@@ -28,10 +28,13 @@ func ResourceHoursOfOperation() *schema.Resource {
 		ReadWithoutTimeout:   resourceHoursOfOperationRead,
 		UpdateWithoutTimeout: resourceHoursOfOperationUpdate,
 		DeleteWithoutTimeout: resourceHoursOfOperationDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+
 		CustomizeDiff: verify.SetTagsDiff,
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
@@ -97,11 +100,6 @@ func ResourceHoursOfOperation() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(1, 250),
-			},
-			"hours_of_operation_arn": {
-				Type:       schema.TypeString,
-				Computed:   true,
-				Deprecated: "use 'arn' attribute instead",
 			},
 			"hours_of_operation_id": {
 				Type:     schema.TypeString,
@@ -193,7 +191,6 @@ func resourceHoursOfOperationRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	d.Set("arn", resp.HoursOfOperation.HoursOfOperationArn)
-	d.Set("hours_of_operation_arn", resp.HoursOfOperation.HoursOfOperationArn) // Deprecated
 	d.Set("hours_of_operation_id", resp.HoursOfOperation.HoursOfOperationId)
 	d.Set("instance_id", instanceID)
 	d.Set("description", resp.HoursOfOperation.Description)

--- a/internal/service/connect/hours_of_operation_data_source.go
+++ b/internal/service/connect/hours_of_operation_data_source.go
@@ -79,11 +79,6 @@ func DataSourceHoursOfOperation() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"hours_of_operation_arn": {
-				Type:       schema.TypeString,
-				Computed:   true,
-				Deprecated: "use 'arn' attribute instead",
-			},
 			"hours_of_operation_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -149,7 +144,6 @@ func dataSourceHoursOfOperationRead(ctx context.Context, d *schema.ResourceData,
 	hoursOfOperation := resp.HoursOfOperation
 
 	d.Set("arn", hoursOfOperation.HoursOfOperationArn)
-	d.Set("hours_of_operation_arn", hoursOfOperation.HoursOfOperationArn) // Deprecated
 	d.Set("hours_of_operation_id", hoursOfOperation.HoursOfOperationId)
 	d.Set("instance_id", instanceID)
 	d.Set("description", hoursOfOperation.Description)

--- a/internal/service/connect/hours_of_operation_data_source_test.go
+++ b/internal/service/connect/hours_of_operation_data_source_test.go
@@ -25,7 +25,6 @@ func testAccHoursOfOperationDataSource_hoursOfOperationID(t *testing.T) {
 				Config: testAccHoursOfOperationDataSourceConfig_id(rName, resourceName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
-					resource.TestCheckResourceAttrPair(datasourceName, "hours_of_operation_arn", resourceName, "hours_of_operation_arn"), // Deprecated
 					resource.TestCheckResourceAttrPair(datasourceName, "hours_of_operation_id", resourceName, "hours_of_operation_id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_id", resourceName, "instance_id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
@@ -55,7 +54,6 @@ func testAccHoursOfOperationDataSource_name(t *testing.T) {
 				Config: testAccHoursOfOperationDataSourceConfig_name(rName, rName2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
-					resource.TestCheckResourceAttrPair(datasourceName, "hours_of_operation_arn", resourceName, "hours_of_operation_arn"), // Deprecated
 					resource.TestCheckResourceAttrPair(datasourceName, "hours_of_operation_id", resourceName, "hours_of_operation_id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "instance_id", resourceName, "instance_id"),
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),

--- a/internal/service/connect/hours_of_operation_test.go
+++ b/internal/service/connect/hours_of_operation_test.go
@@ -48,7 +48,6 @@ func testAccHoursOfOperation_basic(t *testing.T) {
 						"start_time.0.minutes": "0",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "description", originalDescription),
-					resource.TestCheckResourceAttrSet(resourceName, "hours_of_operation_arn"), // Deprecated
 					resource.TestCheckResourceAttrSet(resourceName, "hours_of_operation_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "aws_connect_instance.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName2),
@@ -78,7 +77,6 @@ func testAccHoursOfOperation_basic(t *testing.T) {
 						"start_time.0.minutes": "0",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "description", updatedDescription),
-					resource.TestCheckResourceAttrSet(resourceName, "hours_of_operation_arn"), // Deprecated
 					resource.TestCheckResourceAttrSet(resourceName, "hours_of_operation_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "aws_connect_instance.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName2),

--- a/website/docs/d/connect_hours_of_operation.html.markdown
+++ b/website/docs/d/connect_hours_of_operation.html.markdown
@@ -47,7 +47,6 @@ In addition to all of the arguments above, the following attributes are exported
 * `arn` - ARN of the Hours of Operation.
 * `config` - Configuration information for the hours of operation: day, start time, and end time . Config blocks are documented below. Config blocks are documented below.
 * `description` - Description of the Hours of Operation.
-* `hours_of_operation_arn` - (**Deprecated**) ARN of the Hours of Operation.
 * `hours_of_operation_id` - The identifier for the hours of operation.
 * `instance_id` - Identifier of the hosting Amazon Connect Instance.
 * `name` - Name of the Hours of Operation.

--- a/website/docs/guides/version-5-upgrade.html.md
+++ b/website/docs/guides/version-5-upgrade.html.md
@@ -20,6 +20,7 @@ Upgrade topics:
 - [Provider Arguments](#provider-arguments)
 - [Default Tags](#default-tags)
 - [Data Source: aws_api_gateway_rest_api](#data-source-aws_api_gateway_rest_api)
+- [Data Source: aws_connect_hours_of_operation](#resource-aws_connect_hours_of_operation)
 - [Data Source: aws_identitystore_group](#data-source-aws_identitystore_group)
 - [Data Source: aws_identitystore_user](#data-source-aws_identitystore_user)
 - [Data Source: aws_redshift_service_account](#data-source-aws_redshift_service_account)
@@ -182,6 +183,10 @@ The `statement.rule_group_reference_statement.rule_action_override` attribute ha
 ## Data Source: aws_api_gateway_rest_api
 
 The `minimum_compression_size` attribute is now a String type, allowing it to be computed when set via the `body` attribute.
+
+## Data Source: aws_connect_hours_of_operation
+
+The `hours_of_operation_arn` attribute has been removed.
 
 ## Data Source: aws_identitystore_group
 

--- a/website/docs/guides/version-5-upgrade.html.md
+++ b/website/docs/guides/version-5-upgrade.html.md
@@ -30,6 +30,7 @@ Upgrade topics:
 - [Resource: aws_budgets_budget](#resource-aws_budgets_budget)
 - [Resource: aws_ce_anomaly_subscription](#resource-aws_ce_anomaly_subscription)
 - [Resource: aws_cloudwatch_event_target](#resource-aws_cloudwatch_event_target)
+- [Resource: aws_connect_hours_of_operation](#resource-aws_connect_hours_of_operation)
 - [Resource: aws_connect_queue](#resource-aws_connect_queue)
 - [Resource: aws_connect_routing_profile](#resource-aws_connect_routing_profile)
 - [Resource: aws_docdb_cluster](#resource-aws_docdb_cluster)
@@ -125,6 +126,10 @@ The `threshold` attribute has been removed.
 ## Resource: aws_cloudwatch_event_target
 
 The `ecs_target.propagate_tags` attribute now has no default value. If no value is specified, the tags are not propagated.
+
+## Resource: aws_connect_hours_of_operation
+
+The `hours_of_operation_arn` attribute has been removed.
 
 ## Resource: aws_connect_queue
 

--- a/website/docs/r/connect_hours_of_operation.html.markdown
+++ b/website/docs/r/connect_hours_of_operation.html.markdown
@@ -86,7 +86,6 @@ A `start_time` block supports the following arguments:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The Amazon Resource Name (ARN) of the Hours of Operation.
-* `hours_of_operation_arn` - (**Deprecated**) The Amazon Resource Name (ARN) of the Hours of Operation.
 * `hours_of_operation_id` - The identifier for the hours of operation.
 * `id` - The identifier of the hosting Amazon Connect Instance and identifier of the Hours of Operation separated by a colon (`:`).
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Removes the deprecated `hours_of_operation_arn` attribute.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/31391.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22375.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccConnect_serial/HoursOfOperation/basic$$' PKG=connect
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/connect/... -v -count 1 -parallel 20  -run=TestAccConnect_serial/HoursOfOperation/basic$ -timeout 180m
=== RUN   TestAccConnect_serial
=== PAUSE TestAccConnect_serial
=== CONT  TestAccConnect_serial
=== RUN   TestAccConnect_serial/HoursOfOperation
=== RUN   TestAccConnect_serial/HoursOfOperation/basic
--- PASS: TestAccConnect_serial (102.89s)
    --- PASS: TestAccConnect_serial/HoursOfOperation (102.89s)
        --- PASS: TestAccConnect_serial/HoursOfOperation/basic (102.89s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/connect	108.416s
```
