### PR TITLE
d/aws_guardduty_finding_ids: add `has_findings` attribute

### DIFF
--- a/internal/service/guardduty/finding_ids_data_source.go
+++ b/internal/service/guardduty/finding_ids_data_source.go
@@ -39,6 +39,9 @@ func (d *dataSourceFindingIds) Schema(ctx context.Context, req datasource.Schema
 			"detector_id": schema.StringAttribute{
 				Required: true,
 			},
+			"has_findings": schema.BoolAttribute{
+				Computed: true,
+			},
 			"finding_ids": schema.ListAttribute{
 				Computed:    true,
 				ElementType: types.StringType,
@@ -68,6 +71,7 @@ func (d *dataSourceFindingIds) Read(ctx context.Context, req datasource.ReadRequ
 
 	data.ID = types.StringValue(data.DetectorID.ValueString())
 	data.FindingIDs = flex.FlattenFrameworkStringList(ctx, out)
+	data.HasFindings = types.BoolValue((len(out) > 0))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -98,7 +102,8 @@ func findFindingIds(ctx context.Context, conn *guardduty.GuardDuty, id string) (
 }
 
 type dataSourceFindingIdsData struct {
-	DetectorID types.String `tfsdk:"detector_id"`
-	FindingIDs types.List   `tfsdk:"finding_ids"`
-	ID         types.String `tfsdk:"id"`
+	DetectorID  types.String `tfsdk:"detector_id"`
+	HasFindings types.Bool   `tfsdk:"has_findings"`
+	FindingIDs  types.List   `tfsdk:"finding_ids"`
+	ID          types.String `tfsdk:"id"`
 }

--- a/internal/service/guardduty/finding_ids_data_source_test.go
+++ b/internal/service/guardduty/finding_ids_data_source_test.go
@@ -25,6 +25,7 @@ func TestAccGuardDutyFindingIdsDataSource_basic(t *testing.T) {
 				Config: testAccFindingIdsDataSourceConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "detector_id", detectorDataSourceName, "id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "has_findings"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "finding_ids.#"),
 				),
 			},

--- a/website/docs/d/guardduty_finding_ids.html.markdown
+++ b/website/docs/d/guardduty_finding_ids.html.markdown
@@ -30,4 +30,5 @@ The following arguments are required:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `has_findings` - Indicates whether findings are present for the specified detector.
 * `finding_ids` - A list of finding IDs for the specified detector.


### PR DESCRIPTION
### Description
Adds a `has_findings` attribute. Omitting a changelog entry since the data source has not been released yet.


### Relations
Relates #31711 



### Output from Acceptance Testing

```console
$ make testacc PKG=guardduty TESTS=TestAccGuardDutyFindingIdsDataSource_basic
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/guardduty/... -v -count 1 -parallel 20 -run='TestAccGuardDutyFindingIdsDataSource_basic'  -timeout 180m
=== RUN   TestAccGuardDutyFindingIdsDataSource_basic
=== PAUSE TestAccGuardDutyFindingIdsDataSource_basic
=== CONT  TestAccGuardDutyFindingIdsDataSource_basic
--- PASS: TestAccGuardDutyFindingIdsDataSource_basic (15.33s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/guardduty  18.543s
```
