### PR TITLE
ec2: fix unretriable error when creating vpc, while reading vpc attributes

### DIFF
--- a/.changelog/31877.txt
+++ b/.changelog/31877.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_vpc: Fix race condition when reading VPC attributes on a new resource
+resource/aws_vpc: Fix `reading EC2 VPC (vpc-abcd1234) Attribute (enableDnsSupport): couldn't find resource` errors when reading new resource
 ```

--- a/.changelog/31877.txt
+++ b/.changelog/31877.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpc: Fix race condition when reading VPC attributes on a new resource
+```

--- a/internal/service/ec2/vpc_.go
+++ b/internal/service/ec2/vpc_.go
@@ -285,19 +285,25 @@ func resourceVPCRead(ctx context.Context, d *schema.ResourceData, meta interface
 	d.Set("instance_tenancy", vpc.InstanceTenancy)
 	d.Set("owner_id", ownerID)
 
-	if v, err := FindVPCAttribute(ctx, conn, d.Id(), ec2.VpcAttributeNameEnableDnsHostnames); err != nil {
+	if v, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+		return FindVPCAttribute(ctx, conn, d.Id(), ec2.VpcAttributeNameEnableDnsHostnames)
+	}, d.IsNewResource()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading EC2 VPC (%s) Attribute (%s): %s", d.Id(), ec2.VpcAttributeNameEnableDnsHostnames, err)
 	} else {
 		d.Set("enable_dns_hostnames", v)
 	}
 
-	if v, err := FindVPCAttribute(ctx, conn, d.Id(), ec2.VpcAttributeNameEnableDnsSupport); err != nil {
+	if v, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+		return FindVPCAttribute(ctx, conn, d.Id(), ec2.VpcAttributeNameEnableDnsSupport)
+	}, d.IsNewResource()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading EC2 VPC (%s) Attribute (%s): %s", d.Id(), ec2.VpcAttributeNameEnableDnsSupport, err)
 	} else {
 		d.Set("enable_dns_support", v)
 	}
 
-	if v, err := FindVPCAttribute(ctx, conn, d.Id(), ec2.VpcAttributeNameEnableNetworkAddressUsageMetrics); err != nil {
+	if v, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+		return FindVPCAttribute(ctx, conn, d.Id(), ec2.VpcAttributeNameEnableNetworkAddressUsageMetrics)
+	}, d.IsNewResource()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading EC2 VPC (%s) Attribute (%s): %s", d.Id(), ec2.VpcAttributeNameEnableNetworkAddressUsageMetrics, err)
 	} else {
 		d.Set("enable_network_address_usage_metrics", v)

--- a/internal/service/ec2/vpc_test.go
+++ b/internal/service/ec2/vpc_test.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -1108,17 +1107,8 @@ func testAccCheckVPCDestroy(ctx context.Context) resource.TestCheckFunc {
 				continue
 			}
 
-			_, err := tfresource.RetryWhen(ctx, 2*time.Minute, func() (interface{}, error) {
-				return tfec2.FindVPCByID(ctx, conn, rs.Primary.ID)
-			}, func(err error) (bool, error) {
-				if err != nil && tfresource.NotFound(err) {
-					return false, err
-				} else if err != nil {
-					return false, err
-				} else { // nil error
-					return true, fmt.Errorf("resource found")
-				}
-			})
+			_, err := tfec2.FindVPCByID(ctx, conn, rs.Primary.ID)
+
 			if tfresource.NotFound(err) {
 				continue
 			}

--- a/internal/service/ec2/vpc_test.go
+++ b/internal/service/ec2/vpc_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -1107,8 +1108,17 @@ func testAccCheckVPCDestroy(ctx context.Context) resource.TestCheckFunc {
 				continue
 			}
 
-			_, err := tfec2.FindVPCByID(ctx, conn, rs.Primary.ID)
-
+			_, err := tfresource.RetryWhen(ctx, 2*time.Minute, func() (interface{}, error) {
+				return tfec2.FindVPCByID(ctx, conn, rs.Primary.ID)
+			}, func(err error) (bool, error) {
+				if err != nil && tfresource.NotFound(err) {
+					return false, err
+				} else if err != nil {
+					return false, err
+				} else { // nil error
+					return true, fmt.Errorf("resource found")
+				}
+			})
 			if tfresource.NotFound(err) {
 				continue
 			}


### PR DESCRIPTION
### Description
We run Terraform in CI/CD and there appears to be a race condition in VPC creation. While the provider correctly waits up to 2 minutes for the VPC to be created and return an existant resource, the VPC attributes are assumed to return successfully. I regularly see the following output when creating VPCs:
```
Error: reading EC2 VPC (vpc-abc123) Attribute (enableDnsSupport): couldn't find resource
```

Re-attempting the Terraform run fixes the issue, but this is suboptimal. This PR treats the VPC attributes to the same retry logic as the VPC reading.


### Relations

### References


### Output from Acceptance Testing
```
make testacc TESTS=TestAccVPC_ PKG=ec2                     SIGINT(2) ↵  5315  13:46:28 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPC_'  -timeout 180m
=== RUN   TestAccVPC_basic
=== PAUSE TestAccVPC_basic
=== RUN   TestAccVPC_disappears
=== PAUSE TestAccVPC_disappears
=== RUN   TestAccVPC_tags
=== PAUSE TestAccVPC_tags
=== RUN   TestAccVPC_tags_computed
=== PAUSE TestAccVPC_tags_computed
=== RUN   TestAccVPC_tags_null
=== PAUSE TestAccVPC_tags_null
=== RUN   TestAccVPC_DefaultTags_zeroValue
=== PAUSE TestAccVPC_DefaultTags_zeroValue
=== RUN   TestAccVPC_DefaultTags_providerOnlyTestAccVPC_DefaultTags_providerOnly
=== PAUSE TestAccVPC_DefaultTags_providerOnlyTestAccVPC_DefaultTags_providerOnly
=== RUN   TestAccVPC_DefaultTags_updateToProviderOnly
=== PAUSE TestAccVPC_DefaultTags_updateToProviderOnly
=== RUN   TestAccVPC_DefaultTags_updateToResourceOnly
=== PAUSE TestAccVPC_DefaultTags_updateToResourceOnly
=== RUN   TestAccVPC_DefaultTagsProviderAndResource_nonOverlappingTag
=== PAUSE TestAccVPC_DefaultTagsProviderAndResource_nonOverlappingTag
=== RUN   TestAccVPC_DefaultTagsProviderAndResource_overlappingTag
=== PAUSE TestAccVPC_DefaultTagsProviderAndResource_overlappingTag
=== RUN   TestAccVPC_DefaultTagsProviderAndResource_duplicateTag
=== PAUSE TestAccVPC_DefaultTagsProviderAndResource_duplicateTag
=== RUN   TestAccVPC_DefaultTagsProviderAndResource_moveDuplicateTags
=== PAUSE TestAccVPC_DefaultTagsProviderAndResource_moveDuplicateTags
=== RUN   TestAccVPC_DynamicResourceTagsMergedWithLocals_ignoreChanges
=== PAUSE TestAccVPC_DynamicResourceTagsMergedWithLocals_ignoreChanges
=== RUN   TestAccVPC_DynamicResourceTags_ignoreChanges
=== PAUSE TestAccVPC_DynamicResourceTags_ignoreChanges
=== RUN   TestAccVPC_defaultAndIgnoreTags
=== PAUSE TestAccVPC_defaultAndIgnoreTags
=== RUN   TestAccVPC_ignoreTags
=== PAUSE TestAccVPC_ignoreTags
=== RUN   TestAccVPC_tenancy
=== PAUSE TestAccVPC_tenancy
=== RUN   TestAccVPC_updateDNSHostnames
=== PAUSE TestAccVPC_updateDNSHostnames
=== RUN   TestAccVPC_bothDNSOptionsSet
=== PAUSE TestAccVPC_bothDNSOptionsSet
=== RUN   TestAccVPC_disabledDNSSupport
=== PAUSE TestAccVPC_disabledDNSSupport
=== RUN   TestAccVPC_enableNetworkAddressUsageMetrics
=== PAUSE TestAccVPC_enableNetworkAddressUsageMetrics
=== RUN   TestAccVPC_assignGeneratedIPv6CIDRBlock
=== PAUSE TestAccVPC_assignGeneratedIPv6CIDRBlock
=== RUN   TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup
=== PAUSE TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup
=== RUN   TestAccVPC_IPAMIPv4BasicNetmask
=== PAUSE TestAccVPC_IPAMIPv4BasicNetmask
=== RUN   TestAccVPC_IPAMIPv4BasicExplicitCIDR
=== PAUSE TestAccVPC_IPAMIPv4BasicExplicitCIDR
=== RUN   TestAccVPC_IPAMIPv6
=== PAUSE TestAccVPC_IPAMIPv6
=== CONT  TestAccVPC_basic
=== CONT  TestAccVPC_DynamicResourceTags_ignoreChanges
=== CONT  TestAccVPC_IPAMIPv6
=== CONT  TestAccVPC_DefaultTags_updateToProviderOnly
=== CONT  TestAccVPC_updateDNSHostnames
=== CONT  TestAccVPC_IPAMIPv4BasicNetmask
=== CONT  TestAccVPC_IPAMIPv4BasicExplicitCIDR
=== CONT  TestAccVPC_DefaultTags_providerOnlyTestAccVPC_DefaultTags_providerOnly
=== CONT  TestAccVPC_ignoreTags
=== CONT  TestAccVPC_DefaultTagsProviderAndResource_nonOverlappingTag
=== CONT  TestAccVPC_DefaultTagsProviderAndResource_duplicateTag
=== CONT  TestAccVPC_DynamicResourceTagsMergedWithLocals_ignoreChanges
=== CONT  TestAccVPC_DefaultTagsProviderAndResource_moveDuplicateTags
=== CONT  TestAccVPC_defaultAndIgnoreTags
=== CONT  TestAccVPC_disabledDNSSupport
=== CONT  TestAccVPC_tags_computed
=== CONT  TestAccVPC_DefaultTags_zeroValue
=== CONT  TestAccVPC_enableNetworkAddressUsageMetrics
=== CONT  TestAccVPC_DefaultTagsProviderAndResource_overlappingTag
=== CONT  TestAccVPC_tenancy
=== NAME  TestAccVPC_IPAMIPv6
    vpc_test.go:1079: Step 1/1 error: Error running apply: exit status 1
        
        Error: creating IPAM: ResourceLimitExceeded: You've reached the limit for ipams. You have created 3 ipams and you are limited to 1.
        	status code: 400, request id: 82f2130c-d6db-4a04-8fa6-37c8a64629e8
        
          with aws_vpc_ipam.test,
          on terraform_plugin_test.tf line 4, in resource "aws_vpc_ipam" "test":
           4: resource "aws_vpc_ipam" "test" {
        
=== NAME  TestAccVPC_IPAMIPv4BasicNetmask
    vpc_test.go:1023: Step 1/1 error: Error running apply: exit status 1
        
        Error: creating IPAM: ResourceLimitExceeded: You've reached the limit for ipams. You have created 3 ipams and you are limited to 1.
        	status code: 400, request id: d5fdf049-42bc-4a33-b392-981110f14209
        
          with aws_vpc_ipam.test,
          on terraform_plugin_test.tf line 4, in resource "aws_vpc_ipam" "test":
           4: resource "aws_vpc_ipam" "test" {
        
=== NAME  TestAccVPC_IPAMIPv4BasicExplicitCIDR
    vpc_test.go:1051: Step 1/1 error: Error running apply: exit status 1
        
        Error: creating IPAM: ResourceLimitExceeded: You've reached the limit for ipams. You have created 3 ipams and you are limited to 1.
        	status code: 400, request id: ffbd9af2-91ad-43e0-ad13-c6a8ec64634b
        
          with aws_vpc_ipam.test,
          on terraform_plugin_test.tf line 4, in resource "aws_vpc_ipam" "test":
           4: resource "aws_vpc_ipam" "test" {
        
--- FAIL: TestAccVPC_IPAMIPv6 (16.82s)
=== CONT  TestAccVPC_tags_null
--- FAIL: TestAccVPC_IPAMIPv4BasicNetmask (18.55s)
=== CONT  TestAccVPC_bothDNSOptionsSet
--- FAIL: TestAccVPC_IPAMIPv4BasicExplicitCIDR (19.72s)
=== CONT  TestAccVPC_DefaultTags_updateToResourceOnly
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_duplicateTag (38.36s)
=== CONT  TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup
    acctest.go:848: skipping tests; AWS_DEFAULT_REGION (us-east-1) not supported. Supported: [us-west-2]
--- SKIP: TestAccVPC_assignGeneratedIPv6CIDRBlockWithNetworkBorderGroup (0.00s)
=== CONT  TestAccVPC_assignGeneratedIPv6CIDRBlock
--- PASS: TestAccVPC_tags_computed (39.47s)
=== CONT  TestAccVPC_tags
--- PASS: TestAccVPC_basic (46.06s)
=== CONT  TestAccVPC_disappears
--- PASS: TestAccVPC_tags_null (33.99s)
--- PASS: TestAccVPC_enableNetworkAddressUsageMetrics (55.63s)
--- PASS: TestAccVPC_disabledDNSSupport (55.72s)
--- PASS: TestAccVPC_DynamicResourceTags_ignoreChanges (64.24s)
--- PASS: TestAccVPC_DynamicResourceTagsMergedWithLocals_ignoreChanges (65.12s)
--- PASS: TestAccVPC_ignoreTags (67.90s)
--- PASS: TestAccVPC_bothDNSOptionsSet (49.81s)
--- PASS: TestAccVPC_updateDNSHostnames (69.03s)
--- PASS: TestAccVPC_DefaultTags_updateToProviderOnly (69.68s)
--- PASS: TestAccVPC_defaultAndIgnoreTags (70.57s)
--- PASS: TestAccVPC_disappears (25.62s)
--- PASS: TestAccVPC_DefaultTags_updateToResourceOnly (57.92s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_moveDuplicateTags (79.28s)
--- PASS: TestAccVPC_DefaultTags_zeroValue (80.41s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_overlappingTag (82.74s)
--- PASS: TestAccVPC_DefaultTagsProviderAndResource_nonOverlappingTag (83.11s)
--- PASS: TestAccVPC_DefaultTags_providerOnlyTestAccVPC_DefaultTags_providerOnly (84.22s)
--- PASS: TestAccVPC_tenancy (85.15s)
--- PASS: TestAccVPC_tags (58.36s)
--- PASS: TestAccVPC_assignGeneratedIPv6CIDRBlock (82.98s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	121.617s
FAIL
make: *** [testacc] Error 1
```

I will re-edit the above tests once I have time to run in sequence since the maximum IPAMs is 1 per region.
