### PR TITLE
Move `tags` documentation in `aws_sesv2_email_identity`

### DIFF
--- a/website/docs/r/sesv2_email_identity.html.markdown
+++ b/website/docs/r/sesv2_email_identity.html.markdown
@@ -63,6 +63,7 @@ The following arguments are supported:
 * `email_identity` - (Required) The email address or domain to verify.
 * `configuration_set_name` - (Optional) The configuration set to use by default when sending from this identity. Note that any configuration set defined in the email sending request takes precedence.
 * `dkim_signing_attributes` - (Optional) The configuration of the DKIM authentication settings for an email domain identity.
+* `tags` - (Optional) A map of tags to assign to the service. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### dkim_signing_attributes
 
@@ -86,7 +87,6 @@ In addition to all arguments above, the following attributes are exported:
     * `status` - Describes whether or not Amazon SES has successfully located the DKIM records in the DNS records for the domain. See the [AWS SES API v2 Reference](https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_DkimAttributes.html#SES-Type-DkimAttributes-Status) for supported statuses.
     * `tokens` - If you used Easy DKIM to configure DKIM authentication for the domain, then this object contains a set of unique strings that you use to create a set of CNAME records that you add to the DNS configuration for your domain. When Amazon SES detects these records in the DNS configuration for your domain, the DKIM authentication process is complete. If you configured DKIM authentication for the domain by providing your own public-private key pair, then this object contains the selector for the public key.
 * `identity_type` - The email identity type. Valid values: `EMAIL_ADDRESS`, `DOMAIN`.
-* `tags` - (Optional) A map of tags to assign to the service. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `verified_for_sending_status` - Specifies whether or not the identity is verified.
 
 ## Import


### PR DESCRIPTION
### Description

The description for the `tags` argument of `aws_sesv2_email_identity` was previously listed under Attributes, making it less obvious that these could be defined as arguments. This PR moves the `tags` documentation up to Arguments.

### Relations

Closes #30215

### References

N/a

### Output from Acceptance Testing

N/a, docs
