### PR TITLE
r/aws_quicksight_dashboard: add sweeper

### DIFF
--- a/internal/service/quicksight/sweep.go
+++ b/internal/service/quicksight/sweep.go
@@ -17,6 +17,10 @@ import (
 )
 
 func init() {
+	resource.AddTestSweepers("aws_quicksight_dashboard", &resource.Sweeper{
+		Name: "aws_quicksight_dashboard",
+		F:    sweepDashboards,
+	})
 	resource.AddTestSweepers("aws_quicksight_data_set", &resource.Sweeper{
 		Name: "aws_quicksight_data_set",
 		F:    sweepDataSets,
@@ -43,6 +47,60 @@ const (
 	// Defined locally to avoid cyclic import from internal/acctest
 	acctestResourcePrefix = "tf-acc-test"
 )
+
+func sweepDashboards(region string) error {
+	ctx := sweep.Context(region)
+	client, err := sweep.SharedRegionalSweepClient(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %w", err)
+	}
+
+	conn := client.(*conns.AWSClient).QuickSightConn()
+	sweepResources := make([]sweep.Sweepable, 0)
+	var errs *multierror.Error
+
+	awsAccountId := client.(*conns.AWSClient).AccountID
+
+	input := &quicksight.ListDashboardsInput{
+		AwsAccountId: aws.String(awsAccountId),
+	}
+
+	err = conn.ListDashboardsPagesWithContext(ctx, input, func(page *quicksight.ListDashboardsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, dashboard := range page.DashboardSummaryList {
+			if dashboard == nil {
+				continue
+			}
+
+			r := ResourceDashboard()
+			d := r.Data(nil)
+			d.SetId(fmt.Sprintf("%s,%s", awsAccountId, aws.StringValue(dashboard.DashboardId)))
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("listing QuickSight Dashboards: %w", err))
+	}
+
+	if err := sweep.SweepOrchestratorWithContext(ctx, sweepResources); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("sweeping QuickSight Dashboards for %s: %w", region, err))
+	}
+
+	if sweep.SkipSweepError(errs.ErrorOrNil()) {
+		log.Printf("[WARN] Skipping QuickSight Dashboard sweep for %s: %s", region, errs)
+		return nil
+	}
+
+	return errs.ErrorOrNil()
+}
 
 func sweepDataSets(region string) error {
 	ctx := sweep.Context(region)


### PR DESCRIPTION

### Description
Adds an `aws_quicksight_dashboard` sweeper.


### Relations


Relates #31448 


### Output from Acceptance Testing

```
$ SWEEPARGS=-sweep-run=aws_quicksight_ make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2,us-east-1,us-east-2 -sweep-run=aws_quicksight_ -timeout 60m
<snip>
2023/05/30 11:41:03 Completed Sweepers for region (us-east-2) in 1.426063209s
2023/05/30 11:41:03 Sweeper Tests for region (us-east-2) ran successfully:
        - aws_quicksight_dashboard
        - aws_quicksight_data_set
        - aws_quicksight_data_source
        - aws_quicksight_folder
        - aws_quicksight_user
        - aws_quicksight_template
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      9.423s
```
