### PR TITLE
Ensure `issue_comment` triggers are correctly evaluated

### DIFF
--- a/.github/workflows/reusable-add-or-remove-labels.yml
+++ b/.github/workflows/reusable-add-or-remove-labels.yml
@@ -21,12 +21,15 @@ jobs:
     name: 'Modify Label(s)'
     runs-on: ubuntu-latest
     env:
-      ITEM_TYPE: 'pr'
+      ITEM_TYPE: 'issue'
     steps:
       - name: 'Determine if the Item is an Issue or Pull Request'
-        if: github.event_name == 'issues'
+        # The issue_comment trigger happens for issues and pull requests.
+        # The best way to determine if an issue_comment trigger is related to an issue or pull request is to check
+        # whether or not github.event.issue.pull_request is empty.
+        if: github.event.pull_request || github.event.issue.pull_request
         run: |
-          echo 'ITEM_TYPE=issue' >> $GITHUB_ENV
+          echo 'ITEM_TYPE=pr' >> $GITHUB_ENV
 
       - name: 'Add Label(s) to Issue or Pull Request'
         if: inputs.add != ''


### PR DESCRIPTION
### Description

When creating this reusable workflow, I assumed that checking the `event_type` to see if the event was related to an issue would work well enough for distinguishing between issues and PRs. I failed to account for `issue_comment` triggers, which [are triggered](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment) for both issues _and_ pull requests with an event type of `issue_comment`, bypassing the previous test. This led to failures, as seen in the references section.

### Relations

Relates #31750

### References

- [Failed run due to not accounting for this](https://github.com/hashicorp/terraform-provider-aws/actions/runs/5215614719/jobs/9413376735)
- [GitHub recommendation on a similar approach](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only) (this is only discussing `issue_comment` triggers; the `github.event.pull_request` bit checks other non-comment related pull requests.

### Output from Acceptance Testing

N/a, Actions