### PR TITLE
resource/aws_redshift_cluster: Acceptance tests fixes

### DIFF
--- a/.changelog/31612.txt
+++ b/.changelog/31612.txt
@@ -1,0 +1,7 @@
+```release-note:note
+resource/aws_redshift_cluster: Ignores the parameter `aqua_configuration_status`, since the AWS API ignores it. Now always returns `auto`.
+```
+
+```release-note:bug
+resource/aws_redshift_cluster: No longer errors on deletion when status is `Maintenance`
+```

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -60,6 +60,10 @@ func ResourceCluster() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: validation.StringInSlice(redshift.AquaConfigurationStatus_Values(), false),
+				Deprecated:   "This parameter is no longer supported by the AWS API. It will be removed in the next major version of the provider.",
+				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+					return true
+				},
 			},
 			"arn": {
 				Type:     schema.TypeString,

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -79,7 +79,7 @@ func TestAccRedshiftCluster_aqua(t *testing.T) {
 				Config: testAccClusterConfig_aqua(rName, "enabled"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "aqua_configuration_status", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "aqua_configuration_status", "auto"),
 				),
 			},
 			{
@@ -97,14 +97,14 @@ func TestAccRedshiftCluster_aqua(t *testing.T) {
 				Config: testAccClusterConfig_aqua(rName, "disabled"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "aqua_configuration_status", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "aqua_configuration_status", "auto"),
 				),
 			},
 			{
 				Config: testAccClusterConfig_aqua(rName, "enabled"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "aqua_configuration_status", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "aqua_configuration_status", "auto"),
 				),
 			},
 		},

--- a/internal/service/redshift/wait.go
+++ b/internal/service/redshift/wait.go
@@ -42,7 +42,7 @@ func waitClusterCreated(ctx context.Context, conn *redshift.Redshift, id string,
 
 func waitClusterDeleted(ctx context.Context, conn *redshift.Redshift, id string, timeout time.Duration) (*redshift.Cluster, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{clusterAvailabilityStatusModifying},
+		Pending: []string{clusterAvailabilityStatusMaintenance, clusterAvailabilityStatusModifying},
 		Target:  []string{},
 		Refresh: statusClusterAvailability(ctx, conn, id),
 		Timeout: timeout,

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -61,7 +61,9 @@ The following arguments are supported:
   The version selected runs on all the nodes in the cluster.
 * `allow_version_upgrade` - (Optional) If true , major version upgrades can be applied during the maintenance window to the Amazon Redshift engine that is running on the cluster. Default is `true`.
 * `apply_immediately` - (Optional) Specifies whether any cluster modifications are applied immediately, or during the next maintenance window. Default is `false`.
-* `aqua_configuration_status` - (Optional) The value represents how the cluster is configured to use AQUA (Advanced Query Accelerator) after the cluster is restored. Possible values are `enabled`, `disabled`, and `auto`. Requires Cluster reboot.
+* `aqua_configuration_status` - (Optional, **Deprecated**) The value represents how the cluster is configured to use AQUA (Advanced Query Accelerator) after the cluster is restored.
+  No longer supported by the AWS API.
+  Always returns `auto`.
 * `number_of_nodes` - (Optional) The number of compute nodes in the cluster. This parameter is required when the ClusterType parameter is specified as multi-node. Default is 1.
 * `publicly_accessible` - (Optional) If true, the cluster can be accessed from a public network. Default is `true`.
 * `encrypted` - (Optional) If true , the data in the cluster is encrypted at rest.


### PR DESCRIPTION
### Description

Fixes acceptance test failures:

* Adds `Maintenance` as valid pending status in `waitClusterDeleted`
* Deprecates unused parameter `aqua_configuration_status`

### Output from Acceptance Testing

```
$ make testacc PKG=redshift TESTS=TestAccRedshiftCluster_

--- PASS: TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible (8.32s)
--- PASS: TestAccRedshiftCluster_changeAvailabilityZone_availabilityZoneRelocationNotSet (206.18s)
--- PASS: TestAccRedshiftCluster_disappears (243.71s)
--- PASS: TestAccRedshiftCluster_iamRoles (272.16s)
--- PASS: TestAccRedshiftCluster_kmsKey (302.10s)
--- PASS: TestAccRedshiftCluster_snapshotCopy (316.21s)
--- PASS: TestAccRedshiftCluster_publiclyAccessible (360.08s)
--- PASS: TestAccRedshiftCluster_enhancedVPCRoutingEnabled (377.35s)
--- PASS: TestAccRedshiftCluster_changeAvailabilityZone (574.18s)
--- PASS: TestAccRedshiftCluster_loggingEnabled (607.85s)
--- PASS: TestAccRedshiftCluster_basic (615.25s)
--- PASS: TestAccRedshiftCluster_aqua (438.98s)
--- PASS: TestAccRedshiftCluster_availabilityZoneRelocation (648.17s)
--- PASS: TestAccRedshiftCluster_forceNewUsername (659.48s)
--- PASS: TestAccRedshiftCluster_withFinalSnapshot (688.48s)
--- PASS: TestAccRedshiftCluster_changeAvailabilityZoneAndSetAvailabilityZoneRelocation (763.18s)
--- PASS: TestAccRedshiftCluster_restoreFromSnapshot (898.55s)
--- PASS: TestAccRedshiftCluster_tags (1044.81s)
--- PASS: TestAccRedshiftCluster_changeEncryption2 (1207.14s)
--- PASS: TestAccRedshiftCluster_changeEncryption1 (1341.00s)
--- PASS: TestAccRedshiftCluster_updateNodeCount (1348.97s)
--- PASS: TestAccRedshiftCluster_updateNodeType (1573.68s)
```
