### PR TITLE
Add `db-proxy` to list of `aws_db_event_subscription.source_type` valid values

### DIFF
--- a/website/docs/r/db_event_subscription.html.markdown
+++ b/website/docs/r/db_event_subscription.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 * `name_prefix` - (Optional) The name of the DB event subscription. Conflicts with `name`.
 * `sns_topic` - (Required) The SNS topic to send events to.
 * `source_ids` - (Optional) A list of identifiers of the event sources for which events will be returned. If not specified, then all sources are included in the response. If specified, a source_type must also be specified.
-* `source_type` - (Optional) The type of source that will be generating the events. Valid options are `db-instance`, `db-security-group`, `db-parameter-group`, `db-snapshot`, `db-cluster` or `db-cluster-snapshot`. If not set, all sources will be subscribed to.
+* `source_type` - (Optional) The type of source that will be generating the events. Valid options are `db-instance`, `db-security-group`, `db-parameter-group`, `db-snapshot`, `db-cluster`, `db-cluster-snapshot`, or `db-proxy`. If not set, all sources will be subscribed to.
 * `event_categories` - (Optional) A list of event categories for a SourceType that you want to subscribe to. See http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html or run `aws rds describe-event-categories`.
 * `enabled` - (Optional) A boolean flag to enable/disable the subscription. Defaults to true.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
### Description

This PR adds `db-proxy` to the list of documented valid values for `aws_db_event_subscription.source_type`.


### Relations

Closes #31865

### References

[`CreateEventSubscription` API documentation](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateEventSubscription.html#API_CreateEventSubscription_RequestParameters)

### Output from Acceptance Testing

N/a, docs
