### PR TITLE
Fix example in `aws_scheduler_schedule`

### DIFF
--- a/website/docs/r/scheduler_schedule.html.markdown
+++ b/website/docs/r/scheduler_schedule.html.markdown
@@ -27,7 +27,7 @@ resource "aws_scheduler_schedule" "example" {
     mode = "OFF"
   }
 
-  schedule_expression = "rate(1 hour)"
+  schedule_expression = "rate(1 hours)"
 
   target {
     arn      = aws_sqs_queue.example.arn
@@ -48,7 +48,7 @@ resource "aws_scheduler_schedule" "example" {
     mode = "OFF"
   }
 
-  schedule_expression = "rate(1 hour)"
+  schedule_expression = "rate(1 hours)"
 
   target {
     arn      = "arn:aws:scheduler:::aws-sdk:sqs:sendMessage"


### PR DESCRIPTION
### Description

This PR corrects the `schedule_expression` parameter in the examples in the `aws_scheduler_schedule` resource. The accepted units are plural (`minutes` | `hours` | `days`).

### Relations

Closes #31471

### References

https://docs.aws.amazon.com/scheduler/latest/UserGuide/schedule-types.html

### Output from Acceptance Testing

N/a, docs