### PR TITLE
fix(redshift): Nil-check before reading from Endpoint

### DIFF
--- a/.changelog/31772.txt
+++ b/.changelog/31772.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_redshift_cluster: Fix crash reading clusters in `modifying` state
+```

--- a/internal/service/redshift/cluster_data_source.go
+++ b/internal/service/redshift/cluster_data_source.go
@@ -255,6 +255,7 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	if rsc.Endpoint != nil {
 		d.Set("endpoint", rsc.Endpoint.Address)
+		d.Set("port", rsc.Endpoint.Port)
 	}
 
 	d.Set("enhanced_vpc_routing", rsc.EnhancedVpcRouting)
@@ -269,7 +270,6 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("master_username", rsc.MasterUsername)
 	d.Set("node_type", rsc.NodeType)
 	d.Set("number_of_nodes", rsc.NumberOfNodes)
-	d.Set("port", rsc.Endpoint.Port)
 	d.Set("preferred_maintenance_window", rsc.PreferredMaintenanceWindow)
 	d.Set("publicly_accessible", rsc.PubliclyAccessible)
 	d.Set("default_iam_role_arn", rsc.DefaultIamRoleArn)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Resolves https://github.com/hashicorp/terraform-provider-aws/issues/31407 as per suggested: https://github.com/hashicorp/terraform-provider-aws/issues/31407#issuecomment-1570495244


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Resolves https://github.com/hashicorp/terraform-provider-aws/issues/31407

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://github.com/hashicorp/terraform-provider-aws/issues/31407#issuecomment-1570495244


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

I'll run the tests if required, but I don't see how this change will break existing functionality as it fixes a bug where terraform might crash, as per referenced issue. <insert "how did this not work"-imagery here>
