### PR TITLE
r/aws_servicecatalog_provisioned_product: re-enable product namee update test

### DIFF
--- a/internal/service/servicecatalog/provisioned_product_test.go
+++ b/internal/service/servicecatalog/provisioned_product_test.go
@@ -204,60 +204,55 @@ func TestAccServiceCatalogProvisionedProduct_stackSetProvisioningPreferences(t *
 	})
 }
 
-// NOTE: This test is dependent on a v5.0.0 feature which fixes how
-// products are modified when provisioning_artifact_parameters are
-// changed. Once v5.0.0 is released, this test can be re-enabled.
-// Ref: https://github.com/hashicorp/terraform-provider-aws/pull/31061
-//
-// func TestAccServiceCatalogProvisionedProduct_ProductName_update(t *testing.T) {
-// 	ctx := acctest.Context(t)
-// 	resourceName := "aws_servicecatalog_provisioned_product.test"
+func TestAccServiceCatalogProvisionedProduct_ProductName_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_servicecatalog_provisioned_product.test"
 
-// 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-// 	productName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-// 	productNameUpdated := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-// 	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
-// 	var pprod servicecatalog.ProvisionedProductDetail
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	productName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	productNameUpdated := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	domain := fmt.Sprintf("http://%s", acctest.RandomDomainName())
+	var pprod servicecatalog.ProvisionedProductDetail
 
-// 	resource.ParallelTest(t, resource.TestCase{
-// 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-// 		ErrorCheck:               acctest.ErrorCheck(t, servicecatalog.EndpointsID),
-// 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-// 		CheckDestroy:             testAccCheckProvisionedProductDestroy(ctx),
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: testAccProvisionedProductConfig_productName(rName, domain, acctest.DefaultEmailAddress, "10.1.0.0/16", productName),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					testAccCheckProvisionedProductExists(ctx, resourceName, &pprod),
-// 					resource.TestCheckResourceAttrPair(resourceName, "product_name", "aws_servicecatalog_product.test", "name"),
-// 					resource.TestCheckResourceAttrPair(resourceName, "product_id", "aws_servicecatalog_product.test", "id"),
-// 				),
-// 			},
-// 			{
-// 				// update the product name, but keep provisioned product name as-is to trigger an in-place update
-// 				Config: testAccProvisionedProductConfig_productName(rName, domain, acctest.DefaultEmailAddress, "10.1.0.0/16", productNameUpdated),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					testAccCheckProvisionedProductExists(ctx, resourceName, &pprod),
-// 					resource.TestCheckResourceAttrPair(resourceName, "product_name", "aws_servicecatalog_product.test", "name"),
-// 					resource.TestCheckResourceAttrPair(resourceName, "product_id", "aws_servicecatalog_product.test", "id"),
-// 				),
-// 			},
-// 			{
-// 				ResourceName:      resourceName,
-// 				ImportState:       true,
-// 				ImportStateVerify: true,
-// 				ImportStateVerifyIgnore: []string{
-// 					"accept_language",
-// 					"ignore_errors",
-// 					"product_name",
-// 					"provisioning_artifact_name",
-// 					"provisioning_parameters",
-// 					"retain_physical_resources",
-// 				},
-// 			},
-// 		},
-// 	})
-// }
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, servicecatalog.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckProvisionedProductDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProvisionedProductConfig_productName(rName, domain, acctest.DefaultEmailAddress, "10.1.0.0/16", productName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProvisionedProductExists(ctx, resourceName, &pprod),
+					resource.TestCheckResourceAttrPair(resourceName, "product_name", "aws_servicecatalog_product.test", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "product_id", "aws_servicecatalog_product.test", "id"),
+				),
+			},
+			{
+				// update the product name, but keep provisioned product name as-is to trigger an in-place update
+				Config: testAccProvisionedProductConfig_productName(rName, domain, acctest.DefaultEmailAddress, "10.1.0.0/16", productNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProvisionedProductExists(ctx, resourceName, &pprod),
+					resource.TestCheckResourceAttrPair(resourceName, "product_name", "aws_servicecatalog_product.test", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "product_id", "aws_servicecatalog_product.test", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"accept_language",
+					"ignore_errors",
+					"product_name",
+					"provisioning_artifact_name",
+					"provisioning_parameters",
+					"retain_physical_resources",
+				},
+			},
+		},
+	})
+}
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/26271
 func TestAccServiceCatalogProvisionedProduct_ProvisioningArtifactName_update(t *testing.T) {
@@ -818,27 +813,27 @@ resource "aws_servicecatalog_provisioned_product" "test" {
 `, rName, vpcCidr, failureToleranceCount, maxConcurrencyCount))
 }
 
-// func testAccProvisionedProductConfig_productName(rName, domain, email, vpcCidr, productName string) string {
-// 	return acctest.ConfigCompose(testAccProvisionedProductTemplateURLBaseConfig(productName, domain, email),
-// 		fmt.Sprintf(`
-// resource "aws_servicecatalog_provisioned_product" "test" {
-//   name                       = %[1]q
-//   product_name               = aws_servicecatalog_product.test.name
-//   provisioning_artifact_name = aws_servicecatalog_product.test.provisioning_artifact_parameters[0].name
-//   path_id                    = data.aws_servicecatalog_launch_paths.test.summaries[0].path_id
+func testAccProvisionedProductConfig_productName(rName, domain, email, vpcCidr, productName string) string {
+	return acctest.ConfigCompose(testAccProvisionedProductTemplateURLBaseConfig(productName, domain, email),
+		fmt.Sprintf(`
+resource "aws_servicecatalog_provisioned_product" "test" {
+  name                       = %[1]q
+  product_name               = aws_servicecatalog_product.test.name
+  provisioning_artifact_name = aws_servicecatalog_product.test.provisioning_artifact_parameters[0].name
+  path_id                    = data.aws_servicecatalog_launch_paths.test.summaries[0].path_id
 
-//   provisioning_parameters {
-//     key   = "VPCPrimaryCIDR"
-//     value = %[2]q
-//   }
+  provisioning_parameters {
+    key   = "VPCPrimaryCIDR"
+    value = %[2]q
+  }
 
-//   provisioning_parameters {
-//     key   = "LeaveMeEmpty"
-//     value = ""
-//   }
-// }
-// `, rName, vpcCidr))
-// }
+  provisioning_parameters {
+    key   = "LeaveMeEmpty"
+    value = ""
+  }
+}
+`, rName, vpcCidr))
+}
 
 func testAccProvisionedProductConfig_ProvisionedArtifactName_update(rName, domain, email, vpcCidr, artifactName string) string {
 	return acctest.ConfigCompose(testAccProvisionedProductTemplateURLBaseConfig(rName, domain, email),


### PR DESCRIPTION
### Description
Re-enables a provisioned product test dependent on features released in v5.0.0.


### Relations
Closes #31119
Relates #31115 


### Output from Acceptance Testing

```console
$ make testacc PKG=servicecatalog TESTS=TestAccServiceCatalogProvisionedProduct_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/servicecatalog/... -v -count 1 -parallel 20 -run='TestAccServiceCatalogProvisionedProduct_'  -timeout 180m

--- PASS: TestAccServiceCatalogProvisionedProduct_errorOnCreate (54.10s)
--- PASS: TestAccServiceCatalogProvisionedProduct_disappears (132.30s)
--- PASS: TestAccServiceCatalogProvisionedProduct_basic (136.98s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags (223.56s)
--- PASS: TestAccServiceCatalogProvisionedProduct_update (224.91s)
--- PASS: TestAccServiceCatalogProvisionedProduct_ProvisioningArtifactName_update (226.12s)
--- PASS: TestAccServiceCatalogProvisionedProduct_ProductName_update (236.68s)
--- PASS: TestAccServiceCatalogProvisionedProduct_computedOutputs (243.85s)
--- PASS: TestAccServiceCatalogProvisionedProduct_errorOnUpdate (266.00s)
--- PASS: TestAccServiceCatalogProvisionedProduct_stackSetProvisioningPreferences (312.46s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog     316.001s
```