### PR TITLE
Fix: Check the organization ID match with API Output

### DIFF
--- a/internal/service/organizations/organization.go
+++ b/internal/service/organizations/organization.go
@@ -248,6 +248,11 @@ func resourceOrganizationRead(ctx context.Context, d *schema.ResourceData, meta 
 		return sdkdiag.AppendErrorf(diags, "describing Organization: %s", err)
 	}
 
+	orgId := aws.StringValue(org.Organization.Id)
+	if orgId != d.Id() {
+		return sdkdiag.AppendErrorf(diags, "The current Organization ID (%s) does not match the one retrieved from API (%s)", d.Id(), orgId)
+	}
+
 	log.Printf("[INFO] Listing Accounts for Organization: %s", d.Id())
 	var accounts []*organizations.Account
 	var nonMasterAccounts []*organizations.Account


### PR DESCRIPTION

### Description

When doing an import of an organization, we provide an ID that can be different to the real one, and stored in the state without any comparison.

### Relations

Closes #31783