### PR TITLE
r/aws_connect_security_profile: set correct tags in read

### DIFF
--- a/.changelog/31716.txt
+++ b/.changelog/31716.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_connect_security_profile: Set correct `tags` in state
+```

--- a/internal/service/connect/security_profile.go
+++ b/internal/service/connect/security_profile.go
@@ -155,7 +155,7 @@ func resourceSecurityProfileRead(ctx context.Context, d *schema.ResourceData, me
 		d.Set("permissions", flex.FlattenStringSet(permissions))
 	}
 
-	SetTagsOut(ctx, resp.SecurityProfile.AllowedAccessControlTags)
+	SetTagsOut(ctx, resp.SecurityProfile.Tags)
 
 	return nil
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Set `tags_all` correctly in state

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #31648

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=connect TESTS="TestAccConnect_serial/SecurityProfile/tags"

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/connect/... -v -count 1 -parallel 20 -run='TestAccConnect_serial/SecurityProfile/tags'  -timeout 180m
--- PASS: TestAccConnect_serial (143.74s)
    --- PASS: TestAccConnect_serial/SecurityProfile (143.74s)
        --- PASS: TestAccConnect_serial/SecurityProfile/tags (143.74s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/connect	146.858s
```
