### PR TITLE
[Enhancement]: aws_ssm_document support for requires attribute

### DIFF
--- a/internal/service/ssm/document.go
+++ b/internal/service/ssm/document.go
@@ -111,6 +111,11 @@ func ResourceDocument() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"force_destroy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"hash": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -171,6 +176,34 @@ func ResourceDocument() *schema.Resource {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"requires": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.:/]{3,128}$`), "must be a valid document name"),
+						},
+						"require_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(ssm.DocumentType_Values(), false),
+						},
+						"version": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[1-9][0-9]*$|[$]LATEST|[$]DEFAULT`), "must be numeric, '$LATEST', or '$DEFAULT'"),
+						},
+						"version_name": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]{1,128}$`), "must be a valid version name"),
+						},
+					},
+				},
 			},
 			"schema_version": {
 				Type:     schema.TypeString,
@@ -260,6 +293,10 @@ func resourceDocumentCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	if v, ok := d.GetOk("attachments_source"); ok && len(v.([]interface{})) > 0 {
 		input.Attachments = expandAttachmentsSources(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("requires"); ok && len(v.([]interface{})) > 0 {
+		input.Requires = expandDocumentRequiresList(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("target_type"); ok {
@@ -387,6 +424,12 @@ func resourceDocumentRead(ctx context.Context, d *schema.ResourceData, meta inte
 		} else {
 			d.Set("permissions", nil)
 		}
+	}
+
+	if v, ok := d.GetOk("force_destroy"); ok {
+		d.Set("force_destroy", v.(bool))
+	} else {
+		d.Set("force_destroy", false)
 	}
 
 	SetTagsOut(ctx, doc.Tags)
@@ -528,9 +571,16 @@ func resourceDocumentDelete(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	log.Printf("[INFO] Deleting SSM Document: %s", d.Id())
-	_, err := conn.DeleteDocumentWithContext(ctx, &ssm.DeleteDocumentInput{
+
+	input := &ssm.DeleteDocumentInput{
 		Name: aws.String(d.Get("name").(string)),
-	})
+	}
+
+	if v, ok := d.GetOk("force_destroy"); ok {
+		input.Force = aws.Bool(v.(bool))
+	}
+
+	_, err := conn.DeleteDocumentWithContext(ctx, input)
 
 	if tfawserr.ErrMessageContains(err, ssm.ErrCodeInvalidDocument, "does not exist") {
 		return diags
@@ -722,4 +772,56 @@ func flattenDocumentParameters(apiObjects []*ssm.DocumentParameter) []interface{
 	}
 
 	return tfList
+}
+
+func expandDocumentRequiresList(tfList []interface{}) []*ssm.DocumentRequires {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var requiredDocuments []*ssm.DocumentRequires
+
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]interface{})
+
+		if !ok {
+			continue
+		}
+
+		requiredDocument := expandDocumentRequires(tfMap)
+
+		if requiredDocument == nil {
+			continue
+		}
+
+		requiredDocuments = append(requiredDocuments, requiredDocument)
+	}
+
+	return requiredDocuments
+}
+
+func expandDocumentRequires(tfMap map[string]interface{}) *ssm.DocumentRequires {
+	if tfMap == nil {
+		return nil
+	}
+
+	documentRequires := &ssm.DocumentRequires{}
+
+	if v, ok := tfMap["name"].(string); ok && v != "" {
+		documentRequires.Name = aws.String(v)
+	}
+
+	if v, ok := tfMap["require_type"].(string); ok && v != "" {
+		documentRequires.RequireType = aws.String(v)
+	}
+
+	if v, ok := tfMap["version"].(string); ok && v != "" {
+		documentRequires.Version = aws.String(v)
+	}
+
+	if v, ok := tfMap["version_name"].(string); ok && v != "" {
+		documentRequires.VersionName = aws.String(v)
+	}
+
+	return documentRequires
 }

--- a/internal/service/ssm/document_test.go
+++ b/internal/service/ssm/document_test.go
@@ -589,6 +589,56 @@ func TestAccSSMDocument_tags(t *testing.T) {
 	})
 }
 
+func TestAccSSMDocument_appConfigDocumentWithSchema(t *testing.T) {
+	ctx := acctest.Context(t)
+	schemaResourceName := "aws_ssm_document.test_schema"
+	configResourceName := "aws_ssm_document.test"
+	schemaName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	configName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ssm.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDocumentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDocumentConfig_appConfigSchema(schemaName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocumentExists(ctx, schemaResourceName),
+					resource.TestCheckResourceAttr(schemaResourceName, "name", schemaName),
+					resource.TestCheckResourceAttr(schemaResourceName, "document_version", "1"),
+					resource.TestCheckResourceAttr(schemaResourceName, "document_type", "ApplicationConfigurationSchema"),
+					resource.TestCheckResourceAttr(schemaResourceName, "force_destroy", "true"),
+				),
+				Destroy: false,
+			},
+			{
+				ResourceName:            schemaResourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			{
+				Config: testAccDocumentConfig_appConfig(configName, schemaName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocumentExists(ctx, configResourceName),
+					resource.TestCheckResourceAttr(configResourceName, "name", configName),
+					resource.TestCheckResourceAttr(configResourceName, "document_version", "1"),
+					resource.TestCheckResourceAttr(configResourceName, "document_type", "ApplicationConfiguration"),
+					resource.TestCheckResourceAttr(configResourceName, "requires.#", "1"),
+				),
+			},
+			{
+				ResourceName:            configResourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"requires.#", "requires.0"},
+			},
+		},
+	})
+}
+
 func TestAccSSMDocument_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -1314,4 +1364,75 @@ DOC
   }
 }
 `, rName, key1, value1, key2, value2)
+}
+
+func testAccDocumentConfig_appConfigSchema(schemaName string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_document" "test_schema" {
+  name          = %[1]q
+  document_type = "ApplicationConfigurationSchema"
+  force_destroy = true
+
+  content = <<DOC
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Example Schema",
+  "type": "object",
+  "required": [
+	"requiredProp"
+  ],
+  "properties": {
+	"requiredProp": {
+      "type": "boolean",
+	  "description": "Example boolean prop that is required."
+	},
+	"optionalStringProp": {
+	  "type": "string",
+	  "description": "Example string property that is optional."
+	},
+	"optionalObjectProp": {
+	  "type": "object",
+      "required": [
+        "subProp"
+      ],
+      "properties": {
+        "subProp": {
+          "type": "string",
+          "pattern": "present|absent",
+          "description": "A required property inside an optional object."
+        },
+        "subProp2": {
+          "type": "string",
+          "description": "An optional property inside an optional object."
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}
+DOC
+}
+`, schemaName)
+}
+
+func testAccDocumentConfig_appConfig(configName, schemaName string) string {
+	return fmt.Sprintf(`
+
+resource "aws_ssm_document" "test" {
+  name          = %[1]q
+  document_type = "ApplicationConfiguration"
+
+  requires {
+	name = %[2]q
+    version = "$LATEST"
+  }
+
+  content = <<DOC
+{
+  "requiredProp": true,
+  "optionalObjectProp": {"subProp": "present"}
+}
+DOC
+}
+`, configName, schemaName)
 }

--- a/website/docs/r/ssm_document.html.markdown
+++ b/website/docs/r/ssm_document.html.markdown
@@ -74,8 +74,9 @@ The following arguments are supported:
 * `attachments_source` - (Optional) One or more configuration blocks describing attachments sources to a version of a document. Defined below.
 * `content` - (Required) The JSON or YAML content of the document.
 * `document_format` - (Optional, defaults to JSON) The format of the document. Valid document types include: `JSON` and `YAML`
-* `document_type` - (Required) The type of the document. Valid document types include: `Automation`, `Command`, `Package`, `Policy`, and `Session`
+* `document_type` - (Required) The type of the document. Valid document types include: `ApplicationConfiguration`, `ApplicationConfigurationSchema`, `Automation`, `Command`, `Package`, `Policy`, and `Session`
 * `permissions` - (Optional) Additional Permissions to attach to the document. See [Permissions](#permissions) below for details.
+* `requires` - (Optional) A list of SSM documents required by a document. See [Requires](#requires) below for details.
 * `target_type` - (Optional) The target type which defines the kinds of resources the document can run on. For example, /AWS::EC2::Instance. For a list of valid resource types, see AWS Resource Types Reference (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html)
 * `tags` - (Optional) A map of tags to assign to the object. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `version_name` - (Optional) A field specifying the version of the artifact you are creating with the document. For example, "Release 12, Update 6". This value is unique across all versions of a document and cannot be changed for an existing document version.
@@ -119,6 +120,17 @@ The permissions mapping supports the following:
 
 * `type` - The permission type for the document. The permission type can be `Share`.
 * `account_ids` - The AWS user accounts that should have access to the document. The account IDs can either be a group of account IDs or `All`.
+
+## Requires
+
+This parameter is used exclusively by AWS AppConfig. When a user creates an AWS AppConfig configuration in an SSM document, the user must also specify a required document for validation purposes. In this case, an `ApplicationConfiguration` document requires an `ApplicationConfigurationSchema` document for validation purposes.
+
+The `requires` block supports the following:
+
+* `name` - (Required) The name of the required SSM document. The name can be an Amazon Resource Name (ARN).
+* `require_type` - (Optional) The document type of the required SSM document.
+* `version` - (Optional) The document version required by the current document.
+* `version_name` - (Optional) An optional field specifying the version of the artifact associated with the document. For example, "Release 12, Update 6". This value is unique across all versions of a document, and can't be changed.
 
 ## Import
 


### PR DESCRIPTION
### Description

The `aws_ssm_document` resource lacks support for the `requires` argument. This argument is necessary to be able to create `ApplicationConfiguration` document types with terraform.

This PR implements support for the `requires` argument.

### Relations

Closes #31505

### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccSSMDocument_appConfigDocumentWithSchema PKG=ssm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMDocument_appConfigDocumentWithSchema'  -timeout 180m
=== RUN   TestAccSSMDocument_appConfigDocumentWithSchema
=== PAUSE TestAccSSMDocument_appConfigDocumentWithSchema
=== CONT  TestAccSSMDocument_appConfigDocumentWithSchema
--- PASS: TestAccSSMDocument_appConfigDocumentWithSchema (23.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	25.396s
```
