### PR TITLE
Tech debt: Remove leading `error ` from any error messages

### DIFF
--- a/.ci/semgrep/errors/msgfmt.yml
+++ b/.ci/semgrep/errors/msgfmt.yml
@@ -17,6 +17,7 @@ rules:
 
   # To fix:
   #   find internal/service/*/*.go -print | xargs ruby -p -i -e 'gsub(/diag.Errorf\((")error (.*)\)/, "diag.Errorf(\\1\\2)")'
+  #   find internal/service/*/*.go -print | xargs ruby -p -i -e 'gsub(/diag.Errorf\((")Error (.*)\)/, "diag.Errorf(\\1\\2)")'
   - id: no-diag.Errorf-leading-error
     languages: [go]
     message: Remove leading 'error ' from diag.Errorf("error ...")

--- a/.ci/semgrep/errors/msgfmt.yml
+++ b/.ci/semgrep/errors/msgfmt.yml
@@ -27,3 +27,13 @@ rules:
     patterns:
       - pattern-regex: 'diag.Errorf\("\s*[Ee]rror '
     severity: ERROR
+
+  - id: no-AppendErrorf-leading-error
+    languages: [go]
+    message: Remove leading 'Error ' from AppendErrorf(diags, "Error ...")
+    paths:
+      include:
+        - internal/
+    patterns:
+      - pattern-regex: 'AppendErrorf\(diags, "\s*[Ee]rror '
+    severity: ERROR

--- a/.ci/semgrep/errors/msgfmt.yml
+++ b/.ci/semgrep/errors/msgfmt.yml
@@ -28,6 +28,9 @@ rules:
       - pattern-regex: 'diag.Errorf\("\s*[Ee]rror '
     severity: ERROR
 
+  # To fix:
+  #   find internal/service/*/*.go -print | xargs ruby -p -i -e 'gsub(/AppendErrorf\(diags, (")Error (.*)\)/, "AppendErrorf(diags, \\1\\2)")'
+  #   find internal/service/*/*.go -print | xargs ruby -p -i -e 'gsub(/AppendErrorf\(diags, (")error (.*)\)/, "AppendErrorf(diags, \\1\\2)")'
   - id: no-AppendErrorf-leading-error
     languages: [go]
     message: Remove leading 'Error ' from AppendErrorf(diags, "Error ...")

--- a/internal/service/applicationinsights/application.go
+++ b/internal/service/applicationinsights/application.go
@@ -99,7 +99,7 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	out, err := conn.CreateApplicationWithContext(ctx, input)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating ApplicationInsights Application: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating ApplicationInsights Application: %s", err)
 	}
 
 	d.SetId(aws.StringValue(out.ApplicationInfo.ResourceGroupName))
@@ -178,7 +178,7 @@ func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta
 		log.Printf("[DEBUG] Updating ApplicationInsights Application: %s", d.Id())
 		_, err := conn.UpdateApplicationWithContext(ctx, input)
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "Error Updating ApplicationInsights Application: %s", err)
+			return sdkdiag.AppendErrorf(diags, "updating ApplicationInsights Application (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -199,7 +199,7 @@ func resourceApplicationDelete(ctx context.Context, d *schema.ResourceData, meta
 		if tfawserr.ErrCodeEquals(err, applicationinsights.ErrCodeResourceNotFoundException) {
 			return diags
 		}
-		return sdkdiag.AppendErrorf(diags, "Error deleting ApplicationInsights Application: %s", err)
+		return sdkdiag.AppendErrorf(diags, "deleting ApplicationInsights Application: %s", err)
 	}
 
 	if _, err := waitApplicationTerminated(ctx, conn, d.Id()); err != nil {

--- a/internal/service/appstream/directory_config.go
+++ b/internal/service/appstream/directory_config.go
@@ -78,11 +78,11 @@ func resourceDirectoryConfigCreate(ctx context.Context, d *schema.ResourceData, 
 
 	output, err := conn.CreateDirectoryConfigWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("error creating AppStream Directory Config (%s): %s", directoryName, err)
+		return diag.Errorf("creating AppStream Directory Config (%s): %s", directoryName, err)
 	}
 
 	if output == nil || output.DirectoryConfig == nil {
-		return diag.Errorf("error creating AppStream Directory Config (%s): empty response", directoryName)
+		return diag.Errorf("creating AppStream Directory Config (%s): empty response", directoryName)
 	}
 
 	d.SetId(aws.StringValue(output.DirectoryConfig.DirectoryName))
@@ -102,15 +102,15 @@ func resourceDirectoryConfigRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading AppStream Directory Config (%s): %s", d.Id(), err)
+		return diag.Errorf("reading AppStream Directory Config (%s): %s", d.Id(), err)
 	}
 
 	if len(resp.DirectoryConfigs) == 0 {
-		return diag.Errorf("error reading AppStream Directory Config (%s): %s", d.Id(), "empty response")
+		return diag.Errorf("reading AppStream Directory Config (%s): %s", d.Id(), "empty response")
 	}
 
 	if len(resp.DirectoryConfigs) > 1 {
-		return diag.Errorf("error reading AppStream Directory Config (%s): %s", d.Id(), "multiple Directory Configs found")
+		return diag.Errorf("reading AppStream Directory Config (%s): %s", d.Id(), "multiple Directory Configs found")
 	}
 
 	directoryConfig := resp.DirectoryConfigs[0]
@@ -120,7 +120,7 @@ func resourceDirectoryConfigRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("organizational_unit_distinguished_names", flex.FlattenStringSet(directoryConfig.OrganizationalUnitDistinguishedNames))
 
 	if err = d.Set("service_account_credentials", flattenServiceAccountCredentials(directoryConfig.ServiceAccountCredentials, d)); err != nil {
-		return diag.Errorf("error setting `%s` for AppStream Directory Config (%s): %s", "service_account_credentials", d.Id(), err)
+		return diag.Errorf("setting `%s` for AppStream Directory Config (%s): %s", "service_account_credentials", d.Id(), err)
 	}
 
 	return nil
@@ -142,7 +142,7 @@ func resourceDirectoryConfigUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	_, err := conn.UpdateDirectoryConfigWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("error updating AppStream Directory Config (%s): %s", d.Id(), err)
+		return diag.Errorf("updating AppStream Directory Config (%s): %s", d.Id(), err)
 	}
 
 	return resourceDirectoryConfigRead(ctx, d, meta)
@@ -161,7 +161,7 @@ func resourceDirectoryConfigDelete(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting AppStream Directory Config (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting AppStream Directory Config (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/appstream/fleet.go
+++ b/internal/service/appstream/fleet.go
@@ -285,7 +285,7 @@ func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		output, err = conn.CreateFleetWithContext(ctx, input)
 	}
 	if err != nil {
-		return diag.Errorf("error creating Appstream Fleet (%s): %s", d.Id(), err)
+		return diag.Errorf("creating Appstream Fleet (%s): %s", d.Id(), err)
 	}
 
 	d.SetId(aws.StringValue(output.Fleet.Name))
@@ -295,11 +295,11 @@ func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		Name: aws.String(d.Id()),
 	})
 	if err != nil {
-		return diag.Errorf("error starting Appstream Fleet (%s): %s", d.Id(), err)
+		return diag.Errorf("starting Appstream Fleet (%s): %s", d.Id(), err)
 	}
 
 	if _, err = waitFleetStateRunning(ctx, conn, d.Id()); err != nil {
-		return diag.Errorf("error waiting for Appstream Fleet (%s) to be running: %s", d.Id(), err)
+		return diag.Errorf("waiting for Appstream Fleet (%s) to be running: %s", d.Id(), err)
 	}
 
 	return resourceFleetRead(ctx, d, meta)
@@ -317,15 +317,15 @@ func resourceFleetRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Appstream Fleet (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Appstream Fleet (%s): %s", d.Id(), err)
 	}
 
 	if len(resp.Fleets) == 0 {
-		return diag.Errorf("error reading Appstream Fleet (%s): %s", d.Id(), "empty response")
+		return diag.Errorf("reading Appstream Fleet (%s): %s", d.Id(), "empty response")
 	}
 
 	if len(resp.Fleets) > 1 {
-		return diag.Errorf("error reading Appstream Fleet (%s): %s", d.Id(), "multiple fleets found")
+		return diag.Errorf("reading Appstream Fleet (%s): %s", d.Id(), "multiple fleets found")
 	}
 
 	fleet := resp.Fleets[0]
@@ -393,10 +393,10 @@ func resourceFleetUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			Name: aws.String(d.Id()),
 		})
 		if err != nil {
-			return diag.Errorf("error stopping Appstream Fleet (%s): %s", d.Id(), err)
+			return diag.Errorf("stopping Appstream Fleet (%s): %s", d.Id(), err)
 		}
 		if _, err = waitFleetStateStopped(ctx, conn, d.Id()); err != nil {
-			return diag.Errorf("error waiting for Appstream Fleet (%s) to be stopped: %s", d.Id(), err)
+			return diag.Errorf("waiting for Appstream Fleet (%s) to be stopped: %s", d.Id(), err)
 		}
 	}
 
@@ -458,7 +458,7 @@ func resourceFleetUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	_, err := conn.UpdateFleetWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("error updating Appstream Fleet (%s): %s", d.Id(), err)
+		return diag.Errorf("updating Appstream Fleet (%s): %s", d.Id(), err)
 	}
 
 	// Start fleet workflow if stopped
@@ -467,11 +467,11 @@ func resourceFleetUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			Name: aws.String(d.Id()),
 		})
 		if err != nil {
-			return diag.Errorf("error starting Appstream Fleet (%s): %s", d.Id(), err)
+			return diag.Errorf("starting Appstream Fleet (%s): %s", d.Id(), err)
 		}
 
 		if _, err = waitFleetStateRunning(ctx, conn, d.Id()); err != nil {
-			return diag.Errorf("error waiting for Appstream Fleet (%s) to be running: %s", d.Id(), err)
+			return diag.Errorf("waiting for Appstream Fleet (%s) to be running: %s", d.Id(), err)
 		}
 	}
 
@@ -487,11 +487,11 @@ func resourceFleetDelete(ctx context.Context, d *schema.ResourceData, meta inter
 		Name: aws.String(d.Id()),
 	})
 	if err != nil {
-		return diag.Errorf("error stopping Appstream Fleet (%s): %s", d.Id(), err)
+		return diag.Errorf("stopping Appstream Fleet (%s): %s", d.Id(), err)
 	}
 
 	if _, err = waitFleetStateStopped(ctx, conn, d.Id()); err != nil {
-		return diag.Errorf("error waiting for Appstream Fleet (%s) to be stopped: %s", d.Id(), err)
+		return diag.Errorf("waiting for Appstream Fleet (%s) to be stopped: %s", d.Id(), err)
 	}
 
 	log.Printf("[DEBUG] Deleting AppStream Fleet: (%s)", d.Id())
@@ -504,7 +504,7 @@ func resourceFleetDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Appstream Fleet (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Appstream Fleet (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/appstream/fleet_stack_association.go
+++ b/internal/service/appstream/fleet_stack_association.go
@@ -64,7 +64,7 @@ func resourceFleetStackAssociationCreate(ctx context.Context, d *schema.Resource
 		_, err = conn.AssociateFleetWithContext(ctx, input)
 	}
 	if err != nil {
-		return diag.Errorf("error creating AppStream Fleet Stack Association (%s): %s", d.Id(), err)
+		return diag.Errorf("creating AppStream Fleet Stack Association (%s): %s", d.Id(), err)
 	}
 
 	d.SetId(EncodeStackFleetID(d.Get("fleet_name").(string), d.Get("stack_name").(string)))
@@ -77,7 +77,7 @@ func resourceFleetStackAssociationRead(ctx context.Context, d *schema.ResourceDa
 
 	fleetName, stackName, err := DecodeStackFleetID(d.Id())
 	if err != nil {
-		return diag.Errorf("error decoding AppStream Fleet Stack Association ID (%s): %s", d.Id(), err)
+		return diag.Errorf("decoding AppStream Fleet Stack Association ID (%s): %s", d.Id(), err)
 	}
 
 	err = FindFleetStackAssociation(ctx, conn, fleetName, stackName)
@@ -89,7 +89,7 @@ func resourceFleetStackAssociationRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading AppStream Fleet Stack Association (%s): %s", d.Id(), err)
+		return diag.Errorf("reading AppStream Fleet Stack Association (%s): %s", d.Id(), err)
 	}
 
 	d.Set("fleet_name", fleetName)
@@ -103,7 +103,7 @@ func resourceFleetStackAssociationDelete(ctx context.Context, d *schema.Resource
 
 	fleetName, stackName, err := DecodeStackFleetID(d.Id())
 	if err != nil {
-		return diag.Errorf("error decoding AppStream Fleet Stack Association ID (%s): %s", d.Id(), err)
+		return diag.Errorf("decoding AppStream Fleet Stack Association ID (%s): %s", d.Id(), err)
 	}
 
 	_, err = conn.DisassociateFleetWithContext(ctx, &appstream.DisassociateFleetInput{
@@ -115,7 +115,7 @@ func resourceFleetStackAssociationDelete(ctx context.Context, d *schema.Resource
 		if tfawserr.ErrCodeEquals(err, appstream.ErrCodeResourceNotFoundException) {
 			return nil
 		}
-		return diag.Errorf("error deleting AppStream Fleet Stack Association (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting AppStream Fleet Stack Association (%s): %s", d.Id(), err)
 	}
 	return nil
 }

--- a/internal/service/appstream/user.go
+++ b/internal/service/appstream/user.go
@@ -102,11 +102,11 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	id := EncodeUserID(userName, authType)
 
 	if err != nil {
-		return diag.Errorf("error creating AppStream User (%s): %s", id, err)
+		return diag.Errorf("creating AppStream User (%s): %s", id, err)
 	}
 
 	if _, err = waitUserAvailable(ctx, conn, userName, authType); err != nil {
-		return diag.Errorf("error waiting for AppStream User (%s) to be available: %s", id, err)
+		return diag.Errorf("waiting for AppStream User (%s) to be available: %s", id, err)
 	}
 
 	// Enabling/disabling workflow
@@ -118,7 +118,7 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 
 		_, err = conn.DisableUserWithContext(ctx, input)
 		if err != nil {
-			return diag.Errorf("error disabling AppStream User (%s): %s", id, err)
+			return diag.Errorf("disabling AppStream User (%s): %s", id, err)
 		}
 	}
 
@@ -132,7 +132,7 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	userName, authType, err := DecodeUserID(d.Id())
 	if err != nil {
-		return diag.Errorf("error decoding AppStream User ID (%s): %s", d.Id(), err)
+		return diag.Errorf("decoding AppStream User ID (%s): %s", d.Id(), err)
 	}
 
 	user, err := FindUserByUserNameAndAuthType(ctx, conn, userName, authType)
@@ -142,7 +142,7 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 		return nil
 	}
 	if err != nil {
-		return diag.Errorf("error reading AppStream User (%s): %s", d.Id(), err)
+		return diag.Errorf("reading AppStream User (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", user.Arn)
@@ -162,7 +162,7 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 
 	userName, authType, err := DecodeUserID(d.Id())
 	if err != nil {
-		return diag.Errorf("error decoding AppStream User ID (%s): %s", d.Id(), err)
+		return diag.Errorf("decoding AppStream User ID (%s): %s", d.Id(), err)
 	}
 
 	if d.HasChange("enabled") {
@@ -174,7 +174,7 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 
 			_, err = conn.EnableUserWithContext(ctx, input)
 			if err != nil {
-				return diag.Errorf("error enabling AppStream User (%s): %s", d.Id(), err)
+				return diag.Errorf("enabling AppStream User (%s): %s", d.Id(), err)
 			}
 		} else {
 			input := &appstream.DisableUserInput{
@@ -184,7 +184,7 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 
 			_, err = conn.DisableUserWithContext(ctx, input)
 			if err != nil {
-				return diag.Errorf("error disabling AppStream User (%s): %s", d.Id(), err)
+				return diag.Errorf("disabling AppStream User (%s): %s", d.Id(), err)
 			}
 		}
 	}
@@ -197,7 +197,7 @@ func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interf
 
 	userName, authType, err := DecodeUserID(d.Id())
 	if err != nil {
-		return diag.Errorf("error decoding AppStream User ID (%s): %s", d.Id(), err)
+		return diag.Errorf("decoding AppStream User ID (%s): %s", d.Id(), err)
 	}
 
 	_, err = conn.DeleteUserWithContext(ctx, &appstream.DeleteUserInput{
@@ -209,7 +209,7 @@ func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interf
 		if tfawserr.ErrCodeEquals(err, appstream.ErrCodeResourceNotFoundException) {
 			return nil
 		}
-		return diag.Errorf("error deleting AppStream User (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting AppStream User (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/appstream/user_stack_association.go
+++ b/internal/service/appstream/user_stack_association.go
@@ -72,7 +72,7 @@ func resourceUserStackAssociationCreate(ctx context.Context, d *schema.ResourceD
 	})
 
 	if err != nil {
-		return diag.Errorf("error creating AppStream User Stack Association (%s): %s", id, err)
+		return diag.Errorf("creating AppStream User Stack Association (%s): %s", id, err)
 	}
 	if len(output.Errors) > 0 {
 		var errs *multierror.Error
@@ -80,7 +80,7 @@ func resourceUserStackAssociationCreate(ctx context.Context, d *schema.ResourceD
 		for _, err := range output.Errors {
 			errs = multierror.Append(errs, fmt.Errorf("%s: %s", aws.StringValue(err.ErrorCode), aws.StringValue(err.ErrorMessage)))
 		}
-		return diag.Errorf("error creating AppStream User Stack Association (%s): %s", id, errs)
+		return diag.Errorf("creating AppStream User Stack Association (%s): %s", id, errs)
 	}
 
 	d.SetId(id)
@@ -93,7 +93,7 @@ func resourceUserStackAssociationRead(ctx context.Context, d *schema.ResourceDat
 
 	userName, authType, stackName, err := DecodeUserStackAssociationID(d.Id())
 	if err != nil {
-		return diag.Errorf("error decoding AppStream User Stack Association ID (%s): %s", d.Id(), err)
+		return diag.Errorf("decoding AppStream User Stack Association ID (%s): %s", d.Id(), err)
 	}
 
 	resp, err := conn.DescribeUserStackAssociationsWithContext(ctx,
@@ -110,12 +110,12 @@ func resourceUserStackAssociationRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading AppStream User Stack Association (%s): %s", d.Id(), err)
+		return diag.Errorf("reading AppStream User Stack Association (%s): %s", d.Id(), err)
 	}
 
 	if resp == nil || len(resp.UserStackAssociations) == 0 || resp.UserStackAssociations[0] == nil {
 		if d.IsNewResource() {
-			return diag.Errorf("error reading AppStream User Stack Association (%s): empty output after creation", d.Id())
+			return diag.Errorf("reading AppStream User Stack Association (%s): empty output after creation", d.Id())
 		}
 		log.Printf("[WARN] AppStream User Stack Association (%s) not found, removing from state", d.Id())
 		d.SetId("")
@@ -136,7 +136,7 @@ func resourceUserStackAssociationDelete(ctx context.Context, d *schema.ResourceD
 
 	userName, authType, stackName, err := DecodeUserStackAssociationID(d.Id())
 	if err != nil {
-		return diag.Errorf("error decoding AppStream User Stack Association ID (%s): %s", d.Id(), err)
+		return diag.Errorf("decoding AppStream User Stack Association ID (%s): %s", d.Id(), err)
 	}
 
 	input := &appstream.UserStackAssociation{
@@ -153,7 +153,7 @@ func resourceUserStackAssociationDelete(ctx context.Context, d *schema.ResourceD
 		if tfawserr.ErrCodeEquals(err, appstream.ErrCodeResourceNotFoundException) {
 			return nil
 		}
-		return diag.Errorf("error deleting AppStream User Stack Association (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting AppStream User Stack Association (%s): %s", d.Id(), err)
 	}
 	return nil
 }

--- a/internal/service/appsync/resolver.go
+++ b/internal/service/appsync/resolver.go
@@ -285,11 +285,11 @@ func resourceResolverRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err := d.Set("pipeline_config", flattenPipelineConfig(resolver.PipelineConfig)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error setting pipeline_config: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting pipeline_config: %s", err)
 	}
 
 	if err := d.Set("caching_config", flattenCachingConfig(resolver.CachingConfig)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error setting caching_config: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting caching_config: %s", err)
 	}
 
 	if err := d.Set("runtime", flattenRuntime(resolver.Runtime)); err != nil {

--- a/internal/service/backup/framework_data_source.go
+++ b/internal/service/backup/framework_data_source.go
@@ -110,7 +110,7 @@ func dataSourceFrameworkRead(ctx context.Context, d *schema.ResourceData, meta i
 		FrameworkName: aws.String(name),
 	})
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error getting Backup Framework: %s", err)
+		return sdkdiag.AppendErrorf(diags, "getting Backup Framework: %s", err)
 	}
 
 	d.SetId(aws.StringValue(resp.FrameworkName))

--- a/internal/service/backup/plan_data_source.go
+++ b/internal/service/backup/plan_data_source.go
@@ -50,7 +50,7 @@ func dataSourcePlanRead(ctx context.Context, d *schema.ResourceData, meta interf
 		BackupPlanId: aws.String(id),
 	})
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error getting Backup Plan: %s", err)
+		return sdkdiag.AppendErrorf(diags, "getting Backup Plan: %s", err)
 	}
 
 	d.SetId(aws.StringValue(resp.BackupPlanId))

--- a/internal/service/backup/selection_data_source.go
+++ b/internal/service/backup/selection_data_source.go
@@ -53,7 +53,7 @@ func dataSourceSelectionRead(ctx context.Context, d *schema.ResourceData, meta i
 
 	resp, err := conn.GetBackupSelectionWithContext(ctx, input)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error getting Backup Selection: %s", err)
+		return sdkdiag.AppendErrorf(diags, "getting Backup Selection: %s", err)
 	}
 
 	d.SetId(aws.StringValue(resp.SelectionId))

--- a/internal/service/backup/vault_data_source.go
+++ b/internal/service/backup/vault_data_source.go
@@ -51,7 +51,7 @@ func dataSourceVaultRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	resp, err := conn.DescribeBackupVaultWithContext(ctx, input)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error getting Backup Vault: %s", err)
+		return sdkdiag.AppendErrorf(diags, "getting Backup Vault: %s", err)
 	}
 
 	d.SetId(aws.StringValue(resp.BackupVaultName))

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -107,7 +107,7 @@ func resourceJobQueueCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error waiting for JobQueue state to be \"VALID\": %s", err)
+		return sdkdiag.AppendErrorf(diags, "waiting for JobQueue state to be \"VALID\": %s", err)
 	}
 
 	arn := aws.StringValue(out.JobQueueArn)

--- a/internal/service/ce/anomaly_monitor.go
+++ b/internal/service/ce/anomaly_monitor.go
@@ -93,7 +93,7 @@ func resourceAnomalyMonitorCreate(ctx context.Context, d *schema.ResourceData, m
 			expression := costexplorer.Expression{}
 
 			if err := json.Unmarshal([]byte(v.(string)), &expression); err != nil {
-				return diag.Errorf("Error parsing specification: %s", err)
+				return diag.Errorf("parsing specification: %s", err)
 			}
 
 			input.AnomalyMonitor.MonitorSpecification = &expression
@@ -105,7 +105,7 @@ func resourceAnomalyMonitorCreate(ctx context.Context, d *schema.ResourceData, m
 	resp, err := conn.CreateAnomalyMonitorWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("Error creating Anomaly Monitor: %s", err)
+		return diag.Errorf("creating Anomaly Monitor: %s", err)
 	}
 
 	if resp == nil || resp.MonitorArn == nil {
@@ -135,7 +135,7 @@ func resourceAnomalyMonitorRead(ctx context.Context, d *schema.ResourceData, met
 	if monitor.MonitorSpecification != nil {
 		specificationToJson, err := json.Marshal(monitor.MonitorSpecification)
 		if err != nil {
-			return diag.Errorf("Error parsing specification response: %s", err)
+			return diag.Errorf("parsing specification response: %s", err)
 		}
 		specificationToSet, err := structure.NormalizeJsonString(string(specificationToJson))
 

--- a/internal/service/chime/voice_connector.go
+++ b/internal/service/chime/voice_connector.go
@@ -78,7 +78,7 @@ func resourceVoiceConnectorCreate(ctx context.Context, d *schema.ResourceData, m
 
 	resp, err := conn.CreateVoiceConnectorWithContext(ctx, createInput)
 	if err != nil || resp.VoiceConnector == nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating Chime Voice connector: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Chime Voice connector: %s", err)
 	}
 
 	d.SetId(aws.StringValue(resp.VoiceConnector.VoiceConnectorId))
@@ -107,7 +107,7 @@ func resourceVoiceConnectorRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if err != nil || resp.VoiceConnector == nil {
-		return sdkdiag.AppendErrorf(diags, "Error getting Voice connector (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "getting Voice connector (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", resp.VoiceConnector.VoiceConnectorArn)
@@ -131,7 +131,7 @@ func resourceVoiceConnectorUpdate(ctx context.Context, d *schema.ResourceData, m
 		}
 
 		if _, err := conn.UpdateVoiceConnectorWithContext(ctx, updateInput); err != nil {
-			return sdkdiag.AppendErrorf(diags, "Error updating Voice connector (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Voice connector (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -151,7 +151,7 @@ func resourceVoiceConnectorDelete(ctx context.Context, d *schema.ResourceData, m
 			log.Printf("[WARN] Chime Voice connector %s not found", d.Id())
 			return diags
 		}
-		return sdkdiag.AppendErrorf(diags, "Error deleting Voice connector (%s)", d.Id())
+		return sdkdiag.AppendErrorf(diags, "deleting Voice connector (%s)", d.Id())
 	}
 
 	return diags

--- a/internal/service/chime/voice_connector_group.go
+++ b/internal/service/chime/voice_connector_group.go
@@ -67,7 +67,7 @@ func resourceVoiceConnectorGroupCreate(ctx context.Context, d *schema.ResourceDa
 
 	resp, err := conn.CreateVoiceConnectorGroupWithContext(ctx, input)
 	if err != nil || resp.VoiceConnectorGroup == nil {
-		return diag.Errorf("error creating Chime Voice Connector group: %s", err)
+		return diag.Errorf("creating Chime Voice Connector group: %s", err)
 	}
 
 	d.SetId(aws.StringValue(resp.VoiceConnectorGroup.VoiceConnectorGroupId))
@@ -89,13 +89,13 @@ func resourceVoiceConnectorGroupRead(ctx context.Context, d *schema.ResourceData
 		return nil
 	}
 	if err != nil || resp.VoiceConnectorGroup == nil {
-		return diag.Errorf("error getting Chime Voice Connector group (%s): %s", d.Id(), err)
+		return diag.Errorf("getting Chime Voice Connector group (%s): %s", d.Id(), err)
 	}
 
 	d.Set("name", resp.VoiceConnectorGroup.Name)
 
 	if err := d.Set("connector", flattenVoiceConnectorItems(resp.VoiceConnectorGroup.VoiceConnectorItems)); err != nil {
-		return diag.Errorf("error setting Chime Voice Connector group items (%s): %s", d.Id(), err)
+		return diag.Errorf("setting Chime Voice Connector group items (%s): %s", d.Id(), err)
 	}
 	return nil
 }
@@ -117,7 +117,7 @@ func resourceVoiceConnectorGroupUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if _, err := conn.UpdateVoiceConnectorGroupWithContext(ctx, input); err != nil {
-		return diag.Errorf("error updating Chime Voice Connector group (%s): %s", d.Id(), err)
+		return diag.Errorf("updating Chime Voice Connector group (%s): %s", d.Id(), err)
 	}
 
 	return resourceVoiceConnectorGroupRead(ctx, d, meta)
@@ -141,7 +141,7 @@ func resourceVoiceConnectorGroupDelete(ctx context.Context, d *schema.ResourceDa
 			log.Printf("[WARN] Chime Voice conector group %s not found", d.Id())
 			return nil
 		}
-		return diag.Errorf("error deleting Chime Voice Connector group (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Chime Voice Connector group (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/chime/voice_connector_logging.go
+++ b/internal/service/chime/voice_connector_logging.go
@@ -57,7 +57,7 @@ func resourceVoiceConnectorLoggingCreate(ctx context.Context, d *schema.Resource
 	}
 
 	if _, err := conn.PutVoiceConnectorLoggingConfigurationWithContext(ctx, input); err != nil {
-		return diag.Errorf("error creating Chime Voice Connector (%s) logging configuration: %s", vcId, err)
+		return diag.Errorf("creating Chime Voice Connector (%s) logging configuration: %s", vcId, err)
 	}
 
 	d.SetId(vcId)
@@ -79,7 +79,7 @@ func resourceVoiceConnectorLoggingRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if err != nil || resp.LoggingConfiguration == nil {
-		return diag.Errorf("error getting Chime Voice Connector (%s) logging configuration: %s", d.Id(), err)
+		return diag.Errorf("getting Chime Voice Connector (%s) logging configuration: %s", d.Id(), err)
 	}
 	d.Set("enable_media_metric_logs", resp.LoggingConfiguration.EnableMediaMetricLogs)
 	d.Set("enable_sip_logs", resp.LoggingConfiguration.EnableSIPLogs)
@@ -101,7 +101,7 @@ func resourceVoiceConnectorLoggingUpdate(ctx context.Context, d *schema.Resource
 		}
 
 		if _, err := conn.PutVoiceConnectorLoggingConfigurationWithContext(ctx, input); err != nil {
-			return diag.Errorf("error updating Chime Voice Connector (%s) logging configuration: %s", d.Id(), err)
+			return diag.Errorf("updating Chime Voice Connector (%s) logging configuration: %s", d.Id(), err)
 		}
 	}
 
@@ -126,7 +126,7 @@ func resourceVoiceConnectorLoggingDelete(ctx context.Context, d *schema.Resource
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Chime Voice Connector (%s) logging configuration: %s", d.Id(), err)
+		return diag.Errorf("deleting Chime Voice Connector (%s) logging configuration: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/chime/voice_connector_origination.go
+++ b/internal/service/chime/voice_connector_origination.go
@@ -92,7 +92,7 @@ func resourceVoiceConnectorOriginationCreate(ctx context.Context, d *schema.Reso
 	}
 
 	if _, err := conn.PutVoiceConnectorOriginationWithContext(ctx, input); err != nil {
-		return diag.Errorf("error creating Chime Voice Connector (%s) origination: %s", vcId, err)
+		return diag.Errorf("creating Chime Voice Connector (%s) origination: %s", vcId, err)
 	}
 
 	d.SetId(vcId)
@@ -116,18 +116,18 @@ func resourceVoiceConnectorOriginationRead(ctx context.Context, d *schema.Resour
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting Chime Voice Connector (%s) origination: %s", d.Id(), err)
+		return diag.Errorf("getting Chime Voice Connector (%s) origination: %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.Origination == nil {
-		return diag.Errorf("error getting Chime Voice Connector (%s) origination: empty response", d.Id())
+		return diag.Errorf("getting Chime Voice Connector (%s) origination: empty response", d.Id())
 	}
 
 	d.Set("disabled", resp.Origination.Disabled)
 	d.Set("voice_connector_id", d.Id())
 
 	if err := d.Set("route", flattenOriginationRoutes(resp.Origination.Routes)); err != nil {
-		return diag.Errorf("error setting Chime Voice Connector (%s) origination routes: %s", d.Id(), err)
+		return diag.Errorf("setting Chime Voice Connector (%s) origination routes: %s", d.Id(), err)
 	}
 
 	return nil
@@ -151,7 +151,7 @@ func resourceVoiceConnectorOriginationUpdate(ctx context.Context, d *schema.Reso
 		_, err := conn.PutVoiceConnectorOriginationWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("error updating Chime Voice Connector (%s) origination: %s", d.Id(), err)
+			return diag.Errorf("updating Chime Voice Connector (%s) origination: %s", d.Id(), err)
 		}
 	}
 
@@ -172,7 +172,7 @@ func resourceVoiceConnectorOriginationDelete(ctx context.Context, d *schema.Reso
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Chime Voice Connector (%s) origination: %s", d.Id(), err)
+		return diag.Errorf("deleting Chime Voice Connector (%s) origination: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/chime/voice_connector_streaming.go
+++ b/internal/service/chime/voice_connector_streaming.go
@@ -99,7 +99,7 @@ func resourceVoiceConnectorStreamingCreate(ctx context.Context, d *schema.Resour
 	input.StreamingConfiguration = config
 
 	if _, err := conn.PutVoiceConnectorStreamingConfigurationWithContext(ctx, input); err != nil {
-		return diag.Errorf("error creating Chime Voice Connector (%s) streaming configuration: %s", vcId, err)
+		return diag.Errorf("creating Chime Voice Connector (%s) streaming configuration: %s", vcId, err)
 	}
 
 	d.SetId(vcId)
@@ -122,11 +122,11 @@ func resourceVoiceConnectorStreamingRead(ctx context.Context, d *schema.Resource
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting Chime Voice Connector (%s) streaming: %s", d.Id(), err)
+		return diag.Errorf("getting Chime Voice Connector (%s) streaming: %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.StreamingConfiguration == nil {
-		return diag.Errorf("error getting Chime Voice Connector (%s) streaming: empty response", d.Id())
+		return diag.Errorf("getting Chime Voice Connector (%s) streaming: empty response", d.Id())
 	}
 
 	d.Set("disabled", resp.StreamingConfiguration.Disabled)
@@ -134,11 +134,11 @@ func resourceVoiceConnectorStreamingRead(ctx context.Context, d *schema.Resource
 	d.Set("voice_connector_id", d.Id())
 
 	if err := d.Set("streaming_notification_targets", flattenStreamingNotificationTargets(resp.StreamingConfiguration.StreamingNotificationTargets)); err != nil {
-		return diag.Errorf("error setting Chime Voice Connector streaming configuration targets (%s): %s", d.Id(), err)
+		return diag.Errorf("setting Chime Voice Connector streaming configuration targets (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("media_insights_configuration", flattenMediaInsightsConfiguration(resp.StreamingConfiguration.MediaInsightsConfiguration)); err != nil {
-		return diag.Errorf("error setting Chime Voice Connector streaming configuration media insights configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("setting Chime Voice Connector streaming configuration media insights configuration (%s): %s", d.Id(), err)
 	}
 
 	return nil
@@ -170,7 +170,7 @@ func resourceVoiceConnectorStreamingUpdate(ctx context.Context, d *schema.Resour
 		input.StreamingConfiguration = config
 
 		if _, err := conn.PutVoiceConnectorStreamingConfigurationWithContext(ctx, input); err != nil {
-			return diag.Errorf("error updating Chime Voice Connector (%s) streaming configuration: %s", d.Id(), err)
+			return diag.Errorf("updating Chime Voice Connector (%s) streaming configuration: %s", d.Id(), err)
 		}
 	}
 
@@ -191,7 +191,7 @@ func resourceVoiceConnectorStreamingDelete(ctx context.Context, d *schema.Resour
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Chime Voice Connector (%s) streaming configuration: %s", d.Id(), err)
+		return diag.Errorf("deleting Chime Voice Connector (%s) streaming configuration: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/chime/voice_connector_termination.go
+++ b/internal/service/chime/voice_connector_termination.go
@@ -99,7 +99,7 @@ func resourceVoiceConnectorTerminationCreate(ctx context.Context, d *schema.Reso
 	input.Termination = termination
 
 	if _, err := conn.PutVoiceConnectorTerminationWithContext(ctx, input); err != nil {
-		return diag.Errorf("error creating Chime Voice Connector (%s) termination: %s", vcId, err)
+		return diag.Errorf("creating Chime Voice Connector (%s) termination: %s", vcId, err)
 	}
 
 	d.SetId(vcId)
@@ -123,11 +123,11 @@ func resourceVoiceConnectorTerminationRead(ctx context.Context, d *schema.Resour
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting Chime Voice Connector (%s) termination: %s", d.Id(), err)
+		return diag.Errorf("getting Chime Voice Connector (%s) termination: %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.Termination == nil {
-		return diag.Errorf("error getting Chime Voice Connector (%s) termination: empty response", d.Id())
+		return diag.Errorf("getting Chime Voice Connector (%s) termination: empty response", d.Id())
 	}
 
 	d.Set("cps_limit", resp.Termination.CpsLimit)
@@ -135,10 +135,10 @@ func resourceVoiceConnectorTerminationRead(ctx context.Context, d *schema.Resour
 	d.Set("default_phone_number", resp.Termination.DefaultPhoneNumber)
 
 	if err := d.Set("calling_regions", flex.FlattenStringList(resp.Termination.CallingRegions)); err != nil {
-		return diag.Errorf("error setting termination calling regions (%s): %s", d.Id(), err)
+		return diag.Errorf("setting termination calling regions (%s): %s", d.Id(), err)
 	}
 	if err := d.Set("cidr_allow_list", flex.FlattenStringList(resp.Termination.CidrAllowedList)); err != nil {
-		return diag.Errorf("error setting termination cidr allow list (%s): %s", d.Id(), err)
+		return diag.Errorf("setting termination cidr allow list (%s): %s", d.Id(), err)
 	}
 
 	d.Set("voice_connector_id", d.Id())
@@ -172,7 +172,7 @@ func resourceVoiceConnectorTerminationUpdate(ctx context.Context, d *schema.Reso
 		_, err := conn.PutVoiceConnectorTerminationWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("error updating Chime Voice Connector (%s) termination: %s", d.Id(), err)
+			return diag.Errorf("updating Chime Voice Connector (%s) termination: %s", d.Id(), err)
 		}
 	}
 
@@ -193,7 +193,7 @@ func resourceVoiceConnectorTerminationDelete(ctx context.Context, d *schema.Reso
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Chime Voice Connector termination (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Chime Voice Connector termination (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/chime/voice_connector_termination_credentials.go
+++ b/internal/service/chime/voice_connector_termination_credentials.go
@@ -67,7 +67,7 @@ func resourceVoiceConnectorTerminationCredentialsCreate(ctx context.Context, d *
 	}
 
 	if _, err := conn.PutVoiceConnectorTerminationCredentialsWithContext(ctx, input); err != nil {
-		return diag.Errorf("error creating Chime Voice Connector (%s) termination credentials: %s", vcId, err)
+		return diag.Errorf("creating Chime Voice Connector (%s) termination credentials: %s", vcId, err)
 	}
 
 	d.SetId(vcId)
@@ -90,7 +90,7 @@ func resourceVoiceConnectorTerminationCredentialsRead(ctx context.Context, d *sc
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting Chime Voice Connector (%s) termination credentials: %s", d.Id(), err)
+		return diag.Errorf("getting Chime Voice Connector (%s) termination credentials: %s", d.Id(), err)
 	}
 
 	d.Set("voice_connector_id", d.Id())
@@ -110,7 +110,7 @@ func resourceVoiceConnectorTerminationCredentialsUpdate(ctx context.Context, d *
 		_, err := conn.PutVoiceConnectorTerminationCredentialsWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("error updating Chime Voice Connector (%s) termination credentials: %s", d.Id(), err)
+			return diag.Errorf("updating Chime Voice Connector (%s) termination credentials: %s", d.Id(), err)
 		}
 	}
 
@@ -132,7 +132,7 @@ func resourceVoiceConnectorTerminationCredentialsDelete(ctx context.Context, d *
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Chime Voice Connector (%s) termination credentials: %s", d.Id(), err)
+		return diag.Errorf("deleting Chime Voice Connector (%s) termination credentials: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/cloudformation/type.go
+++ b/internal/service/cloudformation/type.go
@@ -156,17 +156,17 @@ func resourceTypeCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	output, err := conn.RegisterTypeWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error registering CloudFormation Type (%s): %s", typeName, err)
+		return diag.Errorf("registering CloudFormation Type (%s): %s", typeName, err)
 	}
 
 	if output == nil || output.RegistrationToken == nil {
-		return diag.Errorf("error registering CloudFormation Type (%s): empty result", typeName)
+		return diag.Errorf("registering CloudFormation Type (%s): empty result", typeName)
 	}
 
 	registrationOutput, err := WaitTypeRegistrationProgressStatusComplete(ctx, conn, aws.StringValue(output.RegistrationToken))
 
 	if err != nil {
-		return diag.Errorf("error waiting for CloudFormation Type (%s) register: %s", typeName, err)
+		return diag.Errorf("waiting for CloudFormation Type (%s) register: %s", typeName, err)
 	}
 
 	// Type Version ARN is not available until after registration is complete
@@ -187,13 +187,13 @@ func resourceTypeRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading CloudFormation Type (%s): %s", d.Id(), err)
+		return diag.Errorf("reading CloudFormation Type (%s): %s", d.Id(), err)
 	}
 
 	typeARN, versionID, err := TypeVersionARNToTypeARNAndVersionID(d.Id())
 
 	if err != nil {
-		return diag.Errorf("error parsing CloudFormation Type (%s) ARN: %s", d.Id(), err)
+		return diag.Errorf("parsing CloudFormation Type (%s) ARN: %s", d.Id(), err)
 	}
 
 	d.Set("arn", output.Arn)
@@ -205,7 +205,7 @@ func resourceTypeRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	d.Set("is_default_version", output.IsDefaultVersion)
 	if output.LoggingConfig != nil {
 		if err := d.Set("logging_config", []interface{}{flattenLoggingConfig(output.LoggingConfig)}); err != nil {
-			return diag.Errorf("error setting logging_config: %s", err)
+			return diag.Errorf("setting logging_config: %s", err)
 		}
 	} else {
 		d.Set("logging_config", nil)
@@ -237,7 +237,7 @@ func resourceTypeDelete(ctx context.Context, d *schema.ResourceData, meta interf
 		typeARN, _, err := TypeVersionARNToTypeARNAndVersionID(d.Id())
 
 		if err != nil {
-			return diag.Errorf("error parsing CloudFormation Type (%s) ARN: %s", d.Id(), err)
+			return diag.Errorf("parsing CloudFormation Type (%s) ARN: %s", d.Id(), err)
 		}
 
 		input := &cloudformation.ListTypeVersionsInput{
@@ -262,7 +262,7 @@ func resourceTypeDelete(ctx context.Context, d *schema.ResourceData, meta interf
 		})
 
 		if err != nil {
-			return diag.Errorf("error listing CloudFormation Type (%s) Versions: %s", d.Id(), err)
+			return diag.Errorf("listing CloudFormation Type (%s) Versions: %s", d.Id(), err)
 		}
 
 		if len(typeVersionSummaries) <= 1 {
@@ -277,7 +277,7 @@ func resourceTypeDelete(ctx context.Context, d *schema.ResourceData, meta interf
 			}
 
 			if err != nil {
-				return diag.Errorf("error deregistering CloudFormation Type (%s): %s", d.Id(), err)
+				return diag.Errorf("deregistering CloudFormation Type (%s): %s", d.Id(), err)
 			}
 
 			return nil
@@ -289,7 +289,7 @@ func resourceTypeDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if err != nil {
-		return diag.Errorf("error deregistering CloudFormation Type (%s): %s", d.Id(), err)
+		return diag.Errorf("deregistering CloudFormation Type (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/cloudformation/type_data_source.go
+++ b/internal/service/cloudformation/type_data_source.go
@@ -130,11 +130,11 @@ func dataSourceTypeRead(ctx context.Context, d *schema.ResourceData, meta interf
 	output, err := conn.DescribeTypeWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error reading CloudFormation Type: %s", err)
+		return diag.Errorf("reading CloudFormation Type: %s", err)
 	}
 
 	if output == nil {
-		return diag.Errorf("error reading CloudFormation Type: empty response")
+		return diag.Errorf("reading CloudFormation Type: empty response")
 	}
 
 	d.SetId(aws.StringValue(output.Arn))
@@ -148,7 +148,7 @@ func dataSourceTypeRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("is_default_version", output.IsDefaultVersion)
 	if output.LoggingConfig != nil {
 		if err := d.Set("logging_config", []interface{}{flattenLoggingConfig(output.LoggingConfig)}); err != nil {
-			return diag.Errorf("error setting logging_config: %s", err)
+			return diag.Errorf("setting logging_config: %s", err)
 		}
 	} else {
 		d.Set("logging_config", nil)

--- a/internal/service/cloudwatch/dashboard.go
+++ b/internal/service/cloudwatch/dashboard.go
@@ -118,7 +118,7 @@ func resourceDashboardDelete(ctx context.Context, d *schema.ResourceData, meta i
 		if IsDashboardNotFoundErr(err) {
 			return diags
 		}
-		return sdkdiag.AppendErrorf(diags, "Error deleting CloudWatch Dashboard: %s", err)
+		return sdkdiag.AppendErrorf(diags, "deleting CloudWatch Dashboard: %s", err)
 	}
 	log.Printf("[INFO] CloudWatch Dashboard %s deleted", d.Id())
 

--- a/internal/service/codebuild/project.go
+++ b/internal/service/codebuild/project.go
@@ -795,7 +795,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta int
 		resp, err = conn.CreateProjectWithContext(ctx, input)
 	}
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating CodeBuild project: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating CodeBuild project: %s", err)
 	}
 
 	d.SetId(aws.StringValue(resp.Project.Arn))
@@ -812,7 +812,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 		_, err = conn.UpdateProjectVisibilityWithContext(ctx, visInput)
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "Error updating CodeBuild project (%s) visibility: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating CodeBuild project (%s) visibility: %s", d.Id(), err)
 		}
 	}
 	return append(diags, resourceProjectRead(ctx, d, meta)...)
@@ -1385,7 +1385,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		_, err := conn.UpdateProjectVisibilityWithContext(ctx, visInput)
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "Error updating CodeBuild project (%s) visibility: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating CodeBuild project (%s) visibility: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/codebuild/source_credential.go
+++ b/internal/service/codebuild/source_credential.go
@@ -76,7 +76,7 @@ func resourceSourceCredentialCreate(ctx context.Context, d *schema.ResourceData,
 
 	resp, err := conn.ImportSourceCredentialsWithContext(ctx, createOpts)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error importing source credentials: %s", err)
+		return sdkdiag.AppendErrorf(diags, "importing source credentials: %s", err)
 	}
 
 	d.SetId(aws.StringValue(resp.Arn))
@@ -118,7 +118,7 @@ func resourceSourceCredentialDelete(ctx context.Context, d *schema.ResourceData,
 		if tfawserr.ErrCodeEquals(err, codebuild.ErrCodeResourceNotFoundException) {
 			return diags
 		}
-		return sdkdiag.AppendErrorf(diags, "Error deleting CodeBuild Source Credentials(%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting CodeBuild Source Credentials(%s): %s", d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/codecommit/repository.go
+++ b/internal/service/codecommit/repository.go
@@ -89,7 +89,7 @@ func resourceRepositoryCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	out, err := conn.CreateRepositoryWithContext(ctx, input)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating CodeCommit Repository: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating CodeCommit Repository: %s", err)
 	}
 
 	d.SetId(d.Get("repository_name").(string))
@@ -168,7 +168,7 @@ func resourceRepositoryDelete(ctx context.Context, d *schema.ResourceData, meta 
 		RepositoryName: aws.String(d.Id()),
 	})
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error deleting CodeCommit Repository: %s", err.Error())
+		return sdkdiag.AppendErrorf(diags, "deleting CodeCommit Repository: %s", err.Error())
 	}
 
 	return diags

--- a/internal/service/codecommit/repository_data_source.go
+++ b/internal/service/codecommit/repository_data_source.go
@@ -65,7 +65,7 @@ func dataSourceRepositoryRead(ctx context.Context, d *schema.ResourceData, meta 
 			d.SetId("")
 			return sdkdiag.AppendErrorf(diags, "Resource codecommit repository not found for %s", repositoryName)
 		} else {
-			return sdkdiag.AppendErrorf(diags, "Error reading CodeCommit Repository: %s", err)
+			return sdkdiag.AppendErrorf(diags, "reading CodeCommit Repository: %s", err)
 		}
 	}
 

--- a/internal/service/codecommit/trigger.go
+++ b/internal/service/codecommit/trigger.go
@@ -88,7 +88,7 @@ func resourceTriggerCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	resp, err := conn.PutRepositoryTriggersWithContext(ctx, input)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating CodeCommit Trigger: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating CodeCommit Trigger: %s", err)
 	}
 
 	log.Printf("[INFO] Code Commit Trigger Created %s input %s", resp, input)
@@ -109,7 +109,7 @@ func resourceTriggerRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	resp, err := conn.GetRepositoryTriggersWithContext(ctx, input)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error reading CodeCommit Trigger: %s", err.Error())
+		return sdkdiag.AppendErrorf(diags, "reading CodeCommit Trigger: %s", err.Error())
 	}
 
 	log.Printf("[DEBUG] CodeCommit Trigger: %s", resp)

--- a/internal/service/codepipeline/webhook.go
+++ b/internal/service/codepipeline/webhook.go
@@ -143,7 +143,7 @@ func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	webhook, err := conn.PutWebhookWithContext(ctx, request)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating webhook: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating webhook: %s", err)
 	}
 
 	d.SetId(aws.StringValue(webhook.Webhook.Arn))
@@ -220,7 +220,7 @@ func resourceWebhookUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		_, err := conn.PutWebhookWithContext(ctx, request)
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "Error updating webhook: %s", err)
+			return sdkdiag.AppendErrorf(diags, "updating webhook: %s", err)
 		}
 	}
 

--- a/internal/service/cognitoidentity/pool.go
+++ b/internal/service/cognitoidentity/pool.go
@@ -156,7 +156,7 @@ func resourcePoolCreate(ctx context.Context, d *schema.ResourceData, meta interf
 
 	entity, err := conn.CreateIdentityPoolWithContext(ctx, input)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating Cognito Identity Pool: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Cognito Identity Pool: %s", err)
 	}
 
 	d.SetId(aws.StringValue(entity.IdentityPoolId))
@@ -197,19 +197,19 @@ func resourcePoolRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	SetTagsOut(ctx, ip.IdentityPoolTags)
 
 	if err := d.Set("cognito_identity_providers", flattenIdentityProviders(ip.CognitoIdentityProviders)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error setting cognito_identity_providers error: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting cognito_identity_providers error: %s", err)
 	}
 
 	if err := d.Set("openid_connect_provider_arns", flex.FlattenStringList(ip.OpenIdConnectProviderARNs)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error setting openid_connect_provider_arns error: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting openid_connect_provider_arns error: %s", err)
 	}
 
 	if err := d.Set("saml_provider_arns", flex.FlattenStringList(ip.SamlProviderARNs)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error setting saml_provider_arns error: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting saml_provider_arns error: %s", err)
 	}
 
 	if err := d.Set("supported_login_providers", aws.StringValueMap(ip.SupportedLoginProviders)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error setting supported_login_providers error: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting supported_login_providers error: %s", err)
 	}
 
 	return diags
@@ -251,7 +251,7 @@ func resourcePoolDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	})
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error deleting Cognito identity pool (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Cognito identity pool (%s): %s", d.Id(), err)
 	}
 	return diags
 }

--- a/internal/service/cognitoidentity/pool_roles_attachment.go
+++ b/internal/service/cognitoidentity/pool_roles_attachment.go
@@ -114,7 +114,7 @@ func resourcePoolRolesAttachmentCreate(ctx context.Context, d *schema.ResourceDa
 	// Validates role keys to be either authenticated or unauthenticated,
 	// since ValidateFunc validates only the value not the key.
 	if errors := validRoles(d.Get("roles").(map[string]interface{})); len(errors) > 0 {
-		return sdkdiag.AppendErrorf(diags, "Error validating Roles: %v", errors)
+		return sdkdiag.AppendErrorf(diags, "validating Roles: %v", errors)
 	}
 
 	params := &cognitoidentity.SetIdentityPoolRolesInput{
@@ -126,7 +126,7 @@ func resourcePoolRolesAttachmentCreate(ctx context.Context, d *schema.ResourceDa
 		errors := validateRoleMappings(v.(*schema.Set).List())
 
 		if len(errors) > 0 {
-			return sdkdiag.AppendErrorf(diags, "Error validating ambiguous role resolution: %v", errors)
+			return sdkdiag.AppendErrorf(diags, "validating ambiguous role resolution: %v", errors)
 		}
 
 		params.RoleMappings = expandIdentityPoolRoleMappingsAttachment(v.(*schema.Set).List())
@@ -135,7 +135,7 @@ func resourcePoolRolesAttachmentCreate(ctx context.Context, d *schema.ResourceDa
 	log.Printf("[DEBUG] Creating Cognito Identity Pool Roles Association: %#v", params)
 	_, err := conn.SetIdentityPoolRolesWithContext(ctx, params)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating Cognito Identity Pool Roles Association: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Cognito Identity Pool Roles Association: %s", err)
 	}
 
 	d.SetId(d.Get("identity_pool_id").(string))
@@ -164,11 +164,11 @@ func resourcePoolRolesAttachmentRead(ctx context.Context, d *schema.ResourceData
 	d.Set("identity_pool_id", ip.IdentityPoolId)
 
 	if err := d.Set("roles", aws.StringValueMap(ip.Roles)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error setting roles error: %#v", err)
+		return sdkdiag.AppendErrorf(diags, "setting roles error: %#v", err)
 	}
 
 	if err := d.Set("role_mapping", flattenIdentityPoolRoleMappingsAttachment(ip.RoleMappings)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error setting role mappings error: %#v", err)
+		return sdkdiag.AppendErrorf(diags, "setting role mappings error: %#v", err)
 	}
 
 	return diags
@@ -181,7 +181,7 @@ func resourcePoolRolesAttachmentUpdate(ctx context.Context, d *schema.ResourceDa
 	// Validates role keys to be either authenticated or unauthenticated,
 	// since ValidateFunc validates only the value not the key.
 	if errors := validRoles(d.Get("roles").(map[string]interface{})); len(errors) > 0 {
-		return sdkdiag.AppendErrorf(diags, "Error validating Roles: %v", errors)
+		return sdkdiag.AppendErrorf(diags, "validating Roles: %v", errors)
 	}
 
 	params := &cognitoidentity.SetIdentityPoolRolesInput{
@@ -197,7 +197,7 @@ func resourcePoolRolesAttachmentUpdate(ctx context.Context, d *schema.ResourceDa
 			errors := validateRoleMappings(v.(*schema.Set).List())
 
 			if len(errors) > 0 {
-				return sdkdiag.AppendErrorf(diags, "Error validating ambiguous role resolution: %v", errors)
+				return sdkdiag.AppendErrorf(diags, "validating ambiguous role resolution: %v", errors)
 			}
 			mappings = v.(*schema.Set).List()
 		} else {
@@ -210,7 +210,7 @@ func resourcePoolRolesAttachmentUpdate(ctx context.Context, d *schema.ResourceDa
 	log.Printf("[DEBUG] Updating Cognito Identity Pool Roles Association: %#v", params)
 	_, err := conn.SetIdentityPoolRolesWithContext(ctx, params)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error updating Cognito Identity Pool Roles Association: %s", err)
+		return sdkdiag.AppendErrorf(diags, "updating Cognito Identity Pool Roles Association: %s", err)
 	}
 
 	d.SetId(d.Get("identity_pool_id").(string))
@@ -230,7 +230,7 @@ func resourcePoolRolesAttachmentDelete(ctx context.Context, d *schema.ResourceDa
 	})
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error deleting Cognito identity pool roles association: %s", err)
+		return sdkdiag.AppendErrorf(diags, "deleting Cognito identity pool roles association: %s", err)
 	}
 
 	return diags

--- a/internal/service/cognitoidp/identity_provider.go
+++ b/internal/service/cognitoidp/identity_provider.go
@@ -115,7 +115,7 @@ func resourceIdentityProviderCreate(ctx context.Context, d *schema.ResourceData,
 
 	_, err := conn.CreateIdentityProviderWithContext(ctx, params)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating Cognito Identity Provider: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Cognito Identity Provider: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", userPoolID, providerName))

--- a/internal/service/cognitoidp/resource_server.go
+++ b/internal/service/cognitoidp/resource_server.go
@@ -101,7 +101,7 @@ func resourceResourceServerCreate(ctx context.Context, d *schema.ResourceData, m
 	_, err := conn.CreateResourceServerWithContext(ctx, params)
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating Cognito Resource Server: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Cognito Resource Server: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s|%s", userPoolID, identifier))

--- a/internal/service/cognitoidp/user_group.go
+++ b/internal/service/cognitoidp/user_group.go
@@ -89,7 +89,7 @@ func resourceUserGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	resp, err := conn.CreateGroupWithContext(ctx, params)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating Cognito User Group: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Cognito User Group: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", *resp.Group.UserPoolId, *resp.Group.GroupName))
@@ -151,7 +151,7 @@ func resourceUserGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 
 	_, err := conn.UpdateGroupWithContext(ctx, params)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error updating Cognito User Group: %s", err)
+		return sdkdiag.AppendErrorf(diags, "updating Cognito User Group: %s", err)
 	}
 
 	return append(diags, resourceUserGroupRead(ctx, d, meta)...)
@@ -170,7 +170,7 @@ func resourceUserGroupDelete(ctx context.Context, d *schema.ResourceData, meta i
 
 	_, err := conn.DeleteGroupWithContext(ctx, params)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error deleting Cognito User Group: %s", err)
+		return sdkdiag.AppendErrorf(diags, "deleting Cognito User Group: %s", err)
 	}
 
 	return diags

--- a/internal/service/cognitoidp/user_pool_clients_data_source.go
+++ b/internal/service/cognitoidp/user_pool_clients_data_source.go
@@ -67,7 +67,7 @@ func dataSourceuserPoolClientsRead(ctx context.Context, d *schema.ResourceData, 
 	})
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error getting user pool clients: %s", err)
+		return sdkdiag.AppendErrorf(diags, "getting user pool clients: %s", err)
 	}
 
 	d.SetId(userPoolID)

--- a/internal/service/configservice/aggregate_authorization.go
+++ b/internal/service/configservice/aggregate_authorization.go
@@ -70,7 +70,7 @@ func resourceAggregateAuthorizationPut(ctx context.Context, d *schema.ResourceDa
 
 	_, err := conn.PutAggregationAuthorizationWithContext(ctx, input)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating aggregate authorization: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating aggregate authorization: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", accountId, region))

--- a/internal/service/configservice/config_rule.go
+++ b/internal/service/configservice/config_rule.go
@@ -229,7 +229,7 @@ func resourceRulePutConfig(ctx context.Context, d *schema.ResourceData, meta int
 		_, err = conn.PutConfigRuleWithContext(ctx, &input)
 	}
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating AWSConfig rule: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating AWSConfig rule: %s", err)
 	}
 
 	d.SetId(name)

--- a/internal/service/connect/bot_association.go
+++ b/internal/service/connect/bot_association.go
@@ -113,7 +113,7 @@ func resourceBotAssociationCreate(ctx context.Context, d *schema.ResourceData, m
 	lbaId := BotV1AssociationCreateResourceID(instanceId, aws.StringValue(input.LexBot.Name), aws.StringValue(input.LexBot.LexRegion))
 
 	if err != nil {
-		return diag.Errorf("error creating Connect Bot Association (%s): %s", lbaId, err)
+		return diag.Errorf("creating Connect Bot Association (%s): %s", lbaId, err)
 	}
 
 	d.SetId(lbaId)
@@ -139,16 +139,16 @@ func resourceBotAssociationRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Connect Bot Association (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Connect Bot Association (%s): %s", d.Id(), err)
 	}
 
 	if lexBot == nil {
-		return diag.Errorf("error reading Connect Bot Association (%s): empty output", d.Id())
+		return diag.Errorf("reading Connect Bot Association (%s): empty output", d.Id())
 	}
 
 	d.Set("instance_id", instanceId)
 	if err := d.Set("lex_bot", flattenLexBot(lexBot)); err != nil {
-		return diag.Errorf("error setting lex_bot: %s", err)
+		return diag.Errorf("setting lex_bot: %s", err)
 	}
 
 	return nil
@@ -180,7 +180,7 @@ func resourceBotAssociationDelete(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Connect Bot Association (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Connect Bot Association (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/connect/bot_association_data_source.go
+++ b/internal/service/connect/bot_association_data_source.go
@@ -56,18 +56,18 @@ func dataSourceBotAssociationRead(ctx context.Context, d *schema.ResourceData, m
 
 	lexBot, err := FindBotAssociationV1ByNameAndRegionWithContext(ctx, conn, instanceID, name, region)
 	if err != nil {
-		return diag.Errorf("error finding Connect Bot Association (%s,%s): %s", instanceID, name, err)
+		return diag.Errorf("finding Connect Bot Association (%s,%s): %s", instanceID, name, err)
 	}
 
 	if lexBot == nil {
-		return diag.Errorf("error finding Connect Bot Association (%s,%s) : not found", instanceID, name)
+		return diag.Errorf("finding Connect Bot Association (%s,%s) : not found", instanceID, name)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)
 
 	d.Set("instance_id", instanceID)
 	if err := d.Set("lex_bot", flattenLexBot(lexBot)); err != nil {
-		return diag.Errorf("error setting lex_bot: %s", err)
+		return diag.Errorf("setting lex_bot: %s", err)
 	}
 
 	return nil

--- a/internal/service/connect/contact_flow.go
+++ b/internal/service/connect/contact_flow.go
@@ -126,11 +126,11 @@ func resourceContactFlowCreate(ctx context.Context, d *schema.ResourceData, meta
 	output, err := conn.CreateContactFlowWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Connect Contact Flow (%s): %s", name, err)
+		return diag.Errorf("creating Connect Contact Flow (%s): %s", name, err)
 	}
 
 	if output == nil {
-		return diag.Errorf("error creating Connect Contact Flow (%s): empty output", name)
+		return diag.Errorf("creating Connect Contact Flow (%s): empty output", name)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(output.ContactFlowId)))
@@ -159,11 +159,11 @@ func resourceContactFlowRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting Connect Contact Flow (%s): %s", d.Id(), err)
+		return diag.Errorf("getting Connect Contact Flow (%s): %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.ContactFlow == nil {
-		return diag.Errorf("error getting Connect Contact Flow (%s): empty response", d.Id())
+		return diag.Errorf("getting Connect Contact Flow (%s): empty response", d.Id())
 	}
 
 	d.Set("arn", resp.ContactFlow.Arn)
@@ -199,7 +199,7 @@ func resourceContactFlowUpdate(ctx context.Context, d *schema.ResourceData, meta
 		_, updateMetadataInputErr := conn.UpdateContactFlowNameWithContext(ctx, updateMetadataInput)
 
 		if updateMetadataInputErr != nil {
-			return diag.Errorf("error updating Connect Contact Flow (%s): %s", d.Id(), updateMetadataInputErr)
+			return diag.Errorf("updating Connect Contact Flow (%s): %s", d.Id(), updateMetadataInputErr)
 		}
 	}
 
@@ -228,7 +228,7 @@ func resourceContactFlowUpdate(ctx context.Context, d *schema.ResourceData, meta
 		_, updateContentInputErr := conn.UpdateContactFlowContentWithContext(ctx, updateContentInput)
 
 		if updateContentInputErr != nil {
-			return diag.Errorf("error updating Connect Contact Flow content (%s): %s", d.Id(), updateContentInputErr)
+			return diag.Errorf("updating Connect Contact Flow content (%s): %s", d.Id(), updateContentInputErr)
 		}
 	}
 
@@ -254,7 +254,7 @@ func resourceContactFlowDelete(ctx context.Context, d *schema.ResourceData, meta
 	_, deleteContactFlowErr := conn.DeleteContactFlowWithContext(ctx, input)
 
 	if deleteContactFlowErr != nil {
-		return diag.Errorf("error deleting Connect Contact Flow (%s): %s", d.Id(), deleteContactFlowErr)
+		return diag.Errorf("deleting Connect Contact Flow (%s): %s", d.Id(), deleteContactFlowErr)
 	}
 
 	return nil

--- a/internal/service/connect/contact_flow_data_source.go
+++ b/internal/service/connect/contact_flow_data_source.go
@@ -71,11 +71,11 @@ func dataSourceContactFlowRead(ctx context.Context, d *schema.ResourceData, meta
 		contactFlowSummary, err := dataSourceGetContactFlowSummaryByName(ctx, conn, instanceID, name)
 
 		if err != nil {
-			return diag.Errorf("error finding Connect Contact Flow Summary by name (%s): %s", name, err)
+			return diag.Errorf("finding Connect Contact Flow Summary by name (%s): %s", name, err)
 		}
 
 		if contactFlowSummary == nil {
-			return diag.Errorf("error finding Connect Contact Flow Summary by name (%s): not found", name)
+			return diag.Errorf("finding Connect Contact Flow Summary by name (%s): not found", name)
 		}
 
 		input.ContactFlowId = contactFlowSummary.Id
@@ -84,11 +84,11 @@ func dataSourceContactFlowRead(ctx context.Context, d *schema.ResourceData, meta
 	resp, err := conn.DescribeContactFlowWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error getting Connect Contact Flow: %s", err)
+		return diag.Errorf("getting Connect Contact Flow: %s", err)
 	}
 
 	if resp == nil || resp.ContactFlow == nil {
-		return diag.Errorf("error getting Connect Contact Flow: empty response")
+		return diag.Errorf("getting Connect Contact Flow: empty response")
 	}
 
 	contactFlow := resp.ContactFlow
@@ -102,7 +102,7 @@ func dataSourceContactFlowRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("type", contactFlow.Type)
 
 	if err := d.Set("tags", KeyValueTags(ctx, contactFlow.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(contactFlow.Id)))

--- a/internal/service/connect/contact_flow_module.go
+++ b/internal/service/connect/contact_flow_module.go
@@ -120,11 +120,11 @@ func resourceContactFlowModuleCreate(ctx context.Context, d *schema.ResourceData
 	output, err := conn.CreateContactFlowModuleWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Connect Contact Flow Module (%s): %s", name, err)
+		return diag.Errorf("creating Connect Contact Flow Module (%s): %s", name, err)
 	}
 
 	if output == nil {
-		return diag.Errorf("error creating Connect Contact Flow Module (%s): empty output", name)
+		return diag.Errorf("creating Connect Contact Flow Module (%s): empty output", name)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(output.Id)))
@@ -153,11 +153,11 @@ func resourceContactFlowModuleRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting Connect Contact Flow Module (%s): %s", d.Id(), err)
+		return diag.Errorf("getting Connect Contact Flow Module (%s): %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.ContactFlowModule == nil {
-		return diag.Errorf("error getting Connect Contact Flow Module (%s): empty response", d.Id())
+		return diag.Errorf("getting Connect Contact Flow Module (%s): empty response", d.Id())
 	}
 
 	d.Set("arn", resp.ContactFlowModule.Arn)
@@ -192,7 +192,7 @@ func resourceContactFlowModuleUpdate(ctx context.Context, d *schema.ResourceData
 		_, updateMetadataInputErr := conn.UpdateContactFlowModuleMetadataWithContext(ctx, updateMetadataInput)
 
 		if updateMetadataInputErr != nil {
-			return diag.Errorf("error updating Connect Contact Flow Module (%s): %s", d.Id(), updateMetadataInputErr)
+			return diag.Errorf("updating Connect Contact Flow Module (%s): %s", d.Id(), updateMetadataInputErr)
 		}
 	}
 
@@ -221,7 +221,7 @@ func resourceContactFlowModuleUpdate(ctx context.Context, d *schema.ResourceData
 		_, updateContentInputErr := conn.UpdateContactFlowModuleContentWithContext(ctx, updateContentInput)
 
 		if updateContentInputErr != nil {
-			return diag.Errorf("error updating Connect Contact Flow Module content (%s): %s", d.Id(), updateContentInputErr)
+			return diag.Errorf("updating Connect Contact Flow Module content (%s): %s", d.Id(), updateContentInputErr)
 		}
 	}
 
@@ -243,7 +243,7 @@ func resourceContactFlowModuleDelete(ctx context.Context, d *schema.ResourceData
 
 	_, deleteContactFlowModuleErr := conn.DeleteContactFlowModuleWithContext(ctx, input)
 	if deleteContactFlowModuleErr != nil {
-		return diag.Errorf("error deleting Connect Contact Flow Module (%s): %s", d.Id(), deleteContactFlowModuleErr)
+		return diag.Errorf("deleting Connect Contact Flow Module (%s): %s", d.Id(), deleteContactFlowModuleErr)
 	}
 	return nil
 }

--- a/internal/service/connect/contact_flow_module_data_source.go
+++ b/internal/service/connect/contact_flow_module_data_source.go
@@ -75,11 +75,11 @@ func dataSourceContactFlowModuleRead(ctx context.Context, d *schema.ResourceData
 		contactFlowModuleSummary, err := dataSourceGetContactFlowModuleSummaryByName(ctx, conn, instanceID, name)
 
 		if err != nil {
-			return diag.Errorf("error finding Connect Contact Flow Module Summary by name (%s): %s", name, err)
+			return diag.Errorf("finding Connect Contact Flow Module Summary by name (%s): %s", name, err)
 		}
 
 		if contactFlowModuleSummary == nil {
-			return diag.Errorf("error finding Connect Contact Flow Module Summary by name (%s): not found", name)
+			return diag.Errorf("finding Connect Contact Flow Module Summary by name (%s): not found", name)
 		}
 
 		input.ContactFlowModuleId = contactFlowModuleSummary.Id
@@ -88,11 +88,11 @@ func dataSourceContactFlowModuleRead(ctx context.Context, d *schema.ResourceData
 	resp, err := conn.DescribeContactFlowModuleWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error getting Connect Contact Flow Module: %s", err)
+		return diag.Errorf("getting Connect Contact Flow Module: %s", err)
 	}
 
 	if resp == nil || resp.ContactFlowModule == nil {
-		return diag.Errorf("error getting Connect Contact Flow Module: empty response")
+		return diag.Errorf("getting Connect Contact Flow Module: empty response")
 	}
 
 	contactFlowModule := resp.ContactFlowModule
@@ -106,7 +106,7 @@ func dataSourceContactFlowModuleRead(ctx context.Context, d *schema.ResourceData
 	d.Set("status", contactFlowModule.Status)
 
 	if err := d.Set("tags", KeyValueTags(ctx, contactFlowModule.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(contactFlowModule.Id)))

--- a/internal/service/connect/hours_of_operation.go
+++ b/internal/service/connect/hours_of_operation.go
@@ -146,11 +146,11 @@ func resourceHoursOfOperationCreate(ctx context.Context, d *schema.ResourceData,
 	output, err := conn.CreateHoursOfOperationWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Connect Hours of Operation (%s): %s", name, err)
+		return diag.Errorf("creating Connect Hours of Operation (%s): %s", name, err)
 	}
 
 	if output == nil {
-		return diag.Errorf("error creating Connect Hours of Operation (%s): empty output", name)
+		return diag.Errorf("creating Connect Hours of Operation (%s): empty output", name)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(output.HoursOfOperationId)))
@@ -179,11 +179,11 @@ func resourceHoursOfOperationRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting Connect Hours of Operation (%s): %s", d.Id(), err)
+		return diag.Errorf("getting Connect Hours of Operation (%s): %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.HoursOfOperation == nil {
-		return diag.Errorf("error getting Connect Hours of Operation (%s): empty response", d.Id())
+		return diag.Errorf("getting Connect Hours of Operation (%s): empty response", d.Id())
 	}
 
 	if err := d.Set("config", flattenConfigs(resp.HoursOfOperation.Config)); err != nil {
@@ -243,7 +243,7 @@ func resourceHoursOfOperationDelete(ctx context.Context, d *schema.ResourceData,
 	})
 
 	if err != nil {
-		return diag.Errorf("error deleting HoursOfOperation (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting HoursOfOperation (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/connect/hours_of_operation_data_source.go
+++ b/internal/service/connect/hours_of_operation_data_source.go
@@ -121,11 +121,11 @@ func dataSourceHoursOfOperationRead(ctx context.Context, d *schema.ResourceData,
 		hoursOfOperationSummary, err := dataSourceGetHoursOfOperationSummaryByName(ctx, conn, instanceID, name)
 
 		if err != nil {
-			return diag.Errorf("error finding Connect Hours of Operation Summary by name (%s): %s", name, err)
+			return diag.Errorf("finding Connect Hours of Operation Summary by name (%s): %s", name, err)
 		}
 
 		if hoursOfOperationSummary == nil {
-			return diag.Errorf("error finding Connect Hours of Operation Summary by name (%s): not found", name)
+			return diag.Errorf("finding Connect Hours of Operation Summary by name (%s): not found", name)
 		}
 
 		input.HoursOfOperationId = hoursOfOperationSummary.Id
@@ -134,11 +134,11 @@ func dataSourceHoursOfOperationRead(ctx context.Context, d *schema.ResourceData,
 	resp, err := conn.DescribeHoursOfOperationWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error getting Connect Hours of Operation: %s", err)
+		return diag.Errorf("getting Connect Hours of Operation: %s", err)
 	}
 
 	if resp == nil || resp.HoursOfOperation == nil {
-		return diag.Errorf("error getting Connect Hours of Operation: empty response")
+		return diag.Errorf("getting Connect Hours of Operation: empty response")
 	}
 
 	hoursOfOperation := resp.HoursOfOperation
@@ -151,11 +151,11 @@ func dataSourceHoursOfOperationRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("time_zone", hoursOfOperation.TimeZone)
 
 	if err := d.Set("config", flattenConfigs(hoursOfOperation.Config)); err != nil {
-		return diag.Errorf("error setting config: %s", err)
+		return diag.Errorf("setting config: %s", err)
 	}
 
 	if err := d.Set("tags", KeyValueTags(ctx, hoursOfOperation.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(hoursOfOperation.HoursOfOperationId)))

--- a/internal/service/connect/instance_data_source.go
+++ b/internal/service/connect/instance_data_source.go
@@ -105,11 +105,11 @@ func dataSourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta in
 		instanceSummary, err := dataSourceGetInstanceSummaryByInstanceAlias(ctx, conn, instanceAlias)
 
 		if err != nil {
-			return diag.Errorf("error finding Connect Instance Summary by instance_alias (%s): %s", instanceAlias, err)
+			return diag.Errorf("finding Connect Instance Summary by instance_alias (%s): %s", instanceAlias, err)
 		}
 
 		if instanceSummary == nil {
-			return diag.Errorf("error finding Connect Instance Summary by instance_alias (%s): not found", instanceAlias)
+			return diag.Errorf("finding Connect Instance Summary by instance_alias (%s): not found", instanceAlias)
 		}
 
 		matchedInstance = &connect.Instance{
@@ -144,7 +144,7 @@ func dataSourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta in
 	for att := range InstanceAttributeMapping() {
 		value, err := dataSourceInstanceReadAttribute(ctx, conn, d.Id(), att)
 		if err != nil {
-			return diag.Errorf("error reading Connect Instance (%s) attribute (%s): %s", d.Id(), att, err)
+			return diag.Errorf("reading Connect Instance (%s) attribute (%s): %s", d.Id(), att, err)
 		}
 		d.Set(InstanceAttributeMapping()[att], value)
 	}

--- a/internal/service/connect/lambda_function_association.go
+++ b/internal/service/connect/lambda_function_association.go
@@ -52,7 +52,7 @@ func resourceLambdaFunctionAssociationCreate(ctx context.Context, d *schema.Reso
 
 	_, err := conn.AssociateLambdaFunctionWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("error creating Connect Lambda Function Association (%s,%s): %s", instanceId, functionArn, err)
+		return diag.Errorf("creating Connect Lambda Function Association (%s,%s): %s", instanceId, functionArn, err)
 	}
 
 	d.SetId(LambdaFunctionAssociationCreateResourceID(instanceId, functionArn))
@@ -78,7 +78,7 @@ func resourceLambdaFunctionAssociationRead(ctx context.Context, d *schema.Resour
 	}
 
 	if err != nil {
-		return diag.Errorf("error finding Connect Lambda Function Association by Function ARN (%s): %s", functionArn, err)
+		return diag.Errorf("finding Connect Lambda Function Association by Function ARN (%s): %s", functionArn, err)
 	}
 
 	d.Set("function_arn", lfaArn)
@@ -107,7 +107,7 @@ func resourceLambdaFunctionAssociationDelete(ctx context.Context, d *schema.Reso
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Connect Lambda Function Association (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Connect Lambda Function Association (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/connect/lambda_function_association_data_source.go
+++ b/internal/service/connect/lambda_function_association_data_source.go
@@ -34,11 +34,11 @@ func dataSourceLambdaFunctionAssociationRead(ctx context.Context, d *schema.Reso
 
 	lfaArn, err := FindLambdaFunctionAssociationByARNWithContext(ctx, conn, instanceID.(string), functionArn.(string))
 	if err != nil {
-		return diag.Errorf("error finding Connect Lambda Function Association by ARN (%s): %s", functionArn, err)
+		return diag.Errorf("finding Connect Lambda Function Association by ARN (%s): %s", functionArn, err)
 	}
 
 	if lfaArn == "" {
-		return diag.Errorf("error finding Connect Lambda Function Association by ARN (%s): not found", functionArn)
+		return diag.Errorf("finding Connect Lambda Function Association by ARN (%s): not found", functionArn)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)

--- a/internal/service/connect/prompt_data_source.go
+++ b/internal/service/connect/prompt_data_source.go
@@ -45,11 +45,11 @@ func dataSourcePromptRead(ctx context.Context, d *schema.ResourceData, meta inte
 	promptSummary, err := dataSourceGetPromptSummaryByName(ctx, conn, instanceID, name)
 
 	if err != nil {
-		return diag.Errorf("error finding Connect Prompt Summary by name (%s): %s", name, err)
+		return diag.Errorf("finding Connect Prompt Summary by name (%s): %s", name, err)
 	}
 
 	if promptSummary == nil {
-		return diag.Errorf("error finding Connect Prompt Summary by name (%s): not found", name)
+		return diag.Errorf("finding Connect Prompt Summary by name (%s): not found", name)
 	}
 
 	d.Set("arn", promptSummary.Arn)

--- a/internal/service/connect/queue.go
+++ b/internal/service/connect/queue.go
@@ -146,11 +146,11 @@ func resourceQueueCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	output, err := conn.CreateQueueWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Connect Queue (%s): %s", name, err)
+		return diag.Errorf("creating Connect Queue (%s): %s", name, err)
 	}
 
 	if output == nil {
-		return diag.Errorf("error creating Connect Queue (%s): empty output", name)
+		return diag.Errorf("creating Connect Queue (%s): empty output", name)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(output.QueueId)))
@@ -179,11 +179,11 @@ func resourceQueueRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting Connect Queue (%s): %s", d.Id(), err)
+		return diag.Errorf("getting Connect Queue (%s): %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.Queue == nil {
-		return diag.Errorf("error getting Connect Queue (%s): empty response", d.Id())
+		return diag.Errorf("getting Connect Queue (%s): empty response", d.Id())
 	}
 
 	if err := d.Set("outbound_caller_config", flattenOutboundCallerConfig(resp.Queue.OutboundCallerConfig)); err != nil {
@@ -203,7 +203,7 @@ func resourceQueueRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	quickConnectIds, err := getQueueQuickConnectIDs(ctx, conn, instanceID, queueID)
 
 	if err != nil {
-		return diag.Errorf("error finding Connect Queue Quick Connect ID for Queue (%s): %s", queueID, err)
+		return diag.Errorf("finding Connect Queue Quick Connect ID for Queue (%s): %s", queueID, err)
 	}
 
 	d.Set("quick_connect_ids", aws.StringValueSlice(quickConnectIds))

--- a/internal/service/connect/queue_data_source.go
+++ b/internal/service/connect/queue_data_source.go
@@ -97,11 +97,11 @@ func dataSourceQueueRead(ctx context.Context, d *schema.ResourceData, meta inter
 		queueSummary, err := dataSourceGetQueueSummaryByName(ctx, conn, instanceID, name)
 
 		if err != nil {
-			return diag.Errorf("error finding Connect Queue Summary by name (%s): %s", name, err)
+			return diag.Errorf("finding Connect Queue Summary by name (%s): %s", name, err)
 		}
 
 		if queueSummary == nil {
-			return diag.Errorf("error finding Connect Queue Summary by name (%s): not found", name)
+			return diag.Errorf("finding Connect Queue Summary by name (%s): not found", name)
 		}
 
 		input.QueueId = queueSummary.Id
@@ -110,11 +110,11 @@ func dataSourceQueueRead(ctx context.Context, d *schema.ResourceData, meta inter
 	resp, err := conn.DescribeQueueWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error getting Connect Queue: %s", err)
+		return diag.Errorf("getting Connect Queue: %s", err)
 	}
 
 	if resp == nil || resp.Queue == nil {
-		return diag.Errorf("error getting Connect Queue: empty response")
+		return diag.Errorf("getting Connect Queue: empty response")
 	}
 
 	queue := resp.Queue
@@ -128,11 +128,11 @@ func dataSourceQueueRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("status", queue.Status)
 
 	if err := d.Set("outbound_caller_config", flattenOutboundCallerConfig(queue.OutboundCallerConfig)); err != nil {
-		return diag.Errorf("error setting outbound_caller_config: %s", err)
+		return diag.Errorf("setting outbound_caller_config: %s", err)
 	}
 
 	if err := d.Set("tags", KeyValueTags(ctx, queue.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(queue.QueueId)))

--- a/internal/service/connect/quick_connect.go
+++ b/internal/service/connect/quick_connect.go
@@ -156,11 +156,11 @@ func resourceQuickConnectCreate(ctx context.Context, d *schema.ResourceData, met
 	output, err := conn.CreateQuickConnectWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Connect Quick Connect (%s): %s", name, err)
+		return diag.Errorf("creating Connect Quick Connect (%s): %s", name, err)
 	}
 
 	if output == nil {
-		return diag.Errorf("error creating Connect Quick Connect (%s): empty output", name)
+		return diag.Errorf("creating Connect Quick Connect (%s): empty output", name)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(output.QuickConnectId)))
@@ -189,11 +189,11 @@ func resourceQuickConnectRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting Connect Quick Connect (%s): %s", d.Id(), err)
+		return diag.Errorf("getting Connect Quick Connect (%s): %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.QuickConnect == nil {
-		return diag.Errorf("error getting Connect Quick Connect (%s): empty response", d.Id())
+		return diag.Errorf("getting Connect Quick Connect (%s): empty response", d.Id())
 	}
 
 	if err := d.Set("quick_connect_config", flattenQuickConnectConfig(resp.QuickConnect.QuickConnectConfig)); err != nil {
@@ -275,7 +275,7 @@ func resourceQuickConnectDelete(ctx context.Context, d *schema.ResourceData, met
 	})
 
 	if err != nil {
-		return diag.Errorf("error deleting QuickConnect (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting QuickConnect (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/connect/quick_connect_data_source.go
+++ b/internal/service/connect/quick_connect_data_source.go
@@ -121,11 +121,11 @@ func dataSourceQuickConnectRead(ctx context.Context, d *schema.ResourceData, met
 		quickConnectSummary, err := dataSourceGetQuickConnectSummaryByName(ctx, conn, instanceID, name)
 
 		if err != nil {
-			return diag.Errorf("error finding Connect Quick Connect Summary by name (%s): %s", name, err)
+			return diag.Errorf("finding Connect Quick Connect Summary by name (%s): %s", name, err)
 		}
 
 		if quickConnectSummary == nil {
-			return diag.Errorf("error finding Connect Quick Connect Summary by name (%s): not found", name)
+			return diag.Errorf("finding Connect Quick Connect Summary by name (%s): not found", name)
 		}
 
 		input.QuickConnectId = quickConnectSummary.Id
@@ -134,11 +134,11 @@ func dataSourceQuickConnectRead(ctx context.Context, d *schema.ResourceData, met
 	resp, err := conn.DescribeQuickConnectWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error getting Connect Quick Connect: %s", err)
+		return diag.Errorf("getting Connect Quick Connect: %s", err)
 	}
 
 	if resp == nil || resp.QuickConnect == nil {
-		return diag.Errorf("error getting Connect Quick Connect: empty response")
+		return diag.Errorf("getting Connect Quick Connect: empty response")
 	}
 
 	quickConnect := resp.QuickConnect
@@ -149,11 +149,11 @@ func dataSourceQuickConnectRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("quick_connect_id", quickConnect.QuickConnectId)
 
 	if err := d.Set("quick_connect_config", flattenQuickConnectConfig(quickConnect.QuickConnectConfig)); err != nil {
-		return diag.Errorf("error setting quick_connect_config: %s", err)
+		return diag.Errorf("setting quick_connect_config: %s", err)
 	}
 
 	if err := d.Set("tags", KeyValueTags(ctx, quickConnect.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(quickConnect.QuickConnectId)))

--- a/internal/service/connect/routing_profile.go
+++ b/internal/service/connect/routing_profile.go
@@ -152,11 +152,11 @@ func resourceRoutingProfileCreate(ctx context.Context, d *schema.ResourceData, m
 	output, err := conn.CreateRoutingProfileWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Connect Routing Profile (%s): %s", name, err)
+		return diag.Errorf("creating Connect Routing Profile (%s): %s", name, err)
 	}
 
 	if output == nil {
-		return diag.Errorf("error creating Connect Routing Profile (%s): empty output", name)
+		return diag.Errorf("creating Connect Routing Profile (%s): empty output", name)
 	}
 
 	// call the batched association API if the number of queues to associate with the routing profile is > CreateRoutingProfileQueuesMaxItems
@@ -195,11 +195,11 @@ func resourceRoutingProfileRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting Connect Routing Profile (%s): %s", d.Id(), err)
+		return diag.Errorf("getting Connect Routing Profile (%s): %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.RoutingProfile == nil {
-		return diag.Errorf("error getting Connect Routing Profile (%s): empty response", d.Id())
+		return diag.Errorf("getting Connect Routing Profile (%s): empty response", d.Id())
 	}
 
 	routingProfile := resp.RoutingProfile
@@ -220,7 +220,7 @@ func resourceRoutingProfileRead(ctx context.Context, d *schema.ResourceData, met
 	queueConfigs, err := getRoutingProfileQueueConfigs(ctx, conn, instanceID, routingProfileID)
 
 	if err != nil {
-		return diag.Errorf("error finding Connect Routing Profile Queue Configs Summary by Routing Profile ID (%s): %s", routingProfileID, err)
+		return diag.Errorf("finding Connect Routing Profile Queue Configs Summary by Routing Profile ID (%s): %s", routingProfileID, err)
 	}
 
 	d.Set("queue_configs", queueConfigs)
@@ -385,7 +385,7 @@ func updateQueueConfigs(ctx context.Context, conn *connect.Connect, instanceID, 
 // 	})
 
 // 	if err != nil {
-// 		return diag.Errorf("error deleting RoutingProfile (%s): %s", d.Id(), err)
+// 		return diag.Errorf("deleting RoutingProfile (%s): %s", d.Id(), err)
 // 	}
 
 // 	return nil

--- a/internal/service/connect/routing_profile_data_source.go
+++ b/internal/service/connect/routing_profile_data_source.go
@@ -117,11 +117,11 @@ func dataSourceRoutingProfileRead(ctx context.Context, d *schema.ResourceData, m
 		routingProfileSummary, err := dataSourceGetRoutingProfileSummaryByName(ctx, conn, instanceID, name)
 
 		if err != nil {
-			return diag.Errorf("error finding Connect Routing Profile Summary by name (%s): %s", name, err)
+			return diag.Errorf("finding Connect Routing Profile Summary by name (%s): %s", name, err)
 		}
 
 		if routingProfileSummary == nil {
-			return diag.Errorf("error finding Connect Routing Profile Summary by name (%s): not found", name)
+			return diag.Errorf("finding Connect Routing Profile Summary by name (%s): not found", name)
 		}
 
 		input.RoutingProfileId = routingProfileSummary.Id
@@ -130,11 +130,11 @@ func dataSourceRoutingProfileRead(ctx context.Context, d *schema.ResourceData, m
 	resp, err := conn.DescribeRoutingProfileWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error getting Connect Routing Profile: %s", err)
+		return diag.Errorf("getting Connect Routing Profile: %s", err)
 	}
 
 	if resp == nil || resp.RoutingProfile == nil {
-		return diag.Errorf("error getting Connect Routing Profile: empty response")
+		return diag.Errorf("getting Connect Routing Profile: empty response")
 	}
 
 	routingProfile := resp.RoutingProfile
@@ -154,13 +154,13 @@ func dataSourceRoutingProfileRead(ctx context.Context, d *schema.ResourceData, m
 	queueConfigs, err := getRoutingProfileQueueConfigs(ctx, conn, instanceID, *routingProfile.RoutingProfileId)
 
 	if err != nil {
-		return diag.Errorf("error finding Connect Routing Profile Queue Configs Summary by Routing Profile ID (%s): %s", *routingProfile.RoutingProfileId, err)
+		return diag.Errorf("finding Connect Routing Profile Queue Configs Summary by Routing Profile ID (%s): %s", *routingProfile.RoutingProfileId, err)
 	}
 
 	d.Set("queue_configs", queueConfigs)
 
 	if err := d.Set("tags", KeyValueTags(ctx, routingProfile.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(routingProfile.RoutingProfileId)))

--- a/internal/service/connect/security_profile.go
+++ b/internal/service/connect/security_profile.go
@@ -97,11 +97,11 @@ func resourceSecurityProfileCreate(ctx context.Context, d *schema.ResourceData, 
 	output, err := conn.CreateSecurityProfileWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Connect Security Profile (%s): %s", securityProfileName, err)
+		return diag.Errorf("creating Connect Security Profile (%s): %s", securityProfileName, err)
 	}
 
 	if output == nil {
-		return diag.Errorf("error creating Connect Security Profile (%s): empty output", securityProfileName)
+		return diag.Errorf("creating Connect Security Profile (%s): empty output", securityProfileName)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(output.SecurityProfileId)))
@@ -130,11 +130,11 @@ func resourceSecurityProfileRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting Connect Security Profile (%s): %s", d.Id(), err)
+		return diag.Errorf("getting Connect Security Profile (%s): %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.SecurityProfile == nil {
-		return diag.Errorf("error getting Connect Security Profile (%s): empty response", d.Id())
+		return diag.Errorf("getting Connect Security Profile (%s): empty response", d.Id())
 	}
 
 	d.Set("arn", resp.SecurityProfile.Arn)
@@ -148,7 +148,7 @@ func resourceSecurityProfileRead(ctx context.Context, d *schema.ResourceData, me
 	permissions, err := getSecurityProfilePermissions(ctx, conn, instanceID, securityProfileID)
 
 	if err != nil {
-		return diag.Errorf("error finding Connect Security Profile Permissions for Security Profile (%s): %s", securityProfileID, err)
+		return diag.Errorf("finding Connect Security Profile Permissions for Security Profile (%s): %s", securityProfileID, err)
 	}
 
 	if permissions != nil {
@@ -206,7 +206,7 @@ func resourceSecurityProfileDelete(ctx context.Context, d *schema.ResourceData, 
 	})
 
 	if err != nil {
-		return diag.Errorf("error deleting SecurityProfile (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting SecurityProfile (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/connect/security_profile_data_source.go
+++ b/internal/service/connect/security_profile_data_source.go
@@ -77,11 +77,11 @@ func dataSourceSecurityProfileRead(ctx context.Context, d *schema.ResourceData, 
 		securityProfileSummary, err := dataSourceGetSecurityProfileSummaryByName(ctx, conn, instanceID, name)
 
 		if err != nil {
-			return diag.Errorf("error finding Connect Security Profile Summary by name (%s): %s", name, err)
+			return diag.Errorf("finding Connect Security Profile Summary by name (%s): %s", name, err)
 		}
 
 		if securityProfileSummary == nil {
-			return diag.Errorf("error finding Connect Security Profile Summary by name (%s): not found", name)
+			return diag.Errorf("finding Connect Security Profile Summary by name (%s): not found", name)
 		}
 
 		input.SecurityProfileId = securityProfileSummary.Id
@@ -90,11 +90,11 @@ func dataSourceSecurityProfileRead(ctx context.Context, d *schema.ResourceData, 
 	resp, err := conn.DescribeSecurityProfileWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error getting Connect Security Profile: %s", err)
+		return diag.Errorf("getting Connect Security Profile: %s", err)
 	}
 
 	if resp == nil || resp.SecurityProfile == nil {
-		return diag.Errorf("error getting Connect Security Profile: empty response")
+		return diag.Errorf("getting Connect Security Profile: empty response")
 	}
 
 	securityProfile := resp.SecurityProfile
@@ -110,7 +110,7 @@ func dataSourceSecurityProfileRead(ctx context.Context, d *schema.ResourceData, 
 	permissions, err := getSecurityProfilePermissions(ctx, conn, instanceID, *resp.SecurityProfile.Id)
 
 	if err != nil {
-		return diag.Errorf("error finding Connect Security Profile Permissions for Security Profile (%s): %s", *resp.SecurityProfile.Id, err)
+		return diag.Errorf("finding Connect Security Profile Permissions for Security Profile (%s): %s", *resp.SecurityProfile.Id, err)
 	}
 
 	if permissions != nil {
@@ -118,7 +118,7 @@ func dataSourceSecurityProfileRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if err := d.Set("tags", KeyValueTags(ctx, securityProfile.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(resp.SecurityProfile.Id)))

--- a/internal/service/connect/user.go
+++ b/internal/service/connect/user.go
@@ -176,11 +176,11 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	output, err := conn.CreateUserWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Connect User (%s): %s", name, err)
+		return diag.Errorf("creating Connect User (%s): %s", name, err)
 	}
 
 	if output == nil {
-		return diag.Errorf("error creating Connect User (%s): empty output", name)
+		return diag.Errorf("creating Connect User (%s): empty output", name)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(output.UserId)))
@@ -209,11 +209,11 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting Connect User (%s): %s", d.Id(), err)
+		return diag.Errorf("getting Connect User (%s): %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.User == nil {
-		return diag.Errorf("error getting Connect User (%s): empty response", d.Id())
+		return diag.Errorf("getting Connect User (%s): empty response", d.Id())
 	}
 
 	user := resp.User
@@ -228,11 +228,11 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	d.Set("user_id", user.Id)
 
 	if err := d.Set("identity_info", flattenIdentityInfo(user.IdentityInfo)); err != nil {
-		return diag.Errorf("error setting identity_info: %s", err)
+		return diag.Errorf("setting identity_info: %s", err)
 	}
 
 	if err := d.Set("phone_config", flattenPhoneConfig(user.PhoneConfig)); err != nil {
-		return diag.Errorf("error setting phone_config: %s", err)
+		return diag.Errorf("setting phone_config: %s", err)
 	}
 
 	SetTagsOut(ctx, resp.User.Tags)
@@ -352,7 +352,7 @@ func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	})
 
 	if err != nil {
-		return diag.Errorf("error deleting User (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting User (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/connect/user_hierarchy_group.go
+++ b/internal/service/connect/user_hierarchy_group.go
@@ -135,11 +135,11 @@ func resourceUserHierarchyGroupCreate(ctx context.Context, d *schema.ResourceDat
 	output, err := conn.CreateUserHierarchyGroupWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Connect User Hierarchy Group (%s): %s", userHierarchyGroupName, err)
+		return diag.Errorf("creating Connect User Hierarchy Group (%s): %s", userHierarchyGroupName, err)
 	}
 
 	if output == nil {
-		return diag.Errorf("error creating Connect User Hierarchy Group (%s): empty output", userHierarchyGroupName)
+		return diag.Errorf("creating Connect User Hierarchy Group (%s): empty output", userHierarchyGroupName)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(output.HierarchyGroupId)))
@@ -168,11 +168,11 @@ func resourceUserHierarchyGroupRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting Connect User Hierarchy Group (%s): %s", d.Id(), err)
+		return diag.Errorf("getting Connect User Hierarchy Group (%s): %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.HierarchyGroup == nil {
-		return diag.Errorf("error getting Connect User Hierarchy Group (%s): empty response", d.Id())
+		return diag.Errorf("getting Connect User Hierarchy Group (%s): empty response", d.Id())
 	}
 
 	d.Set("arn", resp.HierarchyGroup.Arn)
@@ -182,7 +182,7 @@ func resourceUserHierarchyGroupRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("name", resp.HierarchyGroup.Name)
 
 	if err := d.Set("hierarchy_path", flattenUserHierarchyPath(resp.HierarchyGroup.HierarchyPath)); err != nil {
-		return diag.Errorf("error setting Connect User Hierarchy Group hierarchy_path (%s): %s", d.Id(), err)
+		return diag.Errorf("setting Connect User Hierarchy Group hierarchy_path (%s): %s", d.Id(), err)
 	}
 
 	SetTagsOut(ctx, resp.HierarchyGroup.Tags)
@@ -228,7 +228,7 @@ func resourceUserHierarchyGroupDelete(ctx context.Context, d *schema.ResourceDat
 	})
 
 	if err != nil {
-		return diag.Errorf("error deleting User Hierarchy Group (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting User Hierarchy Group (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/connect/user_hierarchy_group_data_source.go
+++ b/internal/service/connect/user_hierarchy_group_data_source.go
@@ -98,11 +98,11 @@ func dataSourceUserHierarchyGroupRead(ctx context.Context, d *schema.ResourceDat
 		hierarchyGroupSummary, err := userHierarchyGroupSummaryByName(ctx, conn, instanceID, name)
 
 		if err != nil {
-			return diag.Errorf("error finding Connect Hierarchy Group Summary by name (%s): %s", name, err)
+			return diag.Errorf("finding Connect Hierarchy Group Summary by name (%s): %s", name, err)
 		}
 
 		if hierarchyGroupSummary == nil {
-			return diag.Errorf("error finding Connect Hierarchy Group Summary by name (%s): not found", name)
+			return diag.Errorf("finding Connect Hierarchy Group Summary by name (%s): not found", name)
 		}
 
 		input.HierarchyGroupId = hierarchyGroupSummary.Id
@@ -111,11 +111,11 @@ func dataSourceUserHierarchyGroupRead(ctx context.Context, d *schema.ResourceDat
 	resp, err := conn.DescribeUserHierarchyGroupWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error getting Connect Hierarchy Group: %s", err)
+		return diag.Errorf("getting Connect Hierarchy Group: %s", err)
 	}
 
 	if resp == nil || resp.HierarchyGroup == nil {
-		return diag.Errorf("error getting Connect Hierarchy Group: empty response")
+		return diag.Errorf("getting Connect Hierarchy Group: empty response")
 	}
 
 	hierarchyGroup := resp.HierarchyGroup
@@ -127,11 +127,11 @@ func dataSourceUserHierarchyGroupRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("name", hierarchyGroup.Name)
 
 	if err := d.Set("hierarchy_path", flattenUserHierarchyPath(hierarchyGroup.HierarchyPath)); err != nil {
-		return diag.Errorf("error setting Connect User Hierarchy Group hierarchy_path (%s): %s", d.Id(), err)
+		return diag.Errorf("setting Connect User Hierarchy Group hierarchy_path (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("tags", KeyValueTags(ctx, hierarchyGroup.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", instanceID, aws.StringValue(hierarchyGroup.Id)))

--- a/internal/service/connect/user_hierarchy_structure.go
+++ b/internal/service/connect/user_hierarchy_structure.go
@@ -103,7 +103,7 @@ func resourceUserHierarchyStructureCreate(ctx context.Context, d *schema.Resourc
 	_, err := conn.UpdateUserHierarchyStructureWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Connect User Hierarchy Structure for Connect Instance (%s): %s", instanceID, err)
+		return diag.Errorf("creating Connect User Hierarchy Structure for Connect Instance (%s): %s", instanceID, err)
 	}
 
 	d.SetId(instanceID)
@@ -127,15 +127,15 @@ func resourceUserHierarchyStructureRead(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting Connect User Hierarchy Structure (%s): %s", d.Id(), err)
+		return diag.Errorf("getting Connect User Hierarchy Structure (%s): %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.HierarchyStructure == nil {
-		return diag.Errorf("error getting Connect User Hierarchy Structure (%s): empty response", d.Id())
+		return diag.Errorf("getting Connect User Hierarchy Structure (%s): empty response", d.Id())
 	}
 
 	if err := d.Set("hierarchy_structure", flattenUserHierarchyStructure(resp.HierarchyStructure)); err != nil {
-		return diag.Errorf("error setting Connect User Hierarchy Structure hierarchy_structure for Connect instance: (%s)", d.Id())
+		return diag.Errorf("setting Connect User Hierarchy Structure hierarchy_structure for Connect instance: (%s)", d.Id())
 	}
 
 	d.Set("instance_id", instanceID)
@@ -155,7 +155,7 @@ func resourceUserHierarchyStructureUpdate(ctx context.Context, d *schema.Resourc
 		})
 
 		if err != nil {
-			return diag.Errorf("error updating UserHierarchyStructure Name (%s): %s", d.Id(), err)
+			return diag.Errorf("updating UserHierarchyStructure Name (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -173,7 +173,7 @@ func resourceUserHierarchyStructureDelete(ctx context.Context, d *schema.Resourc
 	})
 
 	if err != nil {
-		return diag.Errorf("error deleting UserHierarchyStructure (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting UserHierarchyStructure (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/connect/user_hierarchy_structure_data_source.go
+++ b/internal/service/connect/user_hierarchy_structure_data_source.go
@@ -87,15 +87,15 @@ func dataSourceUserHierarchyStructureRead(ctx context.Context, d *schema.Resourc
 	})
 
 	if err != nil {
-		return diag.Errorf("error getting Connect User Hierarchy Structure for Connect Instance (%s): %s", instanceID, err)
+		return diag.Errorf("getting Connect User Hierarchy Structure for Connect Instance (%s): %s", instanceID, err)
 	}
 
 	if resp == nil || resp.HierarchyStructure == nil {
-		return diag.Errorf("error getting Connect User Hierarchy Structure for Connect Instance (%s): empty response", instanceID)
+		return diag.Errorf("getting Connect User Hierarchy Structure for Connect Instance (%s): empty response", instanceID)
 	}
 
 	if err := d.Set("hierarchy_structure", flattenUserHierarchyStructure(resp.HierarchyStructure)); err != nil {
-		return diag.Errorf("error setting Connect User Hierarchy Structure for Connect Instance: (%s)", instanceID)
+		return diag.Errorf("setting Connect User Hierarchy Structure for Connect Instance: (%s)", instanceID)
 	}
 
 	d.SetId(instanceID)

--- a/internal/service/connect/vocabulary.go
+++ b/internal/service/connect/vocabulary.go
@@ -113,11 +113,11 @@ func resourceVocabularyCreate(ctx context.Context, d *schema.ResourceData, meta 
 	output, err := conn.CreateVocabularyWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Connect Vocabulary (%s): %s", vocabularyName, err)
+		return diag.Errorf("creating Connect Vocabulary (%s): %s", vocabularyName, err)
 	}
 
 	if output == nil {
-		return diag.Errorf("error creating Connect Vocabulary (%s): empty output", vocabularyName)
+		return diag.Errorf("creating Connect Vocabulary (%s): empty output", vocabularyName)
 	}
 
 	vocabularyID := aws.StringValue(output.VocabularyId)
@@ -126,7 +126,7 @@ func resourceVocabularyCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	// waiter since the status changes from CREATION_IN_PROGRESS to either ACTIVE or CREATION_FAILED
 	if _, err := waitVocabularyCreated(ctx, conn, d.Timeout(schema.TimeoutCreate), instanceID, vocabularyID); err != nil {
-		return diag.Errorf("error waiting for Vocabulary (%s) creation: %s", d.Id(), err)
+		return diag.Errorf("waiting for Vocabulary (%s) creation: %s", d.Id(), err)
 	}
 
 	return resourceVocabularyRead(ctx, d, meta)
@@ -153,11 +153,11 @@ func resourceVocabularyRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting Connect Vocabulary (%s): %s", d.Id(), err)
+		return diag.Errorf("getting Connect Vocabulary (%s): %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.Vocabulary == nil {
-		return diag.Errorf("error getting Connect Vocabulary (%s): empty response", d.Id())
+		return diag.Errorf("getting Connect Vocabulary (%s): empty response", d.Id())
 	}
 
 	vocabulary := resp.Vocabulary
@@ -197,11 +197,11 @@ func resourceVocabularyDelete(ctx context.Context, d *schema.ResourceData, meta 
 	})
 
 	if err != nil {
-		return diag.Errorf("error deleting Vocabulary (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Vocabulary (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitVocabularyDeleted(ctx, conn, d.Timeout(schema.TimeoutDelete), instanceID, vocabularyID); err != nil {
-		return diag.Errorf("error waiting for Vocabulary (%s) deletion: %s", d.Id(), err)
+		return diag.Errorf("waiting for Vocabulary (%s) deletion: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/dataexchange/data_set.go
+++ b/internal/service/dataexchange/data_set.go
@@ -70,7 +70,7 @@ func resourceDataSetCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	out, err := conn.CreateDataSetWithContext(ctx, input)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating DataExchange DataSet: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating DataExchange DataSet: %s", err)
 	}
 
 	d.SetId(aws.StringValue(out.Id))
@@ -124,7 +124,7 @@ func resourceDataSetUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		log.Printf("[DEBUG] Updating DataExchange DataSet: %s", d.Id())
 		_, err := conn.UpdateDataSetWithContext(ctx, input)
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "Error Updating DataExchange DataSet: %s", err)
+			return sdkdiag.AppendErrorf(diags, "updating DataExchange DataSet (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -145,7 +145,7 @@ func resourceDataSetDelete(ctx context.Context, d *schema.ResourceData, meta int
 		if tfawserr.ErrCodeEquals(err, dataexchange.ErrCodeResourceNotFoundException) {
 			return diags
 		}
-		return sdkdiag.AppendErrorf(diags, "Error deleting DataExchange DataSet: %s", err)
+		return sdkdiag.AppendErrorf(diags, "deleting DataExchange DataSet: %s", err)
 	}
 
 	return diags

--- a/internal/service/dataexchange/revision.go
+++ b/internal/service/dataexchange/revision.go
@@ -70,7 +70,7 @@ func resourceRevisionCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	out, err := conn.CreateRevisionWithContext(ctx, input)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating DataExchange Revision: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating DataExchange Revision: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", aws.StringValue(out.DataSetId), aws.StringValue(out.Id)))
@@ -126,7 +126,7 @@ func resourceRevisionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		log.Printf("[DEBUG] Updating DataExchange Revision: %s", d.Id())
 		_, err := conn.UpdateRevisionWithContext(ctx, input)
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "Error Updating DataExchange Revision: %s", err)
+			return sdkdiag.AppendErrorf(diags, "updating DataExchange Revision (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -148,7 +148,7 @@ func resourceRevisionDelete(ctx context.Context, d *schema.ResourceData, meta in
 		if tfawserr.ErrCodeEquals(err, dataexchange.ErrCodeResourceNotFoundException) {
 			return diags
 		}
-		return sdkdiag.AppendErrorf(diags, "Error deleting DataExchange Revision: %s", err)
+		return sdkdiag.AppendErrorf(diags, "deleting DataExchange Revision: %s", err)
 	}
 
 	return diags

--- a/internal/service/datapipeline/pipeline.go
+++ b/internal/service/datapipeline/pipeline.go
@@ -71,7 +71,7 @@ func resourcePipelineCreate(ctx context.Context, d *schema.ResourceData, meta in
 	resp, err := conn.CreatePipelineWithContext(ctx, &input)
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating datapipeline: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating datapipeline: %s", err)
 	}
 
 	d.SetId(aws.StringValue(resp.PipelineId))
@@ -90,7 +90,7 @@ func resourcePipelineRead(ctx context.Context, d *schema.ResourceData, meta inte
 		return diags
 	}
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error describing DataPipeline (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "describing DataPipeline (%s): %s", d.Id(), err)
 	}
 
 	d.Set("name", v.Name)

--- a/internal/service/datapipeline/pipeline_data_source.go
+++ b/internal/service/datapipeline/pipeline_data_source.go
@@ -41,7 +41,7 @@ func dataSourcePipelineRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	v, err := PipelineRetrieve(ctx, pipelineId, conn)
 	if err != nil {
-		return diag.Errorf("Error describing DataPipeline Pipeline (%s): %s", pipelineId, err)
+		return diag.Errorf("describing DataPipeline Pipeline (%s): %s", pipelineId, err)
 	}
 
 	d.Set("name", v.Name)

--- a/internal/service/datapipeline/pipeline_data_source.go
+++ b/internal/service/datapipeline/pipeline_data_source.go
@@ -50,7 +50,7 @@ func dataSourcePipelineRead(ctx context.Context, d *schema.ResourceData, meta in
 	tags := KeyValueTags(ctx, v.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	d.SetId(pipelineId)

--- a/internal/service/datapipeline/pipeline_definition.go
+++ b/internal/service/datapipeline/pipeline_definition.go
@@ -172,11 +172,11 @@ func resourcePipelineDefinitionPut(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if err != nil {
-		return diag.Errorf("error creating DataPipeline Pipeline Definition (%s): %s", pipelineID, err)
+		return diag.Errorf("creating DataPipeline Pipeline Definition (%s): %s", pipelineID, err)
 	}
 
 	if aws.BoolValue(output.Errored) {
-		return diag.Errorf("error validating after creation DataPipeline Pipeline Definition (%s): %s", pipelineID, getValidationError(output.ValidationErrors))
+		return diag.Errorf("validating after creation DataPipeline Pipeline Definition (%s): %s", pipelineID, getValidationError(output.ValidationErrors))
 	}
 
 	// Activate pipeline if enabled
@@ -186,7 +186,7 @@ func resourcePipelineDefinitionPut(ctx context.Context, d *schema.ResourceData, 
 
 	_, err = conn.ActivatePipelineWithContext(ctx, input2)
 	if err != nil {
-		return diag.Errorf("error activating DataPipeline Pipeline Definition (%s): %s", pipelineID, err)
+		return diag.Errorf("activating DataPipeline Pipeline Definition (%s): %s", pipelineID, err)
 	}
 
 	d.SetId(pipelineID)
@@ -210,17 +210,17 @@ func resourcePipelineDefinitionRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading DataPipeline Pipeline Definition (%s): %s", d.Id(), err)
+		return diag.Errorf("reading DataPipeline Pipeline Definition (%s): %s", d.Id(), err)
 	}
 
 	if err = d.Set("parameter_object", flattenPipelineDefinitionParameterObjects(resp.ParameterObjects)); err != nil {
-		return diag.Errorf("error setting `%s` for DataPipeline Pipeline Definition (%s): %s", "parameter_object", d.Id(), err)
+		return diag.Errorf("setting `%s` for DataPipeline Pipeline Definition (%s): %s", "parameter_object", d.Id(), err)
 	}
 	if err = d.Set("parameter_value", flattenPipelineDefinitionParameterValues(resp.ParameterValues)); err != nil {
-		return diag.Errorf("error setting `%s` for DataPipeline Pipeline Definition (%s): %s", "parameter_object", d.Id(), err)
+		return diag.Errorf("setting `%s` for DataPipeline Pipeline Definition (%s): %s", "parameter_object", d.Id(), err)
 	}
 	if err = d.Set("pipeline_object", flattenPipelineDefinitionObjects(resp.PipelineObjects)); err != nil {
-		return diag.Errorf("error setting `%s` for DataPipeline Pipeline Definition (%s): %s", "parameter_object", d.Id(), err)
+		return diag.Errorf("setting `%s` for DataPipeline Pipeline Definition (%s): %s", "parameter_object", d.Id(), err)
 	}
 	d.Set("pipeline_id", d.Id())
 

--- a/internal/service/datapipeline/pipeline_definition_data_source.go
+++ b/internal/service/datapipeline/pipeline_definition_data_source.go
@@ -119,17 +119,17 @@ func dataSourcePipelineDefinitionRead(ctx context.Context, d *schema.ResourceDat
 	resp, err := conn.GetPipelineDefinitionWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error getting DataPipeline Definition (%s): %s", pipelineID, err)
+		return diag.Errorf("getting DataPipeline Definition (%s): %s", pipelineID, err)
 	}
 
 	if err = d.Set("parameter_object", flattenPipelineDefinitionParameterObjects(resp.ParameterObjects)); err != nil {
-		return diag.Errorf("error setting `%s` for DataPipeline Pipeline Definition (%s): %s", "parameter_object", pipelineID, err)
+		return diag.Errorf("setting `%s` for DataPipeline Pipeline Definition (%s): %s", "parameter_object", pipelineID, err)
 	}
 	if err = d.Set("parameter_value", flattenPipelineDefinitionParameterValues(resp.ParameterValues)); err != nil {
-		return diag.Errorf("error setting `%s` for DataPipeline Pipeline Definition (%s): %s", "parameter_object", pipelineID, err)
+		return diag.Errorf("setting `%s` for DataPipeline Pipeline Definition (%s): %s", "parameter_object", pipelineID, err)
 	}
 	if err = d.Set("pipeline_object", flattenPipelineDefinitionObjects(resp.PipelineObjects)); err != nil {
-		return diag.Errorf("error setting `%s` for DataPipeline Pipeline Definition (%s): %s", "parameter_object", pipelineID, err)
+		return diag.Errorf("setting `%s` for DataPipeline Pipeline Definition (%s): %s", "parameter_object", pipelineID, err)
 	}
 	d.SetId(pipelineID)
 

--- a/internal/service/dax/cluster.go
+++ b/internal/service/dax/cluster.go
@@ -270,7 +270,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		resp, err = conn.CreateClusterWithContext(ctx, input)
 	}
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating DAX cluster: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating DAX cluster: %s", err)
 	}
 
 	// Assign the cluster id as the resource ID
@@ -292,7 +292,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 	log.Printf("[DEBUG] Waiting for state to become available: %v", d.Id())
 	_, sterr := stateConf.WaitForStateContext(ctx)
 	if sterr != nil {
-		return sdkdiag.AppendErrorf(diags, "Error waiting for DAX cluster (%s) to be created: %s", d.Id(), sterr)
+		return sdkdiag.AppendErrorf(diags, "waiting for DAX cluster (%s) to be created: %s", d.Id(), sterr)
 	}
 
 	return append(diags, resourceClusterRead(ctx, d, meta)...)
@@ -410,7 +410,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		log.Printf("[DEBUG] Modifying DAX Cluster (%s), opts:\n%s", d.Id(), req)
 		_, err := conn.UpdateClusterWithContext(ctx, req)
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "Error updating DAX cluster (%s), error: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating DAX cluster (%s), error: %s", d.Id(), err)
 		}
 		awaitUpdate = true
 	}
@@ -426,7 +426,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 				NewReplicationFactor: aws.Int64(int64(nraw.(int))),
 			})
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "Error increasing nodes in DAX cluster %s, error: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "increasing nodes in DAX cluster %s, error: %s", d.Id(), err)
 			}
 			awaitUpdate = true
 		}
@@ -437,7 +437,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 				NewReplicationFactor: aws.Int64(int64(nraw.(int))),
 			})
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "Error increasing nodes in DAX cluster %s, error: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "increasing nodes in DAX cluster %s, error: %s", d.Id(), err)
 			}
 			awaitUpdate = true
 		}
@@ -457,7 +457,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		_, sterr := stateConf.WaitForStateContext(ctx)
 		if sterr != nil {
-			return sdkdiag.AppendErrorf(diags, "Error waiting for DAX (%s) to update: %s", d.Id(), sterr)
+			return sdkdiag.AppendErrorf(diags, "waiting for DAX (%s) to update: %s", d.Id(), sterr)
 		}
 	}
 
@@ -516,7 +516,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 		_, err = conn.DeleteClusterWithContext(ctx, req)
 	}
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error deleting DAX cluster: %s", err)
+		return sdkdiag.AppendErrorf(diags, "deleting DAX cluster: %s", err)
 	}
 
 	log.Printf("[DEBUG] Waiting for deletion: %v", d.Id())
@@ -531,7 +531,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 
 	_, sterr := stateConf.WaitForStateContext(ctx)
 	if sterr != nil {
-		return sdkdiag.AppendErrorf(diags, "Error waiting for DAX (%s) to delete: %s", d.Id(), sterr)
+		return sdkdiag.AppendErrorf(diags, "waiting for DAX (%s) to delete: %s", d.Id(), sterr)
 	}
 
 	return diags

--- a/internal/service/deploy/deployment_group.go
+++ b/internal/service/deploy/deployment_group.go
@@ -580,7 +580,7 @@ func resourceDeploymentGroupCreate(ctx context.Context, d *schema.ResourceData, 
 		resp, err = conn.CreateDeploymentGroupWithContext(ctx, &input)
 	}
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating CodeDeploy deployment group: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating CodeDeploy deployment group: %s", err)
 	}
 
 	d.SetId(aws.StringValue(resp.DeploymentGroupId))

--- a/internal/service/detective/graph.go
+++ b/internal/service/detective/graph.go
@@ -71,7 +71,7 @@ func resourceGraphCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if err != nil {
-		return diag.Errorf("error creating detective Graph: %s", err)
+		return diag.Errorf("creating detective Graph: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.GraphArn))
@@ -89,7 +89,7 @@ func resourceGraphRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		return nil
 	}
 	if err != nil {
-		return diag.Errorf("error reading detective Graph (%s): %s", d.Id(), err)
+		return diag.Errorf("reading detective Graph (%s): %s", d.Id(), err)
 	}
 
 	d.Set("created_time", aws.TimeValue(resp.CreatedTime).Format(time.RFC3339))
@@ -115,7 +115,7 @@ func resourceGraphDelete(ctx context.Context, d *schema.ResourceData, meta inter
 		if tfawserr.ErrCodeEquals(err, detective.ErrCodeResourceNotFoundException) {
 			return nil
 		}
-		return diag.Errorf("error deleting detective Graph (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting detective Graph (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/detective/invitation_accepter.go
+++ b/internal/service/detective/invitation_accepter.go
@@ -45,7 +45,7 @@ func resourceInvitationAccepterCreate(ctx context.Context, d *schema.ResourceDat
 	_, err := conn.AcceptInvitationWithContext(ctx, acceptInvitationInput)
 
 	if err != nil {
-		return diag.Errorf("error accepting Detective InvitationAccepter (%s): %s", d.Id(), err)
+		return diag.Errorf("accepting Detective InvitationAccepter (%s): %s", d.Id(), err)
 	}
 
 	d.SetId(graphArn)
@@ -65,7 +65,7 @@ func resourceInvitationAccepterRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if err != nil {
-		return diag.Errorf("error listing Detective InvitationAccepter (%s): %s", d.Id(), err)
+		return diag.Errorf("listing Detective InvitationAccepter (%s): %s", d.Id(), err)
 	}
 
 	d.Set("graph_arn", graphArn)
@@ -84,7 +84,7 @@ func resourceInvitationAccepterDelete(ctx context.Context, d *schema.ResourceDat
 		if tfawserr.ErrCodeEquals(err, detective.ErrCodeResourceNotFoundException) {
 			return nil
 		}
-		return diag.Errorf("error disassociating Detective InvitationAccepter (%s): %s", d.Id(), err)
+		return diag.Errorf("disassociating Detective InvitationAccepter (%s): %s", d.Id(), err)
 	}
 	return nil
 }

--- a/internal/service/detective/member.go
+++ b/internal/service/detective/member.go
@@ -127,11 +127,11 @@ func resourceMemberCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err != nil {
-		return diag.Errorf("error creating Detective Member: %s", err)
+		return diag.Errorf("creating Detective Member: %s", err)
 	}
 
 	if _, err = MemberStatusUpdated(ctx, conn, graphArn, accountId, detective.MemberStatusInvited); err != nil {
-		return diag.Errorf("error waiting for Detective Member (%s) to be invited: %s", d.Id(), err)
+		return diag.Errorf("waiting for Detective Member (%s) to be invited: %s", d.Id(), err)
 	}
 
 	d.SetId(EncodeMemberID(graphArn, accountId))
@@ -144,7 +144,7 @@ func resourceMemberRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	graphArn, accountId, err := DecodeMemberID(d.Id())
 	if err != nil {
-		return diag.Errorf("error decoding ID Detective Member (%s): %s", d.Id(), err)
+		return diag.Errorf("decoding ID Detective Member (%s): %s", d.Id(), err)
 	}
 
 	resp, err := FindMemberByGraphARNAndAccountID(ctx, conn, graphArn, accountId)
@@ -156,7 +156,7 @@ func resourceMemberRead(ctx context.Context, d *schema.ResourceData, meta interf
 			d.SetId("")
 			return nil
 		}
-		return diag.Errorf("error reading Detective Member (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Detective Member (%s): %s", d.Id(), err)
 	}
 
 	if !d.IsNewResource() && resp == nil {
@@ -182,7 +182,7 @@ func resourceMemberDelete(ctx context.Context, d *schema.ResourceData, meta inte
 
 	graphArn, accountId, err := DecodeMemberID(d.Id())
 	if err != nil {
-		return diag.Errorf("error decoding ID Detective Member (%s): %s", d.Id(), err)
+		return diag.Errorf("decoding ID Detective Member (%s): %s", d.Id(), err)
 	}
 
 	input := &detective.DeleteMembersInput{
@@ -195,7 +195,7 @@ func resourceMemberDelete(ctx context.Context, d *schema.ResourceData, meta inte
 		if tfawserr.ErrCodeEquals(err, detective.ErrCodeResourceNotFoundException) {
 			return nil
 		}
-		return diag.Errorf("error deleting Detective Member (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Detective Member (%s): %s", d.Id(), err)
 	}
 	return nil
 }

--- a/internal/service/devicefarm/upload.go
+++ b/internal/service/devicefarm/upload.go
@@ -86,7 +86,7 @@ func resourceUploadCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	out, err := conn.CreateUploadWithContext(ctx, input)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating DeviceFarm Upload: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating DeviceFarm Upload: %s", err)
 	}
 
 	arn := aws.StringValue(out.Upload.Arn)
@@ -150,7 +150,7 @@ func resourceUploadUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	log.Printf("[DEBUG] Updating DeviceFarm Upload: %s", d.Id())
 	_, err := conn.UpdateUploadWithContext(ctx, input)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error Updating DeviceFarm Upload: %s", err)
+		return sdkdiag.AppendErrorf(diags, "updating DeviceFarm Upload (%s): %s", d.Id(), err)
 	}
 
 	return append(diags, resourceUploadRead(ctx, d, meta)...)
@@ -170,7 +170,7 @@ func resourceUploadDelete(ctx context.Context, d *schema.ResourceData, meta inte
 		if tfawserr.ErrCodeEquals(err, devicefarm.ErrCodeNotFoundException) {
 			return diags
 		}
-		return sdkdiag.AppendErrorf(diags, "Error deleting DeviceFarm Upload: %s", err)
+		return sdkdiag.AppendErrorf(diags, "deleting DeviceFarm Upload: %s", err)
 	}
 
 	return diags

--- a/internal/service/directconnect/bgp_peer.go
+++ b/internal/service/directconnect/bgp_peer.go
@@ -108,7 +108,7 @@ func resourceBGPPeerCreate(ctx context.Context, d *schema.ResourceData, meta int
 	log.Printf("[DEBUG] Creating Direct Connect BGP peer: %#v", req)
 	_, err := conn.CreateBGPPeerWithContext(ctx, req)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error creating Direct Connect BGP peer: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Direct Connect BGP peer: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s-%s-%d", vifId, addrFamily, asn))
@@ -128,7 +128,7 @@ func resourceBGPPeerCreate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error waiting for Direct Connect BGP peer (%s) to be available: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Direct Connect BGP peer (%s) to be available: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceBGPPeerRead(ctx, d, meta)...)
@@ -144,7 +144,7 @@ func resourceBGPPeerRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	bgpPeerRaw, state, err := bgpPeerStateRefresh(ctx, conn, vifId, addrFamily, asn)()
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error reading Direct Connect BGP peer: %s", err)
+		return sdkdiag.AppendErrorf(diags, "reading Direct Connect BGP peer: %s", err)
 	}
 	if state == directconnect.BGPPeerStateDeleted {
 		log.Printf("[WARN] Direct Connect BGP peer (%s) not found, removing from state", d.Id())

--- a/internal/service/dms/event_subscription.go
+++ b/internal/service/dms/event_subscription.go
@@ -154,7 +154,7 @@ func resourceEventSubscriptionRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error reading DMS event subscription: %s", err)
+		return sdkdiag.AppendErrorf(diags, "reading DMS event subscription: %s", err)
 	}
 
 	if response == nil || len(response.EventSubscriptionsList) == 0 || response.EventSubscriptionsList[0] == nil {

--- a/internal/service/docdb/cluster_instance.go
+++ b/internal/service/docdb/cluster_instance.go
@@ -391,7 +391,7 @@ func resourceClusterInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 			_, err = conn.ModifyDBInstanceWithContext(ctx, req)
 		}
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "Error modifying DB Instance %s: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "modifying DB Instance %s: %s", d.Id(), err)
 		}
 
 		// reuse db_instance refresh func

--- a/internal/service/docdb/global_cluster.go
+++ b/internal/service/docdb/global_cluster.go
@@ -192,7 +192,7 @@ func resourceGlobalClusterRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("global_cluster_identifier", globalCluster.GlobalClusterIdentifier)
 
 	if err := d.Set("global_cluster_members", flattenGlobalClusterMembers(globalCluster.GlobalClusterMembers)); err != nil {
-		return diag.Errorf("error setting global_cluster_members: %s", err)
+		return diag.Errorf("setting global_cluster_members: %s", err)
 	}
 
 	d.Set("global_cluster_resource_id", globalCluster.GlobalClusterResourceId)

--- a/internal/service/dynamodb/kinesis_streaming_destination.go
+++ b/internal/service/dynamodb/kinesis_streaming_destination.go
@@ -56,15 +56,15 @@ func resourceKinesisStreamingDestinationCreate(ctx context.Context, d *schema.Re
 	output, err := conn.EnableKinesisStreamingDestinationWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error enabling DynamoDB Kinesis streaming destination (stream: %s, table: %s): %s", streamArn, tableName, err)
+		return diag.Errorf("enabling DynamoDB Kinesis streaming destination (stream: %s, table: %s): %s", streamArn, tableName, err)
 	}
 
 	if output == nil {
-		return diag.Errorf("error enabling DynamoDB Kinesis streaming destination (stream: %s, table: %s): empty output", streamArn, tableName)
+		return diag.Errorf("enabling DynamoDB Kinesis streaming destination (stream: %s, table: %s): empty output", streamArn, tableName)
 	}
 
 	if err := waitKinesisStreamingDestinationActive(ctx, conn, streamArn, tableName); err != nil {
-		return diag.Errorf("error waiting for DynamoDB Kinesis streaming destination (stream: %s, table: %s) to be active: %s", streamArn, tableName, err)
+		return diag.Errorf("waiting for DynamoDB Kinesis streaming destination (stream: %s, table: %s) to be active: %s", streamArn, tableName, err)
 	}
 
 	d.SetId(fmt.Sprintf("%s,%s", aws.StringValue(output.TableName), aws.StringValue(output.StreamArn)))
@@ -90,12 +90,12 @@ func resourceKinesisStreamingDestinationRead(ctx context.Context, d *schema.Reso
 	}
 
 	if err != nil {
-		return diag.Errorf("error retrieving DynamoDB Kinesis streaming destination (stream: %s, table: %s): %s", streamArn, tableName, err)
+		return diag.Errorf("retrieving DynamoDB Kinesis streaming destination (stream: %s, table: %s): %s", streamArn, tableName, err)
 	}
 
 	if output == nil || aws.StringValue(output.DestinationStatus) == dynamodb.DestinationStatusDisabled {
 		if d.IsNewResource() {
-			return diag.Errorf("error retrieving DynamoDB Kinesis streaming destination (stream: %s, table: %s): empty output after creation", streamArn, tableName)
+			return diag.Errorf("retrieving DynamoDB Kinesis streaming destination (stream: %s, table: %s): empty output after creation", streamArn, tableName)
 		}
 		log.Printf("[WARN] DynamoDB Kinesis Streaming Destination (stream: %s, table: %s) not found, removing from state", streamArn, tableName)
 		d.SetId("")
@@ -125,11 +125,11 @@ func resourceKinesisStreamingDestinationDelete(ctx context.Context, d *schema.Re
 	_, err = conn.DisableKinesisStreamingDestinationWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error disabling DynamoDB Kinesis streaming destination (stream: %s, table: %s): %s", streamArn, tableName, err)
+		return diag.Errorf("disabling DynamoDB Kinesis streaming destination (stream: %s, table: %s): %s", streamArn, tableName, err)
 	}
 
 	if err := waitKinesisStreamingDestinationDisabled(ctx, conn, streamArn, tableName); err != nil {
-		return diag.Errorf("error waiting for DynamoDB Kinesis streaming destination (stream: %s, table: %s) to be disabled: %s", streamArn, tableName, err)
+		return diag.Errorf("waiting for DynamoDB Kinesis streaming destination (stream: %s, table: %s) to be disabled: %s", streamArn, tableName, err)
 	}
 
 	return nil

--- a/internal/service/ec2/ebs_default_kms_key_data_source.go
+++ b/internal/service/ec2/ebs_default_kms_key_data_source.go
@@ -34,7 +34,7 @@ func dataSourceEBSDefaultKMSKeyRead(ctx context.Context, d *schema.ResourceData,
 
 	res, err := conn.GetEbsDefaultKmsKeyIdWithContext(ctx, &ec2.GetEbsDefaultKmsKeyIdInput{})
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error reading EBS default KMS key: %s", err)
+		return sdkdiag.AppendErrorf(diags, "reading EBS default KMS key: %s", err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)

--- a/internal/service/ec2/ebs_encryption_by_default_data_source.go
+++ b/internal/service/ec2/ebs_encryption_by_default_data_source.go
@@ -34,7 +34,7 @@ func dataSourceEBSEncryptionByDefaultRead(ctx context.Context, d *schema.Resourc
 
 	res, err := conn.GetEbsEncryptionByDefaultWithContext(ctx, &ec2.GetEbsEncryptionByDefaultInput{})
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error reading default EBS encryption toggle: %s", err)
+		return sdkdiag.AppendErrorf(diags, "reading default EBS encryption toggle: %s", err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)

--- a/internal/service/ec2/ec2_availability_zones_data_source.go
+++ b/internal/service/ec2/ec2_availability_zones_data_source.go
@@ -99,7 +99,7 @@ func dataSourceAvailabilityZonesRead(ctx context.Context, d *schema.ResourceData
 	log.Printf("[DEBUG] Reading Availability Zones: %s", request)
 	resp, err := conn.DescribeAvailabilityZonesWithContext(ctx, request)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error fetching Availability Zones: %s", err)
+		return sdkdiag.AppendErrorf(diags, "fetching Availability Zones: %s", err)
 	}
 
 	sort.Slice(resp.AvailabilityZones, func(i, j int) bool {
@@ -139,10 +139,10 @@ func dataSourceAvailabilityZonesRead(ctx context.Context, d *schema.ResourceData
 		return sdkdiag.AppendErrorf(diags, "setting group_names: %s", err)
 	}
 	if err := d.Set("names", names); err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error setting Availability Zone names: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting Availability Zone names: %s", err)
 	}
 	if err := d.Set("zone_ids", zoneIds); err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error setting Availability Zone IDs: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting Availability Zone IDs: %s", err)
 	}
 
 	return diags

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1203,7 +1203,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 			networkInterfaces = append(networkInterfaces, ni)
 		}
 		if err := d.Set("network_interface", networkInterfaces); err != nil {
-			return sdkdiag.AppendErrorf(diags, "Error setting network_interfaces: %v", err)
+			return sdkdiag.AppendErrorf(diags, "setting network_interfaces: %v", err)
 		}
 
 		// Set primary network interface details
@@ -1241,7 +1241,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err := d.Set("secondary_private_ips", secondaryPrivateIPs); err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error setting private_ips for AWS Instance (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "setting private_ips for AWS Instance (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("ipv6_addresses", ipv6Addresses); err != nil {
@@ -1779,7 +1779,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			})
 		}
 		if mErr != nil {
-			return sdkdiag.AppendErrorf(diags, "Error updating Instance monitoring: %s", mErr)
+			return sdkdiag.AppendErrorf(diags, "updating Instance monitoring: %s", mErr)
 		}
 	}
 

--- a/internal/service/ec2/ec2_serial_console_access.go
+++ b/internal/service/ec2/ec2_serial_console_access.go
@@ -36,7 +36,7 @@ func resourceSerialConsoleAccessCreate(ctx context.Context, d *schema.ResourceDa
 
 	enabled := d.Get("enabled").(bool)
 	if err := setSerialConsoleAccess(ctx, conn, enabled); err != nil {
-		return diag.Errorf("error setting EC2 Serial Console Access (%t): %s", enabled, err)
+		return diag.Errorf("setting EC2 Serial Console Access (%t): %s", enabled, err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)
@@ -50,7 +50,7 @@ func resourceSerialConsoleAccessRead(ctx context.Context, d *schema.ResourceData
 	output, err := conn.GetSerialConsoleAccessStatusWithContext(ctx, &ec2.GetSerialConsoleAccessStatusInput{})
 
 	if err != nil {
-		return diag.Errorf("error reading EC2 Serial Console Access: %s", err)
+		return diag.Errorf("reading EC2 Serial Console Access: %s", err)
 	}
 
 	d.Set("enabled", output.SerialConsoleAccessEnabled)
@@ -63,7 +63,7 @@ func resourceSerialConsoleAccessUpdate(ctx context.Context, d *schema.ResourceDa
 
 	enabled := d.Get("enabled").(bool)
 	if err := setSerialConsoleAccess(ctx, conn, enabled); err != nil {
-		return diag.Errorf("error updating EC2 Serial Console Access (%t): %s", enabled, err)
+		return diag.Errorf("updating EC2 Serial Console Access (%t): %s", enabled, err)
 	}
 
 	return resourceSerialConsoleAccessRead(ctx, d, meta)
@@ -74,7 +74,7 @@ func resourceSerialConsoleAccessDelete(ctx context.Context, d *schema.ResourceDa
 
 	// Removing the resource disables serial console access.
 	if err := setSerialConsoleAccess(ctx, conn, false); err != nil {
-		return diag.Errorf("error disabling EC2 Serial Console Access: %s", err)
+		return diag.Errorf("disabling EC2 Serial Console Access: %s", err)
 	}
 
 	return nil

--- a/internal/service/ec2/ec2_serial_console_access_data_source.go
+++ b/internal/service/ec2/ec2_serial_console_access_data_source.go
@@ -33,7 +33,7 @@ func dataSourceSerialConsoleAccessRead(ctx context.Context, d *schema.ResourceDa
 	output, err := conn.GetSerialConsoleAccessStatusWithContext(ctx, &ec2.GetSerialConsoleAccessStatusInput{})
 
 	if err != nil {
-		return diag.Errorf("error reading EC2 Serial Console Access: %s", err)
+		return diag.Errorf("reading EC2 Serial Console Access: %s", err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)

--- a/internal/service/ec2/ipam_preview_next_cidr.go
+++ b/internal/service/ec2/ipam_preview_next_cidr.go
@@ -85,7 +85,7 @@ func resourceIPAMPreviewNextCIDRCreate(ctx context.Context, d *schema.ResourceDa
 	output, err := conn.AllocateIpamPoolCidrWithContext(ctx, input)
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error allocating cidr from IPAM pool (%s): %s", d.Get("ipam_pool_id").(string), err)
+		return sdkdiag.AppendErrorf(diags, "allocating cidr from IPAM pool (%s): %s", d.Get("ipam_pool_id").(string), err)
 	}
 
 	if output == nil || output.IpamPoolAllocation == nil {

--- a/internal/service/ec2/ipam_preview_next_cidr_data_source.go
+++ b/internal/service/ec2/ipam_preview_next_cidr_data_source.go
@@ -84,7 +84,7 @@ func dataSourceIPAMPreviewNextCIDRRead(ctx context.Context, d *schema.ResourceDa
 	output, err := conn.AllocateIpamPoolCidrWithContext(ctx, input)
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error previewing next cidr from IPAM pool (%s): %s", d.Get("ipam_pool_id").(string), err)
+		return sdkdiag.AppendErrorf(diags, "previewing next cidr from IPAM pool (%s): %s", d.Get("ipam_pool_id").(string), err)
 	}
 
 	if output == nil || output.IpamPoolAllocation == nil {

--- a/internal/service/ec2/vpc_endpoint_policy.go
+++ b/internal/service/ec2/vpc_endpoint_policy.go
@@ -77,7 +77,7 @@ func resourceVPCEndpointPolicyPut(ctx context.Context, d *schema.ResourceData, m
 
 	log.Printf("[DEBUG] Updating VPC Endpoint Policy: %#v", req)
 	if _, err := conn.ModifyVpcEndpointWithContext(ctx, req); err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error updating VPC Endpoint Policy: %s", err)
+		return sdkdiag.AppendErrorf(diags, "updating VPC Endpoint Policy: %s", err)
 	}
 	d.SetId(endpointID)
 
@@ -135,7 +135,7 @@ func resourceVPCEndpointPolicyDelete(ctx context.Context, d *schema.ResourceData
 
 	log.Printf("[DEBUG] Resetting VPC Endpoint Policy: %#v", req)
 	if _, err := conn.ModifyVpcEndpointWithContext(ctx, req); err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error Resetting VPC Endpoint Policy: %s", err)
+		return sdkdiag.AppendErrorf(diags, "Resetting VPC Endpoint Policy: %s", err)
 	}
 
 	_, err := WaitVPCEndpointAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete))

--- a/internal/service/ec2/vpc_nat_gateway_data_source.go
+++ b/internal/service/ec2/vpc_nat_gateway_data_source.go
@@ -130,7 +130,7 @@ func dataSourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	if err := d.Set("tags", KeyValueTags(ctx, ngw.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	return nil

--- a/internal/service/ec2/vpc_nat_gateways_data_source.go
+++ b/internal/service/ec2/vpc_nat_gateways_data_source.go
@@ -67,7 +67,7 @@ func dataSourceNATGatewaysRead(ctx context.Context, d *schema.ResourceData, meta
 	output, err := FindNATGateways(ctx, conn, input)
 
 	if err != nil {
-		return diag.Errorf("error reading EC2 NAT Gateways: %s", err)
+		return diag.Errorf("reading EC2 NAT Gateways: %s", err)
 	}
 
 	var natGatewayIDs []string

--- a/internal/service/ec2/vpc_network_insights_analysis.go
+++ b/internal/service/ec2/vpc_network_insights_analysis.go
@@ -1416,14 +1416,14 @@ func resourceNetworkInsightsAnalysisCreate(ctx context.Context, d *schema.Resour
 	output, err := conn.StartNetworkInsightsAnalysisWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating EC2 Network Insights Analysis: %s", err)
+		return diag.Errorf("creating EC2 Network Insights Analysis: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.NetworkInsightsAnalysis.NetworkInsightsAnalysisId))
 
 	if d.Get("wait_for_completion").(bool) {
 		if _, err := WaitNetworkInsightsAnalysisCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-			return diag.Errorf("error waiting for EC2 Network Insights Analysis (%s) create: %s", d.Id(), err)
+			return diag.Errorf("waiting for EC2 Network Insights Analysis (%s) create: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ecr/pull_through_cache_rule.go
+++ b/internal/service/ecr/pull_through_cache_rule.go
@@ -64,7 +64,7 @@ func resourcePullThroughCacheRuleCreate(ctx context.Context, d *schema.ResourceD
 	_, err := conn.CreatePullThroughCacheRuleWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating ECR Pull Through Cache Rule (%s): %s", repositoryPrefix, err)
+		return diag.Errorf("creating ECR Pull Through Cache Rule (%s): %s", repositoryPrefix, err)
 	}
 
 	d.SetId(repositoryPrefix)
@@ -84,7 +84,7 @@ func resourcePullThroughCacheRuleRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading ECR Pull Through Cache Rule (%s): %s", d.Id(), err)
+		return diag.Errorf("reading ECR Pull Through Cache Rule (%s): %s", d.Id(), err)
 	}
 
 	d.Set("ecr_repository_prefix", rule.EcrRepositoryPrefix)
@@ -108,7 +108,7 @@ func resourcePullThroughCacheRuleDelete(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting ECR Pull Through Cache Rule (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting ECR Pull Through Cache Rule (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/ecr/pull_through_cache_rule_data_source.go
+++ b/internal/service/ecr/pull_through_cache_rule_data_source.go
@@ -47,7 +47,7 @@ func dataSourcePullThroughCacheRuleRead(ctx context.Context, d *schema.ResourceD
 	rule, err := FindPullThroughCacheRuleByRepositoryPrefix(ctx, conn, repositoryPrefix)
 
 	if err != nil {
-		return diag.Errorf("error reading ECR Pull Through Cache Rule (%s): %s", repositoryPrefix, err)
+		return diag.Errorf("reading ECR Pull Through Cache Rule (%s): %s", repositoryPrefix, err)
 	}
 
 	d.SetId(aws.StringValue(rule.EcrRepositoryPrefix))

--- a/internal/service/eks/addon_data_source.go
+++ b/internal/service/eks/addon_data_source.go
@@ -67,7 +67,7 @@ func dataSourceAddonRead(ctx context.Context, d *schema.ResourceData, meta inter
 	addon, err := FindAddonByClusterNameAndAddonName(ctx, conn, clusterName, addonName)
 
 	if err != nil {
-		return diag.Errorf("error reading EKS Add-On (%s): %s", id, err)
+		return diag.Errorf("reading EKS Add-On (%s): %s", id, err)
 	}
 
 	d.SetId(id)
@@ -79,7 +79,7 @@ func dataSourceAddonRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("service_account_role_arn", addon.ServiceAccountRoleArn)
 
 	if err := d.Set("tags", KeyValueTags(ctx, addon.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	return nil

--- a/internal/service/eks/addon_version_data_source.go
+++ b/internal/service/eks/addon_version_data_source.go
@@ -47,7 +47,7 @@ func dataSourceAddonVersionRead(ctx context.Context, d *schema.ResourceData, met
 	versionInfo, err := FindAddonVersionByAddonNameAndKubernetesVersion(ctx, conn, id, kubernetesVersion, mostRecent)
 
 	if err != nil {
-		return diag.Errorf("error reading EKS Add-On version info (%s, %s): %s", id, kubernetesVersion, err)
+		return diag.Errorf("reading EKS Add-On version info (%s, %s): %s", id, kubernetesVersion, err)
 	}
 
 	d.SetId(id)

--- a/internal/service/eks/identity_provider_config.go
+++ b/internal/service/eks/identity_provider_config.go
@@ -143,7 +143,7 @@ func resourceIdentityProviderConfigCreate(ctx context.Context, d *schema.Resourc
 	_, err := conn.AssociateIdentityProviderConfigWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error associating EKS Identity Provider Config (%s): %s", idpID, err)
+		return diag.Errorf("associating EKS Identity Provider Config (%s): %s", idpID, err)
 	}
 
 	d.SetId(idpID)
@@ -151,7 +151,7 @@ func resourceIdentityProviderConfigCreate(ctx context.Context, d *schema.Resourc
 	_, err = waitOIDCIdentityProviderConfigCreated(ctx, conn, clusterName, configName, d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
-		return diag.Errorf("error waiting for EKS Identity Provider Config (%s) association: %s", d.Id(), err)
+		return diag.Errorf("waiting for EKS Identity Provider Config (%s) association: %s", d.Id(), err)
 	}
 
 	return resourceIdentityProviderConfigRead(ctx, d, meta)
@@ -175,14 +175,14 @@ func resourceIdentityProviderConfigRead(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading EKS Identity Provider Config (%s): %s", d.Id(), err)
+		return diag.Errorf("reading EKS Identity Provider Config (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", oidc.IdentityProviderConfigArn)
 	d.Set("cluster_name", oidc.ClusterName)
 
 	if err := d.Set("oidc", []interface{}{flattenOIDCIdentityProviderConfig(oidc)}); err != nil {
-		return diag.Errorf("error setting oidc: %s", err)
+		return diag.Errorf("setting oidc: %s", err)
 	}
 
 	d.Set("status", oidc.Status)
@@ -224,13 +224,13 @@ func resourceIdentityProviderConfigDelete(ctx context.Context, d *schema.Resourc
 	}
 
 	if err != nil {
-		return diag.Errorf("error disassociating EKS Identity Provider Config (%s): %s", d.Id(), err)
+		return diag.Errorf("disassociating EKS Identity Provider Config (%s): %s", d.Id(), err)
 	}
 
 	_, err = waitOIDCIdentityProviderConfigDeleted(ctx, conn, clusterName, configName, d.Timeout(schema.TimeoutDelete))
 
 	if err != nil {
-		return diag.Errorf("error waiting for EKS Identity Provider Config (%s) disassociation: %s", d.Id(), err)
+		return diag.Errorf("waiting for EKS Identity Provider Config (%s) disassociation: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/eks/node_group.go
+++ b/internal/service/eks/node_group.go
@@ -387,7 +387,7 @@ func resourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading EKS Node Group (%s): %s", d.Id(), err)
+		return diag.Errorf("reading EKS Node Group (%s): %s", d.Id(), err)
 	}
 
 	d.Set("ami_type", nodeGroup.AmiType)
@@ -397,15 +397,15 @@ func resourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("disk_size", nodeGroup.DiskSize)
 
 	if err := d.Set("instance_types", aws.StringValueSlice(nodeGroup.InstanceTypes)); err != nil {
-		return diag.Errorf("error setting instance_types: %s", err)
+		return diag.Errorf("setting instance_types: %s", err)
 	}
 
 	if err := d.Set("labels", aws.StringValueMap(nodeGroup.Labels)); err != nil {
-		return diag.Errorf("error setting labels: %s", err)
+		return diag.Errorf("setting labels: %s", err)
 	}
 
 	if err := d.Set("launch_template", flattenLaunchTemplateSpecification(nodeGroup.LaunchTemplate)); err != nil {
-		return diag.Errorf("error setting launch_template: %s", err)
+		return diag.Errorf("setting launch_template: %s", err)
 	}
 
 	d.Set("node_group_name", nodeGroup.NodegroupName)
@@ -414,16 +414,16 @@ func resourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("release_version", nodeGroup.ReleaseVersion)
 
 	if err := d.Set("remote_access", flattenRemoteAccessConfig(nodeGroup.RemoteAccess)); err != nil {
-		return diag.Errorf("error setting remote_access: %s", err)
+		return diag.Errorf("setting remote_access: %s", err)
 	}
 
 	if err := d.Set("resources", flattenNodeGroupResources(nodeGroup.Resources)); err != nil {
-		return diag.Errorf("error setting resources: %s", err)
+		return diag.Errorf("setting resources: %s", err)
 	}
 
 	if nodeGroup.ScalingConfig != nil {
 		if err := d.Set("scaling_config", []interface{}{flattenNodeGroupScalingConfig(nodeGroup.ScalingConfig)}); err != nil {
-			return diag.Errorf("error setting scaling_config: %s", err)
+			return diag.Errorf("setting scaling_config: %s", err)
 		}
 	} else {
 		d.Set("scaling_config", nil)
@@ -432,16 +432,16 @@ func resourceNodeGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("status", nodeGroup.Status)
 
 	if err := d.Set("subnet_ids", aws.StringValueSlice(nodeGroup.Subnets)); err != nil {
-		return diag.Errorf("error setting subnets: %s", err)
+		return diag.Errorf("setting subnets: %s", err)
 	}
 
 	if err := d.Set("taint", flattenTaints(nodeGroup.Taints)); err != nil {
-		return diag.Errorf("error setting taint: %s", err)
+		return diag.Errorf("setting taint: %s", err)
 	}
 
 	if nodeGroup.UpdateConfig != nil {
 		if err := d.Set("update_config", []interface{}{flattenNodeGroupUpdateConfig(nodeGroup.UpdateConfig)}); err != nil {
-			return diag.Errorf("error setting update_config: %s", err)
+			return diag.Errorf("setting update_config: %s", err)
 		}
 	} else {
 		d.Set("update_config", nil)
@@ -503,7 +503,7 @@ func resourceNodeGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		output, err := conn.UpdateNodegroupVersionWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("error updating EKS Node Group (%s) version: %s", d.Id(), err)
+			return diag.Errorf("updating EKS Node Group (%s) version: %s", d.Id(), err)
 		}
 
 		updateID := aws.StringValue(output.Update.Id)
@@ -511,7 +511,7 @@ func resourceNodeGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		_, err = waitNodegroupUpdateSuccessful(ctx, conn, clusterName, nodeGroupName, updateID, d.Timeout(schema.TimeoutUpdate))
 
 		if err != nil {
-			return diag.Errorf("error waiting for EKS Node Group (%s) version update (%s): %s", d.Id(), updateID, err)
+			return diag.Errorf("waiting for EKS Node Group (%s) version update (%s): %s", d.Id(), updateID, err)
 		}
 	}
 
@@ -542,7 +542,7 @@ func resourceNodeGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		output, err := conn.UpdateNodegroupConfigWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("error updating EKS Node Group (%s) config: %s", d.Id(), err)
+			return diag.Errorf("updating EKS Node Group (%s) config: %s", d.Id(), err)
 		}
 
 		updateID := aws.StringValue(output.Update.Id)
@@ -550,7 +550,7 @@ func resourceNodeGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		_, err = waitNodegroupUpdateSuccessful(ctx, conn, clusterName, nodeGroupName, updateID, d.Timeout(schema.TimeoutUpdate))
 
 		if err != nil {
-			return diag.Errorf("error waiting for EKS Node Group (%s) config update (%s): %s", d.Id(), updateID, err)
+			return diag.Errorf("waiting for EKS Node Group (%s) config update (%s): %s", d.Id(), updateID, err)
 		}
 	}
 
@@ -577,13 +577,13 @@ func resourceNodeGroupDelete(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting EKS Node Group (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting EKS Node Group (%s): %s", d.Id(), err)
 	}
 
 	_, err = waitNodegroupDeleted(ctx, conn, clusterName, nodeGroupName, d.Timeout(schema.TimeoutDelete))
 
 	if err != nil {
-		return diag.Errorf("error waiting for EKS Node Group (%s) to delete: %s", d.Id(), err)
+		return diag.Errorf("waiting for EKS Node Group (%s) to delete: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/emr/release_labels_data_source.go
+++ b/internal/service/emr/release_labels_data_source.go
@@ -55,7 +55,7 @@ func dataSourceReleaseLabelsRead(ctx context.Context, d *schema.ResourceData, me
 	output, err := findReleaseLabels(ctx, conn, input)
 
 	if err != nil {
-		return diag.Errorf("error reading EMR Release Labels: %s", err)
+		return diag.Errorf("reading EMR Release Labels: %s", err)
 	}
 
 	releaseLabels := aws.StringValueSlice(output)

--- a/internal/service/glue/catalog_table_data_source.go
+++ b/internal/service/glue/catalog_table_data_source.go
@@ -345,7 +345,7 @@ func dataSourceCatalogTableRead(ctx context.Context, d *schema.ResourceData, met
 				dbName)
 		}
 
-		return diag.Errorf("Error reading Glue Catalog Table: %s", err)
+		return diag.Errorf("reading Glue Catalog Table: %s", err)
 	}
 
 	table := out.Table

--- a/internal/service/glue/catalog_table_data_source.go
+++ b/internal/service/glue/catalog_table_data_source.go
@@ -366,11 +366,11 @@ func dataSourceCatalogTableRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("retention", table.Retention)
 
 	if err := d.Set("storage_descriptor", flattenStorageDescriptor(table.StorageDescriptor)); err != nil {
-		return diag.Errorf("error setting storage_descriptor: %s", err)
+		return diag.Errorf("setting storage_descriptor: %s", err)
 	}
 
 	if err := d.Set("partition_keys", flattenColumns(table.PartitionKeys)); err != nil {
-		return diag.Errorf("error setting partition_keys: %s", err)
+		return diag.Errorf("setting partition_keys: %s", err)
 	}
 
 	d.Set("view_original_text", table.ViewOriginalText)
@@ -378,12 +378,12 @@ func dataSourceCatalogTableRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("table_type", table.TableType)
 
 	if err := d.Set("parameters", aws.StringValueMap(table.Parameters)); err != nil {
-		return diag.Errorf("error setting parameters: %s", err)
+		return diag.Errorf("setting parameters: %s", err)
 	}
 
 	if table.TargetTable != nil {
 		if err := d.Set("target_table", []interface{}{flattenTableTargetTable(table.TargetTable)}); err != nil {
-			return diag.Errorf("error setting target_table: %s", err)
+			return diag.Errorf("setting target_table: %s", err)
 		}
 	} else {
 		d.Set("target_table", nil)
@@ -396,12 +396,12 @@ func dataSourceCatalogTableRead(ctx context.Context, d *schema.ResourceData, met
 	}
 	partOut, err := conn.GetPartitionIndexesWithContext(ctx, partIndexInput)
 	if err != nil {
-		return diag.Errorf("error getting Glue Partition Indexes: %s", err)
+		return diag.Errorf("getting Glue Partition Indexes: %s", err)
 	}
 
 	if partOut != nil && len(partOut.PartitionIndexDescriptorList) > 0 {
 		if err := d.Set("partition_index", flattenPartitionIndexes(partOut.PartitionIndexDescriptorList)); err != nil {
-			return diag.Errorf("error setting partition_index: %s", err)
+			return diag.Errorf("setting partition_index: %s", err)
 		}
 	}
 

--- a/internal/service/glue/connection_data_source.go
+++ b/internal/service/glue/connection_data_source.go
@@ -91,15 +91,15 @@ func dataSourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta 
 	id := d.Get("id").(string)
 	catalogID, connectionName, err := DecodeConnectionID(id)
 	if err != nil {
-		return diag.Errorf("error decoding Glue Connection %s: %s", id, err)
+		return diag.Errorf("decoding Glue Connection %s: %s", id, err)
 	}
 
 	connection, err := FindConnectionByName(ctx, conn, connectionName, catalogID)
 	if err != nil {
 		if tfresource.NotFound(err) {
-			return diag.Errorf("error Glue Connection (%s) not found", id)
+			return diag.Errorf("Glue Connection (%s) not found", id)
 		}
-		return diag.Errorf("error reading Glue Connection (%s): %s", id, err)
+		return diag.Errorf("reading Glue Connection (%s): %s", id, err)
 	}
 
 	d.SetId(id)
@@ -118,26 +118,26 @@ func dataSourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("arn", connectionArn)
 
 	if err := d.Set("connection_properties", aws.StringValueMap(connection.ConnectionProperties)); err != nil {
-		return diag.Errorf("error setting connection_properties: %s", err)
+		return diag.Errorf("setting connection_properties: %s", err)
 	}
 
 	if err := d.Set("physical_connection_requirements", flattenPhysicalConnectionRequirements(connection.PhysicalConnectionRequirements)); err != nil {
-		return diag.Errorf("error setting physical_connection_requirements: %s", err)
+		return diag.Errorf("setting physical_connection_requirements: %s", err)
 	}
 
 	if err := d.Set("match_criteria", flex.FlattenStringList(connection.MatchCriteria)); err != nil {
-		return diag.Errorf("error setting match_criteria: %s", err)
+		return diag.Errorf("setting match_criteria: %s", err)
 	}
 
 	tags, err := ListTags(ctx, conn, connectionArn)
 
 	if err != nil {
-		return diag.Errorf("error listing tags for Glue Connection (%s): %s", connectionArn, err)
+		return diag.Errorf("listing tags for Glue Connection (%s): %s", connectionArn, err)
 	}
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	return nil

--- a/internal/service/glue/data_catalog_encryption_settings_data_source.go
+++ b/internal/service/glue/data_catalog_encryption_settings_data_source.go
@@ -72,14 +72,14 @@ func dataSourceDataCatalogEncryptionSettingsRead(ctx context.Context, d *schema.
 	})
 
 	if err != nil {
-		return diag.Errorf("error reading Glue Data Catalog Encryption Settings (%s): %s", catalogID, err)
+		return diag.Errorf("reading Glue Data Catalog Encryption Settings (%s): %s", catalogID, err)
 	}
 
 	d.SetId(catalogID)
 	d.Set("catalog_id", d.Id())
 	if output.DataCatalogEncryptionSettings != nil {
 		if err := d.Set("data_catalog_encryption_settings", []interface{}{flattenDataCatalogEncryptionSettings(output.DataCatalogEncryptionSettings)}); err != nil {
-			return diag.Errorf("error setting data_catalog_encryption_settings: %s", err)
+			return diag.Errorf("setting data_catalog_encryption_settings: %s", err)
 		}
 	} else {
 		d.Set("data_catalog_encryption_settings", nil)

--- a/internal/service/guardduty/detector.go
+++ b/internal/service/guardduty/detector.go
@@ -237,7 +237,7 @@ func resourceDetectorUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		log.Printf("[DEBUG] Update GuardDuty Detector: %s", input)
 		_, err := conn.UpdateDetectorWithContext(ctx, &input)
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "Updating GuardDuty Detector '%s' failed: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating GuardDuty Detector (%s): %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/iam/openid_connect_provider_data_source.go
+++ b/internal/service/iam/openid_connect_provider_data_source.go
@@ -64,11 +64,11 @@ func dataSourceOpenIDConnectProviderRead(ctx context.Context, d *schema.Resource
 
 		oidcpEntry, err := dataSourceGetOpenIDConnectProviderByURL(ctx, conn, url)
 		if err != nil {
-			return diag.Errorf("error finding IAM OIDC Provider by url (%s): %s", url, err)
+			return diag.Errorf("finding IAM OIDC Provider by url (%s): %s", url, err)
 		}
 
 		if oidcpEntry == nil {
-			return diag.Errorf("error finding IAM OIDC Provider by url (%s): not found", url)
+			return diag.Errorf("finding IAM OIDC Provider by url (%s): not found", url)
 		}
 		input.OpenIDConnectProviderArn = oidcpEntry.Arn
 	}
@@ -76,7 +76,7 @@ func dataSourceOpenIDConnectProviderRead(ctx context.Context, d *schema.Resource
 	resp, err := conn.GetOpenIDConnectProviderWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error reading IAM OIDC Provider: %s", err)
+		return diag.Errorf("reading IAM OIDC Provider: %s", err)
 	}
 
 	d.SetId(aws.StringValue(input.OpenIDConnectProviderArn))
@@ -86,7 +86,7 @@ func dataSourceOpenIDConnectProviderRead(ctx context.Context, d *schema.Resource
 	d.Set("thumbprint_list", flex.FlattenStringList(resp.ThumbprintList))
 
 	if err := d.Set("tags", KeyValueTags(ctx, resp.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	return nil

--- a/internal/service/iam/saml_provider_data_source.go
+++ b/internal/service/iam/saml_provider_data_source.go
@@ -79,7 +79,7 @@ func dataSourceSAMLProviderRead(ctx context.Context, d *schema.ResourceData, met
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	return nil

--- a/internal/service/iot/indexing_configuration.go
+++ b/internal/service/iot/indexing_configuration.go
@@ -166,7 +166,7 @@ func resourceIndexingConfigurationPut(ctx context.Context, d *schema.ResourceDat
 	_, err := conn.UpdateIndexingConfigurationWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error updating IoT Indexing Configuration: %s", err)
+		return diag.Errorf("updating IoT Indexing Configuration: %s", err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)
@@ -180,19 +180,19 @@ func resourceIndexingConfigurationRead(ctx context.Context, d *schema.ResourceDa
 	output, err := conn.GetIndexingConfigurationWithContext(ctx, &iot.GetIndexingConfigurationInput{})
 
 	if err != nil {
-		return diag.Errorf("error reading IoT Indexing Configuration: %s", err)
+		return diag.Errorf("reading IoT Indexing Configuration: %s", err)
 	}
 
 	if output.ThingGroupIndexingConfiguration != nil {
 		if err := d.Set("thing_group_indexing_configuration", []interface{}{flattenThingGroupIndexingConfiguration(output.ThingGroupIndexingConfiguration)}); err != nil {
-			return diag.Errorf("error setting thing_group_indexing_configuration: %s", err)
+			return diag.Errorf("setting thing_group_indexing_configuration: %s", err)
 		}
 	} else {
 		d.Set("thing_group_indexing_configuration", nil)
 	}
 	if output.ThingIndexingConfiguration != nil {
 		if err := d.Set("thing_indexing_configuration", []interface{}{flattenThingIndexingConfiguration(output.ThingIndexingConfiguration)}); err != nil {
-			return diag.Errorf("error setting thing_indexing_configuration: %s", err)
+			return diag.Errorf("setting thing_indexing_configuration: %s", err)
 		}
 	} else {
 		d.Set("thing_indexing_configuration", nil)

--- a/internal/service/iot/provisioning_template.go
+++ b/internal/service/iot/provisioning_template.go
@@ -144,7 +144,7 @@ func resourceProvisioningTemplateCreate(ctx context.Context, d *schema.ResourceD
 		iot.ErrCodeInvalidRequestException, "The provisioning role cannot be assumed by AWS IoT")
 
 	if err != nil {
-		return diag.Errorf("error creating IoT Provisioning Template (%s): %s", name, err)
+		return diag.Errorf("creating IoT Provisioning Template (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(outputRaw.(*iot.CreateProvisioningTemplateOutput).TemplateName))
@@ -164,7 +164,7 @@ func resourceProvisioningTemplateRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading IoT Provisioning Template (%s): %s", d.Id(), err)
+		return diag.Errorf("reading IoT Provisioning Template (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", output.TemplateArn)
@@ -174,7 +174,7 @@ func resourceProvisioningTemplateRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("name", output.TemplateName)
 	if output.PreProvisioningHook != nil {
 		if err := d.Set("pre_provisioning_hook", []interface{}{flattenProvisioningHook(output.PreProvisioningHook)}); err != nil {
-			return diag.Errorf("error setting pre_provisioning_hook: %s", err)
+			return diag.Errorf("setting pre_provisioning_hook: %s", err)
 		}
 	} else {
 		d.Set("pre_provisioning_hook", nil)
@@ -199,7 +199,7 @@ func resourceProvisioningTemplateUpdate(ctx context.Context, d *schema.ResourceD
 		_, err := conn.CreateProvisioningTemplateVersionWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("error creating IoT Provisioning Template (%s) version: %s", d.Id(), err)
+			return diag.Errorf("creating IoT Provisioning Template (%s) version: %s", d.Id(), err)
 		}
 	}
 
@@ -219,7 +219,7 @@ func resourceProvisioningTemplateUpdate(ctx context.Context, d *schema.ResourceD
 			iot.ErrCodeInvalidRequestException, "The provisioning role cannot be assumed by AWS IoT")
 
 		if err != nil {
-			return diag.Errorf("error updating IoT Provisioning Template (%s): %s", d.Id(), err)
+			return diag.Errorf("updating IoT Provisioning Template (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -239,7 +239,7 @@ func resourceProvisioningTemplateDelete(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting IoT Provisioning Template (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting IoT Provisioning Template (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/kafkaconnect/connector.go
+++ b/internal/service/kafkaconnect/connector.go
@@ -414,7 +414,7 @@ func resourceConnectorCreate(ctx context.Context, d *schema.ResourceData, meta i
 	output, err := conn.CreateConnectorWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating MSK Connect Connector (%s): %s", name, err)
+		return diag.Errorf("creating MSK Connect Connector (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.ConnectorArn))
@@ -422,7 +422,7 @@ func resourceConnectorCreate(ctx context.Context, d *schema.ResourceData, meta i
 	_, err = waitConnectorCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
-		return diag.Errorf("error waiting for MSK Connect Connector (%s) create: %s", d.Id(), err)
+		return diag.Errorf("waiting for MSK Connect Connector (%s) create: %s", d.Id(), err)
 	}
 
 	return resourceConnectorRead(ctx, d, meta)
@@ -440,13 +440,13 @@ func resourceConnectorRead(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading MSK Connect Connector (%s): %s", d.Id(), err)
+		return diag.Errorf("reading MSK Connect Connector (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", connector.ConnectorArn)
 	if connector.Capacity != nil {
 		if err := d.Set("capacity", []interface{}{flattenCapacityDescription(connector.Capacity)}); err != nil {
-			return diag.Errorf("error setting capacity: %s", err)
+			return diag.Errorf("setting capacity: %s", err)
 		}
 	} else {
 		d.Set("capacity", nil)
@@ -455,21 +455,21 @@ func resourceConnectorRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("description", connector.ConnectorDescription)
 	if connector.KafkaCluster != nil {
 		if err := d.Set("kafka_cluster", []interface{}{flattenClusterDescription(connector.KafkaCluster)}); err != nil {
-			return diag.Errorf("error setting kafka_cluster: %s", err)
+			return diag.Errorf("setting kafka_cluster: %s", err)
 		}
 	} else {
 		d.Set("kafka_cluster", nil)
 	}
 	if connector.KafkaClusterClientAuthentication != nil {
 		if err := d.Set("kafka_cluster_client_authentication", []interface{}{flattenClusterClientAuthenticationDescription(connector.KafkaClusterClientAuthentication)}); err != nil {
-			return diag.Errorf("error setting kafka_cluster_client_authentication: %s", err)
+			return diag.Errorf("setting kafka_cluster_client_authentication: %s", err)
 		}
 	} else {
 		d.Set("kafka_cluster_client_authentication", nil)
 	}
 	if connector.KafkaClusterEncryptionInTransit != nil {
 		if err := d.Set("kafka_cluster_encryption_in_transit", []interface{}{flattenClusterEncryptionInTransitDescription(connector.KafkaClusterEncryptionInTransit)}); err != nil {
-			return diag.Errorf("error setting kafka_cluster_encryption_in_transit: %s", err)
+			return diag.Errorf("setting kafka_cluster_encryption_in_transit: %s", err)
 		}
 	} else {
 		d.Set("kafka_cluster_encryption_in_transit", nil)
@@ -477,20 +477,20 @@ func resourceConnectorRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("kafkaconnect_version", connector.KafkaConnectVersion)
 	if connector.LogDelivery != nil {
 		if err := d.Set("log_delivery", []interface{}{flattenLogDeliveryDescription(connector.LogDelivery)}); err != nil {
-			return diag.Errorf("error setting log_delivery: %s", err)
+			return diag.Errorf("setting log_delivery: %s", err)
 		}
 	} else {
 		d.Set("log_delivery", nil)
 	}
 	d.Set("name", connector.ConnectorName)
 	if err := d.Set("plugin", flattenPluginDescriptions(connector.Plugins)); err != nil {
-		return diag.Errorf("error setting plugin: %s", err)
+		return diag.Errorf("setting plugin: %s", err)
 	}
 	d.Set("service_execution_role_arn", connector.ServiceExecutionRoleArn)
 	d.Set("version", connector.CurrentVersion)
 	if connector.WorkerConfiguration != nil {
 		if err := d.Set("worker_configuration", []interface{}{flattenWorkerConfigurationDescription(connector.WorkerConfiguration)}); err != nil {
-			return diag.Errorf("error setting worker_configuration: %s", err)
+			return diag.Errorf("setting worker_configuration: %s", err)
 		}
 	} else {
 		d.Set("worker_configuration", nil)
@@ -512,13 +512,13 @@ func resourceConnectorUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	_, err := conn.UpdateConnectorWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error updating MSK Connect Connector (%s): %s", d.Id(), err)
+		return diag.Errorf("updating MSK Connect Connector (%s): %s", d.Id(), err)
 	}
 
 	_, err = waitConnectorUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 
 	if err != nil {
-		return diag.Errorf("error waiting for MSK Connect Connector (%s) update: %s", d.Id(), err)
+		return diag.Errorf("waiting for MSK Connect Connector (%s) update: %s", d.Id(), err)
 	}
 
 	return resourceConnectorRead(ctx, d, meta)
@@ -537,13 +537,13 @@ func resourceConnectorDelete(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting MSK Connect Connector (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting MSK Connect Connector (%s): %s", d.Id(), err)
 	}
 
 	_, err = waitConnectorDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete))
 
 	if err != nil {
-		return diag.Errorf("error waiting for MSK Connect Connector (%s) delete: %s", d.Id(), err)
+		return diag.Errorf("waiting for MSK Connect Connector (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/kafkaconnect/connector_data_source.go
+++ b/internal/service/kafkaconnect/connector_data_source.go
@@ -58,7 +58,7 @@ func dataSourceConnectorRead(ctx context.Context, d *schema.ResourceData, meta i
 	})
 
 	if err != nil {
-		return diag.Errorf("error listing MSK Connect Connectors: %s", err)
+		return diag.Errorf("listing MSK Connect Connectors: %s", err)
 	}
 
 	if len(output) == 0 || output[0] == nil {

--- a/internal/service/kafkaconnect/custom_plugin.go
+++ b/internal/service/kafkaconnect/custom_plugin.go
@@ -119,7 +119,7 @@ func resourceCustomPluginCreate(ctx context.Context, d *schema.ResourceData, met
 	output, err := conn.CreateCustomPluginWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating MSK Connect Custom Plugin (%s): %s", name, err)
+		return diag.Errorf("creating MSK Connect Custom Plugin (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.CustomPluginArn))
@@ -127,7 +127,7 @@ func resourceCustomPluginCreate(ctx context.Context, d *schema.ResourceData, met
 	_, err = waitCustomPluginCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
-		return diag.Errorf("error waiting for MSK Connect Custom Plugin (%s) create: %s", d.Id(), err)
+		return diag.Errorf("waiting for MSK Connect Custom Plugin (%s) create: %s", d.Id(), err)
 	}
 
 	return resourceCustomPluginRead(ctx, d, meta)
@@ -145,7 +145,7 @@ func resourceCustomPluginRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading MSK Connect Custom Plugin (%s): %s", d.Id(), err)
+		return diag.Errorf("reading MSK Connect Custom Plugin (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", plugin.CustomPluginArn)
@@ -158,7 +158,7 @@ func resourceCustomPluginRead(ctx context.Context, d *schema.ResourceData, meta 
 		d.Set("latest_revision", plugin.LatestRevision.Revision)
 		if plugin.LatestRevision.Location != nil {
 			if err := d.Set("location", []interface{}{flattenCustomPluginLocationDescription(plugin.LatestRevision.Location)}); err != nil {
-				return diag.Errorf("error setting location: %s", err)
+				return diag.Errorf("setting location: %s", err)
 			}
 		} else {
 			d.Set("location", nil)
@@ -185,13 +185,13 @@ func resourceCustomPluginDelete(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting MSK Connect Custom Plugin (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting MSK Connect Custom Plugin (%s): %s", d.Id(), err)
 	}
 
 	_, err = waitCustomPluginDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete))
 
 	if err != nil {
-		return diag.Errorf("error waiting for MSK Connect Custom Plugin (%s) delete: %s", d.Id(), err)
+		return diag.Errorf("waiting for MSK Connect Custom Plugin (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/kafkaconnect/custom_plugin_data_source.go
+++ b/internal/service/kafkaconnect/custom_plugin_data_source.go
@@ -62,7 +62,7 @@ func dataSourceCustomPluginRead(ctx context.Context, d *schema.ResourceData, met
 	})
 
 	if err != nil {
-		return diag.Errorf("error listing MSK Connect Custom Plugins: %s", err)
+		return diag.Errorf("listing MSK Connect Custom Plugins: %s", err)
 	}
 
 	if len(output) == 0 || output[0] == nil {

--- a/internal/service/kafkaconnect/worker_configuration.go
+++ b/internal/service/kafkaconnect/worker_configuration.go
@@ -78,7 +78,7 @@ func resourceWorkerConfigurationCreate(ctx context.Context, d *schema.ResourceDa
 	output, err := conn.CreateWorkerConfigurationWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating MSK Connect Worker Configuration (%s): %s", name, err)
+		return diag.Errorf("creating MSK Connect Worker Configuration (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.WorkerConfigurationArn))
@@ -98,7 +98,7 @@ func resourceWorkerConfigurationRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading MSK Connect Worker Configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("reading MSK Connect Worker Configuration (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", config.WorkerConfigurationArn)

--- a/internal/service/kafkaconnect/worker_configuration_data_source.go
+++ b/internal/service/kafkaconnect/worker_configuration_data_source.go
@@ -62,7 +62,7 @@ func dataSourceWorkerConfigurationRead(ctx context.Context, d *schema.ResourceDa
 	})
 
 	if err != nil {
-		return diag.Errorf("error listing MSK Connect Worker Configurations: %s", err)
+		return diag.Errorf("listing MSK Connect Worker Configurations: %s", err)
 	}
 
 	if len(output) == 0 || output[0] == nil {
@@ -79,7 +79,7 @@ func dataSourceWorkerConfigurationRead(ctx context.Context, d *schema.ResourceDa
 	config, err := FindWorkerConfigurationByARN(ctx, conn, arn)
 
 	if err != nil {
-		return diag.Errorf("error reading MSK Connect Worker Configuration (%s): %s", arn, err)
+		return diag.Errorf("reading MSK Connect Worker Configuration (%s): %s", arn, err)
 	}
 
 	d.SetId(aws.StringValue(config.Name))

--- a/internal/service/kendra/faq_data_source.go
+++ b/internal/service/kendra/faq_data_source.go
@@ -144,12 +144,12 @@ func dataSourceFaqRead(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	tags, err := ListTags(ctx, conn, arn)
 	if err != nil {
-		return diag.Errorf("error listing tags for resource (%s): %s", arn, err)
+		return diag.Errorf("listing tags for resource (%s): %s", arn, err)
 	}
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", id, indexId))

--- a/internal/service/kendra/index.go
+++ b/internal/service/kendra/index.go
@@ -426,11 +426,11 @@ func resourceIndexCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	)
 
 	if err != nil {
-		return diag.Errorf("error creating Kendra Index (%s): %s", name, err)
+		return diag.Errorf("creating Kendra Index (%s): %s", name, err)
 	}
 
 	if outputRaw == nil {
-		return diag.Errorf("error creating Kendra Index (%s): empty output", name)
+		return diag.Errorf("creating Kendra Index (%s): empty output", name)
 	}
 
 	output := outputRaw.(*kendra.CreateIndexOutput)
@@ -439,7 +439,7 @@ func resourceIndexCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	// waiter since the status changes from CREATING to either ACTIVE or FAILED
 	if _, err := waitIndexCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("error waiting for Index (%s) creation: %s", d.Id(), err)
+		return diag.Errorf("waiting for Index (%s) creation: %s", d.Id(), err)
 	}
 
 	callUpdateIndex := false
@@ -473,7 +473,7 @@ func resourceIndexRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting Kendra Index (%s): %s", d.Id(), err)
+		return diag.Errorf("getting Kendra Index (%s): %s", d.Id(), err)
 	}
 
 	arn := arn.ARN{
@@ -572,12 +572,12 @@ func resourceIndexUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		)
 
 		if err != nil {
-			return diag.Errorf("error updating Index (%s): %s", d.Id(), err)
+			return diag.Errorf("updating Index (%s): %s", d.Id(), err)
 		}
 
 		// waiter since the status changes from UPDATING to either ACTIVE or FAILED
 		if _, err := waitIndexUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("error waiting for Index (%s) update: %s", d.Id(), err)
+			return diag.Errorf("waiting for Index (%s) update: %s", d.Id(), err)
 		}
 	}
 
@@ -594,11 +594,11 @@ func resourceIndexDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	})
 
 	if err != nil {
-		return diag.Errorf("error deleting Index (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Index (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitIndexDeleted(ctx, conn, id, d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("error waiting for Index (%s) delete: %s", d.Id(), err)
+		return diag.Errorf("waiting for Index (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/kendra/index_data_source.go
+++ b/internal/service/kendra/index_data_source.go
@@ -287,11 +287,11 @@ func dataSourceIndexRead(ctx context.Context, d *schema.ResourceData, meta inter
 	resp, err := findIndexByID(ctx, conn, id)
 
 	if err != nil {
-		return diag.Errorf("error getting Kendra Index (%s): %s", id, err)
+		return diag.Errorf("getting Kendra Index (%s): %s", id, err)
 	}
 
 	if resp == nil {
-		return diag.Errorf("error getting Kendra Index (%s): empty response", id)
+		return diag.Errorf("getting Kendra Index (%s): empty response", id)
 	}
 
 	arn := arn.ARN{
@@ -339,12 +339,12 @@ func dataSourceIndexRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	tags, err := ListTags(ctx, conn, arn)
 	if err != nil {
-		return diag.Errorf("error listing tags for resource (%s): %s", arn, err)
+		return diag.Errorf("listing tags for resource (%s): %s", arn, err)
 	}
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	d.SetId(id)

--- a/internal/service/lambda/function_url.go
+++ b/internal/service/lambda/function_url.go
@@ -143,7 +143,7 @@ func resourceFunctionURLCreate(ctx context.Context, d *schema.ResourceData, meta
 	_, err := conn.CreateFunctionUrlConfigWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Lambda Function URL (%s): %s", id, err)
+		return diag.Errorf("creating Lambda Function URL (%s): %s", id, err)
 	}
 
 	d.SetId(id)
@@ -168,7 +168,7 @@ func resourceFunctionURLCreate(ctx context.Context, d *schema.ResourceData, meta
 			if tfawserr.ErrMessageContains(err, lambda.ErrCodeResourceConflictException, "The statement id (FunctionURLAllowPublicAccess) provided already exists") {
 				log.Printf("[DEBUG] function permission statement 'FunctionURLAllowPublicAccess' already exists.")
 			} else {
-				return diag.Errorf("error adding Lambda Function URL (%s) permission %s", d.Id(), err)
+				return diag.Errorf("adding Lambda Function URL (%s) permission %s", d.Id(), err)
 			}
 		}
 	}
@@ -194,7 +194,7 @@ func resourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Lambda Function URL (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Lambda Function URL (%s): %s", d.Id(), err)
 	}
 
 	functionURL := aws.StringValue(output.FunctionUrl)
@@ -202,7 +202,7 @@ func resourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("authorization_type", output.AuthType)
 	if output.Cors != nil {
 		if err := d.Set("cors", []interface{}{flattenCors(output.Cors)}); err != nil {
-			return diag.Errorf("error setting cors: %s", err)
+			return diag.Errorf("setting cors: %s", err)
 		}
 	} else {
 		d.Set("cors", nil)
@@ -216,7 +216,7 @@ func resourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta i
 	// Function URL endpoints have the following format:
 	// https://<url-id>.lambda-url.<region>.on.aws
 	if v, err := url.Parse(functionURL); err != nil {
-		return diag.Errorf("error parsing URL (%s): %s", functionURL, err)
+		return diag.Errorf("parsing URL (%s): %s", functionURL, err)
 	} else if v := strings.Split(v.Host, "."); len(v) > 0 {
 		d.Set("url_id", v[0])
 	} else {
@@ -263,7 +263,7 @@ func resourceFunctionURLUpdate(ctx context.Context, d *schema.ResourceData, meta
 	_, err = conn.UpdateFunctionUrlConfigWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error updating Lambda Function URL (%s): %s", d.Id(), err)
+		return diag.Errorf("updating Lambda Function URL (%s): %s", d.Id(), err)
 	}
 
 	return resourceFunctionURLRead(ctx, d, meta)
@@ -294,7 +294,7 @@ func resourceFunctionURLDelete(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Lambda Function URL (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Lambda Function URL (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/lambda/function_url_data_source.go
+++ b/internal/service/lambda/function_url_data_source.go
@@ -102,7 +102,7 @@ func dataSourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta
 	output, err := FindFunctionURLByNameAndQualifier(ctx, conn, name, qualifier)
 
 	if err != nil {
-		return diag.Errorf("error reading Lambda Function URL (%s): %s", id, err)
+		return diag.Errorf("reading Lambda Function URL (%s): %s", id, err)
 	}
 
 	functionURL := aws.StringValue(output.FunctionUrl)
@@ -111,7 +111,7 @@ func dataSourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("authorization_type", output.AuthType)
 	if output.Cors != nil {
 		if err := d.Set("cors", []interface{}{flattenCors(output.Cors)}); err != nil {
-			return diag.Errorf("error setting cors: %s", err)
+			return diag.Errorf("setting cors: %s", err)
 		}
 	} else {
 		d.Set("cors", nil)
@@ -127,7 +127,7 @@ func dataSourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta
 	// Function URL endpoints have the following format:
 	// https://<url-id>.lambda-url.<region>.on.aws
 	if v, err := url.Parse(functionURL); err != nil {
-		return diag.Errorf("error parsing URL (%s): %s", functionURL, err)
+		return diag.Errorf("parsing URL (%s): %s", functionURL, err)
 	} else if v := strings.Split(v.Host, "."); len(v) > 0 {
 		d.Set("url_id", v[0])
 	} else {

--- a/internal/service/lightsail/container_service.go
+++ b/internal/service/lightsail/container_service.go
@@ -185,13 +185,13 @@ func resourceContainerServiceCreate(ctx context.Context, d *schema.ResourceData,
 
 	_, err := conn.CreateContainerServiceWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("error creating Lightsail Container Service (%s): %s", serviceName, err)
+		return diag.Errorf("creating Lightsail Container Service (%s): %s", serviceName, err)
 	}
 
 	d.SetId(serviceName)
 
 	if err := waitContainerServiceCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("error waiting for Lightsail Container Service (%s) creation: %s", d.Id(), err)
+		return diag.Errorf("waiting for Lightsail Container Service (%s) creation: %s", d.Id(), err)
 	}
 
 	// once container service creation and/or deployment successful (now enabled by default), disable it if "is_disabled" is true
@@ -203,11 +203,11 @@ func resourceContainerServiceCreate(ctx context.Context, d *schema.ResourceData,
 
 		_, err := conn.UpdateContainerServiceWithContext(ctx, input)
 		if err != nil {
-			return diag.Errorf("error disabling Lightsail Container Service (%s): %s", d.Id(), err)
+			return diag.Errorf("disabling Lightsail Container Service (%s): %s", d.Id(), err)
 		}
 
 		if err := waitContainerServiceDisabled(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-			return diag.Errorf("error waiting for Lightsail Container Service (%s) to be disabled: %s", d.Id(), err)
+			return diag.Errorf("waiting for Lightsail Container Service (%s) to be disabled: %s", d.Id(), err)
 		}
 	}
 
@@ -226,7 +226,7 @@ func resourceContainerServiceRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Lightsail Container Service (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Lightsail Container Service (%s): %s", d.Id(), err)
 	}
 
 	d.Set("name", cs.ContainerServiceName)
@@ -235,10 +235,10 @@ func resourceContainerServiceRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("is_disabled", cs.IsDisabled)
 
 	if err := d.Set("public_domain_names", flattenContainerServicePublicDomainNames(cs.PublicDomainNames)); err != nil {
-		return diag.Errorf("error setting public_domain_names for Lightsail Container Service (%s): %s", d.Id(), err)
+		return diag.Errorf("setting public_domain_names for Lightsail Container Service (%s): %s", d.Id(), err)
 	}
 	if err := d.Set("private_registry_access", []interface{}{flattenPrivateRegistryAccess(cs.PrivateRegistryAccess)}); err != nil {
-		return diag.Errorf("error setting private_registry_access for Lightsail Container Service (%s): %s", d.Id(), err)
+		return diag.Errorf("setting private_registry_access for Lightsail Container Service (%s): %s", d.Id(), err)
 	}
 	d.Set("arn", cs.Arn)
 	d.Set("availability_zone", cs.Location.AvailabilityZone)
@@ -271,16 +271,16 @@ func resourceContainerServiceUpdate(ctx context.Context, d *schema.ResourceData,
 
 		_, err := conn.UpdateContainerServiceWithContext(ctx, input)
 		if err != nil {
-			return diag.Errorf("error updating Lightsail Container Service (%s): %s", d.Id(), err)
+			return diag.Errorf("updating Lightsail Container Service (%s): %s", d.Id(), err)
 		}
 
 		if d.HasChange("is_disabled") && d.Get("is_disabled").(bool) {
 			if err := waitContainerServiceDisabled(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-				return diag.Errorf("error waiting for Lightsail Container Service (%s) update: %s", d.Id(), err)
+				return diag.Errorf("waiting for Lightsail Container Service (%s) update: %s", d.Id(), err)
 			}
 		} else {
 			if err := waitContainerServiceUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-				return diag.Errorf("error waiting for Lightsail Container Service (%s) update: %s", d.Id(), err)
+				return diag.Errorf("waiting for Lightsail Container Service (%s) update: %s", d.Id(), err)
 			}
 		}
 	}
@@ -302,11 +302,11 @@ func resourceContainerServiceDelete(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Lightsail Container Service (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Lightsail Container Service (%s): %s", d.Id(), err)
 	}
 
 	if err := waitContainerServiceDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("error waiting for Lightsail Container Service (%s) deletion: %s", d.Id(), err)
+		return diag.Errorf("waiting for Lightsail Container Service (%s) deletion: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/lightsail/container_service_deployment_version.go
+++ b/internal/service/lightsail/container_service_deployment_version.go
@@ -183,11 +183,11 @@ func resourceContainerServiceDeploymentVersionCreate(ctx context.Context, d *sch
 
 	output, err := conn.CreateContainerServiceDeploymentWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("error creating Lightsail Container Service (%s) Deployment Version: %s", serviceName, err)
+		return diag.Errorf("creating Lightsail Container Service (%s) Deployment Version: %s", serviceName, err)
 	}
 
 	if output == nil || output.ContainerService == nil || output.ContainerService.NextDeployment == nil {
-		return diag.Errorf("error creating Lightsail Container Service (%s) Deployment Version: empty output", serviceName)
+		return diag.Errorf("creating Lightsail Container Service (%s) Deployment Version: empty output", serviceName)
 	}
 
 	version := int(aws.Int64Value(output.ContainerService.NextDeployment.Version))
@@ -195,7 +195,7 @@ func resourceContainerServiceDeploymentVersionCreate(ctx context.Context, d *sch
 	d.SetId(fmt.Sprintf("%s/%d", serviceName, version))
 
 	if err := waitContainerServiceDeploymentVersionActive(ctx, conn, serviceName, version, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("error waiting for Lightsail Container Service (%s) Deployment Version (%d): %s", serviceName, version, err)
+		return diag.Errorf("waiting for Lightsail Container Service (%s) Deployment Version (%d): %s", serviceName, version, err)
 	}
 
 	return resourceContainerServiceDeploymentVersionRead(ctx, d, meta)
@@ -218,7 +218,7 @@ func resourceContainerServiceDeploymentVersionRead(ctx context.Context, d *schem
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Lightsail Container Service (%s) Deployment Version (%d): %s", serviceName, version, err)
+		return diag.Errorf("reading Lightsail Container Service (%s) Deployment Version (%d): %s", serviceName, version, err)
 	}
 
 	d.Set("created_at", aws.TimeValue(deployment.CreatedAt).Format(time.RFC3339))
@@ -227,11 +227,11 @@ func resourceContainerServiceDeploymentVersionRead(ctx context.Context, d *schem
 	d.Set("version", deployment.Version)
 
 	if err := d.Set("container", flattenContainerServiceDeploymentContainers(deployment.Containers)); err != nil {
-		return diag.Errorf("error setting container for Lightsail Container Service (%s) Deployment Version (%d): %s", serviceName, version, err)
+		return diag.Errorf("setting container for Lightsail Container Service (%s) Deployment Version (%d): %s", serviceName, version, err)
 	}
 
 	if err := d.Set("public_endpoint", flattenContainerServiceDeploymentPublicEndpoint(deployment.PublicEndpoint)); err != nil {
-		return diag.Errorf("error setting public_endpoint for Lightsail Container Service (%s) Deployment Version (%d): %s", serviceName, version, err)
+		return diag.Errorf("setting public_endpoint for Lightsail Container Service (%s) Deployment Version (%d): %s", serviceName, version, err)
 	}
 
 	return nil

--- a/internal/service/macie2/account.go
+++ b/internal/service/macie2/account.go
@@ -89,7 +89,7 @@ func resourceAccountCreate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if err != nil {
-		return diag.Errorf("error enabling Macie Account: %s", err)
+		return diag.Errorf("enabling Macie Account: %s", err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).AccountID)
@@ -112,7 +112,7 @@ func resourceAccountRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Macie Account (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Macie Account (%s): %s", d.Id(), err)
 	}
 
 	d.Set("status", resp.Status)
@@ -139,7 +139,7 @@ func resourceAccountUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 	_, err := conn.UpdateMacieSessionWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("error updating Macie Account (%s): %s", d.Id(), err)
+		return diag.Errorf("updating Macie Account (%s): %s", d.Id(), err)
 	}
 
 	return resourceAccountRead(ctx, d, meta)
@@ -177,7 +177,7 @@ func resourceAccountDelete(ctx context.Context, d *schema.ResourceData, meta int
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled") {
 			return nil
 		}
-		return diag.Errorf("error disabling Macie Account (%s): %s", d.Id(), err)
+		return diag.Errorf("disabling Macie Account (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/macie2/classification_export_configuration.go
+++ b/internal/service/macie2/classification_export_configuration.go
@@ -123,7 +123,7 @@ func resourceClassificationExportConfigurationRead(ctx context.Context, d *schem
 		if (macie2.S3Destination{}) != *output.Configuration.S3Destination { // nosemgrep: ci.prefer-aws-go-sdk-pointer-conversion-conditional
 			var flattenedS3Destination = flattenClassificationExportConfigurationS3DestinationResult(output.Configuration.S3Destination)
 			if err := d.Set("s3_destination", []interface{}{flattenedS3Destination}); err != nil {
-				return diag.Errorf("error setting Macie classification export configuration s3_destination: %s", err)
+				return diag.Errorf("setting Macie classification export configuration s3_destination: %s", err)
 			}
 		}
 		d.SetId(fmt.Sprintf("%s:%s:%s", "macie:classification_export_configuration", meta.(*conns.AWSClient).AccountID, meta.(*conns.AWSClient).Region))

--- a/internal/service/macie2/classification_job.go
+++ b/internal/service/macie2/classification_job.go
@@ -620,7 +620,7 @@ func resourceClassificationJobCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if err != nil {
-		return diag.Errorf("error creating Macie ClassificationJob: %s", err)
+		return diag.Errorf("creating Macie ClassificationJob: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.JobId))
@@ -646,14 +646,14 @@ func resourceClassificationJobRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Macie ClassificationJob (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Macie ClassificationJob (%s): %s", d.Id(), err)
 	}
 
 	if err = d.Set("custom_data_identifier_ids", flex.FlattenStringList(resp.CustomDataIdentifierIds)); err != nil {
-		return diag.Errorf("error setting `%s` for Macie ClassificationJob (%s): %s", "custom_data_identifier_ids", d.Id(), err)
+		return diag.Errorf("setting `%s` for Macie ClassificationJob (%s): %s", "custom_data_identifier_ids", d.Id(), err)
 	}
 	if err = d.Set("schedule_frequency", flattenScheduleFrequency(resp.ScheduleFrequency)); err != nil {
-		return diag.Errorf("error setting `%s` for Macie ClassificationJob (%s): %s", "schedule_frequency", d.Id(), err)
+		return diag.Errorf("setting `%s` for Macie ClassificationJob (%s): %s", "schedule_frequency", d.Id(), err)
 	}
 	d.Set("sampling_percentage", resp.SamplingPercentage)
 	d.Set("name", resp.Name)
@@ -662,7 +662,7 @@ func resourceClassificationJobRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("initial_run", resp.InitialRun)
 	d.Set("job_type", resp.JobType)
 	if err = d.Set("s3_job_definition", flattenS3JobDefinition(resp.S3JobDefinition)); err != nil {
-		return diag.Errorf("error setting `%s` for Macie ClassificationJob (%s): %s", "s3_job_definition", d.Id(), err)
+		return diag.Errorf("setting `%s` for Macie ClassificationJob (%s): %s", "s3_job_definition", d.Id(), err)
 	}
 
 	SetTagsOut(ctx, resp.Tags)
@@ -676,7 +676,7 @@ func resourceClassificationJobRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("job_status", status)
 	d.Set("created_at", aws.TimeValue(resp.CreatedAt).Format(time.RFC3339))
 	if err = d.Set("user_paused_details", flattenUserPausedDetails(resp.UserPausedDetails)); err != nil {
-		return diag.Errorf("error setting `%s` for Macie ClassificationJob (%s): %s", "user_paused_details", d.Id(), err)
+		return diag.Errorf("setting `%s` for Macie ClassificationJob (%s): %s", "user_paused_details", d.Id(), err)
 	}
 
 	return nil
@@ -693,7 +693,7 @@ func resourceClassificationJobUpdate(ctx context.Context, d *schema.ResourceData
 		status := d.Get("job_status").(string)
 
 		if status == macie2.JobStatusCancelled {
-			return diag.Errorf("error updating Macie ClassificationJob (%s): %s", d.Id(), fmt.Sprintf("%s cannot be set", macie2.JobStatusCancelled))
+			return diag.Errorf("updating Macie ClassificationJob (%s): %s", d.Id(), fmt.Sprintf("%s cannot be set", macie2.JobStatusCancelled))
 		}
 
 		input.JobStatus = aws.String(status)
@@ -701,7 +701,7 @@ func resourceClassificationJobUpdate(ctx context.Context, d *schema.ResourceData
 
 	_, err := conn.UpdateClassificationJobWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("error updating Macie ClassificationJob (%s): %s", d.Id(), err)
+		return diag.Errorf("updating Macie ClassificationJob (%s): %s", d.Id(), err)
 	}
 
 	return resourceClassificationJobRead(ctx, d, meta)
@@ -722,7 +722,7 @@ func resourceClassificationJobDelete(ctx context.Context, d *schema.ResourceData
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeValidationException, "cannot update cancelled job for job") {
 			return nil
 		}
-		return diag.Errorf("error deleting Macie ClassificationJob (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Macie ClassificationJob (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/macie2/custom_data_identifier.go
+++ b/internal/service/macie2/custom_data_identifier.go
@@ -148,7 +148,7 @@ func resourceCustomDataIdentifierCreate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err != nil {
-		return diag.Errorf("error creating Macie CustomDataIdentifier: %s", err)
+		return diag.Errorf("creating Macie CustomDataIdentifier: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.CustomDataIdentifierId))
@@ -173,15 +173,15 @@ func resourceCustomDataIdentifierRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Macie CustomDataIdentifier (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Macie CustomDataIdentifier (%s): %s", d.Id(), err)
 	}
 
 	d.Set("regex", resp.Regex)
 	if err = d.Set("keywords", flex.FlattenStringList(resp.Keywords)); err != nil {
-		return diag.Errorf("error setting `%s` for Macie CustomDataIdentifier (%s): %s", "keywords", d.Id(), err)
+		return diag.Errorf("setting `%s` for Macie CustomDataIdentifier (%s): %s", "keywords", d.Id(), err)
 	}
 	if err = d.Set("ignore_words", flex.FlattenStringList(resp.IgnoreWords)); err != nil {
-		return diag.Errorf("error setting `%s` for Macie CustomDataIdentifier (%s): %s", "ignore_words", d.Id(), err)
+		return diag.Errorf("setting `%s` for Macie CustomDataIdentifier (%s): %s", "ignore_words", d.Id(), err)
 	}
 	d.Set("name", resp.Name)
 	d.Set("name_prefix", create.NamePrefixFromName(aws.StringValue(resp.Name)))
@@ -214,7 +214,7 @@ func resourceCustomDataIdentifierDelete(ctx context.Context, d *schema.ResourceD
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled") {
 			return nil
 		}
-		return diag.Errorf("error deleting Macie CustomDataIdentifier (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Macie CustomDataIdentifier (%s): %s", d.Id(), err)
 	}
 	return nil
 }

--- a/internal/service/macie2/findings_filter.go
+++ b/internal/service/macie2/findings_filter.go
@@ -144,7 +144,7 @@ func resourceFindingsFilterCreate(ctx context.Context, d *schema.ResourceData, m
 	var err error
 	input.FindingCriteria, err = expandFindingCriteriaFilter(d.Get("finding_criteria").([]interface{}))
 	if err != nil {
-		return diag.Errorf("error creating Macie FindingsFilter: %s", err)
+		return diag.Errorf("creating Macie FindingsFilter: %s", err)
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -174,7 +174,7 @@ func resourceFindingsFilterCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if err != nil {
-		return diag.Errorf("error creating Macie FindingsFilter: %s", err)
+		return diag.Errorf("creating Macie FindingsFilter: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.Id))
@@ -199,11 +199,11 @@ func resourceFindingsFilterRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Macie FindingsFilter (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Macie FindingsFilter (%s): %s", d.Id(), err)
 	}
 
 	if err = d.Set("finding_criteria", flattenFindingCriteriaFindingsFilter(resp.FindingCriteria)); err != nil {
-		return diag.Errorf("error setting `%s` for Macie FindingsFilter (%s): %s", "finding_criteria", d.Id(), err)
+		return diag.Errorf("setting `%s` for Macie FindingsFilter (%s): %s", "finding_criteria", d.Id(), err)
 	}
 	d.Set("name", resp.Name)
 	d.Set("name_prefix", create.NamePrefixFromName(aws.StringValue(resp.Name)))
@@ -229,7 +229,7 @@ func resourceFindingsFilterUpdate(ctx context.Context, d *schema.ResourceData, m
 	if d.HasChange("finding_criteria") {
 		input.FindingCriteria, err = expandFindingCriteriaFilter(d.Get("finding_criteria").([]interface{}))
 		if err != nil {
-			return diag.Errorf("error updating Macie FindingsFilter (%s): %s", d.Id(), err)
+			return diag.Errorf("updating Macie FindingsFilter (%s): %s", d.Id(), err)
 		}
 	}
 	if d.HasChange("name") {
@@ -250,7 +250,7 @@ func resourceFindingsFilterUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	_, err = conn.UpdateFindingsFilterWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("error updating Macie FindingsFilter (%s): %s", d.Id(), err)
+		return diag.Errorf("updating Macie FindingsFilter (%s): %s", d.Id(), err)
 	}
 
 	return resourceFindingsFilterRead(ctx, d, meta)
@@ -269,7 +269,7 @@ func resourceFindingsFilterDelete(ctx context.Context, d *schema.ResourceData, m
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled") {
 			return nil
 		}
-		return diag.Errorf("error deleting Macie FindingsFilter (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Macie FindingsFilter (%s): %s", d.Id(), err)
 	}
 	return nil
 }

--- a/internal/service/macie2/invitation_accepter.go
+++ b/internal/service/macie2/invitation_accepter.go
@@ -86,7 +86,7 @@ func resourceInvitationAccepterCreate(ctx context.Context, d *schema.ResourceDat
 		})
 	}
 	if err != nil {
-		return diag.Errorf("error listing Macie InvitationAccepter (%s): %s", d.Id(), err)
+		return diag.Errorf("listing Macie InvitationAccepter (%s): %s", d.Id(), err)
 	}
 
 	acceptInvitationInput := &macie2.AcceptInvitationInput{
@@ -97,7 +97,7 @@ func resourceInvitationAccepterCreate(ctx context.Context, d *schema.ResourceDat
 	_, err = conn.AcceptInvitationWithContext(ctx, acceptInvitationInput)
 
 	if err != nil {
-		return diag.Errorf("error accepting Macie InvitationAccepter (%s): %s", d.Id(), err)
+		return diag.Errorf("accepting Macie InvitationAccepter (%s): %s", d.Id(), err)
 	}
 
 	d.SetId(adminAccountID)
@@ -122,11 +122,11 @@ func resourceInvitationAccepterRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Macie InvitationAccepter (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Macie InvitationAccepter (%s): %s", d.Id(), err)
 	}
 
 	if output == nil || output.Administrator == nil {
-		return diag.Errorf("error reading Macie InvitationAccepter (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Macie InvitationAccepter (%s): %s", d.Id(), err)
 	}
 
 	d.Set("administrator_account_id", output.Administrator.AccountId)
@@ -145,7 +145,7 @@ func resourceInvitationAccepterDelete(ctx context.Context, d *schema.ResourceDat
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled") {
 			return nil
 		}
-		return diag.Errorf("error disassociating Macie InvitationAccepter (%s): %s", d.Id(), err)
+		return diag.Errorf("disassociating Macie InvitationAccepter (%s): %s", d.Id(), err)
 	}
 	return nil
 }

--- a/internal/service/macie2/member.go
+++ b/internal/service/macie2/member.go
@@ -125,7 +125,7 @@ func resourceMemberCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err != nil {
-		return diag.Errorf("error creating Macie Member: %s", err)
+		return diag.Errorf("creating Macie Member: %s", err)
 	}
 
 	d.SetId(accountId)
@@ -169,15 +169,15 @@ func resourceMemberCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err != nil {
-		return diag.Errorf("error inviting Macie Member: %s", err)
+		return diag.Errorf("inviting Macie Member: %s", err)
 	}
 
 	if len(output.UnprocessedAccounts) != 0 {
-		return diag.Errorf("error inviting Macie Member: %s: %s", aws.StringValue(output.UnprocessedAccounts[0].ErrorCode), aws.StringValue(output.UnprocessedAccounts[0].ErrorMessage))
+		return diag.Errorf("inviting Macie Member: %s: %s", aws.StringValue(output.UnprocessedAccounts[0].ErrorCode), aws.StringValue(output.UnprocessedAccounts[0].ErrorMessage))
 	}
 
 	if _, err = waitMemberInvited(ctx, conn, d.Id()); err != nil {
-		return diag.Errorf("error waiting for Macie Member (%s) invitation: %s", d.Id(), err)
+		return diag.Errorf("waiting for Macie Member (%s) invitation: %s", d.Id(), err)
 	}
 
 	return resourceMemberRead(ctx, d, meta)
@@ -202,7 +202,7 @@ func resourceMemberRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Macie Member (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Macie Member (%s): %s", d.Id(), err)
 	}
 
 	d.Set("account_id", resp.AccountId)
@@ -279,15 +279,15 @@ func resourceMemberUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			}
 
 			if err != nil {
-				return diag.Errorf("error inviting Macie Member: %s", err)
+				return diag.Errorf("inviting Macie Member: %s", err)
 			}
 
 			if len(output.UnprocessedAccounts) != 0 {
-				return diag.Errorf("error inviting Macie Member: %s: %s", aws.StringValue(output.UnprocessedAccounts[0].ErrorCode), aws.StringValue(output.UnprocessedAccounts[0].ErrorMessage))
+				return diag.Errorf("inviting Macie Member: %s: %s", aws.StringValue(output.UnprocessedAccounts[0].ErrorCode), aws.StringValue(output.UnprocessedAccounts[0].ErrorMessage))
 			}
 
 			if _, err = waitMemberInvited(ctx, conn, d.Id()); err != nil {
-				return diag.Errorf("error waiting for Macie Member (%s) invitation: %s", d.Id(), err)
+				return diag.Errorf("waiting for Macie Member (%s) invitation: %s", d.Id(), err)
 			}
 		} else {
 			input := &macie2.DisassociateMemberInput{
@@ -300,7 +300,7 @@ func resourceMemberUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 					tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled") {
 					return nil
 				}
-				return diag.Errorf("error disassociating Macie Member invite (%s): %s", d.Id(), err)
+				return diag.Errorf("disassociating Macie Member invite (%s): %s", d.Id(), err)
 			}
 		}
 	}
@@ -315,7 +315,7 @@ func resourceMemberUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 
 		_, err := conn.UpdateMemberSessionWithContext(ctx, input)
 		if err != nil {
-			return diag.Errorf("error updating Macie Member (%s): %s", d.Id(), err)
+			return diag.Errorf("updating Macie Member (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -337,7 +337,7 @@ func resourceMemberDelete(ctx context.Context, d *schema.ResourceData, meta inte
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeValidationException, "account is not associated with your account") {
 			return nil
 		}
-		return diag.Errorf("error deleting Macie Member (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Macie Member (%s): %s", d.Id(), err)
 	}
 	return nil
 }

--- a/internal/service/macie2/organization_admin_account.go
+++ b/internal/service/macie2/organization_admin_account.go
@@ -63,7 +63,7 @@ func resourceOrganizationAdminAccountCreate(ctx context.Context, d *schema.Resou
 	}
 
 	if err != nil {
-		return diag.Errorf("error creating Macie OrganizationAdminAccount: %s", err)
+		return diag.Errorf("creating Macie OrganizationAdminAccount: %s", err)
 	}
 
 	d.SetId(adminAccountID)
@@ -86,7 +86,7 @@ func resourceOrganizationAdminAccountRead(ctx context.Context, d *schema.Resourc
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Macie OrganizationAdminAccount (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Macie OrganizationAdminAccount (%s): %s", d.Id(), err)
 	}
 
 	if res == nil {
@@ -117,7 +117,7 @@ func resourceOrganizationAdminAccountDelete(ctx context.Context, d *schema.Resou
 			tfawserr.ErrMessageContains(err, macie2.ErrCodeAccessDeniedException, "Macie is not enabled") {
 			return nil
 		}
-		return diag.Errorf("error deleting Macie OrganizationAdminAccount (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Macie OrganizationAdminAccount (%s): %s", d.Id(), err)
 	}
 	return nil
 }

--- a/internal/service/memorydb/acl.go
+++ b/internal/service/memorydb/acl.go
@@ -91,11 +91,11 @@ func resourceACLCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	_, err := conn.CreateACLWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating MemoryDB ACL (%s): %s", name, err)
+		return diag.Errorf("creating MemoryDB ACL (%s): %s", name, err)
 	}
 
 	if err := waitACLActive(ctx, conn, name); err != nil {
-		return diag.Errorf("error waiting for MemoryDB ACL (%s) to be created: %s", name, err)
+		return diag.Errorf("waiting for MemoryDB ACL (%s) to be created: %s", name, err)
 	}
 
 	d.SetId(name)
@@ -127,7 +127,7 @@ func resourceACLUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 		initialState, err := FindACLByName(ctx, conn, d.Id())
 		if err != nil {
-			return diag.Errorf("error getting MemoryDB ACL (%s) current state: %s", d.Id(), err)
+			return diag.Errorf("getting MemoryDB ACL (%s) current state: %s", d.Id(), err)
 		}
 
 		initialUserNames := map[string]struct{}{}
@@ -149,11 +149,11 @@ func resourceACLUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 			_, err := conn.UpdateACLWithContext(ctx, input)
 			if err != nil {
-				return diag.Errorf("error updating MemoryDB ACL (%s): %s", d.Id(), err)
+				return diag.Errorf("updating MemoryDB ACL (%s): %s", d.Id(), err)
 			}
 
 			if err := waitACLActive(ctx, conn, d.Id()); err != nil {
-				return diag.Errorf("error waiting for MemoryDB ACL (%s) to be modified: %s", d.Id(), err)
+				return diag.Errorf("waiting for MemoryDB ACL (%s) to be modified: %s", d.Id(), err)
 			}
 		}
 	}
@@ -173,7 +173,7 @@ func resourceACLRead(ctx context.Context, d *schema.ResourceData, meta interface
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading MemoryDB ACL (%s): %s", d.Id(), err)
+		return diag.Errorf("reading MemoryDB ACL (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", acl.ARN)
@@ -198,11 +198,11 @@ func resourceACLDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting MemoryDB ACL (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting MemoryDB ACL (%s): %s", d.Id(), err)
 	}
 
 	if err := waitACLDeleted(ctx, conn, d.Id()); err != nil {
-		return diag.Errorf("error waiting for MemoryDB ACL (%s) to be deleted: %s", d.Id(), err)
+		return diag.Errorf("waiting for MemoryDB ACL (%s) to be deleted: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/memorydb/acl_data_source.go
+++ b/internal/service/memorydb/acl_data_source.go
@@ -62,11 +62,11 @@ func dataSourceACLRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
 
 	if err != nil {
-		return diag.Errorf("error listing tags for MemoryDB ACL (%s): %s", d.Id(), err)
+		return diag.Errorf("listing tags for MemoryDB ACL (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	return nil

--- a/internal/service/memorydb/cluster.go
+++ b/internal/service/memorydb/cluster.go
@@ -345,11 +345,11 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 	_, err := conn.CreateClusterWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating MemoryDB Cluster (%s): %s", name, err)
+		return diag.Errorf("creating MemoryDB Cluster (%s): %s", name, err)
 	}
 
 	if err := waitClusterAvailable(ctx, conn, name, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("error waiting for MemoryDB Cluster (%s) to be created: %s", name, err)
+		return diag.Errorf("waiting for MemoryDB Cluster (%s) to be created: %s", name, err)
 	}
 
 	d.SetId(name)
@@ -444,22 +444,22 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		_, err := conn.UpdateClusterWithContext(ctx, input)
 		if err != nil {
-			return diag.Errorf("error updating MemoryDB Cluster (%s): %s", d.Id(), err)
+			return diag.Errorf("updating MemoryDB Cluster (%s): %s", d.Id(), err)
 		}
 
 		if err := waitClusterAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("error waiting for MemoryDB Cluster (%s) to be modified: %s", d.Id(), err)
+			return diag.Errorf("waiting for MemoryDB Cluster (%s) to be modified: %s", d.Id(), err)
 		}
 
 		if waitParameterGroupInSync {
 			if err := waitClusterParameterGroupInSync(ctx, conn, d.Id()); err != nil {
-				return diag.Errorf("error waiting for MemoryDB Cluster (%s) parameter group to be in sync: %s", d.Id(), err)
+				return diag.Errorf("waiting for MemoryDB Cluster (%s) parameter group to be in sync: %s", d.Id(), err)
 			}
 		}
 
 		if waitSecurityGroupsActive {
 			if err := waitClusterSecurityGroupsActive(ctx, conn, d.Id()); err != nil {
-				return diag.Errorf("error waiting for MemoryDB Cluster (%s) security groups to be available: %s", d.Id(), err)
+				return diag.Errorf("waiting for MemoryDB Cluster (%s) security groups to be available: %s", d.Id(), err)
 			}
 		}
 	}
@@ -479,7 +479,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading MemoryDB Cluster (%s): %s", d.Id(), err)
+		return diag.Errorf("reading MemoryDB Cluster (%s): %s", d.Id(), err)
 	}
 
 	d.Set("acl_name", cluster.ACLName)
@@ -494,7 +494,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if v := aws.StringValue(cluster.DataTiering); v != "" {
 		b, err := strconv.ParseBool(v)
 		if err != nil {
-			return diag.Errorf("error reading data_tiering for MemoryDB Cluster (%s): %s", d.Id(), err)
+			return diag.Errorf("reading data_tiering for MemoryDB Cluster (%s): %s", d.Id(), err)
 		}
 
 		d.Set("data_tiering", b)
@@ -511,7 +511,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	numReplicasPerShard, err := deriveClusterNumReplicasPerShard(cluster)
 	if err != nil {
-		return diag.Errorf("error reading num_replicas_per_shard for MemoryDB Cluster (%s): %s", d.Id(), err)
+		return diag.Errorf("reading num_replicas_per_shard for MemoryDB Cluster (%s): %s", d.Id(), err)
 	}
 	d.Set("num_replicas_per_shard", numReplicasPerShard)
 
@@ -562,11 +562,11 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting MemoryDB Cluster (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting MemoryDB Cluster (%s): %s", d.Id(), err)
 	}
 
 	if err := waitClusterDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("error waiting for MemoryDB Cluster (%s) to be deleted: %s", d.Id(), err)
+		return diag.Errorf("waiting for MemoryDB Cluster (%s) to be deleted: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/memorydb/cluster_data_source.go
+++ b/internal/service/memorydb/cluster_data_source.go
@@ -185,7 +185,7 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 	if v := aws.StringValue(cluster.DataTiering); v != "" {
 		b, err := strconv.ParseBool(v)
 		if err != nil {
-			return diag.Errorf("error reading data_tiering for MemoryDB Cluster (%s): %s", d.Id(), err)
+			return diag.Errorf("reading data_tiering for MemoryDB Cluster (%s): %s", d.Id(), err)
 		}
 
 		d.Set("data_tiering", b)
@@ -201,7 +201,7 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	numReplicasPerShard, err := deriveClusterNumReplicasPerShard(cluster)
 	if err != nil {
-		return diag.Errorf("error reading num_replicas_per_shard for MemoryDB Cluster (%s): %s", d.Id(), err)
+		return diag.Errorf("reading num_replicas_per_shard for MemoryDB Cluster (%s): %s", d.Id(), err)
 	}
 	d.Set("num_replicas_per_shard", numReplicasPerShard)
 
@@ -233,11 +233,11 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
 
 	if err != nil {
-		return diag.Errorf("error listing tags for MemoryDB Cluster (%s): %s", d.Id(), err)
+		return diag.Errorf("listing tags for MemoryDB Cluster (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	return nil

--- a/internal/service/memorydb/parameter_group.go
+++ b/internal/service/memorydb/parameter_group.go
@@ -108,7 +108,7 @@ func resourceParameterGroupCreate(ctx context.Context, d *schema.ResourceData, m
 	output, err := conn.CreateParameterGroupWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating MemoryDB Parameter Group (%s): %s", name, err)
+		return diag.Errorf("creating MemoryDB Parameter Group (%s): %s", name, err)
 	}
 
 	d.SetId(name)
@@ -148,7 +148,7 @@ func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 			err := resetParameterGroupParameters(ctx, conn, d.Get("name").(string), paramsToReset)
 
 			if err != nil {
-				return diag.Errorf("error resetting MemoryDB Parameter Group (%s) parameters to defaults: %s", d.Id(), err)
+				return diag.Errorf("resetting MemoryDB Parameter Group (%s) parameters to defaults: %s", d.Id(), err)
 			}
 		}
 
@@ -163,7 +163,7 @@ func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 			err := modifyParameterGroupParameters(ctx, conn, d.Get("name").(string), paramsToModify)
 
 			if err != nil {
-				return diag.Errorf("error modifying MemoryDB Parameter Group (%s) parameters: %s", d.Id(), err)
+				return diag.Errorf("modifying MemoryDB Parameter Group (%s) parameters: %s", d.Id(), err)
 			}
 		}
 	}
@@ -183,7 +183,7 @@ func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading MemoryDB Parameter Group (%s): %s", d.Id(), err)
+		return diag.Errorf("reading MemoryDB Parameter Group (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", group.ARN)
@@ -196,7 +196,7 @@ func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, met
 
 	parameters, err := listParameterGroupParameters(ctx, conn, d.Get("family").(string), d.Id(), userDefinedParameters)
 	if err != nil {
-		return diag.Errorf("error listing parameters for MemoryDB Parameter Group (%s): %s", d.Id(), err)
+		return diag.Errorf("listing parameters for MemoryDB Parameter Group (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("parameter", flattenParameters(parameters)); err != nil {
@@ -219,7 +219,7 @@ func resourceParameterGroupDelete(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting MemoryDB Parameter Group (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting MemoryDB Parameter Group (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/memorydb/parameter_group_data_source.go
+++ b/internal/service/memorydb/parameter_group_data_source.go
@@ -78,7 +78,7 @@ func dataSourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, m
 
 	parameters, err := listParameterGroupParameters(ctx, conn, d.Get("family").(string), d.Id(), userDefinedParameters)
 	if err != nil {
-		return diag.Errorf("error listing parameters for MemoryDB Parameter Group (%s): %s", d.Id(), err)
+		return diag.Errorf("listing parameters for MemoryDB Parameter Group (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("parameter", flattenParameters(parameters)); err != nil {
@@ -88,11 +88,11 @@ func dataSourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, m
 	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
 
 	if err != nil {
-		return diag.Errorf("error listing tags for MemoryDB Parameter Group (%s): %s", d.Id(), err)
+		return diag.Errorf("listing tags for MemoryDB Parameter Group (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	return nil

--- a/internal/service/memorydb/snapshot.go
+++ b/internal/service/memorydb/snapshot.go
@@ -162,11 +162,11 @@ func resourceSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta in
 	_, err := conn.CreateSnapshotWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating MemoryDB Snapshot (%s): %s", name, err)
+		return diag.Errorf("creating MemoryDB Snapshot (%s): %s", name, err)
 	}
 
 	if err := waitSnapshotAvailable(ctx, conn, name, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("error waiting for MemoryDB Snapshot (%s) to be created: %s", name, err)
+		return diag.Errorf("waiting for MemoryDB Snapshot (%s) to be created: %s", name, err)
 	}
 
 	d.SetId(name)
@@ -191,7 +191,7 @@ func resourceSnapshotRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading MemoryDB Snapshot (%s): %s", d.Id(), err)
+		return diag.Errorf("reading MemoryDB Snapshot (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", snapshot.ARN)
@@ -220,11 +220,11 @@ func resourceSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting MemoryDB Snapshot (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting MemoryDB Snapshot (%s): %s", d.Id(), err)
 	}
 
 	if err := waitSnapshotDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("error waiting for MemoryDB Snapshot (%s) to be deleted: %s", d.Id(), err)
+		return diag.Errorf("waiting for MemoryDB Snapshot (%s) to be deleted: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/memorydb/snapshot_data_source.go
+++ b/internal/service/memorydb/snapshot_data_source.go
@@ -128,11 +128,11 @@ func dataSourceSnapshotRead(ctx context.Context, d *schema.ResourceData, meta in
 	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
 
 	if err != nil {
-		return diag.Errorf("error listing tags for MemoryDB Snapshot (%s): %s", d.Id(), err)
+		return diag.Errorf("listing tags for MemoryDB Snapshot (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	return nil

--- a/internal/service/memorydb/subnet_group.go
+++ b/internal/service/memorydb/subnet_group.go
@@ -91,7 +91,7 @@ func resourceSubnetGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 	_, err := conn.CreateSubnetGroupWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating MemoryDB Subnet Group (%s): %s", name, err)
+		return diag.Errorf("creating MemoryDB Subnet Group (%s): %s", name, err)
 	}
 
 	d.SetId(name)
@@ -113,7 +113,7 @@ func resourceSubnetGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 		_, err := conn.UpdateSubnetGroupWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("error updating MemoryDB Subnet Group (%s): %s", d.Id(), err)
+			return diag.Errorf("updating MemoryDB Subnet Group (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -132,7 +132,7 @@ func resourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading MemoryDB Subnet Group (%s): %s", d.Id(), err)
+		return diag.Errorf("reading MemoryDB Subnet Group (%s): %s", d.Id(), err)
 	}
 
 	var subnetIds []*string
@@ -163,7 +163,7 @@ func resourceSubnetGroupDelete(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting MemoryDB Subnet Group (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting MemoryDB Subnet Group (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/memorydb/subnet_group_data_source.go
+++ b/internal/service/memorydb/subnet_group_data_source.go
@@ -72,11 +72,11 @@ func dataSourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta
 	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
 
 	if err != nil {
-		return diag.Errorf("error listing tags for MemoryDB Subnet Group (%s): %s", d.Id(), err)
+		return diag.Errorf("listing tags for MemoryDB Subnet Group (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	return nil

--- a/internal/service/memorydb/user_data_source.go
+++ b/internal/service/memorydb/user_data_source.go
@@ -88,11 +88,11 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interf
 	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
 
 	if err != nil {
-		return diag.Errorf("error listing tags for MemoryDB User (%s): %s", d.Id(), err)
+		return diag.Errorf("listing tags for MemoryDB User (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("tags", tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	return nil

--- a/internal/service/networkfirewall/logging_configuration.go
+++ b/internal/service/networkfirewall/logging_configuration.go
@@ -103,17 +103,17 @@ func resourceLoggingConfigurationRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Logging Configuration for NetworkFirewall Firewall: %s: %s", d.Id(), err)
+		return diag.Errorf("reading Logging Configuration for NetworkFirewall Firewall: %s: %s", d.Id(), err)
 	}
 
 	if output == nil {
-		return diag.Errorf("error reading Logging Configuration for NetworkFirewall Firewall: %s: empty output", d.Id())
+		return diag.Errorf("reading Logging Configuration for NetworkFirewall Firewall: %s: empty output", d.Id())
 	}
 
 	d.Set("firewall_arn", output.FirewallArn)
 
 	if err := d.Set("logging_configuration", flattenLoggingConfiguration(output.LoggingConfiguration)); err != nil {
-		return diag.Errorf("error setting logging_configuration: %s", err)
+		return diag.Errorf("setting logging_configuration: %s", err)
 	}
 
 	return nil
@@ -158,7 +158,7 @@ func resourceLoggingConfigurationDelete(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Logging Configuration for NetworkFirewall Firewall: %s: %s", d.Id(), err)
+		return diag.Errorf("deleting Logging Configuration for NetworkFirewall Firewall: %s: %s", d.Id(), err)
 	}
 
 	if output != nil && output.LoggingConfiguration != nil {

--- a/internal/service/networkfirewall/resource_policy.go
+++ b/internal/service/networkfirewall/resource_policy.go
@@ -69,7 +69,7 @@ func resourceResourcePolicyPut(ctx context.Context, d *schema.ResourceData, meta
 
 	_, err = conn.PutResourcePolicyWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("error putting NetworkFirewall Resource Policy (for resource: %s): %s", resourceArn, err)
+		return diag.Errorf("putting NetworkFirewall Resource Policy (for resource: %s): %s", resourceArn, err)
 	}
 
 	d.SetId(resourceArn)
@@ -90,11 +90,11 @@ func resourceResourcePolicyRead(ctx context.Context, d *schema.ResourceData, met
 		return nil
 	}
 	if err != nil {
-		return diag.Errorf("error reading NetworkFirewall Resource Policy (for resource: %s): %s", resourceArn, err)
+		return diag.Errorf("reading NetworkFirewall Resource Policy (for resource: %s): %s", resourceArn, err)
 	}
 
 	if policy == nil {
-		return diag.Errorf("error reading NetworkFirewall Resource Policy (for resource: %s): empty output", resourceArn)
+		return diag.Errorf("reading NetworkFirewall Resource Policy (for resource: %s): empty output", resourceArn)
 	}
 
 	d.Set("resource_arn", resourceArn)

--- a/internal/service/networkmanager/connection.go
+++ b/internal/service/networkmanager/connection.go
@@ -127,13 +127,13 @@ func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta 
 	output, err := conn.CreateConnectionWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Network Manager Connection: %s", err)
+		return diag.Errorf("creating Network Manager Connection: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.Connection.ConnectionId))
 
 	if _, err := waitConnectionCreated(ctx, conn, globalNetworkID, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("error waiting for Network Manager Connection (%s) create: %s", d.Id(), err)
+		return diag.Errorf("waiting for Network Manager Connection (%s) create: %s", d.Id(), err)
 	}
 
 	return resourceConnectionRead(ctx, d, meta)
@@ -152,7 +152,7 @@ func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Network Manager Connection (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Network Manager Connection (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", connection.ConnectionArn)
@@ -185,11 +185,11 @@ func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		_, err := conn.UpdateConnectionWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("error updating Network Manager Connection (%s): %s", d.Id(), err)
+			return diag.Errorf("updating Network Manager Connection (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitConnectionUpdated(ctx, conn, globalNetworkID, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("error waiting for Network Manager Connection (%s) update: %s", d.Id(), err)
+			return diag.Errorf("waiting for Network Manager Connection (%s) update: %s", d.Id(), err)
 		}
 	}
 
@@ -212,11 +212,11 @@ func resourceConnectionDelete(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Network Manager Connection (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Network Manager Connection (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitConnectionDeleted(ctx, conn, globalNetworkID, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("error waiting for Network Manager Connection (%s) delete: %s", d.Id(), err)
+		return diag.Errorf("waiting for Network Manager Connection (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/networkmanager/connection_data_source.go
+++ b/internal/service/networkmanager/connection_data_source.go
@@ -61,7 +61,7 @@ func dataSourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta 
 	connection, err := FindConnectionByTwoPartKey(ctx, conn, globalNetworkID, connectionID)
 
 	if err != nil {
-		return diag.Errorf("error reading Network Manager Connection (%s): %s", connectionID, err)
+		return diag.Errorf("reading Network Manager Connection (%s): %s", connectionID, err)
 	}
 
 	d.SetId(connectionID)
@@ -75,7 +75,7 @@ func dataSourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("link_id", connection.LinkId)
 
 	if err := d.Set("tags", KeyValueTags(ctx, connection.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	return nil

--- a/internal/service/networkmanager/connections_data_source.go
+++ b/internal/service/networkmanager/connections_data_source.go
@@ -51,7 +51,7 @@ func dataSourceConnectionsRead(ctx context.Context, d *schema.ResourceData, meta
 	output, err := FindConnections(ctx, conn, input)
 
 	if err != nil {
-		return diag.Errorf("error listing Network Manager Connections: %s", err)
+		return diag.Errorf("listing Network Manager Connections: %s", err)
 	}
 
 	var connectionIDs []string

--- a/internal/service/networkmanager/customer_gateway_association.go
+++ b/internal/service/networkmanager/customer_gateway_association.go
@@ -103,13 +103,13 @@ func resourceCustomerGatewayAssociationCreate(ctx context.Context, d *schema.Res
 	)
 
 	if err != nil {
-		return diag.Errorf("error creating Network Manager Customer Gateway Association (%s): %s", id, err)
+		return diag.Errorf("creating Network Manager Customer Gateway Association (%s): %s", id, err)
 	}
 
 	d.SetId(id)
 
 	if _, err := waitCustomerGatewayAssociationCreated(ctx, conn, globalNetworkID, customerGatewayARN, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("error waiting for Network Manager Customer Gateway Association (%s) create: %s", d.Id(), err)
+		return diag.Errorf("waiting for Network Manager Customer Gateway Association (%s) create: %s", d.Id(), err)
 	}
 
 	return resourceCustomerGatewayAssociationRead(ctx, d, meta)
@@ -133,7 +133,7 @@ func resourceCustomerGatewayAssociationRead(ctx context.Context, d *schema.Resou
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Network Manager Customer Gateway Association (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Network Manager Customer Gateway Association (%s): %s", d.Id(), err)
 	}
 
 	d.Set("customer_gateway_arn", output.CustomerGatewayArn)

--- a/internal/service/networkmanager/device.go
+++ b/internal/service/networkmanager/device.go
@@ -195,13 +195,13 @@ func resourceDeviceCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	output, err := conn.CreateDeviceWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Network Manager Device: %s", err)
+		return diag.Errorf("creating Network Manager Device: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.Device.DeviceId))
 
 	if _, err := waitDeviceCreated(ctx, conn, globalNetworkID, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("error waiting for Network Manager Device (%s) create: %s", d.Id(), err)
+		return diag.Errorf("waiting for Network Manager Device (%s) create: %s", d.Id(), err)
 	}
 
 	return resourceDeviceRead(ctx, d, meta)
@@ -220,13 +220,13 @@ func resourceDeviceRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Network Manager Device (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Network Manager Device (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", device.DeviceArn)
 	if device.AWSLocation != nil {
 		if err := d.Set("aws_location", []interface{}{flattenAWSLocation(device.AWSLocation)}); err != nil {
-			return diag.Errorf("error setting aws_location: %s", err)
+			return diag.Errorf("setting aws_location: %s", err)
 		}
 	} else {
 		d.Set("aws_location", nil)
@@ -235,7 +235,7 @@ func resourceDeviceRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("global_network_id", device.GlobalNetworkId)
 	if device.Location != nil {
 		if err := d.Set("location", []interface{}{flattenLocation(device.Location)}); err != nil {
-			return diag.Errorf("error setting location: %s", err)
+			return diag.Errorf("setting location: %s", err)
 		}
 	} else {
 		d.Set("location", nil)
@@ -279,11 +279,11 @@ func resourceDeviceUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		_, err := conn.UpdateDeviceWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("error updating Network Manager Device (%s): %s", d.Id(), err)
+			return diag.Errorf("updating Network Manager Device (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitDeviceUpdated(ctx, conn, globalNetworkID, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("error waiting for Network Manager Device (%s) update: %s", d.Id(), err)
+			return diag.Errorf("waiting for Network Manager Device (%s) update: %s", d.Id(), err)
 		}
 	}
 
@@ -306,11 +306,11 @@ func resourceDeviceDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Network Manager Device (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Network Manager Device (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitDeviceDeleted(ctx, conn, globalNetworkID, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("error waiting for Network Manager Device (%s) delete: %s", d.Id(), err)
+		return diag.Errorf("waiting for Network Manager Device (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/networkmanager/device_data_source.go
+++ b/internal/service/networkmanager/device_data_source.go
@@ -101,14 +101,14 @@ func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	device, err := FindDeviceByTwoPartKey(ctx, conn, globalNetworkID, deviceID)
 
 	if err != nil {
-		return diag.Errorf("error reading Network Manager Device (%s): %s", deviceID, err)
+		return diag.Errorf("reading Network Manager Device (%s): %s", deviceID, err)
 	}
 
 	d.SetId(deviceID)
 	d.Set("arn", device.DeviceArn)
 	if device.AWSLocation != nil {
 		if err := d.Set("aws_location", []interface{}{flattenAWSLocation(device.AWSLocation)}); err != nil {
-			return diag.Errorf("error setting aws_location: %s", err)
+			return diag.Errorf("setting aws_location: %s", err)
 		}
 	} else {
 		d.Set("aws_location", nil)
@@ -117,7 +117,7 @@ func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("device_id", device.DeviceId)
 	if device.Location != nil {
 		if err := d.Set("location", []interface{}{flattenLocation(device.Location)}); err != nil {
-			return diag.Errorf("error setting location: %s", err)
+			return diag.Errorf("setting location: %s", err)
 		}
 	} else {
 		d.Set("location", nil)
@@ -129,7 +129,7 @@ func dataSourceDeviceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("vendor", device.Vendor)
 
 	if err := d.Set("tags", KeyValueTags(ctx, device.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	return nil

--- a/internal/service/networkmanager/devices_data_source.go
+++ b/internal/service/networkmanager/devices_data_source.go
@@ -51,7 +51,7 @@ func dataSourceDevicesRead(ctx context.Context, d *schema.ResourceData, meta int
 	output, err := FindDevices(ctx, conn, input)
 
 	if err != nil {
-		return diag.Errorf("error listing Network Manager Devices: %s", err)
+		return diag.Errorf("listing Network Manager Devices: %s", err)
 	}
 
 	var deviceIDs []string

--- a/internal/service/networkmanager/global_network.go
+++ b/internal/service/networkmanager/global_network.go
@@ -71,13 +71,13 @@ func resourceGlobalNetworkCreate(ctx context.Context, d *schema.ResourceData, me
 	output, err := conn.CreateGlobalNetworkWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Network Manager Global Network: %s", err)
+		return diag.Errorf("creating Network Manager Global Network: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.GlobalNetwork.GlobalNetworkId))
 
 	if _, err := waitGlobalNetworkCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("error waiting for Network Manager Global Network (%s) create: %s", d.Id(), err)
+		return diag.Errorf("waiting for Network Manager Global Network (%s) create: %s", d.Id(), err)
 	}
 
 	return resourceGlobalNetworkRead(ctx, d, meta)
@@ -95,7 +95,7 @@ func resourceGlobalNetworkRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Network Manager Global Network (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Network Manager Global Network (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", globalNetwork.GlobalNetworkArn)
@@ -119,11 +119,11 @@ func resourceGlobalNetworkUpdate(ctx context.Context, d *schema.ResourceData, me
 		_, err := conn.UpdateGlobalNetworkWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("error updating Network Manager Global Network (%s): %s", d.Id(), err)
+			return diag.Errorf("updating Network Manager Global Network (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitGlobalNetworkUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("error waiting for Network Manager Global Network (%s) update: %s", d.Id(), err)
+			return diag.Errorf("waiting for Network Manager Global Network (%s) update: %s", d.Id(), err)
 		}
 	}
 
@@ -166,11 +166,11 @@ func resourceGlobalNetworkDelete(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Network Manager Global Network (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Network Manager Global Network (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitGlobalNetworkDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("error waiting for Network Manager Global Network (%s) delete: %s", d.Id(), err)
+		return diag.Errorf("waiting for Network Manager Global Network (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil
@@ -186,7 +186,7 @@ func deregisterTransitGateways(ctx context.Context, conn *networkmanager.Network
 	}
 
 	if err != nil {
-		return diag.Errorf("error listing Network Manager Transit Gateway Registrations (%s): %s", globalNetworkID, err)
+		return diag.Errorf("listing Network Manager Transit Gateway Registrations (%s): %s", globalNetworkID, err)
 	}
 
 	var diags diag.Diagnostics
@@ -216,7 +216,7 @@ func disassociateCustomerGateways(ctx context.Context, conn *networkmanager.Netw
 	}
 
 	if err != nil {
-		return diag.Errorf("error listing Network Manager Customer Gateway Associations (%s): %s", globalNetworkID, err)
+		return diag.Errorf("listing Network Manager Customer Gateway Associations (%s): %s", globalNetworkID, err)
 	}
 
 	var diags diag.Diagnostics
@@ -246,7 +246,7 @@ func disassociateTransitGatewayConnectPeers(ctx context.Context, conn *networkma
 	}
 
 	if err != nil {
-		return diag.Errorf("error listing Network Manager Transit Gateway Connect Peer Associations (%s): %s", globalNetworkID, err)
+		return diag.Errorf("listing Network Manager Transit Gateway Connect Peer Associations (%s): %s", globalNetworkID, err)
 	}
 
 	var diags diag.Diagnostics

--- a/internal/service/networkmanager/global_network_data_source.go
+++ b/internal/service/networkmanager/global_network_data_source.go
@@ -40,7 +40,7 @@ func dataSourceGlobalNetworkRead(ctx context.Context, d *schema.ResourceData, me
 	globalNetwork, err := FindGlobalNetworkByID(ctx, conn, globalNetworkID)
 
 	if err != nil {
-		return diag.Errorf("error reading Network Manager Global Network (%s): %s", globalNetworkID, err)
+		return diag.Errorf("reading Network Manager Global Network (%s): %s", globalNetworkID, err)
 	}
 
 	d.SetId(globalNetworkID)
@@ -49,7 +49,7 @@ func dataSourceGlobalNetworkRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("global_network_id", globalNetwork.GlobalNetworkId)
 
 	if err := d.Set("tags", KeyValueTags(ctx, globalNetwork.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	return nil

--- a/internal/service/networkmanager/global_networks_data_source.go
+++ b/internal/service/networkmanager/global_networks_data_source.go
@@ -35,7 +35,7 @@ func dataSourceGlobalNetworksRead(ctx context.Context, d *schema.ResourceData, m
 	output, err := FindGlobalNetworks(ctx, conn, &networkmanager.DescribeGlobalNetworksInput{})
 
 	if err != nil {
-		return diag.Errorf("error listing Network Manager Global Networks: %s", err)
+		return diag.Errorf("listing Network Manager Global Networks: %s", err)
 	}
 
 	var globalNetworkIDs []string

--- a/internal/service/networkmanager/link.go
+++ b/internal/service/networkmanager/link.go
@@ -144,13 +144,13 @@ func resourceLinkCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	output, err := conn.CreateLinkWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Network Manager Link: %s", err)
+		return diag.Errorf("creating Network Manager Link: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.Link.LinkId))
 
 	if _, err := waitLinkCreated(ctx, conn, globalNetworkID, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("error waiting for Network Manager Link (%s) create: %s", d.Id(), err)
+		return diag.Errorf("waiting for Network Manager Link (%s) create: %s", d.Id(), err)
 	}
 
 	return resourceLinkRead(ctx, d, meta)
@@ -169,13 +169,13 @@ func resourceLinkRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Network Manager Link (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Network Manager Link (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", link.LinkArn)
 	if link.Bandwidth != nil {
 		if err := d.Set("bandwidth", []interface{}{flattenBandwidth(link.Bandwidth)}); err != nil {
-			return diag.Errorf("error setting bandwidth: %s", err)
+			return diag.Errorf("setting bandwidth: %s", err)
 		}
 	} else {
 		d.Set("bandwidth", nil)
@@ -212,11 +212,11 @@ func resourceLinkUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		_, err := conn.UpdateLinkWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("error updating Network Manager Link (%s): %s", d.Id(), err)
+			return diag.Errorf("updating Network Manager Link (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitLinkUpdated(ctx, conn, globalNetworkID, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("error waiting for Network Manager Link (%s) update: %s", d.Id(), err)
+			return diag.Errorf("waiting for Network Manager Link (%s) update: %s", d.Id(), err)
 		}
 	}
 
@@ -239,11 +239,11 @@ func resourceLinkDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Network Manager Link (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Network Manager Link (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitLinkDeleted(ctx, conn, globalNetworkID, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("error waiting for Network Manager Link (%s) delete: %s", d.Id(), err)
+		return diag.Errorf("waiting for Network Manager Link (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/networkmanager/link_association.go
+++ b/internal/service/networkmanager/link_association.go
@@ -70,13 +70,13 @@ func resourceLinkAssociationCreate(ctx context.Context, d *schema.ResourceData, 
 	_, err := conn.AssociateLinkWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Network Manager Link Association (%s): %s", id, err)
+		return diag.Errorf("creating Network Manager Link Association (%s): %s", id, err)
 	}
 
 	d.SetId(id)
 
 	if _, err := waitLinkAssociationCreated(ctx, conn, globalNetworkID, linkID, deviceID, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("error waiting for Network Manager Link Association (%s) create: %s", d.Id(), err)
+		return diag.Errorf("waiting for Network Manager Link Association (%s) create: %s", d.Id(), err)
 	}
 
 	return resourceLinkAssociationRead(ctx, d, meta)
@@ -100,7 +100,7 @@ func resourceLinkAssociationRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Network Manager Link Association (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Network Manager Link Association (%s): %s", d.Id(), err)
 	}
 
 	d.Set("device_id", output.DeviceId)
@@ -131,11 +131,11 @@ func resourceLinkAssociationDelete(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Network Manager Link Association (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Network Manager Link Association (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitLinkAssociationDeleted(ctx, conn, globalNetworkID, linkID, deviceID, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("error waiting for Network Manager Link Association (%s) delete: %s", d.Id(), err)
+		return diag.Errorf("waiting for Network Manager Link Association (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/networkmanager/link_data_source.go
+++ b/internal/service/networkmanager/link_data_source.go
@@ -73,14 +73,14 @@ func dataSourceLinkRead(ctx context.Context, d *schema.ResourceData, meta interf
 	link, err := FindLinkByTwoPartKey(ctx, conn, globalNetworkID, linkID)
 
 	if err != nil {
-		return diag.Errorf("error reading Network Manager Link (%s): %s", linkID, err)
+		return diag.Errorf("reading Network Manager Link (%s): %s", linkID, err)
 	}
 
 	d.SetId(linkID)
 	d.Set("arn", link.LinkArn)
 	if link.Bandwidth != nil {
 		if err := d.Set("bandwidth", []interface{}{flattenBandwidth(link.Bandwidth)}); err != nil {
-			return diag.Errorf("error setting bandwidth: %s", err)
+			return diag.Errorf("setting bandwidth: %s", err)
 		}
 	} else {
 		d.Set("bandwidth", nil)
@@ -93,7 +93,7 @@ func dataSourceLinkRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("type", link.Type)
 
 	if err := d.Set("tags", KeyValueTags(ctx, link.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	return nil

--- a/internal/service/networkmanager/links_data_source.go
+++ b/internal/service/networkmanager/links_data_source.go
@@ -67,7 +67,7 @@ func dataSourceLinksRead(ctx context.Context, d *schema.ResourceData, meta inter
 	output, err := FindLinks(ctx, conn, input)
 
 	if err != nil {
-		return diag.Errorf("error listing Network Manager Links: %s", err)
+		return diag.Errorf("listing Network Manager Links: %s", err)
 	}
 
 	var linkIDs []string

--- a/internal/service/networkmanager/site.go
+++ b/internal/service/networkmanager/site.go
@@ -127,13 +127,13 @@ func resourceSiteCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	output, err := conn.CreateSiteWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Network Manager Site: %s", err)
+		return diag.Errorf("creating Network Manager Site: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.Site.SiteId))
 
 	if _, err := waitSiteCreated(ctx, conn, globalNetworkID, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("error waiting for Network Manager Site (%s) create: %s", d.Id(), err)
+		return diag.Errorf("waiting for Network Manager Site (%s) create: %s", d.Id(), err)
 	}
 
 	return resourceSiteRead(ctx, d, meta)
@@ -152,7 +152,7 @@ func resourceSiteRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Network Manager Site (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Network Manager Site (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", site.SiteArn)
@@ -160,7 +160,7 @@ func resourceSiteRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	d.Set("global_network_id", site.GlobalNetworkId)
 	if site.Location != nil {
 		if err := d.Set("location", []interface{}{flattenLocation(site.Location)}); err != nil {
-			return diag.Errorf("error setting location: %s", err)
+			return diag.Errorf("setting location: %s", err)
 		}
 	} else {
 		d.Set("location", nil)
@@ -190,11 +190,11 @@ func resourceSiteUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		_, err := conn.UpdateSiteWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("error updating Network Manager Site (%s): %s", d.Id(), err)
+			return diag.Errorf("updating Network Manager Site (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitSiteUpdated(ctx, conn, globalNetworkID, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("error waiting for Network Manager Site (%s) update: %s", d.Id(), err)
+			return diag.Errorf("waiting for Network Manager Site (%s) update: %s", d.Id(), err)
 		}
 	}
 
@@ -228,11 +228,11 @@ func resourceSiteDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Network Manager Site (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Network Manager Site (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitSiteDeleted(ctx, conn, globalNetworkID, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("error waiting for Network Manager Site (%s) delete: %s", d.Id(), err)
+		return diag.Errorf("waiting for Network Manager Site (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/networkmanager/site_data_source.go
+++ b/internal/service/networkmanager/site_data_source.go
@@ -65,7 +65,7 @@ func dataSourceSiteRead(ctx context.Context, d *schema.ResourceData, meta interf
 	site, err := FindSiteByTwoPartKey(ctx, conn, globalNetworkID, siteID)
 
 	if err != nil {
-		return diag.Errorf("error reading Network Manager Site (%s): %s", siteID, err)
+		return diag.Errorf("reading Network Manager Site (%s): %s", siteID, err)
 	}
 
 	d.SetId(siteID)
@@ -74,7 +74,7 @@ func dataSourceSiteRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("global_network_id", site.GlobalNetworkId)
 	if site.Location != nil {
 		if err := d.Set("location", []interface{}{flattenLocation(site.Location)}); err != nil {
-			return diag.Errorf("error setting location: %s", err)
+			return diag.Errorf("setting location: %s", err)
 		}
 	} else {
 		d.Set("location", nil)
@@ -82,7 +82,7 @@ func dataSourceSiteRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("site_id", site.SiteId)
 
 	if err := d.Set("tags", KeyValueTags(ctx, site.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	return nil

--- a/internal/service/networkmanager/sites_data_source.go
+++ b/internal/service/networkmanager/sites_data_source.go
@@ -41,7 +41,7 @@ func dataSourceSitesRead(ctx context.Context, d *schema.ResourceData, meta inter
 	})
 
 	if err != nil {
-		return diag.Errorf("error listing Network Manager Sites: %s", err)
+		return diag.Errorf("listing Network Manager Sites: %s", err)
 	}
 
 	var siteIDs []string

--- a/internal/service/networkmanager/transit_gateway_connect_peer_association.go
+++ b/internal/service/networkmanager/transit_gateway_connect_peer_association.go
@@ -80,13 +80,13 @@ func resourceTransitGatewayConnectPeerAssociationCreate(ctx context.Context, d *
 	_, err := conn.AssociateTransitGatewayConnectPeerWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Network Manager Transit Gateway Connect Peer Association (%s): %s", id, err)
+		return diag.Errorf("creating Network Manager Transit Gateway Connect Peer Association (%s): %s", id, err)
 	}
 
 	d.SetId(id)
 
 	if _, err := waitTransitGatewayConnectPeerAssociationCreated(ctx, conn, globalNetworkID, connectPeerARN, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("error waiting for Network Manager Transit Gateway Connect Peer Association (%s) create: %s", d.Id(), err)
+		return diag.Errorf("waiting for Network Manager Transit Gateway Connect Peer Association (%s) create: %s", d.Id(), err)
 	}
 
 	return resourceTransitGatewayConnectPeerAssociationRead(ctx, d, meta)
@@ -110,7 +110,7 @@ func resourceTransitGatewayConnectPeerAssociationRead(ctx context.Context, d *sc
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Network Manager Transit Gateway Connect Peer Association (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Network Manager Transit Gateway Connect Peer Association (%s): %s", d.Id(), err)
 	}
 
 	d.Set("device_id", output.DeviceId)

--- a/internal/service/networkmanager/transit_gateway_registration.go
+++ b/internal/service/networkmanager/transit_gateway_registration.go
@@ -66,13 +66,13 @@ func resourceTransitGatewayRegistrationCreate(ctx context.Context, d *schema.Res
 	_, err := conn.RegisterTransitGatewayWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Network Manager Transit Gateway Registration (%s): %s", id, err)
+		return diag.Errorf("creating Network Manager Transit Gateway Registration (%s): %s", id, err)
 	}
 
 	d.SetId(id)
 
 	if _, err := waitTransitGatewayRegistrationCreated(ctx, conn, globalNetworkID, transitGatewayARN, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("error waiting for Network Manager Transit Gateway Attachment (%s) create: %s", d.Id(), err)
+		return diag.Errorf("waiting for Network Manager Transit Gateway Attachment (%s) create: %s", d.Id(), err)
 	}
 
 	return resourceTransitGatewayRegistrationRead(ctx, d, meta)
@@ -96,7 +96,7 @@ func resourceTransitGatewayRegistrationRead(ctx context.Context, d *schema.Resou
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Network Manager Transit Gateway Registration (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Network Manager Transit Gateway Registration (%s): %s", d.Id(), err)
 	}
 
 	d.Set("global_network_id", transitGatewayRegistration.GlobalNetworkId)

--- a/internal/service/opensearch/inbound_connection_accepter.go
+++ b/internal/service/opensearch/inbound_connection_accepter.go
@@ -60,7 +60,7 @@ func resourceInboundConnectionAccepterCreate(ctx context.Context, d *schema.Reso
 
 	resp, err := conn.AcceptInboundConnectionWithContext(ctx, acceptOpts)
 	if err != nil {
-		return diag.Errorf("Error accepting Inbound Connection: %s", err)
+		return diag.Errorf("accepting Inbound Connection: %s", err)
 	}
 
 	// Get the ID and store it
@@ -69,7 +69,7 @@ func resourceInboundConnectionAccepterCreate(ctx context.Context, d *schema.Reso
 
 	err = inboundConnectionWaitUntilActive(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.Errorf("Error waiting for Inbound Connection to become active: %s", err)
+		return diag.Errorf("waiting for Inbound Connection to become active: %s", err)
 	}
 
 	return resourceInboundConnectionRead(ctx, d, meta)
@@ -81,7 +81,7 @@ func resourceInboundConnectionRead(ctx context.Context, d *schema.ResourceData, 
 	ccscRaw, statusCode, err := inboundConnectionRefreshState(ctx, conn, d.Id())()
 
 	if err != nil {
-		return diag.Errorf("Error reading Inbound Connection: %s", err)
+		return diag.Errorf("reading Inbound Connection: %s", err)
 	}
 
 	ccsc := ccscRaw.(*opensearchservice.InboundConnection)
@@ -106,11 +106,11 @@ func resourceInboundConnectionDelete(ctx context.Context, d *schema.ResourceData
 	}
 
 	if err != nil {
-		return diag.Errorf("Error deleting Inbound Connection (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Inbound Connection (%s): %s", d.Id(), err)
 	}
 
 	if err := waitForInboundConnectionDeletion(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("Error waiting for VPC Peering Connection (%s) to be deleted: %s", d.Id(), err)
+		return diag.Errorf("waiting for VPC Peering Connection (%s) to be deleted: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/opensearch/outbound_connection.go
+++ b/internal/service/opensearch/outbound_connection.go
@@ -61,7 +61,7 @@ func resourceOutboundConnectionCreate(ctx context.Context, d *schema.ResourceDat
 
 	resp, err := conn.CreateOutboundConnectionWithContext(ctx, createOpts)
 	if err != nil {
-		return diag.Errorf("Error creating Outbound Connection: %s", err)
+		return diag.Errorf("creating Outbound Connection: %s", err)
 	}
 
 	// Get the ID and store it
@@ -70,7 +70,7 @@ func resourceOutboundConnectionCreate(ctx context.Context, d *schema.ResourceDat
 
 	err = outboundConnectionWaitUntilAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.Errorf("Error waiting for Outbound Connection to become available: %s", err)
+		return diag.Errorf("waiting for Outbound Connection to become available: %s", err)
 	}
 
 	return resourceOutboundConnectionRead(ctx, d, meta)
@@ -82,7 +82,7 @@ func resourceOutboundConnectionRead(ctx context.Context, d *schema.ResourceData,
 	ccscRaw, statusCode, err := outboundConnectionRefreshState(ctx, conn, d.Id())()
 
 	if err != nil {
-		return diag.Errorf("Error reading Outbound Connection: %s", err)
+		return diag.Errorf("reading Outbound Connection: %s", err)
 	}
 
 	ccsc := ccscRaw.(*opensearchservice.OutboundConnection)
@@ -116,11 +116,11 @@ func resourceOutboundConnectionDelete(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if err != nil {
-		return diag.Errorf("Error deleting Outbound Connection (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Outbound Connection (%s): %s", d.Id(), err)
 	}
 
 	if err := waitForOutboundConnectionDeletion(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("Error waiting for VPC Peering Connection (%s) to be deleted: %s", d.Id(), err)
+		return diag.Errorf("waiting for VPC Peering Connection (%s) to be deleted: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/organizations/delegated_administrator.go
+++ b/internal/service/organizations/delegated_administrator.go
@@ -85,7 +85,7 @@ func resourceDelegatedAdministratorCreate(ctx context.Context, d *schema.Resourc
 
 	_, err := conn.RegisterDelegatedAdministratorWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("error creating Organizations DelegatedAdministrator (%s): %s", accountID, err)
+		return diag.Errorf("creating Organizations DelegatedAdministrator (%s): %s", accountID, err)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", accountID, servicePrincipal))
@@ -98,7 +98,7 @@ func resourceDelegatedAdministratorRead(ctx context.Context, d *schema.ResourceD
 
 	accountID, servicePrincipal, err := DecodeOrganizationDelegatedAdministratorID(d.Id())
 	if err != nil {
-		return diag.Errorf("error decoding ID AWS Organization (%s) DelegatedAdministrators: %s", d.Id(), err)
+		return diag.Errorf("decoding ID AWS Organization (%s) DelegatedAdministrators: %s", d.Id(), err)
 	}
 	input := &organizations.ListDelegatedAdministratorsInput{
 		ServicePrincipal: aws.String(servicePrincipal),
@@ -114,7 +114,7 @@ func resourceDelegatedAdministratorRead(ctx context.Context, d *schema.ResourceD
 		return !lastPage
 	})
 	if err != nil {
-		return diag.Errorf("error listing AWS Organization (%s) DelegatedAdministrators: %s", d.Id(), err)
+		return diag.Errorf("listing AWS Organization (%s) DelegatedAdministrators: %s", d.Id(), err)
 	}
 
 	if delegatedAccount == nil {
@@ -145,7 +145,7 @@ func resourceDelegatedAdministratorDelete(ctx context.Context, d *schema.Resourc
 
 	accountID, servicePrincipal, err := DecodeOrganizationDelegatedAdministratorID(d.Id())
 	if err != nil {
-		return diag.Errorf("error decoding ID AWS Organization (%s) DelegatedAdministrators: %s", d.Id(), err)
+		return diag.Errorf("decoding ID AWS Organization (%s) DelegatedAdministrators: %s", d.Id(), err)
 	}
 	input := &organizations.DeregisterDelegatedAdministratorInput{
 		AccountId:        aws.String(accountID),
@@ -154,7 +154,7 @@ func resourceDelegatedAdministratorDelete(ctx context.Context, d *schema.Resourc
 
 	_, err = conn.DeregisterDelegatedAdministratorWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("error deleting Organizations DelegatedAdministrator (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Organizations DelegatedAdministrator (%s): %s", d.Id(), err)
 	}
 	return nil
 }

--- a/internal/service/organizations/delegated_administrators_data_source.go
+++ b/internal/service/organizations/delegated_administrators_data_source.go
@@ -87,11 +87,11 @@ func dataSourceDelegatedAdministratorsRead(ctx context.Context, d *schema.Resour
 		return !lastPage
 	})
 	if err != nil {
-		return diag.Errorf("error describing organizations delegated Administrators: %s", err)
+		return diag.Errorf("describing organizations delegated Administrators: %s", err)
 	}
 
 	if err = d.Set("delegated_administrators", flattenDelegatedAdministrators(delegators)); err != nil {
-		return diag.Errorf("error setting delegated_administrators: %s", err)
+		return diag.Errorf("setting delegated_administrators: %s", err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).AccountID)

--- a/internal/service/organizations/delegated_services_data_source.go
+++ b/internal/service/organizations/delegated_services_data_source.go
@@ -60,11 +60,11 @@ func dataSourceDelegatedServicesRead(ctx context.Context, d *schema.ResourceData
 		return !lastPage
 	})
 	if err != nil {
-		return diag.Errorf("error describing organizations delegated services: %s", err)
+		return diag.Errorf("describing organizations delegated services: %s", err)
 	}
 
 	if err = d.Set("delegated_services", flattenDelegatedServices(delegators)); err != nil {
-		return diag.Errorf("error setting delegated_services: %s", err)
+		return diag.Errorf("setting delegated_services: %s", err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).AccountID)

--- a/internal/service/organizations/policy.go
+++ b/internal/service/organizations/policy.go
@@ -106,7 +106,7 @@ func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err != nil {
-		return diag.Errorf("error creating Organizations Policy (%s): %s", name, err)
+		return diag.Errorf("creating Organizations Policy (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(resp.Policy.PolicySummary.Id))
@@ -131,7 +131,7 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Organizations Policy (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Organizations Policy (%s): %s", d.Id(), err)
 	}
 
 	if resp.Policy == nil || resp.Policy.PolicySummary == nil {
@@ -185,7 +185,7 @@ func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	log.Printf("[DEBUG] Updating Organizations Policy: %s", input)
 	_, err := conn.UpdatePolicyWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("error updating Organizations policy (%s): %s", d.Id(), err)
+		return diag.Errorf("updating Organizations policy (%s): %s", d.Id(), err)
 	}
 
 	return resourcePolicyRead(ctx, d, meta)
@@ -209,7 +209,7 @@ func resourcePolicyDelete(ctx context.Context, d *schema.ResourceData, meta inte
 		if tfawserr.ErrCodeEquals(err, organizations.ErrCodePolicyNotFoundException) {
 			return nil
 		}
-		return diag.Errorf("error deleting Organizations policy (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Organizations policy (%s): %s", d.Id(), err)
 	}
 	return nil
 }

--- a/internal/service/quicksight/data_set.go
+++ b/internal/service/quicksight/data_set.go
@@ -885,7 +885,7 @@ func resourceDataSetCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	_, err := conn.CreateDataSetWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("error creating QuickSight Data Set: %s", err)
+		return diag.Errorf("creating QuickSight Data Set: %s", err)
 	}
 
 	if v, ok := d.GetOk("refresh_properties"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
@@ -897,7 +897,7 @@ func resourceDataSetCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 		_, err := conn.PutDataSetRefreshPropertiesWithContext(ctx, input)
 		if err != nil {
-			return diag.Errorf("error putting QuickSight Data Set Refresh Properties: %s", err)
+			return diag.Errorf("putting QuickSight Data Set Refresh Properties: %s", err)
 		}
 	}
 
@@ -926,11 +926,11 @@ func resourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if err != nil {
-		return diag.Errorf("error describing QuickSight Data Set (%s): %s", d.Id(), err)
+		return diag.Errorf("describing QuickSight Data Set (%s): %s", d.Id(), err)
 	}
 
 	if output == nil || output.DataSet == nil {
-		return diag.Errorf("error describing QuickSight Data Set (%s): empty output", d.Id())
+		return diag.Errorf("describing QuickSight Data Set (%s): empty output", d.Id())
 	}
 
 	dataSet := output.DataSet
@@ -942,39 +942,39 @@ func resourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("import_mode", dataSet.ImportMode)
 
 	if err := d.Set("column_groups", flattenColumnGroups(dataSet.ColumnGroups)); err != nil {
-		return diag.Errorf("error setting column_groups: %s", err)
+		return diag.Errorf("setting column_groups: %s", err)
 	}
 
 	if err := d.Set("column_level_permission_rules", flattenColumnLevelPermissionRules(dataSet.ColumnLevelPermissionRules)); err != nil {
-		return diag.Errorf("error setting column_level_permission_rules: %s", err)
+		return diag.Errorf("setting column_level_permission_rules: %s", err)
 	}
 
 	if err := d.Set("data_set_usage_configuration", flattenDataSetUsageConfiguration(dataSet.DataSetUsageConfiguration)); err != nil {
-		return diag.Errorf("error setting data_set_usage_configuration: %s", err)
+		return diag.Errorf("setting data_set_usage_configuration: %s", err)
 	}
 
 	if err := d.Set("field_folders", flattenFieldFolders(dataSet.FieldFolders)); err != nil {
-		return diag.Errorf("error setting field_folders: %s", err)
+		return diag.Errorf("setting field_folders: %s", err)
 	}
 
 	if err := d.Set("logical_table_map", flattenLogicalTableMap(dataSet.LogicalTableMap, logicalTableMapSchema())); err != nil {
-		return diag.Errorf("error setting logical_table_map: %s", err)
+		return diag.Errorf("setting logical_table_map: %s", err)
 	}
 
 	if err := d.Set("output_columns", flattenOutputColumns(dataSet.OutputColumns)); err != nil {
-		return diag.Errorf("error setting output_columns: %s", err)
+		return diag.Errorf("setting output_columns: %s", err)
 	}
 
 	if err := d.Set("physical_table_map", flattenPhysicalTableMap(dataSet.PhysicalTableMap, physicalTableMapSchema())); err != nil {
-		return diag.Errorf("error setting physical_table_map: %s", err)
+		return diag.Errorf("setting physical_table_map: %s", err)
 	}
 
 	if err := d.Set("row_level_permission_data_set", flattenRowLevelPermissionDataSet(dataSet.RowLevelPermissionDataSet)); err != nil {
-		return diag.Errorf("error setting row_level_permission_data_set: %s", err)
+		return diag.Errorf("setting row_level_permission_data_set: %s", err)
 	}
 
 	if err := d.Set("row_level_permission_tag_configuration", flattenRowLevelPermissionTagConfiguration(dataSet.RowLevelPermissionTagConfiguration)); err != nil {
-		return diag.Errorf("error setting row_level_permission_tag_configuration: %s", err)
+		return diag.Errorf("setting row_level_permission_tag_configuration: %s", err)
 	}
 
 	permsResp, err := conn.DescribeDataSetPermissionsWithContext(ctx, &quicksight.DescribeDataSetPermissionsInput{
@@ -983,11 +983,11 @@ func resourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta inter
 	})
 
 	if err != nil {
-		return diag.Errorf("error describing QuickSight Data Source (%s) Permissions: %s", d.Id(), err)
+		return diag.Errorf("describing QuickSight Data Source (%s) Permissions: %s", d.Id(), err)
 	}
 
 	if err := d.Set("permissions", flattenPermissions(permsResp.Permissions)); err != nil {
-		return diag.Errorf("error setting permissions: %s", err)
+		return diag.Errorf("setting permissions: %s", err)
 	}
 
 	propsResp, err := conn.DescribeDataSetRefreshPropertiesWithContext(ctx, &quicksight.DescribeDataSetRefreshPropertiesInput{
@@ -996,12 +996,12 @@ func resourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta inter
 	})
 
 	if err != nil && !(tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) || tfawserr.ErrMessageContains(err, quicksight.ErrCodeInvalidParameterValueException, "not a SPICE dataset")) {
-		return diag.Errorf("error describing refresh properties (%s): %s", d.Id(), err)
+		return diag.Errorf("describing refresh properties (%s): %s", d.Id(), err)
 	}
 
 	if err == nil {
 		if err := d.Set("refresh_properties", flattenRefreshProperties(propsResp.DataSetRefreshProperties)); err != nil {
-			return diag.Errorf("error setting refresh properties: %s", err)
+			return diag.Errorf("setting refresh properties: %s", err)
 		}
 	}
 
@@ -1041,7 +1041,7 @@ func resourceDataSetUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		_, err = conn.UpdateDataSetWithContext(ctx, params)
 		if err != nil {
-			return diag.Errorf("error updating QuickSight Data Set (%s): %s", d.Id(), err)
+			return diag.Errorf("updating QuickSight Data Set (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -1073,7 +1073,7 @@ func resourceDataSetUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		_, err = conn.UpdateDataSetPermissionsWithContext(ctx, params)
 
 		if err != nil {
-			return diag.Errorf("error updating QuickSight Data Set (%s) permissions: %s", dataSetId, err)
+			return diag.Errorf("updating QuickSight Data Set (%s) permissions: %s", dataSetId, err)
 		}
 	}
 
@@ -1092,7 +1092,7 @@ func resourceDataSetUpdate(ctx context.Context, d *schema.ResourceData, meta int
 				DataSetId:    aws.String(dataSetId),
 			})
 			if err != nil {
-				return diag.Errorf("error deleting QuickSight Data Set Refresh Properties (%s): %s", d.Id(), err)
+				return diag.Errorf("deleting QuickSight Data Set Refresh Properties (%s): %s", d.Id(), err)
 			}
 		} else {
 			_, err = conn.PutDataSetRefreshPropertiesWithContext(ctx, &quicksight.PutDataSetRefreshPropertiesInput{
@@ -1101,7 +1101,7 @@ func resourceDataSetUpdate(ctx context.Context, d *schema.ResourceData, meta int
 				DataSetRefreshProperties: expandDataSetRefreshProperties(d.Get("refresh_properties").([]interface{})),
 			})
 			if err != nil {
-				return diag.Errorf("error updating QuickSight Data Set Refresh Properties (%s): %s", d.Id(), err)
+				return diag.Errorf("updating QuickSight Data Set Refresh Properties (%s): %s", d.Id(), err)
 			}
 		}
 	}
@@ -1130,7 +1130,7 @@ func resourceDataSetDelete(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting QuickSight Data Set (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting QuickSight Data Set (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/quicksight/data_set_data_source.go
+++ b/internal/service/quicksight/data_set_data_source.go
@@ -641,52 +641,52 @@ func dataSourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("import_mode", dataSet.ImportMode)
 
 	if err := d.Set("column_groups", flattenColumnGroups(dataSet.ColumnGroups)); err != nil {
-		return diag.Errorf("error setting column_groups: %s", err)
+		return diag.Errorf("setting column_groups: %s", err)
 	}
 
 	if err := d.Set("column_level_permission_rules", flattenColumnLevelPermissionRules(dataSet.ColumnLevelPermissionRules)); err != nil {
-		return diag.Errorf("error setting column_level_permission_rules: %s", err)
+		return diag.Errorf("setting column_level_permission_rules: %s", err)
 	}
 
 	if err := d.Set("data_set_usage_configuration", flattenDataSetUsageConfiguration(dataSet.DataSetUsageConfiguration)); err != nil {
-		return diag.Errorf("error setting data_set_usage_configuration: %s", err)
+		return diag.Errorf("setting data_set_usage_configuration: %s", err)
 	}
 
 	if err := d.Set("field_folders", flattenFieldFolders(dataSet.FieldFolders)); err != nil {
-		return diag.Errorf("error setting field_folders: %s", err)
+		return diag.Errorf("setting field_folders: %s", err)
 	}
 
 	if err := d.Set("logical_table_map", flattenLogicalTableMap(dataSet.LogicalTableMap, logicalTableMapDataSourceSchema())); err != nil {
-		return diag.Errorf("error setting logical_table_map: %s", err)
+		return diag.Errorf("setting logical_table_map: %s", err)
 	}
 
 	if err := d.Set("physical_table_map", flattenPhysicalTableMap(dataSet.PhysicalTableMap, physicalTableMapDataSourceSchema())); err != nil {
-		return diag.Errorf("error setting physical_table_map: %s", err)
+		return diag.Errorf("setting physical_table_map: %s", err)
 	}
 
 	if err := d.Set("row_level_permission_data_set", flattenRowLevelPermissionDataSet(dataSet.RowLevelPermissionDataSet)); err != nil {
-		return diag.Errorf("error setting row_level_permission_data_set: %s", err)
+		return diag.Errorf("setting row_level_permission_data_set: %s", err)
 	}
 
 	if err := d.Set("row_level_permission_tag_configuration", flattenRowLevelPermissionTagConfiguration(dataSet.RowLevelPermissionTagConfiguration)); err != nil {
-		return diag.Errorf("error setting row_level_permission_tag_configuration: %s", err)
+		return diag.Errorf("setting row_level_permission_tag_configuration: %s", err)
 	}
 
 	tags, err := ListTags(ctx, conn, d.Get("arn").(string))
 
 	if err != nil {
-		return diag.Errorf("error listing tags for QuickSight Data Set (%s): %s", d.Id(), err)
+		return diag.Errorf("listing tags for QuickSight Data Set (%s): %s", d.Id(), err)
 	}
 
 	tags = tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	//lintignore:AWSR002
 	if err := d.Set("tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		return diag.Errorf("error setting tags: %s", err)
+		return diag.Errorf("setting tags: %s", err)
 	}
 
 	if err := d.Set("tags_all", tags.Map()); err != nil {
-		return diag.Errorf("error setting tags_all: %s", err)
+		return diag.Errorf("setting tags_all: %s", err)
 	}
 
 	permsResp, err := conn.DescribeDataSetPermissionsWithContext(ctx, &quicksight.DescribeDataSetPermissionsInput{
@@ -695,11 +695,11 @@ func dataSourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta int
 	})
 
 	if err != nil {
-		return diag.Errorf("error describing QuickSight Data Source (%s) Permissions: %s", d.Id(), err)
+		return diag.Errorf("describing QuickSight Data Source (%s) Permissions: %s", d.Id(), err)
 	}
 
 	if err := d.Set("permissions", flattenPermissions(permsResp.Permissions)); err != nil {
-		return diag.Errorf("error setting permissions: %s", err)
+		return diag.Errorf("setting permissions: %s", err)
 	}
 	return nil
 }

--- a/internal/service/quicksight/data_source.go
+++ b/internal/service/quicksight/data_source.go
@@ -640,13 +640,13 @@ func resourceDataSourceCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	_, err := conn.CreateDataSourceWithContext(ctx, params)
 	if err != nil {
-		return diag.Errorf("error creating QuickSight Data Source: %s", err)
+		return diag.Errorf("creating QuickSight Data Source: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", awsAccountId, id))
 
 	if _, err := waitCreated(ctx, conn, awsAccountId, id); err != nil {
-		return diag.Errorf("error waiting from QuickSight Data Source (%s) creation: %s", d.Id(), err)
+		return diag.Errorf("waiting from QuickSight Data Source (%s) creation: %s", d.Id(), err)
 	}
 
 	return resourceDataSourceRead(ctx, d, meta)
@@ -674,11 +674,11 @@ func resourceDataSourceRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if err != nil {
-		return diag.Errorf("error describing QuickSight Data Source (%s): %s", d.Id(), err)
+		return diag.Errorf("describing QuickSight Data Source (%s): %s", d.Id(), err)
 	}
 
 	if output == nil || output.DataSource == nil {
-		return diag.Errorf("error describing QuickSight Data Source (%s): empty output", d.Id())
+		return diag.Errorf("describing QuickSight Data Source (%s): empty output", d.Id())
 	}
 
 	dataSource := output.DataSource
@@ -689,17 +689,17 @@ func resourceDataSourceRead(ctx context.Context, d *schema.ResourceData, meta in
 	d.Set("name", dataSource.Name)
 
 	if err := d.Set("parameters", flattenParameters(dataSource.DataSourceParameters)); err != nil {
-		return diag.Errorf("error setting parameters: %s", err)
+		return diag.Errorf("setting parameters: %s", err)
 	}
 
 	if err := d.Set("ssl_properties", flattenSSLProperties(dataSource.SslProperties)); err != nil {
-		return diag.Errorf("error setting ssl_properties: %s", err)
+		return diag.Errorf("setting ssl_properties: %s", err)
 	}
 
 	d.Set("type", dataSource.Type)
 
 	if err := d.Set("vpc_connection_properties", flattenVPCConnectionProperties(dataSource.VpcConnectionProperties)); err != nil {
-		return diag.Errorf("error setting vpc_connection_properties: %s", err)
+		return diag.Errorf("setting vpc_connection_properties: %s", err)
 	}
 
 	permsResp, err := conn.DescribeDataSourcePermissionsWithContext(ctx, &quicksight.DescribeDataSourcePermissionsInput{
@@ -708,11 +708,11 @@ func resourceDataSourceRead(ctx context.Context, d *schema.ResourceData, meta in
 	})
 
 	if err != nil {
-		return diag.Errorf("error describing QuickSight Data Source (%s) Permissions: %s", d.Id(), err)
+		return diag.Errorf("describing QuickSight Data Source (%s) Permissions: %s", d.Id(), err)
 	}
 
 	if err := d.Set("permission", flattenPermissions(permsResp.Permissions)); err != nil {
-		return diag.Errorf("error setting permission: %s", err)
+		return diag.Errorf("setting permission: %s", err)
 	}
 
 	return nil
@@ -752,11 +752,11 @@ func resourceDataSourceUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		_, err = conn.UpdateDataSourceWithContext(ctx, params)
 
 		if err != nil {
-			return diag.Errorf("error updating QuickSight Data Source (%s): %s", d.Id(), err)
+			return diag.Errorf("updating QuickSight Data Source (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitUpdated(ctx, conn, awsAccountId, dataSourceId); err != nil {
-			return diag.Errorf("error waiting for QuickSight Data Source (%s) to update: %s", d.Id(), err)
+			return diag.Errorf("waiting for QuickSight Data Source (%s) to update: %s", d.Id(), err)
 		}
 	}
 
@@ -788,7 +788,7 @@ func resourceDataSourceUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		_, err = conn.UpdateDataSourcePermissionsWithContext(ctx, params)
 
 		if err != nil {
-			return diag.Errorf("error updating QuickSight Data Source (%s) permissions: %s", dataSourceId, err)
+			return diag.Errorf("updating QuickSight Data Source (%s) permissions: %s", dataSourceId, err)
 		}
 	}
 
@@ -815,7 +815,7 @@ func resourceDataSourceDelete(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting QuickSight Data Source (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting QuickSight Data Source (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/quicksight/folder.go
+++ b/internal/service/quicksight/folder.go
@@ -208,7 +208,7 @@ func resourceFolderRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if err := d.Set("folder_path", flex.FlattenStringList(out.FolderPath)); err != nil {
-		return diag.Errorf("error setting folder_path: %s", err)
+		return diag.Errorf("setting folder_path: %s", err)
 	}
 
 	permsResp, err := conn.DescribeFolderPermissionsWithContext(ctx, &quicksight.DescribeFolderPermissionsInput{
@@ -217,11 +217,11 @@ func resourceFolderRead(ctx context.Context, d *schema.ResourceData, meta interf
 	})
 
 	if err != nil {
-		return diag.Errorf("error describing QuickSight Folder (%s) Permissions: %s", d.Id(), err)
+		return diag.Errorf("describing QuickSight Folder (%s) Permissions: %s", d.Id(), err)
 	}
 
 	if err := d.Set("permissions", flattenPermissions(permsResp.Permissions)); err != nil {
-		return diag.Errorf("error setting permissions: %s", err)
+		return diag.Errorf("setting permissions: %s", err)
 	}
 	return nil
 }
@@ -271,7 +271,7 @@ func resourceFolderUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		_, err = conn.UpdateFolderPermissionsWithContext(ctx, params)
 
 		if err != nil {
-			return diag.Errorf("error updating QuickSight Folder (%s) permissions: %s", folderId, err)
+			return diag.Errorf("updating QuickSight Folder (%s) permissions: %s", folderId, err)
 		}
 	}
 

--- a/internal/service/quicksight/group_membership.go
+++ b/internal/service/quicksight/group_membership.go
@@ -109,7 +109,7 @@ func resourceGroupMembershipRead(ctx context.Context, d *schema.ResourceData, me
 
 	found, err := FindGroupMembership(ctx, conn, listInput, userName)
 	if err != nil {
-		return diag.Errorf("Error listing QuickSight Group Memberships (%s): %s", d.Id(), err)
+		return diag.Errorf("listing QuickSight Group Memberships (%s): %s", d.Id(), err)
 	}
 
 	if !d.IsNewResource() && !found {
@@ -145,7 +145,7 @@ func resourceGroupMembershipDelete(ctx context.Context, d *schema.ResourceData, 
 		if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
 			return nil
 		}
-		return diag.Errorf("Error deleting QuickSight User-group membership %s: %s", d.Id(), err)
+		return diag.Errorf("deleting QuickSight User-group membership %s: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/quicksight/group_membership.go
+++ b/internal/service/quicksight/group_membership.go
@@ -85,7 +85,7 @@ func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, 
 
 	resp, err := conn.CreateGroupMembershipWithContext(ctx, createOpts)
 	if err != nil {
-		return diag.Errorf("error adding QuickSight user (%s) to group (%s): %s", memberName, groupName, err)
+		return diag.Errorf("adding QuickSight user (%s) to group (%s): %s", memberName, groupName, err)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s/%s/%s", awsAccountID, namespace, groupName, aws.StringValue(resp.GroupMember.MemberName)))

--- a/internal/service/quicksight/template.go
+++ b/internal/service/quicksight/template.go
@@ -208,11 +208,11 @@ func resourceTemplateRead(ctx context.Context, d *schema.ResourceData, meta inte
 	})
 
 	if err != nil {
-		return diag.Errorf("error describing QuickSight Template (%s) Definition: %s", d.Id(), err)
+		return diag.Errorf("describing QuickSight Template (%s) Definition: %s", d.Id(), err)
 	}
 
 	if err := d.Set("definition", quicksightschema.FlattenTemplateDefinition(descResp.Definition)); err != nil {
-		return diag.Errorf("error setting definition: %s", err)
+		return diag.Errorf("setting definition: %s", err)
 	}
 
 	permsResp, err := conn.DescribeTemplatePermissionsWithContext(ctx, &quicksight.DescribeTemplatePermissionsInput{
@@ -221,11 +221,11 @@ func resourceTemplateRead(ctx context.Context, d *schema.ResourceData, meta inte
 	})
 
 	if err != nil {
-		return diag.Errorf("error describing QuickSight Template (%s) Permissions: %s", d.Id(), err)
+		return diag.Errorf("describing QuickSight Template (%s) Permissions: %s", d.Id(), err)
 	}
 
 	if err := d.Set("permissions", flattenPermissions(permsResp.Permissions)); err != nil {
-		return diag.Errorf("error setting permissions: %s", err)
+		return diag.Errorf("setting permissions: %s", err)
 	}
 
 	return nil
@@ -288,7 +288,7 @@ func resourceTemplateUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		_, err = conn.UpdateTemplatePermissionsWithContext(ctx, params)
 
 		if err != nil {
-			return diag.Errorf("error updating QuickSight Template (%s) permissions: %s", templateId, err)
+			return diag.Errorf("updating QuickSight Template (%s) permissions: %s", templateId, err)
 		}
 	}
 

--- a/internal/service/route53/traffic_policy.go
+++ b/internal/service/route53/traffic_policy.go
@@ -95,7 +95,7 @@ func resourceTrafficPolicyCreate(ctx context.Context, d *schema.ResourceData, me
 	}, route53.ErrCodeNoSuchTrafficPolicy)
 
 	if err != nil {
-		return diag.Errorf("error creating Route53 Traffic Policy (%s): %s", name, err)
+		return diag.Errorf("creating Route53 Traffic Policy (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(outputRaw.(*route53.CreateTrafficPolicyOutput).TrafficPolicy.Id))
@@ -115,7 +115,7 @@ func resourceTrafficPolicyRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Route53 Traffic Policy (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Route53 Traffic Policy (%s): %s", d.Id(), err)
 	}
 
 	d.Set("comment", trafficPolicy.Comment)
@@ -143,7 +143,7 @@ func resourceTrafficPolicyUpdate(ctx context.Context, d *schema.ResourceData, me
 	_, err := conn.UpdateTrafficPolicyCommentWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error updating Route53 Traffic Policy (%s) comment: %s", d.Id(), err)
+		return diag.Errorf("updating Route53 Traffic Policy (%s) comment: %s", d.Id(), err)
 	}
 
 	return resourceTrafficPolicyRead(ctx, d, meta)
@@ -168,7 +168,7 @@ func resourceTrafficPolicyDelete(ctx context.Context, d *schema.ResourceData, me
 	})
 
 	if err != nil {
-		return diag.Errorf("error listing Route 53 Traffic Policy (%s) versions: %s", d.Id(), err)
+		return diag.Errorf("listing Route 53 Traffic Policy (%s) versions: %s", d.Id(), err)
 	}
 
 	for _, v := range output {
@@ -185,7 +185,7 @@ func resourceTrafficPolicyDelete(ctx context.Context, d *schema.ResourceData, me
 		}
 
 		if err != nil {
-			return diag.Errorf("error deleting Route 53 Traffic Policy (%s) version (%d): %s", d.Id(), version, err)
+			return diag.Errorf("deleting Route 53 Traffic Policy (%s) version (%d): %s", d.Id(), version, err)
 		}
 	}
 

--- a/internal/service/route53/traffic_policy_instance.go
+++ b/internal/service/route53/traffic_policy_instance.go
@@ -81,13 +81,13 @@ func resourceTrafficPolicyInstanceCreate(ctx context.Context, d *schema.Resource
 	}, route53.ErrCodeNoSuchTrafficPolicy)
 
 	if err != nil {
-		return diag.Errorf("error creating Route53 Traffic Policy Instance (%s): %s", name, err)
+		return diag.Errorf("creating Route53 Traffic Policy Instance (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(outputRaw.(*route53.CreateTrafficPolicyInstanceOutput).TrafficPolicyInstance.Id))
 
 	if _, err = waitTrafficPolicyInstanceStateCreated(ctx, conn, d.Id()); err != nil {
-		return diag.Errorf("error waiting for Route53 Traffic Policy Instance (%s) create: %s", d.Id(), err)
+		return diag.Errorf("waiting for Route53 Traffic Policy Instance (%s) create: %s", d.Id(), err)
 	}
 
 	return resourceTrafficPolicyInstanceRead(ctx, d, meta)
@@ -105,7 +105,7 @@ func resourceTrafficPolicyInstanceRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Route53 Traffic Policy Instance (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Route53 Traffic Policy Instance (%s): %s", d.Id(), err)
 	}
 
 	d.Set("hosted_zone_id", trafficPolicyInstance.HostedZoneId)
@@ -131,11 +131,11 @@ func resourceTrafficPolicyInstanceUpdate(ctx context.Context, d *schema.Resource
 	_, err := conn.UpdateTrafficPolicyInstanceWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error updating Route53 Traffic Policy Instance (%s): %s", d.Id(), err)
+		return diag.Errorf("updating Route53 Traffic Policy Instance (%s): %s", d.Id(), err)
 	}
 
 	if _, err = waitTrafficPolicyInstanceStateUpdated(ctx, conn, d.Id()); err != nil {
-		return diag.Errorf("error waiting for Route53 Traffic Policy Instance (%s) update: %s", d.Id(), err)
+		return diag.Errorf("waiting for Route53 Traffic Policy Instance (%s) update: %s", d.Id(), err)
 	}
 
 	return resourceTrafficPolicyInstanceRead(ctx, d, meta)
@@ -154,11 +154,11 @@ func resourceTrafficPolicyInstanceDelete(ctx context.Context, d *schema.Resource
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Route53 Traffic Policy Instance (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Route53 Traffic Policy Instance (%s): %s", d.Id(), err)
 	}
 
 	if _, err = waitTrafficPolicyInstanceStateDeleted(ctx, conn, d.Id()); err != nil {
-		return diag.Errorf("error waiting for Route53 Traffic Policy Instance (%s) delete: %s", d.Id(), err)
+		return diag.Errorf("waiting for Route53 Traffic Policy Instance (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/route53domains/registered_domain.go
+++ b/internal/service/route53domains/registered_domain.go
@@ -251,7 +251,7 @@ func resourceRegisteredDomainCreate(ctx context.Context, d *schema.ResourceData,
 	domainDetail, err := findDomainDetailByName(ctx, conn, domainName)
 
 	if err != nil {
-		return diag.Errorf("error reading Route 53 Domains Domain (%s): %s", domainName, err)
+		return diag.Errorf("reading Route 53 Domains Domain (%s): %s", domainName, err)
 	}
 
 	d.SetId(aws.ToString(domainDetail.DomainName))
@@ -313,7 +313,7 @@ func resourceRegisteredDomainCreate(ctx context.Context, d *schema.ResourceData,
 	tags, err := ListTags(ctx, conn, d.Id())
 
 	if err != nil {
-		return diag.Errorf("error listing tags for Route 53 Domains Domain (%s): %s", d.Id(), err)
+		return diag.Errorf("listing tags for Route 53 Domains Domain (%s): %s", d.Id(), err)
 	}
 
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
@@ -322,7 +322,7 @@ func resourceRegisteredDomainCreate(ctx context.Context, d *schema.ResourceData,
 
 	if !oldTags.Equal(newTags) {
 		if err := UpdateTags(ctx, conn, d.Id(), oldTags, newTags); err != nil {
-			return diag.Errorf("error updating Route 53 Domains Domain (%s) tags: %s", d.Id(), err)
+			return diag.Errorf("updating Route 53 Domains Domain (%s) tags: %s", d.Id(), err)
 		}
 	}
 
@@ -341,14 +341,14 @@ func resourceRegisteredDomainRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Route 53 Domains Domain (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Route 53 Domains Domain (%s): %s", d.Id(), err)
 	}
 
 	d.Set("abuse_contact_email", domainDetail.AbuseContactEmail)
 	d.Set("abuse_contact_phone", domainDetail.AbuseContactPhone)
 	if domainDetail.AdminContact != nil {
 		if err := d.Set("admin_contact", []interface{}{flattenContactDetail(domainDetail.AdminContact)}); err != nil {
-			return diag.Errorf("error setting admin_contact: %s", err)
+			return diag.Errorf("setting admin_contact: %s", err)
 		}
 	} else {
 		d.Set("admin_contact", nil)
@@ -367,11 +367,11 @@ func resourceRegisteredDomainRead(ctx context.Context, d *schema.ResourceData, m
 		d.Set("expiration_date", nil)
 	}
 	if err := d.Set("name_server", flattenNameservers(domainDetail.Nameservers)); err != nil {
-		return diag.Errorf("error setting name_servers: %s", err)
+		return diag.Errorf("setting name_servers: %s", err)
 	}
 	if domainDetail.RegistrantContact != nil {
 		if err := d.Set("registrant_contact", []interface{}{flattenContactDetail(domainDetail.RegistrantContact)}); err != nil {
-			return diag.Errorf("error setting registrant_contact: %s", err)
+			return diag.Errorf("setting registrant_contact: %s", err)
 		}
 	} else {
 		d.Set("registrant_contact", nil)
@@ -384,7 +384,7 @@ func resourceRegisteredDomainRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("status_list", statusList)
 	if domainDetail.TechContact != nil {
 		if err := d.Set("tech_contact", []interface{}{flattenContactDetail(domainDetail.TechContact)}); err != nil {
-			return diag.Errorf("error setting tech_contact: %s", err)
+			return diag.Errorf("setting tech_contact: %s", err)
 		}
 	} else {
 		d.Set("tech_contact", nil)

--- a/internal/service/s3/bucket_accelerate_configuration.go
+++ b/internal/service/s3/bucket_accelerate_configuration.go
@@ -71,7 +71,7 @@ func resourceBucketAccelerateConfigurationCreate(ctx context.Context, d *schema.
 	}, s3.ErrCodeNoSuchBucket)
 
 	if err != nil {
-		return diag.Errorf("error creating S3 bucket (%s) accelerate configuration: %s", bucket, err)
+		return diag.Errorf("creating S3 bucket (%s) accelerate configuration: %s", bucket, err)
 	}
 
 	d.SetId(CreateResourceID(bucket, expectedBucketOwner))
@@ -104,12 +104,12 @@ func resourceBucketAccelerateConfigurationRead(ctx context.Context, d *schema.Re
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading S3 bucket accelerate configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("reading S3 bucket accelerate configuration (%s): %s", d.Id(), err)
 	}
 
 	if output == nil {
 		if d.IsNewResource() {
-			return diag.Errorf("error reading S3 bucket accelerate configuration (%s): empty output", d.Id())
+			return diag.Errorf("reading S3 bucket accelerate configuration (%s): empty output", d.Id())
 		}
 		log.Printf("[WARN] S3 Bucket Accelerate Configuration (%s) not found, removing from state", d.Id())
 		d.SetId("")
@@ -145,7 +145,7 @@ func resourceBucketAccelerateConfigurationUpdate(ctx context.Context, d *schema.
 	_, err = conn.PutBucketAccelerateConfigurationWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error updating S3 bucket accelerate configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("updating S3 bucket accelerate configuration (%s): %s", d.Id(), err)
 	}
 
 	return resourceBucketAccelerateConfigurationRead(ctx, d, meta)
@@ -177,7 +177,7 @@ func resourceBucketAccelerateConfigurationDelete(ctx context.Context, d *schema.
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting S3 bucket accelerate configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting S3 bucket accelerate configuration (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/s3/bucket_acl.go
+++ b/internal/service/s3/bucket_acl.go
@@ -155,7 +155,7 @@ func resourceBucketACLCreate(ctx context.Context, d *schema.ResourceData, meta i
 	}, s3.ErrCodeNoSuchBucket)
 
 	if err != nil {
-		return diag.Errorf("error creating S3 bucket ACL for %s: %s", bucket, err)
+		return diag.Errorf("creating S3 bucket ACL for %s: %s", bucket, err)
 	}
 
 	d.SetId(BucketACLCreateResourceID(bucket, expectedBucketOwner, acl))
@@ -188,18 +188,18 @@ func resourceBucketACLRead(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting S3 bucket ACL (%s): %s", d.Id(), err)
+		return diag.Errorf("getting S3 bucket ACL (%s): %s", d.Id(), err)
 	}
 
 	if output == nil {
-		return diag.Errorf("error getting S3 bucket ACL (%s): empty output", d.Id())
+		return diag.Errorf("getting S3 bucket ACL (%s): empty output", d.Id())
 	}
 
 	d.Set("acl", acl)
 	d.Set("bucket", bucket)
 	d.Set("expected_bucket_owner", expectedBucketOwner)
 	if err := d.Set("access_control_policy", flattenBucketACLAccessControlPolicy(output)); err != nil {
-		return diag.Errorf("error setting access_control_policy: %s", err)
+		return diag.Errorf("setting access_control_policy: %s", err)
 	}
 
 	return nil
@@ -233,7 +233,7 @@ func resourceBucketACLUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	_, err = conn.PutBucketAclWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error updating S3 bucket ACL (%s): %s", d.Id(), err)
+		return diag.Errorf("updating S3 bucket ACL (%s): %s", d.Id(), err)
 	}
 
 	if d.HasChange("acl") {

--- a/internal/service/s3/bucket_cors_configuration.go
+++ b/internal/service/s3/bucket_cors_configuration.go
@@ -105,7 +105,7 @@ func resourceBucketCorsConfigurationCreate(ctx context.Context, d *schema.Resour
 	}, s3.ErrCodeNoSuchBucket)
 
 	if err != nil {
-		return diag.Errorf("error creating S3 bucket (%s) CORS configuration: %s", bucket, err)
+		return diag.Errorf("creating S3 bucket (%s) CORS configuration: %s", bucket, err)
 	}
 
 	d.SetId(CreateResourceID(bucket, expectedBucketOwner))
@@ -140,13 +140,13 @@ func resourceBucketCorsConfigurationRead(ctx context.Context, d *schema.Resource
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading S3 bucket CORS configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("reading S3 bucket CORS configuration (%s): %s", d.Id(), err)
 	}
 
 	output, ok := corsResponse.(*s3.GetBucketCorsOutput)
 	if !ok || output == nil {
 		if d.IsNewResource() {
-			return diag.Errorf("error reading S3 bucket CORS configuration (%s): empty output", d.Id())
+			return diag.Errorf("reading S3 bucket CORS configuration (%s): empty output", d.Id())
 		}
 		log.Printf("[WARN] S3 Bucket CORS Configuration (%s) not found, removing from state", d.Id())
 		d.SetId("")
@@ -157,7 +157,7 @@ func resourceBucketCorsConfigurationRead(ctx context.Context, d *schema.Resource
 	d.Set("expected_bucket_owner", expectedBucketOwner)
 
 	if err := d.Set("cors_rule", flattenBucketCorsConfigurationCorsRules(output.CORSRules)); err != nil {
-		return diag.Errorf("error setting cors_rule: %s", err)
+		return diag.Errorf("setting cors_rule: %s", err)
 	}
 
 	return nil
@@ -185,7 +185,7 @@ func resourceBucketCorsConfigurationUpdate(ctx context.Context, d *schema.Resour
 	_, err = conn.PutBucketCorsWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error updating S3 bucket CORS configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("updating S3 bucket CORS configuration (%s): %s", d.Id(), err)
 	}
 
 	return resourceBucketCorsConfigurationRead(ctx, d, meta)
@@ -214,7 +214,7 @@ func resourceBucketCorsConfigurationDelete(ctx context.Context, d *schema.Resour
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting S3 bucket CORS configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting S3 bucket CORS configuration (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -260,7 +260,7 @@ func resourceBucketLifecycleConfigurationCreate(ctx context.Context, d *schema.R
 
 	rules, err := ExpandLifecycleRules(ctx, d.Get("rule").([]interface{}))
 	if err != nil {
-		return diag.Errorf("error creating S3 Lifecycle Configuration for bucket (%s): %s", bucket, err)
+		return diag.Errorf("creating S3 Lifecycle Configuration for bucket (%s): %s", bucket, err)
 	}
 
 	input := &s3.PutBucketLifecycleConfigurationInput{
@@ -279,13 +279,13 @@ func resourceBucketLifecycleConfigurationCreate(ctx context.Context, d *schema.R
 	}, s3.ErrCodeNoSuchBucket)
 
 	if err != nil {
-		return diag.Errorf("error creating S3 Lifecycle Configuration for bucket (%s): %s", bucket, err)
+		return diag.Errorf("creating S3 Lifecycle Configuration for bucket (%s): %s", bucket, err)
 	}
 
 	d.SetId(CreateResourceID(bucket, expectedBucketOwner))
 
 	if err = waitForLifecycleConfigurationRulesStatus(ctx, conn, bucket, expectedBucketOwner, rules); err != nil {
-		return diag.Errorf("error waiting for S3 Lifecycle Configuration for bucket (%s) to reach expected rules status after update: %s", d.Id(), err)
+		return diag.Errorf("waiting for S3 Lifecycle Configuration for bucket (%s) to reach expected rules status after update: %s", d.Id(), err)
 	}
 
 	return resourceBucketLifecycleConfigurationRead(ctx, d, meta)
@@ -343,13 +343,13 @@ func resourceBucketLifecycleConfigurationRead(ctx context.Context, d *schema.Res
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting S3 Bucket Lifecycle Configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("getting S3 Bucket Lifecycle Configuration (%s): %s", d.Id(), err)
 	}
 
 	d.Set("bucket", bucket)
 	d.Set("expected_bucket_owner", expectedBucketOwner)
 	if err := d.Set("rule", FlattenLifecycleRules(ctx, output.Rules)); err != nil {
-		return diag.Errorf("error setting rule: %s", err)
+		return diag.Errorf("setting rule: %s", err)
 	}
 
 	return nil
@@ -365,7 +365,7 @@ func resourceBucketLifecycleConfigurationUpdate(ctx context.Context, d *schema.R
 
 	rules, err := ExpandLifecycleRules(ctx, d.Get("rule").([]interface{}))
 	if err != nil {
-		return diag.Errorf("error updating S3 Bucket Lifecycle Configuration rule: %s", err)
+		return diag.Errorf("updating S3 Bucket Lifecycle Configuration rule: %s", err)
 	}
 
 	input := &s3.PutBucketLifecycleConfigurationInput{
@@ -384,11 +384,11 @@ func resourceBucketLifecycleConfigurationUpdate(ctx context.Context, d *schema.R
 	}, ErrCodeNoSuchLifecycleConfiguration)
 
 	if err != nil {
-		return diag.Errorf("error updating S3 Bucket Lifecycle Configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("updating S3 Bucket Lifecycle Configuration (%s): %s", d.Id(), err)
 	}
 
 	if err := waitForLifecycleConfigurationRulesStatus(ctx, conn, bucket, expectedBucketOwner, rules); err != nil {
-		return diag.Errorf("error waiting for S3 Lifecycle Configuration for bucket (%s) to reach expected rules status after update: %s", d.Id(), err)
+		return diag.Errorf("waiting for S3 Lifecycle Configuration for bucket (%s) to reach expected rules status after update: %s", d.Id(), err)
 	}
 
 	return resourceBucketLifecycleConfigurationRead(ctx, d, meta)
@@ -417,7 +417,7 @@ func resourceBucketLifecycleConfigurationDelete(ctx context.Context, d *schema.R
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting S3 Bucket Lifecycle Configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting S3 Bucket Lifecycle Configuration (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/s3/bucket_logging.go
+++ b/internal/service/s3/bucket_logging.go
@@ -126,7 +126,7 @@ func resourceBucketLoggingCreate(ctx context.Context, d *schema.ResourceData, me
 	}, s3.ErrCodeNoSuchBucket)
 
 	if err != nil {
-		return diag.Errorf("error putting S3 bucket (%s) logging: %s", bucket, err)
+		return diag.Errorf("putting S3 bucket (%s) logging: %s", bucket, err)
 	}
 
 	d.SetId(CreateResourceID(bucket, expectedBucketOwner))
@@ -161,14 +161,14 @@ func resourceBucketLoggingRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading S3 Bucket (%s) Logging: %s", d.Id(), err)
+		return diag.Errorf("reading S3 Bucket (%s) Logging: %s", d.Id(), err)
 	}
 
 	output, ok := resp.(*s3.GetBucketLoggingOutput)
 
 	if !ok || output.LoggingEnabled == nil {
 		if d.IsNewResource() {
-			return diag.Errorf("error reading S3 Bucket (%s) Logging: empty output", d.Id())
+			return diag.Errorf("reading S3 Bucket (%s) Logging: empty output", d.Id())
 		}
 		log.Printf("[WARN] S3 Bucket Logging (%s) not found, removing from state", d.Id())
 		d.SetId("")
@@ -183,7 +183,7 @@ func resourceBucketLoggingRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("target_prefix", loggingEnabled.TargetPrefix)
 
 	if err := d.Set("target_grant", flattenBucketLoggingTargetGrants(loggingEnabled.TargetGrants)); err != nil {
-		return diag.Errorf("error setting target_grant: %s", err)
+		return diag.Errorf("setting target_grant: %s", err)
 	}
 
 	return nil
@@ -222,7 +222,7 @@ func resourceBucketLoggingUpdate(ctx context.Context, d *schema.ResourceData, me
 	}, s3.ErrCodeNoSuchBucket)
 
 	if err != nil {
-		return diag.Errorf("error updating S3 bucket (%s) logging: %s", d.Id(), err)
+		return diag.Errorf("updating S3 bucket (%s) logging: %s", d.Id(), err)
 	}
 
 	return resourceBucketLoggingRead(ctx, d, meta)
@@ -252,7 +252,7 @@ func resourceBucketLoggingDelete(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting S3 Bucket (%s) Logging: %s", d.Id(), err)
+		return diag.Errorf("deleting S3 Bucket (%s) Logging: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/s3/bucket_object.go
+++ b/internal/service/s3/bucket_object.go
@@ -408,11 +408,11 @@ func resourceBucketObjectUpload(ctx context.Context, d *schema.ResourceData, met
 		source := v.(string)
 		path, err := homedir.Expand(source)
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "Error expanding homedir in source (%s): %s", source, err)
+			return sdkdiag.AppendErrorf(diags, "expanding homedir in source (%s): %s", source, err)
 		}
 		file, err := os.Open(path)
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "Error opening S3 object source (%s): %s", path, err)
+			return sdkdiag.AppendErrorf(diags, "opening S3 object source (%s): %s", path, err)
 		}
 
 		body = file
@@ -511,7 +511,7 @@ func resourceBucketObjectUpload(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if _, err := uploader.Upload(input); err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error uploading object to S3 bucket (%s): %s", bucket, err)
+		return sdkdiag.AppendErrorf(diags, "uploading object to S3 bucket (%s): %s", bucket, err)
 	}
 
 	d.SetId(key)

--- a/internal/service/s3/bucket_policy.go
+++ b/internal/service/s3/bucket_policy.go
@@ -87,7 +87,7 @@ func resourceBucketPolicyPut(ctx context.Context, d *schema.ResourceData, meta i
 		_, err = conn.PutBucketPolicyWithContext(ctx, params)
 	}
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error putting S3 policy: %s", err)
+		return sdkdiag.AppendErrorf(diags, "putting S3 policy: %s", err)
 	}
 
 	d.SetId(bucket)
@@ -148,7 +148,7 @@ func resourceBucketPolicyDelete(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Error deleting S3 policy: %s", err)
+		return sdkdiag.AppendErrorf(diags, "deleting S3 policy: %s", err)
 	}
 
 	return diags

--- a/internal/service/s3/bucket_request_payment_configuration.go
+++ b/internal/service/s3/bucket_request_payment_configuration.go
@@ -71,7 +71,7 @@ func resourceBucketRequestPaymentConfigurationCreate(ctx context.Context, d *sch
 	}, s3.ErrCodeNoSuchBucket)
 
 	if err != nil {
-		return diag.Errorf("error creating S3 bucket (%s) request payment configuration: %s", bucket, err)
+		return diag.Errorf("creating S3 bucket (%s) request payment configuration: %s", bucket, err)
 	}
 
 	d.SetId(CreateResourceID(bucket, expectedBucketOwner))
@@ -104,7 +104,7 @@ func resourceBucketRequestPaymentConfigurationRead(ctx context.Context, d *schem
 	}
 
 	if output == nil {
-		return diag.Errorf("error reading S3 bucket request payment configuration (%s): empty output", d.Id())
+		return diag.Errorf("reading S3 bucket request payment configuration (%s): empty output", d.Id())
 	}
 
 	d.Set("bucket", bucket)
@@ -136,7 +136,7 @@ func resourceBucketRequestPaymentConfigurationUpdate(ctx context.Context, d *sch
 	_, err = conn.PutBucketRequestPaymentWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error updating S3 bucket request payment configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("updating S3 bucket request payment configuration (%s): %s", d.Id(), err)
 	}
 
 	return resourceBucketRequestPaymentConfigurationRead(ctx, d, meta)
@@ -170,7 +170,7 @@ func resourceBucketRequestPaymentConfigurationDelete(ctx context.Context, d *sch
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting S3 bucket request payment configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting S3 bucket request payment configuration (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/s3/bucket_server_side_encryption_configuration.go
+++ b/internal/service/s3/bucket_server_side_encryption_configuration.go
@@ -99,7 +99,7 @@ func resourceBucketServerSideEncryptionConfigurationCreate(ctx context.Context, 
 	)
 
 	if err != nil {
-		return diag.Errorf("error creating S3 bucket (%s) server-side encryption configuration: %s", bucket, err)
+		return diag.Errorf("creating S3 bucket (%s) server-side encryption configuration: %s", bucket, err)
 	}
 
 	d.SetId(CreateResourceID(bucket, expectedBucketOwner))
@@ -138,13 +138,13 @@ func resourceBucketServerSideEncryptionConfigurationRead(ctx context.Context, d 
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading S3 bucket server-side encryption configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("reading S3 bucket server-side encryption configuration (%s): %s", d.Id(), err)
 	}
 
 	output, ok := resp.(*s3.GetBucketEncryptionOutput)
 	if !ok || output.ServerSideEncryptionConfiguration == nil {
 		if d.IsNewResource() {
-			return diag.Errorf("error reading S3 bucket server-side encryption configuration (%s): empty output", d.Id())
+			return diag.Errorf("reading S3 bucket server-side encryption configuration (%s): empty output", d.Id())
 		}
 		log.Printf("[WARN] S3 Bucket Server-Side Encryption Configuration (%s) not found, removing from state", d.Id())
 		d.SetId("")
@@ -156,7 +156,7 @@ func resourceBucketServerSideEncryptionConfigurationRead(ctx context.Context, d 
 	d.Set("bucket", bucket)
 	d.Set("expected_bucket_owner", expectedBucketOwner)
 	if err := d.Set("rule", flattenBucketServerSideEncryptionConfigurationRules(sse.Rules)); err != nil {
-		return diag.Errorf("error setting rule: %s", err)
+		return diag.Errorf("setting rule: %s", err)
 	}
 
 	return nil
@@ -190,7 +190,7 @@ func resourceBucketServerSideEncryptionConfigurationUpdate(ctx context.Context, 
 	)
 
 	if err != nil {
-		return diag.Errorf("error updating S3 bucket (%s) server-side encryption configuration: %s", d.Id(), err)
+		return diag.Errorf("updating S3 bucket (%s) server-side encryption configuration: %s", d.Id(), err)
 	}
 
 	return resourceBucketServerSideEncryptionConfigurationRead(ctx, d, meta)
@@ -219,7 +219,7 @@ func resourceBucketServerSideEncryptionConfigurationDelete(ctx context.Context, 
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting S3 bucket server-side encryption configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting S3 bucket server-side encryption configuration (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/s3/bucket_versioning.go
+++ b/internal/service/s3/bucket_versioning.go
@@ -121,7 +121,7 @@ func resourceBucketVersioningCreate(ctx context.Context, d *schema.ResourceData,
 		}, s3.ErrCodeNoSuchBucket)
 
 		if err != nil {
-			return diag.Errorf("error creating S3 bucket versioning for %s: %s", bucket, err)
+			return diag.Errorf("creating S3 bucket versioning for %s: %s", bucket, err)
 		}
 	} else {
 		log.Printf("[DEBUG] Creating S3 bucket versioning for unversioned bucket: %s", bucket)
@@ -151,13 +151,13 @@ func resourceBucketVersioningRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if err != nil {
-		return diag.Errorf("error getting S3 bucket versioning (%s): %s", d.Id(), err)
+		return diag.Errorf("getting S3 bucket versioning (%s): %s", d.Id(), err)
 	}
 
 	d.Set("bucket", bucket)
 	d.Set("expected_bucket_owner", expectedBucketOwner)
 	if err := d.Set("versioning_configuration", flattenBucketVersioningConfiguration(output)); err != nil {
-		return diag.Errorf("error setting versioning_configuration: %s", err)
+		return diag.Errorf("setting versioning_configuration: %s", err)
 	}
 
 	return nil
@@ -187,7 +187,7 @@ func resourceBucketVersioningUpdate(ctx context.Context, d *schema.ResourceData,
 	_, err = conn.PutBucketVersioningWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error updating S3 bucket versioning (%s): %s", d.Id(), err)
+		return diag.Errorf("updating S3 bucket versioning (%s): %s", d.Id(), err)
 	}
 
 	return resourceBucketVersioningRead(ctx, d, meta)
@@ -231,7 +231,7 @@ func resourceBucketVersioningDelete(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting S3 bucket versioning (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting S3 bucket versioning (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/s3/bucket_website_configuration.go
+++ b/internal/service/s3/bucket_website_configuration.go
@@ -200,7 +200,7 @@ func resourceBucketWebsiteConfigurationCreate(ctx context.Context, d *schema.Res
 	if v, ok := d.GetOk("routing_rules"); ok {
 		var unmarshalledRules []*s3.RoutingRule
 		if err := json.Unmarshal([]byte(v.(string)), &unmarshalledRules); err != nil {
-			return diag.Errorf("error creating S3 Bucket (%s) website configuration: %s", bucket, err)
+			return diag.Errorf("creating S3 Bucket (%s) website configuration: %s", bucket, err)
 		}
 		websiteConfig.RoutingRules = unmarshalledRules
 	}
@@ -219,7 +219,7 @@ func resourceBucketWebsiteConfigurationCreate(ctx context.Context, d *schema.Res
 	}, s3.ErrCodeNoSuchBucket)
 
 	if err != nil {
-		return diag.Errorf("error creating S3 bucket (%s) website configuration: %s", bucket, err)
+		return diag.Errorf("creating S3 bucket (%s) website configuration: %s", bucket, err)
 	}
 
 	d.SetId(CreateResourceID(bucket, expectedBucketOwner))
@@ -253,7 +253,7 @@ func resourceBucketWebsiteConfigurationRead(ctx context.Context, d *schema.Resou
 
 	if output == nil {
 		if d.IsNewResource() {
-			return diag.Errorf("error reading S3 bucket website configuration (%s): empty output", d.Id())
+			return diag.Errorf("reading S3 bucket website configuration (%s): empty output", d.Id())
 		}
 		log.Printf("[WARN] S3 Bucket Website Configuration (%s) not found, removing from state", d.Id())
 		d.SetId("")
@@ -264,25 +264,25 @@ func resourceBucketWebsiteConfigurationRead(ctx context.Context, d *schema.Resou
 	d.Set("expected_bucket_owner", expectedBucketOwner)
 
 	if err := d.Set("error_document", flattenBucketWebsiteConfigurationErrorDocument(output.ErrorDocument)); err != nil {
-		return diag.Errorf("error setting error_document: %s", err)
+		return diag.Errorf("setting error_document: %s", err)
 	}
 
 	if err := d.Set("index_document", flattenBucketWebsiteConfigurationIndexDocument(output.IndexDocument)); err != nil {
-		return diag.Errorf("error setting index_document: %s", err)
+		return diag.Errorf("setting index_document: %s", err)
 	}
 
 	if err := d.Set("redirect_all_requests_to", flattenBucketWebsiteConfigurationRedirectAllRequestsTo(output.RedirectAllRequestsTo)); err != nil {
-		return diag.Errorf("error setting redirect_all_requests_to: %s", err)
+		return diag.Errorf("setting redirect_all_requests_to: %s", err)
 	}
 
 	if err := d.Set("routing_rule", flattenBucketWebsiteConfigurationRoutingRules(output.RoutingRules)); err != nil {
-		return diag.Errorf("error setting routing_rule: %s", err)
+		return diag.Errorf("setting routing_rule: %s", err)
 	}
 
 	if output.RoutingRules != nil {
 		rr, err := normalizeRoutingRules(output.RoutingRules)
 		if err != nil {
-			return diag.Errorf("error while marshaling routing rules: %s", err)
+			return diag.Errorf("while marshaling routing rules: %s", err)
 		}
 		d.Set("routing_rules", rr)
 	} else {
@@ -331,7 +331,7 @@ func resourceBucketWebsiteConfigurationUpdate(ctx context.Context, d *schema.Res
 		} else {
 			var unmarshalledRules []*s3.RoutingRule
 			if err := json.Unmarshal([]byte(d.Get("routing_rules").(string)), &unmarshalledRules); err != nil {
-				return diag.Errorf("error updating S3 Bucket (%s) website configuration: %s", bucket, err)
+				return diag.Errorf("updating S3 Bucket (%s) website configuration: %s", bucket, err)
 			}
 			websiteConfig.RoutingRules = unmarshalledRules
 		}
@@ -344,7 +344,7 @@ func resourceBucketWebsiteConfigurationUpdate(ctx context.Context, d *schema.Res
 		if v, ok := d.GetOk("routing_rules"); ok {
 			var unmarshalledRules []*s3.RoutingRule
 			if err := json.Unmarshal([]byte(v.(string)), &unmarshalledRules); err != nil {
-				return diag.Errorf("error updating S3 Bucket (%s) website configuration: %s", bucket, err)
+				return diag.Errorf("updating S3 Bucket (%s) website configuration: %s", bucket, err)
 			}
 			websiteConfig.RoutingRules = unmarshalledRules
 		}
@@ -362,7 +362,7 @@ func resourceBucketWebsiteConfigurationUpdate(ctx context.Context, d *schema.Res
 	_, err = conn.PutBucketWebsiteWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error updating S3 bucket website configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("updating S3 bucket website configuration (%s): %s", d.Id(), err)
 	}
 
 	return resourceBucketWebsiteConfigurationRead(ctx, d, meta)
@@ -391,7 +391,7 @@ func resourceBucketWebsiteConfigurationDelete(ctx context.Context, d *schema.Res
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting S3 bucket website configuration (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting S3 bucket website configuration (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/s3control/multi_region_access_point.go
+++ b/internal/service/s3control/multi_region_access_point.go
@@ -251,7 +251,7 @@ func resourceMultiRegionAccessPointDelete(ctx context.Context, d *schema.Resourc
 	_, err = waitMultiRegionAccessPointRequestSucceeded(ctx, conn, accountID, aws.StringValue(output.RequestTokenARN), d.Timeout(schema.TimeoutDelete))
 
 	if err != nil {
-		return diag.Errorf("error waiting for S3 Multi-Region Access Point (%s) delete: %s", d.Id(), err)
+		return diag.Errorf("waiting for S3 Multi-Region Access Point (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/securityhub/insight.go
+++ b/internal/service/securityhub/insight.go
@@ -160,11 +160,11 @@ func resourceInsightCreate(ctx context.Context, d *schema.ResourceData, meta int
 	output, err := conn.CreateInsightWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Security Hub Insight (%s): %s", name, err)
+		return diag.Errorf("creating Security Hub Insight (%s): %s", name, err)
 	}
 
 	if output == nil {
-		return diag.Errorf("error creating Security Hub Insight (%s): empty output", name)
+		return diag.Errorf("creating Security Hub Insight (%s): empty output", name)
 	}
 
 	d.SetId(aws.StringValue(output.InsightArn))
@@ -184,12 +184,12 @@ func resourceInsightRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Security Hub Insight (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Security Hub Insight (%s): %s", d.Id(), err)
 	}
 
 	if insight == nil {
 		if d.IsNewResource() {
-			return diag.Errorf("error reading Security Hub Insight (%s): empty output", d.Id())
+			return diag.Errorf("reading Security Hub Insight (%s): empty output", d.Id())
 		}
 		log.Printf("[WARN] Security Hub Insight (%s) not found, removing from state", d.Id())
 		d.SetId("")
@@ -198,7 +198,7 @@ func resourceInsightRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	d.Set("arn", insight.InsightArn)
 	if err := d.Set("filters", flattenSecurityFindingFilters(insight.Filters)); err != nil {
-		return diag.Errorf("error setting filters: %s", err)
+		return diag.Errorf("setting filters: %s", err)
 	}
 	d.Set("group_by_attribute", insight.GroupByAttribute)
 	d.Set("name", insight.Name)
@@ -228,7 +228,7 @@ func resourceInsightUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	_, err := conn.UpdateInsightWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error updating Security Hub Insight (%s): %s", d.Id(), err)
+		return diag.Errorf("updating Security Hub Insight (%s): %s", d.Id(), err)
 	}
 
 	return resourceInsightRead(ctx, d, meta)
@@ -247,7 +247,7 @@ func resourceInsightDelete(ctx context.Context, d *schema.ResourceData, meta int
 		if tfawserr.ErrCodeEquals(err, securityhub.ErrCodeResourceNotFoundException) {
 			return nil
 		}
-		return diag.Errorf("error deleting Security Hub Insight (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Security Hub Insight (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/securityhub/standards_control.go
+++ b/internal/service/securityhub/standards_control.go
@@ -100,7 +100,7 @@ func resourceStandardsControlRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Security Hub Standards Control (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Security Hub Standards Control (%s): %s", d.Id(), err)
 	}
 
 	d.Set("control_id", control.ControlId)
@@ -132,7 +132,7 @@ func resourceStandardsControlPut(ctx context.Context, d *schema.ResourceData, me
 	_, err := conn.UpdateStandardsControlWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error updating Security Hub Standards Control (%s): %s", d.Id(), err)
+		return diag.Errorf("updating Security Hub Standards Control (%s): %s", d.Id(), err)
 	}
 
 	return resourceStandardsControlRead(ctx, d, meta)

--- a/internal/service/ses/template.go
+++ b/internal/service/ses/template.go
@@ -153,10 +153,9 @@ func resourceTemplateUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		Template: &template,
 	}
 
-	log.Printf("[DEBUG] Update SES template: %#v", input)
 	_, err := conn.UpdateTemplateWithContext(ctx, &input)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "Updating SES template '%s' failed: %s", templateName, err.Error())
+		return sdkdiag.AppendErrorf(diags, "updating SES template (%s): %s", templateName, err)
 	}
 
 	return append(diags, resourceTemplateRead(ctx, d, meta)...)

--- a/internal/service/timestreamwrite/database.go
+++ b/internal/service/timestreamwrite/database.go
@@ -85,11 +85,11 @@ func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta in
 	resp, err := conn.CreateDatabaseWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Timestream Database (%s): %s", dbName, err)
+		return diag.Errorf("creating Timestream Database (%s): %s", dbName, err)
 	}
 
 	if resp == nil || resp.Database == nil {
-		return diag.Errorf("error creating Timestream Database (%s): empty output", dbName)
+		return diag.Errorf("creating Timestream Database (%s): empty output", dbName)
 	}
 
 	d.SetId(aws.StringValue(resp.Database.DatabaseName))
@@ -113,11 +113,11 @@ func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err != nil {
-		return diag.Errorf("error reading Timestream Database (%s): %s", d.Id(), err)
+		return diag.Errorf("reading Timestream Database (%s): %s", d.Id(), err)
 	}
 
 	if resp == nil || resp.Database == nil {
-		return diag.Errorf("error reading Timestream Database (%s): empty output", d.Id())
+		return diag.Errorf("reading Timestream Database (%s): empty output", d.Id())
 	}
 
 	db := resp.Database
@@ -143,7 +143,7 @@ func resourceDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		_, err := conn.UpdateDatabaseWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("error updating Timestream Database (%s): %s", d.Id(), err)
+			return diag.Errorf("updating Timestream Database (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -163,7 +163,7 @@ func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Timestream Database (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Timestream Database (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/timestreamwrite/table.go
+++ b/internal/service/timestreamwrite/table.go
@@ -159,11 +159,11 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	output, err := conn.CreateTableWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("error creating Timestream Table (%s): %s", tableName, err)
+		return diag.Errorf("creating Timestream Table (%s): %s", tableName, err)
 	}
 
 	if output == nil || output.Table == nil {
-		return diag.Errorf("error creating Timestream Table (%s): empty output", tableName)
+		return diag.Errorf("creating Timestream Table (%s): empty output", tableName)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", aws.StringValue(output.Table.TableName), aws.StringValue(output.Table.DatabaseName)))
@@ -194,7 +194,7 @@ func resourceTableRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	if output == nil || output.Table == nil {
-		return diag.Errorf("error reading Timestream Table (%s): empty output", d.Id())
+		return diag.Errorf("reading Timestream Table (%s): empty output", d.Id())
 	}
 
 	table := output.Table
@@ -204,11 +204,11 @@ func resourceTableRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	d.Set("database_name", table.DatabaseName)
 
 	if err := d.Set("retention_properties", flattenRetentionProperties(table.RetentionProperties)); err != nil {
-		return diag.Errorf("error setting retention_properties: %s", err)
+		return diag.Errorf("setting retention_properties: %s", err)
 	}
 
 	if err := d.Set("magnetic_store_write_properties", flattenMagneticStoreWriteProperties(table.MagneticStoreWriteProperties)); err != nil {
-		return diag.Errorf("error setting magnetic_store_write_properties: %s", err)
+		return diag.Errorf("setting magnetic_store_write_properties: %s", err)
 	}
 
 	d.Set("table_name", table.TableName)
@@ -242,7 +242,7 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		_, err = conn.UpdateTableWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("error updating Timestream Table (%s): %s", d.Id(), err)
+			return diag.Errorf("updating Timestream Table (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -269,7 +269,7 @@ func resourceTableDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if err != nil {
-		return diag.Errorf("error deleting Timestream Table (%s): %s", d.Id(), err)
+		return diag.Errorf("deleting Timestream Table (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/waf/rule_group.go
+++ b/internal/service/waf/rule_group.go
@@ -172,7 +172,7 @@ func resourceRuleGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 
 		err := updateRuleGroupResource(ctx, d.Id(), oldRules, newRules, conn)
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "Updating WAF Rule Group: %s", err)
+			return sdkdiag.AppendErrorf(diags, "updating WAF Rule Group (%s): %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/wafregional/web_acl.go
+++ b/internal/service/wafregional/web_acl.go
@@ -219,7 +219,7 @@ func resourceWebACLCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 		log.Printf("[DEBUG] Updating WAF Regional Web ACL (%s) Logging Configuration: %s", d.Id(), input)
 		if _, err := conn.PutLoggingConfigurationWithContext(ctx, input); err != nil {
-			return sdkdiag.AppendErrorf(diags, "Updating WAF Regional Web ACL (%s) Logging Configuration: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating WAF Regional Web ACL (%s) Logging Configuration: %s", d.Id(), err)
 		}
 	}
 
@@ -236,7 +236,7 @@ func resourceWebACLCreate(ctx context.Context, d *schema.ResourceData, meta inte
 			return conn.UpdateWebACLWithContext(ctx, req)
 		})
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "Updating WAF Regional ACL: %s", err)
+			return sdkdiag.AppendErrorf(diags, "updating WAF Regional Web ACL (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -333,7 +333,7 @@ func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			return conn.UpdateWebACLWithContext(ctx, req)
 		})
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "Updating WAF Regional ACL: %s", err)
+			return sdkdiag.AppendErrorf(diags, "updating WAF Regional Web ACL (%s): %s", d.Id(), err)
 		}
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Tidies up returned error messages:

* Replaces `diag.FromErr(fmt.Errorf(...))` with `diag.Errorf(...)` (and changes any `%w` to `%s`)
* Removes leading `error ` or `Error ` from `diag.Errorf(...)` and `sdkdiag.AppendErrorf(diags, ...)`
* Adds semgrep rules to prevent these creeping back into the code

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/29005.