### PR TITLE
E autoscaling traffic source data Source

### DIFF
--- a/.changelog/31652.txt
+++ b/.changelog/31652.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_autoscaling_group: Added data source for traffic_sources
+```

--- a/internal/service/autoscaling/group_data_source.go
+++ b/internal/service/autoscaling/group_data_source.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
@@ -493,6 +494,26 @@ func DataSourceGroup() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"traffic_sources": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"identifier": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 2048),
+						},
+
+						"type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 2048),
+						},
+					},
+				},
+			},
 			"vpc_zone_identifier": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -589,6 +610,7 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 	d.Set("target_group_arns", aws.StringValueSlice(group.TargetGroupARNs))
 	d.Set("termination_policies", aws.StringValueSlice(group.TerminationPolicies))
+	d.Set("traffic_sources", flattenTrafficSourceList(g.TrafficSources))
 	d.Set("vpc_zone_identifier", group.VPCZoneIdentifier)
 	if group.WarmPoolConfiguration != nil {
 		if err := d.Set("warm_pool", []interface{}{flattenWarmPoolConfiguration(group.WarmPoolConfiguration)}); err != nil {

--- a/internal/service/autoscaling/group_data_source.go
+++ b/internal/service/autoscaling/group_data_source.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -610,7 +611,7 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 	d.Set("target_group_arns", aws.StringValueSlice(group.TargetGroupARNs))
 	d.Set("termination_policies", aws.StringValueSlice(group.TerminationPolicies))
-	d.Set("traffic_sources", flattenTrafficSourceList(group.TrafficSources))
+	d.Set("traffic_sources", flattenDataTrafficSourceList(group.TrafficSources))
 	d.Set("vpc_zone_identifier", group.VPCZoneIdentifier)
 	if group.WarmPoolConfiguration != nil {
 		if err := d.Set("warm_pool", []interface{}{flattenWarmPoolConfiguration(group.WarmPoolConfiguration)}); err != nil {
@@ -622,4 +623,22 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("warm_pool_size", group.WarmPoolSize)
 
 	return diags
+}
+
+func flattenDataTrafficSourceList(trafficSources []*autoscaling.TrafficSourceIdentifier) []interface{} {
+	if len(trafficSources) == 0 {
+		return []interface{}{}
+	}
+
+	var trafficSourcesList []interface{}
+
+	for _, trafficSource := range trafficSources {
+		m := map[string]interface{}{
+			"identifier": aws.StringValue(trafficSource.Identifier),
+			"type":       aws.StringValue(trafficSource.Type),
+		}
+		trafficSourcesList = append(trafficSourcesList, m)
+	}
+
+	return trafficSourcesList
 }

--- a/internal/service/autoscaling/group_data_source.go
+++ b/internal/service/autoscaling/group_data_source.go
@@ -495,7 +495,7 @@ func DataSourceGroup() *schema.Resource {
 				},
 			},
 			"traffic_sources": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -610,7 +610,7 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 	d.Set("target_group_arns", aws.StringValueSlice(group.TargetGroupARNs))
 	d.Set("termination_policies", aws.StringValueSlice(group.TerminationPolicies))
-	d.Set("traffic_sources", flattenTrafficSourceList(g.TrafficSources))
+	d.Set("traffic_sources", flattenTrafficSourceList(group.TrafficSources))
 	d.Set("vpc_zone_identifier", group.VPCZoneIdentifier)
 	if group.WarmPoolConfiguration != nil {
 		if err := d.Set("warm_pool", []interface{}{flattenWarmPoolConfiguration(group.WarmPoolConfiguration)}); err != nil {

--- a/internal/service/autoscaling/group_data_source_test.go
+++ b/internal/service/autoscaling/group_data_source_test.go
@@ -288,32 +288,33 @@ data "aws_autoscaling_group" "test" {
 }
 
 resource "aws_launch_configuration" "test" {
-	name          = %[1]q
-	image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
-	instance_type = "t2.micro"
-  
-	enable_monitoring = false
-  }
+  name          = %[1]q
+  image_id      = data.aws_ami.amzn-ami-minimal-hvm-ebs.id
+  instance_type = "t2.micro"
 
-  resource "aws_lb_target_group" "test" {
-	name     = %[1]q
-	port     = 80
-	protocol = "HTTP"
-	vpc_id   = aws_vpc.test.id
-  }
+  enable_monitoring = false
+}
+
+resource "aws_lb_target_group" "test" {
+  name     = %[1]q
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = aws_vpc.test.id
+}
 
 resource "aws_autoscaling_group" "test" {
-  name               = %[1]q
+  name                 = %[1]q
   vpc_zone_identifier  = aws_subnet.test[*].id
   max_size             = 0
   min_size             = 0
   launch_configuration = aws_launch_configuration.test.name
 
   traffic_sources {
-    identifier =aws_lb_target_group.test.arn
+    identifier = aws_lb_target_group.test.arn
     type       = "elbv2"
   }
 }
+
 
 `, rName))
 }

--- a/website/docs/d/autoscaling_group.html.markdown
+++ b/website/docs/d/autoscaling_group.html.markdown
@@ -20,107 +20,110 @@ data "aws_autoscaling_group" "foo" {
 
 ## Argument Reference
 
-* `name` - Specify the exact name of the desired autoscaling group.
+- `name` - Specify the exact name of the desired autoscaling group.
 
 ## Attributes Reference
 
 ~> **NOTE:** Some values are not always set and may not be available for
 interpolation.
 
-* `arn` - ARN of the Auto Scaling group.
-* `availability_zones` - One or more Availability Zones for the group.
-* `default_cool_down` - Amount of time, in seconds, after a scaling activity completes before another scaling activity can start.
-* `desired_capacity` - Desired size of the group.
-* `desired_capacity_type` - The unit of measurement for the value returned for `desired_capacity`.
-* `enabled_metrics` - List of metrics enabled for collection.
-* `health_check_grace_period` - The amount of time, in seconds, that Amazon EC2 Auto Scaling waits before checking the health status of an EC2 instance that has come into service.
-* `health_check_type` - Service to use for the health checks. The valid values are EC2 and ELB.
-* `id` - Name of the Auto Scaling Group.
-* `launch_configuration` - The name of the associated launch configuration.
-* `launch_template` - List of launch templates for the group.
-    * `id` - ID of the launch template.
-    * `name` - Name of the launch template.
-    * `version` - Template version.
-* `load_balancers` - One or more load balancers associated with the group.
-* `max_instance_lifetime` - Maximum amount of time, in seconds, that an instance can be in service.
-* `max_size` - Maximum size of the group.
-* `min_size` - Minimum size of the group.
-* `mixed_instances_policy` - List of mixed instances policy objects for the group.
-    * `instances_distribution` - List of instances distribution objects.
-        * `on_demand_allocation_strategy` - Strategy used when launching on-demand instances.
-        * `on_demand_base_capacity` -  Absolute minimum amount of desired capacity that must be fulfilled by on-demand instances.
-        * `spot_allocation_strategy` - Strategy used when launching Spot instances.
-        * `spot_instance_pools` - Number of Spot pools per availability zone to allocate capacity.
-        * `spot_max_price` - Maximum price per unit hour that the user is willing to pay for the Spot instances.
-    * `launch_template` - List of launch templates along with the overrides.
-        * `launch_template_specification` - List of launch template specification objects.
-            * `launch_template_id` - ID of the launch template.
-            * `launch_template_name` - Name of the launch template.
-            * `version` - Template version.
-        * `override` - List of properties overriding the same properties in the launch template.
-            * `instance_requirements` - List of instance requirements objects.
-                * `accelerator_count - List of objects describing the minimum and maximum number of accelerators for an instance type.
-                    * `min` - Minimum.
-                    * `max` - Maximum.
-                * `accelerator_manufacturers` - List of accelerator manufacturer names.
-                * `accelerator_names` - List of accelerator names.
-                * `accelerator_total_memory_mib` - List of objects describing the minimum and maximum total memory of the accelerators.
-                * `accelerator_types` - List of accelerator types.
-                * `allowed_instance_types` - List of instance types to apply the specified attributes against.
-                * `bare_metal` - Indicates whether bare metal instances are included, excluded, or required.
-                * `baseline_ebs_bandwidth_mbps` - List of objects describing the minimum and maximum baseline EBS bandwidth (Mbps).
-                    * `min` - Minimum.
-                    * `max` - Maximum.
-                * `burstable_performance` - Indicates whether burstable performance instance types are included, excluded, or required.
-                * `cpu_manufacturers` - List of CPU manufacturer names.
-                * `excluded_instance_types` - List of excluded instance types.
-                * `instance_generations` - List of instance generation names.
-                * `local_storage` - Indicates whether instance types with instance store volumes are included, excluded, or required.
-                * `local_storage_types` - List of local storage type names.
-                * `memory_gib_per_vcpu` - List of objects describing the minimum and maximum amount of memory (GiB) per vCPU.
-                    * `min` - Minimum.
-                    * `max` - Maximum.
-                * `memory_mib` - List of objects describing the minimum and maximum amount of memory (MiB).
-                    * `min` - Minimum.
-                    * `max` - Maximum.
-                * `network_bandwidth_gbps` - List of objects describing the minimum and maximum amount of network bandwidth (Gbps).
-                    * `min` - Minimum.
-                    * `max`- Maximum.
-                * `network_interface_count` - List of objects describing the minimum and maximum amount of network interfaces.
-                    * `min` - Minimum.
-                    * `max` - Maximum.
-                * `on_demand_max_price_percentage_over_lowest_price` - Price protection threshold for On-Demand Instances.
-                * `require_hibernate_support` - Indicates whether instance types must support On-Demand Instance Hibernation.
-                * `spot_max_price_percentage_over_lowest_price` - Price protection threshold for Spot Instances.
-                * `total_local_storage_gb` - List of objects describing the minimum and maximum total storage (GB).
-                    * `min` - Minimum.
-                    * `max` - Maximum.
-                * `vcpu_count` - List of objects describing the minimum and maximum number of vCPUs.
-                    * `min` - Minimum.
-                    * `max` - Maximum.
-            * `instance_type` - Overriding instance type.
-            * `launch_template_specification` - List of overriding launch template specification objects.
-                * `launch_template_id` - ID of the launch template.
-                * `launch_template_name` - Name of the launch template.
-                * `version` - Template version.
-            * `weighted_capacity` - Number of capacity units, which gives the instance type a proportional weight to other instance types.
-* `name` - Name of the Auto Scaling Group.
-* `placement_group` - Name of the placement group into which to launch your instances, if any. For more information, see Placement Groups (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html) in the Amazon Elastic Compute Cloud User Guide.
-* `predicted_capacity` - Predicted capacity of the group.
-* `service_linked_role_arn` - ARN of the service-linked role that the Auto Scaling group uses to call other AWS services on your behalf.
-* `status` - Current state of the group when DeleteAutoScalingGroup is in progress.
-* `suspended_processes` - List of processes suspended processes for the Auto Scaling Group.
-* `tag` - List of tags for the group.
-    * `key` - Key.
-    * `value` - Value.
-    * `propagate_at_launch` - Whether the tag is propagated to Amazon EC2 instances launched via this ASG.
-* `target_group_arns` - ARNs of the target groups for your load balancer.
-* `termination_policies` - The termination policies for the group.
-* `vpc_zone_identifier` - VPC ID for the group.
-* `warm_pool` - List of warm pool configuration objects.
-    * `instance_reuse_policy` - List of instance reuse policy objects.
-        * `reuse_on_scale_in` - Indicates whether instances in the Auto Scaling group can be returned to the warm pool on scale in.
-    * `max_group_prepared_policy` - Total maximum number of instances that are allowed to be in the warm pool or in any state except Terminated for the Auto Scaling group.
-    * `min_size` - Minimum number of instances to maintain in the warm pool.
-    * `pool_state` - Instance state to transition to after the lifecycle actions are complete.
-* `warm_pool_size` - Current size of the warm pool.
+- `arn` - ARN of the Auto Scaling group.
+- `availability_zones` - One or more Availability Zones for the group.
+- `default_cool_down` - Amount of time, in seconds, after a scaling activity completes before another scaling activity can start.
+- `desired_capacity` - Desired size of the group.
+- `desired_capacity_type` - The unit of measurement for the value returned for `desired_capacity`.
+- `enabled_metrics` - List of metrics enabled for collection.
+- `health_check_grace_period` - The amount of time, in seconds, that Amazon EC2 Auto Scaling waits before checking the health status of an EC2 instance that has come into service.
+- `health_check_type` - Service to use for the health checks. The valid values are EC2 and ELB.
+- `id` - Name of the Auto Scaling Group.
+- `launch_configuration` - The name of the associated launch configuration.
+- `launch_template` - List of launch templates for the group.
+  - `id` - ID of the launch template.
+  - `name` - Name of the launch template.
+  - `version` - Template version.
+- `load_balancers` - One or more load balancers associated with the group.
+- `max_instance_lifetime` - Maximum amount of time, in seconds, that an instance can be in service.
+- `max_size` - Maximum size of the group.
+- `min_size` - Minimum size of the group.
+- `mixed_instances_policy` - List of mixed instances policy objects for the group.
+  - `instances_distribution` - List of instances distribution objects.
+    - `on_demand_allocation_strategy` - Strategy used when launching on-demand instances.
+    - `on_demand_base_capacity` - Absolute minimum amount of desired capacity that must be fulfilled by on-demand instances.
+    - `spot_allocation_strategy` - Strategy used when launching Spot instances.
+    - `spot_instance_pools` - Number of Spot pools per availability zone to allocate capacity.
+    - `spot_max_price` - Maximum price per unit hour that the user is willing to pay for the Spot instances.
+  - `launch_template` - List of launch templates along with the overrides.
+    - `launch_template_specification` - List of launch template specification objects.
+      - `launch_template_id` - ID of the launch template.
+      - `launch_template_name` - Name of the launch template.
+      - `version` - Template version.
+    - `override` - List of properties overriding the same properties in the launch template.
+      - `instance_requirements` - List of instance requirements objects.
+        - `accelerator_count - List of objects describing the minimum and maximum number of accelerators for an instance type.
+          - `min` - Minimum.
+          - `max` - Maximum.
+        - `accelerator_manufacturers` - List of accelerator manufacturer names.
+        - `accelerator_names` - List of accelerator names.
+        - `accelerator_total_memory_mib` - List of objects describing the minimum and maximum total memory of the accelerators.
+        - `accelerator_types` - List of accelerator types.
+        - `allowed_instance_types` - List of instance types to apply the specified attributes against.
+        - `bare_metal` - Indicates whether bare metal instances are included, excluded, or required.
+        - `baseline_ebs_bandwidth_mbps` - List of objects describing the minimum and maximum baseline EBS bandwidth (Mbps).
+          - `min` - Minimum.
+          - `max` - Maximum.
+        - `burstable_performance` - Indicates whether burstable performance instance types are included, excluded, or required.
+        - `cpu_manufacturers` - List of CPU manufacturer names.
+        - `excluded_instance_types` - List of excluded instance types.
+        - `instance_generations` - List of instance generation names.
+        - `local_storage` - Indicates whether instance types with instance store volumes are included, excluded, or required.
+        - `local_storage_types` - List of local storage type names.
+        - `memory_gib_per_vcpu` - List of objects describing the minimum and maximum amount of memory (GiB) per vCPU.
+          - `min` - Minimum.
+          - `max` - Maximum.
+        - `memory_mib` - List of objects describing the minimum and maximum amount of memory (MiB).
+          - `min` - Minimum.
+          - `max` - Maximum.
+        - `network_bandwidth_gbps` - List of objects describing the minimum and maximum amount of network bandwidth (Gbps).
+          - `min` - Minimum.
+          - `max`- Maximum.
+        - `network_interface_count` - List of objects describing the minimum and maximum amount of network interfaces.
+          - `min` - Minimum.
+          - `max` - Maximum.
+        - `on_demand_max_price_percentage_over_lowest_price` - Price protection threshold for On-Demand Instances.
+        - `require_hibernate_support` - Indicates whether instance types must support On-Demand Instance Hibernation.
+        - `spot_max_price_percentage_over_lowest_price` - Price protection threshold for Spot Instances.
+        - `total_local_storage_gb` - List of objects describing the minimum and maximum total storage (GB).
+          - `min` - Minimum.
+          - `max` - Maximum.
+        - `vcpu_count` - List of objects describing the minimum and maximum number of vCPUs.
+          - `min` - Minimum.
+          - `max` - Maximum.
+      - `instance_type` - Overriding instance type.
+      - `launch_template_specification` - List of overriding launch template specification objects.
+        - `launch_template_id` - ID of the launch template.
+        - `launch_template_name` - Name of the launch template.
+        - `version` - Template version.
+      - `weighted_capacity` - Number of capacity units, which gives the instance type a proportional weight to other instance types.
+- `name` - Name of the Auto Scaling Group.
+- `placement_group` - Name of the placement group into which to launch your instances, if any. For more information, see Placement Groups (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html) in the Amazon Elastic Compute Cloud User Guide.
+- `predicted_capacity` - Predicted capacity of the group.
+- `service_linked_role_arn` - ARN of the service-linked role that the Auto Scaling group uses to call other AWS services on your behalf.
+- `status` - Current state of the group when DeleteAutoScalingGroup is in progress.
+- `suspended_processes` - List of processes suspended processes for the Auto Scaling Group.
+- `tag` - List of tags for the group.
+  - `key` - Key.
+  - `value` - Value.
+  - `propagate_at_launch` - Whether the tag is propagated to Amazon EC2 instances launched via this ASG.
+- `target_group_arns` - ARNs of the target groups for your load balancer.
+- `traffic_sources` - ARNs of the target groups for your load balancer.
+  - `identifier` - Identifies the traffic source.
+  - `type` - Provides additional context for the value of Identifier.
+- `termination_policies` - The termination policies for the group.
+- `vpc_zone_identifier` - VPC ID for the group.
+- `warm_pool` - List of warm pool configuration objects.
+  - `instance_reuse_policy` - List of instance reuse policy objects.
+    - `reuse_on_scale_in` - Indicates whether instances in the Auto Scaling group can be returned to the warm pool on scale in.
+  - `max_group_prepared_policy` - Total maximum number of instances that are allowed to be in the warm pool or in any state except Terminated for the Auto Scaling group.
+  - `min_size` - Minimum number of instances to maintain in the warm pool.
+  - `pool_state` - Instance state to transition to after the lifecycle actions are complete.
+- `warm_pool_size` - Current size of the warm pool.

--- a/website/docs/d/autoscaling_group.html.markdown
+++ b/website/docs/d/autoscaling_group.html.markdown
@@ -38,72 +38,72 @@ interpolation.
 - `id` - Name of the Auto Scaling Group.
 - `launch_configuration` - The name of the associated launch configuration.
 - `launch_template` - List of launch templates for the group.
-  - `id` - ID of the launch template.
-  - `name` - Name of the launch template.
-  - `version` - Template version.
+    - `id` - ID of the launch template.
+    - `name` - Name of the launch template.
+    - `version` - Template version.
 - `load_balancers` - One or more load balancers associated with the group.
 - `max_instance_lifetime` - Maximum amount of time, in seconds, that an instance can be in service.
 - `max_size` - Maximum size of the group.
 - `min_size` - Minimum size of the group.
 - `mixed_instances_policy` - List of mixed instances policy objects for the group.
-  - `instances_distribution` - List of instances distribution objects.
-    - `on_demand_allocation_strategy` - Strategy used when launching on-demand instances.
-    - `on_demand_base_capacity` - Absolute minimum amount of desired capacity that must be fulfilled by on-demand instances.
-    - `spot_allocation_strategy` - Strategy used when launching Spot instances.
-    - `spot_instance_pools` - Number of Spot pools per availability zone to allocate capacity.
-    - `spot_max_price` - Maximum price per unit hour that the user is willing to pay for the Spot instances.
-  - `launch_template` - List of launch templates along with the overrides.
-    - `launch_template_specification` - List of launch template specification objects.
-      - `launch_template_id` - ID of the launch template.
-      - `launch_template_name` - Name of the launch template.
-      - `version` - Template version.
-    - `override` - List of properties overriding the same properties in the launch template.
-      - `instance_requirements` - List of instance requirements objects.
-        - `accelerator_count - List of objects describing the minimum and maximum number of accelerators for an instance type.
-          - `min` - Minimum.
-          - `max` - Maximum.
-        - `accelerator_manufacturers` - List of accelerator manufacturer names.
-        - `accelerator_names` - List of accelerator names.
-        - `accelerator_total_memory_mib` - List of objects describing the minimum and maximum total memory of the accelerators.
-        - `accelerator_types` - List of accelerator types.
-        - `allowed_instance_types` - List of instance types to apply the specified attributes against.
-        - `bare_metal` - Indicates whether bare metal instances are included, excluded, or required.
-        - `baseline_ebs_bandwidth_mbps` - List of objects describing the minimum and maximum baseline EBS bandwidth (Mbps).
-          - `min` - Minimum.
-          - `max` - Maximum.
-        - `burstable_performance` - Indicates whether burstable performance instance types are included, excluded, or required.
-        - `cpu_manufacturers` - List of CPU manufacturer names.
-        - `excluded_instance_types` - List of excluded instance types.
-        - `instance_generations` - List of instance generation names.
-        - `local_storage` - Indicates whether instance types with instance store volumes are included, excluded, or required.
-        - `local_storage_types` - List of local storage type names.
-        - `memory_gib_per_vcpu` - List of objects describing the minimum and maximum amount of memory (GiB) per vCPU.
-          - `min` - Minimum.
-          - `max` - Maximum.
-        - `memory_mib` - List of objects describing the minimum and maximum amount of memory (MiB).
-          - `min` - Minimum.
-          - `max` - Maximum.
-        - `network_bandwidth_gbps` - List of objects describing the minimum and maximum amount of network bandwidth (Gbps).
-          - `min` - Minimum.
-          - `max`- Maximum.
-        - `network_interface_count` - List of objects describing the minimum and maximum amount of network interfaces.
-          - `min` - Minimum.
-          - `max` - Maximum.
-        - `on_demand_max_price_percentage_over_lowest_price` - Price protection threshold for On-Demand Instances.
-        - `require_hibernate_support` - Indicates whether instance types must support On-Demand Instance Hibernation.
-        - `spot_max_price_percentage_over_lowest_price` - Price protection threshold for Spot Instances.
-        - `total_local_storage_gb` - List of objects describing the minimum and maximum total storage (GB).
-          - `min` - Minimum.
-          - `max` - Maximum.
-        - `vcpu_count` - List of objects describing the minimum and maximum number of vCPUs.
-          - `min` - Minimum.
-          - `max` - Maximum.
-      - `instance_type` - Overriding instance type.
-      - `launch_template_specification` - List of overriding launch template specification objects.
-        - `launch_template_id` - ID of the launch template.
-        - `launch_template_name` - Name of the launch template.
-        - `version` - Template version.
-      - `weighted_capacity` - Number of capacity units, which gives the instance type a proportional weight to other instance types.
+    - `instances_distribution` - List of instances distribution objects.
+        - `on_demand_allocation_strategy` - Strategy used when launching on-demand instances.
+        - `on_demand_base_capacity` - Absolute minimum amount of desired capacity that must be fulfilled by on-demand instances.
+        - `spot_allocation_strategy` - Strategy used when launching Spot instances.
+        - `spot_instance_pools` - Number of Spot pools per availability zone to allocate capacity.
+        - `spot_max_price` - Maximum price per unit hour that the user is willing to pay for the Spot instances.
+    - `launch_template` - List of launch templates along with the overrides.
+        - `launch_template_specification` - List of launch template specification objects.
+            - `launch_template_id` - ID of the launch template.
+            - `launch_template_name` - Name of the launch template.
+            - `version` - Template version.
+        - `override` - List of properties overriding the same properties in the launch template.
+            - `instance_requirements` - List of instance requirements objects.
+                - `accelerator_count - List of objects describing the minimum and maximum number of accelerators for an instance type.
+                    - `min` - Minimum.
+                    - `max` - Maximum.
+                - `accelerator_manufacturers` - List of accelerator manufacturer names.
+                - `accelerator_names` - List of accelerator names.
+                - `accelerator_total_memory_mib` - List of objects describing the minimum and maximum total memory of the accelerators.
+                - `accelerator_types` - List of accelerator types.
+                - `allowed_instance_types` - List of instance types to apply the specified attributes against.
+                - `bare_metal` - Indicates whether bare metal instances are included, excluded, or required.
+                - `baseline_ebs_bandwidth_mbps` - List of objects describing the minimum and maximum baseline EBS bandwidth (Mbps).
+                    - `min` - Minimum.
+                    - `max` - Maximum.
+                - `burstable_performance` - Indicates whether burstable performance instance types are included, excluded, or required.
+                - `cpu_manufacturers` - List of CPU manufacturer names.
+                - `excluded_instance_types` - List of excluded instance types.
+                - `instance_generations` - List of instance generation names.
+                - `local_storage` - Indicates whether instance types with instance store volumes are included, excluded, or required.
+                - `local_storage_types` - List of local storage type names.
+                - `memory_gib_per_vcpu` - List of objects describing the minimum and maximum amount of memory (GiB) per vCPU.
+                    - `min` - Minimum.
+                    - `max` - Maximum.
+                - `memory_mib` - List of objects describing the minimum and maximum amount of memory (MiB).
+                    - `min` - Minimum.
+                    - `max` - Maximum.
+                - `network_bandwidth_gbps` - List of objects describing the minimum and maximum amount of network bandwidth (Gbps).
+                    - `min` - Minimum.
+                    - `max`- Maximum.
+                - `network_interface_count` - List of objects describing the minimum and maximum amount of network interfaces.
+                    - `min` - Minimum.
+                    - `max` - Maximum.
+                - `on_demand_max_price_percentage_over_lowest_price` - Price protection threshold for On-Demand Instances.
+                - `require_hibernate_support` - Indicates whether instance types must support On-Demand Instance Hibernation.
+                - `spot_max_price_percentage_over_lowest_price` - Price protection threshold for Spot Instances.
+                - `total_local_storage_gb` - List of objects describing the minimum and maximum total storage (GB).
+                    - `min` - Minimum.
+                    - `max` - Maximum.
+                - `vcpu_count` - List of objects describing the minimum and maximum number of vCPUs.
+                    - `min` - Minimum.
+                    - `max` - Maximum.
+            - `instance_type` - Overriding instance type.
+            - `launch_template_specification` - List of overriding launch template specification objects.
+                - `launch_template_id` - ID of the launch template.
+                - `launch_template_name` - Name of the launch template.
+                - `version` - Template version.
+            - `weighted_capacity` - Number of capacity units, which gives the instance type a proportional weight to other instance types.
 - `name` - Name of the Auto Scaling Group.
 - `placement_group` - Name of the placement group into which to launch your instances, if any. For more information, see Placement Groups (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html) in the Amazon Elastic Compute Cloud User Guide.
 - `predicted_capacity` - Predicted capacity of the group.
@@ -111,19 +111,19 @@ interpolation.
 - `status` - Current state of the group when DeleteAutoScalingGroup is in progress.
 - `suspended_processes` - List of processes suspended processes for the Auto Scaling Group.
 - `tag` - List of tags for the group.
-  - `key` - Key.
-  - `value` - Value.
-  - `propagate_at_launch` - Whether the tag is propagated to Amazon EC2 instances launched via this ASG.
+    - `key` - Key.
+    - `value` - Value.
+    - `propagate_at_launch` - Whether the tag is propagated to Amazon EC2 instances launched via this ASG.
 - `target_group_arns` - ARNs of the target groups for your load balancer.
 - `traffic_sources` - ARNs of the target groups for your load balancer.
-  - `identifier` - Identifies the traffic source.
-  - `type` - Provides additional context for the value of Identifier.
+    - `identifier` - Identifies the traffic source.
+    - `type` - Provides additional context for the value of Identifier.
 - `termination_policies` - The termination policies for the group.
 - `vpc_zone_identifier` - VPC ID for the group.
 - `warm_pool` - List of warm pool configuration objects.
-  - `instance_reuse_policy` - List of instance reuse policy objects.
-    - `reuse_on_scale_in` - Indicates whether instances in the Auto Scaling group can be returned to the warm pool on scale in.
-  - `max_group_prepared_policy` - Total maximum number of instances that are allowed to be in the warm pool or in any state except Terminated for the Auto Scaling group.
-  - `min_size` - Minimum number of instances to maintain in the warm pool.
-  - `pool_state` - Instance state to transition to after the lifecycle actions are complete.
+    - `instance_reuse_policy` - List of instance reuse policy objects.
+        - `reuse_on_scale_in` - Indicates whether instances in the Auto Scaling group can be returned to the warm pool on scale in.
+    - `max_group_prepared_policy` - Total maximum number of instances that are allowed to be in the warm pool or in any state except Terminated for the Auto Scaling group.
+    - `min_size` - Minimum number of instances to maintain in the warm pool.
+    - `pool_state` - Instance state to transition to after the lifecycle actions are complete.
 - `warm_pool_size` - Current size of the warm pool.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Add support for the Autoscaling attach-traffic-sources API, this pull requests created the new resource aws_autoscaling_traffic_attachment

Go SDK https://docs.aws.amazon.com/sdk-for-go/api/service/autoscaling/#AutoScaling.AttachTrafficSources
AWS CLI https://docs.aws.amazon.com/cli/latest/reference/autoscaling/attach-traffic-sources.html

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31287.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/31527.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
➜  terraform-provider-aws git:(E-autoscaling-traffic-attachment) make testacc TESTARGS='-run=TestAccAutoScalingGroupDataSource_' PKG=autoscaling  ACCTEST_PARALLELISM=4 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/autoscaling/... -v -count 1 -parallel 4  -run=TestAccAutoScalingGroupDataSource_ -timeout 180m
=== RUN   TestAccAutoScalingGroupDataSource_basic
=== PAUSE TestAccAutoScalingGroupDataSource_basic
=== RUN   TestAccAutoScalingGroupDataSource_launchTemplate
=== PAUSE TestAccAutoScalingGroupDataSource_launchTemplate
=== RUN   TestAccAutoScalingGroupDataSource_trafficSources
=== PAUSE TestAccAutoScalingGroupDataSource_trafficSources
=== RUN   TestAccAutoScalingGroupDataSource_mixedInstancesPolicy
=== PAUSE TestAccAutoScalingGroupDataSource_mixedInstancesPolicy
=== RUN   TestAccAutoScalingGroupDataSource_warmPool
=== PAUSE TestAccAutoScalingGroupDataSource_warmPool
=== RUN   TestAccAutoScalingGroupDataSource_tags
=== PAUSE TestAccAutoScalingGroupDataSource_tags
=== CONT  TestAccAutoScalingGroupDataSource_basic
=== CONT  TestAccAutoScalingGroupDataSource_mixedInstancesPolicy
=== CONT  TestAccAutoScalingGroupDataSource_tags
=== CONT  TestAccAutoScalingGroupDataSource_trafficSources
--- PASS: TestAccAutoScalingGroupDataSource_mixedInstancesPolicy (23.33s)
=== CONT  TestAccAutoScalingGroupDataSource_warmPool
--- PASS: TestAccAutoScalingGroupDataSource_basic (34.98s)
=== CONT  TestAccAutoScalingGroupDataSource_launchTemplate
--- PASS: TestAccAutoScalingGroupDataSource_tags (35.17s)
--- PASS: TestAccAutoScalingGroupDataSource_trafficSources (37.79s)
--- PASS: TestAccAutoScalingGroupDataSource_launchTemplate (29.34s)
--- PASS: TestAccAutoScalingGroupDataSource_warmPool (358.97s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling        385.668s

```
