### PR TITLE
Fix crash when removing all tags for resources with no `identifierAttribute` declared

### DIFF
--- a/internal/provider/intercept.go
+++ b/internal/provider/intercept.go
@@ -359,7 +359,7 @@ func (r tagsInterceptor) run(ctx context.Context, d schemaResourceData, meta any
 	case Finally:
 		switch why {
 		case Update:
-			if !d.GetRawPlan().GetAttr(names.AttrTagsAll).IsWhollyKnown() {
+			if r.tags.IdentifierAttribute != "" && !d.GetRawPlan().GetAttr(names.AttrTagsAll).IsWhollyKnown() {
 				ctx, diags = r.updateFunc(ctx, d, sp, r.tags, serviceName, resourceName, meta, diags)
 				ctx, diags = r.readFunc(ctx, d, sp, r.tags, serviceName, resourceName, meta, diags)
 			}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes the case of a resource having no `identifierAttribute` declared in its `@Tags` annotation and all existing tags are being removed. This was causing a provider crash.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/31498.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccCloudFormationStackSet_tags' PKG=cloudformation
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cloudformation/... -v -count 1 -parallel 20  -run=TestAccCloudFormationStackSet_tags -timeout 180m
=== RUN   TestAccCloudFormationStackSet_tags
=== PAUSE TestAccCloudFormationStackSet_tags
=== CONT  TestAccCloudFormationStackSet_tags
--- PASS: TestAccCloudFormationStackSet_tags (82.95s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation	89.327s
```
```console
% go test -v ./internal/provider
=== RUN   TestInterceptorsWhy
=== PAUSE TestInterceptorsWhy
=== RUN   TestInterceptedHandler
=== PAUSE TestInterceptedHandler
=== RUN   TestProvider
=== PAUSE TestProvider
=== RUN   TestExpandEndpoints
--- PASS: TestExpandEndpoints (0.00s)
=== RUN   TestEndpointMultipleKeys
--- PASS: TestEndpointMultipleKeys (0.00s)
=== RUN   TestEndpointEnvVarPrecedence
2023/05/19 15:01:14 [WARN] The environment variable "AWS_STS_ENDPOINT" is deprecated. Use "TF_AWS_STS_ENDPOINT" instead.
--- PASS: TestEndpointEnvVarPrecedence (0.01s)
=== RUN   TestTagsInterceptor
=== PAUSE TestTagsInterceptor
=== RUN   TestValidAssumeRoleDuration
=== PAUSE TestValidAssumeRoleDuration
=== RUN   TestAccProvider_DefaultTags_emptyBlock
=== PAUSE TestAccProvider_DefaultTags_emptyBlock
=== RUN   TestAccProvider_DefaultTagsTags_none
=== PAUSE TestAccProvider_DefaultTagsTags_none
=== RUN   TestAccProvider_DefaultTagsTags_one
=== PAUSE TestAccProvider_DefaultTagsTags_one
=== RUN   TestAccProvider_DefaultTagsTags_multiple
=== PAUSE TestAccProvider_DefaultTagsTags_multiple
=== RUN   TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
=== PAUSE TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
=== RUN   TestAccProvider_endpoints
=== PAUSE TestAccProvider_endpoints
=== RUN   TestAccProvider_fipsEndpoint
=== PAUSE TestAccProvider_fipsEndpoint
=== RUN   TestAccProvider_unusualEndpoints
=== PAUSE TestAccProvider_unusualEndpoints
=== RUN   TestAccProvider_IgnoreTags_emptyBlock
=== PAUSE TestAccProvider_IgnoreTags_emptyBlock
=== RUN   TestAccProvider_IgnoreTagsKeyPrefixes_none
=== PAUSE TestAccProvider_IgnoreTagsKeyPrefixes_none
=== RUN   TestAccProvider_IgnoreTagsKeyPrefixes_one
=== PAUSE TestAccProvider_IgnoreTagsKeyPrefixes_one
=== RUN   TestAccProvider_IgnoreTagsKeyPrefixes_multiple
=== PAUSE TestAccProvider_IgnoreTagsKeyPrefixes_multiple
=== RUN   TestAccProvider_IgnoreTagsKeys_none
=== PAUSE TestAccProvider_IgnoreTagsKeys_none
=== RUN   TestAccProvider_IgnoreTagsKeys_one
=== PAUSE TestAccProvider_IgnoreTagsKeys_one
=== RUN   TestAccProvider_IgnoreTagsKeys_multiple
=== PAUSE TestAccProvider_IgnoreTagsKeys_multiple
=== RUN   TestAccProvider_Region_c2s
=== PAUSE TestAccProvider_Region_c2s
=== RUN   TestAccProvider_Region_china
=== PAUSE TestAccProvider_Region_china
=== RUN   TestAccProvider_Region_commercial
=== PAUSE TestAccProvider_Region_commercial
=== RUN   TestAccProvider_Region_govCloud
=== PAUSE TestAccProvider_Region_govCloud
=== RUN   TestAccProvider_Region_sc2s
=== PAUSE TestAccProvider_Region_sc2s
=== RUN   TestAccProvider_Region_stsRegion
=== PAUSE TestAccProvider_Region_stsRegion
=== RUN   TestAccProvider_AssumeRole_empty
=== PAUSE TestAccProvider_AssumeRole_empty
=== CONT  TestInterceptorsWhy
--- PASS: TestInterceptorsWhy (0.00s)
=== CONT  TestAccProvider_IgnoreTags_emptyBlock
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_none
=== CONT  TestAccProvider_DefaultTagsTags_one
=== CONT  TestAccProvider_endpoints
=== CONT  TestAccProvider_IgnoreTags_emptyBlock
    provider_acc_test.go:210: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccProvider_IgnoreTags_emptyBlock (0.17s)
=== CONT  TestAccProvider_AssumeRole_empty
=== CONT  TestTagsInterceptor
=== CONT  TestAccProvider_endpoints
    provider_acc_test.go:138: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccProvider_endpoints (0.20s)
=== CONT  TestProvider
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_none
    provider_acc_test.go:231: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccProvider_IgnoreTagsKeyPrefixes_none (0.23s)
=== CONT  TestAccProvider_Region_sc2s
=== CONT  TestInterceptedHandler
=== CONT  TestValidAssumeRoleDuration
=== CONT  TestAccProvider_IgnoreTagsKeys_multiple
=== CONT  TestAccProvider_Region_govCloud
=== CONT  TestAccProvider_DefaultTagsTags_one
    provider_acc_test.go:67: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_Region_govCloud
    provider_acc_test.go:420: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_IgnoreTagsKeys_one
=== CONT  TestAccProvider_Region_commercial
=== CONT  TestAccProvider_IgnoreTagsKeys_one
    provider_acc_test.go:311: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_Region_stsRegion
=== CONT  TestAccProvider_Region_china
    provider_acc_test.go:374: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_IgnoreTagsKeys_none
=== CONT  TestAccProvider_Region_commercial
    provider_acc_test.go:397: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_Region_c2s
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_multiple
=== CONT  TestAccProvider_Region_stsRegion
    provider_acc_test.go:466: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_DefaultTagsTags_none
=== CONT  TestAccProvider_Region_c2s
    provider_acc_test.go:351: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_multiple
    provider_acc_test.go:271: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_unusualEndpoints
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_one
=== CONT  TestAccProvider_Region_sc2s
    provider_acc_test.go:443: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_unusualEndpoints
    provider_acc_test.go:188: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_fipsEndpoint
--- PASS: TestTagsInterceptor (0.00s)
=== CONT  TestAccProvider_DefaultTagsTags_multiple
=== CONT  TestAccProvider_DefaultTagsTags_none
    provider_acc_test.go:47: Acceptance tests skipped unless env 'TF_ACC' set
--- PASS: TestInterceptedHandler (0.00s)
=== CONT  TestAccProvider_IgnoreTagsKeys_multiple
    provider_acc_test.go:331: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_DefaultTagsTags_multiple
    provider_acc_test.go:87: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_AssumeRole_empty
    provider_acc_test.go:486: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_IgnoreTagsKeys_none
    provider_acc_test.go:291: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_fipsEndpoint
    provider_acc_test.go:159: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_IgnoreTagsKeyPrefixes_one
    provider_acc_test.go:251: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccProvider_DefaultTagsTags_none (0.24s)
--- SKIP: TestAccProvider_Region_govCloud (0.16s)
=== CONT  TestAccProvider_DefaultTags_emptyBlock
--- SKIP: TestAccProvider_DefaultTagsTags_one (0.21s)
--- SKIP: TestAccProvider_IgnoreTagsKeys_one (0.18s)
--- SKIP: TestAccProvider_Region_china (0.14s)
=== CONT  TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
--- SKIP: TestAccProvider_Region_commercial (0.12s)
--- PASS: TestValidAssumeRoleDuration (0.00s)
--- SKIP: TestAccProvider_Region_stsRegion (0.17s)
--- SKIP: TestAccProvider_Region_c2s (0.25s)
--- SKIP: TestAccProvider_IgnoreTagsKeyPrefixes_multiple (0.16s)
--- SKIP: TestAccProvider_Region_sc2s (0.18s)
--- SKIP: TestAccProvider_unusualEndpoints (0.16s)
--- SKIP: TestAccProvider_IgnoreTagsKeys_multiple (0.18s)
--- SKIP: TestAccProvider_DefaultTagsTags_multiple (0.19s)
--- SKIP: TestAccProvider_AssumeRole_empty (0.00s)
--- SKIP: TestAccProvider_fipsEndpoint (0.00s)
--- SKIP: TestAccProvider_IgnoreTagsKeys_none (0.18s)
--- SKIP: TestAccProvider_IgnoreTagsKeyPrefixes_one (0.16s)
=== CONT  TestAccProvider_DefaultTags_emptyBlock
    provider_acc_test.go:27: Acceptance tests skipped unless env 'TF_ACC' set
=== CONT  TestAccProvider_DefaultAndIgnoreTags_emptyBlocks
    provider_acc_test.go:110: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccProvider_DefaultTags_emptyBlock (0.22s)
--- SKIP: TestAccProvider_DefaultAndIgnoreTags_emptyBlocks (0.18s)
--- PASS: TestProvider (0.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/provider	9.415s
```
