### PR TITLE
ci/teamcity: Remove hanging build notifications

### DIFF
--- a/.teamcity/components/service_build_config.kt
+++ b/.teamcity/components/service_build_config.kt
@@ -96,7 +96,7 @@ class Service(name: String, spec: ServiceSpec) {
                         buildFailed = false // With the current number of faling tests, this would be too noisy
                         buildFinishedSuccessfully = false // With the number of tests, this would be too noisy
                         firstSuccessAfterFailure = true
-                        buildProbablyHanging = true
+                        buildProbablyHanging = false
                         // Ideally we'd have this enabled, but we have too many failures and this would get very noisy
                         // firstBuildErrorOccurs = true
                     }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -184,7 +184,7 @@ object PullRequest : BuildType({
                 buildFailed = true
                 buildFinishedSuccessfully = true
                 firstBuildErrorOccurs = true
-                buildProbablyHanging = true
+                buildProbablyHanging = false
             }
         }
     }
@@ -344,7 +344,7 @@ object SetUp : BuildType({
                 buildFailed = true
                 buildFinishedSuccessfully = false // With the number of tests, this would be too noisy
                 firstSuccessAfterFailure = true
-                buildProbablyHanging = true
+                buildProbablyHanging = false
                 // Ideally we'd have this enabled, but we have too many failures and this would get very noisy
                 // firstBuildErrorOccurs = true
             }


### PR DESCRIPTION
### Description

Removes the hanging build notifications from TeamCity, since they don't add value and are noisy.
