### PR TITLE
Revert "Use default retry count from AWS SDK"

### DIFF
--- a/.changelog/31276.txt
+++ b/.changelog/31276.txt
@@ -1,3 +1,0 @@
-```release-note:breaking-change
-provider: Now uses the default retry count for AWS SDKs
-```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -419,6 +419,7 @@ func configure(ctx context.Context, provider *schema.Provider, d *schema.Resourc
 		Endpoints:                      make(map[string]string),
 		HTTPProxy:                      d.Get("http_proxy").(string),
 		Insecure:                       d.Get("insecure").(bool),
+		MaxRetries:                     25, // Set default here, not in schema (muxing with v6 provider).
 		Profile:                        d.Get("profile").(string),
 		Region:                         d.Get("region").(string),
 		S3UsePathStyle:                 d.Get("s3_use_path_style").(bool),

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -59,6 +59,7 @@ func SharedRegionalSweepClientWithContext(ctx context.Context, region string) (i
 	}
 
 	conf := &conns.Config{
+		MaxRetries:       5,
 		Region:           region,
 		SuppressDebugLog: true,
 	}

--- a/website/docs/guides/version-5-upgrade.html.md
+++ b/website/docs/guides/version-5-upgrade.html.md
@@ -151,8 +151,6 @@ Version 5.0.0 removes these `provider` arguments:
 * `shared_credentials_file` - Use `shared_credentials_files` instead
 * `skip_get_ec2_platforms` - Removed following the retirement of EC2-Classic
 
-The default value of `max_retries` now uses the default from the AWS SDKs instead of `25`, which could cause the provider to appear to hang in some cases.
-
 ## Default Tags
 
 The following enhancements are included:

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -313,6 +313,7 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 * `insecure` - (Optional) Whether to explicitly allow the provider to perform "insecure" SSL requests. If omitted, the default value is `false`.
 * `max_retries` - (Optional) Maximum number of times an API call is retried when AWS throttles requests or you experience transient failures.
   The delay between the subsequent API calls increases exponentially.
+  If omitted, the default value is `25`.
   Can also be set using the environment variable `AWS_MAX_ATTEMPTS`
   and the shared configuration parameter `max_attempts`.
 * `profile` - (Optional) AWS profile name as set in the shared configuration and credentials files.


### PR DESCRIPTION
Reverts hashicorp/terraform-provider-aws#31276