### PR TITLE
bug: fix perpetual diff on duplicate tags

### DIFF
--- a/internal/tags/key_value_tags.go
+++ b/internal/tags/key_value_tags.go
@@ -779,7 +779,7 @@ func (tags KeyValueTags) ResolveDuplicates(ctx context.Context, defaultConfig *D
 
 	configTags := make(map[string]configTag)
 	if configExists {
-		c := cf.GetAttr("tags")
+		c := cf.GetAttr(names.AttrTags)
 
 		// if the config is null just return the incoming tags
 		// no duplicates to calculate
@@ -803,7 +803,7 @@ func (tags KeyValueTags) ResolveDuplicates(ctx context.Context, defaultConfig *D
 	}
 
 	if config := d.GetRawPlan(); !config.IsNull() && config.IsKnown() {
-		c := config.GetAttr("tags")
+		c := config.GetAttr(names.AttrTags)
 		if !c.IsNull() && c.IsKnown() {
 			for k, v := range c.AsValueMap() {
 				if _, ok := configTags[k]; !ok {
@@ -817,7 +817,7 @@ func (tags KeyValueTags) ResolveDuplicates(ctx context.Context, defaultConfig *D
 	}
 
 	if st := d.GetRawState(); !st.IsNull() && st.IsKnown() {
-		c := st.GetAttr("tags")
+		c := st.GetAttr(names.AttrTags)
 		if !c.IsNull() {
 			for k, v := range c.AsValueMap() {
 				if _, ok := configTags[k]; !ok {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When duplicate tags are moved from from `tags` to `default_tags`, and vice versa, the state fails to update correctly. This causes a perpetual diff.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #31695

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccVPC_ -short' PKG=vpc

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPC_ -short -timeout 180m
    vpc_test.go:1015: skipping long-running test in short mode
--- SKIP: TestAccVPC_IPAMIPv4BasicNetmask (0.00s)
    vpc_test.go:1042: skipping long-running test in short mode
--- SKIP: TestAccVPC_IPAMIPv4BasicExplicitCIDR (0.00s)
    vpc_test.go:1070: skipping long-running test in short mode
--- SKIP: TestAccVPC_IPAMIPv6 (0.00s)
=== NAME  TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup
    ec2_availability_zone_data_source_test.go:219: skipping since no Local Zones are available
--- SKIP: TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup (1.05s)
--- PASS: TestAccVPC_disappears (39.96s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_duplicateTag (43.17s)
--- PASS: TestAccVPC_tags_null (44.91s)
--- PASS: TestAccVPC_tags_computed (46.10s)
--- PASS: TestAccVPC_basic (54.50s)
--- PASS: TestAccVPC_enableNetworkAddressUsageMetrics (64.78s)
--- PASS: TestAccVPC_disabledDNSSupport (65.09s)
--- PASS: TestAccVPC_bothDNSOptionsSet (64.32s)
--- PASS: TestAccVPC_DefaultTags_updateToResourceOnly (77.44s)
--- PASS: TestAccVPC_DefaultTags_updateToProviderOnly (78.58s)
--- PASS: TestAccVPC_DynamicResourceTags_ignoreChanges (79.03s)
--- PASS: TestAccVPC_defaultAndIgnoreTags (82.45s)
--- PASS: TestAccVPC_updateDNSHostnames (83.52s)
--- PASS: TestAccVPC_DefaultTags_zeroValue (91.08s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_overlappingTag (91.80s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_moveDuplicateTags (92.47s)
--- PASS: TestAccVPC_DefaultTags_providerOnlyTestAccVPC_DefaultTags_providerOnly (93.20s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_nonOverlappingTag (95.36s)
--- PASS: TestAccVPC_DynamicResourceTagsMergedWithLocals_ignoreChanges (58.45s)
--- PASS: TestAccVPC_tags (98.73s)
--- PASS: TestAccVPC_ignoreTags (57.67s)
--- PASS: TestAccVPC_tenancy (75.30s)
--- PASS: TestAccVPC_assignGeneratedIPv6CIDRBlock (119.43s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	122.660s
```
