### PR TITLE
Tags: fix for null tags in config

### DIFF
--- a/.changelog/31587.txt
+++ b/.changelog/31587.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+provider/tags: Fix crash when tags are `null`
+```

--- a/internal/service/ec2/vpc_test.go
+++ b/internal/service/ec2/vpc_test.go
@@ -157,6 +157,28 @@ func TestAccVPC_tags_computed(t *testing.T) {
 	})
 }
 
+func TestAccVPC_tags_null(t *testing.T) {
+	ctx := acctest.Context(t)
+	var vpc ec2.Vpc
+	resourceName := "aws_vpc.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckVPCDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCConfig_tags_null,
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckVPCExists(ctx, resourceName, &vpc),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccVPC_DefaultTags_zeroValue(t *testing.T) {
 	ctx := acctest.Context(t)
 	var vpc ec2.Vpc
@@ -1135,6 +1157,16 @@ resource "aws_vpc" "test" {
 
   tags = {
     eip = aws_eip.test.public_ip
+  }
+}
+`
+
+const testAccVPCConfig_tags_null = `
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = null
   }
 }
 `

--- a/internal/tags/key_value_tags.go
+++ b/internal/tags/key_value_tags.go
@@ -780,7 +780,10 @@ func (tags KeyValueTags) ResolveDuplicates(ctx context.Context, defaultConfig *D
 		if !c.IsNull() && c.IsKnown() {
 			for k, v := range c.AsValueMap() {
 				if _, ok := configTags[k]; !ok {
-					configTags[k] = v.AsString()
+					// config tags can be null values. Ignore.
+					if !v.IsNull() {
+						configTags[k] = v.AsString()
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

`null` values can be used as placeholders for tags that are not configured. These values should be ignored when resolving tag differences.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #31583
Closes #31586

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console 
make testacc TESTARGS='-run=TestAccVPC_ -short' PKG=vpc

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPC_ -short -timeout 180m
    vpc_test.go:969: skipping long-running test in short mode
--- SKIP: TestAccVPC_IPAMIPv4BasicNetmask (0.00s)
    vpc_test.go:996: skipping long-running test in short mode
--- SKIP: TestAccVPC_IPAMIPv4BasicExplicitCIDR (0.00s)
    vpc_test.go:1024: skipping long-running test in short mode
--- SKIP: TestAccVPC_IPAMIPv6 (0.00s)
=== NAME  TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup
    ec2_availability_zone_data_source_test.go:219: skipping since no Local Zones are available
--- SKIP: TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup (0.85s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_duplicateTag (31.26s)
--- PASS: TestAccVPC_tags_null (33.71s)
--- PASS: TestAccVPC_tags_computed (36.52s)
--- PASS: TestAccVPC_basic (41.38s)
--- PASS: TestAccVPC_bothDNSOptionsSet (51.27s)
--- PASS: TestAccVPC_enableNetworkAddressUsageMetrics (52.15s)
--- PASS: TestAccVPC_disabledDNSSupport (52.64s)
--- PASS: TestAccVPC_DefaultTags_updateToResourceOnly (57.54s)
--- PASS: TestAccVPC_disappears (23.38s)
--- PASS: TestAccVPC_DefaultTags_updateToProviderOnly (59.32s)
--- PASS: TestAccVPC_DynamicResourceTags_ignoreChanges (60.86s)
--- PASS: TestAccVPC_DynamicResourceTagsMergedWithLocals_ignoreChanges (61.29s)
--- PASS: TestAccVPC_defaultAndIgnoreTags (61.61s)
--- PASS: TestAccVPC_ignoreTags (62.98s)
--- PASS: TestAccVPC_updateDNSHostnames (63.97s)
--- PASS: TestAccVPC_DefaultTags_zeroValue (66.80s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_nonOverlappingTag (70.15s)
--- PASS: TestAccVPC_DefaultTags_providerOnlyTestAccVPC_DefaultTags_providerOnly (70.23s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_overlappingTag (70.82s)
--- PASS: TestAccVPC_tenancy (74.72s)
--- PASS: TestAccVPC_tags (56.09s)
--- PASS: TestAccVPC_assignGeneratedIPv6CIDRBlock (97.65s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	100.941s
```
