### PR TITLE
Remove `name` argument from `aws_db_instance` documentation

### DIFF
--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -269,7 +269,6 @@ information on the [AWS
 Documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html)
 what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
 * `multi_az` - (Optional) Specifies if the RDS instance is multi-AZ
-* `name` - (Optional, **Deprecated** use `db_name` instead) The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
 * `nchar_character_set_name` - (Optional, Forces new resource) The national character set is used in the NCHAR, NVARCHAR2, and NCLOB data types for Oracle instances. This can't be changed. See [Oracle Character Sets
 Supported in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html).
 * `network_type` - (Optional) The network type of the DB instance. Valid values: `IPV4`, `DUAL`.


### PR DESCRIPTION
### Description

In version 5.0.0, the `name` argument was removed from the `aws_db_instance` resource, however, the argument was not removed from the documentation. This PR corrects that. 

### Relations

Closes #31818

### References

Relates: #31232
[Relevant release notes line](https://github.com/hashicorp/terraform-provider-aws/blob/105d934a95b3abe8b4dd692ec09cf335248ff6d7/CHANGELOG.md?plain=1#L144)

### Output from Acceptance Testing

n/a, docs