### PR TITLE
Correct argument name in `aws_fsx_ontap_volume`

### DIFF
--- a/website/docs/r/fsx_ontap_volume.html.markdown
+++ b/website/docs/r/fsx_ontap_volume.html.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
 The following arguments are supported for `tiering_policy` configuration block:
 
 * `name` - (Required) Specifies the tiering policy for the ONTAP volume for moving data to the capacity pool storage. Valid values are `SNAPSHOT_ONLY`, `AUTO`, `ALL`, `NONE`. Default value is `SNAPSHOT_ONLY`.
-* `cooling_policy` - (Optional) Specifies the number of days that user data in a volume must remain inactive before it is considered "cold" and moved to the capacity pool. Used with `AUTO` and `SNAPSHOT_ONLY` tiering policies only. Valid values are whole numbers between 2 and 183. Default values are 31 days for `AUTO` and 2 days for `SNAPSHOT_ONLY`.
+* `cooling_period` - (Optional) Specifies the number of days that user data in a volume must remain inactive before it is considered "cold" and moved to the capacity pool. Used with `AUTO` and `SNAPSHOT_ONLY` tiering policies only. Valid values are whole numbers between 2 and 183. Default values are 31 days for `AUTO` and 2 days for `SNAPSHOT_ONLY`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Description

This PR corrects the documentation of `aws_fsx_ontap_volume`, where `tiering_policy.cooling_period` was incorrectly listed as `tiering_policy.cooling_policy`.

### Relations

Closes #31862

### References

[Schema](https://github.com/hashicorp/terraform-provider-aws/blob/ecb45d645b3b2897504007540e9e480402eeee03/internal/service/fsx/ontap_volume.go#L110)

### Output from Acceptance Testing

N/a, docs
