### PR TITLE
[WIP] Proposal to modify provider `meta` to enable specifying the `region` at each resource

### DIFF
--- a/internal/conns/providermeta.go
+++ b/internal/conns/providermeta.go
@@ -1,0 +1,14 @@
+package conns
+
+import tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+
+type ProviderMeta struct {
+	AccountID         string
+	AllowedRegions    []string
+	AWSClients        map[string]*AWSClient
+	DefaultTagsConfig *tftags.DefaultConfig
+	IgnoreTagsConfig  *tftags.IgnoreConfig
+	Partition         string
+	Region            string
+	ServicePackages   map[string]ServicePackage
+}

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -48,6 +48,10 @@ func (p *fwprovider) Schema(ctx context.Context, req provider.SchemaRequest, res
 				ElementType: types.StringType,
 				Optional:    true,
 			},
+			"allowed_regions": schema.SetAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
 			"custom_ca_bundle": schema.StringAttribute{
 				Optional:    true,
 				Description: "File containing custom root and intermediate certificates. Can also be configured using the `AWS_CA_BUNDLE` environment variable. (Setting `ca_bundle` in the shared config file is not supported.)",
@@ -280,7 +284,7 @@ func (p *fwprovider) Configure(ctx context.Context, request provider.ConfigureRe
 func (p *fwprovider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	var dataSources []func() datasource.DataSource
 
-	for n, sp := range p.Primary.Meta().(*conns.AWSClient).ServicePackages {
+	for n, sp := range p.Primary.Meta().(*conns.ProviderMeta).ServicePackages {
 		servicePackageName := sp.ServicePackageName()
 
 		for _, v := range sp.FrameworkDataSources(ctx) {
@@ -324,7 +328,7 @@ func (p *fwprovider) Resources(ctx context.Context) []func() resource.Resource {
 	var errs *multierror.Error
 	var resources []func() resource.Resource
 
-	for _, sp := range p.Primary.Meta().(*conns.AWSClient).ServicePackages {
+	for _, sp := range p.Primary.Meta().(*conns.ProviderMeta).ServicePackages {
 		servicePackageName := sp.ServicePackageName()
 
 		for _, v := range sp.FrameworkResources(ctx) {

--- a/internal/provider/intercept.go
+++ b/internal/provider/intercept.go
@@ -209,7 +209,7 @@ func (r tagsInterceptor) run(ctx context.Context, d schemaResourceData, meta any
 		return ctx, diags
 	}
 
-	sp, ok := meta.(*conns.AWSClient).ServicePackages[inContext.ServicePackageName]
+	sp, ok := meta.(*conns.ProviderMeta).ServicePackages[inContext.ServicePackageName]
 	if !ok {
 		return ctx, diags
 	}
@@ -273,7 +273,7 @@ func (r tagsInterceptor) run(ctx context.Context, d schemaResourceData, meta any
 							}
 
 							// ISO partitions may not support tagging, giving error.
-							if errs.IsUnsupportedOperationInPartitionError(meta.(*conns.AWSClient).Partition, err) {
+							if errs.IsUnsupportedOperationInPartitionError(meta.(*conns.ProviderMeta).Partition, err) {
 								return ctx, diags
 							}
 
@@ -325,7 +325,7 @@ func (r tagsInterceptor) run(ctx context.Context, d schemaResourceData, meta any
 						}
 
 						// ISO partitions may not support tagging, giving error.
-						if errs.IsUnsupportedOperationInPartitionError(meta.(*conns.AWSClient).Partition, err) {
+						if errs.IsUnsupportedOperationInPartitionError(meta.(*conns.ProviderMeta).Partition, err) {
 							return ctx, diags
 						}
 

--- a/internal/provider/intercept.go
+++ b/internal/provider/intercept.go
@@ -20,6 +20,7 @@ import (
 // schemaResourceData is an interface that implements functions from schema.ResourceData
 type schemaResourceData interface {
 	Get(key string) any
+	GetOk(key string) (interface{}, bool)
 	GetChange(key string) (any, any)
 	GetRawConfig() cty.Value
 	GetRawPlan() cty.Value
@@ -244,6 +245,12 @@ func (r tagsInterceptor) run(ctx context.Context, d schemaResourceData, meta any
 				break
 			}
 
+			var region string
+			if v, ok := d.GetOk("region"); ok {
+				region = v.(string)
+			} else {
+				region = meta.(*conns.ProviderMeta).Region
+			}
 			if d.GetRawPlan().GetAttr("tags_all").IsWhollyKnown() {
 				if d.HasChange(names.AttrTagsAll) {
 					if identifierAttribute := r.tags.IdentifierAttribute; identifierAttribute != "" {
@@ -265,11 +272,11 @@ func (r tagsInterceptor) run(ctx context.Context, d schemaResourceData, meta any
 							if v, ok := sp.(interface {
 								UpdateTags(context.Context, any, string, any, any) error
 							}); ok {
-								err = v.UpdateTags(ctx, meta, identifier, o, n)
+								err = v.UpdateTags(ctx, meta.(*conns.ProviderMeta).AWSClients[region], identifier, o, n)
 							} else if v, ok := sp.(interface {
 								UpdateTags(context.Context, any, string, string, any, any) error
 							}); ok && r.tags.ResourceType != "" {
-								err = v.UpdateTags(ctx, meta, identifier, r.tags.ResourceType, o, n)
+								err = v.UpdateTags(ctx, meta.(*conns.ProviderMeta).AWSClients[region], identifier, r.tags.ResourceType, o, n)
 							}
 
 							// ISO partitions may not support tagging, giving error.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -8,7 +8,9 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	awsbase "github.com/hashicorp/aws-sdk-go-base/v2"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -42,6 +44,12 @@ func New(ctx context.Context) (*schema.Provider, error) {
 				Optional:      true,
 				ConflictsWith: []string{"forbidden_account_ids"},
 				Set:           schema.HashString,
+			},
+			"allowed_regions": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				Set:      schema.HashString,
 			},
 			"assume_role":                   assumeRoleSchema(),
 			"assume_role_with_web_identity": assumeRoleWithWebIdentitySchema(),
@@ -390,20 +398,29 @@ func New(ctx context.Context) (*schema.Provider, error) {
 	// Set the provider Meta (instance data) here.
 	// It will be overwritten by the result of the call to ConfigureContextFunc,
 	// but can be used pre-configuration by other (non-primary) provider servers.
-	var meta *conns.AWSClient
-	if v, ok := provider.Meta().(*conns.AWSClient); ok {
-		meta = v
+	// var meta *conns.AWSClient
+	// if v, ok := provider.Meta().(*conns.AWSClient); ok {
+	// 	meta = v
+	// } else {
+	// 	meta = new(conns.AWSClient)
+	// }
+	// meta.ServicePackages = servicePackageMap
+	// provider.SetMeta(meta)
+
+	var providerMeta *conns.ProviderMeta
+	if v, ok := provider.Meta().(*conns.ProviderMeta); ok {
+		providerMeta = v
 	} else {
-		meta = new(conns.AWSClient)
+		providerMeta = new(conns.ProviderMeta)
 	}
-	meta.ServicePackages = servicePackageMap
-	provider.SetMeta(meta)
+	providerMeta.ServicePackages = servicePackageMap
+	provider.SetMeta(providerMeta)
 
 	return provider, nil
 }
 
 // configure ensures that the provider is fully configured.
-func configure(ctx context.Context, provider *schema.Provider, d *schema.ResourceData) (*conns.AWSClient, diag.Diagnostics) {
+func configure(ctx context.Context, provider *schema.Provider, d *schema.ResourceData) (*conns.ProviderMeta, diag.Diagnostics) {
 	terraformVersion := provider.TerraformVersion
 	if terraformVersion == "" {
 		// Terraform 0.12 introduced this field to the protocol
@@ -498,19 +515,73 @@ func configure(ctx context.Context, provider *schema.Provider, d *schema.Resourc
 		}
 	}
 
-	var meta *conns.AWSClient
-	if v, ok := provider.Meta().(*conns.AWSClient); ok {
-		meta = v
+	// var meta *conns.AWSClient
+	// if v, ok := provider.Meta().(*conns.AWSClient); ok {
+	// 	meta = v
+	// } else {
+	// 	meta = new(conns.AWSClient)
+	// }
+
+	var providerMeta *conns.ProviderMeta
+	if v, ok := provider.Meta().(*conns.ProviderMeta); ok {
+		providerMeta = v
 	} else {
-		meta = new(conns.AWSClient)
-	}
-	meta, diags := config.ConfigureProvider(ctx, meta)
-
-	if diags.HasError() {
-		return nil, diags
+		providerMeta = new(conns.ProviderMeta)
 	}
 
-	return meta, diags
+	providerMeta.DefaultTagsConfig = config.DefaultTagsConfig
+	providerMeta.IgnoreTagsConfig = config.IgnoreTagsConfig
+
+	var diags diag.Diagnostics
+	// awsRegions := []string{"us-east-1", "us-west-2"}
+	providerMeta.AWSClients = make(map[string]*conns.AWSClient)
+	if config.Region == "" {
+		providerMeta.Region = endpoints.UsWest2RegionID
+	} else {
+		providerMeta.Region = config.Region
+	}
+
+	if v, ok := d.GetOk("allowed_regions"); ok && v.(*schema.Set).Len() > 0 {
+		providerMeta.AllowedRegions = append(flex.ExpandStringValueSet(v.(*schema.Set)), providerMeta.Region)
+	} else {
+		meta := new(conns.AWSClient)
+		meta, diags := config.ConfigureProvider(ctx, meta)
+
+		if diags.HasError() {
+			return nil, diags
+		}
+		client := meta.EC2Conn()
+		regions, err := client.DescribeRegions(nil)
+
+		for _, region := range regions.Regions {
+			fmt.Sprint(region.RegionName)
+			providerMeta.AllowedRegions = append(providerMeta.AllowedRegions, aws.ToString(region.RegionName))
+		}
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
+	}
+
+	for _, region := range providerMeta.AllowedRegions {
+
+		_, ok := providerMeta.AWSClients[region]
+		if !ok {
+			config.Region = region
+			meta := new(conns.AWSClient)
+			meta, diags := config.ConfigureProvider(ctx, meta)
+
+			if diags.HasError() {
+				return nil, diags
+			}
+			providerMeta.AWSClients[region] = meta
+		}
+	}
+	providerMeta.AccountID = providerMeta.AWSClients[providerMeta.Region].AccountID
+	providerMeta.Partition = providerMeta.AWSClients[providerMeta.Region].Partition
+	// meta, diags := config.ConfigureProvider(ctx, meta)
+
+	fmt.Sprintf("%v", providerMeta.DefaultTagsConfig)
+	return providerMeta, diags
 }
 
 func assumeRoleSchema() *schema.Schema {

--- a/internal/provider/tags_interceptor_test.go
+++ b/internal/provider/tags_interceptor_test.go
@@ -129,6 +129,10 @@ func (d *resourceData) Get(key string) any {
 	return nil
 }
 
+func (d *resourceData) GetOk(key string) (interface{}, bool) {
+	return nil, false
+}
+
 func (d *resourceData) Id() string {
 	return "id"
 }

--- a/internal/service/ec2/ec2_availability_zone_data_source.go
+++ b/internal/service/ec2/ec2_availability_zone_data_source.go
@@ -82,7 +82,7 @@ func DataSourceAvailabilityZone() *schema.Resource {
 
 func dataSourceAvailabilityZoneRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).EC2Conn()
+	conn := meta.(*conns.ProviderMeta).AWSClients[meta.(*conns.ProviderMeta).Region].EC2Conn()
 
 	input := &ec2.DescribeAvailabilityZonesInput{}
 

--- a/internal/service/ec2/ec2_availability_zones_data_source.go
+++ b/internal/service/ec2/ec2_availability_zones_data_source.go
@@ -71,7 +71,7 @@ func DataSourceAvailabilityZones() *schema.Resource {
 
 func dataSourceAvailabilityZonesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).EC2Conn()
+	conn := meta.(*conns.ProviderMeta).AWSClients[meta.(*conns.ProviderMeta).Region].EC2Conn()
 
 	log.Printf("[DEBUG] Reading Availability Zones.")
 
@@ -138,7 +138,7 @@ func dataSourceAvailabilityZonesRead(ctx context.Context, d *schema.ResourceData
 		zoneIds = append(zoneIds, zoneID)
 	}
 
-	d.SetId(meta.(*conns.AWSClient).Region)
+	d.SetId(meta.(*conns.ProviderMeta).AWSClients[meta.(*conns.ProviderMeta).Region].Region)
 
 	if err := d.Set("group_names", groupNames); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting group_names: %s", err)

--- a/internal/service/lightsail/disk.go
+++ b/internal/service/lightsail/disk.go
@@ -72,7 +72,7 @@ func ResourceDisk() *schema.Resource {
 }
 
 func resourceDiskCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).LightsailConn()
+	conn := meta.(*conns.ProviderMeta).AWSClients[meta.(*conns.ProviderMeta).Region].LightsailConn()
 
 	id := d.Get("name").(string)
 	in := lightsail.CreateDiskInput{
@@ -100,7 +100,7 @@ func resourceDiskCreate(ctx context.Context, d *schema.ResourceData, meta interf
 }
 
 func resourceDiskRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).LightsailConn()
+	conn := meta.(*conns.ProviderMeta).AWSClients[meta.(*conns.ProviderMeta).Region].LightsailConn()
 
 	out, err := FindDiskById(ctx, conn, d.Id())
 
@@ -132,7 +132,7 @@ func resourceDiskUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 }
 
 func resourceDiskDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).LightsailConn()
+	conn := meta.(*conns.ProviderMeta).AWSClients[meta.(*conns.ProviderMeta).Region].LightsailConn()
 
 	out, err := conn.DeleteDiskWithContext(ctx, &lightsail.DeleteDiskInput{
 		DiskName: aws.String(d.Id()),

--- a/internal/service/lightsail/disk_test.go
+++ b/internal/service/lightsail/disk_test.go
@@ -117,7 +117,7 @@ func testAccCheckDiskExists(ctx context.Context, n string, disk *lightsail.Disk)
 			return errors.New("No LightsailDisk ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LightsailConn()
+		conn := acctest.Provider.Meta().(*conns.ProviderMeta).AWSClients[acctest.Provider.Meta().(*conns.ProviderMeta).Region].LightsailConn()
 
 		resp, err := tflightsail.FindDiskById(ctx, conn, rs.Primary.ID)
 
@@ -170,7 +170,7 @@ func testAccCheckDiskDestroy(ctx context.Context) resource.TestCheckFunc {
 				continue
 			}
 
-			conn := acctest.Provider.Meta().(*conns.AWSClient).LightsailConn()
+			conn := acctest.Provider.Meta().(*conns.ProviderMeta).AWSClients[acctest.Provider.Meta().(*conns.ProviderMeta).Region].LightsailConn()
 
 			_, err := tflightsail.FindDiskById(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/lightsail/find.go
+++ b/internal/service/lightsail/find.go
@@ -365,12 +365,6 @@ func FindLoadBalancerHTTPSRedirectionPolicyById(ctx context.Context, conn *light
 }
 
 func FindBucketById(ctx context.Context, conn *lightsail.Lightsail, id string) (*lightsail.Bucket, error) {
-	partCount := flex.ResourceIdPartCount(id)
-	if partCount == 2 {
-		idParts := strings.Split(id, flex.ResourceIdSeparator)
-		id = idParts[0]
-	}
-
 	in := &lightsail.GetBucketsInput{BucketName: aws.String(id)}
 	out, err := conn.GetBucketsWithContext(ctx, in)
 

--- a/internal/service/lightsail/find.go
+++ b/internal/service/lightsail/find.go
@@ -365,6 +365,12 @@ func FindLoadBalancerHTTPSRedirectionPolicyById(ctx context.Context, conn *light
 }
 
 func FindBucketById(ctx context.Context, conn *lightsail.Lightsail, id string) (*lightsail.Bucket, error) {
+	partCount := flex.ResourceIdPartCount(id)
+	if partCount == 2 {
+		idParts := strings.Split(id, flex.ResourceIdSeparator)
+		id = idParts[0]
+	}
+
 	in := &lightsail.GetBucketsInput{BucketName: aws.String(id)}
 	out, err := conn.GetBucketsWithContext(ctx, in)
 

--- a/internal/service/lightsail/instance_test.go
+++ b/internal/service/lightsail/instance_test.go
@@ -333,7 +333,7 @@ func testAccCheckInstanceExists(ctx context.Context, n string) resource.TestChec
 			return errors.New("No LightsailInstance ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LightsailConn()
+		conn := acctest.Provider.Meta().(*conns.ProviderMeta).AWSClients[acctest.Provider.Meta().(*conns.ProviderMeta).Region].LightsailConn()
 
 		out, err := tflightsail.FindInstanceById(ctx, conn, rs.Primary.ID)
 
@@ -356,7 +356,7 @@ func testAccCheckInstanceDestroy(ctx context.Context) resource.TestCheckFunc {
 				continue
 			}
 
-			conn := acctest.Provider.Meta().(*conns.AWSClient).LightsailConn()
+			conn := acctest.Provider.Meta().(*conns.ProviderMeta).AWSClients[acctest.Provider.Meta().(*conns.ProviderMeta).Region].LightsailConn()
 
 			_, err := tflightsail.FindInstanceById(ctx, conn, rs.Primary.ID)
 
@@ -376,7 +376,7 @@ func testAccCheckInstanceDestroy(ctx context.Context) resource.TestCheckFunc {
 }
 
 func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).LightsailConn()
+	conn := acctest.Provider.Meta().(*conns.ProviderMeta).AWSClients[acctest.Provider.Meta().(*conns.ProviderMeta).Region].LightsailConn()
 
 	input := &lightsail.GetInstancesInput{}
 

--- a/internal/verify/diff.go
+++ b/internal/verify/diff.go
@@ -21,8 +21,8 @@ import (
 // after resource READ operations as resource and provider-level tags
 // will be indistinguishable when returned from an AWS API.
 func SetTagsDiff(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
+	defaultTagsConfig := meta.(*conns.ProviderMeta).DefaultTagsConfig
+	ignoreTagsConfig := meta.(*conns.ProviderMeta).IgnoreTagsConfig
 
 	resourceTags := tftags.New(ctx, diff.Get("tags").(map[string]interface{}))
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The pains around multi-region deployments in terraform is an area where I feel a high impact could be made by improving this functionality. Currently today, you have to specify a separate provider per region, use provider aliases and define the same resource at least once per region you want to deploy it to (repeat code). I have been thinking about this issue from two sides.

This Pull request is a Proof of Concept with modifications to the core provider `meta`, `tags_interceptor`, and two resources to show functionality. These modifications will enable for resources to be updated to allow specifying the region at each resource level, with a default region when one is not specified.

This is accomplished by instead of having a single `AWSClient` inside of the provider meta, a map containing all regions and their `AWSClient`. This allows either defaulting to the region provided in the provider configuration, or allowing a region to be specified at the resource level to determine the region it will be deployed and managed in. 

The map of regions can be limited by providing a list to the  newly added `allowed_regions` provider setting. eg `allowed_regions=["us-east-1", "us-east-2" ]`  . If this setting is not provided a client will be established for all available regions for the account.

This will accomplish the following:
1. Enable each resource to be modified to allow region to be specified at each resource and even allow for the same resource to be deployed to multiple regions using a for_each.
2. Allow current behavior of defaulting to the provider configured region as to not introduce a breaking change.
3. Allow for deploying to multiple regions with only the single default `aws` provider configuration.

This PR  only has modified two resources for testing so far. 
1. `aws_lightsail_bucket` - Has been modified to allow passing the `region` at the resource level and tests have been added to test that this works as intended when passing in a region other than the default. 
2. `aws_lightsail_disk` - Has been modified to work with the new provider meta without adding support for region at the resource level, this allows testing and verifying that we can introduce this and still keep existing functionality for all resources and roll out the `region` at each resource level at its own pace. 

I am not an expert on how the provider meta is configured so I am sure optimization could be made, but I feel a solution similar to this would provide the best end user experience when deploying to multiple regions. I am sure there may be more modifications needed before this proposal would be ready for merge. Additionally every resource would need to be updated as well to use the new provider meta ( I only did the two for testing, but this is as easy as a massive find replace). 


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #25308

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccLightsailBucket_' PKG=lightsail     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lightsail/... -v -count 1 -parallel 20  -run=TestAccLightsailBucket_ -timeout 180m
=== RUN   TestAccLightsailBucket_basic
=== PAUSE TestAccLightsailBucket_basic
=== RUN   TestAccLightsailBucket_region
=== PAUSE TestAccLightsailBucket_region
=== RUN   TestAccLightsailBucket_BundleId
=== PAUSE TestAccLightsailBucket_BundleId
=== RUN   TestAccLightsailBucket_disappears
=== PAUSE TestAccLightsailBucket_disappears
=== RUN   TestAccLightsailBucket_tags
=== PAUSE TestAccLightsailBucket_tags
=== CONT  TestAccLightsailBucket_basic
=== CONT  TestAccLightsailBucket_disappears
=== CONT  TestAccLightsailBucket_tags
=== CONT  TestAccLightsailBucket_BundleId
=== CONT  TestAccLightsailBucket_region
--- PASS: TestAccLightsailBucket_disappears (128.44s)
--- PASS: TestAccLightsailBucket_basic (162.29s)
--- PASS: TestAccLightsailBucket_BundleId (264.69s)
--- PASS: TestAccLightsailBucket_region (272.90s)
--- PASS: TestAccLightsailBucket_tags (362.18s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  365.437s


$ make testacc TESTARGS='-run=TestAccLightsailDisk_' PKG=lightsail 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lightsail/... -v -count 1 -parallel 20  -run=TestAccLightsailDisk_ -timeout 180m
=== RUN   TestAccLightsailDisk_basic
=== PAUSE TestAccLightsailDisk_basic
=== RUN   TestAccLightsailDisk_Tags
=== PAUSE TestAccLightsailDisk_Tags
=== RUN   TestAccLightsailDisk_disappears
=== PAUSE TestAccLightsailDisk_disappears
=== CONT  TestAccLightsailDisk_basic
=== CONT  TestAccLightsailDisk_disappears
=== CONT  TestAccLightsailDisk_Tags
--- PASS: TestAccLightsailDisk_disappears (160.14s)
--- PASS: TestAccLightsailDisk_basic (179.56s)
--- PASS: TestAccLightsailDisk_Tags (380.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lightsail  383.867s

...
```
