### PR TITLE
Add writing guidance to the top of each documentation template

### DIFF
--- a/skaff/datasource/websitedoc.tmpl
+++ b/skaff/datasource/websitedoc.tmpl
@@ -6,6 +6,7 @@ description: |-
   Terraform data source for managing an AWS {{ .HumanFriendlyService }} {{ .HumanDataSourceName }}.
 ---
 
+{{- if .IncludeComments }}
 <!---
 TIP: A few guiding principles for writing documentation:
 1. Use simple language while avoiding jargon and figures of speech.
@@ -14,6 +15,7 @@ TIP: A few guiding principles for writing documentation:
 4. Document your feature as it exists now; do not mention the future or past if you can help it.
 5. Use accessible and inclusive language.
 --->
+{{- end }}
 
 # Data Source: aws_{{ .ServicePackage }}_{{ .DataSourceSnake }}
 

--- a/skaff/datasource/websitedoc.tmpl
+++ b/skaff/datasource/websitedoc.tmpl
@@ -6,6 +6,15 @@ description: |-
   Terraform data source for managing an AWS {{ .HumanFriendlyService }} {{ .HumanDataSourceName }}.
 ---
 
+<!---
+TIP: A few guiding principles for writing documentation:
+1. Use simple language while avoiding jargon and figures of speech.
+2. Focus on brevity and clarity to keep a reader's attention.
+3. Use active voice and present tense whenever you can.
+4. Document your feature as it exists now; do not mention the future or past if you can help it.
+5. Use accessible and inclusive language.
+--->
+
 # Data Source: aws_{{ .ServicePackage }}_{{ .DataSourceSnake }}
 
 Terraform data source for managing an AWS {{ .HumanFriendlyService }} {{ .HumanDataSourceName }}.

--- a/skaff/resource/websitedoc.tmpl
+++ b/skaff/resource/websitedoc.tmpl
@@ -6,6 +6,7 @@ description: |-
   Terraform resource for managing an AWS {{ .HumanFriendlyService }} {{ .HumanResourceName }}.
 ---
 
+{{- if .IncludeComments }}
 <!---
 TIP: A few guiding principles for writing documentation:
 1. Use simple language while avoiding jargon and figures of speech.
@@ -14,7 +15,7 @@ TIP: A few guiding principles for writing documentation:
 4. Document your feature as it exists now; do not mention the future or past if you can help it.
 5. Use accessible and inclusive language.
 --->`
-
+{{- end }}
 # Resource: aws_{{ .ServicePackage }}_{{ .ResourceSnake }}
 
 Terraform resource for managing an AWS {{ .HumanFriendlyService }} {{ .HumanResourceName }}.

--- a/skaff/resource/websitedoc.tmpl
+++ b/skaff/resource/websitedoc.tmpl
@@ -6,6 +6,15 @@ description: |-
   Terraform resource for managing an AWS {{ .HumanFriendlyService }} {{ .HumanResourceName }}.
 ---
 
+<!---
+TIP: A few guiding principles for writing documentation:
+1. Use simple language while avoiding jargon and figures of speech.
+2. Focus on brevity and clarity to keep a reader's attention.
+3. Use active voice and present tense whenever you can.
+4. Document your feature as it exists now; do not mention the future or past if you can help it.
+5. Use accessible and inclusive language.
+--->`
+
 # Resource: aws_{{ .ServicePackage }}_{{ .ResourceSnake }}
 
 Terraform resource for managing an AWS {{ .HumanFriendlyService }} {{ .HumanResourceName }}.


### PR DESCRIPTION
### Description
Adding a short list of writing tips to the beginning of each of the skag documentation templates for `Resource` and `Data Source`.  I used `TIP` to indicate that these lists should be deleted after folks have written their docs. 

### Relations
None. 

### References
I tried to distill our [Engineering Style Guide](https://github.com/hashicorp/engineering-docs/blob/main/writing/style-guide.md) into as few points as I could.
