### PR TITLE
fix: Redshift cluster relocation enabled and publicly accessible can both be true

### DIFF
--- a/.changelog/31886.txt
+++ b/.changelog/31886.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_redshift_cluster: allow `availability_zone_relocation_enabled` to be true when `publicly_accessible` is true
+```

--- a/.changelog/31886.txt
+++ b/.changelog/31886.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_redshift_cluster: allow `availability_zone_relocation_enabled` to be true when `publicly_accessible` is true
+resource/aws_redshift_cluster: Allow `availability_zone_relocation_enabled` to be `true` when `publicly_accessible` is `true`
 ```

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -2,7 +2,6 @@ package redshift
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"regexp"
@@ -363,12 +362,6 @@ func ResourceCluster() *schema.Resource {
 
 		CustomizeDiff: customdiff.All(
 			verify.SetTagsDiff,
-			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
-				if diff.Get("availability_zone_relocation_enabled").(bool) && diff.Get("publicly_accessible").(bool) {
-					return errors.New("`availability_zone_relocation_enabled` cannot be true when `publicly_accessible` is true")
-				}
-				return nil
-			},
 			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
 				if diff.Id() == "" {
 					return nil

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -740,6 +740,8 @@ func TestAccRedshiftCluster_availabilityZoneRelocation(t *testing.T) {
 
 func TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible(t *testing.T) {
 	ctx := acctest.Context(t)
+	var v redshift.Cluster
+	resourceName := "aws_redshift_cluster.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -749,8 +751,12 @@ func TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible(t *tes
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccClusterConfig_availabilityZoneRelocationPubliclyAccessible(rName),
-				ExpectError: regexp.MustCompile("`availability_zone_relocation_enabled` cannot be true when `publicly_accessible` is true"),
+				Config: testAccClusterConfig_availabilityZoneRelocationPubliclyAccessible(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "availability_zone_relocation_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "publicly_accessible", "true"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
### Description
Allow `availability_zone_relocation_enabled` to be true when `publicly_accessible` is true.


### Relations
Fixes #31446

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
```
make testacc TESTS=TestAccRedshiftCluster_availabilityZoneRelocation PKG=redshift
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/redshift/... -v -count 1 -parallel 20 -run='TestAccRedshiftCluster_availabilityZoneRelocation'  -timeout 180m
=== RUN   TestAccRedshiftCluster_availabilityZoneRelocation
=== PAUSE TestAccRedshiftCluster_availabilityZoneRelocation
=== RUN   TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible
=== PAUSE TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible
=== CONT  TestAccRedshiftCluster_availabilityZoneRelocation
=== CONT  TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible
--- PASS: TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible (421.86s)
--- PASS: TestAccRedshiftCluster_availabilityZoneRelocation (487.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	492.055s
```
