### PR TITLE
fix format for identity pool id

### DIFF
--- a/website/docs/r/cognito_identity_pool.markdown
+++ b/website/docs/r/cognito_identity_pool.markdown
@@ -70,7 +70,7 @@ backend and the Cognito service to communicate about the developer provider.
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - An identity pool ID, e.g. `us-west-2_abc123`.
+* `id` - An identity pool ID, e.g. `us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3`.
 * `arn` - The ARN of the identity pool.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
@@ -79,5 +79,5 @@ In addition to all arguments above, the following attributes are exported:
 Cognito Identity Pool can be imported using its ID, e.g.,
 
 ```
-$ terraform import aws_cognito_identity_pool.mypool us-west-2_abc123
+$ terraform import aws_cognito_identity_pool.mypool us-west-2:1a234567-8901-234b-5cde-f6789g01h2i3
 ```


### PR DESCRIPTION
### Description
the format currently shown is for a user pool id, and it should be for an identity pool id


### References
it looks like the existing ID for this documentation was copied from the page for user pool.
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool

The format of the ID for identity pools is very difficult to track down anywhere, but the cloudformation docs seem to show it correctly
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-identitypool.html

