### PR TITLE
b/aws_kendra_index-Fix Acceptance tests

### DIFF
--- a/internal/service/kendra/index_test.go
+++ b/internal/service/kendra/index_test.go
@@ -62,7 +62,7 @@ func TestAccKendraIndex_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "capacity_units.0.storage_capacity_units", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
-					resource.TestCheckResourceAttr(resourceName, "document_metadata_configuration_updates.#", "13"),
+					resource.TestCheckResourceAttr(resourceName, "document_metadata_configuration_updates.#", "14"),
 					resource.TestCheckResourceAttr(resourceName, "edition", string(types.IndexEditionEnterpriseEdition)),
 					resource.TestCheckResourceAttr(resourceName, "index_statistics.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "index_statistics.0.faq_statistics.#", "1"),
@@ -462,7 +462,7 @@ func TestAccKendraIndex_addDocumentMetadataConfigurationUpdates(t *testing.T) {
 				Config: testAccIndexConfig_documentMetadataConfigurationUpdatesBase(rName, rName2, rName3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIndexExists(ctx, resourceName, &index),
-					resource.TestCheckResourceAttr(resourceName, "document_metadata_configuration_updates.#", "13"),
+					resource.TestCheckResourceAttr(resourceName, "document_metadata_configuration_updates.#", "14"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "document_metadata_configuration_updates.*", map[string]string{
 						"name":                   "_authors",
 						"type":                   string(types.DocumentAttributeValueTypeStringListValue),
@@ -598,6 +598,18 @@ func TestAccKendraIndex_addDocumentMetadataConfigurationUpdates(t *testing.T) {
 						"search.0.sortable":                   "false",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "document_metadata_configuration_updates.*", map[string]string{
+						"name":                                "_tenant_id",
+						"type":                                string(types.DocumentAttributeValueTypeStringValue),
+						"relevance.#":                         "1",
+						"relevance.0.importance":              "1",
+						"relevance.0.values_importance_map.%": "0",
+						"search.#":                            "1",
+						"search.0.displayable":                "false",
+						"search.0.facetable":                  "false",
+						"search.0.searchable":                 "false",
+						"search.0.sortable":                   "true",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "document_metadata_configuration_updates.*", map[string]string{
 						"name":                                "_version",
 						"type":                                string(types.DocumentAttributeValueTypeStringValue),
 						"relevance.#":                         "1",
@@ -632,7 +644,7 @@ func TestAccKendraIndex_addDocumentMetadataConfigurationUpdates(t *testing.T) {
 				Config: testAccIndexConfig_documentMetadataConfigurationUpdatesAddNewMetadata(rName, rName2, rName3, authorsFacetable, longValDisplayable, stringListValSearchable, dateValSortable, stringValImportance),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIndexExists(ctx, resourceName, &index),
-					resource.TestCheckResourceAttr(resourceName, "document_metadata_configuration_updates.#", "17"),
+					resource.TestCheckResourceAttr(resourceName, "document_metadata_configuration_updates.#", "18"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "document_metadata_configuration_updates.*", map[string]string{
 						"name":                   "_authors",
 						"type":                   string(types.DocumentAttributeValueTypeStringListValue),
@@ -768,6 +780,18 @@ func TestAccKendraIndex_addDocumentMetadataConfigurationUpdates(t *testing.T) {
 						"search.0.sortable":                   "false",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "document_metadata_configuration_updates.*", map[string]string{
+						"name":                                "_tenant_id",
+						"type":                                string(types.DocumentAttributeValueTypeStringValue),
+						"relevance.#":                         "1",
+						"relevance.0.importance":              "1",
+						"relevance.0.values_importance_map.%": "0",
+						"search.#":                            "1",
+						"search.0.displayable":                "false",
+						"search.0.facetable":                  "false",
+						"search.0.searchable":                 "false",
+						"search.0.sortable":                   "true",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "document_metadata_configuration_updates.*", map[string]string{
 						"name":                                "_version",
 						"type":                                string(types.DocumentAttributeValueTypeStringValue),
 						"relevance.#":                         "1",
@@ -876,7 +900,7 @@ func TestAccKendraIndex_inplaceUpdateDocumentMetadataConfigurationUpdates(t *tes
 				Config: testAccIndexConfig_documentMetadataConfigurationUpdatesAddNewMetadata(rName, rName2, rName3, originalAuthorsFacetable, originalLongValDisplayable, originalStringListValSearchable, originalDateValSortable, originalStringValImportance),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIndexExists(ctx, resourceName, &index),
-					resource.TestCheckResourceAttr(resourceName, "document_metadata_configuration_updates.#", "17"),
+					resource.TestCheckResourceAttr(resourceName, "document_metadata_configuration_updates.#", "18"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "document_metadata_configuration_updates.*", map[string]string{
 						"name":                   "_authors",
 						"type":                   string(types.DocumentAttributeValueTypeStringListValue),
@@ -1012,6 +1036,18 @@ func TestAccKendraIndex_inplaceUpdateDocumentMetadataConfigurationUpdates(t *tes
 						"search.0.sortable":                   "false",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "document_metadata_configuration_updates.*", map[string]string{
+						"name":                                "_tenant_id",
+						"type":                                string(types.DocumentAttributeValueTypeStringValue),
+						"relevance.#":                         "1",
+						"relevance.0.importance":              "1",
+						"relevance.0.values_importance_map.%": "0",
+						"search.#":                            "1",
+						"search.0.displayable":                "false",
+						"search.0.facetable":                  "false",
+						"search.0.searchable":                 "false",
+						"search.0.sortable":                   "true",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "document_metadata_configuration_updates.*", map[string]string{
 						"name":                                "_version",
 						"type":                                string(types.DocumentAttributeValueTypeStringValue),
 						"relevance.#":                         "1",
@@ -1095,7 +1131,7 @@ func TestAccKendraIndex_inplaceUpdateDocumentMetadataConfigurationUpdates(t *tes
 				Config: testAccIndexConfig_documentMetadataConfigurationUpdatesAddNewMetadata(rName, rName2, rName3, updatedAuthorsFacetable, updatedLongValDisplayable, updatedStringListValSearchable, updatedDateValSortable, updatedStringValImportance),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIndexExists(ctx, resourceName, &index),
-					resource.TestCheckResourceAttr(resourceName, "document_metadata_configuration_updates.#", "17"),
+					resource.TestCheckResourceAttr(resourceName, "document_metadata_configuration_updates.#", "18"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "document_metadata_configuration_updates.*", map[string]string{
 						"name":                   "_authors",
 						"type":                   string(types.DocumentAttributeValueTypeStringListValue),
@@ -1229,6 +1265,18 @@ func TestAccKendraIndex_inplaceUpdateDocumentMetadataConfigurationUpdates(t *tes
 						"search.0.facetable":                  "false",
 						"search.0.searchable":                 "false",
 						"search.0.sortable":                   "false",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "document_metadata_configuration_updates.*", map[string]string{
+						"name":                                "_tenant_id",
+						"type":                                string(types.DocumentAttributeValueTypeStringValue),
+						"relevance.#":                         "1",
+						"relevance.0.importance":              "1",
+						"relevance.0.values_importance_map.%": "0",
+						"search.#":                            "1",
+						"search.0.displayable":                "false",
+						"search.0.facetable":                  "false",
+						"search.0.searchable":                 "false",
+						"search.0.sortable":                   "true",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "document_metadata_configuration_updates.*", map[string]string{
 						"name":                                "_version",
@@ -1823,6 +1871,21 @@ resource "aws_kendra_index" "test" {
   }
 
   document_metadata_configuration_updates {
+    name = "_tenant_id"
+    type = "STRING_VALUE"
+    search {
+      displayable = false
+      facetable   = false
+      searchable  = false
+      sortable    = true
+    }
+    relevance {
+      importance            = 1
+      values_importance_map = {}
+    }
+  }
+
+  document_metadata_configuration_updates {
     name = "_version"
     type = "STRING_VALUE"
     search {
@@ -2023,6 +2086,21 @@ resource "aws_kendra_index" "test" {
       facetable   = false
       searchable  = false
       sortable    = false
+    }
+    relevance {
+      importance            = 1
+      values_importance_map = {}
+    }
+  }
+
+  document_metadata_configuration_updates {
+    name = "_tenant_id"
+    type = "STRING_VALUE"
+    search {
+      displayable = false
+      facetable   = false
+      searchable  = false
+      sortable    = true
     }
     relevance {
       importance            = 1

--- a/website/docs/r/kendra_index.html.markdown
+++ b/website/docs/r/kendra_index.html.markdown
@@ -72,6 +72,8 @@ resource "aws_kendra_index" "example" {
 
 #### Specifying the predefined elements
 
+Refer to [Amazon Kendra documentation on built-in document fields](https://docs.aws.amazon.com/kendra/latest/dg/hiw-index.html#index-reserved-fields) for more information.
+
 ```terraform
 resource "aws_kendra_index" "example" {
   name     = "example"
@@ -238,6 +240,21 @@ resource "aws_kendra_index" "example" {
       facetable   = false
       searchable  = false
       sortable    = false
+    }
+    relevance {
+      importance            = 1
+      values_importance_map = {}
+    }
+  }
+
+  document_metadata_configuration_updates {
+    name = "_tenant_id"
+    type = "STRING_VALUE"
+    search {
+      displayable = false
+      facetable   = false
+      searchable  = false
+      sortable    = true
     }
     relevance {
       importance            = 1
@@ -447,6 +464,21 @@ resource "aws_kendra_index" "example" {
       facetable   = false
       searchable  = false
       sortable    = false
+    }
+    relevance {
+      importance            = 1
+      values_importance_map = {}
+    }
+  }
+
+  document_metadata_configuration_updates {
+    name = "_tenant_id"
+    type = "STRING_VALUE"
+    search {
+      displayable = false
+      facetable   = false
+      searchable  = false
+      sortable    = true
     }
     relevance {
       importance            = 1


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

A new `document_metadata_configuration_updates` was introduced called `_tenant_id` that broke 3 existing acceptance tests. This PR fixes it by adding the `_tenant_id` block to the test config, adjusting the counts of the tests accordingly, and checking for that block. Impacted tests:

- TestAccKendraIndex_basic
- TestAccKendraIndex_addDocumentMetadataConfigurationUpdates
- TestAccKendraIndex_inplaceUpdateDocumentMetadataConfigurationUpdates

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccKendraIndex_basic\|TestAccKendraIndex_addDocumentMetadataConfigurationUpdates\|TestAccKendraIndex_inplaceUpdateDocumentMetadataConfigurationUpdates' PKG=kendra
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/kendra/... -v -count 1 -parallel 20  -run=TestAccKendraIndex_basic\|TestAccKendraIndex_addDocumentMetadataConfigurationUpdates\|TestAccKendraIndex_inplaceUpdateDocumentMetadataConfigurationUpdates -timeout 180m
=== RUN   TestAccKendraIndex_basic
=== PAUSE TestAccKendraIndex_basic
=== RUN   TestAccKendraIndex_addDocumentMetadataConfigurationUpdates
=== PAUSE TestAccKendraIndex_addDocumentMetadataConfigurationUpdates
=== RUN   TestAccKendraIndex_inplaceUpdateDocumentMetadataConfigurationUpdates
=== PAUSE TestAccKendraIndex_inplaceUpdateDocumentMetadataConfigurationUpdates
=== CONT  TestAccKendraIndex_basic
=== CONT  TestAccKendraIndex_inplaceUpdateDocumentMetadataConfigurationUpdates
=== CONT  TestAccKendraIndex_addDocumentMetadataConfigurationUpdates
--- PASS: TestAccKendraIndex_addDocumentMetadataConfigurationUpdates (687.45s)
--- PASS: TestAccKendraIndex_inplaceUpdateDocumentMetadataConfigurationUpdates (691.77s)
--- PASS: TestAccKendraIndex_basic (830.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kendra     830.444s

...
```
