### PR TITLE
Add support for ModelPackageName in Sagemaker Container Definition

### DIFF
--- a/internal/service/sagemaker/model.go
+++ b/internal/service/sagemaker/model.go
@@ -106,6 +106,12 @@ func ResourceModel() *schema.Resource {
 							ForceNew:     true,
 							ValidateFunc: validModelDataURL,
 						},
+						"model_package_name": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringLenBetween(1, 1024),
+						},
 					},
 				},
 			},
@@ -210,6 +216,12 @@ func ResourceModel() *schema.Resource {
 							Optional:     true,
 							ForceNew:     true,
 							ValidateFunc: validModelDataURL,
+						},
+						"model_package_name": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringLenBetween(1, 1024),
 						},
 					},
 				},
@@ -418,6 +430,9 @@ func expandContainer(m map[string]interface{}) *sagemaker.ContainerDefinition {
 	if v, ok := m["model_data_url"]; ok && v.(string) != "" {
 		container.ModelDataUrl = aws.String(v.(string))
 	}
+	if v, ok := m["model_package_name"]; ok && v.(string) != "" {
+		container.ModelPackageName = aws.String(v.(string))
+	}
 	if v, ok := m["environment"].(map[string]interface{}); ok && len(v) > 0 {
 		container.Environment = flex.ExpandStringMap(v)
 	}
@@ -489,6 +504,9 @@ func flattenContainer(container *sagemaker.ContainerDefinition) []interface{} {
 	}
 	if container.ModelDataUrl != nil {
 		cfg["model_data_url"] = aws.StringValue(container.ModelDataUrl)
+	}
+	if container.ModelPackageName != nil {
+		cfg["model_package_name"] = aws.StringValue(container.ModelDataUrl)
 	}
 	if container.Environment != nil {
 		cfg["environment"] = aws.StringValueMap(container.Environment)

--- a/website/docs/r/sagemaker_model.html.markdown
+++ b/website/docs/r/sagemaker_model.html.markdown
@@ -62,6 +62,7 @@ The `primary_container` and `container` block both support:
 * `image` - (Required) The registry path where the inference code image is stored in Amazon ECR.
 * `mode` - (Optional) The container hosts value `SingleModel/MultiModel`. The default value is `SingleModel`.
 * `model_data_url` - (Optional) The URL for the S3 location where model artifacts are stored.
+* `model_package_name` - (Optional) The name or Amazon Resource Name (ARN) of the model package to use to create the model.
 * `container_hostname` - (Optional) The DNS host name for the container.
 * `environment` - (Optional) Environment variables for the Docker container.
    A list of key value pairs.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Sagemaker Model Create Api has support for passing a ModelPackageName to create models form model-packages but this functionality was not implemented in the provider.

This PR adds this missing functionality. 

### Relations
Closes #31533

### References
https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateModel.html
https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-mkt-model-pkg-model.html#sagemaker-mkt-model-pkg-model-api


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS= TestAccAWSSagemakerModel_ PKG=sagemaker

...
```
