### PR TITLE
Add infrastructure to help automate new Projects

### DIFF
--- a/infrastructure/repository/community.tf
+++ b/infrastructure/repository/community.tf
@@ -23,7 +23,7 @@ data "github_team" "aws" {
 resource "github_actions_secret" "maintainers" {
   repository      = "terraform-provider-aws"
   secret_name     = "MAINTAINERS"
-  plaintext_value = base64encode(jsonencode(concat(data.github_team.aws.members,["dependabot[bot]"])))
+  plaintext_value = base64encode(jsonencode(concat(data.github_team.aws.members, ["dependabot[bot]"])))
 }
 
 // Partners

--- a/infrastructure/repository/projects.tf
+++ b/infrastructure/repository/projects.tf
@@ -1,0 +1,43 @@
+// This configuration file sets up Actions variables for use when automating GitHub Projects.
+// Currently, this consists only of the main team project proof of concept, but may be added at a later date.
+
+// Main Team Project
+// -----------------
+
+// Project ID (vars.team_project in workflow files)
+resource "github_actions_variable" "team_project_id" {
+  repository    = "terraform-provider-aws"
+  variable_name = "team_project"
+  value         = "PVT_kwDOAAuecM4AF-7h"
+}
+
+// Project's "Status" field's ID (vars.team_project_field_status in workflow files)
+resource "github_actions_variable" "team_project_field_status_id" {
+  repository    = "terraform-provider-aws"
+  variable_name = "team_project_field_status"
+  value         = "PVTSSF_lADOAAuecM4AF-7hzgDcsQA"
+}
+
+// Project's "Status" field's options IDs (vars.team_project_status_${option_name_snake_case}
+// This set of variables will take the names of each possible value for the "Status" column, convert them to snake case
+// and prefix them with "team_project_status_". E.g. "To Do" becomes "team_project_status_to_do".
+variable "team_project_field_status_values" {
+  type        = map(string)
+  description = "A mapping of the statuses in the main team project to their IDs"
+  default = {
+    "To Do"         = "f75ad846",
+    "In Progress"   = "47fc9ee4",
+    "Waiting"       = "e85f2e5d",
+    "Maintainer PR" = "28a034bc",
+    "Pending Merge" = "043bc06e",
+    "Backlog"       = "ef47b7a3",
+    "Done"          = "98236657"
+  }
+}
+
+resource "github_actions_variable" "team_project_field_status_option_ids" {
+  for_each      = var.team_project_field_status_values
+  repository    = "terraform-provider-aws"
+  variable_name = "team_project_status_${replace(lower(each.key), " ", "_")}"
+  value         = each.value
+}

--- a/infrastructure/repository/projects.tf
+++ b/infrastructure/repository/projects.tf
@@ -1,5 +1,5 @@
 // This configuration file sets up Actions variables for use when automating GitHub Projects.
-// Currently, this consists only of the main team project proof of concept, but may be added at a later date.
+// Currently, this consists only of the main team project proof of concept, but more may be added at a later date.
 
 // Main Team Project
 // -----------------

--- a/infrastructure/repository/projects.tf
+++ b/infrastructure/repository/projects.tf
@@ -1,22 +1,6 @@
 // This configuration file sets up Actions variables for use when automating GitHub Projects.
 // Currently, this consists only of the main team project proof of concept, but more may be added at a later date.
 
-// Main Team Project
-// -----------------
-
-// Project ID (vars.team_project in workflow files)
-resource "github_actions_variable" "team_project_id" {
-  repository    = "terraform-provider-aws"
-  variable_name = "team_project"
-  value         = "PVT_kwDOAAuecM4AF-7h"
-}
-
-// Project's "Status" field's ID (vars.team_project_field_status in workflow files)
-resource "github_actions_variable" "team_project_field_status_id" {
-  repository    = "terraform-provider-aws"
-  variable_name = "team_project_field_status"
-  value         = "PVTSSF_lADOAAuecM4AF-7hzgDcsQA"
-}
 
 // Project's "Status" field's options IDs (vars.team_project_status_${option_name_snake_case}
 // This set of variables will take the names of each possible value for the "Status" column, convert them to snake case


### PR DESCRIPTION
### Description

This PR adds infrastructure to help with automating new GitHub Projects, specifically when using the reusable workflow from the linked PR.

With this PR, variables are added such that workflows can access IDs more easily. For the "Status" field's values, the variables added follow the format of `vars.team_project_status_${option_name_snake_case}`, for example "To Do" is `vars.team_project_status_to_do`.

### Relations

Relates #31880
Before #31883

### References

[`github_actions_variable` resource documentation](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_variable)

### Output from Acceptance Testing
 
N/a, repo infrastructure
