### PR TITLE
Revert #31800

### DIFF
--- a/.changelog/31800.txt
+++ b/.changelog/31800.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/aws_spot_instance_request: Fix IAM eventual consistency errors on resource Create
-```

--- a/internal/service/ec2/ec2_spot_instance_request.go
+++ b/internal/service/ec2/ec2_spot_instance_request.go
@@ -241,10 +241,6 @@ func resourceSpotInstanceRequestCreate(ctx context.Context, d *schema.ResourceDa
 		},
 	)
 
-	if err != nil {
-		return sdkdiag.AppendFromErr(diags, err)
-	}
-
 	return append(diags, resourceSpotInstanceRequestRead(ctx, d, meta)...)
 }
 

--- a/internal/service/ec2/ec2_spot_instance_request.go
+++ b/internal/service/ec2/ec2_spot_instance_request.go
@@ -2,7 +2,6 @@ package ec2
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"math/big"
 	"strconv"
@@ -17,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -202,23 +200,9 @@ func resourceSpotInstanceRequestCreate(ctx context.Context, d *schema.ResourceDa
 		input.LaunchSpecification.Placement = instanceOpts.SpotPlacement
 	}
 
-	_, err = tfresource.RetryWhen(ctx, propagationTimeout,
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (interface{}, error) {
-			output, err := conn.RequestSpotInstancesWithContext(ctx, input)
-
-			if err != nil {
-				return nil, fmt.Errorf("requesting EC2 Spot Instance: %w", err)
-			}
-
-			d.SetId(aws.StringValue(output.SpotInstanceRequests[0].SpotInstanceRequestId))
-
-			if d.Get("wait_for_fulfillment").(bool) {
-				if _, err := WaitSpotInstanceRequestFulfilled(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-					return nil, fmt.Errorf("waiting for EC2 Spot Instance Request (%s) to be fulfilled: %s", d.Id(), err)
-				}
-			}
-
-			return output, nil
+			return conn.RequestSpotInstancesWithContext(ctx, input)
 		},
 		func(err error) (bool, error) {
 			// IAM instance profiles can take ~10 seconds to propagate in AWS:
@@ -232,14 +216,21 @@ func resourceSpotInstanceRequestCreate(ctx context.Context, d *schema.ResourceDa
 				return true, err
 			}
 
-			// https://github.com/hashicorp/terraform-provider-aws/issues/8164,
-			if errs.Contains(err, "Invalid IAM Instance Profile name") {
-				return true, err
-			}
-
 			return false, err
 		},
 	)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "requesting EC2 Spot Instance: %s", err)
+	}
+
+	d.SetId(aws.StringValue(outputRaw.(*ec2.RequestSpotInstancesOutput).SpotInstanceRequests[0].SpotInstanceRequestId))
+
+	if d.Get("wait_for_fulfillment").(bool) {
+		if _, err := WaitSpotInstanceRequestFulfilled(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for EC2 Spot Instance Request (%s) to be fulfilled: %s", d.Id(), err)
+		}
+	}
 
 	return append(diags, resourceSpotInstanceRequestRead(ctx, d, meta)...)
 }

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -2589,12 +2589,7 @@ func WaitSpotInstanceRequestFulfilled(ctx context.Context, conn *ec2.EC2, id str
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*ec2.SpotInstanceRequest); ok {
-		if fault := output.Fault; fault != nil {
-			errFault := fmt.Errorf("%s: %s", aws.StringValue(fault.Code), aws.StringValue(fault.Message))
-			tfresource.SetLastError(err, fmt.Errorf("%s %w", aws.StringValue(output.Status.Message), errFault))
-		} else {
-			tfresource.SetLastError(err, errors.New(aws.StringValue(output.Status.Message)))
-		}
+		tfresource.SetLastError(err, errors.New(aws.StringValue(output.Status.Message)))
 
 		return output, err
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Reverts the `aws_spot_instance_request` creation changes made in #31800.
Given the new `aws_instance.instance_market_options` configuration block introduced in #31495 and the documentation notes added in #31108, it is best not to overcomplicate the current implementation.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/8164.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/8556.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccEC2SpotInstanceRequest_' PKG=ec2 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 2  -run=TestAccEC2SpotInstanceRequest_ -timeout 180m
=== RUN   TestAccEC2SpotInstanceRequest_basic
=== PAUSE TestAccEC2SpotInstanceRequest_basic
=== RUN   TestAccEC2SpotInstanceRequest_disappears
=== PAUSE TestAccEC2SpotInstanceRequest_disappears
=== RUN   TestAccEC2SpotInstanceRequest_tags
=== PAUSE TestAccEC2SpotInstanceRequest_tags
=== RUN   TestAccEC2SpotInstanceRequest_keyName
=== PAUSE TestAccEC2SpotInstanceRequest_keyName
=== RUN   TestAccEC2SpotInstanceRequest_withLaunchGroup
=== PAUSE TestAccEC2SpotInstanceRequest_withLaunchGroup
=== RUN   TestAccEC2SpotInstanceRequest_withBlockDuration
=== PAUSE TestAccEC2SpotInstanceRequest_withBlockDuration
=== RUN   TestAccEC2SpotInstanceRequest_vpc
=== PAUSE TestAccEC2SpotInstanceRequest_vpc
=== RUN   TestAccEC2SpotInstanceRequest_validUntil
=== PAUSE TestAccEC2SpotInstanceRequest_validUntil
=== RUN   TestAccEC2SpotInstanceRequest_withoutSpotPrice
=== PAUSE TestAccEC2SpotInstanceRequest_withoutSpotPrice
=== RUN   TestAccEC2SpotInstanceRequest_subnetAndSGAndPublicIPAddress
=== PAUSE TestAccEC2SpotInstanceRequest_subnetAndSGAndPublicIPAddress
=== RUN   TestAccEC2SpotInstanceRequest_networkInterfaceAttributes
=== PAUSE TestAccEC2SpotInstanceRequest_networkInterfaceAttributes
=== RUN   TestAccEC2SpotInstanceRequest_getPasswordData
=== PAUSE TestAccEC2SpotInstanceRequest_getPasswordData
=== RUN   TestAccEC2SpotInstanceRequest_interruptStop
=== PAUSE TestAccEC2SpotInstanceRequest_interruptStop
=== RUN   TestAccEC2SpotInstanceRequest_interruptHibernate
=== PAUSE TestAccEC2SpotInstanceRequest_interruptHibernate
=== RUN   TestAccEC2SpotInstanceRequest_interruptUpdate
=== PAUSE TestAccEC2SpotInstanceRequest_interruptUpdate
=== RUN   TestAccEC2SpotInstanceRequest_withInstanceProfile
=== PAUSE TestAccEC2SpotInstanceRequest_withInstanceProfile
=== CONT  TestAccEC2SpotInstanceRequest_basic
=== CONT  TestAccEC2SpotInstanceRequest_withoutSpotPrice
--- PASS: TestAccEC2SpotInstanceRequest_basic (87.56s)
=== CONT  TestAccEC2SpotInstanceRequest_withLaunchGroup
--- PASS: TestAccEC2SpotInstanceRequest_withoutSpotPrice (98.39s)
=== CONT  TestAccEC2SpotInstanceRequest_validUntil
--- PASS: TestAccEC2SpotInstanceRequest_withLaunchGroup (114.67s)
=== CONT  TestAccEC2SpotInstanceRequest_tags
--- PASS: TestAccEC2SpotInstanceRequest_validUntil (104.34s)
=== CONT  TestAccEC2SpotInstanceRequest_keyName
--- PASS: TestAccEC2SpotInstanceRequest_keyName (115.70s)
=== CONT  TestAccEC2SpotInstanceRequest_interruptStop
--- PASS: TestAccEC2SpotInstanceRequest_interruptStop (124.91s)
=== CONT  TestAccEC2SpotInstanceRequest_withInstanceProfile
--- PASS: TestAccEC2SpotInstanceRequest_tags (291.02s)
=== CONT  TestAccEC2SpotInstanceRequest_interruptUpdate
--- PASS: TestAccEC2SpotInstanceRequest_withInstanceProfile (113.83s)
=== CONT  TestAccEC2SpotInstanceRequest_interruptHibernate
--- PASS: TestAccEC2SpotInstanceRequest_interruptUpdate (149.82s)
=== CONT  TestAccEC2SpotInstanceRequest_disappears
--- PASS: TestAccEC2SpotInstanceRequest_interruptHibernate (97.45s)
=== CONT  TestAccEC2SpotInstanceRequest_networkInterfaceAttributes
--- PASS: TestAccEC2SpotInstanceRequest_networkInterfaceAttributes (132.42s)
=== CONT  TestAccEC2SpotInstanceRequest_getPasswordData
--- PASS: TestAccEC2SpotInstanceRequest_disappears (325.33s)
=== CONT  TestAccEC2SpotInstanceRequest_subnetAndSGAndPublicIPAddress
--- PASS: TestAccEC2SpotInstanceRequest_getPasswordData (182.70s)
=== CONT  TestAccEC2SpotInstanceRequest_withBlockDuration
--- PASS: TestAccEC2SpotInstanceRequest_subnetAndSGAndPublicIPAddress (110.07s)
=== CONT  TestAccEC2SpotInstanceRequest_vpc
--- PASS: TestAccEC2SpotInstanceRequest_withBlockDuration (136.56s)
--- PASS: TestAccEC2SpotInstanceRequest_vpc (122.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	1206.393s
```
