### PR TITLE
Move away from `actions-ecosystem/action-remove-labels` GitHub Action

### DIFF
--- a/.github/workflows/autoremove_labels.yml
+++ b/.github/workflows/autoremove_labels.yml
@@ -12,23 +12,16 @@ jobs:
     secrets: inherit
 
   RemoveNeedsTriageFromMaintainers:
+    name: 'Remove needs-triage for Maintainers'
     needs: community_check
     if: github.event.action == 'opened' && needs.community_check.outputs.maintainer == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Remove needs-triage label from member's Issues
-        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0
-        with:
-          labels: |
-            needs-triage
+    uses: ./.github/workflows/reusable-add-or-remove-labels.yml
+    with:
+      remove: needs-triage
 
   RemoveTriagingLabelsFromClosedIssueOrPR:
+    name: 'Remove Triaging Labels from Closed Items'
     if: github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Remove triaging labels from closed issues and PRs
-        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0
-        with:
-          labels: |
-            needs-triage
-            waiting-response
+    uses: ./.github/workflows/reusable-add-or-remove-labels.yml
+    with:
+      remove: needs-triage,waiting-response

--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -10,12 +10,9 @@ jobs:
     secrets: inherit
 
   issue_comment_triage:
+    name: 'Remove stale and waiting-response Labels on Response'
     needs: community_check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0
-        if: github.event_name == 'issue_comment' && needs.community_check.outputs.maintainer == 'false'
-        with:
-          labels: |
-            stale
-            waiting-response
+    if: github.event_name == 'issue_comment' && needs.community_check.outputs.maintainer == 'false'
+    uses: ./.github/workflows/reusable-add-or-remove-labels.yml
+    with:
+      remove: stale,waiting-response

--- a/.github/workflows/pull_request_feed.yml
+++ b/.github/workflows/pull_request_feed.yml
@@ -73,6 +73,6 @@ jobs:
             }
       - name: Apply Partner Label
         if: github.event.action == 'opened' && needs.community_check.outputs.partner == 'true'
-        run: |
-          gh api repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${{ github.event.pull_request.number }}/labels \
-          -f "labels[]=partner"
+        uses: ./.github/workflows/reusable-add-or-remove-labels.yml
+        with:
+          add: partner

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -20,15 +20,11 @@ jobs:
 
   NeedsTriageLabeler:
     needs: community_check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-      - name: Apply needs-triage Label
-        uses: actions/labeler@v4
-        if: github.event.action == 'opened' && needs.community_check.outputs.maintainer == 'false'
-        with:
-          configuration-path: .github/labeler-pr-needs-triage.yml
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+    name: 'Apply needs-triage to New Pull Requests'
+    if: github.event.action == 'opened' && needs.community_check.outputs.maintainer == 'false'
+    uses: ./.github/workflows/reusable-add-or-remove-labels.yml
+    with:
+      add: needs-triage
 
   SizeLabeler:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-add-or-remove-labels.yml
+++ b/.github/workflows/reusable-add-or-remove-labels.yml
@@ -1,0 +1,39 @@
+name: 'Modify Issue or Pull Request Labels'
+
+on:
+  workflow_call:
+    inputs:
+      add:
+        description: '(Optional) The comma-separated label(s) to add to the issue or pull request'
+        required: false
+        type: string
+      remove:
+        description: '(Optional) The comma-separated label(s) to remove from the issue or pull request'
+        required: false
+        type: string
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  ITEM_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
+
+jobs:
+  modify-labels:
+    name: 'Modify Label(s)'
+    runs-on: ubuntu-latest
+    env:
+      ITEM_TYPE: 'pr'
+    steps:
+      - name: 'Determine if the Item is an Issue or Pull Request'
+        if: github.event_name == 'issues'
+        run: |
+          echo 'ITEM_TYPE=issue' >> $GITHUB_ENV
+
+      - name: 'Add Label(s) to Issue or Pull Request'
+        if: inputs.add != ''
+        run: |
+          gh $ITEM_TYPE edit $ITEM_URL --add-label ${{ inputs.add }}
+
+      - name: 'Remove Label(s) From Issue or Pull Request'
+        if: inputs.remove != ''
+        run: |
+          gh $ITEM_TYPE edit $ITEM_URL --remove-label ${{ inputs.remove }}


### PR DESCRIPTION
### Description

This PR adds a new reusable workflow that will add or remove any number of labels, relying entirely on the build in `gh` CLI. In doing so, I've moved us away from the soon-to-be-deprecated `actions-ecosystem/action-remove-labels` Action, and have touched up a few of the other labeling workflows.

The reusable workflow has two optional inputs: `add` and `remove`. These can each take a comma-separated list of labels (and can both be used if we so choose!), and will do the needful. If attempting to remove a label that is not already applied, no errors are thrown, so we won't get false reports of failure based on that.

I figured if we're going to keep adding reusable workflows, it might be worthwhile to prepend them with `reusable-`, but I can back that out if we feel it makes the name too cluttered.

### Relations

Closes #31717

### References

- [`gh pr edit` reference](https://cli.github.com/manual/gh_pr_edit)
- [`gh issue edit` reference](https://cli.github.com/manual/gh_issue_edit)
- [GitHub Actions Workflow Syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions) in case there are any syntax questions

### Output from Acceptance Testing

n/a, Actions (though I'd be interested in setting up a way to easily output some testing for Actions in the future...)
