### PR TITLE
make: Check for vscode in clean target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -81,6 +81,11 @@ build: fmtcheck
 cleango:
 	@echo "==> Cleaning Go..."
 	@echo "WARNING: This will kill gopls and clean Go caches"
+	@vscode=`ps -ef | grep Visual\ Studio\ Code | wc -l | xargs` ; \
+	if [ $$vscode -gt 1 ] ; then \
+		echo "ALERT: vscode is running. Close it and try again." ; \
+		exit 1 ; \
+	fi
 	@for proc in `pgrep gopls` ; do \
 		echo "Killing gopls process $$proc" ; \
 		kill -9 $$proc ; \
@@ -209,7 +214,7 @@ providerlint:
 
 sane:
 	@echo "==> Sane Check (48 tests of Top 30 resources)"
-	@echo "==> Like 'sanity' except full output, stops soon after error"
+	@echo "==> Like 'sanity' except full output and stops soon after 1st error"
 	@echo "==> NOTE: NOT an exhaustive set of tests! Finds big problems only."
 	@TF_ACC=1 $(GO_VER) test \
 		./internal/service/iam/... \
@@ -232,7 +237,7 @@ sane:
 
 sanity:
 	@echo "==> Sanity Check (48 tests of Top 30 resources)"
-	@echo "==> Like 'sane' but little output, runs all tests despite errors"
+	@echo "==> Like 'sane' but less output and runs all tests despite most errors"
 	@echo "==> NOTE: NOT an exhaustive set of tests! Finds big problems only."
 	@iam=`TF_ACC=1 $(GO_VER) test \
 		./internal/service/iam/... \


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make clean
==> Cleaning Go...
WARNING: This will kill gopls and clean Go caches
ALERT: vscode is running. Close it and try again.
make: *** [cleango] Error 1
% make clean
==> Cleaning Go...
WARNING: This will kill gopls and clean Go caches
==> Checking that code complies with gofmt requirements...
go install
go: downloading github.com/hashicorp/terraform-plugin-go v0.15.0
go: downloading github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
go: downloading github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.27
go: downloading github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.28
go: downloading github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.3
go: downloading github.com/hashicorp/go-multierror v1.1.1
go: downloading github.com/hashicorp/terraform-plugin-framework v1.2.0
go: downloading github.com/hashicorp/terraform-plugin-log v0.8.0
go: downloading github.com/hashicorp/terraform-plugin-mux v0.10.0
go: downloading github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
go: downloading github.com/aws/aws-sdk-go-v2 v1.18.0
go: downloading golang.org/x/exp v0.0.0-20230206171751-46f607a40771
go: downloading github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.19.12
go: downloading github.com/aws/aws-sdk-go-v2/service/account v1.10.6
go: downloading github.com/aws/aws-sdk-go-v2/service/acm v1.17.11
go: downloading github.com/aws/aws-sdk-go-v2/service/auditmanager v1.24.7
go: downloading github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.1.4
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.20.11
go: downloading github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.11.12
go: downloading github.com/aws/aws-sdk-go-v2/service/comprehend v1.24.2
go: downloading github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.24.0
go: downloading github.com/aws/aws-sdk-go-v2/service/directoryservice v1.17.1
go: downloading github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.1.10
go: downloading github.com/aws/aws-sdk-go-v2/service/ec2 v1.98.0
go: downloading github.com/aws/aws-sdk-go-v2/service/fis v1.14.10
go: downloading github.com/aws/aws-sdk-go-v2/service/healthlake v1.15.11
go: downloading github.com/aws/aws-sdk-go-v2/service/identitystore v1.16.11
go: downloading github.com/aws/aws-sdk-go-v2/service/inspector2 v1.13.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ivschat v1.4.5
go: downloading github.com/aws/aws-sdk-go-v2/service/kendra v1.40.1
go: downloading github.com/aws/aws-sdk-go-v2/service/lambda v1.34.1
go: downloading github.com/aws/aws-sdk-go-v2/service/medialive v1.31.4
go: downloading github.com/aws/aws-sdk-go-v2/service/oam v1.1.11
go: downloading github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.2.4
go: downloading github.com/aws/aws-sdk-go-v2/service/pipes v1.2.6
go: downloading github.com/aws/aws-sdk-go-v2/service/rbin v1.8.12
go: downloading github.com/aws/aws-sdk-go-v2/service/rds v1.44.1
go: downloading github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.2.13
go: downloading github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.2.0
go: downloading github.com/aws/aws-sdk-go-v2/service/route53domains v1.14.10
go: downloading github.com/aws/aws-sdk-go-v2/service/s3control v1.31.5
go: downloading github.com/aws/aws-sdk-go-v2/service/scheduler v1.1.11
go: downloading github.com/aws/aws-sdk-go-v2/service/securitylake v1.4.0
go: downloading github.com/aws/aws-sdk-go-v2/service/sesv2 v1.18.0
go: downloading github.com/aws/aws-sdk-go-v2/service/ssm v1.36.4
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.15.4
go: downloading github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.21.4
go: downloading github.com/aws/aws-sdk-go-v2/service/transcribe v1.26.6
go: downloading github.com/aws/aws-sdk-go-v2/service/vpclattice v1.0.5
go: downloading github.com/aws/aws-sdk-go-v2/service/xray v1.16.11
go: downloading github.com/aws/aws-sdk-go v1.44.272
go: downloading github.com/hashicorp/terraform-plugin-framework-validators v0.10.0
go: downloading golang.org/x/crypto v0.9.0
go: downloading github.com/hashicorp/awspolicyequivalence v1.6.0
go: downloading github.com/shopspring/decimal v1.3.1
go: downloading github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.20.0
go: downloading github.com/mattbaird/jsonpatch v0.0.0-20200820163806-098863c1fc24
go: downloading github.com/hashicorp/go-uuid v1.0.3
go: downloading github.com/mitchellh/go-homedir v1.1.0
go: downloading github.com/mitchellh/copystructure v1.2.0
go: downloading github.com/hashicorp/errwrap v1.1.0
go: downloading github.com/hashicorp/go-version v1.6.0
go: downloading github.com/aws/aws-sdk-go-v2/config v1.18.25
go: downloading github.com/aws/aws-sdk-go-v2/credentials v1.13.24
go: downloading github.com/aws/aws-sdk-go-v2/service/iam v1.19.12
go: downloading github.com/aws/aws-sdk-go-v2/service/sts v1.19.0
go: downloading github.com/aws/smithy-go v1.13.5
go: downloading go.opentelemetry.io/otel v1.15.1
go: downloading github.com/mitchellh/mapstructure v1.5.0
go: downloading github.com/jmespath/go-jmespath v0.4.0
go: downloading github.com/beevik/etree v1.2.0
go: downloading github.com/hashicorp/go-cleanhttp v0.5.2
go: downloading github.com/hashicorp/terraform-plugin-framework-timeouts v0.3.1
go: downloading gopkg.in/yaml.v2 v2.4.0
go: downloading github.com/google/go-cmp v0.5.9
go: downloading golang.org/x/text v0.9.0
go: downloading github.com/hashicorp/go-hclog v1.5.0
go: downloading github.com/hashicorp/go-plugin v1.4.9
go: downloading github.com/mitchellh/go-testing-interface v1.14.1
go: downloading google.golang.org/grpc v1.54.0
go: downloading github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.33
go: downloading github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.14.2
go: downloading github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.27
go: downloading github.com/mitchellh/reflectwalk v1.0.2
go: downloading github.com/xeipuuv/gojsonschema v1.2.0
go: downloading github.com/aws/aws-sdk-go-v2/internal/ini v1.3.34
go: downloading github.com/aws/aws-sdk-go-v2/service/sso v1.12.10
go: downloading github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.10
go: downloading github.com/ProtonMail/go-crypto v0.0.0-20230201104953-d1d05f4e2bfb
go: downloading github.com/hashicorp/terraform-registry-address v0.2.0
go: downloading google.golang.org/protobuf v1.30.0
go: downloading github.com/vmihailenco/msgpack/v5 v5.3.5
go: downloading github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.27
go: downloading github.com/vmihailenco/msgpack v4.0.4+incompatible
go: downloading github.com/hashicorp/hcl/v2 v2.16.2
go: downloading github.com/zclconf/go-cty v1.13.1
go: downloading go.opentelemetry.io/otel/trace v1.15.1
go: downloading github.com/fatih/color v1.14.1
go: downloading github.com/mattn/go-isatty v0.0.17
go: downloading github.com/hashicorp/terraform-svchost v0.1.0
go: downloading golang.org/x/net v0.10.0
go: downloading github.com/hashicorp/logutils v1.0.0
go: downloading github.com/golang/protobuf v1.5.2
go: downloading github.com/hashicorp/yamux v0.1.1
go: downloading github.com/oklog/run v1.1.0
go: downloading github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415
go: downloading github.com/vmihailenco/tagparser/v2 v2.0.0
go: downloading github.com/mattn/go-colorable v0.1.13
go: downloading golang.org/x/sys v0.8.0
go: downloading github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb
go: downloading github.com/cloudflare/circl v1.3.3
go: downloading github.com/agext/levenshtein v1.2.3
go: downloading github.com/apparentlymart/go-textseg/v13 v13.0.0
go: downloading github.com/mitchellh/go-wordwrap v1.0.1
go: downloading google.golang.org/genproto v0.0.0-20230202175211-008b39050e57
cd .ci/providerlint && go install .
cd .ci/tools && go install github.com/bflad/tfproviderdocs
go: downloading github.com/bflad/tfproviderdocs v0.9.1
go: downloading github.com/mitchellh/cli v1.1.2
go: downloading github.com/hashicorp/terraform-json v0.14.0
go: downloading github.com/bmatcuk/doublestar v1.3.4
go: downloading github.com/yuin/goldmark v1.5.4
go: downloading github.com/mattn/go-isatty v0.0.18
go: downloading golang.org/x/net v0.9.0
go: downloading github.com/fatih/color v1.15.0
go: downloading github.com/yuin/goldmark-meta v0.0.0-20191126180153-f0638e958b60
go: downloading github.com/armon/go-radix v1.0.0
go: downloading github.com/bgentry/speakeasy v0.1.0
go: downloading github.com/posener/complete v1.2.3
go: downloading github.com/Masterminds/sprig v2.22.0+incompatible
go: downloading golang.org/x/sys v0.7.0
go: downloading github.com/Masterminds/goutils v1.1.1
go: downloading github.com/Masterminds/semver v1.5.0
go: downloading github.com/google/uuid v1.3.0
go: downloading github.com/huandu/xstrings v1.3.2
go: downloading github.com/imdario/mergo v0.3.12
go: downloading golang.org/x/crypto v0.8.0
cd .ci/tools && go install github.com/client9/misspell/cmd/misspell
go: downloading github.com/client9/misspell v0.3.4
cd .ci/tools && go install github.com/golangci/golangci-lint/cmd/golangci-lint
go: downloading github.com/golangci/golangci-lint v1.52.2
go: downloading github.com/gofrs/flock v0.8.1
go: downloading github.com/spf13/pflag v1.0.5
go: downloading github.com/spf13/viper v1.13.0
go: downloading github.com/spf13/cobra v1.6.1
go: downloading gopkg.in/yaml.v3 v3.0.1
go: downloading golang.org/x/tools v0.8.0
go: downloading github.com/sirupsen/logrus v1.9.0
go: downloading github.com/stretchr/testify v1.8.2
go: downloading github.com/go-xmlfmt/xmlfmt v1.1.2
go: downloading github.com/ldez/gomoddirectives v0.2.3
go: downloading github.com/golangci/revgrep v0.0.0-20220804021717-745bb2f7c2e6
go: downloading 4d63.com/gocheckcompilerdirectives v1.2.1
go: downloading 4d63.com/gochecknoglobals v0.2.1
go: downloading github.com/Abirdcfly/dupword v0.0.11
go: downloading github.com/Antonboom/errname v0.1.9
go: downloading github.com/Antonboom/nilnil v0.1.3
go: downloading github.com/BurntSushi/toml v1.2.1
go: downloading github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24
go: downloading github.com/GaijinEntertainment/go-exhaustruct/v2 v2.3.0
go: downloading github.com/OpenPeeDeeP/depguard v1.1.1
go: downloading github.com/alexkohler/prealloc v1.0.0
go: downloading github.com/alingse/asasalint v0.0.11
go: downloading github.com/ashanbrown/forbidigo v1.5.1
go: downloading github.com/ashanbrown/makezero v1.1.1
go: downloading github.com/bkielbasa/cyclop v1.2.0
go: downloading github.com/blizzy78/varnamelen v0.8.0
go: downloading github.com/bombsimon/wsl/v3 v3.4.0
go: downloading github.com/breml/bidichk v0.2.4
go: downloading github.com/breml/errchkjson v0.3.1
go: downloading github.com/butuzov/ireturn v0.1.1
go: downloading github.com/charithe/durationcheck v0.0.10
go: downloading github.com/curioswitch/go-reassign v0.2.0
go: downloading github.com/daixiang0/gci v0.10.1
go: downloading github.com/denis-tingaikin/go-header v0.4.3
go: downloading github.com/esimonov/ifshort v1.0.4
go: downloading github.com/firefart/nonamedreturns v1.0.4
go: downloading github.com/fzipp/gocyclo v0.6.0
go: downloading github.com/go-critic/go-critic v0.7.0
go: downloading github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2
go: downloading github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a
go: downloading github.com/golangci/go-misc v0.0.0-20220329215616-d24fe342adfe
go: downloading github.com/golangci/gofmt v0.0.0-20220901101216-f2edd75033f2
go: downloading github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0
go: downloading github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca
go: downloading github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4
go: downloading github.com/golangci/misspell v0.4.0
go: downloading github.com/gordonklaus/ineffassign v0.0.0-20230107090616-13ace0543b28
go: downloading github.com/gostaticanalysis/forcetypeassert v0.1.0
go: downloading github.com/gostaticanalysis/nilerr v0.1.1
go: downloading github.com/hexops/gotextdiff v1.0.3
go: downloading github.com/jgautheron/goconst v1.5.1
go: downloading github.com/jingyugao/rowserrcheck v1.1.1
go: downloading github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af
go: downloading github.com/julz/importas v0.1.0
go: downloading github.com/junk1tm/musttag v0.5.0
go: downloading github.com/kisielk/errcheck v1.6.3
go: downloading github.com/kkHAIKE/contextcheck v1.1.4
go: downloading github.com/kulti/thelper v0.6.3
go: downloading github.com/kunwardeep/paralleltest v1.0.6
go: downloading github.com/kyoh86/exportloopref v0.1.11
go: downloading github.com/ldez/tagliatelle v0.4.0
go: downloading github.com/leonklingele/grouper v1.1.1
go: downloading github.com/lufeee/execinquery v1.2.1
go: downloading github.com/maratori/testableexamples v1.0.0
go: downloading github.com/maratori/testpackage v1.1.1
go: downloading github.com/matoous/godox v0.0.0-20230222163458-006bad1f9d26
go: downloading github.com/mbilski/exhaustivestruct v1.2.0
go: downloading github.com/mgechev/revive v1.3.1
go: downloading github.com/moricho/tparallel v0.3.1
go: downloading github.com/nakabonne/nestif v0.3.1
go: downloading github.com/nishanths/exhaustive v0.9.5
go: downloading github.com/nishanths/predeclared v0.2.2
go: downloading github.com/nunnatsa/ginkgolinter v0.9.0
go: downloading github.com/polyfloyd/go-errorlint v1.4.0
go: downloading github.com/ryancurrah/gomodguard v1.3.0
go: downloading github.com/ryanrolds/sqlclosecheck v0.4.0
go: downloading github.com/sanposhiho/wastedassign/v2 v2.0.7
go: downloading github.com/sashamelentyev/interfacebloat v1.1.0
go: downloading github.com/sashamelentyev/usestdlibvars v1.23.0
go: downloading github.com/securego/gosec/v2 v2.15.0
go: downloading github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c
go: downloading github.com/sivchari/containedctx v1.0.2
go: downloading github.com/sivchari/nosnakecase v1.7.0
go: downloading github.com/sivchari/tenv v1.7.1
go: downloading github.com/sonatard/noctx v0.0.2
go: downloading github.com/sourcegraph/go-diff v0.7.0
go: downloading github.com/ssgreg/nlreturn/v2 v2.2.1
go: downloading github.com/stbenjam/no-sprintf-host-port v0.1.1
go: downloading github.com/tdakkota/asciicheck v0.2.0
go: downloading github.com/tetafro/godot v1.4.11
go: downloading github.com/timakin/bodyclose v0.0.0-20221125081123-e39cf3fc478e
go: downloading github.com/timonwong/loggercheck v0.9.4
go: downloading github.com/tomarrell/wrapcheck/v2 v2.8.1
go: downloading github.com/tommy-muehle/go-mnd/v2 v2.5.1
go: downloading github.com/ultraware/funlen v0.0.3
go: downloading github.com/ultraware/whitespace v0.0.5
go: downloading github.com/uudashr/gocognit v1.0.6
go: downloading github.com/yagipy/maintidx v1.0.0
go: downloading github.com/yeya24/promlinter v0.2.0
go: downloading gitlab.com/bosi/decorder v0.2.3
go: downloading mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed
go: downloading honnef.co/go/tools v0.4.3
go: downloading mvdan.cc/gofumpt v0.5.0
go: downloading mvdan.cc/unparam v0.0.0-20221223090309-7455f1af531d
go: downloading golang.org/x/mod v0.10.0
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading github.com/stretchr/objx v0.5.0
go: downloading github.com/fsnotify/fsnotify v1.5.4
go: downloading github.com/spf13/afero v1.9.5
go: downloading github.com/spf13/cast v1.5.0
go: downloading github.com/spf13/jwalterweatherman v1.1.0
go: downloading github.com/gobwas/glob v0.2.3
go: downloading golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
go: downloading golang.org/x/sync v0.1.0
go: downloading go.uber.org/zap v1.24.0
go: downloading github.com/kisielk/gotool v1.0.0
go: downloading github.com/gostaticanalysis/comment v1.4.2
go: downloading github.com/gostaticanalysis/analysisutil v0.7.1
go: downloading github.com/ettle/strcase v0.1.1
go: downloading github.com/go-toolsmith/astcopy v1.1.0
go: downloading github.com/go-toolsmith/astfmt v1.1.0
go: downloading github.com/go-toolsmith/astcast v1.1.0
go: downloading github.com/go-toolsmith/astequal v1.1.0
go: downloading github.com/go-toolsmith/astp v1.1.0
go: downloading github.com/go-toolsmith/strparse v1.1.0
go: downloading github.com/go-toolsmith/typep v1.1.0
go: downloading github.com/quasilyte/go-ruleguard v0.3.19
go: downloading github.com/quasilyte/regex/syntax v0.0.0-20210819130434-b3f0c404a727
go: downloading github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354
go: downloading github.com/fatih/structtag v1.2.0
go: downloading github.com/prometheus/client_golang v1.12.1
go: downloading github.com/prometheus/client_model v0.2.0
go: downloading mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b
go: downloading github.com/subosito/gotenv v1.4.1
go: downloading github.com/hashicorp/hcl v1.0.0
go: downloading gopkg.in/ini.v1 v1.67.0
go: downloading github.com/magiconair/properties v1.8.6
go: downloading github.com/pelletier/go-toml/v2 v2.0.5
go: downloading golang.org/x/exp/typeparams v0.0.0-20230224173230-c95f2b4c22f2
go: downloading github.com/chavacava/garif v0.0.0-20230227094218-b8c73b2037b8
go: downloading github.com/olekukonko/tablewriter v0.0.5
go: downloading go.uber.org/atomic v1.7.0
go: downloading go.uber.org/multierr v1.6.0
go: downloading github.com/quasilyte/gogrep v0.5.0
go: downloading github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567
go: downloading github.com/prometheus/common v0.32.1
go: downloading github.com/beorn7/perks v1.0.1
go: downloading github.com/cespare/xxhash/v2 v2.2.0
go: downloading github.com/prometheus/procfs v0.7.3
go: downloading github.com/mattn/go-runewidth v0.0.14
go: downloading github.com/pelletier/go-toml v1.9.5
go: downloading github.com/rivo/uniseg v0.4.4
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.1
cd .ci/tools && go install github.com/katbyte/terrafmt
go: downloading github.com/katbyte/terrafmt v0.5.2
go: downloading github.com/gookit/color v1.5.2
go: downloading github.com/katbyte/andreyvit-diff v0.0.1
go: downloading github.com/hashicorp/hc-install v0.4.0
go: downloading github.com/hashicorp/terraform-exec v0.17.2
go: downloading github.com/katbyte/sergi-go-diff v1.1.1
go: downloading github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778
cd .ci/tools && go install github.com/terraform-linters/tflint
go: downloading github.com/terraform-linters/tflint v0.46.1
go: downloading github.com/terraform-linters/tflint-plugin-sdk v0.16.1
go: downloading github.com/sourcegraph/jsonrpc2 v0.2.0
go: downloading github.com/jessevdk/go-flags v1.5.0
go: downloading github.com/terraform-linters/tflint-ruleset-terraform v0.2.2
go: downloading github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
go: downloading github.com/jstemmer/go-junit-report v1.0.0
go: downloading github.com/owenrumney/go-sarif v1.1.1
go: downloading github.com/google/go-github/v35 v35.3.0
go: downloading golang.org/x/oauth2 v0.7.0
go: downloading google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f
go: downloading github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
go: downloading github.com/oklog/run v1.0.0
go: downloading github.com/zclconf/go-cty-yaml v1.0.3
go: downloading github.com/apparentlymart/go-cidr v1.1.0
go: downloading github.com/Masterminds/semver/v3 v3.2.0
go: downloading github.com/hashicorp/terraform-registry-address v0.1.0
go: downloading github.com/hashicorp/go-getter v1.7.0
go: downloading github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734
go: downloading github.com/google/go-querystring v1.0.0
go: downloading google.golang.org/api v0.103.0
go: downloading cloud.google.com/go/storage v1.27.0
go: downloading github.com/aws/aws-sdk-go v1.44.122
go: downloading github.com/hashicorp/go-safetemp v1.0.0
go: downloading github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
go: downloading github.com/ulikunitz/xz v0.5.10
go: downloading github.com/klauspost/compress v1.15.11
go: downloading cloud.google.com/go v0.107.0
go: downloading cloud.google.com/go/compute/metadata v0.2.3
go: downloading cloud.google.com/go/iam v0.8.0
go: downloading github.com/googleapis/gax-go/v2 v2.7.0
go: downloading cloud.google.com/go/compute v1.15.1
go: downloading go.opencensus.io v0.24.0
go: downloading golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
go: downloading github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
go: downloading github.com/googleapis/enterprise-certificate-proxy v0.2.0
cd .ci/tools && go install github.com/pavius/impi/cmd/impi
go: downloading github.com/pavius/impi v0.0.3
cd .ci/tools && go install github.com/hashicorp/go-changelog/cmd/changelog-build
go: downloading github.com/breathingdust/go-changelog v0.0.0-20210127001721-f985d5709c15
go: downloading github.com/go-git/go-git/v5 v5.4.2
go: downloading github.com/go-git/go-billy/v5 v5.3.1
go: downloading github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7
go: downloading github.com/emirpasic/gods v1.12.0
go: downloading github.com/sergi/go-diff v1.2.0
go: downloading github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99
go: downloading github.com/go-git/gcfg v1.5.0
go: downloading github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351
go: downloading github.com/xanzy/ssh-agent v0.3.0
go: downloading gopkg.in/warnings.v0 v0.1.2
cd .ci/tools && go install github.com/rhysd/actionlint/cmd/actionlint
go: downloading github.com/rhysd/actionlint v1.6.24
go: downloading github.com/robfig/cron v1.2.0
cd .ci/tools && go install mvdan.cc/gofumpt
% make sane
==> Sane Check (48 tests of Top 30 resources)
==> Like 'sanity' except full output and stops soon after 1st error
==> NOTE: NOT an exhaustive set of tests! Finds big problems only.
=== RUN   TestAccIAMInstanceProfile_basic
=== PAUSE TestAccIAMInstanceProfile_basic
=== RUN   TestAccIAMInstanceProfile_tags
=== PAUSE TestAccIAMInstanceProfile_tags
=== RUN   TestAccIAMPolicyDocumentDataSource_basic
=== PAUSE TestAccIAMPolicyDocumentDataSource_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== RUN   TestAccIAMPolicy_basic
=== PAUSE TestAccIAMPolicy_basic
=== RUN   TestAccIAMPolicy_tags
=== PAUSE TestAccIAMPolicy_tags
=== RUN   TestAccIAMPolicy_policy
=== PAUSE TestAccIAMPolicy_policy
=== RUN   TestAccIAMRolePolicyAttachment_basic
=== PAUSE TestAccIAMRolePolicyAttachment_basic
=== RUN   TestAccIAMRolePolicyAttachment_disappears
=== PAUSE TestAccIAMRolePolicyAttachment_disappears
=== RUN   TestAccIAMRolePolicyAttachment_Disappears_role
=== PAUSE TestAccIAMRolePolicyAttachment_Disappears_role
=== RUN   TestAccIAMRolePolicy_basic
=== PAUSE TestAccIAMRolePolicy_basic
=== RUN   TestAccIAMRolePolicy_unknownsInPolicy
=== PAUSE TestAccIAMRolePolicy_unknownsInPolicy
=== RUN   TestAccIAMRole_basic
=== PAUSE TestAccIAMRole_basic
=== RUN   TestAccIAMRole_namePrefix
=== PAUSE TestAccIAMRole_namePrefix
=== RUN   TestAccIAMRole_disappears
=== PAUSE TestAccIAMRole_disappears
=== RUN   TestAccIAMRole_InlinePolicy_basic
=== PAUSE TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMInstanceProfile_basic
=== CONT  TestAccIAMRolePolicyAttachment_disappears
=== CONT  TestAccIAMPolicy_basic
=== CONT  TestAccIAMRole_basic
=== CONT  TestAccIAMPolicy_policy
=== CONT  TestAccIAMRolePolicyAttachment_basic
=== CONT  TestAccIAMInstanceProfile_tags
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== CONT  TestAccIAMRolePolicy_basic
=== CONT  TestAccIAMRolePolicyAttachment_Disappears_role
=== CONT  TestAccIAMRole_namePrefix
=== CONT  TestAccIAMRolePolicy_unknownsInPolicy
=== CONT  TestAccIAMPolicyDocumentDataSource_basic
=== CONT  TestAccIAMPolicy_tags
=== CONT  TestAccIAMRole_disappears
=== CONT  TestAccIAMRole_InlinePolicy_basic
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceConflicting (49.18s)
--- PASS: TestAccIAMPolicyDocumentDataSource_basic (50.45s)
--- PASS: TestAccIAMRolePolicyAttachment_Disappears_role (57.43s)
--- PASS: TestAccIAMRole_disappears (57.63s)
--- PASS: TestAccIAMRolePolicyAttachment_disappears (60.15s)
--- PASS: TestAccIAMRolePolicy_unknownsInPolicy (61.96s)
--- PASS: TestAccIAMPolicy_basic (63.25s)
--- PASS: TestAccIAMRole_namePrefix (65.41s)
--- PASS: TestAccIAMRole_basic (66.31s)
--- PASS: TestAccIAMInstanceProfile_basic (66.54s)
--- PASS: TestAccIAMRolePolicyAttachment_basic (86.97s)
--- PASS: TestAccIAMRolePolicy_basic (87.53s)
--- PASS: TestAccIAMPolicy_policy (88.13s)
--- PASS: TestAccIAMPolicy_tags (103.92s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (104.05s)
--- PASS: TestAccIAMInstanceProfile_tags (105.50s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	107.628s
=== RUN   TestAccLogsGroup_basic
=== PAUSE TestAccLogsGroup_basic
=== RUN   TestAccLogsGroup_multiple
=== PAUSE TestAccLogsGroup_multiple
=== CONT  TestAccLogsGroup_basic
=== CONT  TestAccLogsGroup_multiple
--- PASS: TestAccLogsGroup_multiple (46.80s)
--- PASS: TestAccLogsGroup_basic (55.50s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	57.555s
=== RUN   TestAccVPCDataSource_basic
=== PAUSE TestAccVPCDataSource_basic
=== RUN   TestAccVPCRouteTableAssociation_Subnet_basic
=== PAUSE TestAccVPCRouteTableAssociation_Subnet_basic
=== RUN   TestAccVPCRouteTable_basic
=== PAUSE TestAccVPCRouteTable_basic
=== RUN   TestAccVPCSecurityGroupRule_race
=== PAUSE TestAccVPCSecurityGroupRule_race
=== RUN   TestAccVPCSecurityGroupRule_protocolChange
=== PAUSE TestAccVPCSecurityGroupRule_protocolChange
=== RUN   TestAccVPCSecurityGroup_basic
=== PAUSE TestAccVPCSecurityGroup_basic
=== RUN   TestAccVPCSecurityGroup_ipRangesWithSameRules
=== PAUSE TestAccVPCSecurityGroup_ipRangesWithSameRules
=== RUN   TestAccVPCSecurityGroup_vpcAllEgress
=== PAUSE TestAccVPCSecurityGroup_vpcAllEgress
=== RUN   TestAccVPCSubnet_basic
=== PAUSE TestAccVPCSubnet_basic
=== RUN   TestAccVPC_tenancy
=== PAUSE TestAccVPC_tenancy
=== CONT  TestAccVPCDataSource_basic
=== CONT  TestAccVPCSecurityGroup_basic
=== CONT  TestAccVPCRouteTableAssociation_Subnet_basic
=== CONT  TestAccVPCSubnet_basic
=== CONT  TestAccVPCSecurityGroup_ipRangesWithSameRules
=== CONT  TestAccVPCRouteTable_basic
=== CONT  TestAccVPCSecurityGroupRule_race
=== CONT  TestAccVPCSecurityGroupRule_protocolChange
=== CONT  TestAccVPCSecurityGroup_vpcAllEgress
=== CONT  TestAccVPC_tenancy
--- PASS: TestAccVPCSubnet_basic (63.82s)
--- PASS: TestAccVPCRouteTable_basic (68.52s)
--- PASS: TestAccVPCRouteTableAssociation_Subnet_basic (68.71s)
--- PASS: TestAccVPCDataSource_basic (70.75s)
--- PASS: TestAccVPCSecurityGroup_basic (70.87s)
--- PASS: TestAccVPCSecurityGroup_ipRangesWithSameRules (71.99s)
--- PASS: TestAccVPCSecurityGroup_vpcAllEgress (73.50s)
--- PASS: TestAccVPC_tenancy (107.61s)
--- PASS: TestAccVPCSecurityGroupRule_protocolChange (112.02s)
--- PASS: TestAccVPCSecurityGroupRule_race (196.19s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	199.731s
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSService_basicImport
=== PAUSE TestAccECSService_basicImport
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== CONT  TestAccECSService_basic
=== CONT  TestAccECSTaskDefinition_basic
=== CONT  TestAccECSService_basicImport
--- PASS: TestAccECSTaskDefinition_basic (76.94s)
--- PASS: TestAccECSService_basic (127.72s)
--- PASS: TestAccECSService_basicImport (224.95s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	229.712s
=== RUN   TestAccELBV2TargetGroup_basic
=== PAUSE TestAccELBV2TargetGroup_basic
=== CONT  TestAccELBV2TargetGroup_basic
--- PASS: TestAccELBV2TargetGroup_basic (51.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	55.932s
=== RUN   TestAccKMSKey_basic
=== PAUSE TestAccKMSKey_basic
=== CONT  TestAccKMSKey_basic
--- PASS: TestAccKMSKey_basic (51.93s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	56.673s
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== RUN   TestAccLambdaPermission_basic
=== PAUSE TestAccLambdaPermission_basic
=== CONT  TestAccLambdaFunction_basic
=== CONT  TestAccLambdaPermission_basic
--- PASS: TestAccLambdaFunction_basic (71.19s)
--- PASS: TestAccLambdaPermission_basic (74.35s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	76.275s
=== RUN   TestAccMetaPartitionDataSource_basic
=== PAUSE TestAccMetaPartitionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_basic
=== PAUSE TestAccMetaRegionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_endpoint
=== PAUSE TestAccMetaRegionDataSource_endpoint
=== RUN   TestAccMetaRegionDataSource_endpointAndName
=== PAUSE TestAccMetaRegionDataSource_endpointAndName
=== CONT  TestAccMetaPartitionDataSource_basic
=== CONT  TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaRegionDataSource_basic
=== CONT  TestAccMetaRegionDataSource_endpointAndName
--- PASS: TestAccMetaPartitionDataSource_basic (41.29s)
--- PASS: TestAccMetaRegionDataSource_basic (41.91s)
--- PASS: TestAccMetaRegionDataSource_endpoint (43.17s)
--- PASS: TestAccMetaRegionDataSource_endpointAndName (43.68s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	47.349s
=== RUN   TestAccRoute53Record_basic
=== PAUSE TestAccRoute53Record_basic
=== RUN   TestAccRoute53Record_Latency_basic
=== PAUSE TestAccRoute53Record_Latency_basic
=== RUN   TestAccRoute53ZoneDataSource_name
=== PAUSE TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_basic
=== CONT  TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_Latency_basic
--- PASS: TestAccRoute53ZoneDataSource_name (86.15s)
--- PASS: TestAccRoute53Record_basic (171.01s)
--- PASS: TestAccRoute53Record_Latency_basic (181.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	185.988s
=== RUN   TestAccS3BucketACL_updateACL
=== PAUSE TestAccS3BucketACL_updateACL
=== RUN   TestAccS3BucketPolicy_basic
=== PAUSE TestAccS3BucketPolicy_basic
=== RUN   TestAccS3BucketPublicAccessBlock_basic
=== PAUSE TestAccS3BucketPublicAccessBlock_basic
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Security_corsUpdate
=== PAUSE TestAccS3Bucket_Security_corsUpdate
=== CONT  TestAccS3BucketACL_updateACL
=== CONT  TestAccS3Bucket_Basic_basic
=== CONT  TestAccS3BucketPublicAccessBlock_basic
=== CONT  TestAccS3BucketPolicy_basic
=== CONT  TestAccS3Bucket_Security_corsUpdate
--- PASS: TestAccS3Bucket_Basic_basic (55.38s)
--- PASS: TestAccS3BucketPolicy_basic (55.51s)
--- PASS: TestAccS3BucketPublicAccessBlock_basic (56.24s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (76.19s)
--- PASS: TestAccS3BucketACL_updateACL (77.59s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	82.393s
=== RUN   TestAccSecretsManagerSecret_basic
=== PAUSE TestAccSecretsManagerSecret_basic
=== RUN   TestAccSecretsManagerSecret_basicReplica
=== PAUSE TestAccSecretsManagerSecret_basicReplica
=== CONT  TestAccSecretsManagerSecret_basic
=== CONT  TestAccSecretsManagerSecret_basicReplica
--- PASS: TestAccSecretsManagerSecret_basic (48.69s)
--- PASS: TestAccSecretsManagerSecret_basicReplica (58.35s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	63.107s
=== RUN   TestAccSTSCallerIdentityDataSource_basic
=== PAUSE TestAccSTSCallerIdentityDataSource_basic
=== CONT  TestAccSTSCallerIdentityDataSource_basic
--- PASS: TestAccSTSCallerIdentityDataSource_basic (38.53s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sts	43.262s
```
