### PR TITLE
Add budget datasource to resource budget

### DIFF
--- a/.changelog/31691.txt
+++ b/.changelog/31691.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_budgets_budget
+```

--- a/internal/service/budgets/budget_data_source.go
+++ b/internal/service/budgets/budget_data_source.go
@@ -1,0 +1,352 @@
+package budgets
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/budgets"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_budgets_budget")
+func DataSourceBudget() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceBudgetRead,
+
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"auto_adjust_data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"auto_adjust_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"historical_options": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"budget_adjustment_period": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"lookback_available_periods": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"last_auto_adjust_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"budget_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"budget_limit": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"amount": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"unit": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"calculated_spend": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"actual_spend": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"amount": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"unit": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"cost_filter": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+			"cost_types": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"include_credit": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"include_discount": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"include_other_subscription": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"include_recurring": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"include_refund": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"include_subscription": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"include_support": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"include_tax": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"include_upfront": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"use_amortized": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"use_blended": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name_prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"notification": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"comparison_operator": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"notification_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"subscriber_email_addresses": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"subscriber_sns_topic_arns": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"threshold": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"threshold_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"planned_limit": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"amount": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"start_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"unit": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"time_period_end": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"time_period_start": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"time_unit": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"budget_exceeded": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+const (
+	DSNameBudget = "Budget Data Source"
+)
+
+func dataSourceBudgetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).BudgetsConn()
+
+	budgetName := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
+
+	accountID := d.Get("account_id").(string)
+	if accountID == "" {
+		accountID = meta.(*conns.AWSClient).AccountID
+	}
+	d.Set("account_id", accountID)
+
+	budget, err := FindBudgetByTwoPartKey(ctx, conn, accountID, budgetName)
+	if err != nil {
+		return create.DiagError(names.Budgets, create.ErrActionReading, DSNameBudget, d.Id(), err)
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", accountID, budgetName))
+
+	arn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition,
+		Service:   "budgets",
+		AccountID: accountID,
+		Resource:  fmt.Sprintf("budget/%s", budgetName),
+	}
+	d.Set("arn", arn.String())
+
+	d.Set("budget_type", budget.BudgetType)
+
+	if err := d.Set("budget_limit", flattenSpend(budget.BudgetLimit)); err != nil {
+		return diag.Errorf("setting budget_spend: %s", err)
+	}
+
+	if err := d.Set("calculated_spend", flattenCalculatedSpend(budget.CalculatedSpend)); err != nil {
+		return diag.Errorf("setting calculated_spend: %s", err)
+	}
+
+	d.Set("budget_exceeded", false)
+	if budget.CalculatedSpend != nil && budget.CalculatedSpend.ActualSpend != nil {
+		if aws.StringValue(budget.BudgetLimit.Unit) == aws.StringValue(budget.CalculatedSpend.ActualSpend.Unit) {
+			bLimit, err := strconv.ParseFloat(aws.StringValue(budget.BudgetLimit.Amount), 64)
+			if err != nil {
+				return create.DiagError(names.Budgets, create.ErrActionReading, DSNameBudget, d.Id(), err)
+			}
+			bSpend, err := strconv.ParseFloat(aws.StringValue(budget.CalculatedSpend.ActualSpend.Amount), 64)
+			if err != nil {
+				return create.DiagError(names.Budgets, create.ErrActionReading, DSNameBudget, d.Id(), err)
+			}
+
+			if bLimit < bSpend {
+				d.Set("budget_exceeded", true)
+			} else {
+				d.Set("budget_exceeded", false)
+			}
+		}
+	}
+
+	d.Set("name", budget.BudgetName)
+	d.Set("name_prefix", create.NamePrefixFromName(aws.StringValue(budget.BudgetName)))
+
+	return nil
+}
+
+func flattenCalculatedSpend(apiObject *budgets.CalculatedSpend) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	attrs := map[string]interface{}{
+		"actual_spend": flattenSpend(apiObject.ActualSpend),
+	}
+	return []interface{}{attrs}
+}
+
+func flattenSpend(apiObject *budgets.Spend) []interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	attrs := map[string]interface{}{
+		"amount": aws.StringValue(apiObject.Amount),
+		"unit":   aws.StringValue(apiObject.Unit),
+	}
+
+	return []interface{}{attrs}
+}

--- a/internal/service/budgets/budget_data_source_test.go
+++ b/internal/service/budgets/budget_data_source_test.go
@@ -1,0 +1,63 @@
+package budgets_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/budgets"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccBudgetsBudgetDataSource_basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	ctx := acctest.Context(t)
+	var budget budgets.Budget
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_budgets_budget.test"
+	dataSourceName := "data.aws_budgets_budget.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, budgets.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBudgetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBudgetDataSourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccBudgetExists(ctx, resourceName, &budget),
+					acctest.CheckResourceAttrAccountID(dataSourceName, "account_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "calculated_spend.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "budget_limit.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBudgetDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_budgets_budget" "test" {
+  name         = %[1]q
+  budget_type  = "RI_UTILIZATION"
+  limit_amount = "100.0"
+  limit_unit   = "PERCENTAGE"
+  time_unit    = "QUARTERLY"
+
+  cost_filter {
+    name   = "Service"
+    values = ["Amazon Redshift"]
+  }
+}
+
+data "aws_budgets_budget" "test" {
+  name = aws_budgets_budget.test.name
+}
+`, rName)
+}

--- a/internal/service/budgets/service_package_gen.go
+++ b/internal/service/budgets/service_package_gen.go
@@ -20,7 +20,12 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {
-	return []*types.ServicePackageSDKDataSource{}
+	return []*types.ServicePackageSDKDataSource{
+		{
+			Factory:  DataSourceBudget,
+			TypeName: "aws_budgets_budget",
+		},
+	}
 }
 
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {

--- a/website/docs/d/budgets_budget.html.markdown
+++ b/website/docs/d/budgets_budget.html.markdown
@@ -1,0 +1,133 @@
+---
+subcategory: "Web Services Budgets"
+layout: "aws"
+page_title: "AWS: aws_budgets_budget"
+description: |-
+  Terraform data source for managing an AWS Web Services Budgets Budget.
+---
+
+# Data Source: aws_budgets_budget
+
+Terraform data source for managing an AWS Web Services Budgets Budget.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_budgets_budget" "test" {
+  name = aws_budgets_budget.test.name
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - The name of a budget. Unique within accounts.
+
+The following arguments are optional:
+
+* `account_id` - The ID of the target account for budget. Will use current user's account_id by default if omitted.
+* `name_prefix` - The prefix of the name of a budget. Unique within accounts.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `auto_adjust_data` - Object containing [AutoAdjustData] which determines the budget amount for an auto-adjusting budget.
+* `budget_type` - Whether this budget tracks monetary cost or usage.
+* `budget_limit` - The total amount of cost, usage, RI utilization, RI coverage, Savings Plans utilization, or Savings Plans coverage that you want to track with your budget. Contains object [Spend](#spend)
+* `calculated_spend` - The spend objects that are associated with this budget. The [actualSpend](#actual-spend) tracks how much you've used, cost, usage, RI units, or Savings Plans units and the [forecastedSpend](#forecasted-spend) tracks how much that you're predicted to spend based on your historical usage profile.
+* `cost_filter` - A list of [CostFilter](#cost-filter) name/values pair to apply to budget.
+* `cost_types` - Object containing [CostTypes](#cost-types) The types of cost included in a budget, such as tax and subscriptions.
+* `time_period_end` - The end of the time period covered by the budget. There are no restrictions on the end date. Format: `2017-01-01_12:00`.
+* `time_period_start` - The start of the time period covered by the budget. If you don't specify a start date, AWS defaults to the start of your chosen time period. The start date must come before the end date. Format: `2017-01-01_12:00`.
+* `time_unit` - The length of time until a budget resets the actual and forecasted spend. Valid values: `MONTHLY`, `QUARTERLY`, `ANNUALLY`, and `DAILY`.
+* `notification` - Object containing [Budget Notifications](#budget-notification). Can be used multiple times to define more than one budget notification.
+* `planned_limit` - Object containing [Planned Budget Limits](#planned-budget-limits). Can be used multiple times to plan more than one budget limit. See [PlannedBudgetLimits](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_budgets_Budget.html#awscostmanagement-Type-budgets_Budget-PlannedBudgetLimits) documentation.
+
+### Actual Spend
+
+The amount of cost, usage, RI units, or Savings Plans units that you used. Type is [Spend](#spend)
+
+### Auto Adjust Data
+
+The parameters that determine the budget amount for an auto-adjusting budget.
+
+`auto_adjust_type` (Required) - The string that defines whether your budget auto-adjusts based on historical or forecasted data. Valid values: `FORECAST`,`HISTORICAL`
+`historical_options` (Optional) - Configuration block of [Historical Options](#historical-options). Required for `auto_adjust_type` of `HISTORICAL` Configuration block that defines the historical data that your auto-adjusting budget is based on.
+`last_auto_adjust_time` (Optional) - The last time that your budget was auto-adjusted.
+
+### Budget Notification
+
+Valid keys for `notification` parameter.
+
+* `comparison_operator` - (Required) Comparison operator to use to evaluate the condition. Can be `LESS_THAN`, `EQUAL_TO` or `GREATER_THAN`.
+* `threshold` - (Required) Threshold when the notification should be sent.
+* `threshold_type` - (Required) What kind of threshold is defined. Can be `PERCENTAGE` OR `ABSOLUTE_VALUE`.
+* `notification_type` - (Required) What kind of budget value to notify on. Can be `ACTUAL` or `FORECASTED`
+* `subscriber_email_addresses` - (Optional) E-Mail addresses to notify. Either this or `subscriber_sns_topic_arns` is required.
+* `subscriber_sns_topic_arns` - (Optional) SNS topics to notify. Either this or `subscriber_email_addresses` is required.
+
+### Cost Filter
+
+Based on your choice of budget type, you can choose one or more of the available budget filters.
+
+* `PurchaseType`
+* `UsageTypeGroup`
+* `Service`
+* `Operation`
+* `UsageType`
+* `BillingEntity`
+* `CostCategory`
+* `LinkedAccount`
+* `TagKeyValue`
+* `LegalEntityName`
+* `InvoicingEntity`
+* `AZ`
+* `Region`
+* `InstanceType`
+
+Refer to [AWS CostFilter documentation](https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-create-filters.html) for further detail.
+
+### Cost Types
+
+Valid keys for `cost_types` parameter.
+
+* `include_credit` - A boolean value whether to include credits in the cost budget. Defaults to `true`
+* `include_discount` - Whether a budget includes discounts. Defaults to `true`
+* `include_other_subscription` - A boolean value whether to include other subscription costs in the cost budget. Defaults to `true`
+* `include_recurring` - A boolean value whether to include recurring costs in the cost budget. Defaults to `true`
+* `include_refund` - A boolean value whether to include refunds in the cost budget. Defaults to `true`
+* `include_subscription` - A boolean value whether to include subscriptions in the cost budget. Defaults to `true`
+* `include_support` - A boolean value whether to include support costs in the cost budget. Defaults to `true`
+* `include_tax` - A boolean value whether to include tax in the cost budget. Defaults to `true`
+* `include_upfront` - A boolean value whether to include upfront costs in the cost budget. Defaults to `true`
+* `use_amortized` - Whether a budget uses the amortized rate. Defaults to `false`
+* `use_blended` - A boolean value whether to use blended costs in the cost budget. Defaults to `false`
+
+Refer to [AWS CostTypes documentation](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_budgets_CostTypes.html) for further detail.
+
+### Forecasted Spend
+
+The amount of cost, usage, RI units, or Savings Plans units that you're forecasted to use.
+Type is [Spend](#spend)
+
+### Historical Options
+
+`budget_adjustment_period` (Required) - The number of budget periods included in the moving-average calculation that determines your auto-adjusted budget amount.
+`lookback_available_periods` (Optional) - The integer that describes how many budget periods in your BudgetAdjustmentPeriod are included in the calculation of your current budget limit. If the first budget period in your BudgetAdjustmentPeriod has no cost data, then that budget period isn’t included in the average that determines your budget limit. You can’t set your own LookBackAvailablePeriods. The value is automatically calculated from the `budget_adjustment_period` and your historical cost data.
+
+### Planned Budget Limits
+
+Valid keys for `planned_limit` parameter.
+
+* `start_time` - (Required) The start time of the budget limit. Format: `2017-01-01_12:00`. See [PlannedBudgetLimits](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_budgets_Budget.html#awscostmanagement-Type-budgets_Budget-PlannedBudgetLimits) documentation.
+* `amount` - (Required) The amount of cost or usage being measured for a budget.
+* `unit` - (Required) The unit of measurement used for the budget forecast, actual spend, or budget threshold, such as dollars or GB. See [Spend](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/data-type-spend.html) documentation.
+
+### Spend
+
+`amount` - The cost or usage amount that's associated with a budget forecast, actual spend, or budget threshold. Length Constraints: Minimum length of `1`. Maximum length of `2147483647`.
+`unit` - The unit of measurement that's used for the budget forecast, actual spend, or budget threshold, such as USD or GBP. Length Constraints: Minimum length of `1`. Maximum length of `2147483647`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Add budget data source to resource budget


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
> make testacc TESTARGS='-run=TestAccBudgetsBudgetDataSource_basic' PKG=budgets
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/budgets/... -v -count 1 -parallel 20  -run=TestAccBudgetsBudgetDataSource_basic -timeout 180m
=== RUN   TestAccBudgetsBudgetDataSource_basic
=== PAUSE TestAccBudgetsBudgetDataSource_basic
=== CONT  TestAccBudgetsBudgetDataSource_basic
--- PASS: TestAccBudgetsBudgetDataSource_basic (12.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/budgets    15.523s

...
```
