### PR TITLE
Revert `s3Config.DisableRestProtocolURICleaning` deprecation suppression

### DIFF
--- a/.ci/.golangci2.yml
+++ b/.ci/.golangci2.yml
@@ -33,10 +33,6 @@ issues:
     - linters:
         - staticcheck
       text: "SA1019: strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0"
-    - linters:
-        - staticcheck
-      path: internal/conns/
-      text: "SA1019: s3Config.DisableRestProtocolURICleaning is deprecated"
     # Per-Service
     - linters:
         - staticcheck


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Reverts the `golangci-lint` deprecation suppression of `s3Config.DisableRestProtocolURICleaning`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/31501.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/31502.
Relates https://github.com/aws/aws-sdk-go/pull/4849.