### PR TITLE
r/aws_quicksight_analysis: Fix assignment of KPI visual field well target values

### DIFF
--- a/.changelog/31901.txt
+++ b/.changelog/31901.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_quicksight_analysis: Fix assignment of KPI visual field well target values
+```

--- a/internal/service/quicksight/schema/visual_kpi.go
+++ b/internal/service/quicksight/schema/visual_kpi.go
@@ -229,7 +229,7 @@ func expandKPIFieldWells(tfList []interface{}) *quicksight.KPIFieldWells {
 		config.TrendGroups = expandDimensionFields(v)
 	}
 	if v, ok := tfMap["target_values"].([]interface{}); ok && len(v) > 0 {
-		config.Values = expandMeasureFields(v)
+		config.TargetValues = expandMeasureFields(v)
 	}
 	if v, ok := tfMap["values"].([]interface{}); ok && len(v) > 0 {
 		config.Values = expandMeasureFields(v)


### PR DESCRIPTION
### Relations

Fixes #31901
Relates To #31542

### Output from Acceptance Testing

```
$ make testacc PKG=quicksight TESTS=TestAccQuickSightAnalysis
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightAnalysis'  -timeout 180m
?   	github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema	[no test files]
=== RUN   TestAccQuickSightAnalysis_basic
=== PAUSE TestAccQuickSightAnalysis_basic
=== RUN   TestAccQuickSightAnalysis_disappears
=== PAUSE TestAccQuickSightAnalysis_disappears
=== RUN   TestAccQuickSightAnalysis_sourceEntity
=== PAUSE TestAccQuickSightAnalysis_sourceEntity
=== RUN   TestAccQuickSightAnalysis_update
=== PAUSE TestAccQuickSightAnalysis_update
=== RUN   TestAccQuickSightAnalysis_parametersConfig
=== PAUSE TestAccQuickSightAnalysis_parametersConfig
=== RUN   TestAccQuickSightAnalysis_forceDelete
=== PAUSE TestAccQuickSightAnalysis_forceDelete
=== CONT  TestAccQuickSightAnalysis_basic
=== CONT  TestAccQuickSightAnalysis_forceDelete
=== CONT  TestAccQuickSightAnalysis_parametersConfig
=== CONT  TestAccQuickSightAnalysis_update
=== CONT  TestAccQuickSightAnalysis_sourceEntity
=== CONT  TestAccQuickSightAnalysis_disappears
--- PASS: TestAccQuickSightAnalysis_forceDelete (66.34s)
--- PASS: TestAccQuickSightAnalysis_disappears (68.08s)
--- PASS: TestAccQuickSightAnalysis_parametersConfig (72.49s)
--- PASS: TestAccQuickSightAnalysis_basic (74.27s)
--- PASS: TestAccQuickSightAnalysis_sourceEntity (81.64s)
--- PASS: TestAccQuickSightAnalysis_update (113.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/quicksight	113.725s

```
