### PR TITLE
`r/aws_quicksight_analysis`: Fix schema mapping for string set elements

### DIFF
--- a/.changelog/31903.txt
+++ b/.changelog/31903.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+r/aws_quicksight_analysis: Fix schema mapping for string set elements
+```

--- a/internal/service/quicksight/schema/template_filter.go
+++ b/internal/service/quicksight/schema/template_filter.go
@@ -482,7 +482,7 @@ func filterScopeConfigurationSchema() *schema.Schema {
 											Optional: true,
 											MinItems: 1,
 											MaxItems: 50,
-											Elem:     schema.TypeString,
+											Elem:     &schema.Schema{Type: schema.TypeString},
 										},
 									},
 								},

--- a/internal/service/quicksight/schema/visual_actions.go
+++ b/internal/service/quicksight/schema/visual_actions.go
@@ -74,7 +74,7 @@ func visualCustomActionsSchema(maxItems int) *schema.Schema {
 																	Optional: true,
 																	MinItems: 1,
 																	MaxItems: 30,
-																	Elem:     schema.TypeString,
+																	Elem:     &schema.Schema{Type: schema.TypeString},
 																},
 															},
 														},


### PR DESCRIPTION
### Relations

Fixes #31903

### Output from Acceptance Testing

```
$make testacc PKG=quicksight TESTS=TestAccQuickSightTemplate
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightTemplate'  -timeout 180m
?   	github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema	[no test files]
=== RUN   TestAccQuickSightTemplateAlias_basic
=== PAUSE TestAccQuickSightTemplateAlias_basic
=== RUN   TestAccQuickSightTemplateAlias_disappears
=== PAUSE TestAccQuickSightTemplateAlias_disappears
=== RUN   TestAccQuickSightTemplate_basic
=== PAUSE TestAccQuickSightTemplate_basic
=== RUN   TestAccQuickSightTemplate_disappears
=== PAUSE TestAccQuickSightTemplate_disappears
=== RUN   TestAccQuickSightTemplate_barChart
=== PAUSE TestAccQuickSightTemplate_barChart
=== RUN   TestAccQuickSightTemplate_table
=== PAUSE TestAccQuickSightTemplate_table
=== RUN   TestAccQuickSightTemplate_sourceEntity
=== PAUSE TestAccQuickSightTemplate_sourceEntity
=== RUN   TestAccQuickSightTemplate_tags
=== PAUSE TestAccQuickSightTemplate_tags
=== RUN   TestAccQuickSightTemplate_update
=== PAUSE TestAccQuickSightTemplate_update
=== CONT  TestAccQuickSightTemplateAlias_basic
=== CONT  TestAccQuickSightTemplate_table
=== CONT  TestAccQuickSightTemplate_update
=== CONT  TestAccQuickSightTemplate_barChart
=== CONT  TestAccQuickSightTemplateAlias_disappears
=== CONT  TestAccQuickSightTemplate_basic
=== CONT  TestAccQuickSightTemplate_sourceEntity
=== CONT  TestAccQuickSightTemplate_tags
=== CONT  TestAccQuickSightTemplate_disappears
--- PASS: TestAccQuickSightTemplateAlias_disappears (61.26s)
--- PASS: TestAccQuickSightTemplate_disappears (63.51s)
--- PASS: TestAccQuickSightTemplate_barChart (65.35s)
--- PASS: TestAccQuickSightTemplateAlias_basic (71.16s)
--- PASS: TestAccQuickSightTemplate_sourceEntity (87.52s)
--- PASS: TestAccQuickSightTemplate_basic (88.74s)
--- PASS: TestAccQuickSightTemplate_table (107.91s)
--- PASS: TestAccQuickSightTemplate_update (125.89s)
--- PASS: TestAccQuickSightTemplate_tags (140.36s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/quicksight	140.496s
```
