### PR TITLE
Correct links within `aws_vpc_peering_connection_options` documentation

### DIFF
--- a/website/docs/r/vpc_peering_connection_options.html.markdown
+++ b/website/docs/r/vpc_peering_connection_options.html.markdown
@@ -138,22 +138,14 @@ resource "aws_vpc_peering_connection_options" "accepter" {
 The following arguments are supported:
 
 * `vpc_peering_connection_id` - (Required) The ID of the requester VPC peering connection.
-* `accepter` (Optional) - An optional configuration block that allows for [VPC Peering Connection]
-(https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html) options to be set for the VPC that accepts
-the peering connection (a maximum of one).
-* `requester` (Optional) - A optional configuration block that allows for [VPC Peering Connection]
-(https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html) options to be set for the VPC that requests
-the peering connection (a maximum of one).
+* `accepter` (Optional) - An optional configuration block that allows for [VPC Peering Connection](https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html) options to be set for the VPC that acceptsthe peering connection (a maximum of one).
+* `requester` (Optional) - A optional configuration block that allows for [VPC Peering Connection](https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html) options to be set for the VPC that requeststhe peering connection (a maximum of one).
 
 #### Accepter and Requester Arguments
 
--> **Note:** When enabled, the DNS resolution feature requires that VPCs participating in the peering
-must have support for the DNS hostnames enabled. This can be done using the [`enable_dns_hostnames`]
-(vpc.html#enable_dns_hostnames) attribute in the [`aws_vpc`](vpc.html) resource. See [Using DNS with Your VPC]
-(http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-dns.html) user guide for more information.
+-> **Note:** When enabled, the DNS resolution feature requires that VPCs participating in the peering must have support for the DNS hostnames enabled. This can be done using the [`enable_dns_hostnames`](vpc.html#enable_dns_hostnames) attribute in the [`aws_vpc`](vpc.html) resource. See [Using DNS with Your VPC](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-dns.html) user guide for more information.
 
-* `allow_remote_vpc_dns_resolution` - (Optional) Allow a local VPC to resolve public DNS hostnames to
-private IP addresses when queried from instances in the peer VPC.
+* `allow_remote_vpc_dns_resolution` - (Optional) Allow a local VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the peer VPC.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Description

Due to manual line breaks introducing a space between the `]` and `(`, the links in the `aws_vpc_peering_connection_options` document were incorrectly formatted. This PR corrects that.

### References

These links will obviously not really help once the PR is merged, but for the sake of quickly visualizing the issue:

- [`accepter`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_options#accepter)
- [`requester`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_options#requester)

### Output from Acceptance Testing

N/a, docs
