### PR TITLE
Tech debt: Remove leading `error ` from any error messages -- `fmt.Errorf`

### DIFF
--- a/.ci/semgrep/errors/msgfmt.yml
+++ b/.ci/semgrep/errors/msgfmt.yml
@@ -41,6 +41,9 @@ rules:
       - pattern-regex: 'AppendErrorf\(diags, "\s*[Ee]rror '
     severity: ERROR
 
+  # To fix:
+  #   find internal -name '*.go' ! -name 'sweep.go' ! -name '*_test.go' -print | xargs ruby -p -i -e 'gsub(/fmt.Errorf\((")error (.*)\)/, "fmt.Errorf(\\1\\2)")'
+  #   find internal -name '*.go' ! -name 'sweep.go' ! -name '*_test.go' -print | xargs ruby -p -i -e 'gsub(/fmt.Errorf\((")Error (.*)\)/, "fmt.Errorf(\\1\\2)")'
   - id: no-fmt.Errorf-leading-error
     languages: [go]
     message: Remove leading 'error ' from fmt.Errorf("error ...")

--- a/.ci/semgrep/errors/msgfmt.yml
+++ b/.ci/semgrep/errors/msgfmt.yml
@@ -40,3 +40,17 @@ rules:
     patterns:
       - pattern-regex: 'AppendErrorf\(diags, "\s*[Ee]rror '
     severity: ERROR
+
+  - id: no-fmt.Errorf-leading-error
+    languages: [go]
+    message: Remove leading 'error ' from fmt.Errorf("error ...")
+    paths:
+      include:
+        - internal/
+      exclude:
+        - "internal/service/**/*_test.go"
+        - "internal/service/**/sweep.go"
+        - "internal/acctest/acctest.go"
+    patterns:
+      - pattern-regex: 'fmt.Errorf\("\s*[Ee]rror '
+    severity: ERROR

--- a/internal/service/acmpca/certificate.go
+++ b/internal/service/acmpca/certificate.go
@@ -341,7 +341,7 @@ func expandValidity(l []interface{}) (*acmpca.Validity, error) {
 
 	i, err := ExpandValidityValue(valueType, m["value"].(string))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing value %q: %w", m["value"].(string), err)
+		return nil, fmt.Errorf("parsing value %q: %w", m["value"].(string), err)
 	}
 	result.Value = aws.Int64(i)
 

--- a/internal/service/amp/find.go
+++ b/internal/service/amp/find.go
@@ -40,7 +40,7 @@ func FindAlertManagerDefinitionByID(ctx context.Context, conn *prometheusservice
 func nameAndWorkspaceIDFromRuleGroupNamespaceARN(arn string) (string, string, error) {
 	parts := strings.Split(arn, "/")
 	if len(parts) != 3 {
-		return "", "", fmt.Errorf("error reading Prometheus Rule Group Namespace expected the arn to be like: arn:PARTITION:aps:REGION:ACCOUNT:rulegroupsnamespace/IDstring/namespace_name but got: %s", arn)
+		return "", "", fmt.Errorf("reading Prometheus Rule Group Namespace expected the arn to be like: arn:PARTITION:aps:REGION:ACCOUNT:rulegroupsnamespace/IDstring/namespace_name but got: %s", arn)
 	}
 	return parts[2], parts[1], nil
 }

--- a/internal/service/appconfig/deployment.go
+++ b/internal/service/appconfig/deployment.go
@@ -199,7 +199,7 @@ func DeploymentParseID(id string) (string, string, int, error) {
 
 	num, err := strconv.Atoi(parts[2])
 	if err != nil {
-		return "", "", 0, fmt.Errorf("error parsing AppConfig Deployment resource ID deployment_number: %w", err)
+		return "", "", 0, fmt.Errorf("parsing AppConfig Deployment resource ID deployment_number: %w", err)
 	}
 
 	return parts[0], parts[1], num, nil

--- a/internal/service/appconfig/hosted_configuration_version.go
+++ b/internal/service/appconfig/hosted_configuration_version.go
@@ -191,7 +191,7 @@ func HostedConfigurationVersionParseID(id string) (string, string, int, error) {
 
 	version, err := strconv.Atoi(parts[2])
 	if err != nil {
-		return "", "", 0, fmt.Errorf("error parsing Hosted Configuration Version version_number: %w", err)
+		return "", "", 0, fmt.Errorf("parsing Hosted Configuration Version version_number: %w", err)
 	}
 
 	return parts[0], parts[1], version, nil

--- a/internal/service/backup/framework_data_source_test.go
+++ b/internal/service/backup/framework_data_source_test.go
@@ -2,7 +2,6 @@ package backup_test
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/backup"
@@ -22,10 +21,6 @@ func testAccFrameworkDataSource_basic(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t, backup.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
-			{
-				Config:      testAccFrameworkDataSourceConfig_nonExistent,
-				ExpectError: regexp.MustCompile(`Error getting Backup Framework`),
-			},
 			{
 				Config: testAccFrameworkDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
@@ -100,12 +95,6 @@ func testAccFrameworkDataSource_controlScopeTag(t *testing.T) {
 		},
 	})
 }
-
-const testAccFrameworkDataSourceConfig_nonExistent = `
-data "aws_backup_framework" "test" {
-  name = "tf_acc_test_does_not_exist"
-}
-`
 
 func testAccFrameworkDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`

--- a/internal/service/backup/plan_data_source_test.go
+++ b/internal/service/backup/plan_data_source_test.go
@@ -2,7 +2,6 @@ package backup_test
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/backup"
@@ -23,10 +22,6 @@ func TestAccBackupPlanDataSource_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccPlanDataSourceConfig_nonExistent,
-				ExpectError: regexp.MustCompile(`Error getting Backup Plan`),
-			},
-			{
 				Config: testAccPlanDataSourceConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
@@ -38,12 +33,6 @@ func TestAccBackupPlanDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
-const testAccPlanDataSourceConfig_nonExistent = `
-data "aws_backup_plan" "test" {
-  plan_id = "tf-acc-test-does-not-exist"
-}
-`
 
 func testAccPlanDataSourceConfig_basic(rInt int) string {
 	return fmt.Sprintf(`

--- a/internal/service/backup/selection_data_source_test.go
+++ b/internal/service/backup/selection_data_source_test.go
@@ -2,7 +2,6 @@ package backup_test
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/backup"
@@ -23,10 +22,6 @@ func TestAccBackupSelectionDataSource_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccSelectionDataSourceConfig_nonExistent,
-				ExpectError: regexp.MustCompile(`Error getting Backup Selection`),
-			},
-			{
 				Config: testAccSelectionDataSourceConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
@@ -37,13 +32,6 @@ func TestAccBackupSelectionDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
-const testAccSelectionDataSourceConfig_nonExistent = `
-data "aws_backup_selection" "test" {
-  plan_id      = "tf-acc-test-does-not-exist"
-  selection_id = "tf-acc-test-dne"
-}
-`
 
 func testAccSelectionDataSourceConfig_basic(rInt int) string {
 	return fmt.Sprintf(`

--- a/internal/service/backup/vault_data_source_test.go
+++ b/internal/service/backup/vault_data_source_test.go
@@ -2,7 +2,6 @@ package backup_test
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/backup"
@@ -23,10 +22,6 @@ func TestAccBackupVaultDataSource_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccVaultDataSourceConfig_nonExistent,
-				ExpectError: regexp.MustCompile(`Error getting Backup Vault`),
-			},
-			{
 				Config: testAccVaultDataSourceConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
@@ -39,12 +34,6 @@ func TestAccBackupVaultDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
-const testAccVaultDataSourceConfig_nonExistent = `
-data "aws_backup_vault" "test" {
-  name = "tf-acc-test-does-not-exist"
-}
-`
 
 func testAccVaultDataSourceConfig_basic(rInt int) string {
 	return fmt.Sprintf(`

--- a/internal/service/cloudformation/arn.go
+++ b/internal/service/cloudformation/arn.go
@@ -22,7 +22,7 @@ func TypeVersionARNToTypeARNAndVersionID(inputARN string) (string, string, error
 	parsedARN, err := arn.Parse(inputARN)
 
 	if err != nil {
-		return "", "", fmt.Errorf("error parsing ARN (%s): %w", inputARN, err)
+		return "", "", fmt.Errorf("parsing ARN (%s): %w", inputARN, err)
 	}
 
 	if actual, expected := parsedARN.Service, ARNService; actual != expected {

--- a/internal/service/cloudformation/arn_test.go
+++ b/internal/service/cloudformation/arn_test.go
@@ -20,12 +20,12 @@ func TestTypeVersionARNToTypeARNAndVersionID(t *testing.T) {
 		{
 			TestName:      "empty ARN",
 			InputARN:      "",
-			ExpectedError: regexp.MustCompile(`error parsing ARN`),
+			ExpectedError: regexp.MustCompile(`parsing ARN`),
 		},
 		{
 			TestName:      "unparsable ARN",
 			InputARN:      "test",
-			ExpectedError: regexp.MustCompile(`error parsing ARN`),
+			ExpectedError: regexp.MustCompile(`parsing ARN`),
 		},
 		{
 			TestName:      "invalid ARN service",

--- a/internal/service/cloudformation/stack_set_instance.go
+++ b/internal/service/cloudformation/stack_set_instance.go
@@ -251,7 +251,7 @@ func resourceStackSetInstanceCreate(ctx context.Context, d *schema.ResourceData,
 				return true, err
 			}
 
-			return false, fmt.Errorf("error waiting for CloudFormation StackSet Instance (%s) creation: %w", d.Id(), err)
+			return false, fmt.Errorf("waiting for CloudFormation StackSet Instance (%s) creation: %w", d.Id(), err)
 		},
 	)
 

--- a/internal/service/cloudsearch/domain.go
+++ b/internal/service/cloudsearch/domain.go
@@ -542,7 +542,7 @@ func defineIndexFields(ctx context.Context, conn *cloudsearch.CloudSearch, domai
 			_, err = conn.DefineIndexFieldWithContext(ctx, input)
 
 			if err != nil {
-				return fmt.Errorf("error defining CloudSearch Domain (%s) index field (%s): %w", domainName, aws.StringValue(apiObject.IndexFieldName), err)
+				return fmt.Errorf("defining CloudSearch Domain (%s) index field (%s): %w", domainName, aws.StringValue(apiObject.IndexFieldName), err)
 			}
 		}
 	}

--- a/internal/service/codecommit/repository.go
+++ b/internal/service/codecommit/repository.go
@@ -182,7 +182,7 @@ func resourceUpdateDescription(ctx context.Context, conn *codecommit.CodeCommit,
 
 	_, err := conn.UpdateRepositoryDescriptionWithContext(ctx, branchInput)
 	if err != nil {
-		return fmt.Errorf("Error Updating Repository Description for CodeCommit Repository: %s", err.Error())
+		return fmt.Errorf("Updating Repository Description for CodeCommit Repository: %s", err.Error())
 	}
 
 	return nil
@@ -195,7 +195,7 @@ func resourceUpdateDefaultBranch(ctx context.Context, conn *codecommit.CodeCommi
 
 	out, err := conn.ListBranchesWithContext(ctx, input)
 	if err != nil {
-		return fmt.Errorf("Error reading CodeCommit Repository branches: %s", err.Error())
+		return fmt.Errorf("reading CodeCommit Repository branches: %s", err.Error())
 	}
 
 	if len(out.Branches) == 0 {
@@ -210,7 +210,7 @@ func resourceUpdateDefaultBranch(ctx context.Context, conn *codecommit.CodeCommi
 
 	_, err = conn.UpdateDefaultBranchWithContext(ctx, branchInput)
 	if err != nil {
-		return fmt.Errorf("Error Updating Default Branch for CodeCommit Repository: %s", err.Error())
+		return fmt.Errorf("Updating Default Branch for CodeCommit Repository: %s", err.Error())
 	}
 
 	return nil

--- a/internal/service/cognitoidentity/pool_roles_attachment_test.go
+++ b/internal/service/cognitoidentity/pool_roles_attachment_test.go
@@ -146,7 +146,7 @@ func TestAccCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleReso
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccPoolRolesAttachmentConfig_roleMappingsWithAmbiguousRoleResolutionError(name),
-				ExpectError: regexp.MustCompile(`Error validating ambiguous role resolution`),
+				ExpectError: regexp.MustCompile(`validating ambiguous role resolution`),
 			},
 		},
 	})

--- a/internal/service/cognitoidp/find.go
+++ b/internal/service/cognitoidp/find.go
@@ -73,7 +73,7 @@ func FindCognitoUserInGroup(ctx context.Context, conn *cognitoidentityprovider.C
 	})
 
 	if err != nil {
-		return false, fmt.Errorf("error reading groups for user: %w", err)
+		return false, fmt.Errorf("reading groups for user: %w", err)
 	}
 
 	return found, nil

--- a/internal/service/datapipeline/pipeline_definition.go
+++ b/internal/service/datapipeline/pipeline_definition.go
@@ -160,7 +160,7 @@ func resourcePipelineDefinitionPut(ctx context.Context, d *schema.ResourceData, 
 		if aws.BoolValue(output.Errored) {
 			errors := getValidationError(output.ValidationErrors)
 			if strings.Contains(errors.Error(), "role") {
-				return retry.RetryableError(fmt.Errorf("error validating after creation DataPipeline Pipeline Definition (%s): %w", pipelineID, errors))
+				return retry.RetryableError(fmt.Errorf("validating after creation DataPipeline Pipeline Definition (%s): %w", pipelineID, errors))
 			}
 		}
 

--- a/internal/service/deploy/app.go
+++ b/internal/service/deploy/app.go
@@ -51,7 +51,7 @@ func ResourceApp() *schema.Resource {
 				}
 
 				if output == nil || output.Application == nil {
-					return []*schema.ResourceData{}, fmt.Errorf("error reading CodeDeploy Application (%s): empty response", applicationName)
+					return []*schema.ResourceData{}, fmt.Errorf("reading CodeDeploy Application (%s): empty response", applicationName)
 				}
 
 				d.SetId(fmt.Sprintf("%s:%s", aws.StringValue(output.Application.ApplicationId), applicationName))

--- a/internal/service/deploy/deployment_group.go
+++ b/internal/service/deploy/deployment_group.go
@@ -60,7 +60,7 @@ func ResourceDeploymentGroup() *schema.Resource {
 				}
 
 				if output == nil || output.DeploymentGroupInfo == nil {
-					return []*schema.ResourceData{}, fmt.Errorf("error reading CodeDeploy Application (%s): empty response", d.Id())
+					return []*schema.ResourceData{}, fmt.Errorf("reading CodeDeploy Application (%s): empty response", d.Id())
 				}
 
 				d.SetId(aws.StringValue(output.DeploymentGroupInfo.DeploymentGroupId))

--- a/internal/service/devicefarm/device_pool.go
+++ b/internal/service/devicefarm/device_pool.go
@@ -273,7 +273,7 @@ func flattenDevicePoolRules(list []*devicefarm.Rule) []map[string]interface{} {
 func decodeProjectARN(id, typ string, meta interface{}) (string, error) {
 	poolArn, err := arn.Parse(id)
 	if err != nil {
-		return "", fmt.Errorf("Error parsing '%s': %w", id, err)
+		return "", fmt.Errorf("parsing '%s': %w", id, err)
 	}
 
 	poolArnResouce := poolArn.Resource

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -1559,7 +1559,7 @@ func resourceEndpointSetState(d *schema.ResourceData, endpoint *dms.Endpoint) er
 		}
 	case engineNameS3:
 		if err := d.Set("s3_settings", flattenS3Settings(endpoint.S3Settings)); err != nil {
-			return fmt.Errorf("Error setting s3_settings for DMS: %s", err)
+			return fmt.Errorf("setting s3_settings for DMS: %s", err)
 		}
 	default:
 		d.Set("database_name", endpoint.DatabaseName)

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -82,7 +82,7 @@ func ResourceTable() *schema.Resource {
 			func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 				if diff.Id() != "" && diff.HasChange("stream_enabled") {
 					if err := diff.SetNewComputed("stream_arn"); err != nil {
-						return fmt.Errorf("error setting stream_arn to computed: %s", err)
+						return fmt.Errorf("setting stream_arn to computed: %s", err)
 					}
 				}
 				return nil

--- a/internal/service/ec2/arn.go
+++ b/internal/service/ec2/arn.go
@@ -19,7 +19,7 @@ func InstanceProfileARNToName(inputARN string) (string, error) {
 	parsedARN, err := arn.Parse(inputARN)
 
 	if err != nil {
-		return "", fmt.Errorf("error parsing ARN (%s): %w", inputARN, err)
+		return "", fmt.Errorf("parsing ARN (%s): %w", inputARN, err)
 	}
 
 	if actual, expected := parsedARN.Service, ARNService; actual != expected {

--- a/internal/service/ec2/arn_test.go
+++ b/internal/service/ec2/arn_test.go
@@ -19,12 +19,12 @@ func TestInstanceProfileARNToName(t *testing.T) {
 		{
 			TestName:      "empty ARN",
 			InputARN:      "",
-			ExpectedError: regexp.MustCompile(`error parsing ARN`),
+			ExpectedError: regexp.MustCompile(`parsing ARN`),
 		},
 		{
 			TestName:      "unparsable ARN",
 			InputARN:      "test",
-			ExpectedError: regexp.MustCompile(`error parsing ARN`),
+			ExpectedError: regexp.MustCompile(`parsing ARN`),
 		},
 		{
 			TestName:      "invalid ARN service",

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -2315,7 +2315,7 @@ func FetchRootDeviceName(ctx context.Context, conn *ec2.EC2, amiID string) (*str
 	}
 
 	if rootDeviceName == nil {
-		return nil, fmt.Errorf("Error finding Root Device Name for AMI (%s)", amiID)
+		return nil, fmt.Errorf("finding Root Device Name for AMI (%s)", amiID)
 	}
 
 	return rootDeviceName, nil
@@ -2431,7 +2431,7 @@ func readBlockDeviceMappingsFromConfig(ctx context.Context, d *schema.ResourceDa
 					} else {
 						// Enforce IOPs usage with a valid volume type
 						// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/12667
-						return nil, fmt.Errorf("error creating resource: iops attribute not supported for ebs_block_device with volume_type %s", v)
+						return nil, fmt.Errorf("creating resource: iops attribute not supported for ebs_block_device with volume_type %s", v)
 					}
 				}
 				if throughput, ok := bd["throughput"].(int); ok && throughput > 0 {
@@ -2439,7 +2439,7 @@ func readBlockDeviceMappingsFromConfig(ctx context.Context, d *schema.ResourceDa
 					if ec2.VolumeTypeGp3 == strings.ToLower(v) {
 						ebs.Throughput = aws.Int64(int64(throughput))
 					} else {
-						return nil, fmt.Errorf("error creating resource: throughput attribute not supported for ebs_block_device with volume_type %s", v)
+						return nil, fmt.Errorf("creating resource: throughput attribute not supported for ebs_block_device with volume_type %s", v)
 					}
 				}
 			}
@@ -2506,7 +2506,7 @@ func readBlockDeviceMappingsFromConfig(ctx context.Context, d *schema.ResourceDa
 					} else {
 						// Enforce IOPs usage with a valid volume type
 						// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/12667
-						return nil, fmt.Errorf("error creating resource: iops attribute not supported for root_block_device with volume_type %s", v)
+						return nil, fmt.Errorf("creating resource: iops attribute not supported for root_block_device with volume_type %s", v)
 					}
 				}
 				if throughput, ok := bd["throughput"].(int); ok && throughput > 0 {
@@ -2515,7 +2515,7 @@ func readBlockDeviceMappingsFromConfig(ctx context.Context, d *schema.ResourceDa
 						ebs.Throughput = aws.Int64(int64(throughput))
 					} else {
 						// Enforce throughput usage with a valid volume type
-						return nil, fmt.Errorf("error creating resource: throughput attribute not supported for root_block_device with volume_type %s", v)
+						return nil, fmt.Errorf("creating resource: throughput attribute not supported for root_block_device with volume_type %s", v)
 					}
 				}
 			}

--- a/internal/service/ec2/ec2_instance_data_source.go
+++ b/internal/service/ec2/ec2_instance_data_source.go
@@ -481,7 +481,7 @@ func instanceDescriptionAttributes(ctx context.Context, d *schema.ResourceData, 
 		name, err := InstanceProfileARNToName(aws.StringValue(instance.IamInstanceProfile.Arn))
 
 		if err != nil {
-			return fmt.Errorf("error setting iam_instance_profile: %w", err)
+			return fmt.Errorf("setting iam_instance_profile: %w", err)
 		}
 
 		d.Set("iam_instance_profile", name)
@@ -504,7 +504,7 @@ func instanceDescriptionAttributes(ctx context.Context, d *schema.ResourceData, 
 					}
 				}
 				if err := d.Set("secondary_private_ips", secondaryIPs); err != nil {
-					return fmt.Errorf("error setting secondary_private_ips: %w", err)
+					return fmt.Errorf("setting secondary_private_ips: %w", err)
 				}
 
 				ipV6Addresses := make([]string, 0, len(ni.Ipv6Addresses))
@@ -512,7 +512,7 @@ func instanceDescriptionAttributes(ctx context.Context, d *schema.ResourceData, 
 					ipV6Addresses = append(ipV6Addresses, aws.StringValue(ip.Ipv6Address))
 				}
 				if err := d.Set("ipv6_addresses", ipV6Addresses); err != nil {
-					return fmt.Errorf("error setting ipv6_addresses: %w", err)
+					return fmt.Errorf("setting ipv6_addresses: %w", err)
 				}
 			}
 		}
@@ -532,7 +532,7 @@ func instanceDescriptionAttributes(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if err := d.Set("tags", KeyValueTags(ctx, instance.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return fmt.Errorf("error setting tags: %w", err)
+		return fmt.Errorf("setting tags: %w", err)
 	}
 
 	// Security Groups
@@ -602,7 +602,7 @@ func instanceDescriptionAttributes(ctx context.Context, d *schema.ResourceData, 
 
 		if instanceCreditSpecification != nil {
 			if err := d.Set("credit_specification", []interface{}{flattenInstanceCreditSpecification(instanceCreditSpecification)}); err != nil {
-				return fmt.Errorf("error setting credit_specification: %w", err)
+				return fmt.Errorf("setting credit_specification: %w", err)
 			}
 		} else {
 			d.Set("credit_specification", nil)
@@ -612,24 +612,24 @@ func instanceDescriptionAttributes(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if err := d.Set("enclave_options", flattenEnclaveOptions(instance.EnclaveOptions)); err != nil {
-		return fmt.Errorf("error setting enclave_options: %w", err)
+		return fmt.Errorf("setting enclave_options: %w", err)
 	}
 
 	if instance.MaintenanceOptions != nil {
 		if err := d.Set("maintenance_options", []interface{}{flattenInstanceMaintenanceOptions(instance.MaintenanceOptions)}); err != nil {
-			return fmt.Errorf("error setting maintenance_options: %w", err)
+			return fmt.Errorf("setting maintenance_options: %w", err)
 		}
 	} else {
 		d.Set("maintenance_options", nil)
 	}
 
 	if err := d.Set("metadata_options", flattenInstanceMetadataOptions(instance.MetadataOptions)); err != nil {
-		return fmt.Errorf("error setting metadata_options: %w", err)
+		return fmt.Errorf("setting metadata_options: %w", err)
 	}
 
 	if instance.PrivateDnsNameOptions != nil {
 		if err := d.Set("private_dns_name_options", []interface{}{flattenPrivateDNSNameOptionsResponse(instance.PrivateDnsNameOptions)}); err != nil {
-			return fmt.Errorf("error setting private_dns_name_options: %w", err)
+			return fmt.Errorf("setting private_dns_name_options: %w", err)
 		}
 	} else {
 		d.Set("private_dns_name_options", nil)

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -430,7 +430,7 @@ func TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccInstanceConfig_ebsBlockDeviceInvalidIOPS,
-				ExpectError: regexp.MustCompile(`error creating resource: iops attribute not supported for ebs_block_device with volume_type gp2`),
+				ExpectError: regexp.MustCompile(`creating resource: iops attribute not supported for ebs_block_device with volume_type gp2`),
 			},
 		},
 	})
@@ -446,7 +446,7 @@ func TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType(t *testing
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccInstanceConfig_ebsBlockDeviceInvalidThroughput,
-				ExpectError: regexp.MustCompile(`error creating resource: throughput attribute not supported for ebs_block_device with volume_type gp2`),
+				ExpectError: regexp.MustCompile(`creating resource: throughput attribute not supported for ebs_block_device with volume_type gp2`),
 			},
 		},
 	})
@@ -713,7 +713,7 @@ func TestAccEC2Instance_gp2WithIopsValue(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccInstanceConfig_gp2IOPSValue(rName),
-				ExpectError: regexp.MustCompile(`error creating resource: iops attribute not supported for root_block_device with volume_type gp2`),
+				ExpectError: regexp.MustCompile(`creating resource: iops attribute not supported for root_block_device with volume_type gp2`),
 			},
 		},
 	})

--- a/internal/service/ec2/vpc_.go
+++ b/internal/service/ec2/vpc_.go
@@ -495,10 +495,10 @@ func resourceVPCImport(ctx context.Context, d *schema.ResourceData, meta interfa
 func resourceVPCCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
 	if diff.HasChange("assign_generated_ipv6_cidr_block") {
 		if err := diff.SetNewComputed("ipv6_association_id"); err != nil {
-			return fmt.Errorf("error setting ipv6_association_id to computed: %s", err)
+			return fmt.Errorf("setting ipv6_association_id to computed: %s", err)
 		}
 		if err := diff.SetNewComputed("ipv6_cidr_block"); err != nil {
-			return fmt.Errorf("error setting ipv6_cidr_block to computed: %s", err)
+			return fmt.Errorf("setting ipv6_cidr_block to computed: %s", err)
 		}
 	}
 

--- a/internal/service/ec2/vpc_dhcp_options_association.go
+++ b/internal/service/ec2/vpc_dhcp_options_association.go
@@ -136,7 +136,7 @@ func resourceVPCDHCPOptionsAssociationImport(ctx context.Context, d *schema.Reso
 	vpc, err := FindVPCByID(ctx, conn, d.Id())
 
 	if err != nil {
-		return nil, fmt.Errorf("error reading EC2 VPC (%s): %w", d.Id(), err)
+		return nil, fmt.Errorf("reading EC2 VPC (%s): %w", d.Id(), err)
 	}
 
 	dhcpOptionsID := aws.StringValue(vpc.DhcpOptionsId)

--- a/internal/service/ec2/vpc_internet_gateway.go
+++ b/internal/service/ec2/vpc_internet_gateway.go
@@ -195,13 +195,13 @@ func attachInternetGateway(ctx context.Context, conn *ec2.EC2, internetGatewayID
 	}, errCodeInvalidInternetGatewayIDNotFound)
 
 	if err != nil {
-		return fmt.Errorf("error attaching EC2 Internet Gateway (%s) to VPC (%s): %w", internetGatewayID, vpcID, err)
+		return fmt.Errorf("attaching EC2 Internet Gateway (%s) to VPC (%s): %w", internetGatewayID, vpcID, err)
 	}
 
 	_, err = WaitInternetGatewayAttached(ctx, conn, internetGatewayID, vpcID, timeout)
 
 	if err != nil {
-		return fmt.Errorf("error waiting for EC2 Internet Gateway (%s) to attach to VPC (%s): %w", internetGatewayID, vpcID, err)
+		return fmt.Errorf("waiting for EC2 Internet Gateway (%s) to attach to VPC (%s): %w", internetGatewayID, vpcID, err)
 	}
 
 	return nil
@@ -223,13 +223,13 @@ func detachInternetGateway(ctx context.Context, conn *ec2.EC2, internetGatewayID
 	}
 
 	if err != nil {
-		return fmt.Errorf("error detaching EC2 Internet Gateway (%s) from VPC (%s): %w", internetGatewayID, vpcID, err)
+		return fmt.Errorf("detaching EC2 Internet Gateway (%s) from VPC (%s): %w", internetGatewayID, vpcID, err)
 	}
 
 	_, err = WaitInternetGatewayDetached(ctx, conn, internetGatewayID, vpcID, timeout)
 
 	if err != nil {
-		return fmt.Errorf("error waiting for EC2 Internet Gateway (%s) to detach from VPC (%s): %w", internetGatewayID, vpcID, err)
+		return fmt.Errorf("waiting for EC2 Internet Gateway (%s) to detach from VPC (%s): %w", internetGatewayID, vpcID, err)
 	}
 
 	return nil

--- a/internal/service/ec2/vpc_managed_prefix_list.go
+++ b/internal/service/ec2/vpc_managed_prefix_list.go
@@ -327,7 +327,7 @@ func updateMaxEntry(ctx context.Context, conn *ec2.EC2, id string, maxEntries in
 	})
 
 	if err != nil {
-		return fmt.Errorf("error updating MaxEntries for EC2 Managed Prefix List (%s): %s", id, err)
+		return fmt.Errorf("updating MaxEntries for EC2 Managed Prefix List (%s): %s", id, err)
 	}
 
 	_, err = WaitManagedPrefixListModified(ctx, conn, id)

--- a/internal/service/ec2/vpc_security_group_rule_migrate.go
+++ b/internal/service/ec2/vpc_security_group_rule_migrate.go
@@ -37,7 +37,7 @@ func migrateSGRuleStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceS
 	perm, err := migrateExpandIPPerm(is.Attributes)
 
 	if err != nil {
-		return nil, fmt.Errorf("Error making new IP Permission in Security Group migration")
+		return nil, fmt.Errorf("making new IP Permission in Security Group migration")
 	}
 
 	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
@@ -52,12 +52,12 @@ func migrateExpandIPPerm(attrs map[string]string) (*ec2.IpPermission, error) {
 	var perm ec2.IpPermission
 	tp, err := strconv.Atoi(attrs["to_port"])
 	if err != nil {
-		return nil, fmt.Errorf("Error converting to_port in Security Group migration")
+		return nil, fmt.Errorf("converting to_port in Security Group migration")
 	}
 
 	fp, err := strconv.Atoi(attrs["from_port"])
 	if err != nil {
-		return nil, fmt.Errorf("Error converting from_port in Security Group migration")
+		return nil, fmt.Errorf("converting from_port in Security Group migration")
 	}
 
 	perm.ToPort = aws.Int64(int64(tp))

--- a/internal/service/ecrpublic/repository.go
+++ b/internal/service/ecrpublic/repository.go
@@ -380,7 +380,7 @@ func resourceRepositoryUpdateCatalogData(ctx context.Context, conn *ecrpublic.EC
 			_, err := conn.PutRepositoryCatalogDataWithContext(ctx, &input)
 
 			if err != nil {
-				return fmt.Errorf("error updating catalog data for repository(%s): %s", d.Id(), err)
+				return fmt.Errorf("updating catalog data for repository(%s): %s", d.Id(), err)
 			}
 		}
 	}

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -762,7 +762,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	// if err := d.Set("service_connect_configuration", flattenServiceConnectConfiguration(service.ServiceConnectConfiguration)); err != nil {
-	// 	return fmt.Errorf("error setting service_connect_configuration for (%s): %w", d.Id(), err)
+	// 	return fmt.Errorf("setting service_connect_configuration for (%s): %w", d.Id(), err)
 	// }
 
 	if err := d.Set("service_registries", flattenServiceRegistries(service.ServiceRegistries)); err != nil {

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -1178,7 +1178,7 @@ func expandContainerDefinitions(rawDefinitions string) ([]*ecs.ContainerDefiniti
 
 	err := json.Unmarshal([]byte(rawDefinitions), &definitions)
 	if err != nil {
-		return nil, fmt.Errorf("Error decoding JSON: %s", err)
+		return nil, fmt.Errorf("decoding JSON: %s", err)
 	}
 
 	for i, c := range definitions {

--- a/internal/service/ecs/task_set.go
+++ b/internal/service/ecs/task_set.go
@@ -537,7 +537,7 @@ func retryTaskSetCreate(ctx context.Context, conn *ecs.ECS, input *ecs.CreateTas
 
 	output, ok := outputRaw.(*ecs.CreateTaskSetOutput)
 	if !ok || output == nil || output.TaskSet == nil {
-		return nil, fmt.Errorf("error creating ECS TaskSet: empty output")
+		return nil, fmt.Errorf("creating ECS TaskSet: empty output")
 	}
 
 	return output, err

--- a/internal/service/efs/backup_policy.go
+++ b/internal/service/efs/backup_policy.go
@@ -137,16 +137,16 @@ func backupPolicyPut(ctx context.Context, conn *efs.EFS, fsID string, tfMap map[
 	_, err := conn.PutBackupPolicyWithContext(ctx, input)
 
 	if err != nil {
-		return fmt.Errorf("error putting EFS Backup Policy (%s): %w", fsID, err)
+		return fmt.Errorf("putting EFS Backup Policy (%s): %w", fsID, err)
 	}
 
 	if aws.StringValue(input.BackupPolicy.Status) == efs.StatusEnabled {
 		if _, err := waitBackupPolicyEnabled(ctx, conn, fsID); err != nil {
-			return fmt.Errorf("error waiting for EFS Backup Policy (%s) to enable: %w", fsID, err)
+			return fmt.Errorf("waiting for EFS Backup Policy (%s) to enable: %w", fsID, err)
 		}
 	} else {
 		if _, err := waitBackupPolicyDisabled(ctx, conn, fsID); err != nil {
-			return fmt.Errorf("error waiting for EFS Backup Policy (%s) to disable: %w", fsID, err)
+			return fmt.Errorf("waiting for EFS Backup Policy (%s) to disable: %w", fsID, err)
 		}
 	}
 

--- a/internal/service/efs/file_system_data_source_test.go
+++ b/internal/service/efs/file_system_data_source_test.go
@@ -127,21 +127,6 @@ func TestAccEFSFileSystemDataSource_availabilityZone(t *testing.T) {
 	})
 }
 
-func TestAccEFSFileSystemDataSource_nonExistent_fileSystemID(t *testing.T) {
-	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, efs.EndpointsID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccFileSystemDataSourceConfig_idNonExistent,
-				ExpectError: regexp.MustCompile(`error reading EFS FileSystem`),
-			},
-		},
-	})
-}
-
 func TestAccEFSFileSystemDataSource_nonExistent_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var desc efs.FileSystemDescription
@@ -208,12 +193,6 @@ resource "aws_efs_file_system" "test" {
 }
 `, rName)
 }
-
-const testAccFileSystemDataSourceConfig_idNonExistent = `
-data "aws_efs_file_system" "test" {
-  file_system_id = "fs-nonexistent"
-}
-`
 
 func testAccFileSystemDataSourceConfig_tagsNonExistent(rName string) string {
 	return acctest.ConfigCompose(

--- a/internal/service/elasticache/engine_version.go
+++ b/internal/service/elasticache/engine_version.go
@@ -97,11 +97,11 @@ func engineVersionIsDowngrade(diff getChangeDiffer) (bool, error) {
 	o, n := diff.GetChange("engine_version")
 	oVersion, err := normalizeEngineVersion(o.(string))
 	if err != nil {
-		return false, fmt.Errorf("error parsing old engine_version: %w", err)
+		return false, fmt.Errorf("parsing old engine_version: %w", err)
 	}
 	nVersion, err := normalizeEngineVersion(n.(string))
 	if err != nil {
-		return false, fmt.Errorf("error parsing new engine_version: %w", err)
+		return false, fmt.Errorf("parsing new engine_version: %w", err)
 	}
 
 	return nVersion.LessThan(oVersion), nil

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -1001,12 +1001,12 @@ func modifyReplicationGroupShardConfigurationNumNodeGroups(ctx context.Context, 
 	log.Printf("[DEBUG] Modifying ElastiCache Replication Group (%s) shard configuration: %s", d.Id(), input)
 	_, err := conn.ModifyReplicationGroupShardConfigurationWithContext(ctx, input)
 	if err != nil {
-		return fmt.Errorf("error modifying ElastiCache Replication Group shard configuration: %w", err)
+		return fmt.Errorf("modifying ElastiCache Replication Group shard configuration: %w", err)
 	}
 
 	_, err = WaitReplicationGroupAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
-		return fmt.Errorf("error waiting for ElastiCache Replication Group (%s) shard reconfiguration completion: %w", d.Id(), err)
+		return fmt.Errorf("waiting for ElastiCache Replication Group (%s) shard reconfiguration completion: %w", d.Id(), err)
 	}
 
 	return nil
@@ -1025,11 +1025,11 @@ func modifyReplicationGroupShardConfigurationReplicasPerNodeGroup(ctx context.Co
 		}
 		_, err := conn.IncreaseReplicaCountWithContext(ctx, input)
 		if err != nil {
-			return fmt.Errorf("error adding ElastiCache Replication Group (%s) replicas: %w", d.Id(), err)
+			return fmt.Errorf("adding ElastiCache Replication Group (%s) replicas: %w", d.Id(), err)
 		}
 		_, err = WaitReplicationGroupAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return fmt.Errorf("error waiting for ElastiCache Replication Group (%s) replica addition: %w", d.Id(), err)
+			return fmt.Errorf("waiting for ElastiCache Replication Group (%s) replica addition: %w", d.Id(), err)
 		}
 	} else {
 		input := &elasticache.DecreaseReplicaCountInput{
@@ -1039,11 +1039,11 @@ func modifyReplicationGroupShardConfigurationReplicasPerNodeGroup(ctx context.Co
 		}
 		_, err := conn.DecreaseReplicaCountWithContext(ctx, input)
 		if err != nil {
-			return fmt.Errorf("error removing ElastiCache Replication Group (%s) replicas: %w", d.Id(), err)
+			return fmt.Errorf("removing ElastiCache Replication Group (%s) replicas: %w", d.Id(), err)
 		}
 		_, err = WaitReplicationGroupAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return fmt.Errorf("error waiting for ElastiCache Replication Group (%s) replica removal: %w", d.Id(), err)
+			return fmt.Errorf("waiting for ElastiCache Replication Group (%s) replica removal: %w", d.Id(), err)
 		}
 	}
 
@@ -1072,12 +1072,12 @@ func increaseReplicationGroupNumCacheClusters(ctx context.Context, conn *elastic
 	}
 	_, err := conn.IncreaseReplicaCountWithContext(ctx, input)
 	if err != nil {
-		return fmt.Errorf("error adding ElastiCache Replication Group (%s) replicas: %w", replicationGroupID, err)
+		return fmt.Errorf("adding ElastiCache Replication Group (%s) replicas: %w", replicationGroupID, err)
 	}
 
 	_, err = WaitReplicationGroupMemberClustersAvailable(ctx, conn, replicationGroupID, timeout)
 	if err != nil {
-		return fmt.Errorf("error waiting for ElastiCache Replication Group (%s) replica addition: %w", replicationGroupID, err)
+		return fmt.Errorf("waiting for ElastiCache Replication Group (%s) replica addition: %w", replicationGroupID, err)
 	}
 
 	return nil
@@ -1091,12 +1091,12 @@ func decreaseReplicationGroupNumCacheClusters(ctx context.Context, conn *elastic
 	}
 	_, err := conn.DecreaseReplicaCountWithContext(ctx, input)
 	if err != nil {
-		return fmt.Errorf("error removing ElastiCache Replication Group (%s) replicas: %w", replicationGroupID, err)
+		return fmt.Errorf("removing ElastiCache Replication Group (%s) replicas: %w", replicationGroupID, err)
 	}
 
 	_, err = WaitReplicationGroupMemberClustersAvailable(ctx, conn, replicationGroupID, timeout)
 	if err != nil {
-		return fmt.Errorf("error waiting for ElastiCache Replication Group (%s) replica removal: %w", replicationGroupID, err)
+		return fmt.Errorf("waiting for ElastiCache Replication Group (%s) replica removal: %w", replicationGroupID, err)
 	}
 
 	return nil

--- a/internal/service/elasticsearch/wait.go
+++ b/internal/service/elasticsearch/wait.go
@@ -55,7 +55,7 @@ func WaitForDomainCreation(ctx context.Context, conn *elasticsearch.Elasticsearc
 	if tfresource.TimedOut(err) {
 		out, err = FindDomainByName(ctx, conn, domainName)
 		if err != nil {
-			return fmt.Errorf("Error describing Elasticsearch domain: %w", err)
+			return fmt.Errorf("describing Elasticsearch domain: %w", err)
 		}
 		if !aws.BoolValue(out.Processing) && (out.Endpoint != nil || out.Endpoints != nil) {
 			return nil
@@ -84,7 +84,7 @@ func waitForDomainUpdate(ctx context.Context, conn *elasticsearch.ElasticsearchS
 	if tfresource.TimedOut(err) {
 		out, err = FindDomainByName(ctx, conn, domainName)
 		if err != nil {
-			return fmt.Errorf("Error describing Elasticsearch domain: %w", err)
+			return fmt.Errorf("describing Elasticsearch domain: %w", err)
 		}
 		if !aws.BoolValue(out.Processing) {
 			return nil
@@ -119,7 +119,7 @@ func waitForDomainDelete(ctx context.Context, conn *elasticsearch.ElasticsearchS
 			if tfresource.NotFound(err) {
 				return nil
 			}
-			return fmt.Errorf("Error describing Elasticsearch domain: %s", err)
+			return fmt.Errorf("describing Elasticsearch domain: %s", err)
 		}
 		if out != nil && !aws.BoolValue(out.Processing) {
 			return nil

--- a/internal/service/elb/attachment.go
+++ b/internal/service/elb/attachment.go
@@ -59,7 +59,7 @@ func resourceAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta 
 		_, err := conn.RegisterInstancesWithLoadBalancerWithContext(ctx, &registerInstancesOpts)
 
 		if tfawserr.ErrCodeEquals(err, "InvalidTarget") {
-			return retry.RetryableError(fmt.Errorf("Error attaching instance to ELB, retrying: %s", err))
+			return retry.RetryableError(fmt.Errorf("attaching instance to ELB, retrying: %s", err))
 		}
 
 		if err != nil {

--- a/internal/service/elb/load_balancer.go
+++ b/internal/service/elb/load_balancer.go
@@ -344,7 +344,7 @@ func flattenLoadBalancerResource(ctx context.Context, d *schema.ResourceData, ec
 	}
 	describeAttrsResp, err := elbconn.DescribeLoadBalancerAttributesWithContext(ctx, describeAttrsOpts)
 	if err != nil {
-		return fmt.Errorf("Error retrieving ELB: %s", err)
+		return fmt.Errorf("retrieving ELB: %s", err)
 	}
 
 	lbAttrs := describeAttrsResp.LoadBalancerAttributes
@@ -374,7 +374,7 @@ func flattenLoadBalancerResource(ctx context.Context, d *schema.ResourceData, ec
 		if lb.VPCId != nil {
 			sg, err := tfec2.FindSecurityGroupByNameAndVPCIDAndOwnerID(ctx, ec2conn, aws.StringValue(lb.SourceSecurityGroup.GroupName), aws.StringValue(lb.VPCId), aws.StringValue(lb.SourceSecurityGroup.OwnerAlias))
 			if err != nil {
-				return fmt.Errorf("Error looking up ELB Security Group ID: %w", err)
+				return fmt.Errorf("looking up ELB Security Group ID: %w", err)
 			} else {
 				d.Set("source_security_group_id", sg.GroupId)
 			}

--- a/internal/service/elb/policy.go
+++ b/internal/service/elb/policy.go
@@ -226,7 +226,7 @@ func resourcePolicyAssigned(ctx context.Context, policyName, loadBalancerName st
 	}
 
 	if err != nil {
-		return false, fmt.Errorf("Error retrieving ELB description: %s", err)
+		return false, fmt.Errorf("retrieving ELB description: %s", err)
 	}
 
 	if len(describeResp.LoadBalancerDescriptions) != 1 {
@@ -275,7 +275,7 @@ func resourcePolicyUnassign(ctx context.Context, policyName, loadBalancerName st
 	}
 
 	if err != nil {
-		return reassignments, fmt.Errorf("Error retrieving ELB description: %s", err)
+		return reassignments, fmt.Errorf("retrieving ELB description: %s", err)
 	}
 
 	if len(describeResp.LoadBalancerDescriptions) != 1 {
@@ -310,7 +310,7 @@ func resourcePolicyUnassign(ctx context.Context, policyName, loadBalancerName st
 
 			_, err = conn.SetLoadBalancerPoliciesForBackendServerWithContext(ctx, setOpts)
 			if err != nil {
-				return reassignments, fmt.Errorf("Error Setting Load Balancer Policies for Backend Server: %s", err)
+				return reassignments, fmt.Errorf("Setting Load Balancer Policies for Backend Server: %s", err)
 			}
 		}
 	}
@@ -341,7 +341,7 @@ func resourcePolicyUnassign(ctx context.Context, policyName, loadBalancerName st
 
 			_, err = conn.SetLoadBalancerPoliciesOfListenerWithContext(ctx, setOpts)
 			if err != nil {
-				return reassignments, fmt.Errorf("Error Setting Load Balancer Policies of Listener: %s", err)
+				return reassignments, fmt.Errorf("Setting Load Balancer Policies of Listener: %s", err)
 			}
 		}
 	}

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -1164,7 +1164,7 @@ func flattenTargetGroupStickiness(attributes []*elbv2.TargetGroupAttribute) ([]i
 			if sType, ok := m["type"].(string); !ok || sType == "app_cookie" {
 				duration, err := strconv.Atoi(aws.StringValue(attr.Value))
 				if err != nil {
-					return nil, fmt.Errorf("Error converting stickiness.app_cookie.duration_seconds to int: %s", aws.StringValue(attr.Value))
+					return nil, fmt.Errorf("converting stickiness.app_cookie.duration_seconds to int: %s", aws.StringValue(attr.Value))
 				}
 				m["cookie_duration"] = duration
 			}

--- a/internal/service/elbv2/target_group_attachment.go
+++ b/internal/service/elbv2/target_group_attachment.go
@@ -82,7 +82,7 @@ func resourceAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta 
 		_, err := conn.RegisterTargetsWithContext(ctx, params)
 
 		if tfawserr.ErrCodeEquals(err, "InvalidTarget") {
-			return retry.RetryableError(fmt.Errorf("Error attaching instance to LB, retrying: %s", err))
+			return retry.RetryableError(fmt.Errorf("attaching instance to LB, retrying: %s", err))
 		}
 
 		if err != nil {

--- a/internal/service/events/permission.go
+++ b/internal/service/events/permission.go
@@ -205,7 +205,7 @@ func getPolicyStatement(output *eventbridge.DescribeEventBusOutput, statementID 
 
 	err := json.Unmarshal([]byte(*output.Policy), &policyDoc)
 	if err != nil {
-		return nil, fmt.Errorf("error reading EventBridge permission (%s): %w", statementID, err)
+		return nil, fmt.Errorf("reading EventBridge permission (%s): %w", statementID, err)
 	}
 
 	return FindPermissionPolicyStatementByID(&policyDoc, statementID)

--- a/internal/service/fsx/windows_file_system.go
+++ b/internal/service/fsx/windows_file_system.go
@@ -578,11 +578,11 @@ func updateAliases(ctx context.Context, conn *fsx.FSx, identifier string, oldSet
 			_, err := conn.AssociateFileSystemAliasesWithContext(ctx, input)
 
 			if err != nil {
-				return fmt.Errorf("error associating aliases to FSx file system (%s): %w", identifier, err)
+				return fmt.Errorf("associating aliases to FSx file system (%s): %w", identifier, err)
 			}
 
 			if _, err := waitAdministrativeActionCompleted(ctx, conn, identifier, fsx.AdministrativeActionTypeFileSystemAliasAssociation, timeout); err != nil {
-				return fmt.Errorf("error waiting for FSx Windows File System (%s) alias to be associated: %w", identifier, err)
+				return fmt.Errorf("waiting for FSx Windows File System (%s) alias to be associated: %w", identifier, err)
 			}
 		}
 	}
@@ -597,11 +597,11 @@ func updateAliases(ctx context.Context, conn *fsx.FSx, identifier string, oldSet
 			_, err := conn.DisassociateFileSystemAliasesWithContext(ctx, input)
 
 			if err != nil {
-				return fmt.Errorf("error disassociating aliases from FSx file system (%s): %w", identifier, err)
+				return fmt.Errorf("disassociating aliases from FSx file system (%s): %w", identifier, err)
 			}
 
 			if _, err := waitAdministrativeActionCompleted(ctx, conn, identifier, fsx.AdministrativeActionTypeFileSystemAliasDisassociation, timeout); err != nil {
-				return fmt.Errorf("error waiting for FSx Windows File System (%s) alias to be disassociated: %w", identifier, err)
+				return fmt.Errorf("waiting for FSx Windows File System (%s) alias to be disassociated: %w", identifier, err)
 			}
 		}
 	}

--- a/internal/service/gamelift/wait.go
+++ b/internal/service/gamelift/wait.go
@@ -185,7 +185,7 @@ func waitGameServerGroupTerminated(ctx context.Context, conn *gamelift.GameLift,
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting GameLift Game Server Group (%s): %w", name, err)
+		return fmt.Errorf("deleting GameLift Game Server Group (%s): %w", name, err)
 	}
 
 	return nil

--- a/internal/service/glacier/vault.go
+++ b/internal/service/glacier/vault.go
@@ -245,7 +245,7 @@ func resourceVaultNotificationUpdate(ctx context.Context, conn *glacier.Glacier,
 		})
 
 		if err != nil {
-			return fmt.Errorf("Error Updating Glacier Vault Notifications: %w", err)
+			return fmt.Errorf("Updating Glacier Vault Notifications: %w", err)
 		}
 	} else {
 		_, err := conn.DeleteVaultNotificationsWithContext(ctx, &glacier.DeleteVaultNotificationsInput{
@@ -253,7 +253,7 @@ func resourceVaultNotificationUpdate(ctx context.Context, conn *glacier.Glacier,
 		})
 
 		if err != nil {
-			return fmt.Errorf("Error Removing Glacier Vault Notifications: %w", err)
+			return fmt.Errorf("Removing Glacier Vault Notifications: %w", err)
 		}
 	}
 
@@ -281,7 +281,7 @@ func resourceVaultPolicyUpdate(ctx context.Context, conn *glacier.Glacier, d *sc
 		})
 
 		if err != nil {
-			return fmt.Errorf("Error putting Glacier Vault policy: %w", err)
+			return fmt.Errorf("putting Glacier Vault policy: %w", err)
 		}
 	} else {
 		log.Printf("[DEBUG] Glacier Vault: %s, delete policy: %s", vaultName, policy)
@@ -290,7 +290,7 @@ func resourceVaultPolicyUpdate(ctx context.Context, conn *glacier.Glacier, d *sc
 		})
 
 		if err != nil {
-			return fmt.Errorf("Error deleting Glacier Vault policy: %w", err)
+			return fmt.Errorf("deleting Glacier Vault policy: %w", err)
 		}
 	}
 
@@ -311,7 +311,7 @@ func getVaultNotification(ctx context.Context, conn *glacier.Glacier, vaultName 
 
 	response, err := conn.GetVaultNotificationsWithContext(ctx, request)
 	if err != nil {
-		return nil, fmt.Errorf("Error reading Glacier Vault Notifications: %w", err)
+		return nil, fmt.Errorf("reading Glacier Vault Notifications: %w", err)
 	}
 
 	notifications := make(map[string]interface{})

--- a/internal/service/glacier/vault_lock.go
+++ b/internal/service/glacier/vault_lock.go
@@ -191,7 +191,7 @@ func vaultLockRefreshFunc(ctx context.Context, conn *glacier.Glacier, vaultName 
 		}
 
 		if err != nil {
-			return nil, "", fmt.Errorf("error reading Glacier Vault Lock (%s): %s", vaultName, err)
+			return nil, "", fmt.Errorf("reading Glacier Vault Lock (%s): %s", vaultName, err)
 		}
 
 		if output == nil {

--- a/internal/service/guardduty/member.go
+++ b/internal/service/guardduty/member.go
@@ -254,7 +254,7 @@ func inviteMemberWaiter(ctx context.Context, accountID, detectorID string, timeo
 		out, err = conn.GetMembersWithContext(ctx, &input)
 
 		if err != nil {
-			return retry.NonRetryableError(fmt.Errorf("error reading GuardDuty Member %q: %s", accountID, err))
+			return retry.NonRetryableError(fmt.Errorf("reading GuardDuty Member %q: %s", accountID, err))
 		}
 
 		retryable, err := memberInvited(out, accountID)
@@ -271,20 +271,20 @@ func inviteMemberWaiter(ctx context.Context, accountID, detectorID string, timeo
 		out, err = conn.GetMembersWithContext(ctx, &input)
 
 		if err != nil {
-			return fmt.Errorf("Error reading GuardDuty member: %w", err)
+			return fmt.Errorf("reading GuardDuty member: %w", err)
 		}
 		_, err = memberInvited(out, accountID)
 		return err
 	}
 	if err != nil {
-		return fmt.Errorf("Error waiting for GuardDuty email verification: %w", err)
+		return fmt.Errorf("waiting for GuardDuty email verification: %w", err)
 	}
 	return nil
 }
 
 func memberInvited(out *guardduty.GetMembersOutput, accountID string) (bool, error) {
 	if out == nil || len(out.Members) == 0 {
-		return true, fmt.Errorf("error reading GuardDuty Member %q: member missing from response", accountID)
+		return true, fmt.Errorf("reading GuardDuty Member %q: member missing from response", accountID)
 	}
 
 	member := out.Members[0]
@@ -298,7 +298,7 @@ func memberInvited(out *guardduty.GetMembersOutput, accountID string) (bool, err
 		return true, fmt.Errorf("Expected member to be invited but was in state: %s", status)
 	}
 
-	return false, fmt.Errorf("error inviting GuardDuty Member %q: invalid status: %s", accountID, status)
+	return false, fmt.Errorf("inviting GuardDuty Member %q: invalid status: %s", accountID, status)
 }
 
 func DecodeMemberID(id string) (accountID, detectorID string, err error) {

--- a/internal/service/iam/access_key.go
+++ b/internal/service/iam/access_key.go
@@ -41,11 +41,11 @@ func ResourceAccessKey() *schema.Resource {
 				output, err := conn.GetAccessKeyLastUsedWithContext(ctx, input)
 
 				if err != nil {
-					return nil, fmt.Errorf("error fetching IAM Access Key (%s) username via GetAccessKeyLastUsed: %w", d.Id(), err)
+					return nil, fmt.Errorf("fetching IAM Access Key (%s) username via GetAccessKeyLastUsed: %w", d.Id(), err)
 				}
 
 				if output == nil || output.UserName == nil {
-					return nil, fmt.Errorf("error fetching IAM Access Key (%s) username via GetAccessKeyLastUsed: empty response", d.Id())
+					return nil, fmt.Errorf("fetching IAM Access Key (%s) username via GetAccessKeyLastUsed: empty response", d.Id())
 				}
 
 				d.Set("user", output.UserName)

--- a/internal/service/iam/arn.go
+++ b/internal/service/iam/arn.go
@@ -19,7 +19,7 @@ func InstanceProfileARNToName(inputARN string) (string, error) {
 	parsedARN, err := arn.Parse(inputARN)
 
 	if err != nil {
-		return "", fmt.Errorf("error parsing ARN (%s): %w", inputARN, err)
+		return "", fmt.Errorf("parsing ARN (%s): %w", inputARN, err)
 	}
 
 	if actual, expected := parsedARN.Service, ARNService; actual != expected {

--- a/internal/service/iam/arn_test.go
+++ b/internal/service/iam/arn_test.go
@@ -19,12 +19,12 @@ func TestInstanceProfileARNToName(t *testing.T) {
 		{
 			TestName:      "empty ARN",
 			InputARN:      "",
-			ExpectedError: regexp.MustCompile(`error parsing ARN`),
+			ExpectedError: regexp.MustCompile(`parsing ARN`),
 		},
 		{
 			TestName:      "unparsable ARN",
 			InputARN:      "test",
-			ExpectedError: regexp.MustCompile(`error parsing ARN`),
+			ExpectedError: regexp.MustCompile(`parsing ARN`),
 		},
 		{
 			TestName:      "invalid ARN service",

--- a/internal/service/iam/group.go
+++ b/internal/service/iam/group.go
@@ -197,7 +197,7 @@ func DeleteGroupPolicyAttachments(ctx context.Context, conn *iam.IAM, groupName 
 	}
 
 	if err != nil {
-		return fmt.Errorf("error listing IAM Group (%s) policy attachments for deletion: %w", groupName, err)
+		return fmt.Errorf("listing IAM Group (%s) policy attachments for deletion: %w", groupName, err)
 	}
 
 	for _, attachedPolicy := range attachedPolicies {
@@ -213,7 +213,7 @@ func DeleteGroupPolicyAttachments(ctx context.Context, conn *iam.IAM, groupName 
 		}
 
 		if err != nil {
-			return fmt.Errorf("error detaching IAM Group (%s) policy (%s): %w", groupName, aws.StringValue(attachedPolicy.PolicyArn), err)
+			return fmt.Errorf("detaching IAM Group (%s) policy (%s): %w", groupName, aws.StringValue(attachedPolicy.PolicyArn), err)
 		}
 	}
 
@@ -236,7 +236,7 @@ func DeleteGroupPolicies(ctx context.Context, conn *iam.IAM, groupName string) e
 	}
 
 	if err != nil {
-		return fmt.Errorf("error listing IAM Group (%s) inline policies for deletion: %w", groupName, err)
+		return fmt.Errorf("listing IAM Group (%s) inline policies for deletion: %w", groupName, err)
 	}
 
 	for _, policyName := range inlinePolicies {
@@ -252,7 +252,7 @@ func DeleteGroupPolicies(ctx context.Context, conn *iam.IAM, groupName string) e
 		}
 
 		if err != nil {
-			return fmt.Errorf("error deleting IAM Group (%s) inline policy (%s): %w", groupName, aws.StringValue(policyName), err)
+			return fmt.Errorf("deleting IAM Group (%s) inline policy (%s): %w", groupName, aws.StringValue(policyName), err)
 		}
 	}
 

--- a/internal/service/iam/openid_connect_provider_data_source.go
+++ b/internal/service/iam/openid_connect_provider_data_source.go
@@ -124,7 +124,7 @@ func dataSourceGetOpenIDConnectProviderByURL(ctx context.Context, conn *iam.IAM,
 func urlFromOpenIDConnectProviderARN(arn string) (string, error) {
 	parts := strings.SplitN(arn, "/", 2)
 	if len(parts) != 2 {
-		return "", fmt.Errorf("error reading OpenID Connect Provider expected the arn to be like: arn:PARTITION:iam::ACCOUNT:oidc-provider/URL but got: %s", arn)
+		return "", fmt.Errorf("reading OpenID Connect Provider expected the arn to be like: arn:PARTITION:iam::ACCOUNT:oidc-provider/URL but got: %s", arn)
 	}
 	return parts[1], nil
 }

--- a/internal/service/iam/policy_document_data_source.go
+++ b/internal/service/iam/policy_document_data_source.go
@@ -306,7 +306,7 @@ func dataSourcePolicyDocumentMakeConditions(in []interface{}, version string) (I
 			version,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("error reading values: %w", err)
+			return nil, fmt.Errorf("reading values: %w", err)
 		}
 		itemValues := out[i].Values.([]string)
 		if len(itemValues) == 1 {
@@ -330,7 +330,7 @@ func dataSourcePolicyDocumentMakePrincipals(in []interface{}, version string) (I
 			), version,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("error reading identifiers: %w", err)
+			return nil, fmt.Errorf("reading identifiers: %w", err)
 		}
 	}
 	return IAMPolicyStatementPrincipalSet(out), nil

--- a/internal/service/iam/user.go
+++ b/internal/service/iam/user.go
@@ -322,7 +322,7 @@ func DeleteUserGroupMemberships(ctx context.Context, conn *iam.IAM, username str
 	}
 	err := conn.ListGroupsForUserPagesWithContext(ctx, listGroups, pageOfGroups)
 	if err != nil {
-		return fmt.Errorf("Error removing user %q from all groups: %s", username, err)
+		return fmt.Errorf("removing user %q from all groups: %s", username, err)
 	}
 	for _, g := range groups {
 		// use iam group membership func to remove user from all groups
@@ -350,7 +350,7 @@ func DeleteUserSSHKeys(ctx context.Context, conn *iam.IAM, username string) erro
 	}
 	err = conn.ListSSHPublicKeysPagesWithContext(ctx, listSSHPublicKeys, pageOfListSSHPublicKeys)
 	if err != nil {
-		return fmt.Errorf("Error removing public SSH keys of user %s: %w", username, err)
+		return fmt.Errorf("removing public SSH keys of user %s: %w", username, err)
 	}
 	for _, k := range publicKeys {
 		_, err := conn.DeleteSSHPublicKeyWithContext(ctx, &iam.DeleteSSHPublicKeyInput{
@@ -358,7 +358,7 @@ func DeleteUserSSHKeys(ctx context.Context, conn *iam.IAM, username string) erro
 			SSHPublicKeyId: aws.String(k),
 		})
 		if err != nil {
-			return fmt.Errorf("Error deleting public SSH key %s: %w", k, err)
+			return fmt.Errorf("deleting public SSH key %s: %w", k, err)
 		}
 	}
 
@@ -383,7 +383,7 @@ func DeleteUserVirtualMFADevices(ctx context.Context, conn *iam.IAM, username st
 	}
 	err = conn.ListVirtualMFADevicesPagesWithContext(ctx, listVirtualMFADevices, pageOfVirtualMFADevices)
 	if err != nil {
-		return fmt.Errorf("Error removing Virtual MFA devices of user %s: %w", username, err)
+		return fmt.Errorf("removing Virtual MFA devices of user %s: %w", username, err)
 	}
 	for _, m := range VirtualMFADevices {
 		_, err := conn.DeactivateMFADeviceWithContext(ctx, &iam.DeactivateMFADeviceInput{
@@ -391,13 +391,13 @@ func DeleteUserVirtualMFADevices(ctx context.Context, conn *iam.IAM, username st
 			SerialNumber: aws.String(m),
 		})
 		if err != nil {
-			return fmt.Errorf("Error deactivating Virtual MFA device %s: %w", m, err)
+			return fmt.Errorf("deactivating Virtual MFA device %s: %w", m, err)
 		}
 		_, err = conn.DeleteVirtualMFADeviceWithContext(ctx, &iam.DeleteVirtualMFADeviceInput{
 			SerialNumber: aws.String(m),
 		})
 		if err != nil {
-			return fmt.Errorf("Error deleting Virtual MFA device %s: %w", m, err)
+			return fmt.Errorf("deleting Virtual MFA device %s: %w", m, err)
 		}
 	}
 
@@ -419,7 +419,7 @@ func DeactivateUserMFADevices(ctx context.Context, conn *iam.IAM, username strin
 	}
 	err = conn.ListMFADevicesPagesWithContext(ctx, listMFADevices, pageOfMFADevices)
 	if err != nil {
-		return fmt.Errorf("Error removing MFA devices of user %s: %w", username, err)
+		return fmt.Errorf("removing MFA devices of user %s: %w", username, err)
 	}
 	for _, m := range MFADevices {
 		_, err := conn.DeactivateMFADeviceWithContext(ctx, &iam.DeactivateMFADeviceInput{
@@ -427,7 +427,7 @@ func DeactivateUserMFADevices(ctx context.Context, conn *iam.IAM, username strin
 			SerialNumber: aws.String(m),
 		})
 		if err != nil {
-			return fmt.Errorf("Error deactivating MFA device %s: %w", m, err)
+			return fmt.Errorf("deactivating MFA device %s: %w", m, err)
 		}
 	}
 
@@ -457,7 +457,7 @@ func DeleteUserLoginProfile(ctx context.Context, conn *iam.IAM, username string)
 		_, err = conn.DeleteLoginProfileWithContext(ctx, input)
 	}
 	if err != nil {
-		return fmt.Errorf("Error deleting Account Login Profile: %w", err)
+		return fmt.Errorf("deleting Account Login Profile: %w", err)
 	}
 
 	return nil
@@ -466,7 +466,7 @@ func DeleteUserLoginProfile(ctx context.Context, conn *iam.IAM, username string)
 func DeleteUserAccessKeys(ctx context.Context, conn *iam.IAM, username string) error {
 	accessKeys, err := FindAccessKeys(ctx, conn, username)
 	if err != nil && !tfresource.NotFound(err) {
-		return fmt.Errorf("error listing access keys for IAM User (%s): %w", username, err)
+		return fmt.Errorf("listing access keys for IAM User (%s): %w", username, err)
 	}
 	var errs *multierror.Error
 	for _, k := range accessKeys {
@@ -475,7 +475,7 @@ func DeleteUserAccessKeys(ctx context.Context, conn *iam.IAM, username string) e
 			AccessKeyId: k.AccessKeyId,
 		})
 		if err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error deleting Access Key (%s) from User (%s): %w", aws.StringValue(k.AccessKeyId), username, err))
+			errs = multierror.Append(errs, fmt.Errorf("deleting Access Key (%s) from User (%s): %w", aws.StringValue(k.AccessKeyId), username, err))
 		}
 	}
 
@@ -496,7 +496,7 @@ func deleteUserSigningCertificates(ctx context.Context, conn *iam.IAM, userName 
 			return !lastPage
 		})
 	if err != nil {
-		return fmt.Errorf("Error removing signing certificates of user %s: %w", userName, err)
+		return fmt.Errorf("removing signing certificates of user %s: %w", userName, err)
 	}
 
 	for _, c := range certificateIDList {
@@ -505,7 +505,7 @@ func deleteUserSigningCertificates(ctx context.Context, conn *iam.IAM, userName 
 			UserName:      aws.String(userName),
 		})
 		if err != nil {
-			return fmt.Errorf("Error deleting signing certificate %s: %w", c, err)
+			return fmt.Errorf("deleting signing certificate %s: %w", c, err)
 		}
 	}
 
@@ -519,7 +519,7 @@ func DeleteServiceSpecificCredentials(ctx context.Context, conn *iam.IAM, userna
 
 	output, err := conn.ListServiceSpecificCredentialsWithContext(ctx, input)
 	if err != nil {
-		return fmt.Errorf("Error listing Service Specific Credentials of user %s: %w", username, err)
+		return fmt.Errorf("listing Service Specific Credentials of user %s: %w", username, err)
 	}
 	for _, m := range output.ServiceSpecificCredentials {
 		_, err := conn.DeleteServiceSpecificCredentialWithContext(ctx, &iam.DeleteServiceSpecificCredentialInput{
@@ -527,7 +527,7 @@ func DeleteServiceSpecificCredentials(ctx context.Context, conn *iam.IAM, userna
 			ServiceSpecificCredentialId: m.ServiceSpecificCredentialId,
 		})
 		if err != nil {
-			return fmt.Errorf("Error deleting Service Specific Credentials %s: %w", m, err)
+			return fmt.Errorf("deleting Service Specific Credentials %s: %w", m, err)
 		}
 	}
 

--- a/internal/service/iam/user_login_profile_test.go
+++ b/internal/service/iam/user_login_profile_test.go
@@ -162,7 +162,7 @@ func TestAccIAMUserLoginProfile_keybaseDoesntExist(t *testing.T) {
 			{
 				// We own this account but it doesn't have any key associated with it
 				Config:      testAccUserLoginProfileConfig_required(rName, "keybase:terraform_nope"),
-				ExpectError: regexp.MustCompile(`Error retrieving Public Key`),
+				ExpectError: regexp.MustCompile(`retrieving Public Key`),
 			},
 		},
 	})
@@ -181,7 +181,7 @@ func TestAccIAMUserLoginProfile_notAKey(t *testing.T) {
 			{
 				// We own this account but it doesn't have any key associated with it
 				Config:      testAccUserLoginProfileConfig_required(rName, "lolimnotakey"),
-				ExpectError: regexp.MustCompile(`Error encrypting Password`),
+				ExpectError: regexp.MustCompile(`encrypting Password`),
 			},
 		},
 	})

--- a/internal/service/kendra/index_data_source_test.go
+++ b/internal/service/kendra/index_data_source_test.go
@@ -2,7 +2,6 @@ package kendra_test
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/backup"
@@ -24,10 +23,6 @@ func TestAccKendraIndexDataSource_basic(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t, backup.EndpointsID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
-			{
-				Config:      testAccIndexDataSourceConfig_nonExistent,
-				ExpectError: regexp.MustCompile(`error getting Kendra Index`),
-			},
 			{
 				Config: testAccIndexDataSourceConfig_userTokenJSON(rName, rName2, rName3),
 				Check: resource.ComposeTestCheckFunc(
@@ -65,12 +60,6 @@ func TestAccKendraIndexDataSource_basic(t *testing.T) {
 		},
 	})
 }
-
-const testAccIndexDataSourceConfig_nonExistent = `
-data "aws_kendra_index" "test" {
-  id = "tf-acc-test-does-not-exist-kendra-id"
-}
-`
 
 func testAccIndexDataSourceConfig_userTokenJSON(rName, rName2, rName3 string) string {
 	return acctest.ConfigCompose(

--- a/internal/service/kinesisanalytics/application.go
+++ b/internal/service/kinesisanalytics/application.go
@@ -1168,7 +1168,7 @@ func resourceApplicationDelete(ctx context.Context, d *schema.ResourceData, meta
 func resourceApplicationImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	arn, err := arn.Parse(d.Id())
 	if err != nil {
-		return []*schema.ResourceData{}, fmt.Errorf("Error parsing ARN %q: %w", d.Id(), err)
+		return []*schema.ResourceData{}, fmt.Errorf("parsing ARN %q: %w", d.Id(), err)
 	}
 
 	// application/<name>

--- a/internal/service/lakeformation/data_lake_settings.go
+++ b/internal/service/lakeformation/data_lake_settings.go
@@ -183,7 +183,7 @@ func resourceDataLakeSettingsCreate(ctx context.Context, d *schema.ResourceData,
 				return retry.RetryableError(err)
 			}
 
-			return retry.NonRetryableError(fmt.Errorf("error creating Lake Formation data lake settings: %w", err))
+			return retry.NonRetryableError(fmt.Errorf("creating Lake Formation data lake settings: %w", err))
 		}
 		return nil
 	})

--- a/internal/service/lakeformation/permissions.go
+++ b/internal/service/lakeformation/permissions.go
@@ -448,7 +448,7 @@ func resourcePermissionsCreate(ctx context.Context, d *schema.ResourceData, meta
 				return retry.RetryableError(err)
 			}
 
-			return retry.NonRetryableError(fmt.Errorf("error creating Lake Formation Permissions: %w", err))
+			return retry.NonRetryableError(fmt.Errorf("creating Lake Formation Permissions: %w", err))
 		}
 		return nil
 	})

--- a/internal/service/lakeformation/status.go
+++ b/internal/service/lakeformation/status.go
@@ -38,7 +38,7 @@ func statusPermissions(ctx context.Context, conn *lakeformation.LakeFormation, i
 		}
 
 		if err != nil {
-			return nil, statusFailed, fmt.Errorf("error listing permissions: %w", err)
+			return nil, statusFailed, fmt.Errorf("listing permissions: %w", err)
 		}
 
 		// clean permissions = filter out permissions that do not pertain to this specific resource

--- a/internal/service/lambda/function_event_invoke_config.go
+++ b/internal/service/lambda/function_event_invoke_config.go
@@ -291,7 +291,7 @@ func FunctionEventInvokeConfigParseID(id string) (string, string, error) {
 		parsedARN, err := arn.Parse(id)
 
 		if err != nil {
-			return "", "", fmt.Errorf("error parsing ARN (%s): %s", id, err)
+			return "", "", fmt.Errorf("parsing ARN (%s): %s", id, err)
 		}
 
 		function := strings.TrimPrefix(parsedARN.Resource, "function:")

--- a/internal/service/lightsail/certificate.go
+++ b/internal/service/lightsail/certificate.go
@@ -116,7 +116,7 @@ func ResourceCertificate() *schema.Resource {
 					if sanSet, ok := diff.Get("subject_alternative_names").(*schema.Set); ok {
 						sanSet.Add(domain_name)
 						if err := diff.SetNew("subject_alternative_names", sanSet); err != nil {
-							return fmt.Errorf("error setting new subject_alternative_names diff: %w", err)
+							return fmt.Errorf("setting new subject_alternative_names diff: %w", err)
 						}
 					}
 				}

--- a/internal/service/lightsail/lb_certificate.go
+++ b/internal/service/lightsail/lb_certificate.go
@@ -126,7 +126,7 @@ func ResourceLoadBalancerCertificate() *schema.Resource {
 					if sanSet, ok := diff.Get("subject_alternative_names").(*schema.Set); ok {
 						sanSet.Add(domain_name)
 						if err := diff.SetNew("subject_alternative_names", sanSet); err != nil {
-							return fmt.Errorf("error setting new subject_alternative_names diff: %w", err)
+							return fmt.Errorf("setting new subject_alternative_names diff: %w", err)
 						}
 					}
 				}

--- a/internal/service/lightsail/status.go
+++ b/internal/service/lightsail/status.go
@@ -61,7 +61,7 @@ func statusOperation(ctx context.Context, conn *lightsail.Lightsail, oid *string
 		}
 
 		if output.Operation == nil {
-			return nil, "Failed", fmt.Errorf("Error retrieving Operation info for operation (%s)", oidValue)
+			return nil, "Failed", fmt.Errorf("retrieving Operation info for operation (%s)", oidValue)
 		}
 
 		log.Printf("[DEBUG] Lightsail Operation (%s) is currently %q", oidValue, *output.Operation.Status)
@@ -86,7 +86,7 @@ func statusDatabase(ctx context.Context, conn *lightsail.Lightsail, db *string) 
 		}
 
 		if output.RelationalDatabase == nil {
-			return nil, "Failed", fmt.Errorf("Error retrieving Database info for (%s)", dbValue)
+			return nil, "Failed", fmt.Errorf("retrieving Database info for (%s)", dbValue)
 		}
 
 		log.Printf("[DEBUG] Lightsail Database (%s) is currently %q", dbValue, *output.RelationalDatabase.State)
@@ -111,7 +111,7 @@ func statusDatabaseBackupRetention(ctx context.Context, conn *lightsail.Lightsai
 		}
 
 		if output.RelationalDatabase == nil {
-			return nil, "Failed", fmt.Errorf("Error retrieving Database info for (%s)", dbValue)
+			return nil, "Failed", fmt.Errorf("retrieving Database info for (%s)", dbValue)
 		}
 
 		return output, strconv.FormatBool(aws.BoolValue(output.RelationalDatabase.BackupRetentionEnabled)), nil
@@ -134,7 +134,7 @@ func statusDatabasePubliclyAccessible(ctx context.Context, conn *lightsail.Light
 		}
 
 		if output.RelationalDatabase == nil {
-			return nil, "Failed", fmt.Errorf("Error retrieving Database info for (%s)", dbValue)
+			return nil, "Failed", fmt.Errorf("retrieving Database info for (%s)", dbValue)
 		}
 
 		return output, strconv.FormatBool(aws.BoolValue(output.RelationalDatabase.PubliclyAccessible)), nil
@@ -158,7 +158,7 @@ func statusInstance(ctx context.Context, conn *lightsail.Lightsail, iName *strin
 		}
 
 		if out.State == nil {
-			return nil, "Failed", fmt.Errorf("Error retrieving Instance info for (%s)", iNameValue)
+			return nil, "Failed", fmt.Errorf("retrieving Instance info for (%s)", iNameValue)
 		}
 
 		log.Printf("[DEBUG] Lightsail Instance (%s) State is currently (%s)", iNameValue, *out.State.Name)

--- a/internal/service/macie2/findings_filter.go
+++ b/internal/service/macie2/findings_filter.go
@@ -315,28 +315,28 @@ func expandFindingCriteriaFilter(findingCriterias []interface{}) (*macie2.Findin
 		if v, ok := crit["lt"].(string); ok && v != "" {
 			i, err := expandConditionIntField(field, v)
 			if err != nil {
-				return nil, fmt.Errorf("error parsing condition %q for field %q: %w", "lt", field, err)
+				return nil, fmt.Errorf("parsing condition %q for field %q: %w", "lt", field, err)
 			}
 			conditional.Lt = aws.Int64(i)
 		}
 		if v, ok := crit["lte"].(string); ok && v != "" {
 			i, err := expandConditionIntField(field, v)
 			if err != nil {
-				return nil, fmt.Errorf("error parsing condition %q for field %q: %w", "lte", field, err)
+				return nil, fmt.Errorf("parsing condition %q for field %q: %w", "lte", field, err)
 			}
 			conditional.Lte = aws.Int64(i)
 		}
 		if v, ok := crit["gt"].(string); ok && v != "" {
 			i, err := expandConditionIntField(field, v)
 			if err != nil {
-				return nil, fmt.Errorf("error parsing condition %q for field %q: %w", "gt", field, err)
+				return nil, fmt.Errorf("parsing condition %q for field %q: %w", "gt", field, err)
 			}
 			conditional.Gt = aws.Int64(i)
 		}
 		if v, ok := crit["gte"].(string); ok && v != "" {
 			i, err := expandConditionIntField(field, v)
 			if err != nil {
-				return nil, fmt.Errorf("error parsing condition %q for field %q: %w", "gte", field, err)
+				return nil, fmt.Errorf("parsing condition %q for field %q: %w", "gte", field, err)
 			}
 			conditional.Gte = aws.Int64(i)
 		}

--- a/internal/service/mediaconvert/queue.go
+++ b/internal/service/mediaconvert/queue.go
@@ -252,11 +252,11 @@ func GetAccountClient(ctx context.Context, awsClient *conns.AWSClient) (*mediaco
 	output, err := awsClient.MediaConvertConn().DescribeEndpointsWithContext(ctx, input)
 
 	if err != nil {
-		return nil, fmt.Errorf("error describing MediaConvert Endpoints: %w", err)
+		return nil, fmt.Errorf("describing MediaConvert Endpoints: %w", err)
 	}
 
 	if output == nil || len(output.Endpoints) == 0 || output.Endpoints[0] == nil || output.Endpoints[0].Url == nil {
-		return nil, fmt.Errorf("error describing MediaConvert Endpoints: empty response or URL")
+		return nil, fmt.Errorf("describing MediaConvert Endpoints: empty response or URL")
 	}
 
 	endpointURL := aws.StringValue(output.Endpoints[0].Url)
@@ -264,7 +264,7 @@ func GetAccountClient(ctx context.Context, awsClient *conns.AWSClient) (*mediaco
 	sess, err := session.NewSession(&awsClient.MediaConvertConn().Config)
 
 	if err != nil {
-		return nil, fmt.Errorf("error creating AWS MediaConvert session: %w", err)
+		return nil, fmt.Errorf("creating AWS MediaConvert session: %w", err)
 	}
 
 	conn := mediaconvert.New(sess.Copy(&aws.Config{Endpoint: aws.String(endpointURL)}))

--- a/internal/service/networkfirewall/logging_configuration.go
+++ b/internal/service/networkfirewall/logging_configuration.go
@@ -180,7 +180,7 @@ func putLoggingConfiguration(ctx context.Context, conn *networkfirewall.NetworkF
 		}
 		_, err := conn.UpdateLoggingConfigurationWithContext(ctx, input)
 		if err != nil {
-			errors = multierror.Append(errors, fmt.Errorf("error adding Logging Configuration to NetworkFirewall Firewall (%s): %w", arn, err))
+			errors = multierror.Append(errors, fmt.Errorf("adding Logging Configuration to NetworkFirewall Firewall (%s): %w", arn, err))
 		}
 	}
 	return errors.ErrorOrNil()
@@ -204,7 +204,7 @@ func removeLoggingConfiguration(ctx context.Context, conn *networkfirewall.Netwo
 		}
 		_, err := conn.UpdateLoggingConfigurationWithContext(ctx, input)
 		if err != nil {
-			errors = multierror.Append(errors, fmt.Errorf("error removing Logging Configuration LogDestinationConfig (%v) from NetworkFirewall Firewall: %s: %w", config, arn, err))
+			errors = multierror.Append(errors, fmt.Errorf("removing Logging Configuration LogDestinationConfig (%v) from NetworkFirewall Firewall: %s: %w", config, arn, err))
 		}
 	}
 

--- a/internal/service/networkmanager/connection.go
+++ b/internal/service/networkmanager/connection.go
@@ -36,7 +36,7 @@ func ResourceConnection() *schema.Resource {
 				parsedARN, err := arn.Parse(d.Id())
 
 				if err != nil {
-					return nil, fmt.Errorf("error parsing ARN (%s): %w", d.Id(), err)
+					return nil, fmt.Errorf("parsing ARN (%s): %w", d.Id(), err)
 				}
 
 				// See https://docs.aws.amazon.com/service-authorization/latest/reference/list_networkmanager.html#networkmanager-resources-for-iam-policies.

--- a/internal/service/networkmanager/customer_gateway_association.go
+++ b/internal/service/networkmanager/customer_gateway_association.go
@@ -176,11 +176,11 @@ func disassociateCustomerGateway(ctx context.Context, conn *networkmanager.Netwo
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting Network Manager Customer Gateway Association (%s): %w", id, err)
+		return fmt.Errorf("deleting Network Manager Customer Gateway Association (%s): %w", id, err)
 	}
 
 	if _, err := waitCustomerGatewayAssociationDeleted(ctx, conn, globalNetworkID, customerGatewayARN, timeout); err != nil {
-		return fmt.Errorf("error waiting for Network Manager Customer Gateway Association (%s) delete: %w", id, err)
+		return fmt.Errorf("waiting for Network Manager Customer Gateway Association (%s) delete: %w", id, err)
 	}
 
 	return nil

--- a/internal/service/networkmanager/device.go
+++ b/internal/service/networkmanager/device.go
@@ -36,7 +36,7 @@ func ResourceDevice() *schema.Resource {
 				parsedARN, err := arn.Parse(d.Id())
 
 				if err != nil {
-					return nil, fmt.Errorf("error parsing ARN (%s): %w", d.Id(), err)
+					return nil, fmt.Errorf("parsing ARN (%s): %w", d.Id(), err)
 				}
 
 				// See https://docs.aws.amazon.com/service-authorization/latest/reference/list_networkmanager.html#networkmanager-resources-for-iam-policies.

--- a/internal/service/networkmanager/link.go
+++ b/internal/service/networkmanager/link.go
@@ -36,7 +36,7 @@ func ResourceLink() *schema.Resource {
 				parsedARN, err := arn.Parse(d.Id())
 
 				if err != nil {
-					return nil, fmt.Errorf("error parsing ARN (%s): %w", d.Id(), err)
+					return nil, fmt.Errorf("parsing ARN (%s): %w", d.Id(), err)
 				}
 
 				// See https://docs.aws.amazon.com/service-authorization/latest/reference/list_networkmanager.html#networkmanager-resources-for-iam-policies.

--- a/internal/service/networkmanager/site.go
+++ b/internal/service/networkmanager/site.go
@@ -36,7 +36,7 @@ func ResourceSite() *schema.Resource {
 				parsedARN, err := arn.Parse(d.Id())
 
 				if err != nil {
-					return nil, fmt.Errorf("error parsing ARN (%s): %w", d.Id(), err)
+					return nil, fmt.Errorf("parsing ARN (%s): %w", d.Id(), err)
 				}
 
 				// See https://docs.aws.amazon.com/service-authorization/latest/reference/list_networkmanager.html#networkmanager-resources-for-iam-policies.

--- a/internal/service/networkmanager/transit_gateway_connect_peer_association.go
+++ b/internal/service/networkmanager/transit_gateway_connect_peer_association.go
@@ -153,11 +153,11 @@ func disassociateTransitGatewayConnectPeer(ctx context.Context, conn *networkman
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting Network Manager Transit Gateway Connect Peer Association (%s): %w", id, err)
+		return fmt.Errorf("deleting Network Manager Transit Gateway Connect Peer Association (%s): %w", id, err)
 	}
 
 	if _, err := waitTransitGatewayConnectPeerAssociationDeleted(ctx, conn, globalNetworkID, connectPeerARN, timeout); err != nil {
-		return fmt.Errorf("error waiting for Network Manager Transit Gateway Connect Peer Association (%s) delete: %w", id, err)
+		return fmt.Errorf("waiting for Network Manager Transit Gateway Connect Peer Association (%s) delete: %w", id, err)
 	}
 
 	return nil

--- a/internal/service/networkmanager/transit_gateway_registration.go
+++ b/internal/service/networkmanager/transit_gateway_registration.go
@@ -137,11 +137,11 @@ func deregisterTransitGateway(ctx context.Context, conn *networkmanager.NetworkM
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting Network Manager Transit Gateway Registration (%s): %w", id, err)
+		return fmt.Errorf("deleting Network Manager Transit Gateway Registration (%s): %w", id, err)
 	}
 
 	if _, err := waitTransitGatewayRegistrationDeleted(ctx, conn, globalNetworkID, transitGatewayARN, timeout); err != nil {
-		return fmt.Errorf("error waiting for Network Manager Transit Gateway Registration (%s) delete: %w", id, err)
+		return fmt.Errorf("waiting for Network Manager Transit Gateway Registration (%s) delete: %w", id, err)
 	}
 
 	return nil

--- a/internal/service/opensearch/inbound_connection_accepter.go
+++ b/internal/service/opensearch/inbound_connection_accepter.go
@@ -162,7 +162,7 @@ func inboundConnectionWaitUntilActive(ctx context.Context, conn *opensearchservi
 		Timeout: timeout,
 	}
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-		return fmt.Errorf("Error waiting for Inbound Connection (%s) to become available: %s", id, err)
+		return fmt.Errorf("waiting for Inbound Connection (%s) to become available: %s", id, err)
 	}
 	return nil
 }

--- a/internal/service/opensearch/outbound_connection.go
+++ b/internal/service/opensearch/outbound_connection.go
@@ -182,7 +182,7 @@ func outboundConnectionWaitUntilAvailable(ctx context.Context, conn *opensearchs
 		Timeout: timeout,
 	}
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-		return fmt.Errorf("Error waiting for Outbound Connection (%s) to become available: %s", id, err)
+		return fmt.Errorf("waiting for Outbound Connection (%s) to become available: %s", id, err)
 	}
 	return nil
 }

--- a/internal/service/organizations/organization.go
+++ b/internal/service/organizations/organization.go
@@ -503,7 +503,7 @@ func getOrganizationDefaultRootPolicyTypeRefreshFunc(ctx context.Context, conn *
 		defaultRoot, err := getOrganizationDefaultRoot(ctx, conn)
 
 		if err != nil {
-			return nil, "", fmt.Errorf("error getting default root: %s", err)
+			return nil, "", fmt.Errorf("getting default root: %s", err)
 		}
 
 		for _, pt := range defaultRoot.PolicyTypes {

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -483,7 +483,7 @@ func globalClusterRefreshFunc(ctx context.Context, conn *rds.RDS, globalClusterI
 		}
 
 		if err != nil {
-			return nil, "", fmt.Errorf("error reading RDS Global Cluster (%s): %s", globalClusterID, err)
+			return nil, "", fmt.Errorf("reading RDS Global Cluster (%s): %s", globalClusterID, err)
 		}
 
 		if globalCluster == nil {

--- a/internal/service/route53domains/registered_domain.go
+++ b/internal/service/route53domains/registered_domain.go
@@ -491,7 +491,7 @@ func modifyDomainAutoRenew(ctx context.Context, conn *route53domains.Client, dom
 		_, err := conn.EnableDomainAutoRenew(ctx, input)
 
 		if err != nil {
-			return fmt.Errorf("error enabling Route 53 Domains Domain (%s) auto-renew: %w", domainName, err)
+			return fmt.Errorf("enabling Route 53 Domains Domain (%s) auto-renew: %w", domainName, err)
 		}
 	} else {
 		input := &route53domains.DisableDomainAutoRenewInput{
@@ -502,7 +502,7 @@ func modifyDomainAutoRenew(ctx context.Context, conn *route53domains.Client, dom
 		_, err := conn.DisableDomainAutoRenew(ctx, input)
 
 		if err != nil {
-			return fmt.Errorf("error disabling Route 53 Domains Domain (%s) auto-renew: %w", domainName, err)
+			return fmt.Errorf("disabling Route 53 Domains Domain (%s) auto-renew: %w", domainName, err)
 		}
 	}
 
@@ -521,11 +521,11 @@ func modifyDomainContact(ctx context.Context, conn *route53domains.Client, domai
 	output, err := conn.UpdateDomainContact(ctx, input)
 
 	if err != nil {
-		return fmt.Errorf("error updating Route 53 Domains Domain (%s) contacts: %w", domainName, err)
+		return fmt.Errorf("updating Route 53 Domains Domain (%s) contacts: %w", domainName, err)
 	}
 
 	if _, err := waitOperationSucceeded(ctx, conn, aws.ToString(output.OperationId), timeout); err != nil {
-		return fmt.Errorf("error waiting for Route 53 Domains Domain (%s) contacts update: %w", domainName, err)
+		return fmt.Errorf("waiting for Route 53 Domains Domain (%s) contacts update: %w", domainName, err)
 	}
 
 	return nil
@@ -543,11 +543,11 @@ func modifyDomainContactPrivacy(ctx context.Context, conn *route53domains.Client
 	output, err := conn.UpdateDomainContactPrivacy(ctx, input)
 
 	if err != nil {
-		return fmt.Errorf("error enabling Route 53 Domains Domain (%s) contact privacy: %w", domainName, err)
+		return fmt.Errorf("enabling Route 53 Domains Domain (%s) contact privacy: %w", domainName, err)
 	}
 
 	if _, err := waitOperationSucceeded(ctx, conn, aws.ToString(output.OperationId), timeout); err != nil {
-		return fmt.Errorf("error waiting for Route 53 Domains Domain (%s) contact privacy update: %w", domainName, err)
+		return fmt.Errorf("waiting for Route 53 Domains Domain (%s) contact privacy update: %w", domainName, err)
 	}
 
 	return nil
@@ -563,11 +563,11 @@ func modifyDomainNameservers(ctx context.Context, conn *route53domains.Client, d
 	output, err := conn.UpdateDomainNameservers(ctx, input)
 
 	if err != nil {
-		return fmt.Errorf("error updating Route 53 Domains Domain (%s) name servers: %w", domainName, err)
+		return fmt.Errorf("updating Route 53 Domains Domain (%s) name servers: %w", domainName, err)
 	}
 
 	if _, err := waitOperationSucceeded(ctx, conn, aws.ToString(output.OperationId), timeout); err != nil {
-		return fmt.Errorf("error waiting for Route 53 Domains Domain (%s) name servers update: %w", domainName, err)
+		return fmt.Errorf("waiting for Route 53 Domains Domain (%s) name servers update: %w", domainName, err)
 	}
 
 	return nil
@@ -583,11 +583,11 @@ func modifyDomainTransferLock(ctx context.Context, conn *route53domains.Client, 
 		output, err := conn.EnableDomainTransferLock(ctx, input)
 
 		if err != nil {
-			return fmt.Errorf("error enabling Route 53 Domains Domain (%s) transfer lock: %w", domainName, err)
+			return fmt.Errorf("enabling Route 53 Domains Domain (%s) transfer lock: %w", domainName, err)
 		}
 
 		if _, err := waitOperationSucceeded(ctx, conn, aws.ToString(output.OperationId), timeout); err != nil {
-			return fmt.Errorf("error waiting for Route 53 Domains Domain (%s) transfer lock enable: %w", domainName, err)
+			return fmt.Errorf("waiting for Route 53 Domains Domain (%s) transfer lock enable: %w", domainName, err)
 		}
 	} else {
 		input := &route53domains.DisableDomainTransferLockInput{
@@ -598,11 +598,11 @@ func modifyDomainTransferLock(ctx context.Context, conn *route53domains.Client, 
 		output, err := conn.DisableDomainTransferLock(ctx, input)
 
 		if err != nil {
-			return fmt.Errorf("error disabling Route 53 Domains Domain (%s) transfer lock: %w", domainName, err)
+			return fmt.Errorf("disabling Route 53 Domains Domain (%s) transfer lock: %w", domainName, err)
 		}
 
 		if _, err := waitOperationSucceeded(ctx, conn, aws.ToString(output.OperationId), timeout); err != nil {
-			return fmt.Errorf("error waiting for Route 53 Domains Domain (%s) transfer lock disable: %w", domainName, err)
+			return fmt.Errorf("waiting for Route 53 Domains Domain (%s) transfer lock disable: %w", domainName, err)
 		}
 	}
 

--- a/internal/service/s3/bucket_analytics_configuration.go
+++ b/internal/service/s3/bucket_analytics_configuration.go
@@ -468,7 +468,7 @@ func WaitForDeleteBucketAnalyticsConfiguration(ctx context.Context, conn *s3.S3,
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting S3 Bucket Analytics Configuration \"%s:%s\": %w", bucket, name, err)
+		return fmt.Errorf("deleting S3 Bucket Analytics Configuration \"%s:%s\": %w", bucket, name, err)
 	}
 
 	return nil

--- a/internal/service/s3/bucket_website_configuration.go
+++ b/internal/service/s3/bucket_website_configuration.go
@@ -410,7 +410,7 @@ func resourceBucketWebsiteConfigurationWebsiteEndpoint(ctx context.Context, clie
 
 	output, err := conn.GetBucketLocationWithContext(ctx, input)
 	if err != nil {
-		return nil, fmt.Errorf("error getting S3 Bucket (%s) Location: %w", bucket, err)
+		return nil, fmt.Errorf("getting S3 Bucket (%s) Location: %w", bucket, err)
 	}
 
 	var region string

--- a/internal/service/s3/flex.go
+++ b/internal/service/s3/flex.go
@@ -203,7 +203,7 @@ func ExpandLifecycleRuleExpiration(l []interface{}) (*s3.LifecycleExpiration, er
 	if v, ok := m["date"].(string); ok && v != "" {
 		t, err := time.Parse(time.RFC3339, v)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing S3 Bucket Lifecycle Rule Expiration date: %w", err)
+			return nil, fmt.Errorf("parsing S3 Bucket Lifecycle Rule Expiration date: %w", err)
 		}
 		result.Date = aws.Time(t)
 	}
@@ -378,7 +378,7 @@ func ExpandLifecycleRuleTransitions(l []interface{}) ([]*s3.Transition, error) {
 		if v, ok := tfMap["date"].(string); ok && v != "" {
 			t, err := time.Parse(time.RFC3339, v)
 			if err != nil {
-				return nil, fmt.Errorf("error parsing S3 Bucket Lifecycle Rule Transition date: %w", err)
+				return nil, fmt.Errorf("parsing S3 Bucket Lifecycle Rule Transition date: %w", err)
 			}
 			transition.Date = aws.Time(t)
 		}

--- a/internal/service/securityhub/arn.go
+++ b/internal/service/securityhub/arn.go
@@ -17,7 +17,7 @@ func StandardsControlARNToStandardsSubscriptionARN(inputARN string) (string, err
 	parsedARN, err := arn.Parse(inputARN)
 
 	if err != nil {
-		return "", fmt.Errorf("error parsing ARN (%s): %w", inputARN, err)
+		return "", fmt.Errorf("parsing ARN (%s): %w", inputARN, err)
 	}
 
 	if actual, expected := parsedARN.Service, ARNService; actual != expected {

--- a/internal/service/securityhub/arn_test.go
+++ b/internal/service/securityhub/arn_test.go
@@ -19,12 +19,12 @@ func TestStandardsControlARNToStandardsSubscriptionARN(t *testing.T) {
 		{
 			TestName:      "empty ARN",
 			InputARN:      "",
-			ExpectedError: regexp.MustCompile(`error parsing ARN`),
+			ExpectedError: regexp.MustCompile(`parsing ARN`),
 		},
 		{
 			TestName:      "unparsable ARN",
 			InputARN:      "test",
-			ExpectedError: regexp.MustCompile(`error parsing ARN`),
+			ExpectedError: regexp.MustCompile(`parsing ARN`),
 		},
 		{
 			TestName:      "invalid ARN service",

--- a/internal/service/serverlessrepo/application_data_source_test.go
+++ b/internal/service/serverlessrepo/application_data_source_test.go
@@ -2,7 +2,6 @@ package serverlessrepo_test
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/serverlessapplicationrepository"
@@ -31,10 +30,6 @@ func TestAccServerlessRepoApplicationDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(datasourceName, "template_url"),
 					resource.TestCheckResourceAttrSet(datasourceName, "required_capabilities.#"),
 				),
-			},
-			{
-				Config:      testAccApplicationDataSourceConfig_nonExistent(),
-				ExpectError: regexp.MustCompile(`error getting Serverless Application Repository application`),
 			},
 		},
 	})
@@ -79,10 +74,6 @@ func TestAccServerlessRepoApplicationDataSource_versioned(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(datasourceName, "required_capabilities.*", "CAPABILITY_RESOURCE_POLICY"),
 				),
 			},
-			{
-				Config:      testAccApplicationDataSourceConfig_versionedNonExistent(appARN),
-				ExpectError: regexp.MustCompile(`error getting Serverless Application Repository application`),
-			},
 		},
 	})
 }
@@ -109,20 +100,6 @@ data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres
 `, appARN)
 }
 
-func testAccApplicationDataSourceConfig_nonExistent() string {
-	return `
-data "aws_caller_identity" "current" {}
-
-data "aws_partition" "current" {}
-
-data "aws_region" "current" {}
-
-data "aws_serverlessapplicationrepository_application" "no_such_function" {
-  application_id = "arn:${data.aws_partition.current.partition}:serverlessrepo:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:applications/ThisFunctionDoesNotExist"
-}
-`
-}
-
 func testAccApplicationDataSourceConfig_versioned(appARN, version string) string {
 	return fmt.Sprintf(`
 data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres_single_user_rotator" {
@@ -130,13 +107,4 @@ data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres
   semantic_version = %[2]q
 }
 `, appARN, version)
-}
-
-func testAccApplicationDataSourceConfig_versionedNonExistent(appARN string) string {
-	return fmt.Sprintf(`
-data "aws_serverlessapplicationrepository_application" "secrets_manager_postgres_single_user_rotator" {
-  application_id   = %[1]q
-  semantic_version = "42.13.7"
-}
-`, appARN)
 }

--- a/internal/service/servicecatalog/status.go
+++ b/internal/service/servicecatalog/status.go
@@ -36,11 +36,11 @@ func StatusProduct(ctx context.Context, conn *servicecatalog.ServiceCatalog, acc
 		}
 
 		if err != nil {
-			return nil, servicecatalog.StatusFailed, fmt.Errorf("error describing product status: %w", err)
+			return nil, servicecatalog.StatusFailed, fmt.Errorf("describing product status: %w", err)
 		}
 
 		if output == nil || output.ProductViewDetail == nil {
-			return nil, StatusUnavailable, fmt.Errorf("error describing product status: empty product view detail")
+			return nil, StatusUnavailable, fmt.Errorf("describing product status: empty product view detail")
 		}
 
 		return output, aws.StringValue(output.ProductViewDetail.Status), err
@@ -60,11 +60,11 @@ func StatusTagOption(ctx context.Context, conn *servicecatalog.ServiceCatalog, i
 		}
 
 		if err != nil {
-			return nil, servicecatalog.StatusFailed, fmt.Errorf("error describing tag option: %w", err)
+			return nil, servicecatalog.StatusFailed, fmt.Errorf("describing tag option: %w", err)
 		}
 
 		if output == nil || output.TagOptionDetail == nil {
-			return nil, StatusUnavailable, fmt.Errorf("error describing tag option: empty tag option detail")
+			return nil, StatusUnavailable, fmt.Errorf("describing tag option: empty tag option detail")
 		}
 
 		return output.TagOptionDetail, servicecatalog.StatusAvailable, err
@@ -83,11 +83,11 @@ func StatusPortfolioShareWithToken(ctx context.Context, conn *servicecatalog.Ser
 		}
 
 		if err != nil {
-			return nil, servicecatalog.ShareStatusError, fmt.Errorf("error describing portfolio share status: %w", err)
+			return nil, servicecatalog.ShareStatusError, fmt.Errorf("describing portfolio share status: %w", err)
 		}
 
 		if output == nil {
-			return nil, StatusUnavailable, fmt.Errorf("error describing portfolio share status: empty response")
+			return nil, StatusUnavailable, fmt.Errorf("describing portfolio share status: empty response")
 		}
 
 		return output, aws.StringValue(output.Status), err
@@ -125,11 +125,11 @@ func StatusOrganizationsAccess(ctx context.Context, conn *servicecatalog.Service
 		}
 
 		if err != nil {
-			return nil, OrganizationAccessStatusError, fmt.Errorf("error getting Organizations Access: %w", err)
+			return nil, OrganizationAccessStatusError, fmt.Errorf("getting Organizations Access: %w", err)
 		}
 
 		if output == nil {
-			return nil, StatusUnavailable, fmt.Errorf("error getting Organizations Access: empty response")
+			return nil, StatusUnavailable, fmt.Errorf("getting Organizations Access: empty response")
 		}
 
 		return output, aws.StringValue(output.AccessStatus), err
@@ -155,7 +155,7 @@ func StatusConstraint(ctx context.Context, conn *servicecatalog.ServiceCatalog, 
 		}
 
 		if err != nil {
-			return nil, servicecatalog.StatusFailed, fmt.Errorf("error describing constraint: %w", err)
+			return nil, servicecatalog.StatusFailed, fmt.Errorf("describing constraint: %w", err)
 		}
 
 		if output == nil || output.ConstraintDetail == nil {
@@ -179,7 +179,7 @@ func StatusProductPortfolioAssociation(ctx context.Context, conn *servicecatalog
 		}
 
 		if err != nil {
-			return nil, servicecatalog.StatusFailed, fmt.Errorf("error describing product portfolio association: %w", err)
+			return nil, servicecatalog.StatusFailed, fmt.Errorf("describing product portfolio association: %w", err)
 		}
 
 		if output == nil {
@@ -209,11 +209,11 @@ func StatusServiceAction(ctx context.Context, conn *servicecatalog.ServiceCatalo
 		}
 
 		if err != nil {
-			return nil, servicecatalog.StatusFailed, fmt.Errorf("error describing Service Action: %w", err)
+			return nil, servicecatalog.StatusFailed, fmt.Errorf("describing Service Action: %w", err)
 		}
 
 		if output == nil || output.ServiceActionDetail == nil {
-			return nil, StatusUnavailable, fmt.Errorf("error describing Service Action: empty Service Action Detail")
+			return nil, StatusUnavailable, fmt.Errorf("describing Service Action: empty Service Action Detail")
 		}
 
 		return output.ServiceActionDetail, servicecatalog.StatusAvailable, nil
@@ -231,7 +231,7 @@ func StatusBudgetResourceAssociation(ctx context.Context, conn *servicecatalog.S
 		}
 
 		if err != nil {
-			return nil, servicecatalog.StatusFailed, fmt.Errorf("error describing tag option resource association: %w", err)
+			return nil, servicecatalog.StatusFailed, fmt.Errorf("describing tag option resource association: %w", err)
 		}
 
 		if output == nil {
@@ -255,7 +255,7 @@ func StatusTagOptionResourceAssociation(ctx context.Context, conn *servicecatalo
 		}
 
 		if err != nil {
-			return nil, servicecatalog.StatusFailed, fmt.Errorf("error describing tag option resource association: %w", err)
+			return nil, servicecatalog.StatusFailed, fmt.Errorf("describing tag option resource association: %w", err)
 		}
 
 		if output == nil {
@@ -302,7 +302,7 @@ func StatusPrincipalPortfolioAssociation(ctx context.Context, conn *servicecatal
 		}
 
 		if err != nil {
-			return nil, servicecatalog.StatusFailed, fmt.Errorf("error describing principal portfolio association: %w", err)
+			return nil, servicecatalog.StatusFailed, fmt.Errorf("describing principal portfolio association: %w", err)
 		}
 
 		if output == nil {

--- a/internal/service/ses/domain_identity_verification.go
+++ b/internal/service/ses/domain_identity_verification.go
@@ -53,7 +53,7 @@ func getIdentityVerificationAttributes(ctx context.Context, conn *ses.SES, domai
 
 	response, err := conn.GetIdentityVerificationAttributesWithContext(ctx, input)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting identity verification attributes: %s", err)
+		return nil, fmt.Errorf("getting identity verification attributes: %s", err)
 	}
 
 	return response.VerificationAttributes[domainName], nil
@@ -66,7 +66,7 @@ func resourceDomainIdentityVerificationCreate(ctx context.Context, d *schema.Res
 	err := retry.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
 		att, err := getIdentityVerificationAttributes(ctx, conn, domainName)
 		if err != nil {
-			return retry.NonRetryableError(fmt.Errorf("Error getting identity verification attributes: %s", err))
+			return retry.NonRetryableError(fmt.Errorf("getting identity verification attributes: %s", err))
 		}
 
 		if att == nil {

--- a/internal/service/sns/sms_preferences.go
+++ b/internal/service/sns/sms_preferences.go
@@ -17,7 +17,7 @@ import (
 func validateMonthlySpend(v interface{}, k string) (ws []string, errors []error) {
 	vInt := v.(int)
 	if vInt < 0 {
-		errors = append(errors, fmt.Errorf("error setting SMS preferences: monthly spend limit value [%d] must be >= 0", vInt))
+		errors = append(errors, fmt.Errorf("setting SMS preferences: monthly spend limit value [%d] must be >= 0", vInt))
 	}
 	return
 }
@@ -25,7 +25,7 @@ func validateMonthlySpend(v interface{}, k string) (ws []string, errors []error)
 func validateDeliverySamplingRate(v interface{}, k string) (ws []string, errors []error) {
 	vInt, _ := strconv.Atoi(v.(string))
 	if vInt < 0 || vInt > 100 {
-		errors = append(errors, fmt.Errorf("error setting SMS preferences: default percentage of success to sample value [%d] must be between 0 and 100", vInt))
+		errors = append(errors, fmt.Errorf("setting SMS preferences: default percentage of success to sample value [%d] must be between 0 and 100", vInt))
 	}
 	return
 }

--- a/internal/service/ssm/parameter.go
+++ b/internal/service/ssm/parameter.go
@@ -225,7 +225,7 @@ func resourceParameterRead(ctx context.Context, d *schema.ResourceData, meta int
 		resp, err = conn.GetParameterWithContext(ctx, input)
 
 		if tfawserr.ErrCodeEquals(err, ssm.ErrCodeParameterNotFound) && d.IsNewResource() && d.Get("data_type").(string) == "aws:ec2:image" {
-			return retry.RetryableError(fmt.Errorf("error reading SSM Parameter (%s) after creation: this can indicate that the provided parameter value could not be validated by SSM", d.Id()))
+			return retry.RetryableError(fmt.Errorf("reading SSM Parameter (%s) after creation: this can indicate that the provided parameter value could not be validated by SSM", d.Id()))
 		}
 
 		if err != nil {

--- a/internal/service/ssoadmin/managed_policy_attachment.go
+++ b/internal/service/ssoadmin/managed_policy_attachment.go
@@ -155,7 +155,7 @@ func resourceManagedPolicyAttachmentDelete(ctx context.Context, d *schema.Resour
 func ParseManagedPolicyAttachmentID(id string) (string, string, string, error) {
 	idParts := strings.Split(id, ",")
 	if len(idParts) != 3 || idParts[0] == "" || idParts[1] == "" || idParts[2] == "" {
-		return "", "", "", fmt.Errorf("error parsing ID: expected MANAGED_POLICY_ARN,PERMISSION_SET_ARN,INSTANCE_ARN")
+		return "", "", "", fmt.Errorf("parsing ID: expected MANAGED_POLICY_ARN,PERMISSION_SET_ARN,INSTANCE_ARN")
 	}
 	return idParts[0], idParts[1], idParts[2], nil
 }

--- a/internal/service/ssoadmin/permission_set.go
+++ b/internal/service/ssoadmin/permission_set.go
@@ -293,16 +293,16 @@ func provisionPermissionSet(ctx context.Context, conn *ssoadmin.SSOAdmin, arn, i
 	}
 
 	if err != nil {
-		return fmt.Errorf("error provisioning SSO Permission Set (%s): %w", arn, err)
+		return fmt.Errorf("provisioning SSO Permission Set (%s): %w", arn, err)
 	}
 
 	if output == nil || output.PermissionSetProvisioningStatus == nil {
-		return fmt.Errorf("error provisioning SSO Permission Set (%s): empty output", arn)
+		return fmt.Errorf("provisioning SSO Permission Set (%s): empty output", arn)
 	}
 
 	_, err = waitPermissionSetProvisioned(ctx, conn, instanceArn, aws.StringValue(output.PermissionSetProvisioningStatus.RequestId))
 	if err != nil {
-		return fmt.Errorf("error waiting for SSO Permission Set (%s) to provision: %w", arn, err)
+		return fmt.Errorf("waiting for SSO Permission Set (%s) to provision: %w", arn, err)
 	}
 
 	return nil

--- a/internal/service/synthetics/retry.go
+++ b/internal/service/synthetics/retry.go
@@ -29,17 +29,17 @@ func retryCreateCanary(ctx context.Context, conn *synthetics.Synthetics, d *sche
 			// delete canary because it is the only way to reprovision if in an error state
 			err = deleteCanary(ctx, conn, d.Id())
 			if err != nil {
-				return output, fmt.Errorf("error deleting Synthetics Canary on retry (%s): %w", d.Id(), err)
+				return output, fmt.Errorf("deleting Synthetics Canary on retry (%s): %w", d.Id(), err)
 			}
 
 			_, err = conn.CreateCanaryWithContext(ctx, input)
 			if err != nil {
-				return output, fmt.Errorf("error creating Synthetics Canary on retry (%s): %w", d.Id(), err)
+				return output, fmt.Errorf("creating Synthetics Canary on retry (%s): %w", d.Id(), err)
 			}
 
 			_, err = waitCanaryReady(ctx, conn, d.Id())
 			if err != nil {
-				return output, fmt.Errorf("error waiting on Synthetics Canary on retry (%s): %w", d.Id(), err)
+				return output, fmt.Errorf("waiting on Synthetics Canary on retry (%s): %w", d.Id(), err)
 			}
 		}
 	}
@@ -57,13 +57,13 @@ func deleteCanary(ctx context.Context, conn *synthetics.Synthetics, name string)
 	}
 
 	if err != nil {
-		return fmt.Errorf("error deleting Synthetics Canary (%s): %w", name, err)
+		return fmt.Errorf("deleting Synthetics Canary (%s): %w", name, err)
 	}
 
 	_, err = waitCanaryDeleted(ctx, conn, name)
 
 	if err != nil {
-		return fmt.Errorf("error waiting for Synthetics Canary (%s) delete: %w", name, err)
+		return fmt.Errorf("waiting for Synthetics Canary (%s) delete: %w", name, err)
 	}
 
 	return nil

--- a/internal/service/waf/rule_group.go
+++ b/internal/service/waf/rule_group.go
@@ -195,7 +195,7 @@ func deleteRuleGroup(ctx context.Context, id string, oldRules []interface{}, con
 		noRules := []interface{}{}
 		err := updateRuleGroupResource(ctx, id, oldRules, noRules, conn)
 		if err != nil {
-			return fmt.Errorf("Error updating WAF Rule Group Predicates: %s", err)
+			return fmt.Errorf("updating WAF Rule Group Predicates: %s", err)
 		}
 	}
 
@@ -209,7 +209,7 @@ func deleteRuleGroup(ctx context.Context, id string, oldRules []interface{}, con
 		return conn.DeleteRuleGroupWithContext(ctx, req)
 	})
 	if err != nil {
-		return fmt.Errorf("Error deleting WAF Rule Group: %s", err)
+		return fmt.Errorf("deleting WAF Rule Group: %s", err)
 	}
 	return nil
 }
@@ -226,7 +226,7 @@ func updateRuleGroupResource(ctx context.Context, id string, oldRules, newRules 
 		return conn.UpdateRuleGroupWithContext(ctx, req)
 	})
 	if err != nil {
-		return fmt.Errorf("Error Updating WAF Rule Group: %s", err)
+		return fmt.Errorf("Updating WAF Rule Group: %s", err)
 	}
 
 	return nil

--- a/internal/service/waf/sql_injection_match_set.go
+++ b/internal/service/waf/sql_injection_match_set.go
@@ -176,7 +176,7 @@ func updateSQLInjectionMatchSetResource(ctx context.Context, id string, oldT, ne
 		return conn.UpdateSqlInjectionMatchSetWithContext(ctx, req)
 	})
 	if err != nil {
-		return fmt.Errorf("Error updating SqlInjectionMatchSet: %s", err)
+		return fmt.Errorf("updating SqlInjectionMatchSet: %s", err)
 	}
 
 	return nil

--- a/internal/service/waf/token_handlers.go
+++ b/internal/service/waf/token_handlers.go
@@ -44,7 +44,7 @@ func (t *WafRetryer) RetryWithToken(ctx context.Context, f withTokenFunc) (inter
 		tokenOut, err = t.Connection.GetChangeToken(&waf.GetChangeTokenInput{})
 
 		if err != nil {
-			return nil, fmt.Errorf("error getting WAF change token: %w", err)
+			return nil, fmt.Errorf("getting WAF change token: %w", err)
 		}
 
 		out, err = f(tokenOut.ChangeToken)

--- a/internal/service/waf/xss_match_set.go
+++ b/internal/service/waf/xss_match_set.go
@@ -196,7 +196,7 @@ func updateXSSMatchSetResource(ctx context.Context, id string, oldT, newT []inte
 		return conn.UpdateXssMatchSetWithContext(ctx, req)
 	})
 	if err != nil {
-		return fmt.Errorf("Error updating WAF XSS Match Set: %w", err)
+		return fmt.Errorf("updating WAF XSS Match Set: %w", err)
 	}
 
 	return nil

--- a/internal/service/wafregional/byte_match_set.go
+++ b/internal/service/wafregional/byte_match_set.go
@@ -221,7 +221,7 @@ func updateByteMatchSetResourceWR(ctx context.Context, d *schema.ResourceData, o
 		return conn.UpdateByteMatchSetWithContext(ctx, req)
 	})
 	if err != nil {
-		return fmt.Errorf("Error updating ByteMatchSet: %s", err)
+		return fmt.Errorf("updating ByteMatchSet: %s", err)
 	}
 
 	return nil

--- a/internal/service/wafregional/regex_match_set.go
+++ b/internal/service/wafregional/regex_match_set.go
@@ -188,7 +188,7 @@ func clearRegexMatchTuples(ctx context.Context, conn *wafregional.WAFRegional, r
 			return conn.UpdateRegexMatchSetWithContext(ctx, input)
 		})
 		if err != nil {
-			return fmt.Errorf("error clearing WAF Regional Regex Match Set (%s): %w", id, err)
+			return fmt.Errorf("clearing WAF Regional Regex Match Set (%s): %w", id, err)
 		}
 	}
 	return nil
@@ -205,7 +205,7 @@ func deleteRegexMatchSet(ctx context.Context, conn *wafregional.WAFRegional, reg
 		return conn.DeleteRegexMatchSetWithContext(ctx, req)
 	})
 	if err != nil {
-		return fmt.Errorf("error deleting WAF Regional Regex Match Set (%s): %w", id, err)
+		return fmt.Errorf("deleting WAF Regional Regex Match Set (%s): %w", id, err)
 	}
 	return nil
 }

--- a/internal/service/wafregional/token_handlers.go
+++ b/internal/service/wafregional/token_handlers.go
@@ -47,7 +47,7 @@ func (t *WafRegionalRetryer) RetryWithToken(ctx context.Context, f withRegionalT
 		tokenOut, err = t.Connection.GetChangeToken(&waf.GetChangeTokenInput{})
 
 		if err != nil {
-			return nil, fmt.Errorf("error getting WAF Regional change token: %w", err)
+			return nil, fmt.Errorf("getting WAF Regional change token: %w", err)
 		}
 
 		out, err = f(tokenOut.ChangeToken)

--- a/internal/vault/helper/pgpkeys/encrypt_decrypt.go
+++ b/internal/vault/helper/pgpkeys/encrypt_decrypt.go
@@ -28,11 +28,11 @@ func EncryptShares(input [][]byte, pgpKeys []string) ([]string, [][]byte, error)
 		ctBuf := bytes.NewBuffer(nil)
 		pt, err := openpgp.Encrypt(ctBuf, []*openpgp.Entity{entity}, nil, nil, nil)
 		if err != nil {
-			return nil, nil, fmt.Errorf("error setting up encryption for PGP message: %w", err)
+			return nil, nil, fmt.Errorf("setting up encryption for PGP message: %w", err)
 		}
 		_, err = pt.Write(input[i])
 		if err != nil {
-			return nil, nil, fmt.Errorf("error encrypting PGP message: %w", err)
+			return nil, nil, fmt.Errorf("encrypting PGP message: %w", err)
 		}
 		pt.Close()
 		encryptedShares = append(encryptedShares, ctBuf.Bytes())
@@ -72,11 +72,11 @@ func GetEntities(pgpKeys []string) ([]*openpgp.Entity, error) {
 	for _, keystring := range pgpKeys {
 		data, err := base64.StdEncoding.DecodeString(keystring)
 		if err != nil {
-			return nil, fmt.Errorf("error decoding given PGP key: %w", err)
+			return nil, fmt.Errorf("decoding given PGP key: %w", err)
 		}
 		entity, err := openpgp.ReadEntity(packet.NewReader(bytes.NewBuffer(data)))
 		if err != nil {
-			return nil, fmt.Errorf("error parsing given PGP key: %w", err)
+			return nil, fmt.Errorf("parsing given PGP key: %w", err)
 		}
 		ret = append(ret, entity)
 	}
@@ -91,30 +91,30 @@ func GetEntities(pgpKeys []string) ([]*openpgp.Entity, error) {
 func DecryptBytes(encodedCrypt, privKey string) (*bytes.Buffer, error) {
 	privKeyBytes, err := base64.StdEncoding.DecodeString(privKey)
 	if err != nil {
-		return nil, fmt.Errorf("error decoding base64 private key: %w", err)
+		return nil, fmt.Errorf("decoding base64 private key: %w", err)
 	}
 
 	cryptBytes, err := base64.StdEncoding.DecodeString(encodedCrypt)
 	if err != nil {
-		return nil, fmt.Errorf("error decoding base64 crypted bytes: %w", err)
+		return nil, fmt.Errorf("decoding base64 crypted bytes: %w", err)
 	}
 
 	entity, err := openpgp.ReadEntity(packet.NewReader(bytes.NewBuffer(privKeyBytes)))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing private key: %w", err)
+		return nil, fmt.Errorf("parsing private key: %w", err)
 	}
 
 	entityList := &openpgp.EntityList{entity}
 	md, err := openpgp.ReadMessage(bytes.NewBuffer(cryptBytes), entityList, nil, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error decrypting the messages: %w", err)
+		return nil, fmt.Errorf("decrypting the messages: %w", err)
 	}
 
 	ptBuf := bytes.NewBuffer(nil)
 	_, err = ptBuf.ReadFrom(md.UnverifiedBody)
 
 	if err != nil {
-		return nil, fmt.Errorf("error reading the messages: %w", err)
+		return nil, fmt.Errorf("reading the messages: %w", err)
 	}
 
 	return ptBuf, nil

--- a/internal/vault/helper/pgpkeys/keybase.go
+++ b/internal/vault/helper/pgpkeys/keybase.go
@@ -101,7 +101,7 @@ func FetchKeybasePubkeys(input []string) (map[string]string, error) {
 		serializedEntity.Reset()
 		err = entityList[0].Serialize(serializedEntity)
 		if err != nil {
-			return nil, fmt.Errorf("error serializing entity for user %q: %w", usernames[i], err)
+			return nil, fmt.Errorf("serializing entity for user %q: %w", usernames[i], err)
 		}
 
 		// The API returns values in the same ordering requested, so this should properly match

--- a/internal/verify/diff.go
+++ b/internal/verify/diff.go
@@ -36,7 +36,7 @@ func SetTagsDiff(ctx context.Context, diff *schema.ResourceDiff, meta interface{
 
 	if !diff.GetRawPlan().GetAttr("tags").IsWhollyKnown() {
 		if err := diff.SetNewComputed("tags_all"); err != nil {
-			return fmt.Errorf("error setting tags_all to computed: %w", err)
+			return fmt.Errorf("setting tags_all to computed: %w", err)
 		}
 		return nil
 	}
@@ -47,25 +47,25 @@ func SetTagsDiff(ctx context.Context, diff *schema.ResourceDiff, meta interface{
 
 		if newTags.HasZeroValue() {
 			if err := diff.SetNewComputed("tags_all"); err != nil {
-				return fmt.Errorf("error setting tags_all to computed: %w", err)
+				return fmt.Errorf("setting tags_all to computed: %w", err)
 			}
 		}
 
 		if len(allTags) > 0 && (!newTags.HasZeroValue() || !allTags.HasZeroValue()) {
 			if err := diff.SetNew("tags_all", allTags.Map()); err != nil {
-				return fmt.Errorf("error setting new tags_all diff: %w", err)
+				return fmt.Errorf("setting new tags_all diff: %w", err)
 			}
 		}
 
 		if len(allTags) == 0 {
 			if err := diff.SetNewComputed("tags_all"); err != nil {
-				return fmt.Errorf("error setting tags_all to computed: %w", err)
+				return fmt.Errorf("setting tags_all to computed: %w", err)
 			}
 		}
 	} else if !diff.HasChange("tags") {
 		if len(allTags) > 0 && !allTags.HasZeroValue() {
 			if err := diff.SetNew("tags_all", allTags.Map()); err != nil {
-				return fmt.Errorf("error setting new tags_all diff: %w", err)
+				return fmt.Errorf("setting new tags_all diff: %w", err)
 			}
 			return nil
 		}
@@ -76,7 +76,7 @@ func SetTagsDiff(ctx context.Context, diff *schema.ResourceDiff, meta interface{
 		}
 		if len(allTags) > 0 && !ta.DeepEqual(allTags) && allTags.HasZeroValue() {
 			if err := diff.SetNewComputed("tags_all"); err != nil {
-				return fmt.Errorf("error setting tags_all to computed: %w", err)
+				return fmt.Errorf("setting tags_all to computed: %w", err)
 			}
 			return nil
 		}
@@ -85,17 +85,17 @@ func SetTagsDiff(ctx context.Context, diff *schema.ResourceDiff, meta interface{
 		if !ta.DeepEqual(allTags) {
 			if allTags.HasZeroValue() {
 				if err := diff.SetNewComputed("tags_all"); err != nil {
-					return fmt.Errorf("error setting tags_all to computed: %w", err)
+					return fmt.Errorf("setting tags_all to computed: %w", err)
 				}
 			}
 		}
 	} else if len(diff.Get("tags_all").(map[string]interface{})) > 0 {
 		if err := diff.SetNewComputed("tags_all"); err != nil {
-			return fmt.Errorf("error setting tags_all to computed: %w", err)
+			return fmt.Errorf("setting tags_all to computed: %w", err)
 		}
 	} else if diff.HasChange("tags_all") {
 		if err := diff.SetNewComputed("tags_all"); err != nil {
-			return fmt.Errorf("error setting tags_all to computed: %w", err)
+			return fmt.Errorf("setting tags_all to computed: %w", err)
 		}
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Tidies up returned error messages (excluding sweepers and tests):

* Removes leading `error ` or `Error ` from `fmt.Errorf(...)`
* Adds semgrep rule to prevent these creeping back into the code
 
### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/31805.

### Output from Acceptance Testing

```console
% make testacc TESTARGS='-run=TestAccCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError' PKG=cognitoidentity ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cognitoidentity/... -v -count 1 -parallel 2  -run=TestAccCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError -timeout 180m
=== RUN   TestAccCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError
=== PAUSE TestAccCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError
=== CONT  TestAccCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError
--- PASS: TestAccCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError (12.44s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidentity	18.107s
```
```console
% make testacc TESTARGS='-run=TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType\|TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType\|TestAccEC2Instance_gp2WithIopsValue' PKG=ec2 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 2  -run=TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType\|TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType\|TestAccEC2Instance_gp2WithIopsValue -timeout 180m
=== RUN   TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType
=== PAUSE TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType
=== RUN   TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType
=== PAUSE TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType
=== RUN   TestAccEC2Instance_gp2WithIopsValue
=== PAUSE TestAccEC2Instance_gp2WithIopsValue
=== CONT  TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType
=== CONT  TestAccEC2Instance_gp2WithIopsValue
=== CONT  TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType
--- PASS: TestAccEC2Instance_gp2WithIopsValue (15.27s)
--- PASS: TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType (16.02s)
--- PASS: TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType (15.21s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	36.332s
```
```console
% make testacc TESTARGS='-run=TestAccIAMUserLoginProfile_keybaseDoesntExist\|TestAccIAMUserLoginProfile_notAKey' PKG=iam ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/iam/... -v -count 1 -parallel 2  -run=TestAccIAMUserLoginProfile_keybaseDoesntExist\|TestAccIAMUserLoginProfile_notAKey -timeout 180m
=== RUN   TestAccIAMUserLoginProfile_keybaseDoesntExist
=== PAUSE TestAccIAMUserLoginProfile_keybaseDoesntExist
=== RUN   TestAccIAMUserLoginProfile_notAKey
=== PAUSE TestAccIAMUserLoginProfile_notAKey
=== CONT  TestAccIAMUserLoginProfile_keybaseDoesntExist
=== CONT  TestAccIAMUserLoginProfile_notAKey
--- PASS: TestAccIAMUserLoginProfile_keybaseDoesntExist (37.73s)
--- PASS: TestAccIAMUserLoginProfile_notAKey (37.74s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	42.988s
```