### PR TITLE
b/aws_kendra-index-user_group_resolution_configuration

### DIFF
--- a/internal/service/kendra/index.go
+++ b/internal/service/kendra/index.go
@@ -1065,7 +1065,7 @@ func flattenUserGroupResolutionConfiguration(userGroupResolutionConfiguration *t
 	}
 
 	values := map[string]interface{}{
-		"user_group_resolution_configuration": userGroupResolutionConfiguration.UserGroupResolutionMode,
+		"user_group_resolution_mode": userGroupResolutionConfiguration.UserGroupResolutionMode,
 	}
 
 	return []interface{}{values}

--- a/internal/service/kendra/index_test.go
+++ b/internal/service/kendra/index_test.go
@@ -396,6 +396,48 @@ func TestAccKendraIndex_updateRoleARN(t *testing.T) {
 	})
 }
 
+func TestAccKendraIndex_updateUserGroupResolutionConfigurationMode(t *testing.T) {
+	ctx := acctest.Context(t)
+	var index kendra.DescribeIndexOutput
+
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	rName2 := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	rName3 := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	originalUserGroupResolutionMode := types.UserGroupResolutionModeAwsSso
+	updatedUserGroupResolutionMode := types.UserGroupResolutionModeNone
+	resourceName := "aws_kendra_index.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KendraEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIndexDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIndexConfig_userGroupResolutionMode(rName, rName2, rName3, string(originalUserGroupResolutionMode)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIndexExists(ctx, resourceName, &index),
+					resource.TestCheckResourceAttr(resourceName, "user_group_resolution_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_group_resolution_configuration.0.user_group_resolution_mode", string(originalUserGroupResolutionMode)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccIndexConfig_userGroupResolutionMode(rName, rName2, rName3, string(updatedUserGroupResolutionMode)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIndexExists(ctx, resourceName, &index),
+					resource.TestCheckResourceAttr(resourceName, "user_group_resolution_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_group_resolution_configuration.0.user_group_resolution_mode", string(updatedUserGroupResolutionMode)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKendraIndex_addDocumentMetadataConfigurationUpdates(t *testing.T) {
 	ctx := acctest.Context(t)
 	var index kendra.DescribeIndexOutput
@@ -1553,6 +1595,21 @@ resource "aws_kendra_index" "test" {
   }
 }
 `, rName3, groupAttributeField, userNameAttributeField))
+}
+
+func testAccIndexConfig_userGroupResolutionMode(rName, rName2, rName3, UserGroupResolutionMode string) string {
+	return acctest.ConfigCompose(
+		testAccIndexConfigBase(rName, rName2),
+		fmt.Sprintf(`
+resource "aws_kendra_index" "test" {
+  name     = %[1]q
+  role_arn = aws_iam_role.access_cw.arn
+
+  user_group_resolution_configuration {
+    user_group_resolution_mode = %[2]q
+  }
+}
+`, rName3, UserGroupResolutionMode))
 }
 
 func testAccIndexConfig_tags(rName, rName2, rName3, description string) string {

--- a/website/docs/r/kendra_index.html.markdown
+++ b/website/docs/r/kendra_index.html.markdown
@@ -55,6 +55,19 @@ resource "aws_kendra_index" "example" {
 }
 ```
 
+### With user group resolution configuration
+
+```terraform
+resource "aws_kendra_index" "example" {
+  name     = "example"
+  role_arn = aws_iam_role.this.arn
+
+  user_group_resolution_configuration {
+    user_group_resolution_mode = "AWS_SSO"
+  }
+}
+```
+
 ### With Document Metadata Configuration Updates
 
 #### Specifying the predefined elements


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The `flattenUserGroupResolutionConfiguration` was incorrectly setting an attribute which affected the state after an apply

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31416

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccKendraIndex_updateUserGroupResolutionConfigurationMode'  PKG=kendra
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kendra/... -v -count 1 -parallel 20  -run=TestAccKendraIndex_updateUserGroupResolutionConfigurationMode -timeout 180m
=== RUN   TestAccKendraIndex_updateUserGroupResolutionConfigurationMode
=== PAUSE TestAccKendraIndex_updateUserGroupResolutionConfigurationMode
=== CONT  TestAccKendraIndex_updateUserGroupResolutionConfigurationMode
--- PASS: TestAccKendraIndex_updateUserGroupResolutionConfigurationMode (1323.89s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kendra     1324.056s

...
```
