### PR TITLE
Add `MaxItems` to `aws_lambda_event_source_mapping.queues`

### DIFF
--- a/.changelog/31931.txt
+++ b/.changelog/31931.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lambda_event_source_mapping: The `queues` argument has changed from a set to a list with a maximum of one element.
+```

--- a/internal/service/lambda/event_source_mapping.go
+++ b/internal/service/lambda/event_source_mapping.go
@@ -235,6 +235,7 @@ func ResourceEventSourceMapping() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
+				MaxItems: 1,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringLenBetween(1, 1000),

--- a/internal/service/lambda/event_source_mapping.go
+++ b/internal/service/lambda/event_source_mapping.go
@@ -232,7 +232,7 @@ func ResourceEventSourceMapping() *schema.Resource {
 				Computed:     true,
 			},
 			"queues": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
 				MaxItems: 1,
@@ -427,8 +427,8 @@ func resourceEventSourceMappingCreate(ctx context.Context, d *schema.ResourceDat
 		input.ParallelizationFactor = aws.Int64(int64(v.(int)))
 	}
 
-	if v, ok := d.GetOk("queues"); ok && v.(*schema.Set).Len() > 0 {
-		input.Queues = flex.ExpandStringSet(v.(*schema.Set))
+	if v, ok := d.GetOk("queues"); ok && len(v.([]interface{})) > 0 {
+		input.Queues = flex.ExpandStringList(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("scaling_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -161,7 +161,7 @@ resource "aws_lambda_event_source_mapping" "example" {
 * `maximum_record_age_in_seconds`: - (Optional) The maximum age of a record that Lambda sends to a function for processing. Only available for stream sources (DynamoDB and Kinesis). Must be either -1 (forever, and the default value) or between 60 and 604800 (inclusive).
 * `maximum_retry_attempts`: - (Optional) The maximum number of times to retry when the function returns an error. Only available for stream sources (DynamoDB and Kinesis). Minimum and default of -1 (forever), maximum of 10000.
 * `parallelization_factor`: - (Optional) The number of batches to process from each shard concurrently. Only available for stream sources (DynamoDB and Kinesis). Minimum and default of 1, maximum of 10.
-* `queues` - (Optional) The name of the Amazon MQ broker destination queue to consume. Only available for MQ sources. A single queue name must be specified.
+* `queues` - (Optional) The name of the Amazon MQ broker destination queue to consume. Only available for MQ sources. The list must contain exactly one queue.
 * `scaling_config` - (Optional) Scaling configuration of the event source. Only available for SQS queues. Detailed below.
 * `self_managed_event_source`: - (Optional) For Self Managed Kafka sources, the location of the self managed cluster. If set, configuration must also include `source_access_configuration`. Detailed below.
 * `self_managed_kafka_event_source_config` - (Optional) Additional configuration block for Self Managed Kafka sources. Incompatible with "event_source_arn" and "amazon_managed_kafka_event_source_config". Detailed below.

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -161,7 +161,7 @@ resource "aws_lambda_event_source_mapping" "example" {
 * `maximum_record_age_in_seconds`: - (Optional) The maximum age of a record that Lambda sends to a function for processing. Only available for stream sources (DynamoDB and Kinesis). Must be either -1 (forever, and the default value) or between 60 and 604800 (inclusive).
 * `maximum_retry_attempts`: - (Optional) The maximum number of times to retry when the function returns an error. Only available for stream sources (DynamoDB and Kinesis). Minimum and default of -1 (forever), maximum of 10000.
 * `parallelization_factor`: - (Optional) The number of batches to process from each shard concurrently. Only available for stream sources (DynamoDB and Kinesis). Minimum and default of 1, maximum of 10.
-* `queues` - (Optional) The name of the Amazon MQ broker destination queue to consume. Only available for MQ sources. The list must contain exactly one queue.
+* `queues` - (Optional) The name of the Amazon MQ broker destination queue to consume. Only available for MQ sources. The list must contain exactly one queue name.
 * `scaling_config` - (Optional) Scaling configuration of the event source. Only available for SQS queues. Detailed below.
 * `self_managed_event_source`: - (Optional) For Self Managed Kafka sources, the location of the self managed cluster. If set, configuration must also include `source_access_configuration`. Detailed below.
 * `self_managed_kafka_event_source_config` - (Optional) Additional configuration block for Self Managed Kafka sources. Incompatible with "event_source_arn" and "amazon_managed_kafka_event_source_config". Detailed below.


### PR DESCRIPTION
### Description

This PR adds `MaxItems: 1` to the `aws_lambda_event_source_mapping.queues` argument, as this argument only accepts a single item. Documentation is also modified to reflect this requirement.

While the AWS Go SDK `lambda.CreateEventSouceMappingInput` type's `Queues` field doesn't specify a limit of one item, the API documentation (linked below) does, and adding additional items leads to errors (see related issue):

> Array Members: Fixed number of 1 item.

### Relations

Closes #31919

### References

- [AWS API `CreateEventSourceMapping` documentation](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateEventSourceMapping.html#API_CreateEventSourceMapping_RequestSyntax)

### Output from Acceptance Testing

```shell
$ make testacc TESTS=TestAccLambdaEventSourceMapping PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaEventSourceMapping'  -timeout 180m
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_basic
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_basic
=== RUN   TestAccLambdaEventSourceMapping_SQS_basic
=== PAUSE TestAccLambdaEventSourceMapping_SQS_basic
=== RUN   TestAccLambdaEventSourceMapping_DynamoDB_basic
=== PAUSE TestAccLambdaEventSourceMapping_DynamoDB_basic
=== RUN   TestAccLambdaEventSourceMapping_DynamoDB_functionResponseTypes
=== PAUSE TestAccLambdaEventSourceMapping_DynamoDB_functionResponseTypes
=== RUN   TestAccLambdaEventSourceMapping_DynamoDB_streamAdded
=== PAUSE TestAccLambdaEventSourceMapping_DynamoDB_streamAdded
=== RUN   TestAccLambdaEventSourceMapping_SQS_batchWindow
=== PAUSE TestAccLambdaEventSourceMapping_SQS_batchWindow
=== RUN   TestAccLambdaEventSourceMapping_disappears
=== PAUSE TestAccLambdaEventSourceMapping_disappears
=== RUN   TestAccLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== PAUSE TestAccLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_batchWindow
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_batchWindow
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_bisectBatch
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_bisectBatch
=== RUN   TestAccLambdaEventSourceMapping_Kinesis_destination
=== PAUSE TestAccLambdaEventSourceMapping_Kinesis_destination
=== RUN   TestAccLambdaEventSourceMapping_msk
=== PAUSE TestAccLambdaEventSourceMapping_msk
=== RUN   TestAccLambdaEventSourceMapping_mskWithEventSourceConfig
=== PAUSE TestAccLambdaEventSourceMapping_mskWithEventSourceConfig
=== RUN   TestAccLambdaEventSourceMapping_selfManagedKafka
=== PAUSE TestAccLambdaEventSourceMapping_selfManagedKafka
=== RUN   TestAccLambdaEventSourceMapping_selfManagedKafkaWithEventSourceConfig
=== PAUSE TestAccLambdaEventSourceMapping_selfManagedKafkaWithEventSourceConfig
=== RUN   TestAccLambdaEventSourceMapping_activeMQ
=== PAUSE TestAccLambdaEventSourceMapping_activeMQ
=== RUN   TestAccLambdaEventSourceMapping_rabbitMQ
=== PAUSE TestAccLambdaEventSourceMapping_rabbitMQ
=== RUN   TestAccLambdaEventSourceMapping_SQS_filterCriteria
=== PAUSE TestAccLambdaEventSourceMapping_SQS_filterCriteria
=== RUN   TestAccLambdaEventSourceMapping_SQS_scalingConfig
=== PAUSE TestAccLambdaEventSourceMapping_SQS_scalingConfig
=== RUN   TestAccLambdaEventSourceMapping_documentDB
=== PAUSE TestAccLambdaEventSourceMapping_documentDB
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_basic
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts
=== CONT  TestAccLambdaEventSourceMapping_selfManagedKafka
=== CONT  TestAccLambdaEventSourceMapping_SQS_changesInEnabledAreDetected
=== CONT  TestAccLambdaEventSourceMapping_DynamoDB_streamAdded
=== CONT  TestAccLambdaEventSourceMapping_documentDB
=== CONT  TestAccLambdaEventSourceMapping_SQS_scalingConfig
=== CONT  TestAccLambdaEventSourceMapping_SQS_filterCriteria
=== CONT  TestAccLambdaEventSourceMapping_activeMQ
=== CONT  TestAccLambdaEventSourceMapping_selfManagedKafkaWithEventSourceConfig
=== CONT  TestAccLambdaEventSourceMapping_disappears
=== CONT  TestAccLambdaEventSourceMapping_SQS_batchWindow
=== CONT  TestAccLambdaEventSourceMapping_DynamoDB_basic
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_batchWindow
=== CONT  TestAccLambdaEventSourceMapping_DynamoDB_functionResponseTypes
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp
=== CONT  TestAccLambdaEventSourceMapping_rabbitMQ
--- PASS: TestAccLambdaEventSourceMapping_SQS_batchWindow (93.44s)
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_batchWindow (94.49s)
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_bisectBatch
--- PASS: TestAccLambdaEventSourceMapping_selfManagedKafka (112.67s)
=== CONT  TestAccLambdaEventSourceMapping_mskWithEventSourceConfig
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_startingPositionTimestamp (124.74s)
=== CONT  TestAccLambdaEventSourceMapping_msk
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsNegativeOne (134.29s)
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_destination
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttempts (135.82s)
=== CONT  TestAccLambdaEventSourceMapping_SQS_basic
--- PASS: TestAccLambdaEventSourceMapping_selfManagedKafkaWithEventSourceConfig (147.12s)
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_parallelizationFactor (152.19s)
=== CONT  TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne
--- PASS: TestAccLambdaEventSourceMapping_DynamoDB_functionResponseTypes (160.23s)
=== NAME  TestAccLambdaEventSourceMapping_documentDB
    event_source_mapping_test.go:1180: Step 1/2 error: Error running apply: exit status 1

        Error: creating DocumentDB cluster: DBClusterParameterGroupNotFound: DBClusterParameterGroup not found: default.docdb4.0
                status code: 404, request id: 4d952800-8a84-456f-8bb9-e9aa9b464df3

          with aws_docdb_cluster.test,
          on terraform_plugin_test.tf line 106, in resource "aws_docdb_cluster" "test":
         106: resource "aws_docdb_cluster" "test" {

--- FAIL: TestAccLambdaEventSourceMapping_documentDB (170.39s)
--- PASS: TestAccLambdaEventSourceMapping_DynamoDB_basic (174.70s)
--- PASS: TestAccLambdaEventSourceMapping_DynamoDB_streamAdded (199.45s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRetryAttemptsZero (199.68s)
--- PASS: TestAccLambdaEventSourceMapping_SQS_changesInEnabledAreDetected (201.15s)
--- PASS: TestAccLambdaEventSourceMapping_disappears (213.54s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_tumblingWindowInSeconds (124.69s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_bisectBatch (130.79s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_basic (230.16s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_destination (108.85s)
--- PASS: TestAccLambdaEventSourceMapping_SQS_scalingConfig (249.61s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSeconds (108.35s)
--- PASS: TestAccLambdaEventSourceMapping_Kinesis_maximumRecordAgeInSecondsNegativeOne (109.72s)
--- PASS: TestAccLambdaEventSourceMapping_SQS_filterCriteria (282.50s)
--- PASS: TestAccLambdaEventSourceMapping_SQS_basic (164.29s)
--- PASS: TestAccLambdaEventSourceMapping_rabbitMQ (924.68s)
--- PASS: TestAccLambdaEventSourceMapping_activeMQ (1253.40s)
--- PASS: TestAccLambdaEventSourceMapping_mskWithEventSourceConfig (3332.59s)
--- PASS: TestAccLambdaEventSourceMapping_msk (3475.20s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/lambda     3603.295s
FAIL
make: *** [testacc] Error 1
```
