### PR TITLE
Update `aws_eks_node_group` documentation, add `update_config` argument

### DIFF
--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -136,7 +136,7 @@ The following arguments are required:
 
 * `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
 * `node_role_arn` – (Required) Amazon Resource Name (ARN) of the IAM Role that provides permissions for the EKS Node Group.
-* `scaling_config` - (Required) Configuration block with scaling settings. See [scaling_config](#scaling_config-configuration-block) below for details.
+* `scaling_config` - (Required) Configuration block with scaling settings. See [`scaling_config`](#scaling_config-configuration-block) below for details.
 * `subnet_ids` – (Required) Identifiers of EC2 Subnets to associate with the EKS Node Group.
 
 The following arguments are optional:
@@ -147,14 +147,14 @@ The following arguments are optional:
 * `force_update_version` - (Optional) Force version update if existing pods are unable to be drained due to a pod disruption budget issue.
 * `instance_types` - (Optional) List of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. Terraform will only perform drift detection if a configuration value is provided.
 * `labels` - (Optional) Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
-* `launch_template` - (Optional) Configuration block with Launch Template settings. See [launch_template](#launch_template-configuration-block) below for details.
+* `launch_template` - (Optional) Configuration block with Launch Template settings. See [`launch_template`](#launch_template-configuration-block) below for details.
 * `node_group_name` – (Optional) Name of the EKS Node Group. If omitted, Terraform will assign a random, unique name. Conflicts with `node_group_name_prefix`. The node group name can't be longer than 63 characters. It must start with a letter or digit, but can also include hyphens and underscores for the remaining characters.
 * `node_group_name_prefix` – (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `node_group_name`.
 * `release_version` – (Optional) AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version.
-* `remote_access` - (Optional) Configuration block with remote access settings. See [remote_access](#remote_access-configuration-block) below for details.
+* `remote_access` - (Optional) Configuration block with remote access settings. See [`remote_access`](#remote_access-configuration-block) below for details.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `taint` - (Optional) The Kubernetes taints to be applied to the nodes in the node group. Maximum of 50 taints per node group. See [taint](#taint-configuration-block) below for details.
-* `update_config` - (Optional) Configuration block with update settings. See [update_config](#update_config-configuration-block) below for details.
+* `update_config` - (Optional) Configuration block with update settings. See [`update_config`](#update_config-configuration-block) below for details.
 * `version` – (Optional) Kubernetes version. Defaults to EKS Cluster Kubernetes version. Terraform will only perform drift detection if a configuration value is provided.
 
 ### launch_template Configuration Block

--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -136,7 +136,7 @@ The following arguments are required:
 
 * `cluster_name` – (Required) Name of the EKS Cluster. Must be between 1-100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (`^[0-9A-Za-z][A-Za-z0-9\-_]+$`).
 * `node_role_arn` – (Required) Amazon Resource Name (ARN) of the IAM Role that provides permissions for the EKS Node Group.
-* `scaling_config` - (Required) Configuration block with scaling settings. Detailed below.
+* `scaling_config` - (Required) Configuration block with scaling settings. See [scaling_config](#scaling_config-configuration-block) below for details.
 * `subnet_ids` – (Required) Identifiers of EC2 Subnets to associate with the EKS Node Group.
 
 The following arguments are optional:
@@ -147,13 +147,14 @@ The following arguments are optional:
 * `force_update_version` - (Optional) Force version update if existing pods are unable to be drained due to a pod disruption budget issue.
 * `instance_types` - (Optional) List of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. Terraform will only perform drift detection if a configuration value is provided.
 * `labels` - (Optional) Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed.
-* `launch_template` - (Optional) Configuration block with Launch Template settings. Detailed below.
+* `launch_template` - (Optional) Configuration block with Launch Template settings. See [launch_template](#launch_template-configuration-block) below for details.
 * `node_group_name` – (Optional) Name of the EKS Node Group. If omitted, Terraform will assign a random, unique name. Conflicts with `node_group_name_prefix`. The node group name can't be longer than 63 characters. It must start with a letter or digit, but can also include hyphens and underscores for the remaining characters.
 * `node_group_name_prefix` – (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `node_group_name`.
 * `release_version` – (Optional) AMI version of the EKS Node Group. Defaults to latest version for Kubernetes version.
-* `remote_access` - (Optional) Configuration block with remote access settings. Detailed below.
+* `remote_access` - (Optional) Configuration block with remote access settings. See [remote_access](#remote_access-configuration-block) below for details.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `taint` - (Optional) The Kubernetes taints to be applied to the nodes in the node group. Maximum of 50 taints per node group. Detailed below.
+* `taint` - (Optional) The Kubernetes taints to be applied to the nodes in the node group. Maximum of 50 taints per node group. See [taint](#taint-configuration-block) below for details.
+* `update_config` - (Optional) Configuration block with update settings. See [update_config](#update_config-configuration-block) below for details.
 * `version` – (Optional) Kubernetes version. Defaults to EKS Cluster Kubernetes version. Terraform will only perform drift detection if a configuration value is provided.
 
 ### launch_template Configuration Block


### PR DESCRIPTION
### Description

This PR updates the `aws_eks_node_group` documentation to take care of two tasks:

1. Add the `update_config` argument, which was missing (though arguments of the block were present)
2. Add links to a few of the configuration block references, rather than having them only mentioned as "Detailed below"

### Relations

Closes #30368

### References

- [AWS API documentation for `CreateNodegroup`](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateNodegroup.html) - reference for the `update_config` argument definition.

### Output from Acceptance Testing

N/a, docs
