### PR TITLE
Update `aws_xray_sampling_rule` example

### DIFF
--- a/website/docs/r/xray_sampling_rule.html.markdown
+++ b/website/docs/r/xray_sampling_rule.html.markdown
@@ -15,7 +15,7 @@ Creates and manages an AWS XRay Sampling Rule.
 ```terraform
 resource "aws_xray_sampling_rule" "example" {
   rule_name      = "example"
-  priority       = 10000
+  priority       = 9999
   version        = 1
   reservoir_size = 1
   fixed_rate     = 0.05


### PR DESCRIPTION
### Description

This PR corrects the example in `aws_xray_sampling_rule` such that the `priority` argument passes validation.

### Relations

Closes #31591

### References

- [Schema `ValidateFunc`](https://github.com/hashicorp/terraform-provider-aws/blob/b9e8c729f2b6dacaa5a7a90e5fccdc8c9c59f4d2/internal/service/xray/sampling_rule.go#L69)

### Output from Acceptance Testing

N/a, docs
