### PR TITLE
[Docs]: d/aws_iam_role: Fix `role_last_used` attribute reference

### DIFF
--- a/website/docs/d/iam_role.html.markdown
+++ b/website/docs/d/iam_role.html.markdown
@@ -41,4 +41,4 @@ data "aws_iam_role" "example" {
 ### role_last_used
 
 * `region` - The name of the AWS Region in which the role was last used.
-* `last_used_time` - The date and time, in RFC 3339 format, that the role was last used.
+* `last_used_date` - The date and time, in RFC 3339 format, that the role was last used.


### PR DESCRIPTION
### Description
Updates the `role_last_used` attribute documentation to match the schema.

https://github.com/hashicorp/terraform-provider-aws/blob/ecb45d645b3b2897504007540e9e480402eeee03/internal/service/iam/role_data_source.go#L55-L70
