### PR TITLE
[Docs]: Terraform plugin versions and `skaff` Plugin-Framework support

### DIFF
--- a/docs/skaff.md
+++ b/docs/skaff.md
@@ -7,6 +7,7 @@
 1. Figure out what you're trying to do:
     * Create a resource or a data source?
     * [AWS Go SDK v1 or v2](aws-go-sdk-versions.md) code?
+    * [Terraform Plugin-Framework or Plugin-SDK](terraform-plugin-versions.md) based?
     * [Name](naming.md) of the new resource or data source?
 2. Use `skaff` to generate provider code
 3. Go through the generated code completing code and customizing for the AWS Go SDK API
@@ -73,12 +74,13 @@ Usage:
   skaff datasource [flags]
 
 Flags:
-  -c, --clear-comments     Do not include instructional comments in source
-  -f, --force              Force creation, overwriting existing files
+  -c, --clear-comments     do not include instructional comments in source
+  -f, --force              force creation, overwriting existing files
   -h, --help               help for datasource
-  -n, --name string        Name of the entity
-  -s, --snakename string   If skaff doesn't get it right, explicitly give name in snake case (e.g., db_vpc_instance)
-  -o, --v1                 Generate code targeting aws-sdk-go v1 (some existing services) 
+  -n, --name string        name of the entity
+  -p, --plugin-framework   generate for Terraform Plugin-Framework
+  -s, --snakename string   if skaff doesn't get it right, explicitly give name in snake case (e.g., db_vpc_instance)
+  -o, --v1                 generate for AWS Go SDK v1 (some existing services)
 ```
 
 ### Resource
@@ -91,10 +93,11 @@ Usage:
   skaff resource [flags]
 
 Flags:
-  -c, --clear-comments     Do not include instructional comments in source
-  -f, --force              Force creation, overwriting existing files
+  -c, --clear-comments     do not include instructional comments in source
+  -f, --force              force creation, overwriting existing files
   -h, --help               help for resource
-  -n, --name string        Name of the entity
-  -s, --snakename string   If skaff doesn't get it right, explicitly give name in snake case (e.g., db_vpc_instance)
-  -o, --v1                 Generate code targeting aws-sdk-go v1 (some existing services) 
+  -n, --name string        name of the entity
+  -p, --plugin-framework   generate for Terraform Plugin-Framework
+  -s, --snakename string   if skaff doesn't get it right, explicitly give name in snake case (e.g., db_vpc_instance)
+  -o, --v1                 generate for AWS Go SDK v1 (some existing services)
 ```

--- a/docs/skaff.md
+++ b/docs/skaff.md
@@ -7,7 +7,7 @@
 1. Figure out what you're trying to do:
     * Create a resource or a data source?
     * [AWS Go SDK v1 or v2](aws-go-sdk-versions.md) code?
-    * [Terraform Plugin-Framework or Plugin-SDK](terraform-plugin-versions.md) based?
+    * [Terraform Plugin Framework or Plugin SDKv2](terraform-plugin-versions.md) based?
     * [Name](naming.md) of the new resource or data source?
 2. Use `skaff` to generate provider code
 3. Go through the generated code completing code and customizing for the AWS Go SDK API

--- a/docs/terraform-plugin-versions.md
+++ b/docs/terraform-plugin-versions.md
@@ -1,0 +1,9 @@
+# Terraform Plugin Versions
+
+The Terraform AWS Provider is constructed with HashiCorp-maintained packages for building plugins. Most existing resources are implemented with [Terraform Plugin-SDK V2](https://developer.hashicorp.com/terraform/plugin/sdkv2), while newer resources may use [Terraform Plugin Framework](https://developer.hashicorp.com/terraform/plugin/framework). A thorough comparison of the packages can be found [here](https://developer.hashicorp.com/terraform/plugin/framework-benefits).
+
+At this time community contributions in either package will be accepted. The AWS Provider is [muxed](https://developer.hashicorp.com/terraform/plugin/framework/migrating/mux) to allow resources and data sources implemented in both packages. As AWS Provider tooling around Plugin-Framework (and the library itself) matures, we will being requiring all net-new resources be implemented with it. [`skaff`](skaff.md) currently supports generating Plugin-Framework based resources using the optional `-p`/`--plugin-framework` flag. Factors to consider when choosing between packages are:
+
+1. What other resources in a given service use
+2. Level of comfort with the new idioms introduced in Plugin-Framework
+3. [Advantages](https://developer.hashicorp.com/terraform/plugin/framework-benefits#plugin-framework-benefits) Plugin-Framework may afford over Plugin-SDK (improved null handling, plan modifications, etc.)

--- a/docs/terraform-plugin-versions.md
+++ b/docs/terraform-plugin-versions.md
@@ -1,9 +1,9 @@
 # Terraform Plugin Versions
 
-The Terraform AWS Provider is constructed with HashiCorp-maintained packages for building plugins. Most existing resources are implemented with [Terraform Plugin-SDK V2](https://developer.hashicorp.com/terraform/plugin/sdkv2), while newer resources may use [Terraform Plugin Framework](https://developer.hashicorp.com/terraform/plugin/framework). A thorough comparison of the packages can be found [here](https://developer.hashicorp.com/terraform/plugin/framework-benefits).
+The Terraform AWS Provider is constructed with HashiCorp-maintained packages for building plugins. Most existing resources are implemented with [Terraform Plugin SDKv2](https://developer.hashicorp.com/terraform/plugin/sdkv2), while newer resources may use [Terraform Plugin Framework](https://developer.hashicorp.com/terraform/plugin/framework). A thorough comparison of the packages can be found [here](https://developer.hashicorp.com/terraform/plugin/framework-benefits).
 
-At this time community contributions in either package will be accepted. The AWS Provider is [muxed](https://developer.hashicorp.com/terraform/plugin/framework/migrating/mux) to allow resources and data sources implemented in both packages. As AWS Provider tooling around Plugin-Framework (and the library itself) matures, we will being requiring all net-new resources be implemented with it. [`skaff`](skaff.md) currently supports generating Plugin-Framework based resources using the optional `-p`/`--plugin-framework` flag. Factors to consider when choosing between packages are:
+At this time community contributions in either package will be accepted. The AWS Provider is [muxed](https://developer.hashicorp.com/terraform/plugin/framework/migrating/mux) to allow resources and data sources implemented in both packages. As AWS Provider tooling around Plugin Framework (and the library itself) matures, we will being requiring all net-new resources be implemented with it. [`skaff`](skaff.md) currently supports generating Plugin Framework based resources using the optional `-p`/`--plugin-framework` flag. Factors to consider when choosing between packages are:
 
 1. What other resources in a given service use
-2. Level of comfort with the new idioms introduced in Plugin-Framework
-3. [Advantages](https://developer.hashicorp.com/terraform/plugin/framework-benefits#plugin-framework-benefits) Plugin-Framework may afford over Plugin-SDK (improved null handling, plan modifications, etc.)
+2. Level of comfort with the new idioms introduced in Plugin Framework
+3. [Advantages](https://developer.hashicorp.com/terraform/plugin/framework-benefits#plugin-framework-benefits) Plugin Framework may afford over Plugin SDKv2 (improved null handling, plan modifications, etc.)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
       - Data Handling and Conversion: data-handling-and-conversion.md
       - Dependency Updates: dependency-updates.md
       - AWS SDK for Go Versions: aws-go-sdk-versions.md
+      - Terraform Plugin Versions: terraform-plugin-versions.md
       - AWS Go SDK Base: aws-go-sdk-base.md
       - Error Handling: error-handling.md
       - Provider Design: provider-design.md


### PR DESCRIPTION

### Description
Adds a new page to the contributor documentation on Terraform plugin versions (Plugin-SDK versus Plugin-Framework), and documents `skaff` support for Plugin-Framework based resources.

### Relations
Relates #30799 


