### PR TITLE
Update cloudwatch_event_target.html.markdown

### DIFF
--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -389,7 +389,8 @@ data "aws_iam_policy_document" "example_log_policy" {
     principals {
       type = "Service"
       identifiers = [
-        "events.amazonaws.com"
+        "events.amazonaws.com",
+        "delivery.logs.amazonaws.com"
       ]
     }
   }
@@ -406,7 +407,8 @@ data "aws_iam_policy_document" "example_log_policy" {
     principals {
       type = "Service"
       identifiers = [
-        "events.amazonaws.com"
+        "events.amazonaws.com",
+        "delivery.logs.amazonaws.com"
       ]
     }
 


### PR DESCRIPTION
### Description

Adding "delivery.logs.amazonaws.com" as a service principal, as this now appears necessary to get a log forwarding target to work (As a result of many hours of experimentation!). Also example here: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-use-resource-based.html#eb-cloudwatchlogs-permissions
