### PR TITLE
Move partner labeler to a distinct job

### DIFF
--- a/.github/workflows/pull_request_feed.yml
+++ b/.github/workflows/pull_request_feed.yml
@@ -71,8 +71,3 @@ jobs:
                 }
               ]
             }
-      - name: Apply Partner Label
-        if: github.event.action == 'opened' && needs.community_check.outputs.partner == 'true'
-        uses: ./.github/workflows/reusable-add-or-remove-labels.yml
-        with:
-          add: partner

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -26,6 +26,14 @@ jobs:
     with:
       add: needs-triage
 
+  PartnerLabeler:
+    needs: community_check
+    name: 'Apply Partner Label'
+    if: github.event.action == 'opened' && needs.community_check.outputs.partner == 'true'
+    uses: ./.github/workflows/reusable-add-or-remove-labels.yml
+    with:
+      add: partner
+
   SizeLabeler:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Description

Reusable workflows can only be used at the job level, not in steps within a job. This PR moves the partner labeler to a distinct job so that it can properly use the reusable flow to add the label.

### References

- [Failed step from a previous job](https://github.com/hashicorp/terraform-provider-aws/actions/runs/5230914202/jobs/9444743245)
- [GitHub Actions documentation](https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations):

> **Reusable workflows are called directly within a job, and not from within a job step.** You cannot, therefore, use GITHUB_ENV to pass values to job steps in the caller workflow.

### Output from Acceptance Testing

N/a, Actions
