### PR TITLE
Acceptance test cleanup

### DIFF
--- a/internal/service/elasticache/cluster_test.go
+++ b/internal/service/elasticache/cluster_test.go
@@ -1721,11 +1721,9 @@ resource "aws_elasticache_cluster" "test" {
   node_type              = "cache.t3.small"
   num_cache_nodes        = 1
   engine                 = "redis"
-  engine_version         = "2.8.19"
   port                   = 6379
   subnet_group_name      = aws_elasticache_subnet_group.test.name
   security_group_ids     = [aws_security_group.test.id]
-  parameter_group_name   = "default.redis2.8"
   notification_topic_arn = aws_sns_topic.test.arn
   availability_zone      = data.aws_availability_zones.available.names[0]
 }
@@ -1799,12 +1797,10 @@ resource "aws_security_group_rule" "test" {
 }
 
 resource "aws_elasticache_cluster" "test" {
-  cluster_id           = %[1]q
-  engine               = "redis"
-  engine_version       = "5.0.4"
-  node_type            = "cache.t2.micro"
-  num_cache_nodes      = 1
-  parameter_group_name = "default.redis5.0"
+  cluster_id      = %[1]q
+  engine          = "redis"
+  node_type       = "cache.t2.micro"
+  num_cache_nodes = 1
 }
 `, rName)
 }


### PR DESCRIPTION
### Description

Removes unneeded `engine_version` from `aws_elasticache_cluster` acceptance tests

### Output from Acceptance Testing

```
$ make testacc PKG=elasticache TESTS=TestAccElastiCacheCluster_

--- PASS: TestAccElastiCacheCluster_Engine_None (4.98s)
--- SKIP: TestAccElastiCacheCluster_outpost_memcached (0.99s)
--- SKIP: TestAccElastiCacheCluster_outpostID_redis (0.13s)
--- SKIP: TestAccElastiCacheCluster_outpostID_memcached (0.14s)
--- SKIP: TestAccElastiCacheCluster_outpost_redis (0.12s)
--- PASS: TestAccElastiCacheCluster_Memcached_finalSnapshot (6.59s)
--- PASS: TestAccElastiCacheCluster_AZMode_memcached (614.25s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_redis (1.58s)
--- PASS: TestAccElastiCacheCluster_Engine_memcached (619.74s)
--- PASS: TestAccElastiCacheCluster_Engine_redis_v5 (632.44s)
--- PASS: TestAccElastiCacheCluster_ipDiscovery (652.06s)
--- PASS: TestAccElastiCacheCluster_ParameterGroupName_default (659.14s)
--- PASS: TestAccElastiCacheCluster_port (679.36s)
--- PASS: TestAccElastiCacheCluster_Redis_autoMinorVersionUpgrade (696.83s)
--- PASS: TestAccElastiCacheCluster_AZMode_redis (696.90s)
--- PASS: TestAccElastiCacheCluster_vpc (697.08s)
--- PASS: TestAccElastiCacheCluster_snapshotsWithUpdates (692.80s)
--- PASS: TestAccElastiCacheCluster_PortRedis_default (733.78s)
--- PASS: TestAccElastiCacheCluster_multiAZInVPC (766.01s)
--- PASS: TestAccElastiCacheCluster_Redis_finalSnapshot (973.24s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_increaseWithPreferredAvailabilityZones (1020.09s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_decrease (1139.32s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_increase (1189.97s)
--- PASS: TestAccElastiCacheCluster_Engine_redis (599.92s)
--- PASS: TestAccElastiCacheCluster_tags (630.52s)
--- PASS: TestAccElastiCacheCluster_EngineVersion_memcached (1324.45s)
--- PASS: TestAccElastiCacheCluster_tagWithOtherModification (733.90s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_singleReplica (1454.46s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_multipleReplica (1513.33s)
--- PASS: TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations (1203.67s)
--- PASS: TestAccElastiCacheCluster_NodeTypeResize_memcached (1243.22s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_availabilityZone (1431.75s)
--- PASS: TestAccElastiCacheCluster_NodeTypeResize_redis (1414.26s)
--- PASS: TestAccElastiCacheCluster_EngineVersion_redis (3002.68s)
```

`TestAccElastiCacheCluster_vpc` has an unrelated intermittent failure