### PR TITLE
New resource aws_quicksight_analysis

### DIFF
--- a/.changelog/31542.txt
+++ b/.changelog/31542.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_quicksight_analysis
+```

--- a/internal/service/quicksight/analysis.go
+++ b/internal/service/quicksight/analysis.go
@@ -1,0 +1,393 @@
+package quicksight
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/quicksight"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	quicksightschema "github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+const (
+	recoveryWindowInDaysMin     = 7
+	recoveryWindowInDaysMax     = 30
+	recoveryWindowInDaysDefault = recoveryWindowInDaysMax
+)
+
+// @SDKResource("aws_quicksight_analysis", name="Analysis")
+// @Tags(identifierAttribute="arn")
+func ResourceAnalysis() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceAnalysisCreate,
+		ReadWithoutTimeout:   resourceAnalysisRead,
+		UpdateWithoutTimeout: resourceAnalysisUpdate,
+		DeleteWithoutTimeout: resourceAnalysisDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				d.Set("recovery_window_in_days", recoveryWindowInDaysDefault)
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"aws_account_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidAccountID,
+			},
+			"created_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"analysis_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"definition": quicksightschema.AnalysisDefinitionSchema(),
+			"last_updated_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_published_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 2048),
+			},
+			"parameters": quicksightschema.ParametersSchema(),
+			"permissions": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MinItems: 1,
+				MaxItems: 64,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"actions": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MinItems: 1,
+							MaxItems: 16,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"principal": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(1, 256),
+						},
+					},
+				},
+			},
+			"recovery_window_in_days": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  30,
+				ValidateFunc: validation.Any(
+					validation.IntBetween(recoveryWindowInDaysMin, recoveryWindowInDaysMax),
+					validation.IntInSlice([]int{0}),
+				),
+			},
+			"source_entity": quicksightschema.AnalysisSourceEntitySchema(),
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			"theme_arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+const (
+	ResNameAnalysis = "Analysis"
+)
+
+func resourceAnalysisCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).QuickSightConn()
+
+	awsAccountId := meta.(*conns.AWSClient).AccountID
+	if v, ok := d.GetOk("aws_account_id"); ok {
+		awsAccountId = v.(string)
+	}
+	analysisId := d.Get("analysis_id").(string)
+
+	d.SetId(createAnalysisId(awsAccountId, analysisId))
+
+	input := &quicksight.CreateAnalysisInput{
+		AwsAccountId: aws.String(awsAccountId),
+		AnalysisId:   aws.String(analysisId),
+		Name:         aws.String(d.Get("name").(string)),
+		Tags:         GetTagsIn(ctx),
+	}
+
+	if v, ok := d.GetOk("source_entity"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.SourceEntity = quicksightschema.ExpandAnalysisSourceEntity(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("definition"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.Definition = quicksightschema.ExpandAnalysisDefinition(d.Get("definition").([]interface{}))
+	}
+
+	if v, ok := d.GetOk("parameters"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.Parameters = quicksightschema.ExpandParameters(d.Get("parameters").([]interface{}))
+	}
+
+	if v, ok := d.GetOk("permissions"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.Permissions = expandResourcePermissions(v.([]interface{}))
+	}
+
+	_, err := conn.CreateAnalysisWithContext(ctx, input)
+	if err != nil {
+		return create.DiagError(names.QuickSight, create.ErrActionCreating, ResNameAnalysis, d.Get("name").(string), err)
+	}
+
+	if _, err := waitAnalysisCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return create.DiagError(names.QuickSight, create.ErrActionWaitingForCreation, ResNameAnalysis, d.Id(), err)
+	}
+
+	return resourceAnalysisRead(ctx, d, meta)
+}
+
+func resourceAnalysisRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).QuickSightConn()
+
+	awsAccountId, analysisId, err := ParseAnalysisId(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	out, err := FindAnalysisByID(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] QuickSight Analysis (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	// Ressource is logically deleted with DELETED status
+	if !d.IsNewResource() && aws.StringValue(out.Status) == quicksight.ResourceStatusDeleted {
+		log.Printf("[WARN] QuickSight Analysis (%s) deleted, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.QuickSight, create.ErrActionReading, ResNameAnalysis, d.Id(), err)
+	}
+
+	d.Set("arn", out.Arn)
+	d.Set("aws_account_id", awsAccountId)
+	d.Set("created_time", out.CreatedTime.Format(time.RFC3339))
+	d.Set("last_updated_time", out.LastUpdatedTime.Format(time.RFC3339))
+	d.Set("name", out.Name)
+	d.Set("status", out.Status)
+	d.Set("analysis_id", out.AnalysisId)
+
+	descResp, err := conn.DescribeAnalysisDefinitionWithContext(ctx, &quicksight.DescribeAnalysisDefinitionInput{
+		AwsAccountId: aws.String(awsAccountId),
+		AnalysisId:   aws.String(analysisId),
+	})
+
+	if err != nil {
+		return diag.Errorf("describing QuickSight Analysis (%s) Definition: %s", d.Id(), err)
+	}
+
+	if err := d.Set("definition", quicksightschema.FlattenAnalysisDefinition(descResp.Definition)); err != nil {
+		return diag.Errorf("setting definition: %s", err)
+	}
+
+	permsResp, err := conn.DescribeAnalysisPermissionsWithContext(ctx, &quicksight.DescribeAnalysisPermissionsInput{
+		AwsAccountId: aws.String(awsAccountId),
+		AnalysisId:   aws.String(analysisId),
+	})
+
+	if err != nil {
+		return diag.Errorf("describing QuickSight Analysis (%s) Permissions: %s", d.Id(), err)
+	}
+
+	if err := d.Set("permissions", flattenPermissions(permsResp.Permissions)); err != nil {
+		return diag.Errorf("setting permissions: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAnalysisUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).QuickSightConn()
+
+	awsAccountId, analysisId, err := ParseAnalysisId(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if d.HasChangesExcept("permissions", "tags", "tags_all") {
+		in := &quicksight.UpdateAnalysisInput{
+			AwsAccountId: aws.String(awsAccountId),
+			AnalysisId:   aws.String(analysisId),
+			Name:         aws.String(d.Get("name").(string)),
+		}
+
+		_, createdFromEntity := d.GetOk("source_entity")
+		if createdFromEntity {
+			in.SourceEntity = quicksightschema.ExpandAnalysisSourceEntity(d.Get("source_entity").([]interface{}))
+		} else {
+			in.Definition = quicksightschema.ExpandAnalysisDefinition(d.Get("definition").([]interface{}))
+		}
+
+		if v, ok := d.GetOk("parameters"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+			in.Parameters = quicksightschema.ExpandParameters(d.Get("parameters").([]interface{}))
+		}
+
+		log.Printf("[DEBUG] Updating QuickSight Analysis (%s): %#v", d.Id(), in)
+		_, err := conn.UpdateAnalysisWithContext(ctx, in)
+		if err != nil {
+			return create.DiagError(names.QuickSight, create.ErrActionUpdating, ResNameAnalysis, d.Id(), err)
+		}
+
+		if _, err := waitAnalysisUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return create.DiagError(names.QuickSight, create.ErrActionWaitingForUpdate, ResNameAnalysis, d.Id(), err)
+		}
+	}
+
+	if d.HasChange("permissions") {
+		oraw, nraw := d.GetChange("permissions")
+		o := oraw.([]interface{})
+		n := nraw.([]interface{})
+
+		toGrant, toRevoke := DiffPermissions(o, n)
+
+		params := &quicksight.UpdateAnalysisPermissionsInput{
+			AwsAccountId: aws.String(awsAccountId),
+			AnalysisId:   aws.String(analysisId),
+		}
+
+		if len(toGrant) > 0 {
+			params.GrantPermissions = toGrant
+		}
+
+		if len(toRevoke) > 0 {
+			params.RevokePermissions = toRevoke
+		}
+
+		_, err = conn.UpdateAnalysisPermissionsWithContext(ctx, params)
+
+		if err != nil {
+			return diag.Errorf("updating QuickSight Analysis (%s) permissions: %s", analysisId, err)
+		}
+	}
+
+	return resourceAnalysisRead(ctx, d, meta)
+}
+
+func resourceAnalysisDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).QuickSightConn()
+
+	awsAccountId, analysisId, err := ParseAnalysisId(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	input := &quicksight.DeleteAnalysisInput{
+		AwsAccountId: aws.String(awsAccountId),
+		AnalysisId:   aws.String(analysisId),
+	}
+
+	recoveryWindowInDays := d.Get("recovery_window_in_days").(int)
+	if recoveryWindowInDays == 0 {
+		input.ForceDeleteWithoutRecovery = aws.Bool(true)
+	} else {
+		input.RecoveryWindowInDays = aws.Int64(int64(recoveryWindowInDays))
+	}
+
+	log.Printf("[INFO] Deleting QuickSight Analysis %s", d.Id())
+	_, err = conn.DeleteAnalysisWithContext(ctx, input)
+
+	if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.QuickSight, create.ErrActionDeleting, ResNameAnalysis, d.Id(), err)
+	}
+
+	return nil
+}
+
+func FindAnalysisByID(ctx context.Context, conn *quicksight.QuickSight, id string) (*quicksight.Analysis, error) {
+	awsAccountId, analysisId, err := ParseAnalysisId(id)
+	if err != nil {
+		return nil, err
+	}
+
+	descOpts := &quicksight.DescribeAnalysisInput{
+		AwsAccountId: aws.String(awsAccountId),
+		AnalysisId:   aws.String(analysisId),
+	}
+
+	out, err := conn.DescribeAnalysisWithContext(ctx, descOpts)
+
+	if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: descOpts,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil || out.Analysis == nil {
+		return nil, tfresource.NewEmptyResultError(descOpts)
+	}
+
+	return out.Analysis, nil
+}
+
+func ParseAnalysisId(id string) (string, string, error) {
+	parts := strings.SplitN(id, ",", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("unexpected format of ID (%s), expected AWS_ACCOUNT_ID,ANALYSIS_ID", id)
+	}
+	return parts[0], parts[1], nil
+}
+
+func createAnalysisId(awsAccountID, analysisId string) string {
+	return fmt.Sprintf("%s,%s", awsAccountID, analysisId)
+}

--- a/internal/service/quicksight/analysis_test.go
+++ b/internal/service/quicksight/analysis_test.go
@@ -1,0 +1,611 @@
+package quicksight_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/quicksight"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfquicksight "github.com/hashicorp/terraform-provider-aws/internal/service/quicksight"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccQuickSightAnalysis_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var analysis quicksight.Analysis
+	resourceName := "aws_quicksight_analysis.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, quicksight.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAnalysisDestroy(ctx, false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnalysisConfig_basic(rId, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAnalysisExists(ctx, resourceName, &analysis),
+					resource.TestCheckResourceAttr(resourceName, "analysis_id", rId),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", quicksight.ResourceStatusCreationSuccessful),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccQuickSightAnalysis_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var analysis quicksight.Analysis
+	resourceName := "aws_quicksight_analysis.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, quicksight.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAnalysisDestroy(ctx, false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnalysisConfig_basic(rId, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAnalysisExists(ctx, resourceName, &analysis),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfquicksight.ResourceAnalysis(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccQuickSightAnalysis_sourceEntity(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var analysis quicksight.Analysis
+	resourceName := "aws_quicksight_analysis.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	sourceName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	sourceId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, quicksight.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAnalysisDestroy(ctx, false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnalysisConfig_TemplateSourceEntity(rId, rName, sourceId, sourceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAnalysisExists(ctx, resourceName, &analysis),
+					resource.TestCheckResourceAttr(resourceName, "analysis_id", rId),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", quicksight.ResourceStatusCreationSuccessful),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "source_entity.0.source_template.0.arn", "quicksight", fmt.Sprintf("template/%s", sourceId)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"source_entity"},
+			},
+		},
+	})
+}
+
+func TestAccQuickSightAnalysis_update(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var analysis quicksight.Analysis
+	resourceName := "aws_quicksight_analysis.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameUpdated := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, quicksight.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAnalysisDestroy(ctx, false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnalysisConfig_basic(rId, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAnalysisExists(ctx, resourceName, &analysis),
+					resource.TestCheckResourceAttr(resourceName, "analysis_id", rId),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", quicksight.ResourceStatusCreationSuccessful),
+				),
+			},
+			{
+				Config: testAccAnalysisConfig_basic(rId, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAnalysisExists(ctx, resourceName, &analysis),
+					resource.TestCheckResourceAttr(resourceName, "analysis_id", rId),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "status", quicksight.ResourceStatusUpdateSuccessful),
+				),
+			},
+		},
+	})
+}
+
+func TestAccQuickSightAnalysis_parametersConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var analysis quicksight.Analysis
+	resourceName := "aws_quicksight_analysis.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, quicksight.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAnalysisDestroy(ctx, false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnalysisConfig_ParametersConfig(rId, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAnalysisExists(ctx, resourceName, &analysis),
+					resource.TestCheckResourceAttr(resourceName, "analysis_id", rId),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", quicksight.ResourceStatusCreationSuccessful),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parameters"},
+			},
+		},
+	})
+}
+
+func TestAccQuickSightAnalysis_forceDelete(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var analysis quicksight.Analysis
+	resourceName := "aws_quicksight_analysis.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, quicksight.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAnalysisDestroy(ctx, true),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAnalysisConfig_ForceDelete(rId, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAnalysisExists(ctx, resourceName, &analysis),
+					resource.TestCheckResourceAttr(resourceName, "analysis_id", rId),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", quicksight.ResourceStatusCreationSuccessful),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAnalysisDestroy(ctx context.Context, forceDelete bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).QuickSightConn()
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_quicksight_analysis" {
+				continue
+			}
+
+			output, err := tfquicksight.FindAnalysisByID(ctx, conn, rs.Primary.ID)
+			if err != nil {
+				if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
+					return nil
+				}
+				return err
+			}
+
+			if output != nil && (forceDelete || aws.StringValue(output.Status) != quicksight.ResourceStatusDeleted) {
+				return fmt.Errorf("QuickSight Analysis (%s) still exists", rs.Primary.ID)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAnalysisExists(ctx context.Context, name string, analysis *quicksight.Analysis) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.QuickSight, create.ErrActionCheckingExistence, tfquicksight.ResNameAnalysis, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.QuickSight, create.ErrActionCheckingExistence, tfquicksight.ResNameAnalysis, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).QuickSightConn()
+		output, err := tfquicksight.FindAnalysisByID(ctx, conn, rs.Primary.ID)
+
+		if err != nil {
+			return create.Error(names.QuickSight, create.ErrActionCheckingExistence, tfquicksight.ResNameAnalysis, rs.Primary.ID, err)
+		}
+
+		*analysis = *output
+
+		return nil
+	}
+}
+
+func testAccAnalysisConfigBase(rId string, rName string) string {
+	return acctest.ConfigCompose(
+		testAccDataSetConfigBase(rId, rName),
+		fmt.Sprintf(`
+resource "aws_quicksight_data_set" "test" {
+  data_set_id = %[1]q
+  name        = %[2]q
+  import_mode = "SPICE"
+
+  physical_table_map {
+    physical_table_map_id = %[1]q
+    s3_source {
+      data_source_arn = aws_quicksight_data_source.test.arn
+      input_columns {
+        name = "Column1"
+        type = "STRING"
+      }
+      input_columns {
+        name = "Column2"
+        type = "STRING"
+      }
+      upload_settings {}
+    }
+  }
+  logical_table_map {
+    logical_table_map_id = %[1]q
+    alias                = "Group1"
+    source {
+      physical_table_id = %[1]q
+    }
+    data_transforms {
+      cast_column_type_operation {
+        column_name     = "Column2"
+        new_column_type = "INTEGER"
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      physical_table_map
+    ]
+  }
+}
+`, rId, rName))
+}
+
+func testAccAnalysisConfig_basic(rId, rName string) string {
+	return acctest.ConfigCompose(
+		testAccAnalysisConfigBase(rId, rName),
+		fmt.Sprintf(`
+resource "aws_quicksight_analysis" "test" {
+  analysis_id = %[1]q
+  name        = %[2]q
+  definition {
+    data_set_identifiers_declarations {
+      data_set_arn = aws_quicksight_data_set.test.arn
+      identifier   = "1"
+    }
+    sheets {
+      title    = "Test"
+      sheet_id = "Test1"
+      visuals {
+        custom_content_visual {
+          data_set_identifier = "1"
+          title {
+            format_text {
+              plain_text = "Test"
+            }
+          }
+          visual_id = "Test1"
+        }
+      }
+      visuals {
+        line_chart_visual {
+          visual_id = "LineChart"
+          title {
+            format_text {
+              plain_text = "Line Chart Test"
+            }
+          }
+          chart_configuration {
+            field_wells {
+              line_chart_aggregated_field_wells {
+                category {
+                  categorical_dimension_field {
+                    field_id = "1"
+                    column {
+                      data_set_identifier = "1"
+                      column_name         = "Column1"
+                    }
+                  }
+                }
+                values {
+                  categorical_measure_field {
+                    field_id = "2"
+                    column {
+                      data_set_identifier = "1"
+                      column_name         = "Column1"
+                    }
+                    aggregation_function = "COUNT"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, rId, rName))
+}
+
+func testAccAnalysisConfig_TemplateSourceEntity(rId, rName, sourceId, sourceName string) string {
+	return acctest.ConfigCompose(
+		testAccAnalysisConfigBase(rId, rName),
+		fmt.Sprintf(`
+resource "aws_quicksight_template" "test" {
+  template_id         = %[3]q
+  name                = %[4]q
+  version_description = "test"
+  definition {
+    data_set_configuration {
+      data_set_schema {
+        column_schema_list {
+          name      = "Column1"
+          data_type = "STRING"
+        }
+        column_schema_list {
+          name      = "Column2"
+          data_type = "INTEGER"
+        }
+      }
+      placeholder = "1"
+    }
+    sheets {
+      title    = "Test"
+      sheet_id = "Test1"
+      visuals {
+        custom_content_visual {
+          data_set_identifier = "1"
+          title {
+            format_text {
+              plain_text = "Test"
+            }
+          }
+          visual_id = "Test1"
+        }
+      }
+      visuals {
+        line_chart_visual {
+          visual_id = "LineChart"
+          title {
+            format_text {
+              plain_text = "Line Chart Test"
+            }
+          }
+          chart_configuration {
+            field_wells {
+              line_chart_aggregated_field_wells {
+                category {
+                  categorical_dimension_field {
+                    field_id = "1"
+                    column {
+                      data_set_identifier = "1"
+                      column_name         = "Column1"
+                    }
+                  }
+                }
+                values {
+                  categorical_measure_field {
+                    field_id = "2"
+                    column {
+                      data_set_identifier = "1"
+                      column_name         = "Column1"
+                    }
+                    aggregation_function = "COUNT"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "aws_quicksight_analysis" "test" {
+  analysis_id = %[1]q
+  name        = %[2]q
+  source_entity {
+    source_template {
+      arn = aws_quicksight_template.test.arn
+      data_set_references {
+        data_set_arn         = aws_quicksight_data_set.test.arn
+        data_set_placeholder = "1"
+      }
+    }
+  }
+}
+`, rId, rName, sourceId, sourceName))
+}
+
+func testAccAnalysisConfig_ParametersConfig(rId, rName string) string {
+	return acctest.ConfigCompose(
+		testAccAnalysisConfigBase(rId, rName),
+		fmt.Sprintf(`
+resource "aws_quicksight_analysis" "test" {
+  analysis_id = %[1]q
+  name        = %[2]q
+  parameters {
+    string_parameters {
+      name   = "test"
+      values = ["value"]
+    }
+  }
+  definition {
+    data_set_identifiers_declarations {
+      data_set_arn = aws_quicksight_data_set.test.arn
+      identifier   = "1"
+    }
+    parameter_declarations {
+      string_parameter_declaration {
+        name                 = "test"
+        parameter_value_type = "SINGLE_VALUED"
+        default_values {
+          static_values = ["value"]
+        }
+        values_when_unset {
+          value_when_unset_option = "NULL"
+        }
+      }
+    }
+    sheets {
+      title    = "Example"
+      sheet_id = "Example1"
+      visuals {
+        line_chart_visual {
+          visual_id = "LineChart"
+          title {
+            format_text {
+              plain_text = "Line Chart Example"
+            }
+          }
+          chart_configuration {
+            field_wells {
+              line_chart_aggregated_field_wells {
+                category {
+                  categorical_dimension_field {
+                    field_id = "1"
+                    column {
+                      data_set_identifier = "1"
+                      column_name         = "Column1"
+                    }
+                  }
+                }
+                values {
+                  categorical_measure_field {
+                    field_id = "2"
+                    column {
+                      data_set_identifier = "1"
+                      column_name         = "Column1"
+                    }
+                    aggregation_function = "COUNT"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, rId, rName))
+}
+
+func testAccAnalysisConfig_ForceDelete(rId, rName string) string {
+	return acctest.ConfigCompose(
+		testAccAnalysisConfigBase(rId, rName),
+		fmt.Sprintf(`
+resource "aws_quicksight_analysis" "test" {
+  analysis_id = %[1]q
+  name        = %[2]q
+
+  recovery_window_in_days = 0
+
+  definition {
+    data_set_identifiers_declarations {
+      data_set_arn = aws_quicksight_data_set.test.arn
+      identifier   = "1"
+    }
+    sheets {
+      title    = "Example"
+      sheet_id = "Example1"
+      visuals {
+        line_chart_visual {
+          visual_id = "LineChart"
+          title {
+            format_text {
+              plain_text = "Line Chart Example"
+            }
+          }
+          chart_configuration {
+            field_wells {
+              line_chart_aggregated_field_wells {
+                category {
+                  categorical_dimension_field {
+                    field_id = "1"
+                    column {
+                      data_set_identifier = "1"
+                      column_name         = "Column1"
+                    }
+                  }
+                }
+                values {
+                  categorical_measure_field {
+                    field_id = "2"
+                    column {
+                      data_set_identifier = "1"
+                      column_name         = "Column1"
+                    }
+                    aggregation_function = "COUNT"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, rId, rName))
+}

--- a/internal/service/quicksight/schema/analysis.go
+++ b/internal/service/quicksight/schema/analysis.go
@@ -1,0 +1,254 @@
+package schema
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/quicksight"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+)
+
+func AnalysisDefinitionSchema() *schema.Schema {
+	return &schema.Schema{ // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_AnalysisDefinition.html
+		Type:     schema.TypeList,
+		MaxItems: 1,
+		Optional: true,
+		Computed: true,
+		ExactlyOneOf: []string{
+			"definition",
+			"source_entity",
+		},
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"data_set_identifiers_declarations": dataSetIdentifierDeclarationsSchema(), // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DataSetIdentifierDeclaration.html
+				"analysis_defaults":                 analysisDefaultSchema(),               // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_AnalysisDefaults.html
+				"calculated_fields": { // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CalculatedField.html
+					Type:     schema.TypeList,
+					MinItems: 1,
+					MaxItems: 500,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"data_set_identifier": stringSchema(true, validation.StringLenBetween(1, 2048)),
+							"expression":          stringSchema(true, validation.StringLenBetween(1, 4096)),
+							"name":                stringSchema(true, validation.StringLenBetween(1, 128)),
+						},
+					},
+				},
+				"column_configurations": { // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_ColumnConfiguration.html
+					Type:     schema.TypeList,
+					MinItems: 1,
+					MaxItems: 200,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"column":               columnSchema(),              // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_ColumnIdentifier.html
+							"format_configuration": formatConfigurationSchema(), // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_FormatConfiguration.html
+							"role":                 stringSchema(false, validation.StringInSlice(quicksight.ColumnRole_Values(), false)),
+						},
+					},
+				},
+				"filter_groups": { // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_FilterGroup.html
+					Type:     schema.TypeList,
+					MinItems: 1,
+					MaxItems: 2000,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"cross_dataset":       stringSchema(true, validation.StringInSlice(quicksight.CrossDatasetTypes_Values(), false)),
+							"filter_group_id":     idSchema(),
+							"filters":             filtersSchema(),                  // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_Filter.html
+							"scope_configuration": filterScopeConfigurationSchema(), // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_FilterScopeConfiguration.html
+							"status":              stringSchema(false, validation.StringInSlice(quicksight.Status_Values(), false)),
+						},
+					},
+				},
+				"parameter_declarations": { // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_ParameterDeclaration.html
+					Type:     schema.TypeList,
+					MinItems: 1,
+					MaxItems: 200,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"date_time_parameter_declaration": dateTimeParameterDeclarationSchema(), // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DateTimeParameterDeclaration.html
+							"decimal_parameter_declaration":   decimalParameterDeclarationSchema(),  // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DecimalParameterDeclaration.html
+							"integer_parameter_declaration":   integerParameterDeclarationSchema(),  // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_IntegerParameterDeclaration.html
+							"string_parameter_declaration":    stringParameterDeclarationSchema(),   // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_StringParameterDeclaration.html
+						},
+					},
+				},
+				"sheets": { // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_SheetDefinition.html
+					Type:     schema.TypeList,
+					MinItems: 1,
+					MaxItems: 20,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"sheet_id": idSchema(),
+							"content_type": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Computed:     true,
+								ValidateFunc: validation.StringInSlice(quicksight.SheetContentType_Values(), false),
+							},
+							"description":           stringSchema(false, validation.StringLenBetween(1, 1024)),
+							"filter_controls":       filterControlsSchema(), // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_FilterControl.html
+							"layouts":               layoutSchema(),         // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_Layout.html
+							"name":                  stringSchema(false, validation.StringLenBetween(1, 2048)),
+							"parameter_controls":    parameterControlsSchema(),   // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_ParameterControl.html
+							"sheet_control_layouts": sheetControlLayoutsSchema(), // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_SheetControlLayout.html
+							"text_boxes": { // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_SheetTextBox.html
+								Type:     schema.TypeList,
+								MinItems: 1,
+								MaxItems: 100,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"sheet_text_box_id": idSchema(),
+										"content":           stringSchema(false, validation.StringLenBetween(1, 150000)),
+									},
+								},
+							},
+							"title":   stringSchema(false, validation.StringLenBetween(1, 1024)),
+							"visuals": visualsSchema(), // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_Visual.html
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func AnalysisSourceEntitySchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		MaxItems: 1,
+		Optional: true,
+		ExactlyOneOf: []string{
+			"definition",
+			"source_entity",
+		},
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"source_template": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"arn": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"data_set_references": dataSetReferencesSchema(), // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DataSetReference.html
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func ExpandAnalysisSourceEntity(tfList []interface{}) *quicksight.AnalysisSourceEntity {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	sourceEntity := &quicksight.AnalysisSourceEntity{}
+
+	if v, ok := tfMap["source_template"].([]interface{}); ok && len(v) > 0 {
+		sourceEntity.SourceTemplate = expandAnalysisSourceTemplate(v[0].(map[string]interface{}))
+	}
+
+	return sourceEntity
+}
+
+func expandAnalysisSourceTemplate(tfMap map[string]interface{}) *quicksight.AnalysisSourceTemplate {
+	if tfMap == nil {
+		return nil
+	}
+
+	sourceTemplate := &quicksight.AnalysisSourceTemplate{}
+	if v, ok := tfMap["arn"].(string); ok && v != "" {
+		sourceTemplate.Arn = aws.String(v)
+	}
+	if v, ok := tfMap["data_set_references"].([]interface{}); ok && len(v) > 0 {
+		sourceTemplate.DataSetReferences = expandDataSetReferences(v)
+	}
+
+	return sourceTemplate
+}
+
+func ExpandAnalysisDefinition(tfList []interface{}) *quicksight.AnalysisDefinition {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	definition := &quicksight.AnalysisDefinition{}
+
+	if v, ok := tfMap["analysis_defaults"].([]interface{}); ok && len(v) > 0 {
+		definition.AnalysisDefaults = expandAnalysisDefaults(v)
+	}
+	if v, ok := tfMap["calculated_fields"].([]interface{}); ok && len(v) > 0 {
+		definition.CalculatedFields = expandCalculatedFields(v)
+	}
+	if v, ok := tfMap["column_configurations"].([]interface{}); ok && len(v) > 0 {
+		definition.ColumnConfigurations = expandColumnConfigurations(v)
+	}
+	if v, ok := tfMap["data_set_identifiers_declarations"].([]interface{}); ok && len(v) > 0 {
+		definition.DataSetIdentifierDeclarations = expandDataSetIdentifierDeclarations(v)
+	}
+	if v, ok := tfMap["filter_groups"].([]interface{}); ok && len(v) > 0 {
+		definition.FilterGroups = expandFilterGroups(v)
+	}
+	if v, ok := tfMap["parameter_declarations"].([]interface{}); ok && len(v) > 0 {
+		definition.ParameterDeclarations = expandParameterDeclarations(v)
+	}
+	if v, ok := tfMap["sheets"].([]interface{}); ok && len(v) > 0 {
+		definition.Sheets = expandSheetDefinitions(v)
+	}
+
+	return definition
+}
+
+func FlattenAnalysisDefinition(apiObject *quicksight.AnalysisDefinition) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+	if apiObject.AnalysisDefaults != nil {
+		tfMap["analysis_defaults"] = flattenAnalysisDefaults(apiObject.AnalysisDefaults)
+	}
+	if apiObject.CalculatedFields != nil {
+		tfMap["calculated_fields"] = flattenCalculatedFields(apiObject.CalculatedFields)
+	}
+	if apiObject.ColumnConfigurations != nil {
+		tfMap["column_configurations"] = flattenColumnConfigurations(apiObject.ColumnConfigurations)
+	}
+	if apiObject.DataSetIdentifierDeclarations != nil {
+		tfMap["data_set_identifiers_declarations"] = flattenDataSetIdentifierDeclarations(apiObject.DataSetIdentifierDeclarations)
+	}
+	if apiObject.FilterGroups != nil {
+		tfMap["filter_groups"] = flattenFilterGroups(apiObject.FilterGroups)
+	}
+	if apiObject.ParameterDeclarations != nil {
+		tfMap["parameter_declarations"] = flattenParameterDeclarations(apiObject.ParameterDeclarations)
+	}
+	if apiObject.Sheets != nil {
+		tfMap["sheets"] = flattenSheetDefinitions(apiObject.Sheets)
+	}
+
+	return []interface{}{tfMap}
+}

--- a/internal/service/quicksight/service_package_gen.go
+++ b/internal/service/quicksight/service_package_gen.go
@@ -82,6 +82,14 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			Name:     "Account Subscription",
 		},
 		{
+			Factory:  ResourceAnalysis,
+			TypeName: "aws_quicksight_analysis",
+			Name:     "Analysis",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
+		},
+		{
 			Factory:  ResourceDashboard,
 			TypeName: "aws_quicksight_dashboard",
 			Name:     "Dashboard",

--- a/internal/service/quicksight/status.go
+++ b/internal/service/quicksight/status.go
@@ -62,3 +62,19 @@ func statusDashboard(ctx context.Context, conn *quicksight.QuickSight, id string
 		return out, *out.Version.Status, nil
 	}
 }
+
+// Fetch Analysis status
+func statusAnalysis(ctx context.Context, conn *quicksight.QuickSight, id string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		out, err := FindAnalysisByID(ctx, conn, id)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return out, *out.Status, nil
+	}
+}

--- a/website/docs/r/quicksight_analysis.html.markdown
+++ b/website/docs/r/quicksight_analysis.html.markdown
@@ -1,0 +1,166 @@
+---
+subcategory: "QuickSight"
+layout: "aws"
+page_title: "AWS: aws_quicksight_analysis"
+description: |-
+  Manages a QuickSight Analysis.
+---
+
+# Resource: aws_quicksight_analysis
+
+Resource for managing a QuickSight Analysis.
+
+## Example Usage
+
+### From Source Template
+
+```terraform
+resource "aws_quicksight_analysis" "example" {
+  analysis_id = "example-id"
+  name        = "example-name"
+  source_entity {
+    source_template {
+      arn = aws_quicksight_template.source.arn
+      data_set_references {
+        data_set_arn         = aws_quicksight_data_set.dataset.arn
+        data_set_placeholder = "1"
+      }
+    }
+  }
+}
+```
+
+### With Definition
+
+```terraform
+resource "aws_quicksight_analysis" "example" {
+  analysis_id = "example-id"
+  name        = "example-name"
+  definition {
+    data_set_identifiers_declarations {
+      data_set_arn = aws_quicksight_data_set.dataset.arn
+      identifier   = "1"
+    }
+    sheets {
+      title    = "Example"
+      sheet_id = "Example1"
+      visuals {
+        line_chart_visual {
+          visual_id = "LineChart"
+          title {
+            format_text {
+              plain_text = "Line Chart Example"
+            }
+          }
+          chart_configuration {
+            field_wells {
+              line_chart_aggregated_field_wells {
+                category {
+                  categorical_dimension_field {
+                    field_id = "1"
+                    column {
+                      data_set_identifier = "1"
+                      column_name         = "Column1"
+                    }
+                  }
+                }
+                values {
+                  categorical_measure_field {
+                    field_id = "2"
+                    column {
+                      data_set_identifier = "1"
+                      column_name         = "Column1"
+                    }
+                    aggregation_function = "COUNT"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `analysis_id` - (Required, Forces new resource) Identifier for the analysis.
+* `name` - (Required) Display name for the analysis.
+
+The following arguments are optional:
+
+* `aws_account_id` - (Optional, Forces new resource) AWS account ID.
+* `definition` - (Optional) A detailed analysis definition. Only one of `definition` or `source_entity` should be configured. See [definition](#definition).
+* `parameters` - (Optional) The parameters for the creation of the analysis, which you want to use to override the default settings. An analysis can have any type of parameters, and some parameters might accept multiple values. See [parameters](#parameters).
+* `permissions` - (Optional) A set of resource permissions on the analysis. Maximum of 64 items. See [permissions](#permissions).
+* `recovery_window_in_days` - (Optional) A value that specifies the number of days that Amazon QuickSight waits before it deletes the analysis. Use `0` to force deletion without recovery. Minimum value of `7`. Maximum value of `30`. Default to `30`.
+* `source_entity` - (Optional) The entity that you are using as a source when you create the analysis (template). Only one of `definition` or `source_entity` should be configured. See [source_entity](#source_entity).
+* `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `theme_arn` - (Optional) The Amazon Resource Name (ARN) of the theme that is being used for this analysis. The theme ARN must exist in the same AWS account where you create the analysis.
+
+### permissions
+
+* `actions` - (Required) List of IAM actions to grant or revoke permissions on.
+* `principal` - (Required) ARN of the principal. See the [ResourcePermission documentation](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_ResourcePermission.html) for the applicable ARN values.
+
+### source_entity
+
+* `source_template` - (Optional) The source template. See [source_template](#source_template).
+
+### source_template
+
+* `arn` - (Required) The Amazon Resource Name (ARN) of the resource.
+* `data_set_references` - (Required) List of dataset references. See [data_set_references](#data_set_references).
+
+### data_set_references
+
+* `data_set_arn` - (Required) Dataset Amazon Resource Name (ARN).
+* `data_set_placeholder` - (Required) Dataset placeholder.
+
+### parameters
+
+* `date_time_parameters` - (Optional) A list of parameters that have a data type of date-time. See [AWS API Documentation for complete description](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DateTimeParameter.html).
+* `decimal_parameters` - (Optional) A list of parameters that have a data type of decimal. See [AWS API Documentation for complete description](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DecimalParameter.html).
+* `integer_parameters` - (Optional) A list of parameters that have a data type of integer. See [AWS API Documentation for complete description](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_IntegerParameter.html).
+* `string_parameters` - (Optional) A list of parameters that have a data type of string. See [AWS API Documentation for complete description](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_StringParameter.html).
+
+### definition
+
+* `data_set_identifiers_declarations` - (Required) A list dataset identifier declarations. With this mapping,you can use dataset identifiers instead of dataset Amazon Resource Names (ARNs) throughout the analysis sub-structures. See [AWS API Documentation for complete description](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DataSetIdentifierDeclaration.html).
+* `analysis_defaults` - (Optional) The configuration for default analysis settings. See [AWS API Documentation for complete description](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_AnalysisDefaults.html).
+* `calculated_fields` - (Optional) A list of calculated field definitions for the analysis. See [AWS API Documentation for complete description](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CalculatedField.html).
+* `column_configurations` - (Optional) A list of analysis-level column configurations. Column configurations are used to set default formatting for a column that's used throughout an analysis. See [AWS API Documentation for complete description](ttps://docs.aws.amazon.com/quicksight/latest/APIReference/API_ColumnConfiguration.html).
+* `filter_groups` - (Optional) A list of filter definitions for an analysis. See [AWS API Documentation for complete description](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_FilterGroup.html). For more information, see [Filtering Data](https://docs.aws.amazon.com/quicksight/latest/user/filtering-visual-data.html) in Amazon QuickSight User Guide.
+* `parameters_declarations` - (Optional) A list of parameter declarations for an analysis. Parameters are named variables that can transfer a value for use by an action or an object. See [AWS API Documentation for complete description](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_ParameterDeclaration.html). For more information, see [Parameters in Amazon QuickSight](https://docs.aws.amazon.com/quicksight/latest/user/parameters-in-quicksight.html) in the Amazon QuickSight User Guide.
+* `sheets` - (Optional) A list of sheet definitions for an analysis. See [AWS API Documentation for complete description](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_SheetDefinition.html).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the analysis.
+* `created_time` - The time that the analysis was created.
+* `id` - A comma-delimited string joining AWS account ID and analysis ID.
+* `last_updated_time` - The time that the analysis was last updated.
+* `status` - The analysis creation status.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block).
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `5m`)
+* `update` - (Default `5m`)
+* `delete` - (Default `5m`)
+
+## Import
+
+A QuickSight Analysis can be imported using the AWS account ID and analysis ID separated by a comma (`,`) e.g.,
+
+```
+$ terraform import aws_quicksight_analysis.example 123456789012,example-id
+```


### PR DESCRIPTION
### Description
New resource for Quicksight Analysis.

- Definition mostly reuse underlying resources shared with Template and Dashboard.
- Tests for basic usage, update, analysis specific attributes

### Relations

Relates #31666

https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CreateAnalysis.html
https://docs.aws.amazon.com/quicksight/latest/APIReference/API_UpdateAnalysis.html
https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DescribeAnalysis.html
https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DescribeAnalysisDefinition.html
https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DescribeAnalysisPermissions.html
https://docs.aws.amazon.com/quicksight/latest/APIReference/API_DeleteAnalysis.html


### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccQuickSightAnalysis PKG=quicksight
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightAnalysis'  -timeout 180m
=== RUN   TestAccQuickSightAnalysis_basic
=== PAUSE TestAccQuickSightAnalysis_basic
=== RUN   TestAccQuickSightAnalysis_disappears
=== PAUSE TestAccQuickSightAnalysis_disappears
=== RUN   TestAccQuickSightAnalysis_sourceEntity
=== PAUSE TestAccQuickSightAnalysis_sourceEntity
=== RUN   TestAccQuickSightAnalysis_update
=== PAUSE TestAccQuickSightAnalysis_update
=== RUN   TestAccQuickSightAnalysis_parametersConfig
=== PAUSE TestAccQuickSightAnalysis_parametersConfig
=== RUN   TestAccQuickSightAnalysis_forceDelete
=== PAUSE TestAccQuickSightAnalysis_forceDelete
=== CONT  TestAccQuickSightAnalysis_basic
=== CONT  TestAccQuickSightAnalysis_update
=== CONT  TestAccQuickSightAnalysis_forceDelete
=== CONT  TestAccQuickSightAnalysis_sourceEntity
=== CONT  TestAccQuickSightAnalysis_parametersConfig
=== CONT  TestAccQuickSightAnalysis_disappears
--- PASS: TestAccQuickSightAnalysis_forceDelete (84.90s)
--- PASS: TestAccQuickSightAnalysis_disappears (86.16s)
--- PASS: TestAccQuickSightAnalysis_parametersConfig (91.33s)
--- PASS: TestAccQuickSightAnalysis_basic (95.25s)
--- PASS: TestAccQuickSightAnalysis_sourceEntity (102.38s)
--- PASS: TestAccQuickSightAnalysis_update (135.77s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 135.952s
```
