### PR TITLE
Suppress `golangci-lint` `s3Config.DisableRestProtocolURICleaning is deprecated` warning

### DIFF
--- a/.ci/.golangci2.yml
+++ b/.ci/.golangci2.yml
@@ -33,6 +33,10 @@ issues:
     - linters:
         - staticcheck
       text: "SA1019: strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0"
+    - linters:
+        - staticcheck
+      path: internal/conns/
+      text: "SA1019: s3Config.DisableRestProtocolURICleaning is deprecated"
     # Per-Service
     - linters:
         - staticcheck


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Suppresses https://github.com/hashicorp/terraform-provider-aws/actions/runs/5021709902/jobs/9004392130?pr=31474

```
  Running [/home/runner/golangci-lint-1.52.2-linux-amd64/golangci-lint run --out-format=github-actions --config .ci/.golangci2.yml] in [] ...
  Error: SA1019: s3Config.DisableRestProtocolURICleaning is deprecated: This setting no longer has any effect. RESTful paths are no longer cleaned after request serialization.  (staticcheck)
  
  Error: issues found
  Ran golangci-lint in 557396ms
```

until https://github.com/hashicorp/terraform-provider-aws/issues/31501 is addressed.