### PR TITLE
Add EBS Volumes as Target Resource for FIS experiment templates

### DIFF
--- a/.changelog/31499.txt
+++ b/.changelog/31499.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_fis_experiment_template: Add support for EBS Volumes to `actions.*.target`
+```

--- a/.changelog/31499.txt
+++ b/.changelog/31499.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_fis_experiment_template: Add support for EBS Volumes to `actions.*.target`
+resource/aws_fis_experiment_template: Add support for `Volumes` to `actions.*.target`
 ```

--- a/internal/service/fis/experiment_template.go
+++ b/internal/service/fis/experiment_template.go
@@ -810,6 +810,7 @@ func validExperimentTemplateActionTargetKey() schema.SchemaValidateFunc {
 		"Roles",
 		"SpotInstances",
 		"Subnets",
+		"Volumes",
 	}
 
 	return validation.All(

--- a/internal/service/fis/experiment_template_test.go
+++ b/internal/service/fis/experiment_template_test.go
@@ -265,6 +265,54 @@ func TestAccFISExperimentTemplate_eks(t *testing.T) {
 	})
 }
 
+func TestAccFISExperimentTemplate_ebs(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_fis_experiment_template.test"
+	var conf types.ExperimentTemplate
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, fis.ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckExperimentTemplateDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExperimentTemplateConfig_ebsVolume(rName, "EBS Volume Pause I/O Experiment", "ebs-paused-io-action", "EBS Volume Pause I/O", "aws:ebs:pause-volume-io", "Volumes", "ebs-volume-to-pause-io", "duration", "PT6M", "aws:ec2:ebs-volume", "ALL", "env", "test"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccExperimentTemplateExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "description", "EBS Volume Pause I/O Experiment"),
+					resource.TestCheckResourceAttrPair(resourceName, "role_arn", "aws_iam_role.test_fis", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "stop_condition.0.source", "none"),
+					resource.TestCheckResourceAttr(resourceName, "stop_condition.0.value", ""),
+					resource.TestCheckResourceAttr(resourceName, "stop_condition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "action.0.name", "ebs-paused-io-action"),
+					resource.TestCheckResourceAttr(resourceName, "action.0.description", "EBS Volume Pause I/O"),
+					resource.TestCheckResourceAttr(resourceName, "action.0.action_id", "aws:ebs:pause-volume-io"),
+					resource.TestCheckResourceAttr(resourceName, "action.0.parameter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "action.0.parameter.0.key", "duration"),
+					resource.TestCheckResourceAttr(resourceName, "action.0.parameter.0.value", "PT6M"),
+					resource.TestCheckResourceAttr(resourceName, "action.0.start_after.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "action.0.target.0.key", "Volumes"),
+					resource.TestCheckResourceAttr(resourceName, "action.0.target.0.value", "ebs-volume-to-pause-io"),
+					resource.TestCheckResourceAttr(resourceName, "action.0.target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "target.0.name", "ebs-volume-to-pause-io"),
+					resource.TestCheckResourceAttr(resourceName, "target.0.resource_type", "aws:ec2:ebs-volume"),
+					resource.TestCheckResourceAttr(resourceName, "target.0.selection_mode", "ALL"),
+					resource.TestCheckResourceAttr(resourceName, "target.0.filter.#", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, "target.0.resource_arns.0", "aws_ebs_volume.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "target.0.resource_tag.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "target.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccExperimentTemplateExists(ctx context.Context, resourceName string, config *types.ExperimentTemplate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -573,4 +621,77 @@ resource "aws_fis_experiment_template" "test" {
   }
 }
 `, rName+"-fis", desc, actionName, actionDesc, actionID, actionTargetK, actionTargetV, paramK1, paramV1, paramK2, paramV2, paramK3, paramV3, paramK4, paramV4, paramK5, paramV5, targetResType, targetSelectMode, targetResTagK, targetResTagV))
+}
+
+func testAccExperimentTemplateConfig_baseEbsVolume(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_ebs_volume" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  size              = 40
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccExperimentTemplateConfig_ebsVolume(rName, desc, actionName, actionDesc, actionID, actionTargetK, actionTargetV, paramK1, paramV1, targetResType, targetSelectMode, targetResTagK, targetResTagV string) string {
+	return acctest.ConfigCompose(testAccExperimentTemplateConfig_baseEbsVolume(rName), fmt.Sprintf(`
+resource "aws_iam_role" "test_fis" {
+  name = %[1]q
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = [
+          "fis.${data.aws_partition.current.dns_suffix}",
+        ]
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_fis_experiment_template" "test" {
+  description = %[2]q
+  role_arn    = aws_iam_role.test_fis.arn
+
+  stop_condition {
+    source = "none"
+  }
+
+  action {
+    name        = %[3]q
+    description = %[4]q
+    action_id   = %[5]q
+
+    target {
+      key   = %[6]q
+      value = %[7]q
+    }
+
+    parameter {
+      key   = %[8]q
+      value = %[9]q
+    }
+  }
+
+  target {
+    name           = %[7]q
+    resource_type  = %[10]q
+    selection_mode = %[11]q
+
+    resource_arns = tolist([aws_ebs_volume.test.arn])
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName+"-fis", desc, actionName, actionDesc, actionID, actionTargetK, actionTargetV, paramK1, paramV1, targetResType, targetSelectMode, targetResTagK, targetResTagV))
 }

--- a/internal/service/fis/experiment_template_test.go
+++ b/internal/service/fis/experiment_template_test.go
@@ -623,7 +623,7 @@ resource "aws_fis_experiment_template" "test" {
 `, rName+"-fis", desc, actionName, actionDesc, actionID, actionTargetK, actionTargetV, paramK1, paramV1, paramK2, paramV2, paramK3, paramV3, paramK4, paramV4, paramK5, paramV5, targetResType, targetSelectMode, targetResTagK, targetResTagV))
 }
 
-func testAccExperimentTemplateConfig_baseEbsVolume(rName string) string {
+func testAccExperimentTemplateConfig_baseEBSVolume(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -639,7 +639,7 @@ resource "aws_ebs_volume" "test" {
 }
 
 func testAccExperimentTemplateConfig_ebsVolume(rName, desc, actionName, actionDesc, actionID, actionTargetK, actionTargetV, paramK1, paramV1, targetResType, targetSelectMode, targetResTagK, targetResTagV string) string {
-	return acctest.ConfigCompose(testAccExperimentTemplateConfig_baseEbsVolume(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccExperimentTemplateConfig_baseEBSVolume(rName), fmt.Sprintf(`
 resource "aws_iam_role" "test_fis" {
   name = %[1]q
 

--- a/website/docs/r/fis_experiment_template.html.markdown
+++ b/website/docs/r/fis_experiment_template.html.markdown
@@ -80,7 +80,7 @@ For a list of parameters supported by each action, see [AWS FIS actions referenc
 
 #### `target` (`action.*.target`)
 
-* `key` - (Required) Target type. Valid values are `Cluster` (EKS Cluster), `Clusters` (ECS Clusters), `DBInstances` (RDS DB Instances), `Instances` (EC2 Instances), `Nodegroups` (EKS Node groups), `Roles` (IAM Roles), `SpotInstances` (EC2 Spot Instances), `Subnets` (VPC Subnets).
+* `key` - (Required) Target type. Valid values are `Cluster` (EKS Cluster), `Clusters` (ECS Clusters), `DBInstances` (RDS DB Instances), `Instances` (EC2 Instances), `Nodegroups` (EKS Node groups), `Roles` (IAM Roles), `SpotInstances` (EC2 Spot Instances), `Subnets` (VPC Subnets), `Volumes` (EBS Volumes).
 * `value` - (Required) Target name, referencing a corresponding target.
 
 ### `stop_condition`


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Adds EBS volumes as a target resource type for FIS experiment templates.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31470 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/fis/latest/userguide/fis-actions-reference.html#ebs-actions-reference

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccFISExperimentTemplate_ebs  PKG=fis                 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/fis/... -v -count 1 -parallel 20 -run='TestAccFISExperimentTemplate_ebs'  -timeout 180m
=== RUN   TestAccFISExperimentTemplate_ebs
=== PAUSE TestAccFISExperimentTemplate_ebs
=== CONT  TestAccFISExperimentTemplate_ebs
--- PASS: TestAccFISExperimentTemplate_ebs (39.79s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fis        43.594s
...
```
