### PR TITLE
New data source: aws_ecr_pull_through_cache_rule

### DIFF
--- a/.changelog/31696.txt
+++ b/.changelog/31696.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_ecr_pull_through_cache_rule
+```

--- a/internal/service/ecr/pull_through_cache_rule_data_source.go
+++ b/internal/service/ecr/pull_through_cache_rule_data_source.go
@@ -2,7 +2,6 @@ package ecr
 
 import (
 	"context"
-	"log"
 	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -10,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 // @SDKDataSource("aws_ecr_pull_through_cache_rule")
@@ -48,14 +46,8 @@ func dataSourcePullThroughCacheRuleRead(ctx context.Context, d *schema.ResourceD
 
 	rule, err := FindPullThroughCacheRuleByRepositoryPrefix(ctx, conn, repositoryPrefix)
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] ECR Pull Through Cache Rule (%s) not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
-	}
-
 	if err != nil {
-		return diag.Errorf("error reading ECR Pull Through Cache Rule (%s): %s", d.Id(), err)
+		return diag.Errorf("error reading ECR Pull Through Cache Rule (%s): %s", repositoryPrefix, err)
 	}
 
 	d.SetId(aws.StringValue(rule.EcrRepositoryPrefix))

--- a/internal/service/ecr/pull_through_cache_rule_data_source.go
+++ b/internal/service/ecr/pull_through_cache_rule_data_source.go
@@ -1,0 +1,64 @@
+package ecr
+
+import (
+	"context"
+	"log"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+// @SDKDataSource("aws_ecr_pull_through_cache_rule")
+func DataSourcePullThroughCacheRule() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourcePullThroughCacheRuleRead,
+		Schema: map[string]*schema.Schema{
+			"ecr_repository_prefix": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(2, 20),
+					validation.StringMatch(
+						regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*$`),
+						"must only include alphanumeric, underscore, period, or hyphen characters"),
+				),
+			},
+			"registry_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"upstream_registry_url": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func dataSourcePullThroughCacheRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).ECRConn()
+
+	rule, err := FindPullThroughCacheRuleByRepositoryPrefix(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] ECR Pull Through Cache Rule (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("error reading ECR Pull Through Cache Rule (%s): %s", d.Id(), err)
+	}
+
+	d.Set("ecr_repository_prefix", rule.EcrRepositoryPrefix)
+	d.Set("registry_id", rule.RegistryId)
+	d.Set("upstream_registry_url", rule.UpstreamRegistryUrl)
+
+	return nil
+}

--- a/internal/service/ecr/pull_through_cache_rule_data_source_test.go
+++ b/internal/service/ecr/pull_through_cache_rule_data_source_test.go
@@ -1,7 +1,6 @@
 package ecr_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ecr"
@@ -11,25 +10,28 @@ import (
 
 func TestAccECRPullThroughCacheRuleDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	prefix := "ecr-public"
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ecr.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPullThroughCacheRuleDataSourceConfig_basic(prefix),
+				Config: testAccPullThroughCacheRuleDataSourceConfig_basic(),
 				Check:  resource.ComposeTestCheckFunc(),
 			},
 		},
 	})
 }
 
-func testAccPullThroughCacheRuleDataSourceConfig_basic(prefix string) string {
-	return fmt.Sprintf(`
-data "aws_ecr_pull_through_cache_rule" "default" {
-  ecr_repository_prefix = %q
+func testAccPullThroughCacheRuleDataSourceConfig_basic() string {
+	return `
+resource "aws_ecr_pull_through_cache_rule" "ecr_public" {
+  ecr_repository_prefix = "ecr-public"
+  upstream_registry_url = "public.ecr.aws"
 }
-`, prefix)
+
+data "aws_ecr_pull_through_cache_rule" "default" {
+  ecr_repository_prefix = aws_ecr_pull_through_cache_rule.ecr_public.ecr_repository_prefix
+}
+`
 }

--- a/internal/service/ecr/pull_through_cache_rule_data_source_test.go
+++ b/internal/service/ecr/pull_through_cache_rule_data_source_test.go
@@ -1,0 +1,35 @@
+package ecr_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccECRPullThroughCacheRuleDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	ecr_repository_prefix := "ecr-public"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ecr.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPullThroughCacheRuleDataSourceConfig_basic(ecr_repository_prefix),
+				Check:  resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}
+
+func testAccPullThroughCacheRuleDataSourceConfig_basic(ecr_repository_prefix string) string {
+	return fmt.Sprintf(`
+data "aws_ecr_pull_through_cache_rule" "by_tag" {
+  ecr_repository_prefix = %q
+}
+`, ecr_repository_prefix)
+}

--- a/internal/service/ecr/pull_through_cache_rule_data_source_test.go
+++ b/internal/service/ecr/pull_through_cache_rule_data_source_test.go
@@ -10,6 +10,9 @@ import (
 
 func TestAccECRPullThroughCacheRuleDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
+	resourceName := "aws_ecr_pull_through_cache_rule.ecr_public"
+	accountId := acctest.AccountID()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, ecr.EndpointsID),
@@ -17,7 +20,10 @@ func TestAccECRPullThroughCacheRuleDataSource_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPullThroughCacheRuleDataSourceConfig_basic(),
-				Check:  resource.ComposeTestCheckFunc(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "upstream_registry_url", "public.ecr.aws"),
+					resource.TestCheckResourceAttr(resourceName, "registry_id", accountId),
+				),
 			},
 		},
 	})

--- a/internal/service/ecr/pull_through_cache_rule_data_source_test.go
+++ b/internal/service/ecr/pull_through_cache_rule_data_source_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccECRPullThroughCacheRuleDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	resourceName := "aws_ecr_pull_through_cache_rule.ecr_public"
+	dataSource := "data.aws_ecr_pull_through_cache_rule.test"
 	accountId := acctest.AccountID()
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -21,8 +21,8 @@ func TestAccECRPullThroughCacheRuleDataSource_basic(t *testing.T) {
 			{
 				Config: testAccPullThroughCacheRuleDataSourceConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "upstream_registry_url", "public.ecr.aws"),
-					resource.TestCheckResourceAttr(resourceName, "registry_id", accountId),
+					resource.TestCheckResourceAttr(dataSource, "upstream_registry_url", "public.ecr.aws"),
+					resource.TestCheckResourceAttr(dataSource, "registry_id", accountId),
 				),
 			},
 		},
@@ -31,13 +31,13 @@ func TestAccECRPullThroughCacheRuleDataSource_basic(t *testing.T) {
 
 func testAccPullThroughCacheRuleDataSourceConfig_basic() string {
 	return `
-resource "aws_ecr_pull_through_cache_rule" "ecr_public" {
+resource "aws_ecr_pull_through_cache_rule" "test" {
   ecr_repository_prefix = "ecr-public"
   upstream_registry_url = "public.ecr.aws"
 }
 
-data "aws_ecr_pull_through_cache_rule" "default" {
-  ecr_repository_prefix = aws_ecr_pull_through_cache_rule.ecr_public.ecr_repository_prefix
+data "aws_ecr_pull_through_cache_rule" "test" {
+  ecr_repository_prefix = aws_ecr_pull_through_cache_rule.test.ecr_repository_prefix
 }
 `
 }

--- a/internal/service/ecr/pull_through_cache_rule_data_source_test.go
+++ b/internal/service/ecr/pull_through_cache_rule_data_source_test.go
@@ -11,7 +11,6 @@ import (
 func TestAccECRPullThroughCacheRuleDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSource := "data.aws_ecr_pull_through_cache_rule.test"
-	accountId := acctest.AccountID()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -22,7 +21,7 @@ func TestAccECRPullThroughCacheRuleDataSource_basic(t *testing.T) {
 				Config: testAccPullThroughCacheRuleDataSourceConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSource, "upstream_registry_url", "public.ecr.aws"),
-					resource.TestCheckResourceAttr(dataSource, "registry_id", accountId),
+					acctest.CheckResourceAttrAccountID(dataSource, "registry_id"),
 				),
 			},
 		},

--- a/internal/service/ecr/pull_through_cache_rule_data_source_test.go
+++ b/internal/service/ecr/pull_through_cache_rule_data_source_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccECRPullThroughCacheRuleDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	ecr_repository_prefix := "ecr-public"
+	prefix := "ecr-public"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -19,17 +19,17 @@ func TestAccECRPullThroughCacheRuleDataSource_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPullThroughCacheRuleDataSourceConfig_basic(ecr_repository_prefix),
+				Config: testAccPullThroughCacheRuleDataSourceConfig_basic(prefix),
 				Check:  resource.ComposeTestCheckFunc(),
 			},
 		},
 	})
 }
 
-func testAccPullThroughCacheRuleDataSourceConfig_basic(ecr_repository_prefix string) string {
+func testAccPullThroughCacheRuleDataSourceConfig_basic(prefix string) string {
 	return fmt.Sprintf(`
-data "aws_ecr_pull_through_cache_rule" "by_tag" {
+data "aws_ecr_pull_through_cache_rule" "default" {
   ecr_repository_prefix = %q
 }
-`, ecr_repository_prefix)
+`, prefix)
 }

--- a/internal/service/ecr/service_package_gen.go
+++ b/internal/service/ecr/service_package_gen.go
@@ -30,6 +30,10 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			TypeName: "aws_ecr_image",
 		},
 		{
+			Factory:  DataSourcePullThroughCacheRule,
+			TypeName: "aws_ecr_pull_through_cache_rule",
+		},
+		{
 			Factory:  DataSourceRepository,
 			TypeName: "aws_ecr_repository",
 		},

--- a/website/docs/d/ecr_pull_through_cache_rule.html.markdown
+++ b/website/docs/d/ecr_pull_through_cache_rule.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "ECR (Elastic Container Registry)"
+layout: "aws"
+page_title: "AWS: aws_ecr_pull_through_cache_rule"
+description: |-
+  Provides details about an ECR Pull Through Cache Rule
+---
+
+# Data Source: aws_ecr_pull_through_cache_rule
+
+The ECR Pull Through Cache Rule data source allows the upstream registry URL and registry ID to be retrieved for a Pull Through Cache Rule.
+
+## Example Usage
+
+```terraform
+data "aws_ecr_pull_through_cache_rule" "ecr_public" {
+  ecr_repository_prefix = "ecr-public"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `ecr_repository_prefix` - (Required) The repository name prefix to use when caching images from the source registry.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `id` - The repository name prefix.
+- `upstream_registry_url` - The registry URL of the upstream public registry to use as the source.
+- `registry_id` - The registry ID where the repository was created.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Provides a new data source for the ECR Pull Through Cache Rule

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31578

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccECRPullThroughCacheRuleDataSource_basic' PKG=ecr
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20  -run=TestAccECRPullThroughCacheRuleDataSource_basic -timeout 180m
=== RUN   TestAccECRPullThroughCacheRuleDataSource_basic
=== PAUSE TestAccECRPullThroughCacheRuleDataSource_basic
=== CONT  TestAccECRPullThroughCacheRuleDataSource_basic
--- PASS: TestAccECRPullThroughCacheRuleDataSource_basic (28.73s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        30.876s
```
