### PR TITLE
fix: ensure endpoint group weight 0 is taken into account

### DIFF
--- a/.changelog/31767.txt
+++ b/.changelog/31767.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_globalaccelerator_endpoint_group: Fix bug updating `endpoint_configuration.weight` to `0`
+```

--- a/internal/service/globalaccelerator/endpoint_group.go
+++ b/internal/service/globalaccelerator/endpoint_group.go
@@ -377,7 +377,7 @@ func expandEndpointConfiguration(tfMap map[string]interface{}) *globalaccelerato
 		apiObject.EndpointId = aws.String(v)
 	}
 
-	if v, ok := tfMap["weight"].(int); ok && v != 0 {
+	if v, ok := tfMap["weight"].(int); ok {
 		apiObject.Weight = aws.Int64(int64(v))
 	}
 

--- a/internal/service/globalaccelerator/endpoint_group_test.go
+++ b/internal/service/globalaccelerator/endpoint_group_test.go
@@ -97,7 +97,7 @@ func TestAccGlobalAcceleratorEndpointGroup_ALBEndpoint_clientIP(t *testing.T) {
 		CheckDestroy:             testAccCheckEndpointGroupDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointGroupConfig_albClientIP(rName, false),
+				Config: testAccEndpointGroupConfig_albClientIP(rName, false, 20),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointGroupExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrGlobalARN(resourceName, "arn", "globalaccelerator", regexp.MustCompile(`accelerator/[^/]+/listener/[^/]+/endpoint-group/[^/]+`)),
@@ -124,14 +124,14 @@ func TestAccGlobalAcceleratorEndpointGroup_ALBEndpoint_clientIP(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccEndpointGroupConfig_albClientIP(rName, true),
+				Config: testAccEndpointGroupConfig_albClientIP(rName, true, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointGroupExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrGlobalARN(resourceName, "arn", "globalaccelerator", regexp.MustCompile(`accelerator/[^/]+/listener/[^/]+/endpoint-group/[^/]+`)),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "endpoint_configuration.*", map[string]string{
 						"client_ip_preservation_enabled": "true",
-						"weight":                         "20",
+						"weight":                         "0",
 					}),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "endpoint_configuration.*.endpoint_id", albResourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint_group_region", acctest.Region()),
@@ -528,7 +528,7 @@ resource "aws_globalaccelerator_endpoint_group" "test" {
 `, rName)
 }
 
-func testAccEndpointGroupConfig_albClientIP(rName string, clientIP bool) string {
+func testAccEndpointGroupConfig_albClientIP(rName string, clientIP bool, weight int) string {
 	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
 resource "aws_lb" "test" {
   name            = %[1]q
@@ -596,7 +596,7 @@ resource "aws_globalaccelerator_endpoint_group" "test" {
 
   endpoint_configuration {
     endpoint_id                    = aws_lb.test.id
-    weight                         = 20
+    weight                         = %[3]d
     client_ip_preservation_enabled = %[2]t
   }
 
@@ -607,7 +607,7 @@ resource "aws_globalaccelerator_endpoint_group" "test" {
   threshold_count               = 3
   traffic_dial_percentage       = 100
 }
-`, rName, clientIP))
+`, rName, clientIP, weight))
 }
 
 func testAccEndpointGroupConfig_instance(rName string) string {


### PR DESCRIPTION
Zero is a valid value for an endpoint group configuration and it shouldn't be ignored and not sent to the API.

The current behaviour causes a endpoint weight of 128 to be used instead as it is AWS default value if no weight is set. This causes traffic to be sent despite the expectations that a zero value will cause no traffic on the endpoint.

### Description

This Pull request fix the issue https://github.com/hashicorp/terraform-provider-aws/issues/31254 where a zero value for a global accelerator endpoint group configuration is ignored despite being a valid value.

### Relations

Closes #31254

### References

https://docs.aws.amazon.com/global-accelerator/latest/api/API_EndpointConfiguration.html
