### PR TITLE
r/aws_quicksight_data_set: Ignore failure to read refresh properties for non-SPICE datasets

### DIFF
--- a/.changelog/31488.txt
+++ b/.changelog/31488.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_quicksight_data_set: Ignore failure to read refresh properties for non-SPICE datasets
+```

--- a/internal/service/quicksight/data_set.go
+++ b/internal/service/quicksight/data_set.go
@@ -995,7 +995,7 @@ func resourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta inter
 		DataSetId:    aws.String(dataSetId),
 	})
 
-	if err != nil && !tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
+	if err != nil && !(tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) || tfawserr.ErrMessageContains(err, quicksight.ErrCodeInvalidParameterValueException, "not a SPICE dataset")) {
 		return diag.Errorf("error describing refresh properties (%s): %s", d.Id(), err)
 	}
 


### PR DESCRIPTION
### Description

Ignore failure to read refresh properties for non-SPICE datasets.

### Relations

Fixes #31485
Related To: #30778
