### PR TITLE
r/aws_glue_data_quality_ruleset - support `target_table` `catalog_id`

### DIFF
--- a/.changelog/31926.txt
+++ b/.changelog/31926.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_glue_data_quality_ruleset: Add `catalog_id` argument to `target_table` block
+```

--- a/internal/service/glue/data_quality_ruleset.go
+++ b/internal/service/glue/data_quality_ruleset.go
@@ -75,13 +75,12 @@ func ResourceDataQualityRuleset() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						// not found in SDK
-						// "catalog_id": {
-						// 	Type:         schema.TypeString,
-						// 	Optional:     true,
-						// 	ForceNew:     true,
-						// 	ValidateFunc: validation.StringLenBetween(1, 255),
-						// },
+						"catalog_id": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringLenBetween(1, 255),
+						},
 						"database_name": {
 							Type:         schema.TypeString,
 							Required:     true,
@@ -223,6 +222,10 @@ func expandTargetTable(tfMap map[string]interface{}) *glue.DataQualityTargetTabl
 		TableName:    aws.String(tfMap["table_name"].(string)),
 	}
 
+	if v, ok := tfMap["catalog_id"].(string); ok && v != "" {
+		apiObject.CatalogId = aws.String(v)
+	}
+
 	return apiObject
 }
 
@@ -234,6 +237,10 @@ func flattenTargetTable(apiObject *glue.DataQualityTargetTable) []interface{} {
 	tfMap := map[string]interface{}{
 		"database_name": aws.StringValue(apiObject.DatabaseName),
 		"table_name":    aws.StringValue(apiObject.TableName),
+	}
+
+	if v := apiObject.CatalogId; v != nil {
+		tfMap["catalog_id"] = aws.StringValue(v)
 	}
 
 	return []interface{}{tfMap}

--- a/internal/service/glue/data_quality_ruleset_test.go
+++ b/internal/service/glue/data_quality_ruleset_test.go
@@ -148,6 +148,7 @@ func TestAccGlueDataQualityRuleset_targetTableRequired(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataQualityRulesetExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "target_table.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "target_table.0.catalog_id", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "target_table.0.database_name", "aws_glue_catalog_database.test", "name"),
 					resource.TestCheckResourceAttrPair(resourceName, "target_table.0.table_name", "aws_glue_catalog_table.test", "name"),
 				),

--- a/internal/service/glue/data_quality_ruleset_test.go
+++ b/internal/service/glue/data_quality_ruleset_test.go
@@ -127,7 +127,7 @@ func TestAccGlueDataQualityRuleset_updateDescription(t *testing.T) {
 	})
 }
 
-func TestAccGlueDataQualityRuleset_targetTable(t *testing.T) {
+func TestAccGlueDataQualityRuleset_targetTableRequired(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -148,6 +148,41 @@ func TestAccGlueDataQualityRuleset_targetTable(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataQualityRulesetExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "target_table.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_table.0.database_name", "aws_glue_catalog_database.test", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_table.0.table_name", "aws_glue_catalog_table.test", "name"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccGlueDataQualityRuleset_targetTableFull(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	ruleset := "Rules = [Completeness \"colA\" between 0.4 and 0.8]"
+	resourceName := "aws_glue_data_quality_ruleset.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, glue.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataQualityRulesetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:  testAccDataQualityRulesetConfig_targetTableFull(rName, rName2, rName3, ruleset),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataQualityRulesetExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "target_table.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_table.0.catalog_id", "aws_glue_catalog_table.test", "catalog_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "target_table.0.database_name", "aws_glue_catalog_database.test", "name"),
 					resource.TestCheckResourceAttrPair(resourceName, "target_table.0.table_name", "aws_glue_catalog_table.test", "name"),
 				),
@@ -335,6 +370,23 @@ resource "aws_glue_data_quality_ruleset" "test" {
   ruleset = %[2]q
 
   target_table {
+    database_name = aws_glue_catalog_database.test.name
+    table_name    = aws_glue_catalog_table.test.name
+  }
+}
+`, rName, ruleset))
+}
+
+func testAccDataQualityRulesetConfig_targetTableFull(rName, rName2, rName3, ruleset string) string {
+	return acctest.ConfigCompose(
+		testAccDataQualityRulesetConfigTargetTableConfigBasic(rName2, rName3),
+		fmt.Sprintf(`
+resource "aws_glue_data_quality_ruleset" "test" {
+  name    = %[1]q
+  ruleset = %[2]q
+
+  target_table {
+    catalog_id    = aws_glue_catalog_table.test.catalog_id
     database_name = aws_glue_catalog_database.test.name
     table_name    = aws_glue_catalog_table.test.name
   }

--- a/website/docs/r/glue_data_quality_ruleset.html.markdown
+++ b/website/docs/r/glue_data_quality_ruleset.html.markdown
@@ -70,6 +70,7 @@ The following arguments are supported:
 
 ### target_table
 
+* `catalog_id` - (Optional, Forces new resource) The catalog id where the AWS Glue table exists.
 * `database_name` - (Required, Forces new resource) Name of the database where the AWS Glue table exists.
 * `table_name` - (Required, Forces new resource) Name of the AWS Glue table.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The AWS GO SDK released support for `catalog_id` in `target_table` [here](https://docs.aws.amazon.com/sdk-for-go/api/service/glue/#DataQualityTargetTable). Feature request: add this optional argument to the resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31925
Relates #31604

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

* [AWS GO SDK - Glue DataQualityTargetTable](https://docs.aws.amazon.com/sdk-for-go/api/service/glue/#DataQualityTargetTable)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccGlueDataQualityRuleset' PKG=glue
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20  -run=TestAccGlueDataQualityRuleset -timeout 180m
=== RUN   TestAccGlueDataQualityRuleset_basic
=== PAUSE TestAccGlueDataQualityRuleset_basic
=== RUN   TestAccGlueDataQualityRuleset_updateRuleset
=== PAUSE TestAccGlueDataQualityRuleset_updateRuleset
=== RUN   TestAccGlueDataQualityRuleset_updateDescription
=== PAUSE TestAccGlueDataQualityRuleset_updateDescription
=== RUN   TestAccGlueDataQualityRuleset_targetTableRequired
=== PAUSE TestAccGlueDataQualityRuleset_targetTableRequired
=== RUN   TestAccGlueDataQualityRuleset_targetTableFull
=== PAUSE TestAccGlueDataQualityRuleset_targetTableFull
=== RUN   TestAccGlueDataQualityRuleset_tags
=== PAUSE TestAccGlueDataQualityRuleset_tags
=== RUN   TestAccGlueDataQualityRuleset_disappears
=== PAUSE TestAccGlueDataQualityRuleset_disappears
=== CONT  TestAccGlueDataQualityRuleset_basic
=== CONT  TestAccGlueDataQualityRuleset_disappears
=== CONT  TestAccGlueDataQualityRuleset_tags
=== CONT  TestAccGlueDataQualityRuleset_targetTableFull
=== CONT  TestAccGlueDataQualityRuleset_targetTableRequired
=== CONT  TestAccGlueDataQualityRuleset_updateDescription
=== CONT  TestAccGlueDataQualityRuleset_updateRuleset
--- PASS: TestAccGlueDataQualityRuleset_disappears (43.30s)
--- PASS: TestAccGlueDataQualityRuleset_basic (57.77s)
--- PASS: TestAccGlueDataQualityRuleset_targetTableRequired (60.02s)
--- PASS: TestAccGlueDataQualityRuleset_targetTableFull (60.06s)
--- PASS: TestAccGlueDataQualityRuleset_updateDescription (81.54s)
--- PASS: TestAccGlueDataQualityRuleset_updateRuleset (83.24s)
--- PASS: TestAccGlueDataQualityRuleset_tags (104.11s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       104.297s

...
```
