### PR TITLE
Clarify the difference between db_instance_port and port in aws_db_instance

### DIFF
--- a/website/docs/d/db_instance.html.markdown
+++ b/website/docs/d/db_instance.html.markdown
@@ -26,8 +26,7 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-~> **NOTE:** The `port` field may be empty while an Aurora cluster is still in the process of being created. This can occur if the cluster was initiated with the  
-[AWS CLI `create-db-cluster`](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster.html) command, but no DB instance has yet been added to it. 
+~> **NOTE:** The `port` field may be empty while an Aurora cluster is still in the process of being created. This can occur if the cluster was initiated with the [AWS CLI `create-db-cluster`](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster.html) command, but no DB instance has yet been added to it.
 
 In addition to all arguments above, the following attributes are exported:
 

--- a/website/docs/d/db_instance.html.markdown
+++ b/website/docs/d/db_instance.html.markdown
@@ -26,6 +26,9 @@ The following arguments are supported:
 
 ## Attributes Reference
 
+~> **NOTE:** The `port` field may be empty while an Aurora cluster is still in the process of being created. This can occur if the cluster was initiated with the  
+[AWS CLI `create-db-cluster`](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster.html) command, but no DB instance has yet been added to it. 
+
 In addition to all arguments above, the following attributes are exported:
 
 * `address` - Hostname of the RDS instance. See also `endpoint` and `port`.
@@ -55,7 +58,7 @@ In addition to all arguments above, the following attributes are exported:
 * `multi_az` - If the DB instance is a Multi-AZ deployment.
 * `network_type` - Network type of the DB instance.
 * `option_group_memberships` - Provides the list of option group memberships for this DB instance.
-* `port` - Database port.
+* `port` - Database endpoint port, primarily used by an Aurora DB cluster. For a conventional RDS DB instance, the `db_instance_port` is typically the preferred choice.
 * `preferred_backup_window` - Specifies the daily time range during which automated backups are created.
 * `preferred_maintenance_window` -  Specifies the weekly time range during which system maintenance can occur in UTC.
 * `publicly_accessible` - Accessibility options for the DB instance.


### PR DESCRIPTION
### Description
Update `aws_db_instance` data source to clarify the difference between `db_instance_port` and `port`.


### Relations
Closes #31441


### References
N/A


### Output from Acceptance Testing
N/A