### PR TITLE
r/aws_glue_data_quality_ruleset

### DIFF
--- a/.changelog/31604.txt
+++ b/.changelog/31604.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_glue_data_quality_ruleset
+```

--- a/internal/service/glue/data_quality_ruleset.go
+++ b/internal/service/glue/data_quality_ruleset.go
@@ -1,0 +1,86 @@
+package glue
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKResource("aws_glue_data_quality_ruleset", name="Data Quality Ruleset")
+// @Tags(identifierAttribute="arn")
+func ResourceDataQualityRuleset() *schema.Resource {
+	return &schema.Resource{
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		CustomizeDiff: verify.SetTagsDiff,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_on": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 2048),
+			},
+			"last_modified_on": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 255),
+			},
+			"recommendation_run_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ruleset": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 65536),
+			},
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			"target_table": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// not found in SDK
+						// "catalog_id": {
+						// 	Type:         schema.TypeString,
+						// 	Optional:     true,
+						// 	ForceNew:     true,
+						// 	ValidateFunc: validation.StringLenBetween(1, 255),
+						// },
+						"database_name": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringLenBetween(1, 255),
+						},
+						"table_name": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringLenBetween(1, 255),
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/service/glue/data_quality_ruleset.go
+++ b/internal/service/glue/data_quality_ruleset.go
@@ -27,6 +27,7 @@ func ResourceDataQualityRuleset() *schema.Resource {
 		CreateWithoutTimeout: resourceDataQualityRulesetCreate,
 		ReadWithoutTimeout:   resourceDataQualityRulesetRead,
 		UpdateWithoutTimeout: resourceDataQualityRulesetUpdate,
+		DeleteWithoutTimeout: resourceDataQualityRulesetDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -195,6 +196,21 @@ func resourceDataQualityRulesetUpdate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	return append(diags, resourceDataQualityRulesetRead(ctx, d, meta)...)
+}
+
+func resourceDataQualityRulesetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).GlueConn()
+
+	log.Printf("[DEBUG] Glue Data Quality Ruleset: %s", d.Id())
+	_, err := conn.DeleteDataQualityRulesetWithContext(ctx, &glue.DeleteDataQualityRulesetInput{
+		Name: aws.String(d.Get("name").(string)),
+	})
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "deleting Glue Data Quality Ruleset (%s): %s", d.Id(), err)
+	}
+
+	return diags
 }
 
 func expandTargetTable(tfMap map[string]interface{}) *glue.DataQualityTargetTable {

--- a/internal/service/glue/data_quality_ruleset.go
+++ b/internal/service/glue/data_quality_ruleset.go
@@ -1,9 +1,21 @@
 package glue
 
 import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -12,6 +24,7 @@ import (
 // @Tags(identifierAttribute="arn")
 func ResourceDataQualityRuleset() *schema.Resource {
 	return &schema.Resource{
+		ReadWithoutTimeout: resourceDataQualityRulesetRead,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -83,4 +96,57 @@ func ResourceDataQualityRuleset() *schema.Resource {
 			},
 		},
 	}
+}
+
+func resourceDataQualityRulesetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).GlueConn()
+
+	name := d.Id()
+
+	dataQualityRuleset, err := FindDataQualityRulesetByName(ctx, conn, name)
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Glue Data Quality Ruleset (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Glue Data Quality Ruleset (%s): %s", d.Id(), err)
+	}
+
+	dataQualityRulesetArn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   "glue",
+		Region:    meta.(*conns.AWSClient).Region,
+		AccountID: meta.(*conns.AWSClient).AccountID,
+		Resource:  fmt.Sprintf("dataQualityRuleset/%s", aws.StringValue(dataQualityRuleset.Name)),
+	}.String()
+
+	d.Set("arn", dataQualityRulesetArn)
+	d.Set("created_on", dataQualityRuleset.CreatedOn.Format(time.RFC3339))
+	d.Set("name", dataQualityRuleset.Name)
+	d.Set("description", dataQualityRuleset.Description)
+	d.Set("last_modified_on", dataQualityRuleset.CreatedOn.Format(time.RFC3339))
+	d.Set("recommendation_run_id", dataQualityRuleset.RecommendationRunId)
+	d.Set("ruleset", dataQualityRuleset.Ruleset)
+
+	if err := d.Set("target_table", flattenTargetTable(dataQualityRuleset.TargetTable)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting target_table: %s", err)
+	}
+
+	return diags
+}
+
+func flattenTargetTable(apiObject *glue.DataQualityTargetTable) []interface{} {
+	if apiObject == nil {
+		return []interface{}{}
+	}
+
+	tfMap := map[string]interface{}{
+		"database_name": aws.StringValue(apiObject.DatabaseName),
+		"table_name":    aws.StringValue(apiObject.TableName),
+	}
+
+	return []interface{}{tfMap}
 }

--- a/internal/service/glue/data_quality_ruleset_test.go
+++ b/internal/service/glue/data_quality_ruleset_test.go
@@ -1,0 +1,120 @@
+package glue_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfglue "github.com/hashicorp/terraform-provider-aws/internal/service/glue"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func TestAccGlueDataQualityRuleset_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	ruleset := "Rules = [Completeness \"colA\" between 0.4 and 0.8]"
+	resourceName := "aws_glue_data_quality_ruleset.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, glue.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataQualityRulesetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataQualityRulesetConfig_basic(rName, ruleset),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDataQualityRulesetExists(ctx, resourceName),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("dataQualityRuleset/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "created_on"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "last_modified_on"),
+					resource.TestCheckResourceAttr(resourceName, "ruleset", ruleset),
+					resource.TestCheckResourceAttr(resourceName, "target_table.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDataQualityRulesetExists(ctx context.Context, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).GlueConn()
+
+		resp, err := tfglue.FindDataQualityRulesetByName(ctx, conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if resp == nil {
+			return fmt.Errorf("No Glue Data Quality Ruleset Found")
+		}
+
+		if aws.StringValue(resp.Name) != rs.Primary.ID {
+			return fmt.Errorf("Glue Data Quality Ruleset Mismatch - existing: %q, state: %q",
+				aws.StringValue(resp.Name), rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDataQualityRulesetDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).GlueConn()
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_glue_data_quality_ruleset" {
+				continue
+			}
+
+			_, err := tfglue.FindDataQualityRulesetByName(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("Glue Data Quality Ruleset %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccDataQualityRulesetConfig_basic(rName, ruleset string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_data_quality_ruleset" "test" {
+  name    = %[1]q
+  ruleset = %[2]q
+}
+`, rName, ruleset)
+}

--- a/internal/service/glue/data_quality_ruleset_test.go
+++ b/internal/service/glue/data_quality_ruleset_test.go
@@ -52,6 +52,31 @@ func TestAccGlueDataQualityRuleset_basic(t *testing.T) {
 	})
 }
 
+func TestAccGlueDataQualityRuleset_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	ruleset := "Rules = [Completeness \"colA\" between 0.4 and 0.8]"
+	resourceName := "aws_glue_data_quality_ruleset.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, glue.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataQualityRulesetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataQualityRulesetConfig_basic(rName, ruleset),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataQualityRulesetExists(ctx, resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfglue.ResourceDataQualityRuleset(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckDataQualityRulesetExists(ctx context.Context, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/internal/service/glue/data_quality_ruleset_test.go
+++ b/internal/service/glue/data_quality_ruleset_test.go
@@ -52,6 +52,43 @@ func TestAccGlueDataQualityRuleset_basic(t *testing.T) {
 	})
 }
 
+func TestAccGlueDataQualityRuleset_updateRuleset(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	originalRuleset := "Rules = [Completeness \"colA\" between 0.4 and 0.8]"
+	updatedRuleset := "Rules = [Completeness \"colA\" between 0.5 and 1.0]"
+	resourceName := "aws_glue_data_quality_ruleset.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, glue.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataQualityRulesetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataQualityRulesetConfig_basic(rName, originalRuleset),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDataQualityRulesetExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ruleset", originalRuleset),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDataQualityRulesetConfig_basic(rName, updatedRuleset),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDataQualityRulesetExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ruleset", updatedRuleset),
+				),
+			},
+		},
+	})
+}
+
 func TestAccGlueDataQualityRuleset_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 

--- a/internal/service/glue/data_quality_ruleset_test.go
+++ b/internal/service/glue/data_quality_ruleset_test.go
@@ -89,6 +89,44 @@ func TestAccGlueDataQualityRuleset_updateRuleset(t *testing.T) {
 	})
 }
 
+func TestAccGlueDataQualityRuleset_updateDescription(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	ruleset := "Rules = [Completeness \"colA\" between 0.4 and 0.8]"
+	originalDescription := "original description"
+	updatedDescription := "updated description"
+	resourceName := "aws_glue_data_quality_ruleset.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, glue.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataQualityRulesetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataQualityRulesetConfig_description(rName, ruleset, originalDescription),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDataQualityRulesetExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", originalDescription),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDataQualityRulesetConfig_description(rName, ruleset, updatedDescription),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDataQualityRulesetExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", updatedDescription),
+				),
+			},
+		},
+	})
+}
+
 func TestAccGlueDataQualityRuleset_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 
@@ -229,6 +267,16 @@ resource "aws_glue_data_quality_ruleset" "test" {
   ruleset = %[2]q
 }
 `, rName, ruleset)
+}
+
+func testAccDataQualityRulesetConfig_description(rName, ruleset, description string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_data_quality_ruleset" "test" {
+  name        = %[1]q
+  ruleset     = %[2]q
+  description = %[3]q
+}
+`, rName, ruleset, description)
 }
 
 func testAccDataQualityRulesetConfig_tags1(rName, ruleset, tagKey1, tagValue1 string) string {

--- a/internal/service/glue/find.go
+++ b/internal/service/glue/find.go
@@ -85,6 +85,30 @@ func FindDatabaseByName(ctx context.Context, conn *glue.Glue, catalogID, name st
 	return output, nil
 }
 
+func FindDataQualityRulesetByName(ctx context.Context, conn *glue.Glue, name string) (*glue.GetDataQualityRulesetOutput, error) {
+	input := &glue.GetDataQualityRulesetInput{
+		Name: aws.String(name),
+	}
+
+	output, err := conn.GetDataQualityRulesetWithContext(ctx, input)
+	if tfawserr.ErrCodeEquals(err, glue.ErrCodeEntityNotFoundException) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
+}
+
 // FindTableByName returns the Table corresponding to the specified name.
 func FindTableByName(ctx context.Context, conn *glue.Glue, catalogID, dbName, name string) (*glue.GetTableOutput, error) {
 	input := &glue.GetTableInput{

--- a/internal/service/glue/service_package_gen.go
+++ b/internal/service/glue/service_package_gen.go
@@ -79,6 +79,14 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			TypeName: "aws_glue_data_catalog_encryption_settings",
 		},
 		{
+			Factory:  ResourceDataQualityRuleset,
+			TypeName: "aws_glue_data_quality_ruleset",
+			Name:     "Data Quality Ruleset",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
+		},
+		{
 			Factory:  ResourceDevEndpoint,
 			TypeName: "aws_glue_dev_endpoint",
 			Name:     "Dev Endpoint",

--- a/website/docs/r/glue_data_quality_ruleset.html.markdown
+++ b/website/docs/r/glue_data_quality_ruleset.html.markdown
@@ -1,0 +1,92 @@
+---
+subcategory: "Glue"
+layout: "aws"
+page_title: "AWS: aws_glue_data_quality_ruleset"
+description: |-
+  Provides a Glue Data Quality Ruleset.
+---
+
+# Resource: aws_glue_data_quality_ruleset
+
+Provides a Glue Data Quality Ruleset Resource. You can refer to the [Glue Developer Guide](https://docs.aws.amazon.com/glue/latest/dg/glue-data-quality.html) for a full explanation of the Glue Data Quality Ruleset functionality
+
+## Example Usage
+
+### Basic
+
+```terraform
+resource "aws_glue_data_quality_ruleset" "example" {
+  name    = "example"
+  ruleset = "Rules = [Completeness \"colA\" between 0.4 and 0.8]"
+}
+```
+
+### With description
+
+```terraform
+resource "aws_glue_data_quality_ruleset" "example" {
+  name        = "example"
+  description = "example"
+  ruleset     = "Rules = [Completeness \"colA\" between 0.4 and 0.8]"
+}
+```
+
+### With tags
+
+```terraform
+resource "aws_glue_data_quality_ruleset" "example" {
+  name    = "example"
+  ruleset = "Rules = [Completeness \"colA\" between 0.4 and 0.8]"
+
+  tags = {
+    "hello" = "world"
+  }
+}
+```
+
+### With target_table
+
+```terraform
+resource "aws_glue_data_quality_ruleset" "example" {
+  name    = "example"
+  ruleset = "Rules = [Completeness \"colA\" between 0.4 and 0.8]"
+
+  target_table {
+    database_name = aws_glue_catalog_database.example.name
+    table_name    = aws_glue_catalog_table.example.name
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Optional) Description of the data quality ruleset.
+* `name` - (Required, Forces new resource) Name of the data quality ruleset.
+* `ruleset` - (Optional) A Data Quality Definition Language (DQDL) ruleset. For more information, see the AWS Glue developer guide.
+* `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `target_table` - (Optional, Forces new resource) A Configuration block specifying a target table associated with the data quality ruleset. See [`target_table`](#target_table) below.
+
+### target_table
+
+* `database_name` - (Required, Forces new resource) Name of the database where the AWS Glue table exists.
+* `table_name` - (Required, Forces new resource) Name of the AWS Glue table.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the Glue Data Quality Ruleset.
+* `created_on` - The time and date that this data quality ruleset was created.
+* `last_modified_on` - The time and date that this data quality ruleset was created.
+* `recommendation_run_id` - When a ruleset was created from a recommendation run, this run ID is generated to link the two together.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+
+## Import
+
+Glue Data Quality Ruleset can be imported using the `name`, e.g.,
+
+```
+$ terraform import aws_glue_data_quality_ruleset.example exampleName
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31598

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- [CreateDataQualityRuleset](https://docs.aws.amazon.com/glue/latest/webapi/API_CreateDataQualityRuleset.html)
- [GetDataQualityRuleset](https://docs.aws.amazon.com/glue/latest/webapi/API_GetDataQualityRuleset.html)
- [UpdateDataQualityRuleset](https://docs.aws.amazon.com/glue/latest/webapi/API_UpdateDataQualityRuleset.html)
- [DeleteDataQualityRuleset](https://docs.aws.amazon.com/glue/latest/webapi/API_DeleteDataQualityRuleset.html)

Note: while the [DataQualityTargetTable object](https://docs.aws.amazon.com/glue/latest/webapi/API_DataQualityTargetTable.html) supports `CatalogId`, the AWS GO SDK does not: [DataQualityTargetTable](https://docs.aws.amazon.com/sdk-for-go/api/service/glue/#DataQualityTargetTable)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccGlueDataQualityRuleset' PKG=glue
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20  -run=TestAccGlueDataQualityRuleset -timeout 180m
=== RUN   TestAccGlueDataQualityRuleset_basic
=== PAUSE TestAccGlueDataQualityRuleset_basic
=== RUN   TestAccGlueDataQualityRuleset_updateRuleset
=== PAUSE TestAccGlueDataQualityRuleset_updateRuleset
=== RUN   TestAccGlueDataQualityRuleset_updateDescription
=== PAUSE TestAccGlueDataQualityRuleset_updateDescription
=== RUN   TestAccGlueDataQualityRuleset_targetTable
=== PAUSE TestAccGlueDataQualityRuleset_targetTable
=== RUN   TestAccGlueDataQualityRuleset_tags
=== PAUSE TestAccGlueDataQualityRuleset_tags
=== RUN   TestAccGlueDataQualityRuleset_disappears
=== PAUSE TestAccGlueDataQualityRuleset_disappears
=== CONT  TestAccGlueDataQualityRuleset_basic
=== CONT  TestAccGlueDataQualityRuleset_targetTable
=== CONT  TestAccGlueDataQualityRuleset_disappears
=== CONT  TestAccGlueDataQualityRuleset_tags
=== CONT  TestAccGlueDataQualityRuleset_updateDescription
=== CONT  TestAccGlueDataQualityRuleset_updateRuleset
--- PASS: TestAccGlueDataQualityRuleset_disappears (29.01s)
--- PASS: TestAccGlueDataQualityRuleset_basic (37.60s)
--- PASS: TestAccGlueDataQualityRuleset_targetTable (40.06s)
--- PASS: TestAccGlueDataQualityRuleset_updateRuleset (58.80s)
--- PASS: TestAccGlueDataQualityRuleset_updateDescription (58.86s)
--- PASS: TestAccGlueDataQualityRuleset_tags (75.85s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       75.990s

...
```
