### PR TITLE
medialive/channel: fix attributes spelling issue in expandHLSCDNSetti…

### DIFF
--- a/internal/service/medialive/channel_encoder_settings_schema.go
+++ b/internal/service/medialive/channel_encoder_settings_schema.go
@@ -3428,19 +3428,19 @@ func expandHLSCDNSettings(tfList []interface{}) *types.HlsCdnSettings {
 	m := tfList[0].(map[string]interface{})
 
 	var out types.HlsCdnSettings
-	if v, ok := m["hls_akamai_setting"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := m["hls_akamai_settings"].([]interface{}); ok && len(v) > 0 {
 		out.HlsAkamaiSettings = expandHSLAkamaiSettings(v)
 	}
-	if v, ok := m["hls_basic_put_setting"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := m["hls_basic_put_settings"].([]interface{}); ok && len(v) > 0 {
 		out.HlsBasicPutSettings = expandHSLBasicPutSettings(v)
 	}
-	if v, ok := m["hls_media_store_setting"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := m["hls_media_store_settings"].([]interface{}); ok && len(v) > 0 {
 		out.HlsMediaStoreSettings = expandHLSMediaStoreSettings(v)
 	}
-	if v, ok := m["hls_s3_setting"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := m["hls_s3_settings"].([]interface{}); ok && len(v) > 0 {
 		out.HlsS3Settings = expandHSLS3Settings(v)
 	}
-	if v, ok := m["hls_webdav_setting"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := m["hls_webdav_settings"].([]interface{}); ok && len(v) > 0 {
 		out.HlsWebdavSettings = expandHLSWebdavSettings(v)
 	}
 	return &out


### PR DESCRIPTION
…ngs() #31787

## Description


### Relations
Closes #31787 

### References

### Output from Acceptance Testing

```
$ make testacc TESTS=TestAccXXX PKG=ec2

ake testacc TESTARGS='-run=TestAccMediaLiveChannel_' PKG=medialive

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/medialive/... -v -count 1 -parallel 20  -run=TestAccMediaLiveChannel_ -timeout 180m
--- PASS: TestAccMediaLiveChannel_basic (75.04s)
--- PASS: TestAccMediaLiveChannel_M2TS_settings (85.35s)
--- PASS: TestAccMediaLiveChannel_MsSmooth_outputSettings (90.55s)
--- PASS: TestAccMediaLiveChannel_AudioDescriptions_codecSettings (93.78s)
--- PASS: TestAccMediaLiveChannel_VideoDescriptions_CodecSettings_h264Settings (94.22s)
--- PASS: TestAccMediaLiveChannel_disappears (137.96s)
--- PASS: TestAccMediaLiveChannel_hls (152.00s)
--- PASS: TestAccMediaLiveChannel_VideoDescriptions_CodecSettings_h265Settings (158.66s)
--- PASS: TestAccMediaLiveChannel_updateTags (184.00s)
--- PASS: TestAccMediaLiveChannel_update (220.44s)
--- PASS: TestAccMediaLiveChannel_UDP_outputSettings (234.80s)
--- PASS: TestAccMediaLiveChannel_status (269.16s)
PASS
ok  	github.com/nicoguyo/terraform-provider-aws/internal/service/medialive	272.309s
...
```
