### PR TITLE
r/aws_s3_bucket_object: Add deprecation message to schemas

### DIFF
--- a/internal/service/s3/bucket_object.go
+++ b/internal/service/s3/bucket_object.go
@@ -189,6 +189,8 @@ func ResourceBucketObject() *schema.Resource {
 				Optional: true,
 			},
 		},
+
+		DeprecationMessage: `use the aws_s3_object resource instead`,
 	}
 }
 

--- a/internal/service/s3/bucket_object_data_source.go
+++ b/internal/service/s3/bucket_object_data_source.go
@@ -130,6 +130,8 @@ func DataSourceBucketObject() *schema.Resource {
 
 			"tags": tftags.TagsSchemaComputed(),
 		},
+
+		DeprecationMessage: `use the aws_s3_object data source instead`,
 	}
 }
 

--- a/internal/service/s3/bucket_objects_data_source.go
+++ b/internal/service/s3/bucket_objects_data_source.go
@@ -67,6 +67,8 @@ func DataSourceBucketObjects() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
+
+		DeprecationMessage: `use the aws_s3_objects data source instead`,
 	}
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds `DeprecationMessage` to resource and data source schemas.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/29722.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/22877.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccS3BucketObject_empty$$\|TestAccS3BucketObjectDataSource_basic$$\|TestAccS3BucketObjectsDataSource_basic$$' PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20  -run=TestAccS3BucketObject_empty$\|TestAccS3BucketObjectDataSource_basic$\|TestAccS3BucketObjectsDataSource_basic$ -timeout 180m
=== RUN   TestAccS3BucketObjectDataSource_basic
=== PAUSE TestAccS3BucketObjectDataSource_basic
=== RUN   TestAccS3BucketObject_empty
=== PAUSE TestAccS3BucketObject_empty
=== RUN   TestAccS3BucketObjectsDataSource_basic
=== PAUSE TestAccS3BucketObjectsDataSource_basic
=== CONT  TestAccS3BucketObjectDataSource_basic
=== CONT  TestAccS3BucketObjectsDataSource_basic
=== CONT  TestAccS3BucketObject_empty
--- PASS: TestAccS3BucketObjectDataSource_basic (22.49s)
--- PASS: TestAccS3BucketObject_empty (24.27s)
--- PASS: TestAccS3BucketObjectsDataSource_basic (36.76s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	42.057s
```
