### PR TITLE
Tech debt: Migrate `swf` resources to AWS SDK for Go v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.4
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.15.4
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.21.4
+	github.com/aws/aws-sdk-go-v2/service/swf v1.15.0
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.26.6
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.0.5
 	github.com/aws/aws-sdk-go-v2/service/xray v1.16.11

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.10 h1:PkHIIJs8qvq0e5QybnZoG1K
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.10/go.mod h1:AFvkxc8xfBe8XA+5St5XIHHrQQtkxqrRincx4hmMHOk=
 github.com/aws/aws-sdk-go-v2/service/sts v1.19.0 h1:2DQLAKDteoEDI8zpCzqBMaZlJuoE9iTYD0gFmXVax9E=
 github.com/aws/aws-sdk-go-v2/service/sts v1.19.0/go.mod h1:BgQOMsg8av8jset59jelyPW7NoZcZXLVpDsXunGDrk8=
+github.com/aws/aws-sdk-go-v2/service/swf v1.15.0 h1:ZcQ8IYzUhmiVZ7lV4E0lttk+Tei/RZk/Oko8+G34cWI=
+github.com/aws/aws-sdk-go-v2/service/swf v1.15.0/go.mod h1:p5K3luEySutRPjMsXcmoc9dumbUus6ZOj4XBYC3XMII=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.26.6 h1:I2Y2Y8V+uq2ZoD+yTxjKYuPOTtScHMXUWdbuCdjNZy4=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.26.6/go.mod h1:VgAk4W80KzgqmBdm1jk+FjqiD5VgAz0FGvqECq7q79I=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.0.5 h1:ZQizySv5AeKbYYtkDiUcxSnwTqAJ4URIxdoLWfZ7rhw=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -39,6 +39,7 @@ import (
 	ssm_sdkv2 "github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssmcontacts"
 	"github.com/aws/aws-sdk-go-v2/service/ssmincidents"
+	"github.com/aws/aws-sdk-go-v2/service/swf"
 	"github.com/aws/aws-sdk-go-v2/service/transcribe"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/aws/aws-sdk-go-v2/service/xray"
@@ -309,7 +310,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/storagegateway"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/support"
-	"github.com/aws/aws-sdk-go/service/swf"
 	"github.com/aws/aws-sdk-go/service/synthetics"
 	"github.com/aws/aws-sdk-go/service/textract"
 	"github.com/aws/aws-sdk-go/service/timestreamquery"
@@ -624,7 +624,7 @@ type AWSClient struct {
 	ssoadminConn                     *ssoadmin.SSOAdmin
 	ssooidcConn                      *ssooidc.SSOOIDC
 	stsConn                          *sts.STS
-	swfConn                          *swf.SWF
+	swfClient                        *swf.Client
 	sagemakerConn                    *sagemaker.SageMaker
 	sagemakera2iruntimeConn          *augmentedairuntime.AugmentedAIRuntime
 	sagemakeredgeConn                *sagemakeredgemanager.SagemakerEdgeManager
@@ -1782,8 +1782,8 @@ func (client *AWSClient) STSConn() *sts.STS {
 	return client.stsConn
 }
 
-func (client *AWSClient) SWFConn() *swf.SWF {
-	return client.swfConn
+func (client *AWSClient) SWFClient() *swf.Client {
+	return client.swfClient
 }
 
 func (client *AWSClient) SageMakerConn() *sagemaker.SageMaker {

--- a/internal/conns/config_gen.go
+++ b/internal/conns/config_gen.go
@@ -37,6 +37,7 @@ import (
 	ssm_sdkv2 "github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssmcontacts"
 	"github.com/aws/aws-sdk-go-v2/service/ssmincidents"
+	"github.com/aws/aws-sdk-go-v2/service/swf"
 	"github.com/aws/aws-sdk-go-v2/service/transcribe"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/aws/aws-sdk-go-v2/service/xray"
@@ -301,7 +302,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssooidc"
 	"github.com/aws/aws-sdk-go/service/storagegateway"
 	"github.com/aws/aws-sdk-go/service/support"
-	"github.com/aws/aws-sdk-go/service/swf"
 	"github.com/aws/aws-sdk-go/service/synthetics"
 	"github.com/aws/aws-sdk-go/service/textract"
 	"github.com/aws/aws-sdk-go/service/timestreamquery"
@@ -563,7 +563,6 @@ func (c *Config) sdkv1Conns(client *AWSClient, sess *session.Session) {
 	client.ssoConn = sso.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SSO])}))
 	client.ssoadminConn = ssoadmin.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SSOAdmin])}))
 	client.ssooidcConn = ssooidc.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SSOOIDC])}))
-	client.swfConn = swf.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SWF])}))
 	client.sagemakerConn = sagemaker.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SageMaker])}))
 	client.sagemakera2iruntimeConn = augmentedairuntime.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SageMakerA2IRuntime])}))
 	client.sagemakeredgeConn = sagemakeredgemanager.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.Endpoints[names.SageMakerEdge])}))
@@ -730,6 +729,11 @@ func (c *Config) sdkv2Conns(client *AWSClient, cfg aws_sdkv2.Config) {
 	client.ssmincidentsClient = ssmincidents.NewFromConfig(cfg, func(o *ssmincidents.Options) {
 		if endpoint := c.Endpoints[names.SSMIncidents]; endpoint != "" {
 			o.EndpointResolver = ssmincidents.EndpointResolverFromURL(endpoint)
+		}
+	})
+	client.swfClient = swf.NewFromConfig(cfg, func(o *swf.Options) {
+		if endpoint := c.Endpoints[names.SWF]; endpoint != "" {
+			o.EndpointResolver = swf.EndpointResolverFromURL(endpoint)
 		}
 	})
 	client.schedulerClient = scheduler.NewFromConfig(cfg, func(o *scheduler.Options) {

--- a/internal/service/swf/domain.go
+++ b/internal/service/swf/domain.go
@@ -6,14 +6,16 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/swf"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/swf"
+	"github.com/aws/aws-sdk-go-v2/service/swf/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -22,7 +24,7 @@ import (
 
 // @SDKResource("aws_swf_domain", name="Domain")
 // @Tags(identifierAttribute="arn")
-func ResourceDomain() *schema.Resource {
+func resourceDomain() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDomainCreate,
 		ReadWithoutTimeout:   resourceDomainRead,
@@ -79,7 +81,8 @@ func ResourceDomain() *schema.Resource {
 }
 
 func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).SWFConn()
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).SWFClient()
 
 	name := create.Name(d.Get("name").(string), d.Get("name_prefix").(string))
 	input := &swf.RegisterDomainInput{
@@ -92,10 +95,10 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		input.Description = aws.String(v.(string))
 	}
 
-	_, err := conn.RegisterDomainWithContext(ctx, input)
+	_, err := conn.RegisterDomain(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating SWF Domain (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating SWF Domain (%s): %s", name, err)
 	}
 
 	d.SetId(name)
@@ -104,9 +107,10 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).SWFConn()
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).SWFClient()
 
-	output, err := FindDomainByName(ctx, conn, d.Id())
+	output, err := findDomainByName(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SWF Domain (%s) not found, removing from state", d.Id())
@@ -115,17 +119,17 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if err != nil {
-		return diag.Errorf("reading SWF Domain (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading SWF Domain (%s): %s", d.Id(), err)
 	}
 
-	arn := aws.StringValue(output.DomainInfo.Arn)
+	arn := aws.ToString(output.DomainInfo.Arn)
 	d.Set("arn", arn)
 	d.Set("description", output.DomainInfo.Description)
 	d.Set("name", output.DomainInfo.Name)
-	d.Set("name_prefix", create.NamePrefixFromName(aws.StringValue(output.DomainInfo.Name)))
+	d.Set("name_prefix", create.NamePrefixFromName(aws.ToString(output.DomainInfo.Name)))
 	d.Set("workflow_execution_retention_period_in_days", output.Configuration.WorkflowExecutionRetentionPeriodInDays)
 
-	return nil
+	return diags
 }
 
 func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -134,31 +138,32 @@ func resourceDomainUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func resourceDomainDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).SWFConn()
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).SWFClient()
 
-	_, err := conn.DeprecateDomainWithContext(ctx, &swf.DeprecateDomainInput{
+	_, err := conn.DeprecateDomain(ctx, &swf.DeprecateDomainInput{
 		Name: aws.String(d.Get("name").(string)),
 	})
 
-	if tfawserr.ErrCodeEquals(err, swf.ErrCodeDomainDeprecatedFault, swf.ErrCodeUnknownResourceFault) {
-		return nil
+	if errs.IsA[*types.DomainDeprecatedFault](err) || errs.IsA[*types.UnknownResourceFault](err) {
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting SWF Domain (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting SWF Domain (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
-func FindDomainByName(ctx context.Context, conn *swf.SWF, name string) (*swf.DescribeDomainOutput, error) {
+func findDomainByName(ctx context.Context, conn *swf.Client, name string) (*swf.DescribeDomainOutput, error) {
 	input := &swf.DescribeDomainInput{
 		Name: aws.String(name),
 	}
 
-	output, err := conn.DescribeDomainWithContext(ctx, input)
+	output, err := conn.DescribeDomain(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, swf.ErrCodeUnknownResourceFault) {
+	if errs.IsA[*types.UnknownResourceFault](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
@@ -173,9 +178,9 @@ func FindDomainByName(ctx context.Context, conn *swf.SWF, name string) (*swf.Des
 		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	if status := aws.StringValue(output.DomainInfo.Status); status == swf.RegistrationStatusDeprecated {
+	if status := output.DomainInfo.Status; status == types.RegistrationStatusDeprecated {
 		return nil, &retry.NotFoundError{
-			Message:     status,
+			Message:     string(status),
 			LastRequest: input,
 		}
 	}

--- a/internal/service/swf/domain_test.go
+++ b/internal/service/swf/domain_test.go
@@ -63,6 +63,32 @@ func TestAccSWFDomain_basic(t *testing.T) {
 	})
 }
 
+func TestAccSWFDomain_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_swf_domain.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckDomainTestingEnabled(t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SWFEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfswf.ResourceDomain(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccSWFDomain_nameGenerated(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_swf_domain.test"

--- a/internal/service/swf/exports_test.go
+++ b/internal/service/swf/exports_test.go
@@ -1,0 +1,8 @@
+package swf
+
+// Exports for use in tests only.
+var (
+	FindDomainByName = findDomainByName
+
+	ResourceDomain = resourceDomain
+)

--- a/internal/service/swf/generate.go
+++ b/internal/service/swf/generate.go
@@ -1,4 +1,4 @@
-//go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsSlice -TagType=ResourceTag -UpdateTags
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ListTags -ServiceTagsSlice -TagType=ResourceTag -UpdateTags
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 
 package swf

--- a/internal/service/swf/service_package_gen.go
+++ b/internal/service/swf/service_package_gen.go
@@ -26,7 +26,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
 		{
-			Factory:  ResourceDomain,
+			Factory:  resourceDomain,
 			TypeName: "aws_swf_domain",
 			Name:     "Domain",
 			Tags: &types.ServicePackageResourceTags{

--- a/internal/service/swf/sweep.go
+++ b/internal/service/swf/sweep.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/swf"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/swf"
+	"github.com/aws/aws-sdk-go-v2/service/swf/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
@@ -27,35 +28,32 @@ func sweepDomains(region string) error {
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
 	}
-	conn := client.(*conns.AWSClient).SWFConn()
+	conn := client.(*conns.AWSClient).SWFClient()
 	input := &swf.ListDomainsInput{
-		RegistrationStatus: aws.String(swf.RegistrationStatusRegistered),
+		RegistrationStatus: types.RegistrationStatusRegistered,
 	}
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	err = conn.ListDomainsPagesWithContext(ctx, input, func(page *swf.ListDomainsOutput, lastPage bool) bool {
-		if page == nil {
-			return !lastPage
+	pages := swf.NewListDomainsPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if sweep.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping SWF Domain sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("error listing SWF Domains (%s): %w", region, err)
 		}
 
 		for _, v := range page.DomainInfos {
-			r := ResourceDomain()
+			r := resourceDomain()
 			d := r.Data(nil)
-			d.SetId(aws.StringValue(v.Name))
+			d.SetId(aws.ToString(v.Name))
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
-
-		return !lastPage
-	})
-
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping SWF Domain sweep for %s: %s", region, err)
-		return nil
-	}
-
-	if err != nil {
-		return fmt.Errorf("error listing SWF Domains (%s): %w", region, err)
 	}
 
 	err = sweep.SweepOrchestratorWithContext(ctx, sweepResources)

--- a/internal/service/swf/tags_gen.go
+++ b/internal/service/swf/tags_gen.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/swf"
-	"github.com/aws/aws-sdk-go/service/swf/swfiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/swf"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/swf/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
@@ -17,12 +17,12 @@ import (
 // ListTags lists swf service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func ListTags(ctx context.Context, conn swfiface.SWFAPI, identifier string) (tftags.KeyValueTags, error) {
+func ListTags(ctx context.Context, conn *swf.Client, identifier string) (tftags.KeyValueTags, error) {
 	input := &swf.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResourceWithContext(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -34,7 +34,7 @@ func ListTags(ctx context.Context, conn swfiface.SWFAPI, identifier string) (tft
 // ListTags lists swf service tags and set them in Context.
 // It is called from outside this package.
 func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier string) error {
-	tags, err := ListTags(ctx, meta.(*conns.AWSClient).SWFConn(), identifier)
+	tags, err := ListTags(ctx, meta.(*conns.AWSClient).SWFClient(), identifier)
 
 	if err != nil {
 		return err
@@ -50,11 +50,11 @@ func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier stri
 // []*SERVICE.Tag handling
 
 // Tags returns swf service tags.
-func Tags(tags tftags.KeyValueTags) []*swf.ResourceTag {
-	result := make([]*swf.ResourceTag, 0, len(tags))
+func Tags(tags tftags.KeyValueTags) []awstypes.ResourceTag {
+	result := make([]awstypes.ResourceTag, 0, len(tags))
 
 	for k, v := range tags.Map() {
-		tag := &swf.ResourceTag{
+		tag := awstypes.ResourceTag{
 			Key:   aws.String(k),
 			Value: aws.String(v),
 		}
@@ -66,11 +66,11 @@ func Tags(tags tftags.KeyValueTags) []*swf.ResourceTag {
 }
 
 // KeyValueTags creates tftags.KeyValueTags from swf service tags.
-func KeyValueTags(ctx context.Context, tags []*swf.ResourceTag) tftags.KeyValueTags {
+func KeyValueTags(ctx context.Context, tags []awstypes.ResourceTag) tftags.KeyValueTags {
 	m := make(map[string]*string, len(tags))
 
 	for _, tag := range tags {
-		m[aws.StringValue(tag.Key)] = tag.Value
+		m[aws.ToString(tag.Key)] = tag.Value
 	}
 
 	return tftags.New(ctx, m)
@@ -78,7 +78,7 @@ func KeyValueTags(ctx context.Context, tags []*swf.ResourceTag) tftags.KeyValueT
 
 // GetTagsIn returns swf service tags from Context.
 // nil is returned if there are no input tags.
-func GetTagsIn(ctx context.Context) []*swf.ResourceTag {
+func GetTagsIn(ctx context.Context) []awstypes.ResourceTag {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		if tags := Tags(inContext.TagsIn.UnwrapOrDefault()); len(tags) > 0 {
 			return tags
@@ -89,7 +89,7 @@ func GetTagsIn(ctx context.Context) []*swf.ResourceTag {
 }
 
 // SetTagsOut sets swf service tags in Context.
-func SetTagsOut(ctx context.Context, tags []*swf.ResourceTag) {
+func SetTagsOut(ctx context.Context, tags []awstypes.ResourceTag) {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		inContext.TagsOut = types.Some(KeyValueTags(ctx, tags))
 	}
@@ -98,7 +98,7 @@ func SetTagsOut(ctx context.Context, tags []*swf.ResourceTag) {
 // UpdateTags updates swf service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func UpdateTags(ctx context.Context, conn swfiface.SWFAPI, identifier string, oldTagsMap, newTagsMap any) error {
+func UpdateTags(ctx context.Context, conn *swf.Client, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -107,10 +107,10 @@ func UpdateTags(ctx context.Context, conn swfiface.SWFAPI, identifier string, ol
 	if len(removedTags) > 0 {
 		input := &swf.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.Keys()),
+			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResourceWithContext(ctx, input)
+		_, err := conn.UntagResource(ctx, input)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -125,7 +125,7 @@ func UpdateTags(ctx context.Context, conn swfiface.SWFAPI, identifier string, ol
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResourceWithContext(ctx, input)
+		_, err := conn.TagResource(ctx, input)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)
@@ -138,5 +138,5 @@ func UpdateTags(ctx context.Context, conn swfiface.SWFAPI, identifier string, ol
 // UpdateTags updates swf service tags.
 // It is called from outside this package.
 func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
-	return UpdateTags(ctx, meta.(*conns.AWSClient).SWFConn(), identifier, oldTags, newTags)
+	return UpdateTags(ctx, meta.(*conns.AWSClient).SWFClient(), identifier, oldTags, newTags)
 }

--- a/names/names.go
+++ b/names/names.go
@@ -47,6 +47,7 @@ const (
 	SSMEndpointID                        = "ssm"
 	SSMContactsEndpointID                = "ssm-contacts"
 	SSMIncidentsEndpointID               = "ssm-incidents"
+	SWFEndpointID                        = "swf"
 	TranscribeEndpointID                 = "transcribe"
 	VPCLatticeEndpointID                 = "vpc-lattice"
 	XRayEndpointID                       = "xray"

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -344,7 +344,7 @@ storagegateway,storagegateway,storagegateway,storagegateway,,storagegateway,,,St
 sts,sts,sts,sts,,sts,,,STS,STS,x,1,,aws_caller_identity,aws_sts_,,caller_identity,STS (Security Token),AWS,,,AWS_STS_ENDPOINT,TF_AWS_STS_ENDPOINT,
 ,,,,,,,,,,,,,,,,,Sumerian,Amazon,x,,,,No SDK support
 support,support,support,support,,support,,,Support,Support,,1,,,aws_support_,,support_,Support,AWS,,,,,
-swf,swf,swf,swf,,swf,,,SWF,SWF,,1,,,aws_swf_,,swf_,SWF (Simple Workflow),Amazon,,,,,
+swf,swf,swf,swf,,swf,,,SWF,SWF,,,2,,aws_swf_,,swf_,SWF (Simple Workflow),Amazon,,,,,
 ,,,,,,,,,,,,,,,,,Tag Editor,AWS,x,,,,Part of Resource Groups Tagging
 textract,textract,textract,textract,,textract,,,Textract,Textract,,1,,,aws_textract_,,textract_,Textract,Amazon,,,,,
 timestream-query,timestreamquery,timestreamquery,timestreamquery,,timestreamquery,,,TimestreamQuery,TimestreamQuery,,1,,,aws_timestreamquery_,,timestreamquery_,Timestream Query,Amazon,,,,,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Ibid.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% SWF_DOMAIN_TESTING_ENABLED=true make testacc TESTARGS='-run=TestAccSWFDomain_' PKG=swf ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/swf/... -v -count 1 -parallel 2  -run=TestAccSWFDomain_ -timeout 180m
=== RUN   TestAccSWFDomain_basic
=== PAUSE TestAccSWFDomain_basic
=== RUN   TestAccSWFDomain_disappears
=== PAUSE TestAccSWFDomain_disappears
=== RUN   TestAccSWFDomain_nameGenerated
=== PAUSE TestAccSWFDomain_nameGenerated
=== RUN   TestAccSWFDomain_namePrefix
=== PAUSE TestAccSWFDomain_namePrefix
=== RUN   TestAccSWFDomain_tags
=== PAUSE TestAccSWFDomain_tags
=== RUN   TestAccSWFDomain_description
=== PAUSE TestAccSWFDomain_description
=== CONT  TestAccSWFDomain_basic
=== CONT  TestAccSWFDomain_namePrefix
--- PASS: TestAccSWFDomain_namePrefix (34.49s)
=== CONT  TestAccSWFDomain_description
--- PASS: TestAccSWFDomain_basic (35.04s)
=== CONT  TestAccSWFDomain_nameGenerated
--- PASS: TestAccSWFDomain_description (33.22s)
=== CONT  TestAccSWFDomain_tags
--- PASS: TestAccSWFDomain_nameGenerated (33.23s)
=== CONT  TestAccSWFDomain_disappears
--- PASS: TestAccSWFDomain_disappears (18.72s)
=== CONT  TestAccSWFDomain_tags
--- PASS: TestAccSWFDomain_tags (173.89s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/swf	246.929s
```
