### PR TITLE
Increase CognitoUserPool schema name length to 32 #7726

### DIFF
--- a/internal/service/cognitoidp/validate.go
+++ b/internal/service/cognitoidp/validate.go
@@ -125,8 +125,8 @@ func validUserPoolSchemaName(v interface{}, k string) (ws []string, es []error) 
 		es = append(es, fmt.Errorf("%q cannot be less than 1 character", k))
 	}
 
-	if len(value) > 20 {
-		es = append(es, fmt.Errorf("%q cannot be longer than 20 character", k))
+	if len(value) > 32 {
+		es = append(es, fmt.Errorf("%q cannot be longer than 32 character", k))
 	}
 
 	if !regexp.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}]+`).MatchString(value) {


### PR DESCRIPTION
As described https://github.com/hashicorp/terraform-provider-aws/issues/7726 CognitoUserPool schema name length can be longer than 20 characters. For example, existing pools I have have "phone_number_verified" attributes and it's referenced in AWS documentation here https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html


Closes #7726
