### PR TITLE
[Docs]: Fixed documentation on aws_vpc_security_group_ingress_rule and aws_vpc_security_group_egress_rule to avoid Terraform detecting changes on loop

### DIFF
--- a/.changelog/30035.txt
+++ b/.changelog/30035.txt
@@ -1,0 +1,7 @@
+```release-note:note
+resource/aws_vpc_security_group_ingress_rule: End user documentation change to clearly mention `from_port` and `to_port` should not be defined when `ip_protocol` is set to `-1`, to avoid terraform detecting changes endlessly. Resolves confusion that is seen in GitHub issues [#1177](https://github.com/hashicorp/terraform/issues/1177), [#1729](https://github.com/hashicorp/terraform/issues/1729), [#30035](https://github.com/hashicorp/terraform-provider-aws/issues/30035).
+```
+
+```release-note:note
+resource/aws_vpc_security_group_egress_rule: End user documentation change to clearly mention `from_port` and `to_port` should not be defined when `ip_protocol` is set to `-1`, to avoid terraform detecting changes endlessly. Resolves confusion that is seen in GitHub issues [#1177](https://github.com/hashicorp/terraform/issues/1177), [#1729](https://github.com/hashicorp/terraform/issues/1729), [#30035](https://github.com/hashicorp/terraform-provider-aws/issues/30035).
+```

--- a/website/docs/r/vpc_security_group_egress_rule.html.markdown
+++ b/website/docs/r/vpc_security_group_egress_rule.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 * `cidr_ipv6` - (Optional) The destination IPv6 CIDR range.
 * `description` - (Optional) The security group rule description.
 * `from_port` - (Optional) The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 type.
-* `ip_protocol` - (Optional) The IP protocol name or number. Use `-1` to specify all protocols.
+* `ip_protocol` - (Optional) The IP protocol name or number. Use `-1` to specify all protocols. Note that if `ip_protocol` is set to `-1`, it translates to all protocols, all port ranges, and `from_port` and `to_port` values should not be defined.
 * `prefix_list_id` - (Optional) The ID of the destination prefix list.
 * `referenced_security_group_id` - (Optional) The destination security group that is referenced in the rule.
 * `security_group_id` - (Required) The ID of the security group.

--- a/website/docs/r/vpc_security_group_ingress_rule.html.markdown
+++ b/website/docs/r/vpc_security_group_ingress_rule.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 * `cidr_ipv6` - (Optional) The source IPv6 CIDR range.
 * `description` - (Optional) The security group rule description.
 * `from_port` - (Optional) The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 type.
-* `ip_protocol` - (Optional) The IP protocol name or number. Use `-1` to specify all protocols.
+* `ip_protocol` - (Optional) The IP protocol name or number. Use `-1` to specify all protocols. Note that if `ip_protocol` is set to `-1`, it translates to all protocols, all port ranges, and `from_port` and `to_port` values should not be defined.
 * `prefix_list_id` - (Optional) The ID of the source prefix list.
 * `referenced_security_group_id` - (Optional) The source security group that is referenced in the rule.
 * `security_group_id` - (Required) The ID of the security group.


### PR DESCRIPTION
[Docs]: Fixed documentation on aws_vpc_security_group_ingress_rule and aws_vpc_security_group_egress_rule to avoid Terraform detecting changes on loop

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixed documentation on `aws_vpc_security_group_ingress_rule` and `aws_vpc_security_group_egress_rule` to explicitly not define `from_port` and `to_port` when `ip_protocol` is set to `-1`, to avoid terraform from detecting changes endlessly.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates [#1177](https://github.com/hashicorp/terraform/issues/1177)
Relates [#1729](https://github.com/hashicorp/terraform/issues/1729)
Closes [#30035](https://github.com/hashicorp/terraform-provider-aws/issues/30035)

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
[#30035](https://github.com/hashicorp/terraform-provider-aws/issues/30035)