### PR TITLE
`r/aws_quicksight_data_set`: Allow physical_table_map to be optional

### DIFF
--- a/.changelog/31863.txt
+++ b/.changelog/31863.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_quicksight_data_set: Allow physical table map to be optional
+```

--- a/internal/service/quicksight/data_set.go
+++ b/internal/service/quicksight/data_set.go
@@ -218,7 +218,7 @@ func ResourceDataSet() *schema.Resource {
 			},
 			"physical_table_map": {
 				Type:     schema.TypeSet,
-				Required: true,
+				Optional: true,
 				MaxItems: 32,
 				Elem:     physicalTableMapSchema(),
 			},
@@ -1644,10 +1644,6 @@ func expandDataSetUntagColumnOperation(tfList []interface{}) *quicksight.UntagCo
 }
 
 func expandDataSetPhysicalTableMap(tfSet *schema.Set) map[string]*quicksight.PhysicalTable {
-	if tfSet.Len() == 0 {
-		return nil
-	}
-
 	physicalTableMap := make(map[string]*quicksight.PhysicalTable)
 	for _, v := range tfSet.List() {
 		vMap, ok := v.(map[string]interface{})
@@ -2426,10 +2422,6 @@ func flattenJoinKeyProperties(apiObject *quicksight.JoinKeyProperties) map[strin
 }
 
 func flattenPhysicalTableMap(apiObject map[string]*quicksight.PhysicalTable, resourceSchema *schema.Resource) *schema.Set {
-	if len(apiObject) == 0 {
-		return nil
-	}
-
 	var tfList []interface{}
 	for k, v := range apiObject {
 		if v == nil {

--- a/internal/service/quicksight/data_set_test.go
+++ b/internal/service/quicksight/data_set_test.go
@@ -1077,18 +1077,15 @@ resource "aws_quicksight_data_set" "test" {
 
 func testAccDataSetConfigNoPhysicalTableMap(rId, rName string) string {
 	return acctest.ConfigCompose(
-		testAccDataSetConfigBase(
-			sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
-			sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
-		),
+		testAccDataSetConfigBase(rId, rName),
 		fmt.Sprintf(`
 resource "aws_quicksight_data_set" "left" {
-  data_set_id = %[1]q
-  name        = %[2]q
+  data_set_id = "%[1]s-left"
+  name        = "%[2]s-left"
   import_mode = "SPICE"
 
   physical_table_map {
-    physical_table_map_id = %[1]q
+    physical_table_map_id = "%[1]s-left"
     s3_source {
       data_source_arn = aws_quicksight_data_source.test.arn
       input_columns {
@@ -1103,12 +1100,12 @@ resource "aws_quicksight_data_set" "left" {
 }
 
 resource "aws_quicksight_data_set" "right" {
-  data_set_id = %[3]q
-  name        = %[4]q
+  data_set_id = "%[1]s-right"
+  name        = "%[2]s-right"
   import_mode = "SPICE"
 
   physical_table_map {
-    physical_table_map_id = %[3]q
+    physical_table_map_id = "%[1]s-right"
     s3_source {
       data_source_arn = aws_quicksight_data_source.test.arn
       input_columns {
@@ -1123,8 +1120,8 @@ resource "aws_quicksight_data_set" "right" {
 }
 
 resource "aws_quicksight_data_set" "test" {
-  data_set_id = %[5]q
-  name        = %[6]q
+  data_set_id = %[1]q
+  name        = %[2]q
   import_mode = "SPICE"
 
   logical_table_map {
@@ -1156,13 +1153,5 @@ resource "aws_quicksight_data_set" "test" {
     }
   }
 }
-`,
-			sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
-			sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
-			sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
-			sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
-			rId,
-			rName,
-		),
-	)
+`, rId, rName))
 }

--- a/internal/service/quicksight/data_set_test.go
+++ b/internal/service/quicksight/data_set_test.go
@@ -453,6 +453,46 @@ func TestAccQuickSightDataSet_tags(t *testing.T) {
 	})
 }
 
+func TestAccQuickSightDataSet_noPhysicalTableMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dataSet quicksight.DataSet
+	resourceName := "aws_quicksight_data_set.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, quicksight.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataSetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSetConfigNoPhysicalTableMap(rId, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSetExists(ctx, resourceName, &dataSet),
+					resource.TestCheckResourceAttr(resourceName, "data_set_id", rId),
+					acctest.CheckResourceAttrRegionalARN(resourceName, "arn", "quicksight", fmt.Sprintf("dataset/%s", rId)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "import_mode", "SPICE"),
+					resource.TestCheckResourceAttr(resourceName, "physical_table_map.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.logical_table_map_id", "joined"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.alias", "j"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.source.0.join_instruction.0.right_operand", "right"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.source.0.join_instruction.0.left_operand", "left"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.source.0.join_instruction.0.type", "INNER"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.source.0.join_instruction.0.on_clause", "Column1 = Column2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckDataSetExists(ctx context.Context, resourceName string, dataSet *quicksight.DataSet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -1033,4 +1073,96 @@ resource "aws_quicksight_data_set" "test" {
   }
 }
 `, rId, rName, key1, value1, key2, value2))
+}
+
+func testAccDataSetConfigNoPhysicalTableMap(rId, rName string) string {
+	return acctest.ConfigCompose(
+		testAccDataSetConfigBase(
+			sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+			sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+		),
+		fmt.Sprintf(`
+resource "aws_quicksight_data_set" "left" {
+  data_set_id = %[1]q
+  name        = %[2]q
+  import_mode = "SPICE"
+
+  physical_table_map {
+    physical_table_map_id = %[1]q
+    s3_source {
+      data_source_arn = aws_quicksight_data_source.test.arn
+      input_columns {
+        name = "Column1"
+        type = "STRING"
+      }
+      upload_settings {
+        format = "JSON"
+      }
+    }
+  }
+}
+
+resource "aws_quicksight_data_set" "right" {
+  data_set_id = %[3]q
+  name        = %[4]q
+  import_mode = "SPICE"
+
+  physical_table_map {
+    physical_table_map_id = %[3]q
+    s3_source {
+      data_source_arn = aws_quicksight_data_source.test.arn
+      input_columns {
+        name = "Column2"
+        type = "STRING"
+      }
+      upload_settings {
+        format = "JSON"
+      }
+    }
+  }
+}
+
+resource "aws_quicksight_data_set" "test" {
+  data_set_id = %[5]q
+  name        = %[6]q
+  import_mode = "SPICE"
+
+  logical_table_map {
+    logical_table_map_id = "right"
+    alias                = "r"
+    source {
+      data_set_arn = aws_quicksight_data_set.right.arn
+    }
+  }
+
+  logical_table_map {
+    logical_table_map_id = "left"
+    alias                = "l"
+    source {
+      data_set_arn = aws_quicksight_data_set.left.arn
+    }
+  }
+
+  logical_table_map {
+    logical_table_map_id = "joined"
+    alias                = "j"
+    source {
+      join_instruction {
+        left_operand  = "left"
+        right_operand = "right"
+        type          = "INNER"
+        on_clause     = "Column1 = Column2"
+      }
+    }
+  }
+}
+`,
+			sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+			sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+			sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+			sdkacctest.RandomWithPrefix(acctest.ResourcePrefix),
+			rId,
+			rName,
+		),
+	)
 }


### PR DESCRIPTION
### Description

Currently, the schema for the `aws_quicksight_data_set` resource marks the `physical_table_map` field as `Required`. 

However, the AWS API makes clear that while required, the map it represents may contain zero entries:

```
PhysicalTableMap

    Declares the physical tables that are available in the underlying data sources.

    Type: String to PhysicalTable object map

    Map Entries: Minimum number of 0 items. Maximum number of 32 items.

    Key Length Constraints: Minimum length of 1. Maximum length of 64.

    Key Pattern: [0-9a-zA-Z-]*

    Required: Yes
```
[Source](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CreateDataSet.html#API_CreateDataSet_RequestSyntax)

The present schema definition of `Required` therefore makes it impossible to specify an empty map. 

This PR fixes this by updating the `physical_table_map` field to be `Optional` and ensures that an empty map is passed to the AWS SDK in the event that no `physical_table_map` blocks have been specified.


### Relations

Fixes #31863
Related To: #30349

### References

* https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CreateDataSet.html#API_CreateDataSet_RequestSyntax

### Output from Acceptance Testing

```
$ make testacc PKG=quicksight TESTS=TestAccQuickSightDataSet
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightDataSet'  -timeout 180m
?   	github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema	[no test files]
=== RUN   TestAccQuickSightDataSetDataSource_basic
=== PAUSE TestAccQuickSightDataSetDataSource_basic
=== RUN   TestAccQuickSightDataSet_basic
=== PAUSE TestAccQuickSightDataSet_basic
=== RUN   TestAccQuickSightDataSet_disappears
=== PAUSE TestAccQuickSightDataSet_disappears
=== RUN   TestAccQuickSightDataSet_columnGroups
=== PAUSE TestAccQuickSightDataSet_columnGroups
=== RUN   TestAccQuickSightDataSet_columnLevelPermissionRules
=== PAUSE TestAccQuickSightDataSet_columnLevelPermissionRules
=== RUN   TestAccQuickSightDataSet_dataSetUsageConfiguration
=== PAUSE TestAccQuickSightDataSet_dataSetUsageConfiguration
=== RUN   TestAccQuickSightDataSet_fieldFolders
=== PAUSE TestAccQuickSightDataSet_fieldFolders
=== RUN   TestAccQuickSightDataSet_logicalTableMap
=== PAUSE TestAccQuickSightDataSet_logicalTableMap
=== RUN   TestAccQuickSightDataSet_permissions
=== PAUSE TestAccQuickSightDataSet_permissions
=== RUN   TestAccQuickSightDataSet_rowLevelPermissionTagConfiguration
=== PAUSE TestAccQuickSightDataSet_rowLevelPermissionTagConfiguration
=== RUN   TestAccQuickSightDataSet_refreshProperties
    data_set_test.go:373: Environment variable QUICKSIGHT_ATHENA_TESTING_ENABLED is not set
--- SKIP: TestAccQuickSightDataSet_refreshProperties (0.00s)
=== RUN   TestAccQuickSightDataSet_tags
=== PAUSE TestAccQuickSightDataSet_tags
=== RUN   TestAccQuickSightDataSet_noPhysicalTableMap
=== PAUSE TestAccQuickSightDataSet_noPhysicalTableMap
=== CONT  TestAccQuickSightDataSetDataSource_basic
=== CONT  TestAccQuickSightDataSet_fieldFolders
=== CONT  TestAccQuickSightDataSet_noPhysicalTableMap
=== CONT  TestAccQuickSightDataSet_tags
=== CONT  TestAccQuickSightDataSet_rowLevelPermissionTagConfiguration
=== CONT  TestAccQuickSightDataSet_columnGroups
=== CONT  TestAccQuickSightDataSet_permissions
=== CONT  TestAccQuickSightDataSet_logicalTableMap
=== CONT  TestAccQuickSightDataSet_basic
=== CONT  TestAccQuickSightDataSet_disappears
=== CONT  TestAccQuickSightDataSet_columnLevelPermissionRules
=== CONT  TestAccQuickSightDataSet_dataSetUsageConfiguration
--- PASS: TestAccQuickSightDataSet_disappears (44.39s)
--- PASS: TestAccQuickSightDataSetDataSource_basic (49.79s)
--- PASS: TestAccQuickSightDataSet_rowLevelPermissionTagConfiguration (54.89s)
--- PASS: TestAccQuickSightDataSet_columnGroups (54.89s)
--- PASS: TestAccQuickSightDataSet_basic (55.04s)
--- PASS: TestAccQuickSightDataSet_fieldFolders (55.82s)
--- PASS: TestAccQuickSightDataSet_dataSetUsageConfiguration (55.87s)
--- PASS: TestAccQuickSightDataSet_columnLevelPermissionRules (56.42s)
--- PASS: TestAccQuickSightDataSet_noPhysicalTableMap (56.95s)
--- PASS: TestAccQuickSightDataSet_logicalTableMap (82.24s)
--- PASS: TestAccQuickSightDataSet_tags (95.20s)
--- PASS: TestAccQuickSightDataSet_permissions (106.93s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/quicksight	107.055s
...
