### PR TITLE
Tech debt: Remove `AWSClient.s3ConnURICleaningDisabled`

### DIFF
--- a/internal/conns/awsclient.go
+++ b/internal/conns/awsclient.go
@@ -1,9 +1,11 @@
 package conns
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/apigatewayv2"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -23,8 +25,11 @@ func (client *AWSClient) RegionalHostname(prefix string) string {
 	return fmt.Sprintf("%s.%s.%s", prefix, client.Region, client.DNSSuffix)
 }
 
-func (client *AWSClient) S3ConnURICleaningDisabled() *s3.S3 {
-	return client.s3ConnURICleaningDisabled
+func (client *AWSClient) S3ConnURICleaningDisabled(context.Context) *s3.S3 {
+	config := client.S3Conn().Config
+	config.DisableRestProtocolURICleaning = aws.Bool(true)
+
+	return s3.New(client.Session.Copy(&config))
 }
 
 // SetHTTPClient sets the http.Client used for AWS API calls.

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -670,8 +670,6 @@ type AWSClient struct {
 	workspacesConn                   *workspaces.WorkSpaces
 	workspaceswebConn                *workspacesweb.WorkSpacesWeb
 	xrayClient                       *xray.Client
-
-	s3ConnURICleaningDisabled *s3.S3
 }
 
 func (client *AWSClient) ACMClient() *acm.Client {

--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -218,9 +218,6 @@ func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWS
 	}
 	client.s3Conn = s3.New(sess.Copy(s3Config))
 
-	s3Config.DisableRestProtocolURICleaning = aws.Bool(true)
-	client.s3ConnURICleaningDisabled = s3.New(sess.Copy(s3Config))
-
 	// "Global" services that require customizations.
 	globalAcceleratorConfig := &aws.Config{
 		Endpoint: aws.String(c.Endpoints[names.GlobalAccelerator]),

--- a/internal/generate/awsclient/file.tmpl
+++ b/internal/generate/awsclient/file.tmpl
@@ -45,8 +45,6 @@ type AWSClient struct {
 	{{ .ProviderPackage }}Client *{{ .GoV2Package }}.{{ .ClientTypeName }}
 	{{- end }}
 {{- end }}
-
-    s3ConnURICleaningDisabled *s3.S3
 }
 
 {{ range .Services }}

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -1377,7 +1377,7 @@ func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta inte
 			// Use a S3 service client that can handle multiple slashes in URIs.
 			// While aws_s3_object resources cannot create these object
 			// keys, other AWS services and applications using the S3 Bucket can.
-			conn = meta.(*conns.AWSClient).S3ConnURICleaningDisabled()
+			conn := meta.(*conns.AWSClient).S3ConnURICleaningDisabled(ctx)
 
 			// bucket may have things delete them
 			log.Printf("[DEBUG] S3 Bucket attempting to forceDestroy %s", err)

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -2595,7 +2595,7 @@ func testAccCheckBucketExistsWithProvider(ctx context.Context, n string, provide
 func testAccCheckBucketAddObjects(ctx context.Context, n string, keys ...string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs := s.RootModule().Resources[n]
-		conn := acctest.Provider.Meta().(*conns.AWSClient).S3ConnURICleaningDisabled()
+		conn := acctest.Provider.Meta().(*conns.AWSClient).S3ConnURICleaningDisabled(ctx)
 
 		for _, key := range keys {
 			_, err := conn.PutObjectWithContext(ctx, &s3.PutObjectInput{

--- a/internal/service/s3/sweep.go
+++ b/internal/service/s3/sweep.go
@@ -47,7 +47,7 @@ func sweepObjects(region string) error {
 		return fmt.Errorf("getting client: %s", err)
 	}
 
-	conn := client.(*conns.AWSClient).S3ConnURICleaningDisabled()
+	conn := client.(*conns.AWSClient).S3ConnURICleaningDisabled(ctx)
 	input := &s3.ListBucketsInput{}
 
 	output, err := conn.ListBucketsWithContext(ctx, input)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Remove the `s3ConnURICleaningDisabled` field from `conns.AWSClient`, instead creating a new customized S3 API client every time `S3ConnURICleaningDisabled()` is called.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccS3Bucket_Basic_forceDestroy' PKG=s3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/s3/... -v -count 1 -parallel 20  -run=TestAccS3Bucket_Basic_forceDestroy -timeout 180m
=== RUN   TestAccS3Bucket_Basic_forceDestroy
=== PAUSE TestAccS3Bucket_Basic_forceDestroy
=== RUN   TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
=== PAUSE TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
=== RUN   TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
=== PAUSE TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
=== CONT  TestAccS3Bucket_Basic_forceDestroy
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (28.86s)
--- PASS: TestAccS3Bucket_Basic_forceDestroy (29.31s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (32.08s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	37.731s
```
