### PR TITLE
r/aws_iam_role: Remove `role_last_used` attribute

### DIFF
--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -160,22 +160,6 @@ func ResourceRole() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: verify.ValidARN,
 			},
-			"role_last_used": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"region": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"last_used_date": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"unique_id": {
@@ -322,10 +306,6 @@ func resourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	inlinePolicies, err := readRoleInlinePolicies(ctx, aws.StringValue(role.RoleName), meta)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading inline policies for IAM role %s, error: %s", d.Id(), err)
-	}
-
-	if err := d.Set("role_last_used", flattenRoleLastUsed(role.RoleLastUsed)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting role_last_used: %s", err)
 	}
 
 	var configPoliciesList []*iam.PutRolePolicyInput
@@ -752,21 +732,6 @@ func deleteRoleInlinePolicies(ctx context.Context, conn *iam.IAM, roleName strin
 	}
 
 	return nil
-}
-
-func flattenRoleLastUsed(apiObject *iam.RoleLastUsed) []interface{} {
-	if apiObject == nil {
-		return nil
-	}
-
-	tfMap := map[string]interface{}{
-		"region": aws.StringValue(apiObject.Region),
-	}
-
-	if apiObject.LastUsedDate != nil {
-		tfMap["last_used_date"] = apiObject.LastUsedDate.Format(time.RFC3339)
-	}
-	return []interface{}{tfMap}
 }
 
 func flattenRoleInlinePolicy(apiObject *iam.PutRolePolicyInput) map[string]interface{} {

--- a/internal/service/iam/role_data_source.go
+++ b/internal/service/iam/role_data_source.go
@@ -131,3 +131,18 @@ func dataSourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	return diags
 }
+
+func flattenRoleLastUsed(apiObject *iam.RoleLastUsed) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{
+		"region": aws.StringValue(apiObject.Region),
+	}
+
+	if apiObject.LastUsedDate != nil {
+		tfMap["last_used_date"] = apiObject.LastUsedDate.Format(time.RFC3339)
+	}
+	return []interface{}{tfMap}
+}

--- a/internal/service/iam/role_data_source_test.go
+++ b/internal/service/iam/role_data_source_test.go
@@ -74,7 +74,6 @@ const testAccRoleDataSourceConfig_AssumeRolePolicy_ExpectedJSON = `{
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "",
       "Effect": "Allow",
       "Action": "sts:AssumeRole",
       "Principal": {

--- a/website/docs/r/iam_role.html.markdown
+++ b/website/docs/r/iam_role.html.markdown
@@ -208,14 +208,8 @@ In addition to all arguments above, the following attributes are exported:
 * `create_date` - Creation date of the IAM role.
 * `id` - Name of the role.
 * `name` - Name of the role.
-* `role_last_used` - Contains information about the last time that an IAM role was used. See [`role_last_used`](#role_last_used) for details.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `unique_id` - Stable and unique string identifying the role.
-
-### role_last_used
-
-* `region` - The name of the AWS Region in which the role was last used.
-* `last_used_time` - The date and time, in RFC 3339 format, that the role was last used.
 
 ## Import
 


### PR DESCRIPTION
### Description
Removes the recently added read-only `role_last_used` attribute to address the concerns expressed in #30861. While technically a breaking change, we've opted to remove the attribute in a minor release rather than wait until `v6.0.0` (12-18 months from now). We are considering a breaking change acceptable in this context for the following reasons:

1. The attribute, while functioning correctly, is causing a negative user experience, evidenced by the number of upvotes and comments on the linked issue in a relatively short time since its release.
2. The attribute is relatively new (release with `v4.64.0`, from April 2023), read-only, and unlikely to be used as an input to any other resource.
3. The corresponding data source provides an alternative source for this information.


### Relations
Closes #30861
Relates #30750 


### Output from Acceptance Testing

```console
$ make testacc PKG=iam TESTS=TestAccIAMRole_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRole_'  -timeout 180m

--- PASS: TestAccIAMRole_badJSON (5.70s)
=== CONT  TestAccIAMRole_permissionsBoundary
--- PASS: TestAccIAMRole_InlinePolicy_empty (39.38s)
=== CONT  TestAccIAMRole_policiesForceDetach
--- PASS: TestAccIAMRole_nameGenerated (43.76s)
=== CONT  TestAccIAMRole_disappears
--- PASS: TestAccIAMRole_basic (46.95s)
=== CONT  TestAccIAMRole_diffs
--- PASS: TestAccIAMRole_namePrefix (47.13s)
=== CONT  TestAccIAMRole_description
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored (66.48s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack (66.78s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty (69.50s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack (69.84s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved (69.88s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty (71.52s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved (71.81s)
--- PASS: TestAccIAMRole_testNameChange (73.54s)
--- PASS: TestAccIAMRole_tags (73.73s)
--- PASS: TestAccIAMRole_disappears (32.68s)
--- PASS: TestAccIAMRole_policiesForceDetach (38.74s)
--- PASS: TestAccIAMRole_maxSessionDuration (79.21s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored (82.68s)
--- PASS: TestAccIAMRole_InlinePolicy_ignoreOrder (83.94s)
--- PASS: TestAccIAMRole_ManagedPolicy_basic (86.92s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (87.95s)
--- PASS: TestAccIAMRole_description (56.24s)
--- PASS: TestAccIAMRole_diffsCondition (106.23s)
--- PASS: TestAccIAMRole_permissionsBoundary (103.47s)
--- PASS: TestAccIAMRole_diffs (225.03s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        275.285s
```

```console
$ make testacc PKG=iam TESTS=TestAccIAMRoleDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRoleDataSource_'  -timeout 180m

--- PASS: TestAccIAMRoleDataSource_tags (13.13s)
--- PASS: TestAccIAMRoleDataSource_basic (13.14s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        16.373s
```
