### PR TITLE
SEC-090 Compliance: Switch to official Slack notifier action for regressions 

### DIFF
--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -8,33 +8,41 @@ on:
       - labeled
 jobs:
   slack-notification:
-    if: ${{ github.event.label.name == 'regression' }}
+    name: Slack Notifier
+    if: github.event.label.name == 'regression'
     runs-on: ubuntu-latest
     steps:
-      - name: Issues
-        if: ${{ github.event_name == 'issues' }}
-        uses: actions-ecosystem/action-slack-notifier@v1
+      - name: Send Slack Notification
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          EVENT_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
+          EVENT_TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
         with:
-          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel: ${{ secrets.SLACK_CHANNEL }}
-          color: red
-          verbose: false
-          message: |
-            :warning: The following issue has been labeled as a regression:
-            https://github.com/${{ github.repository }}/issues/${{ github.event.issue.number }}
-      - name: Pull Requests
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions-ecosystem/action-slack-notifier@v1
-        with:
-          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel: ${{ secrets.SLACK_CHANNEL }}
-          color: red
-          verbose: false
-          message: |
-            :warning: The following pull request has been labeled as a regression:
-            https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+          channel-id: ${{ secrets.SLACK_CHANNEL }}
+          payload: |
+            {
+            	"blocks": [
+            		{
+            			"type": "section",
+            			"text": {
+            				"type": "mrkdwn",
+            				"text": ":warning: The following has been labeled as a regression:"
+            			}
+            		},
+            		{
+            			"type": "section",
+            			"text": {
+            				"type": "mrkdwn",
+            				"text": "<${{ env.EVENT_URL }}|${{ env.EVENT_TITLE }}>"
+            			}
+            		}
+            	]
+            }
+
   AddToWorkingBoard:
-    if: ${{ github.event.label.name == 'regression' }}
+    name: Add regression to Working Board
+    if: github.event.label.name == 'regression'
     runs-on: ubuntu-latest
     steps:
       - name: Add regressions to To Do column


### PR DESCRIPTION
### Description

This PR moves the regressions Slack notification workflow over to the official `slackapi` Action to comply with TSCCR.

### Relations

Relates: https://github.com/hashicorp/security-tsccr/pull/454
Relates: #31014

### References

- [GitHub Action repo](https://github.com/slackapi/slack-github-action)
- [Existing workflow using this Action](https://github.com/hashicorp/terraform-provider-aws/blob/main/.github/workflows/pull_request_feed.yml)

### Output from Acceptance Testing
 
N/a, Actions
