### PR TITLE
r/aws_networkfirewall_firewall_policy: Add stream exception policy

### DIFF
--- a/.changelog/31541.txt
+++ b/.changelog/31541.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_networkfirewall_firewall_policy: Add `stream_exception_policy` option to `firewall_policy.stateful_engine_options`
+```

--- a/internal/service/networkfirewall/firewall_policy.go
+++ b/internal/service/networkfirewall/firewall_policy.go
@@ -63,8 +63,13 @@ func ResourceFirewallPolicy() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"rule_order": {
 										Type:         schema.TypeString,
-										Required:     true,
+										Optional:     true,
 										ValidateFunc: validation.StringInSlice(networkfirewall.RuleOrder_Values(), false),
+									},
+									"stream_exception_policy": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice(networkfirewall.StreamExceptionPolicy_Values(), false),
 									},
 								},
 							},
@@ -338,6 +343,9 @@ func expandStatefulEngineOptions(l []interface{}) *networkfirewall.StatefulEngin
 	if v, ok := m["rule_order"].(string); ok {
 		options.RuleOrder = aws.String(v)
 	}
+	if v, ok := m["stream_exception_policy"].(string); ok {
+		options.StreamExceptionPolicy = aws.String(v)
+	}
 
 	return options
 }
@@ -477,7 +485,8 @@ func flattenStatefulEngineOptions(options *networkfirewall.StatefulEngineOptions
 	}
 
 	m := map[string]interface{}{
-		"rule_order": aws.StringValue(options.RuleOrder),
+		"rule_order":              aws.StringValue(options.RuleOrder),
+		"stream_exception_policy": aws.StringValue(options.StreamExceptionPolicy),
 	}
 
 	return []interface{}{m}

--- a/internal/service/networkfirewall/firewall_policy.go
+++ b/internal/service/networkfirewall/firewall_policy.go
@@ -340,10 +340,10 @@ func expandStatefulEngineOptions(l []interface{}) *networkfirewall.StatefulEngin
 	options := &networkfirewall.StatefulEngineOptions{}
 
 	m := l[0].(map[string]interface{})
-	if v, ok := m["rule_order"].(string); ok {
+	if v, ok := m["rule_order"].(string); ok && v != "" {
 		options.RuleOrder = aws.String(v)
 	}
-	if v, ok := m["stream_exception_policy"].(string); ok {
+	if v, ok := m["stream_exception_policy"].(string); ok && v != "" {
 		options.StreamExceptionPolicy = aws.String(v)
 	}
 
@@ -484,9 +484,12 @@ func flattenStatefulEngineOptions(options *networkfirewall.StatefulEngineOptions
 		return []interface{}{}
 	}
 
-	m := map[string]interface{}{
-		"rule_order":              aws.StringValue(options.RuleOrder),
-		"stream_exception_policy": aws.StringValue(options.StreamExceptionPolicy),
+	m := map[string]interface{}{}
+	if options.RuleOrder != nil {
+		m["rule_order"] = aws.StringValue(options.RuleOrder)
+	}
+	if options.StreamExceptionPolicy != nil {
+		m["stream_exception_policy"] = aws.StringValue(options.StreamExceptionPolicy)
 	}
 
 	return []interface{}{m}

--- a/internal/service/networkfirewall/firewall_policy_data_source.go
+++ b/internal/service/networkfirewall/firewall_policy_data_source.go
@@ -48,6 +48,10 @@ func DataSourceFirewallPolicy() *schema.Resource {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
+									"stream_exception_policy": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
 								},
 							},
 						},

--- a/internal/service/networkfirewall/firewall_policy_test.go
+++ b/internal/service/networkfirewall/firewall_policy_test.go
@@ -156,12 +156,13 @@ func TestAccNetworkFirewallFirewallPolicy_statefulEngineOption(t *testing.T) {
 		CheckDestroy:             testAccCheckFirewallPolicyDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFirewallPolicyConfig_statefulEngineOptions(rName, "STRICT_ORDER"),
+				Config: testAccFirewallPolicyConfig_statefulEngineOptions(rName, "STRICT_ORDER", "DROP"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFirewallPolicyExists(ctx, resourceName, &firewallPolicy),
 					resource.TestCheckResourceAttr(resourceName, "firewall_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_engine_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_engine_options.0.rule_order", networkfirewall.RuleOrderStrictOrder),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_engine_options.0.stream_exception_policy", networkfirewall.StreamExceptionPolicyDrop),
 				),
 			},
 			{
@@ -186,12 +187,13 @@ func TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption(t *testing.
 		CheckDestroy:             testAccCheckFirewallPolicyDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFirewallPolicyConfig_statefulEngineOptions(rName, "DEFAULT_ACTION_ORDER"),
+				Config: testAccFirewallPolicyConfig_statefulEngineOptions(rName, "DEFAULT_ACTION_ORDER", "CONTINUE"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFirewallPolicyExists(ctx, resourceName, &firewallPolicy1),
 					resource.TestCheckResourceAttr(resourceName, "firewall_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_engine_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_engine_options.0.rule_order", networkfirewall.RuleOrderDefaultActionOrder),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_engine_options.0.stream_exception_policy", networkfirewall.StreamExceptionPolicyContinue),
 				),
 			},
 			{
@@ -203,13 +205,14 @@ func TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption(t *testing.
 				),
 			},
 			{
-				Config: testAccFirewallPolicyConfig_statefulEngineOptions(rName, "STRICT_ORDER"),
+				Config: testAccFirewallPolicyConfig_statefulEngineOptions(rName, "STRICT_ORDER", "REJECT"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFirewallPolicyExists(ctx, resourceName, &firewallPolicy3),
 					testAccCheckFirewallPolicyRecreated(&firewallPolicy2, &firewallPolicy3),
 					resource.TestCheckResourceAttr(resourceName, "firewall_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_engine_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_engine_options.0.rule_order", networkfirewall.RuleOrderStrictOrder),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_engine_options.0.stream_exception_policy", networkfirewall.StreamExceptionPolicyReject),
 				),
 			},
 			{
@@ -1110,7 +1113,7 @@ resource "aws_networkfirewall_firewall_policy" "test" {
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
-func testAccFirewallPolicyConfig_statefulEngineOptions(rName, ruleOrder string) string {
+func testAccFirewallPolicyConfig_statefulEngineOptions(rName, ruleOrder, streamExceptionPolicy string) string {
 	return fmt.Sprintf(`
 resource "aws_networkfirewall_firewall_policy" "test" {
   name = %[1]q
@@ -1120,11 +1123,12 @@ resource "aws_networkfirewall_firewall_policy" "test" {
     stateless_default_actions          = ["aws:pass"]
 
     stateful_engine_options {
-      rule_order = %[2]q
+      rule_order              = %[2]q
+      stream_exception_policy = %[3]q
     }
   }
 }
-`, rName, ruleOrder)
+`, rName, ruleOrder, streamExceptionPolicy)
 }
 
 func testAccFirewallPolicyConfig_statefulDefaultActions(rName string) string {

--- a/internal/service/networkfirewall/firewall_policy_test.go
+++ b/internal/service/networkfirewall/firewall_policy_test.go
@@ -1182,7 +1182,7 @@ resource "aws_networkfirewall_firewall_policy" "test" {
     stateless_default_actions          = ["aws:pass"]
 
     stateful_engine_options {
-      rule_order              = %[2]q
+      rule_order = %[2]q
     }
   }
 }

--- a/website/docs/r/networkfirewall_firewall_policy.html.markdown
+++ b/website/docs/r/networkfirewall_firewall_policy.html.markdown
@@ -103,7 +103,9 @@ The `stateful_engine_options` block supports the following argument:
 
 ~> **NOTE:** If the `STRICT_ORDER` rule order is specified, this firewall policy can only reference stateful rule groups that utilize `STRICT_ORDER`.
 
-* `rule_order` - (Required) Indicates how to manage the order of stateful rule evaluation for the policy. Default value: `DEFAULT_ACTION_ORDER`. Valid values: `DEFAULT_ACTION_ORDER`, `STRICT_ORDER`.
+* `rule_order` - Indicates how to manage the order of stateful rule evaluation for the policy. Default value: `DEFAULT_ACTION_ORDER`. Valid values: `DEFAULT_ACTION_ORDER`, `STRICT_ORDER`.
+
+* `stream_exception_policy` - Describes how to treat traffic which has broken midstream. Default value: `DROP`. Valid values: `DROP`, `CONTINUE`, `REJECT`.
 
 ### Stateful Rule Group Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This adds the `stream_exception_policy` option to a Network Firewall policy, updates the existing Stateful Engine Options test, and also adds tests for when only one of the options is defined.


### Relations
Closes https://github.com/hashicorp/terraform-provider-aws/issues/31539

### References
API docs: https://docs.aws.amazon.com/network-firewall/latest/APIReference/API_StatefulEngineOptions.html


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
NB I've been using the parallelism flag because there's a quota of 20 policies per AWS account and I've already got one, hence 19.
```
$ make testacc TESTS=TestAccNetworkFirewallFirewallPolicy_.*tatefulEngine PKG=networkfirewall P=19
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkfirewall/... -v -count 1 -parallel 19 -run='TestAccNetworkFirewallFirewallPolicy_.*tatefulEngine'  -timeout 180m
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulEngineOption
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulEngineOption
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsSingle
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsSingle
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulEngineOption
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsSingle
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulEngineOption (127.13s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsSingle (155.51s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption (276.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall    279.368s
```
EDIT: I originally pasted test output of `TestAccNetworkFirewallFirewallPolicy` though not all of them are relevant.

<details><summary>It's all here if you're interested</summary>

```
$ make testacc TESTS=TestAccNetworkFirewallFirewallPolicy PKG=networkfirewall P=4
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkfirewall/... -v -count 1 -parallel 4 -run='TestAccNetworkFirewallFirewallPolicy'  -timeout 180m
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_arn
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_arn
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_name
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_name
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_nameAndARN
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_nameAndARN
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_withOverriddenManagedRuleGroup
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_withOverriddenManagedRuleGroup
=== RUN   TestAccNetworkFirewallFirewallPolicy_basic
=== PAUSE TestAccNetworkFirewallFirewallPolicy_basic
=== RUN   TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration
=== PAUSE TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulDefaultActions
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulDefaultActions
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulEngineOption
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulEngineOption
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsSingle
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsSingle
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceManaged
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceManaged
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_multipleStatefulRuleGroupReferences
=== PAUSE TestAccNetworkFirewallFirewallPolicy_multipleStatefulRuleGroupReferences
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupPriorityReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupPriorityReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupOverrideActionReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupOverrideActionReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupPriorityReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupPriorityReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_statelessRuleGroupReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statelessRuleGroupReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatelessRuleGroupReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatelessRuleGroupReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_multipleStatelessRuleGroupReferences
=== PAUSE TestAccNetworkFirewallFirewallPolicy_multipleStatelessRuleGroupReferences
=== RUN   TestAccNetworkFirewallFirewallPolicy_statelessCustomAction
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statelessCustomAction
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatelessCustomAction
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatelessCustomAction
=== RUN   TestAccNetworkFirewallFirewallPolicy_multipleStatelessCustomActions
=== PAUSE TestAccNetworkFirewallFirewallPolicy_multipleStatelessCustomActions
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAction
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAction
=== RUN   TestAccNetworkFirewallFirewallPolicy_tags
=== PAUSE TestAccNetworkFirewallFirewallPolicy_tags
=== RUN   TestAccNetworkFirewallFirewallPolicy_disappears
=== PAUSE TestAccNetworkFirewallFirewallPolicy_disappears
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_arn
=== CONT  TestAccNetworkFirewallFirewallPolicy_multipleStatefulRuleGroupReferences
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulEngineOption
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupReference
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_arn (136.63s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceManaged
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulEngineOption (137.65s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReference
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupReference (163.66s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsSingle
--- PASS: TestAccNetworkFirewallFirewallPolicy_multipleStatefulRuleGroupReferences (202.21s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceManaged (148.44s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_basic
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsSingle (143.63s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulDefaultActions
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReference (172.57s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration
--- PASS: TestAccNetworkFirewallFirewallPolicy_basic (145.98s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statelessCustomAction
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulDefaultActions (147.18s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_disappears
--- PASS: TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration (172.70s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_tags
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption (286.27s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAction
--- PASS: TestAccNetworkFirewallFirewallPolicy_statelessCustomAction (146.21s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_multipleStatelessCustomActions
--- PASS: TestAccNetworkFirewallFirewallPolicy_disappears (132.87s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatelessCustomAction
--- PASS: TestAccNetworkFirewallFirewallPolicy_tags (161.24s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statelessRuleGroupReference
--- PASS: TestAccNetworkFirewallFirewallPolicy_statelessRuleGroupReference (189.50s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_multipleStatelessRuleGroupReferences
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAction (345.22s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatelessRuleGroupReference
--- PASS: TestAccNetworkFirewallFirewallPolicy_multipleStatelessCustomActions (288.96s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupOverrideActionReference
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatelessRuleGroupReference (158.63s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupPriorityReference
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupOverrideActionReference (147.39s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupPriorityReference
--- PASS: TestAccNetworkFirewallFirewallPolicy_multipleStatelessRuleGroupReferences (181.39s)
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_nameAndARN
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatelessCustomAction (543.69s)
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_withOverriddenManagedRuleGroup
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_nameAndARN (144.66s)
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_name
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupPriorityReference (171.21s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupPriorityReference (199.78s)
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_withOverriddenManagedRuleGroup (155.41s)
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_name (144.56s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall    1306.680s
```

</details>