### PR TITLE
Update Workflow to use `next_global_id` rather than `legacy_global_id`

### DIFF
--- a/.github/workflows/project-partner-label.yml
+++ b/.github/workflows/project-partner-label.yml
@@ -4,7 +4,7 @@ on:
     types:
       - labeled
 env:
-  DESTINATION_COLUMN_ID: 'MDEzOlByb2plY3RDb2x1bW4xMjE0MzAxNw=='
+  DESTINATION_COLUMN_ID: 'PC_lAPOAAuecM4AXZPtzgC5Sak'
   GH_TOKEN: ${{ secrets.ORGSCOPED_GITHUB_TOKEN }}
 jobs:
   tag-created:


### PR DESCRIPTION
### Description

This PR updates the workflow that adds items labeled `partner` to the Partner working board such that the ID used for the GraphQL mutation is the `next_global_id` rather than the `legacy_global_id`, as requested by the response from the API (linked Action run output below).

### Relations

Relates #31793 - The workflows updated in that PR will need a subsequent update similar to this, but oddly enough, it doesn't appear that you can get the `next_global_id` from anything but a mutation response, so we'll need to follow up and check the logs once those workflows run to get that value.

### References

[Action log output](https://github.com/hashicorp/terraform-provider-aws/actions/runs/5200588589/jobs/9379510726) - This job completed successfully, but threw the warn message that alerted me to the change.


### Output from Acceptance Testing

n/a, Actions
