### PR TITLE
tags: ignore null config tags when tags are computed

### DIFF
--- a/.changelog/31687.txt
+++ b/.changelog/31687.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+provider/tags: Fix crash when some `tags` are `null` and others are `computed`
+```

--- a/internal/provider/tags_interceptor.go
+++ b/internal/provider/tags_interceptor.go
@@ -43,7 +43,9 @@ func tagsUpdateFunc(ctx context.Context, d schemaResourceData, sp conns.ServiceP
 		c := config.GetAttr(names.AttrTags)
 		if !c.IsNull() {
 			for k, v := range c.AsValueMap() {
-				configTags[k] = v.AsString()
+				if !v.IsNull() {
+					configTags[k] = v.AsString()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

`tags` can be `null` and used as placeholder values. These `null` values should be ignored when calculating values that should be applied

This may result in a crash if null tags are applied to a resource where other tags are computed.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Relates #31644

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccVPC_ -short' PKG=vpc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPC_ -short -timeout 180m
    vpc_test.go:969: skipping long-running test in short mode
--- SKIP: TestAccVPC_IPAMIPv4BasicNetmask (0.00s)
    vpc_test.go:996: skipping long-running test in short mode
--- SKIP: TestAccVPC_IPAMIPv4BasicExplicitCIDR (0.00s)
    vpc_test.go:1024: skipping long-running test in short mode
--- SKIP: TestAccVPC_IPAMIPv6 (0.00s)
=== NAME  TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup
    ec2_availability_zone_data_source_test.go:219: skipping since no Local Zones are available
--- SKIP: TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup (1.30s)
--- PASS: TestAccVPC_disappears (38.84s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_duplicateTag (42.37s)
--- PASS: TestAccVPC_tags_computed (44.87s)
--- PASS: TestAccVPC_tags_null (45.98s)
--- PASS: TestAccVPC_basic (51.22s)
--- PASS: TestAccVPC_disabledDNSSupport (61.92s)
--- PASS: TestAccVPC_bothDNSOptionsSet (61.94s)
--- PASS: TestAccVPC_enableNetworkAddressUsageMetrics (62.23s)
--- PASS: TestAccVPC_DefaultTags_updateToProviderOnly (73.15s)
--- PASS: TestAccVPC_DynamicResourceTagsMergedWithLocals_ignoreChanges (75.12s)
--- PASS: TestAccVPC_DefaultTags_updateToResourceOnly (76.38s)
--- PASS: TestAccVPC_ignoreTags (78.65s)
--- PASS: TestAccVPC_defaultAndIgnoreTags (78.96s)
--- PASS: TestAccVPC_updateDNSHostnames (80.26s)
--- PASS: TestAccVPC_DefaultTags_zeroValue (84.87s)
--- PASS: TestAccVPC_DefaultTags_providerOnlyTestAccVPC_DefaultTags_providerOnly (88.74s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_nonOverlappingTag (90.27s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_overlappingTag (90.77s)
--- PASS: TestAccVPC_DynamicResourceTags_ignoreChanges (54.03s)
--- PASS: TestAccVPC_tenancy (94.25s)
--- PASS: TestAccVPC_tags (66.80s)
--- PASS: TestAccVPC_assignGeneratedIPv6CIDRBlock (114.63s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	117.955s
```
