### PR TITLE
Update acceptance tests and documentation for removal of `aws_kinesis_firehose_delivery_stream` `s3_configuration`

### DIFF
--- a/internal/service/cloudwatch/metric_stream_test.go
+++ b/internal/service/cloudwatch/metric_stream_test.go
@@ -623,9 +623,9 @@ EOF
 
 resource "aws_kinesis_firehose_delivery_stream" "s3_stream" {
   name        = %[1]q
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.firehose_to_s3.arn
     bucket_arn = aws_s3_bucket.bucket.arn
   }

--- a/internal/service/connect/instance_storage_config_data_source_test.go
+++ b/internal/service/connect/instance_storage_config_data_source_test.go
@@ -175,11 +175,6 @@ resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.bucket.id
-  acl    = "private"
-}
-
 resource "aws_iam_role_policy" "firehose" {
   name = %[1]q
   role = aws_iam_role.firehose.id
@@ -232,9 +227,9 @@ EOF
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
   name        = %[1]q
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.firehose.arn
     bucket_arn = aws_s3_bucket.bucket.arn
   }

--- a/internal/service/connect/instance_storage_config_test.go
+++ b/internal/service/connect/instance_storage_config_test.go
@@ -610,11 +610,6 @@ resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.bucket.id
-  acl    = "private"
-}
-
 resource "aws_iam_role_policy" "firehose" {
   name = %[1]q
   role = aws_iam_role.firehose.id
@@ -678,9 +673,9 @@ locals {
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.firehose]
   name        = %[1]q
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.firehose.arn
     bucket_arn = aws_s3_bucket.bucket.arn
   }
@@ -689,9 +684,9 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 resource "aws_kinesis_firehose_delivery_stream" "test2" {
   depends_on  = [aws_iam_role_policy.firehose]
   name        = %[2]q
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.firehose.arn
     bucket_arn = aws_s3_bucket.bucket.arn
   }

--- a/internal/service/logs/README.md
+++ b/internal/service/logs/README.md
@@ -1,4 +1,4 @@
-# Terraform AWS Provider CloudWatchLogs Package
+# Terraform AWS Provider CloudWatch Logs Package
 
 This area is primarily for AWS provider contributors and maintainers. For information on _using_ Terraform and the AWS provider, see the links below.
 
@@ -6,5 +6,5 @@ This area is primarily for AWS provider contributors and maintainers. For inform
 
 * [Find out about contributing](https://hashicorp.github.io/terraform-provider-aws/#contribute) to the AWS provider!
 * AWS Provider Docs: [Home](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
-* AWS Provider Docs: [One of the CloudWatchLogs resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_destination)
-* AWS Docs: [AWS SDK for Go CloudWatchLogs](https://docs.aws.amazon.com/sdk-for-go/api/service/cloudwatchlogs/)
+* AWS Provider Docs: [One of the CloudWatch Logs resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_destination)
+* AWS Docs: [AWS SDK for Go CloudWatch Logs](https://docs.aws.amazon.com/sdk-for-go/api/service/cloudwatchlogs/)

--- a/internal/service/logs/data_protection_policy_document_data_source_test.go
+++ b/internal/service/logs/data_protection_policy_document_data_source_test.go
@@ -169,9 +169,9 @@ resource "aws_kinesis_firehose_delivery_stream" "audit" {
   depends_on = [aws_iam_role_policy.firehose]
 
   name        = %[2]q
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.firehose.arn
     bucket_arn = aws_s3_bucket.audit.arn
   }

--- a/internal/service/networkfirewall/logging_configuration_test.go
+++ b/internal/service/networkfirewall/logging_configuration_test.go
@@ -766,11 +766,6 @@ resource "aws_s3_bucket" "test" {
     create_before_destroy = true
   }
 }
-
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
 `, rName)
 }
 
@@ -861,17 +856,12 @@ resource "aws_s3_bucket" "logs" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket_acl" "logs_acl" {
-  bucket = aws_s3_bucket.logs.id
-  acl    = "private"
-}
-
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   depends_on  = [aws_iam_role_policy.test]
   name        = %[2]q
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.test.arn
     bucket_arn = aws_s3_bucket.logs.arn
   }

--- a/internal/service/ses/event_destination_test.go
+++ b/internal/service/ses/event_destination_test.go
@@ -173,11 +173,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[2]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_iam_role" "test" {
   name = %[2]q
 
@@ -207,9 +202,9 @@ EOF
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   name        = %[2]q
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.test.arn
     bucket_arn = aws_s3_bucket.test.arn
   }

--- a/internal/service/sesv2/configuration_set_event_destination_test.go
+++ b/internal/service/sesv2/configuration_set_event_destination_test.go
@@ -348,11 +348,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_iam_role" "bucket" {
   name = "%[1]s2"
 
@@ -422,9 +417,9 @@ func testAccConfigurationSetEventDestinationConfig_kinesisFirehoseDestination1(r
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test1" {
   name        = "%[1]s-1"
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.bucket.arn
     bucket_arn = aws_s3_bucket.test.arn
   }
@@ -458,9 +453,9 @@ func testAccConfigurationSetEventDestinationConfig_kinesisFirehoseDestination2(r
 		fmt.Sprintf(`
 resource "aws_kinesis_firehose_delivery_stream" "test2" {
   name        = "%[1]s-2"
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.bucket.arn
     bucket_arn = aws_s3_bucket.test.arn
   }

--- a/internal/service/sns/topic_subscription_test.go
+++ b/internal/service/sns/topic_subscription_test.go
@@ -1315,11 +1315,6 @@ resource "aws_s3_bucket" "bucket" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.bucket.id
-  acl    = "private"
-}
-
 data "aws_partition" "current" {}
 
 resource "aws_iam_role" "firehose_role" {
@@ -1344,9 +1339,9 @@ EOF
 
 resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   name        = %[1]q
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.firehose_role.arn
     bucket_arn = aws_s3_bucket.bucket.arn
   }

--- a/internal/service/waf/web_acl_test.go
+++ b/internal/service/waf/web_acl_test.go
@@ -560,11 +560,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -583,15 +578,14 @@ resource "aws_iam_role" "test" {
   ]
 }
 EOF
-
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   # the name must begin with aws-waf-logs-
   name        = "aws-waf-logs-%[1]s"
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.test.arn
     bucket_arn = aws_s3_bucket.test.arn
   }
@@ -631,11 +625,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -660,9 +649,9 @@ EOF
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   # the name must begin with aws-waf-logs-
   name        = "aws-waf-logs-%[1]s"
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.test.arn
     bucket_arn = aws_s3_bucket.test.arn
   }

--- a/internal/service/wafregional/web_acl_test.go
+++ b/internal/service/wafregional/web_acl_test.go
@@ -808,11 +808,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -837,9 +832,9 @@ EOF
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   # the name must begin with aws-waf-logs-
   name        = "aws-waf-logs-%[1]s"
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.test.arn
     bucket_arn = aws_s3_bucket.test.arn
   }
@@ -866,11 +861,6 @@ resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_bucket.test.id
-  acl    = "private"
-}
-
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -895,9 +885,9 @@ EOF
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   # the name must begin with aws-waf-logs-
   name        = "aws-waf-logs-%[1]s"
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.test.arn
     bucket_arn = aws_s3_bucket.test.arn
   }

--- a/website/docs/d/redshift_cluster.html.markdown
+++ b/website/docs/d/redshift_cluster.html.markdown
@@ -21,14 +21,6 @@ resource "aws_kinesis_firehose_delivery_stream" "example_stream" {
   name        = "terraform-kinesis-firehose-example-stream"
   destination = "redshift"
 
-  s3_configuration {
-    role_arn           = aws_iam_role.firehose_role.arn
-    bucket_arn         = aws_s3_bucket.bucket.arn
-    buffer_size        = 10
-    buffer_interval    = 400
-    compression_format = "GZIP"
-  }
-
   redshift_configuration {
     role_arn           = aws_iam_role.firehose_role.arn
     cluster_jdbcurl    = "jdbc:redshift://${data.aws_redshift_cluster.example.endpoint}/${data.aws_redshift_cluster.example.database_name}"
@@ -37,6 +29,14 @@ resource "aws_kinesis_firehose_delivery_stream" "example_stream" {
     data_table_name    = "example-table"
     copy_options       = "delimiter '|'" # the default delimiter
     data_table_columns = "example-col"
+
+    s3_configuration {
+      role_arn           = aws_iam_role.firehose_role.arn
+      bucket_arn         = aws_s3_bucket.bucket.arn
+      buffer_size        = 10
+      buffer_interval    = 400
+      compression_format = "GZIP"
+    }
   }
 }
 ```

--- a/website/docs/r/cloudwatch_metric_stream.html.markdown
+++ b/website/docs/r/cloudwatch_metric_stream.html.markdown
@@ -124,9 +124,9 @@ resource "aws_iam_role_policy" "firehose_to_s3" {
 
 resource "aws_kinesis_firehose_delivery_stream" "s3_stream" {
   name        = "metric-stream-test-stream"
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.firehose_to_s3.arn
     bucket_arn = aws_s3_bucket.bucket.arn
   }

--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -84,9 +84,9 @@ resource "aws_iam_role" "firehose_role" {
 
 resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   name        = "terraform-kinesis-firehose-msk-broker-logs-stream"
-  destination = "s3"
+  destination = "extended_s3"
 
-  s3_configuration {
+  extended_s3_configuration {
     role_arn   = aws_iam_role.firehose_role.arn
     bucket_arn = aws_s3_bucket.bucket.arn
   }


### PR DESCRIPTION
### Description

v5.0 of the AWS Provider removes the parameter `s3_configuration` from `aws_kinesis_firehose_delivery_stream` in favour of `extended_s3_configuration`

### Output from Acceptance Testing

```
$ make testacc PKG=cloudwatch TESTS=TestAccCloudWatchMetricStream_

--- PASS: TestAccCloudWatchMetricStream_includeFilters (26.96s)
--- PASS: TestAccCloudWatchMetricStream_includeFiltersWithMetricNames (27.53s)
--- PASS: TestAccCloudWatchMetricStream_excludeFiltersWithMetricNames (27.71s)
--- PASS: TestAccCloudWatchMetricStream_excludeFilters (28.29s)
--- PASS: TestAccCloudWatchMetricStream_additional_statistics (69.05s)
--- PASS: TestAccCloudWatchMetricStream_update (77.07s)
--- PASS: TestAccCloudWatchMetricStream_includeLinkedAccountsMetrics (344.80s)
--- PASS: TestAccCloudWatchMetricStream_nameGenerated (375.81s)
--- PASS: TestAccCloudWatchMetricStream_namePrefix (375.82s)
--- PASS: TestAccCloudWatchMetricStream_basic (507.04s)
--- PASS: TestAccCloudWatchMetricStream_tags (533.07s)
--- PASS: TestAccCloudWatchMetricStream_disappears (543.78s)
```

```
$ make testacc PKG=elasticache TESTS=TestAccElastiCacheCluster_

--- SKIP: TestAccElastiCacheCluster_outpostID_memcached (1.43s)
--- SKIP: TestAccElastiCacheCluster_outpost_redis (1.45s)
--- SKIP: TestAccElastiCacheCluster_outpost_memcached (1.47s)
--- SKIP: TestAccElastiCacheCluster_outpostID_redis (1.51s)
--- PASS: TestAccElastiCacheCluster_Engine_None (8.38s)
--- PASS: TestAccElastiCacheCluster_Memcached_finalSnapshot (11.24s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_redis (10.12s)
--- PASS: TestAccElastiCacheCluster_ParameterGroupName_default (629.07s)
--- PASS: TestAccElastiCacheCluster_AZMode_redis (641.56s)
--- PASS: TestAccElastiCacheCluster_port (649.64s)
--- PASS: TestAccElastiCacheCluster_AZMode_memcached (652.58s)
--- PASS: TestAccElastiCacheCluster_PortRedis_default (669.20s)
--- PASS: TestAccElastiCacheCluster_Engine_memcached (672.36s)
--- PASS: TestAccElastiCacheCluster_Engine_redis (662.01s)
--- PASS: TestAccElastiCacheCluster_Engine_redis_v5 (682.24s)
--- PASS: TestAccElastiCacheCluster_ipDiscovery (699.50s)
--- PASS: TestAccElastiCacheCluster_Redis_autoMinorVersionUpgrade (709.48s)
--- PASS: TestAccElastiCacheCluster_snapshotsWithUpdates (718.62s)
--- PASS: TestAccElastiCacheCluster_multiAZInVPC (819.89s)
--- PASS: TestAccElastiCacheCluster_Redis_finalSnapshot (841.30s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_decrease (942.10s)
--- PASS: TestAccElastiCacheCluster_tags (618.01s)
--- PASS: TestAccElastiCacheCluster_vpc (614.66s)
--- PASS: TestAccElastiCacheCluster_EngineVersion_memcached (1336.83s)
--- PASS: TestAccElastiCacheCluster_tagWithOtherModification (780.20s)
--- PASS: TestAccElastiCacheCluster_NodeTypeResize_redis (1469.99s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_multipleReplica (1499.65s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_singleReplica (1500.51s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_availabilityZone (1531.78s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_increaseWithPreferredAvailabilityZones (1000.15s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_increase (1029.52s)
--- PASS: TestAccElastiCacheCluster_NodeTypeResize_memcached (1212.10s)
--- PASS: TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations (1322.24s)
--- PASS: TestAccElastiCacheCluster_EngineVersion_redis (2964.64s)
```

```
$ make testacc PKG=logs TESTS=TestAccLogsDataProtectionPolicyDocumentDataSource_

--- PASS: TestAccLogsDataProtectionPolicyDocumentDataSource_errorOnNoOperation (2.23s)
--- PASS: TestAccLogsDataProtectionPolicyDocumentDataSource_errorOnBadOrderOfStatements (2.25s)
--- PASS: TestAccLogsDataProtectionPolicyDocumentDataSource_empty (14.74s)
--- PASS: TestAccLogsDataProtectionPolicyDocumentDataSource_basic (250.71s)
```

```
$ make testacc PKG=networkfirewall TESTS=TestAccNetworkFirewallLoggingConfiguration_ ACCTEST_PARALLELISM=5

--- PASS: TestAccNetworkFirewallLoggingConfiguration_S3LogDestination_prefix (1107.04s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_S3LogDestination_bucketName (1107.37s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_CloudWatchLogDestination_logGroup (1127.45s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_KinesisLogDestination_deliveryStream (1435.24s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_S3LogDestination_logType (1092.87s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_updateFirewallARN (2208.98s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_CloudWatchLogDestination_logType (1150.28s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_KinesisLogDestination_logType (1143.26s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_updateToSingleAlertTypeLogDestination (1115.42s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_disappears (1189.82s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_updateToSingleFlowTypeLogDestination (1181.70s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_updateToMultipleLogDestinations (1254.27s)
--- PASS: TestAccNetworkFirewallLoggingConfiguration_updateLogDestinationType (1464.37s)
```

```
$ make testacc PKG=ses TESTS=TestAccSESEventDestination_

--- PASS: TestAccSESEventDestination_disappears (207.35s)
--- PASS: TestAccSESEventDestination_basic (225.17s)
```

```
$ make testacc PKG=sesv2 TESTS=TestAccSESV2ConfigurationSetEventDestination_

--- PASS: TestAccSESV2ConfigurationSetEventDestination_disappears (16.89s)
--- PASS: TestAccSESV2ConfigurationSetEventDestination_cloudWatchDestination (30.09s)
--- PASS: TestAccSESV2ConfigurationSetEventDestination_basic (30.32s)
--- PASS: TestAccSESV2ConfigurationSetEventDestination_snsDestination (31.53s)
--- PASS: TestAccSESV2ConfigurationSetEventDestination_pinpointDestination (31.73s)
--- PASS: TestAccSESV2ConfigurationSetEventDestination_kinesisFirehoseDestination (349.62s)
```

```
$ make testacc PKG=sns TESTS=TestAccSNSTopicSubscription_

--- PASS: TestAccSNSTopicSubscription_filterPolicyScope_policyNotSet (5.06s)
--- PASS: TestAccSNSTopicSubscription_email (21.37s)
--- PASS: TestAccSNSTopicSubscription_deliveryPolicy (86.87s)
--- PASS: TestAccSNSTopicSubscription_filterPolicy (86.99s)
--- PASS: TestAccSNSTopicSubscription_rawMessageDelivery (87.36s)
--- PASS: TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint (97.83s)
--- PASS: TestAccSNSTopicSubscription_Disappears_topic (98.51s)
--- PASS: TestAccSNSTopicSubscription_basic (103.42s)
--- PASS: TestAccSNSTopicSubscription_disappears (113.79s)
--- PASS: TestAccSNSTopicSubscription_autoConfirmingEndpoint (136.99s)
--- PASS: TestAccSNSTopicSubscription_redrivePolicy (148.96s)
--- FAIL: TestAccSNSTopicSubscription_filterPolicyScope (197.89s)
--- PASS: TestAccSNSTopicSubscription_firehose (230.05s)
```

`TestAccSNSTopicSubscription_filterPolicyScope` has a pre-existing intermittent failure

```
$ make testacc PKG=waf TESTS=TestAccWAFWebACL_

--- PASS: TestAccWAFWebACL_disappears (40.50s)
--- PASS: TestAccWAFWebACL_basic (54.01s)
--- PASS: TestAccWAFWebACL_defaultAction (77.32s)
--- PASS: TestAccWAFWebACL_changeNameForceNew (79.27s)
--- PASS: TestAccWAFWebACL_tags (99.88s)
--- FAIL: TestAccWAFWebACL_rules (395.10s)
--- PASS: TestAccWAFWebACL_logging (1400.43s)
```

`TestAccWAFWebACL_rules` has a pre-existing failure

```
$ make testacc PKG=wafregional TESTS=TestAccWAFRegionalWebACL_

--- PASS: TestAccWAFRegionalWebACL_noRules (34.21s)
--- PASS: TestAccWAFRegionalWebACL_createRateBased (62.67s)
--- PASS: TestAccWAFRegionalWebACL_basic (63.58s)
--- PASS: TestAccWAFRegionalWebACL_disappears (64.17s)
--- PASS: TestAccWAFRegionalWebACL_createGroup (70.40s)
--- PASS: TestAccWAFRegionalWebACL_changeRules (74.24s)
--- PASS: TestAccWAFRegionalWebACL_changeDefaultAction (92.52s)
--- PASS: TestAccWAFRegionalWebACL_tags (93.10s)
--- PASS: TestAccWAFRegionalWebACL_changeNameForceNew (126.01s)
--- PASS: TestAccWAFRegionalWebACL_logging (568.80s)
```