### PR TITLE
Clarify `aws_codedeploy_deployment_group` argument requirements

### DIFF
--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -315,7 +315,7 @@ The `target_group_pair_info` configuration block supports the following:
 
 The `prod_traffic_route` configuration block supports the following:
 
-* `listener_arns` - (Required) List of Amazon Resource Names (ARNs) of the load balancer listeners.
+* `listener_arns` - (Required) List of Amazon Resource Names (ARNs) of the load balancer listeners. Must contain exactly one listener ARN.
 
 ##### load_balancer_info target_group_pair_info target_group Argument Reference
 


### PR DESCRIPTION
### Description

This PR aims to clarify that the `aws_codedeploy_deployment_group` resource's `load_balancer_info.target_group_pair_info.prod_traffic_route.listener_arns` argument may only contain one listener ARN.

### Relations

Closes #31243

### References

https://docs.aws.amazon.com/sdk-for-go/api/service/codedeploy/#TrafficRoute

>  // The Amazon Resource Name (ARN) of one listener. The listener identifies the
    // route between a target group and a load balancer. This is an array of strings
    // with a maximum size of one.

### Output from Acceptance Testing

N/a, docs