### PR TITLE
Remove reference to previously required tag on `aws_eks_node_group.subnet_ids`

### DIFF
--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -127,10 +127,6 @@ resource "aws_subnet" "example" {
   availability_zone = data.aws_availability_zones.available.names[count.index]
   cidr_block        = cidrsubnet(aws_vpc.example.cidr_block, 8, count.index)
   vpc_id            = aws_vpc.example.id
-
-  tags = {
-    "kubernetes.io/cluster/${aws_eks_cluster.example.name}" = "shared"
-  }
 }
 ```
 
@@ -141,7 +137,7 @@ The following arguments are required:
 * `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
 * `node_role_arn` – (Required) Amazon Resource Name (ARN) of the IAM Role that provides permissions for the EKS Node Group.
 * `scaling_config` - (Required) Configuration block with scaling settings. Detailed below.
-* `subnet_ids` – (Required) Identifiers of EC2 Subnets to associate with the EKS Node Group. These subnets must have the following resource tag: `kubernetes.io/cluster/CLUSTER_NAME` (where `CLUSTER_NAME` is replaced with the name of the EKS Cluster).
+* `subnet_ids` – (Required) Identifiers of EC2 Subnets to associate with the EKS Node Group.
 
 The following arguments are optional:
 


### PR DESCRIPTION
### Description

On Kubernetes version `1.18` and earlier, subnets specified for EKS node groups had a tag of `kubernetes.io/cluster/my-cluster` automatically applied, which was noted as a required tag on subnets specified in `aws_eks_node_group.subnet_ids`. This is no longer a requirement, and the versions of Kubernetes that required this are no longer supported by AWS. As such, this PR removes this note from the documentation.

### Relations

Closes #31704

### References

- [Amazon EKS VPC and subnet requirements and considerations](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html#network-requirements-subnets)
- [Amazon EKS Kubernetes versions](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)

### Output from Acceptance Testing

N/a, docs
