### PR TITLE
resource/aws_autoscaling_group: Ignore scaling activities from before the scaling operation started

### DIFF
--- a/.changelog/31551.txt
+++ b/.changelog/31551.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_autoscaling_group: Now ignores previous failed scaling activities
+```

--- a/internal/service/autoscaling/group_test.go
+++ b/internal/service/autoscaling/group_test.go
@@ -597,14 +597,14 @@ func TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitectu
 		CheckDestroy:             testAccCheckGroupDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccGroupConfig_withPotentialScalingActivityError(rName, "t4g.micro"),
+				Config:      testAccGroupConfig_withPotentialScalingActivityError(rName, "t4g.micro", 1),
 				ExpectError: regexp.MustCompile(`The architecture 'arm64' of the specified instance type does not match the architecture 'x86_64' of the specified AMI`),
 			},
 		},
 	})
 }
 
-func TestAccAutoScalingGroup_withNoScalingActivityErrorCorrectInstanceArchitecture(t *testing.T) {
+func TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture_Recovers(t *testing.T) {
 	ctx := acctest.Context(t)
 	var group autoscaling.Group
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -617,8 +617,18 @@ func TestAccAutoScalingGroup_withNoScalingActivityErrorCorrectInstanceArchitectu
 		CheckDestroy:             testAccCheckGroupDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGroupConfig_withPotentialScalingActivityError(rName, "t2.micro"),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccGroupConfig_withPotentialScalingActivityError(rName, "t2.micro", 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGroupExists(ctx, resourceName, &group),
+				),
+			},
+			{
+				Config:      testAccGroupConfig_withPotentialScalingActivityError(rName, "t4g.micro", 2),
+				ExpectError: regexp.MustCompile(`The architecture 'arm64' of the specified instance type does not match the architecture 'x86_64' of the specified AMI`),
+			},
+			{
+				Config: testAccGroupConfig_withPotentialScalingActivityError(rName, "t2.micro", 3),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGroupExists(ctx, resourceName, &group),
 				),
 			},
@@ -3603,9 +3613,13 @@ func testAccGroupConfig_launchConfigurationBase(rName, instanceType string) stri
 		acctest.ConfigLatestAmazonLinuxHVMEBSAMI(),
 		fmt.Sprintf(`
 resource "aws_launch_configuration" "test" {
-  name          = %[1]q
+  name_prefix   = %[1]q
   image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
   instance_type = %[2]q
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 `, rName, instanceType))
 }
@@ -4120,20 +4134,24 @@ resource "aws_autoscaling_group" "test" {
 `, rName))
 }
 
-func testAccGroupConfig_withPotentialScalingActivityError(rName, instanceType string) string {
+func testAccGroupConfig_withPotentialScalingActivityError(rName, instanceType string, instanceCount int) string {
 	return acctest.ConfigCompose(testAccGroupConfig_launchConfigurationBase(rName, instanceType), fmt.Sprintf(`
 resource "aws_autoscaling_group" "test" {
   availability_zones        = [data.aws_availability_zones.available.names[0]]
   name                      = %[1]q
-  max_size                  = 1
+  max_size                  = %[2]d
   min_size                  = 1
   health_check_grace_period = 300
   health_check_type         = "ELB"
-  desired_capacity          = 1
+  desired_capacity          = %[2]d
   force_delete              = true
   termination_policies      = ["OldestInstance", "ClosestToNextInstanceHour"]
   wait_for_capacity_timeout = "2m"
   launch_configuration      = aws_launch_configuration.test.name
+
+  instance_refresh {
+    strategy = "Rolling"
+  }
 
   tag {
     key                 = "Name"
@@ -4141,7 +4159,7 @@ resource "aws_autoscaling_group" "test" {
     propagate_at_launch = true
   }
 }
-`, rName))
+`, rName, instanceCount))
 }
 
 func testAccGroupConfig_serviceLinkedRoleARN(rName string) string {


### PR DESCRIPTION
### Description

The AWS API returns the last six weeks of Auto Scaling Group scaling activities. If old errored activities exist, this can cause failures.

Now ignores scaling activities before the start of the operation.

### Relations

Closes #26377

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=autoscaling TESTS=TestAccAutoScalingGroup_

--- PASS: TestAccAutoScalingGroup_basic (53.70s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_spotMaxPricePercentageOverLowestPrice (55.90s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice (78.87s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_instanceGenerations (93.05s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandAllocationStrategy (100.30s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandBaseCapacity (105.52s)
--- PASS: TestAccAutoScalingGroup_serviceLinkedRoleARN (110.45s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_excludedInstanceTypes (123.86s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorageTypes (127.46s)
--- PASS: TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture (32.36s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_cpuManufacturers (158.72s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_requireHibernateSupport (160.78s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorage (166.01s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_allowedInstanceTypes (173.61s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryGiBPerVCPU (174.16s)
--- PASS: TestAccAutoScalingGroup_withScalingActivityErrorPlacementGroupNotSupportedOnInstanceType (46.95s)
--- PASS: TestAccAutoScalingGroup_withMetrics (85.88s)
--- FAIL: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeUnits (194.43s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicy_capacityRebalance (38.52s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_totalLocalStorageGB (205.45s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_bareMetal (167.85s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeVCPU (228.87s)
--- PASS: TestAccAutoScalingGroup_enablingMetrics (143.70s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_burstablePerformance (268.86s)
--- PASS: TestAccAutoScalingGroup_launchTempPartitionNum (100.09s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkInterfaceCount (287.27s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_baselineEBSBandwidthMbps (236.86s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceTypeWithLaunchTemplateSpecification (41.56s)
--- PASS: TestAccAutoScalingGroup_Destroy_whenProtectedFromScaleIn (147.59s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkBandwidthGbps (325.94s)
--- PASS: TestAccAutoScalingGroup_terminationPolicies (98.36s)
--- PASS: TestAccAutoScalingGroup_withLoadBalancer (248.71s)
--- PASS: TestAccAutoScalingGroup_targetGroups (130.22s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeUnits (136.00s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTypes (67.66s)
--- PASS: TestAccAutoScalingGroup_tags (142.71s)
--- PASS: TestAccAutoScalingGroup_suspendingProcesses (260.55s)
--- PASS: TestAccAutoScalingGroup_disappears (33.04s)
--- PASS: TestAccAutoScalingGroup_namePrefix (46.09s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorManufacturers (80.28s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTotalMemoryMiB (107.86s)
--- PASS: TestAccAutoScalingGroup_defaultInstanceWarmup (52.31s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorCount (102.40s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryMiBAndVCPUCount (99.22s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotAllocationStrategy (43.58s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity (134.22s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceType (76.19s)
--- PASS: TestAccAutoScalingGroup_vpcUpdates (245.47s)
--- PASS: TestAccAutoScalingGroup_nameGenerated (138.97s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotMaxPrice (90.49s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName (85.82s)
--- PASS: TestAccAutoScalingGroup_ALBTargetGroups_elbCapacity (303.91s)
--- PASS: TestAccAutoScalingGroup_withPlacementGroup (348.27s)
--- PASS: TestAccAutoScalingGroup_launchTemplate (41.34s)
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_triggers (122.03s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_updateToZeroOnDemandBaseCapacity (70.92s)
--- PASS: TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture_Recovers (440.83s)
--- PASS: TestAccAutoScalingGroup_maxInstanceLifetime (68.47s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_version (168.72s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotInstancePools (61.06s)
--- PASS: TestAccAutoScalingGroup_LaunchTemplate_update (101.24s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandPercentageAboveBaseCapacity (85.19s)
--- PASS: TestAccAutoScalingGroup_simple (337.65s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorNames (304.58s)
--- PASS: TestAccAutoScalingGroup_WithLoadBalancer_toTargetGroup (454.74s)
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_start (189.68s)
--- PASS: TestAccAutoScalingGroup_mixedInstancesPolicy (451.33s)
--- PASS: TestAccAutoScalingGroup_warmPool (447.89s)
--- PASS: TestAccAutoScalingGroup_largeDesiredCapacity (213.17s)
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_basic (202.22s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity_withELB (358.82s)
--- PASS: TestAccAutoScalingGroup_initialLifecycleHook (224.68s)
--- PASS: TestAccAutoScalingGroup_loadBalancers (545.29s)
```
