### PR TITLE
medialive/channel: fix`hls_cdn_settings` mapping

### DIFF
--- a/.changelog/31647.txt
+++ b/.changelog/31647.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_medialive_channel: Fix attribute spelling in `hls_cdn_settings` expand
+```

--- a/internal/service/medialive/channel_encoder_settings_schema.go
+++ b/internal/service/medialive/channel_encoder_settings_schema.go
@@ -3263,7 +3263,7 @@ func expandHLSGroupSettings(tfList []interface{}) *types.HlsGroupSettings {
 	if v, ok := m["encryption_type"].(string); ok && v != "" {
 		out.EncryptionType = types.HlsEncryptionType(v)
 	}
-	if v, ok := m["hls_cdn_setting"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := m["hls_cdn_settings"].([]interface{}); ok && len(v) > 0 {
 		out.HlsCdnSettings = expandHLSCDNSettings(v)
 	}
 	if v, ok := m["hls_id3_segment_tagging"].(string); ok && v != "" {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #31629

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccMediaLiveChannel_' PKG=medialive

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/medialive/... -v -count 1 -parallel 20  -run=TestAccMediaLiveChannel_ -timeout 180m
--- PASS: TestAccMediaLiveChannel_basic (75.04s)
--- PASS: TestAccMediaLiveChannel_M2TS_settings (85.35s)
--- PASS: TestAccMediaLiveChannel_MsSmooth_outputSettings (90.55s)
--- PASS: TestAccMediaLiveChannel_AudioDescriptions_codecSettings (93.78s)
--- PASS: TestAccMediaLiveChannel_VideoDescriptions_CodecSettings_h264Settings (94.22s)
--- PASS: TestAccMediaLiveChannel_disappears (137.96s)
--- PASS: TestAccMediaLiveChannel_hls (152.00s)
--- PASS: TestAccMediaLiveChannel_VideoDescriptions_CodecSettings_h265Settings (158.66s)
--- PASS: TestAccMediaLiveChannel_updateTags (184.00s)
--- PASS: TestAccMediaLiveChannel_update (220.44s)
--- PASS: TestAccMediaLiveChannel_UDP_outputSettings (234.80s)
--- PASS: TestAccMediaLiveChannel_status (269.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/medialive	272.309s
```
