### PR TITLE
Updates `skaff` to collect `diags`

### DIFF
--- a/skaff/datasource/datasource.tmpl
+++ b/skaff/datasource/datasource.tmpl
@@ -148,6 +148,7 @@ const (
 )
 
 func dataSource{{ .DataSource }}Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	{{- if .IncludeComments }}
 	// TIP: ==== RESOURCE READ ====
 	// Generally, the Read function should do the following things. Make
@@ -158,7 +159,7 @@ func dataSource{{ .DataSource }}Read(ctx context.Context, d *schema.ResourceData
 	// 3. Set the ID
 	// 4. Set the arguments and attributes
 	// 5. Set the tags
-	// 6. Return nil
+	// 6. Return diags
 	{{- end }}
 	{{- if .IncludeComments }}
 
@@ -176,7 +177,7 @@ func dataSource{{ .DataSource }}Read(ctx context.Context, d *schema.ResourceData
 
 	out, err := find{{ .DataSource }}ByName(ctx, conn, name)
 	if err != nil {
-		return create.DiagError(names.{{ .Service }}, create.ErrActionReading, DSName{{ .DataSource }}, name, err)
+		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionReading, DSName{{ .DataSource }}, name, err)...)
 	}
 	{{ if .IncludeComments }}
 	// TIP: -- 3. Set the ID
@@ -212,19 +213,19 @@ func dataSource{{ .DataSource }}Read(ctx context.Context, d *schema.ResourceData
 	// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/
 	{{- end }}
 	if err := d.Set("complex_argument", flattenComplexArguments(out.ComplexArguments)); err != nil {
-		return create.DiagError(names.{{ .Service }}, create.ErrActionSetting, DSName{{ .DataSource }}, d.Id(), err)
+		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionSetting, DSName{{ .DataSource }}, d.Id(), err)...)
 	}
 	{{ if .IncludeComments }}
 	// TIP: Setting a JSON string to avoid errorneous diffs.
 	{{- end }}
 	p, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), aws.ToString(out.Policy))
 	if err != nil {
-		return create.DiagError(names.{{ .Service }}, create.ErrActionSetting, DSName{{ .DataSource }}, d.Id(), err)
+		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionSetting, DSName{{ .DataSource }}, d.Id(), err)...)
 	}
 
 	p, err = structure.NormalizeJsonString(p)
 	if err != nil {
-		return create.DiagError(names.{{ .Service }}, create.ErrActionReading, DSName{{ .DataSource }}, d.Id(), err)
+		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionReading, DSName{{ .DataSource }}, d.Id(), err)...)
 	}
 
 	d.Set("policy", p)
@@ -240,10 +241,10 @@ func dataSource{{ .DataSource }}Read(ctx context.Context, d *schema.ResourceData
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", KeyValueTags(out.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return create.DiagError(names.{{ .Service }}, create.ErrActionSetting, DSName{{ .DataSource }}, d.Id(), err)
+		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionSetting, DSName{{ .DataSource }}, d.Id(), err)...)
 	}
 	{{ if .IncludeComments }}
-	// TIP: -- 6. Return nil
+	// TIP: -- 6. Return diags
 	{{- end }}
-	return nil
+	return diags
 }

--- a/skaff/datasource/datasource.tmpl
+++ b/skaff/datasource/datasource.tmpl
@@ -17,10 +17,7 @@ package {{ .ServicePackage }}
 // In other words, as generated, this is a rough outline of the work you will
 // need to do. If something doesn't make sense for your situation, get rid of
 // it.
-//
-// Remember to register this new data source in the provider
-// (internal/provider/provider.go) once you finish. Otherwise, Terraform won't
-// know about it.{{- end }}
+{{- end }}
 
 import (
 {{- if .IncludeComments }}

--- a/skaff/datasource/datasource.tmpl
+++ b/skaff/datasource/datasource.tmpl
@@ -44,8 +44,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
-
-{{- if .AWSGoSDKV2 }}
+{{ if .AWSGoSDKV2 }}
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/{{ .ServicePackage }}"
 	"github.com/aws/aws-sdk-go-v2/service/{{ .ServicePackage }}/types"

--- a/skaff/datasource/datasource.tmpl
+++ b/skaff/datasource/datasource.tmpl
@@ -63,6 +63,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 {{ if .IncludeComments }}
 // TIP: ==== FILE STRUCTURE ====
@@ -217,7 +218,7 @@ func dataSource{{ .DataSource }}Read(ctx context.Context, d *schema.ResourceData
 	{{ if .IncludeComments }}
 	// TIP: Setting a JSON string to avoid errorneous diffs.
 	{{- end }}
-	p, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), aws.ToString(out.Policy))
+	p, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), {{ if .AWSGoSDKV2 }}aws.ToString{{ else }}aws.StringValue{{ end }}(out.Policy))
 	if err != nil {
 		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionSetting, DSName{{ .DataSource }}, d.Id(), err)...)
 	}

--- a/skaff/datasource/datasourcetest.tmpl
+++ b/skaff/datasource/datasourcetest.tmpl
@@ -17,10 +17,7 @@ package {{ .ServicePackage }}_test
 // In other words, as generated, this is a rough outline of the work you will
 // need to do. If something doesn't make sense for your situation, get rid of
 // it.
-//
-// Remember to register this new data source in the provider
-// (internal/provider/provider.go) once you finish. Otherwise, Terraform won't
-// know about it.{{- end }}
+{{- end }}
 
 import (
 {{- if .IncludeComments }}

--- a/skaff/resource/resource.tmpl
+++ b/skaff/resource/resource.tmpl
@@ -60,6 +60,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -499,12 +500,10 @@ func resource{{ .Resource }}Delete(ctx context.Context, d *schema.ResourceData, 
 	// resource. If that happens, we don't want it to show up as an error.
 	{{- end }}
 	{{- if .AWSGoSDKV2 }}
+	if errs.IsA[*types.ResourceNotFoundException](err){
+		return diags
+	}
 	if err != nil {
-		var nfe *types.ResourceNotFoundException
-		if errors.As(err, &nfe) {
-			return diags
-		}
-
 		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionDeleting, ResName{{ .Resource }}, d.Id(), err)...)
 	}
 	{{- else }}
@@ -670,15 +669,13 @@ func find{{ .Resource }}ByID(ctx context.Context, conn *{{ .ServiceLower }}.{{ .
 
 	{{- if .AWSGoSDKV2 }}
 	out, err := conn.Get{{ .Resource }}(ctx, in)
-	if err != nil {
-		var nfe *types.ResourceNotFoundException
-		if errors.As(err, &nfe) {
-			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: in,
-			}
+	if errs.IsA[*types.ResourceNotFoundException](err){
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
 		}
-
+	}
+	if err != nil {
 		return nil, err
 	}
 	{{- else }}

--- a/skaff/resource/resource.tmpl
+++ b/skaff/resource/resource.tmpl
@@ -17,10 +17,7 @@ package {{ .ServicePackage }}
 // In other words, as generated, this is a rough outline of the work you will
 // need to do. If something doesn't make sense for your situation, get rid of
 // it.
-//
-// Remember to register this new resource in the provider
-// (internal/provider/provider.go) once you finish. Otherwise, Terraform won't
-// know about it.{{- end }}
+{{- end }}
 
 import (
 {{- if .IncludeComments }}

--- a/skaff/resource/resource.tmpl
+++ b/skaff/resource/resource.tmpl
@@ -280,7 +280,7 @@ func resource{{ .Resource }}Create(ctx context.Context, d *schema.ResourceData, 
 	// TIP: -- 4. Set the minimum arguments and/or attributes for the Read function to
 	// work.
 	{{- end }}
-	d.SetId(aws.ToString(out.{{ .Resource }}.{{ .Resource }}ID))
+	d.SetId({{ if .AWSGoSDKV2 }}aws.ToString{{ else }}aws.StringValue{{ end }}(out.{{ .Resource }}.{{ .Resource }}ID))
 	{{ if .IncludeComments }}
 	// TIP: -- 5. Use a waiter to wait for create to complete
 	{{- end }}
@@ -359,7 +359,7 @@ func resource{{ .Resource }}Read(ctx context.Context, d *schema.ResourceData, me
 	{{ if .IncludeComments }}
 	// TIP: Setting a JSON string to avoid errorneous diffs.
 	{{- end }}
-	p, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), aws.ToString(out.Policy))
+	p, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), {{ if .AWSGoSDKV2 }}aws.ToString{{ else }}aws.StringValue{{ end }}(out.Policy))
 	if err != nil {
 		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionSetting, ResName{{ .Resource }}, d.Id(), err)...)
 	}
@@ -446,7 +446,7 @@ func resource{{ .Resource }}Update(ctx context.Context, d *schema.ResourceData, 
 	{{ if .IncludeComments }}
 	// TIP: -- 4. Use a waiter to wait for update to complete
 	{{- end }}
-	if _, err := wait{{ .Resource }}Updated(ctx, conn, aws.ToString(out.OperationId), d.Timeout(schema.TimeoutUpdate)); err != nil {
+	if _, err := wait{{ .Resource }}Updated(ctx, conn, {{ if .AWSGoSDKV2 }}aws.ToString{{ else }}aws.StringValue{{ end }}(out.OperationId), d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionWaitingForUpdate, ResName{{ .Resource }}, d.Id(), err)...)
 	}
 	{{ if .IncludeComments }}
@@ -647,7 +647,7 @@ func status{{ .Resource }}(ctx context.Context, conn *{{ .ServiceLower }}.{{ .Se
 			return nil, "", err
 		}
 
-		return out, aws.ToString(out.Status), nil
+		return out, {{ if .AWSGoSDKV2 }}aws.ToString{{ else }}aws.StringValue{{ end }}(out.Status), nil
 	}
 }
 {{ if .IncludeComments }}
@@ -717,11 +717,11 @@ func flattenComplexArgument(apiObject *{{ .ServiceLower }}.ComplexArgument) map[
 	m := map[string]interface{}{}
 
 	if v := apiObject.SubFieldOne; v != nil {
-		m["sub_field_one"] = aws.ToString(v)
+		m["sub_field_one"] = {{ if .AWSGoSDKV2 }}aws.ToString{{ else }}aws.StringValue{{ end }}(v)
 	}
 
 	if v := apiObject.SubFieldTwo; v != nil {
-		m["sub_field_two"] = aws.ToString(v)
+		m["sub_field_two"] = {{ if .AWSGoSDKV2 }}aws.ToString{{ else }}aws.StringValue{{ end }}(v)
 	}
 
 	return m

--- a/skaff/resource/resource.tmpl
+++ b/skaff/resource/resource.tmpl
@@ -202,6 +202,7 @@ const (
 )
 
 func resource{{ .Resource }}Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	{{- if .IncludeComments }}
 	// TIP: ==== RESOURCE CREATE ====
 	// Generally, the Create function should do the following things. Make
@@ -268,11 +269,11 @@ func resource{{ .Resource }}Create(ctx context.Context, d *schema.ResourceData, 
 		// TIP: Since d.SetId() has not been called yet, you cannot use d.Id()
 		// in error messages at this point.
 		{{- end }}
-		return create.DiagError(names.{{ .Service }}, create.ErrActionCreating, ResName{{ .Resource }}, d.Get("name").(string), err)
+		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionCreating, ResName{{ .Resource }}, d.Get("name").(string), err)...)
 	}
 
 	if out == nil || out.{{ .Resource }} == nil {
-		return create.DiagError(names.{{ .Service }}, create.ErrActionCreating, ResName{{ .Resource }}, d.Get("name").(string), errors.New("empty output"))
+		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionCreating, ResName{{ .Resource }}, d.Get("name").(string), errors.New("empty output"))...)
 	}
 	{{ if .IncludeComments }}
 	// TIP: -- 4. Set the minimum arguments and/or attributes for the Read function to
@@ -283,15 +284,16 @@ func resource{{ .Resource }}Create(ctx context.Context, d *schema.ResourceData, 
 	// TIP: -- 5. Use a waiter to wait for create to complete
 	{{- end }}
 	if _, err := wait{{ .Resource }}Created(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.{{ .Service }}, create.ErrActionWaitingForCreation, ResName{{ .Resource }}, d.Id(), err)
+		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionWaitingForCreation, ResName{{ .Resource }}, d.Id(), err)...)
 	}
 	{{ if .IncludeComments }}
 	// TIP: -- 6. Call the Read function in the Create return
 	{{- end }}
-	return resource{{ .Resource }}Read(ctx, d, meta)
+	return append(diags, resource{{ .Resource }}Read(ctx, d, meta)...)
 }
 
 func resource{{ .Resource }}Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	{{- if .IncludeComments }}
 	// TIP: ==== RESOURCE READ ====
 	// Generally, the Read function should do the following things. Make
@@ -302,7 +304,7 @@ func resource{{ .Resource }}Read(ctx context.Context, d *schema.ResourceData, me
 	// 3. Set ID to empty where resource is not new and not found
 	// 4. Set the arguments and attributes
 	// 5. Set the tags
-	// 6. Return nil
+	// 6. Return diags
 	{{- end }}
 	{{- if .IncludeComments }}
 
@@ -320,11 +322,11 @@ func resource{{ .Resource }}Read(ctx context.Context, d *schema.ResourceData, me
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] {{ .Service }} {{ .Resource }} (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.{{ .Service }}, create.ErrActionReading, ResName{{ .Resource }}, d.Id(), err)
+		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionReading, ResName{{ .Resource }}, d.Id(), err)...)
 	}
 	{{ if .IncludeComments }}
 	// TIP: -- 4. Set the arguments and attributes
@@ -351,30 +353,31 @@ func resource{{ .Resource }}Read(ctx context.Context, d *schema.ResourceData, me
 	// https://hashicorp.github.io/terraform-provider-aws/data-handling-and-conversion/#root-typeset-of-resource-and-aws-list-of-structure
 	{{- end }}
 	if err := d.Set("complex_argument", flattenComplexArguments(out.ComplexArguments)); err != nil {
-		return create.DiagError(names.{{ .Service }}, create.ErrActionSetting, ResName{{ .Resource }}, d.Id(), err)
+		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionSetting, ResName{{ .Resource }}, d.Id(), err)...)
 	}
 	{{ if .IncludeComments }}
 	// TIP: Setting a JSON string to avoid errorneous diffs.
 	{{- end }}
 	p, err := verify.SecondJSONUnlessEquivalent(d.Get("policy").(string), aws.ToString(out.Policy))
 	if err != nil {
-		return create.DiagError(names.{{ .Service }}, create.ErrActionSetting, ResName{{ .Resource }}, d.Id(), err)
+		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionSetting, ResName{{ .Resource }}, d.Id(), err)...)
 	}
 
 	p, err = structure.NormalizeJsonString(p)
 	if err != nil {
-		return create.DiagError(names.{{ .Service }}, create.ErrActionSetting, ResName{{ .Resource }}, d.Id(), err)
+		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionSetting, ResName{{ .Resource }}, d.Id(), err)...)
 	}
 
 	d.Set("policy", p)
 
 	{{ if .IncludeComments }}
-	// TIP: -- 6. Return nil
+	// TIP: -- 6. Return diags
 	{{- end }}
-	return nil
+	return diags
 }
 
 func resource{{ .Resource }}Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	{{- if .IncludeComments }}
 	// TIP: ==== RESOURCE UPDATE ====
 	// Not all resources have Update functions. There are a few reasons:
@@ -423,9 +426,9 @@ func resource{{ .Resource }}Update(ctx context.Context, d *schema.ResourceData, 
 	if !update {
 		{{- if .IncludeComments }}
 		// TIP: If update doesn't do anything at all, which is rare, you can
-		// return nil. Otherwise, return a read call, as below.
+		// return diags. Otherwise, return a read call, as below.
 		{{- end }}
-		return nil
+		return diags
 	}
 	{{ if .IncludeComments }}
 	// TIP: -- 3. Call the AWS modify/update function
@@ -437,21 +440,22 @@ func resource{{ .Resource }}Update(ctx context.Context, d *schema.ResourceData, 
 	out, err := conn.Update{{ .Resource }}WithContext(ctx, in)
 	{{- end }}
 	if err != nil {
-		return create.DiagError(names.{{ .Service }}, create.ErrActionUpdating, ResName{{ .Resource }}, d.Id(), err)
+		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionUpdating, ResName{{ .Resource }}, d.Id(), err)...)
 	}
 	{{ if .IncludeComments }}
 	// TIP: -- 4. Use a waiter to wait for update to complete
 	{{- end }}
 	if _, err := wait{{ .Resource }}Updated(ctx, conn, aws.ToString(out.OperationId), d.Timeout(schema.TimeoutUpdate)); err != nil {
-		return create.DiagError(names.{{ .Service }}, create.ErrActionWaitingForUpdate, ResName{{ .Resource }}, d.Id(), err)
+		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionWaitingForUpdate, ResName{{ .Resource }}, d.Id(), err)...)
 	}
 	{{ if .IncludeComments }}
 	// TIP: -- 5. Call the Read function in the Update return
 	{{- end }}
-	return resource{{ .Resource }}Read(ctx, d, meta)
+	return append(diags, resource{{ .Resource }}Read(ctx, d, meta)...)
 }
 
 func resource{{ .Resource }}Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	{{- if .IncludeComments }}
 	// TIP: ==== RESOURCE DELETE ====
 	// Most resources have Delete functions. There are rare situations
@@ -467,7 +471,7 @@ func resource{{ .Resource }}Delete(ctx context.Context, d *schema.ResourceData, 
 	// 2. Populate a delete input structure
 	// 3. Call the AWS delete function
 	// 4. Use a waiter to wait for delete to complete
-	// 5. Return nil
+	// 5. Return diags
 	{{- end }}
 	{{- if .IncludeComments }}
 
@@ -498,30 +502,30 @@ func resource{{ .Resource }}Delete(ctx context.Context, d *schema.ResourceData, 
 	if err != nil {
 		var nfe *types.ResourceNotFoundException
 		if errors.As(err, &nfe) {
-			return nil
+			return diags
 		}
 
-		return create.DiagError(names.{{ .Service }}, create.ErrActionDeleting, ResName{{ .Resource }}, d.Id(), err)
+		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionDeleting, ResName{{ .Resource }}, d.Id(), err)...)
 	}
 	{{- else }}
 	if tfawserr.ErrCodeEquals(err, {{ .ServiceLower }}.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.{{ .Service }}, create.ErrActionDeleting, ResName{{ .Resource }}, d.Id(), err)
+		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionDeleting, ResName{{ .Resource }}, d.Id(), err)...)
 	}
 	{{- end }}
 	{{ if .IncludeComments }}
 	// TIP: -- 4. Use a waiter to wait for delete to complete
 	{{- end }}
 	if _, err := wait{{ .Resource }}Deleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return create.DiagError(names.{{ .Service }}, create.ErrActionWaitingForDeletion, ResName{{ .Resource }}, d.Id(), err)
+		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionWaitingForDeletion, ResName{{ .Resource }}, d.Id(), err)...)
 	}
 	{{ if .IncludeComments }}
-	// TIP: -- 5. Return nil
+	// TIP: -- 5. Return diags
 	{{- end }}
-	return nil
+	return diags
 }
 {{ if .IncludeComments }}
 // TIP: ==== STATUS CONSTANTS ====

--- a/skaff/resource/resource.tmpl
+++ b/skaff/resource/resource.tmpl
@@ -510,7 +510,6 @@ func resource{{ .Resource }}Delete(ctx context.Context, d *schema.ResourceData, 
 	if tfawserr.ErrCodeEquals(err, {{ .ServiceLower }}.ErrCodeResourceNotFoundException) {
 		return diags
 	}
-
 	if err != nil {
 		return append(diags, create.DiagError(names.{{ .Service }}, create.ErrActionDeleting, ResName{{ .Resource }}, d.Id(), err)...)
 	}
@@ -686,7 +685,6 @@ func find{{ .Resource }}ByID(ctx context.Context, conn *{{ .ServiceLower }}.{{ .
 			LastRequest: in,
 		}
 	}
-
 	if err != nil {
 		return nil, err
 	}

--- a/skaff/resource/resourcetest.tmpl
+++ b/skaff/resource/resourcetest.tmpl
@@ -50,7 +50,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/{{ .ServicePackage }}"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 {{- end }}
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -58,16 +57,14 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/names"
 {{- if .IncludeComments }}
 
 	// TIP: You will often need to import the package that this test file lives
-    // in. Since it is in the "test" context, it must import the package to use
-    // any normal context constants, variables, or functions.
+	// in. Since it is in the "test" context, it must import the package to use
+	// any normal context constants, variables, or functions.
 {{- end }}
 	tf{{ .ServicePackage }} "github.com/hashicorp/terraform-provider-aws/internal/service/{{ .ServicePackage }}"
-{{- if .AWSGoSDKV2 }}
-	"github.com/hashicorp/terraform-provider-aws/names"
-{{- end }}
 )
 {{ if .IncludeComments }}
 // TIP: File Structure. The basic outline for all test files should be as
@@ -83,7 +80,7 @@ import (
 // 7. Helper functions (exists, destroy, check, etc.)
 // 8. Functions that return Terraform configurations
 {{- end }}
-{{ if .IncludeComments }}
+{{- if .IncludeComments }}
 
 // TIP: ==== UNIT TESTS ====
 // This is an example of a unit test. Its name is not prefixed with
@@ -146,7 +143,6 @@ func Test{{ .Resource }}ExampleUnitTest(t *testing.T) {
 	}
 }
 {{ if .IncludeComments }}
-
 // TIP: ==== ACCEPTANCE TESTS ====
 // This is an example of a basic acceptance test. This should test as much of
 // standard functionality of the resource as possible, and test importing, if
@@ -158,8 +154,8 @@ func Test{{ .Resource }}ExampleUnitTest(t *testing.T) {
 func TestAcc{{ .Service }}{{ .Resource }}_basic(t *testing.T) {
 	ctx := acctest.Context(t)
     {{- if .IncludeComments }}
-    // TIP: This is a long-running test guard for tests that run longer than
-    // 300s (5 min) generally.
+	// TIP: This is a long-running test guard for tests that run longer than
+	// 300s (5 min) generally.
     {{- end }}
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -266,7 +262,7 @@ func TestAcc{{ .Service }}{{ .Resource }}_disappears(t *testing.T) {
 
 func testAccCheck{{ .Resource }}Destroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).{{ .Service }}{{ if .AWSGoSDKV2 }}Client(){{ else }}Conn(){{ end }}
+		conn := acctest.Provider.Meta().(*conns.AWSClient).{{ .Service }}{{ if .AWSGoSDKV2 }}Client(){{ else }}Conn(){{ end }}
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_{{ .ServicePackage }}_{{ .ResourceSnake }}" {
@@ -290,17 +286,14 @@ func testAccCheck{{ .Resource }}Destroy(ctx context.Context) resource.TestCheckF
 			if errs.IsA[*types.ResourceNotFoundException](err){
 				return nil
 			}
-			if err != nil {
-				return err
-			}
 			{{ else }}
-			if err != nil {
-				if tfawserr.ErrCodeEquals(err, {{ .ServicePackage }}.ErrCodeNotFoundException) {
-					return nil
-				}
+			if tfawserr.ErrCodeEquals(err, {{ .ServicePackage }}.ErrCodeNotFoundException) {
 				return nil
 			}
-			{{ end }}
+			{{ end -}}
+			if err != nil {
+				return nil
+			}
 
 			return create.Error(names.{{ .Service }}, create.ErrActionCheckingDestroyed, tf{{ .ServicePackage }}.ResName{{ .Resource }}, rs.Primary.ID, errors.New("not destroyed"))
 		}
@@ -356,7 +349,6 @@ func testAccPreCheck(ctx context.Context, t *testing.T) {
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)
 	}
-
 	if err != nil {
 		t.Fatalf("unexpected PreCheck error: %s", err)
 	}

--- a/skaff/resource/resourcetest.tmpl
+++ b/skaff/resource/resourcetest.tmpl
@@ -356,8 +356,8 @@ func testAccPreCheck(ctx context.Context, t *testing.T) {
 
 func testAccCheck{{ .Resource }}NotRecreated(before, after *{{ .ServicePackage }}.Describe{{ .Resource }}Response) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if before, after := aws.StringValue(before.{{ .Resource }}Id), aws.StringValue(after.{{ .Resource }}Id); before != after {
-			return create.Error(names.{{ .Service }}, create.ErrActionCheckingNotRecreated, tf{{ .ServicePackage }}.ResName{{ .Resource }}, aws.StringValue(before.{{ .Resource }}Id), errors.New("recreated"))
+		if before, after := {{ if .AWSGoSDKV2 }}aws.ToString{{ else }}aws.StringValue{{ end }}(before.{{ .Resource }}Id), {{ if .AWSGoSDKV2 }}aws.ToString{{ else }}aws.StringValue{{ end }}(after.{{ .Resource }}Id); before != after {
+			return create.Error(names.{{ .Service }}, create.ErrActionCheckingNotRecreated, tf{{ .ServicePackage }}.ResName{{ .Resource }}, {{ if .AWSGoSDKV2 }}aws.ToString{{ else }}aws.StringValue{{ end }}(before.{{ .Resource }}Id), errors.New("recreated"))
 		}
 
 		return nil

--- a/skaff/resource/resourcetest.tmpl
+++ b/skaff/resource/resourcetest.tmpl
@@ -285,19 +285,21 @@ func testAccCheck{{ .Resource }}Destroy(ctx context.Context) resource.TestCheckF
 				{{ .Resource }}Id: aws.String(rs.Primary.ID),
 			})
 			{{- end }}
+			{{- if .AWSGoSDKV2 }}
+			if errs.IsA[*types.ResourceNotFoundException](err){
+				return nil
+			}
 			if err != nil {
-				{{- if .AWSGoSDKV2 }}
-				var nfe *types.ResourceNotFoundException
-				if errors.As(err, &nfe) {
-					return nil
-				}
-				{{- else }}
+				return err
+			}
+			{{ else }}
+			if err != nil {
 				if tfawserr.ErrCodeEquals(err, {{ .ServicePackage }}.ErrCodeNotFoundException) {
 					return nil
 				}
-				{{- end }}
-				return err
+				return nil
 			}
+			{{ end }}
 
 			return create.Error(names.{{ .Service }}, create.ErrActionCheckingDestroyed, tf{{ .ServicePackage }}.ResName{{ .Resource }}, rs.Primary.ID, errors.New("not destroyed"))
 		}

--- a/skaff/resource/resourcetest.tmpl
+++ b/skaff/resource/resourcetest.tmpl
@@ -17,10 +17,7 @@ package {{ .ServicePackage }}_test
 // In other words, as generated, this is a rough outline of the work you will
 // need to do. If something doesn't make sense for your situation, get rid of
 // it.
-//
-// Remember to register this new resource in the provider
-// (internal/provider/provider.go) once you finish. Otherwise, Terraform won't
-// know about it.{{- end }}
+{{- end }}
 
 import (
 {{- if .IncludeComments }}

--- a/skaff/resource/resourcetest.tmpl
+++ b/skaff/resource/resourcetest.tmpl
@@ -57,6 +57,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 {{- if .IncludeComments }}
 
 	// TIP: You will often need to import the package that this test file lives


### PR DESCRIPTION
### Description

Updates `skaff` templates so that `diags` are collected rather than immediately returning. This ensures that if a Warning Diagnostic is added at some point, it will not get lost accidentally.

Also removes unneeded registration reminder and fixes spacing for data source imports