### PR TITLE
Add CREATING_SNAPSHOT status while waiting for MWAA version upgrade

### DIFF
--- a/.changelog/31833.txt
+++ b/.changelog/31833.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_mwaa_environment: Add CREATING_SNAPSHOT status while waiting for MWAA version upgrade
+```

--- a/.changelog/31833.txt
+++ b/.changelog/31833.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_mwaa_environment: Add CREATING_SNAPSHOT status while waiting for MWAA version upgrade
+resource/aws_mwaa_environment: Consider `CREATING_SNAPSHOT` a valid pending state for resource update
 ```

--- a/.changelog/31833.txt
+++ b/.changelog/31833.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_mwaa_environment: Consider `CREATING_SNAPSHOT` a valid pending state for resource update
 ```
+
+```release-note:note
+resource/aws_mwaa_environment: Upgrading your environment to a new major version of Apache Airflow forces replacement of the resource
+```

--- a/internal/service/mwaa/environment.go
+++ b/internal/service/mwaa/environment.go
@@ -9,7 +9,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/mwaa"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	gversion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -264,7 +266,25 @@ func ResourceEnvironment() *schema.Resource {
 			},
 		},
 
-		CustomizeDiff: verify.SetTagsDiff,
+		CustomizeDiff: customdiff.Sequence(
+			customdiff.ForceNewIf("airflow_version", func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+				o, n := d.GetChange("airflow_version")
+
+				if oldVersion, err := gversion.NewVersion(o.(string)); err != nil {
+					if newVersion, err := gversion.NewVersion(n.(string)); err != nil {
+						// https://docs.aws.amazon.com/mwaa/latest/userguide/airflow-versions.html#airflow-versions-upgrade:
+						// 	Amazon MWAA supports minor version upgrades.
+						// 	This means you can upgrade your environment from version x.4.z to x.5.z.
+						// 	However, you cannot upgrade your environment to a new major version of Apache Airflow.
+						// 	For example, upgrading from version 1.y.z to 2.y.z is not supported.
+						return oldVersion.Segments()[0] < newVersion.Segments()[0]
+					}
+				}
+
+				return false
+			}),
+			verify.SetTagsDiff,
+		),
 	}
 }
 
@@ -346,7 +366,6 @@ func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta
 		input.WeeklyMaintenanceWindowStart = aws.String(v.(string))
 	}
 
-	log.Printf("[INFO] Creating MWAA Environment: %s", input)
 	/*
 		Execution roles created just before the MWAA Environment may result in ValidationExceptions
 		due to IAM permission propagation delays.
@@ -511,7 +530,6 @@ func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta
 			input.WeeklyMaintenanceWindowStart = aws.String(d.Get("weekly_maintenance_window_start").(string))
 		}
 
-		log.Printf("[INFO] Updating MWAA Environment: %s", input)
 		_, err := conn.UpdateEnvironmentWithContext(ctx, input)
 
 		if err != nil {

--- a/internal/service/mwaa/environment.go
+++ b/internal/service/mwaa/environment.go
@@ -272,12 +272,14 @@ func ResourceEnvironment() *schema.Resource {
 
 				if oldVersion, err := gversion.NewVersion(o.(string)); err != nil {
 					if newVersion, err := gversion.NewVersion(n.(string)); err != nil {
-						// https://docs.aws.amazon.com/mwaa/latest/userguide/airflow-versions.html#airflow-versions-upgrade:
-						// 	Amazon MWAA supports minor version upgrades.
-						// 	This means you can upgrade your environment from version x.4.z to x.5.z.
-						// 	However, you cannot upgrade your environment to a new major version of Apache Airflow.
-						// 	For example, upgrading from version 1.y.z to 2.y.z is not supported.
-						return oldVersion.Segments()[0] < newVersion.Segments()[0]
+						if len(oldVersion.Segments()) > 0 && len(newVersion.Segments()) > 0 {
+							// https://docs.aws.amazon.com/mwaa/latest/userguide/airflow-versions.html#airflow-versions-upgrade:
+							// 	Amazon MWAA supports minor version upgrades.
+							// 	This means you can upgrade your environment from version x.4.z to x.5.z.
+							// 	However, you cannot upgrade your environment to a new major version of Apache Airflow.
+							// 	For example, upgrading from version 1.y.z to 2.y.z is not supported.
+							return oldVersion.Segments()[0] < newVersion.Segments()[0]
+						}
 					}
 				}
 

--- a/internal/service/mwaa/environment.go
+++ b/internal/service/mwaa/environment.go
@@ -635,7 +635,7 @@ func waitEnvironmentCreated(ctx context.Context, conn *mwaa.MWAA, name string, t
 
 func waitEnvironmentUpdated(ctx context.Context, conn *mwaa.MWAA, name string, timeout time.Duration) (*mwaa.Environment, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{mwaa.EnvironmentStatusUpdating},
+		Pending: []string{mwaa.EnvironmentStatusUpdating, mwaa.EnvironmentStatusCreatingSnapshot},
 		Target:  []string{mwaa.EnvironmentStatusAvailable},
 		Refresh: statusEnvironment(ctx, conn, name),
 		Timeout: timeout,

--- a/internal/service/mwaa/environment.go
+++ b/internal/service/mwaa/environment.go
@@ -270,16 +270,14 @@ func ResourceEnvironment() *schema.Resource {
 			customdiff.ForceNewIf("airflow_version", func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
 				o, n := d.GetChange("airflow_version")
 
-				if oldVersion, err := gversion.NewVersion(o.(string)); err != nil {
-					if newVersion, err := gversion.NewVersion(n.(string)); err != nil {
-						if len(oldVersion.Segments()) > 0 && len(newVersion.Segments()) > 0 {
-							// https://docs.aws.amazon.com/mwaa/latest/userguide/airflow-versions.html#airflow-versions-upgrade:
-							// 	Amazon MWAA supports minor version upgrades.
-							// 	This means you can upgrade your environment from version x.4.z to x.5.z.
-							// 	However, you cannot upgrade your environment to a new major version of Apache Airflow.
-							// 	For example, upgrading from version 1.y.z to 2.y.z is not supported.
-							return oldVersion.Segments()[0] < newVersion.Segments()[0]
-						}
+				if oldVersion, err := gversion.NewVersion(o.(string)); err == nil {
+					if newVersion, err := gversion.NewVersion(n.(string)); err == nil {
+						// https://docs.aws.amazon.com/mwaa/latest/userguide/airflow-versions.html#airflow-versions-upgrade:
+						// 	Amazon MWAA supports minor version upgrades.
+						// 	This means you can upgrade your environment from version x.4.z to x.5.z.
+						// 	However, you cannot upgrade your environment to a new major version of Apache Airflow.
+						// 	For example, upgrading from version 1.y.z to 2.y.z is not supported.
+						return oldVersion.Segments()[0] < newVersion.Segments()[0]
 					}
 				}
 

--- a/internal/service/mwaa/environment_test.go
+++ b/internal/service/mwaa/environment_test.go
@@ -152,7 +152,7 @@ func TestAccMWAAEnvironment_airflowOptions(t *testing.T) {
 
 func TestAccMWAAEnvironment_log(t *testing.T) {
 	ctx := acctest.Context(t)
-	var environment mwaa.Environment
+	var environment1, environment2 mwaa.Environment
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_mwaa_environment.test"
 
@@ -165,7 +165,7 @@ func TestAccMWAAEnvironment_log(t *testing.T) {
 			{
 				Config: testAccEnvironmentConfig_logging(rName, "true", mwaa.LoggingLevelCritical),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEnvironmentExists(ctx, resourceName, &environment),
+					testAccCheckEnvironmentExists(ctx, resourceName, &environment1),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
 
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.dag_processing_logs.#", "1"),
@@ -202,7 +202,8 @@ func TestAccMWAAEnvironment_log(t *testing.T) {
 			{
 				Config: testAccEnvironmentConfig_logging(rName, "false", mwaa.LoggingLevelInfo),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEnvironmentExists(ctx, resourceName, &environment),
+					testAccCheckEnvironmentExists(ctx, resourceName, &environment2),
+					testAccCheckEnvironmentNotRecreated(&environment2, &environment1),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "1"),
 
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.0.dag_processing_logs.#", "1"),
@@ -313,7 +314,7 @@ func TestAccMWAAEnvironment_full(t *testing.T) {
 
 func TestAccMWAAEnvironment_pluginsS3ObjectVersion(t *testing.T) {
 	ctx := acctest.Context(t)
-	var environment mwaa.Environment
+	var environment1, environment2 mwaa.Environment
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_mwaa_environment.test"
 	s3ObjectResourceName := "aws_s3_object.plugins"
@@ -327,7 +328,7 @@ func TestAccMWAAEnvironment_pluginsS3ObjectVersion(t *testing.T) {
 			{
 				Config: testAccEnvironmentConfig_pluginsS3ObjectVersion(rName, "test"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEnvironmentExists(ctx, resourceName, &environment),
+					testAccCheckEnvironmentExists(ctx, resourceName, &environment1),
 					resource.TestCheckResourceAttrPair(resourceName, "plugins_s3_object_version", s3ObjectResourceName, "version_id"),
 				),
 			},
@@ -339,7 +340,8 @@ func TestAccMWAAEnvironment_pluginsS3ObjectVersion(t *testing.T) {
 			{
 				Config: testAccEnvironmentConfig_pluginsS3ObjectVersion(rName, "test-updated"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEnvironmentExists(ctx, resourceName, &environment),
+					testAccCheckEnvironmentExists(ctx, resourceName, &environment2),
+					testAccCheckEnvironmentNotRecreated(&environment2, &environment1),
 					resource.TestCheckResourceAttrPair(resourceName, "plugins_s3_object_version", s3ObjectResourceName, "version_id"),
 				),
 			},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

MWAA now supports in-place version upgrades. 
In a successful MWAA version upgrade scenario, the status will show UPDATING, then CREATING_SNAPSHOT as Amazon MWAA captures a backup of metadata. Finally, the status will return first to UPDATING, then to AVAILABLE when the procedure is done.

This PR adds CREATING_SNAPSHOT status as a valid status along with UPDATING status when waiting for MWAA upgrade



### Relations

Closes #31825.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/21640.

### References

https://aws.amazon.com/blogs/big-data/introducing-in-place-version-upgrades-with-amazon-mwaa/
https://docs.aws.amazon.com/mwaa/latest/userguide/upgrading-environment.html


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


