### PR TITLE
Adds cross account and region Route 53 VPC association tests

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -1205,12 +1205,23 @@ provider "aws" {
 // This can only be used for single provider configuration testing as it
 // overwrites the "aws" provider configuration.
 func ConfigRegionalProvider(region string) string {
+	return ConfigNamedRegionalProvider(ProviderName, region)
+}
+
+func ConfigAlternateAccountAlternateRegionProvider() string {
+	return ConfigNamedAlternateAccountAlternateRegionProvider(ProviderNameAlternate)
+}
+
+func ConfigNamedAlternateAccountAlternateRegionProvider(providerName string) string {
 	//lintignore:AT004
 	return fmt.Sprintf(`
-provider "aws" {
-  region = %[1]q
+provider %[1]q {
+  access_key = %[2]q
+  profile    = %[3]q
+  region     = %[4]q
+  secret_key = %[5]q
 }
-`, region)
+`, providerName, os.Getenv(envvar.AlternateAccessKeyId), os.Getenv(envvar.AlternateProfile), AlternateRegion(), os.Getenv(envvar.AlternateSecretAccessKey))
 }
 
 func RegionProviderFunc(region string, providers *[]*schema.Provider) func() *schema.Provider {

--- a/internal/service/ec2/transitgateway_peering_attachment_accepter_test.go
+++ b/internal/service/ec2/transitgateway_peering_attachment_accepter_test.go
@@ -2,14 +2,12 @@ package ec2_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/envvar"
 )
 
 func testAccTransitGatewayPeeringAttachmentAccepter_basic(t *testing.T) {
@@ -146,18 +144,6 @@ func testAccTransitGatewayPeeringAttachmentAccepter_differentAccount(t *testing.
 	})
 }
 
-func testAccAlternateAccountAlternateRegionProviderConfig() string {
-	//lintignore:AT004
-	return fmt.Sprintf(`
-provider %[1]q {
-  access_key = %[2]q
-  profile    = %[3]q
-  region     = %[4]q
-  secret_key = %[5]q
-}
-`, acctest.ProviderNameAlternate, os.Getenv(envvar.AlternateAccessKeyId), os.Getenv(envvar.AlternateProfile), acctest.AlternateRegion(), os.Getenv(envvar.AlternateSecretAccessKey))
-}
-
 func testAccTransitGatewayPeeringAttachmentAccepterConfig_base(rName string) string {
 	return fmt.Sprintf(`
 data "aws_region" "current" {}
@@ -235,7 +221,7 @@ resource "aws_ec2_transit_gateway_peering_attachment_accepter" "test" {
 
 func testAccTransitGatewayPeeringAttachmentAccepterConfig_differentAccount(rName string) string {
 	return acctest.ConfigCompose(
-		testAccAlternateAccountAlternateRegionProviderConfig(),
+		acctest.ConfigAlternateAccountAlternateRegionProvider(),
 		testAccTransitGatewayPeeringAttachmentAccepterConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_ec2_transit_gateway_peering_attachment_accepter" "test" {

--- a/internal/service/ec2/transitgateway_peering_attachment_test.go
+++ b/internal/service/ec2/transitgateway_peering_attachment_test.go
@@ -250,11 +250,17 @@ resource "aws_ec2_transit_gateway" "peer" {
 }
 
 func testAccTransitGatewayPeeringAttachmentConfig_sameAccount_base(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), testAccTransitGatewayPeeringAttachmentConfig_base(rName))
+	return acctest.ConfigCompose(
+		acctest.ConfigAlternateRegionProvider(),
+		testAccTransitGatewayPeeringAttachmentConfig_base(rName),
+	)
 }
 
 func testAccTransitGatewayPeeringAttachmentConfig_differentAccount_base(rName string) string {
-	return acctest.ConfigCompose(testAccAlternateAccountAlternateRegionProviderConfig(), testAccTransitGatewayPeeringAttachmentConfig_base(rName))
+	return acctest.ConfigCompose(
+		acctest.ConfigAlternateAccountAlternateRegionProvider(),
+		testAccTransitGatewayPeeringAttachmentConfig_base(rName),
+	)
 }
 
 func testAccTransitGatewayPeeringAttachmentConfig_sameAccount(rName string) string {

--- a/internal/service/ec2/vpc_peering_connection_accepter_test.go
+++ b/internal/service/ec2/vpc_peering_connection_accepter_test.go
@@ -331,7 +331,9 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
 }
 
 func testAccVPCPeeringConnectionAccepterConfig_differentRegionDifferentAccount(rName string) string {
-	return acctest.ConfigCompose(testAccAlternateAccountAlternateRegionProviderConfig(), fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		acctest.ConfigAlternateAccountAlternateRegionProvider(),
+		fmt.Sprintf(`
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
 

--- a/internal/service/route53/vpc_association_authorization_test.go
+++ b/internal/service/route53/vpc_association_authorization_test.go
@@ -33,6 +33,7 @@ func TestAccRoute53VPCAssociationAuthorization_basic(t *testing.T) {
 				Config: testAccVPCAssociationAuthorizationConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCAssociationAuthorizationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "vpc_region", acctest.Region()),
 				),
 			},
 			{
@@ -94,6 +95,36 @@ func TestAccRoute53VPCAssociationAuthorization_concurrent(t *testing.T) {
 					testAccCheckVPCAssociationAuthorizationExists(ctx, resourceNameAlternate),
 					testAccCheckVPCAssociationAuthorizationExists(ctx, resourceNameThird),
 				),
+			},
+		},
+	})
+}
+
+func TestAccRoute53VPCAssociationAuthorization_crossRegion(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_route53_vpc_association_authorization.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, route53.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+		CheckDestroy:             testAccCheckVPCAssociationAuthorizationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCAssociationAuthorizationConfig_crossRegion(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCAssociationAuthorizationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "vpc_region", acctest.AlternateRegion()),
+				),
+			},
+			{
+				Config:            testAccVPCAssociationAuthorizationConfig_crossRegion(),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -182,7 +213,7 @@ resource "aws_route53_vpc_association_authorization" "test" {
 
 resource "aws_vpc" "alternate" {
   provider             = "awsalternate"
-  cidr_block           = "10.7.0.0/16"
+  cidr_block           = cidrsubnet("10.0.0.0/8", 8, 1)
   enable_dns_hostnames = true
   enable_dns_support   = true
 }
@@ -196,7 +227,7 @@ resource "aws_route53_zone" "test" {
 }
 
 resource "aws_vpc" "test" {
-  cidr_block           = "10.6.0.0/16"
+  cidr_block           = cidrsubnet("10.0.0.0/8", 8, 0)
   enable_dns_hostnames = true
   enable_dns_support   = true
 }
@@ -252,6 +283,43 @@ resource "aws_vpc" "alternate" {
 resource "aws_vpc" "third" {
   provider             = "awsthird"
   cidr_block           = cidrsubnet("10.0.0.0/8", 8, 2)
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+`)
+}
+
+func testAccVPCAssociationAuthorizationConfig_crossRegion() string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAlternateAccountAlternateRegionProvider(), `
+resource "aws_route53_vpc_association_authorization" "test" {
+  zone_id    = aws_route53_zone.test.id
+  vpc_id     = aws_vpc.alternate.id
+  vpc_region = data.aws_region.alternate.name
+}
+
+resource "aws_vpc" "alternate" {
+  provider = "awsalternate"
+
+  cidr_block           = cidrsubnet("10.0.0.0/8", 8, 1)
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+data "aws_region" "alternate" {
+  provider = "awsalternate"
+}
+
+resource "aws_route53_zone" "test" {
+  name = "example.com"
+
+  vpc {
+    vpc_id = aws_vpc.test.id
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block           = cidrsubnet("10.0.0.0/8", 8, 0)
   enable_dns_hostnames = true
   enable_dns_support   = true
 }

--- a/internal/service/route53/zone_association_test.go
+++ b/internal/service/route53/zone_association_test.go
@@ -161,13 +161,43 @@ func TestAccRoute53ZoneAssociation_crossRegion(t *testing.T) {
 		CheckDestroy:             testAccCheckZoneAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccZoneAssociationConfig_region(domainName),
+				Config: testAccZoneAssociationConfig_crossRegion(domainName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckZoneAssociationExists(ctx, resourceName),
 				),
 			},
 			{
-				Config:            testAccZoneAssociationConfig_region(domainName),
+				Config:            testAccZoneAssociationConfig_crossRegion(domainName),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccRoute53ZoneAssociation_crossAccountAndRegion(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_route53_zone_association.test"
+	domainName := acctest.RandomFQDomainName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, route53.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+		CheckDestroy:             testAccCheckZoneAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccZoneAssociationConfig_crossAccountAndRegion(domainName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckZoneAssociationExists(ctx, resourceName),
+				),
+			},
+			{
+				Config:            testAccZoneAssociationConfig_crossAccountAndRegion(domainName),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -328,7 +358,7 @@ resource "aws_route53_zone_association" "test" {
 `, domainName))
 }
 
-func testAccZoneAssociationConfig_region(domainName string) string {
+func testAccZoneAssociationConfig_crossRegion(domainName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigMultipleRegionProvider(2),
 		fmt.Sprintf(`
@@ -377,6 +407,55 @@ resource "aws_route53_zone_association" "test" {
   vpc_id     = aws_vpc.alternate.id
   vpc_region = data.aws_region.alternate.name
   zone_id    = aws_route53_zone.test.id
+}
+`, domainName))
+}
+
+func testAccZoneAssociationConfig_crossAccountAndRegion(domainName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAlternateAccountAlternateRegionProvider(),
+		fmt.Sprintf(`
+resource "aws_route53_zone_association" "test" {
+  vpc_id  = aws_route53_vpc_association_authorization.test.vpc_id
+  zone_id = aws_route53_vpc_association_authorization.test.zone_id
+}
+
+resource "aws_route53_vpc_association_authorization" "test" {
+  provider = "awsalternate"
+
+  vpc_id     = aws_vpc.test.id
+  zone_id    = aws_route53_zone.test.id
+  vpc_region = data.aws_region.current.name
+}
+
+data "aws_region" "current" {}
+
+resource "aws_vpc" "test" {
+  cidr_block           = "10.6.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+resource "aws_vpc" "alternate" {
+  provider = "awsalternate"
+
+  cidr_block           = "10.7.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+resource "aws_route53_zone" "test" {
+  provider = "awsalternate"
+
+  name = %[1]q
+
+  vpc {
+    vpc_id = aws_vpc.alternate.id
+  }
+
+  lifecycle {
+    ignore_changes = [vpc]
+  }
 }
 `, domainName))
 }


### PR DESCRIPTION
### Description

Adds `aws_route53_zone_association` and `aws_route53_vpc_association_authorization` acceptance tests for cross account-and-region associations.

### Output from Acceptance Testing

```
$ make testacc PKG=route53 TESTS='TestAccRoute53ZoneAssociation_|TestAccRoute53VPCAssociationAuthorization_'

--- PASS: TestAccRoute53VPCAssociationAuthorization_disappears (81.47s)
--- PASS: TestAccRoute53VPCAssociationAuthorization_concurrent (82.90s)
--- PASS: TestAccRoute53VPCAssociationAuthorization_basic (85.59s)
--- PASS: TestAccRoute53VPCAssociationAuthorization_crossRegion (86.71s)
--- PASS: TestAccRoute53ZoneAssociation_disappears (112.93s)
--- PASS: TestAccRoute53ZoneAssociation_basic (115.69s)
--- PASS: TestAccRoute53ZoneAssociation_crossAccount (118.89s)
--- PASS: TestAccRoute53ZoneAssociation_Disappears_zone (121.35s)
--- PASS: TestAccRoute53ZoneAssociation_Disappears_vpc (125.10s)
--- PASS: TestAccRoute53ZoneAssociation_crossAccountAndRegion (130.28s)
--- PASS: TestAccRoute53ZoneAssociation_crossRegion (144.15s)
```
