### PR TITLE
r/aws_lambda_provisioned_concurrency_config: Use comma-delimited `id`

### DIFF
--- a/.changelog/31933.txt
+++ b/.changelog/31933.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lambda_provisioned_concurrency_config: The `function_name` argument now properly handles ARN values
+```

--- a/internal/service/lambda/provisioned_concurrency_config.go
+++ b/internal/service/lambda/provisioned_concurrency_config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -16,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 )
 
 // @SDKResource("aws_lambda_provisioned_concurrency_config")
@@ -25,12 +25,23 @@ func ResourceProvisionedConcurrencyConfig() *schema.Resource {
 		ReadWithoutTimeout:   resourceProvisionedConcurrencyConfigRead,
 		UpdateWithoutTimeout: resourceProvisionedConcurrencyConfigUpdate,
 		DeleteWithoutTimeout: resourceProvisionedConcurrencyConfigDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(15 * time.Minute),
 			Update: schema.DefaultTimeout(15 * time.Minute),
+		},
+
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceProvisionedConcurrencyConfigV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: provisionedConcurrencyConfigStateUpgradeV0,
+				Version: 0,
+			},
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -60,6 +71,10 @@ func ResourceProvisionedConcurrencyConfig() *schema.Resource {
 	}
 }
 
+const (
+	ProvisionedConcurrencyIDPartCount = 2
+)
+
 func resourceProvisionedConcurrencyConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaConn(ctx)
@@ -75,10 +90,15 @@ func resourceProvisionedConcurrencyConfigCreate(ctx context.Context, d *schema.R
 	_, err := conn.PutProvisionedConcurrencyConfigWithContext(ctx, input)
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "putting Lambda Provisioned Concurrency Config (%s:%s): %s", functionName, qualifier, err)
+		return sdkdiag.AppendErrorf(diags, "putting Lambda Provisioned Concurrency Config (%s,%s): %s", functionName, qualifier, err)
 	}
 
-	d.SetId(fmt.Sprintf("%s:%s", functionName, qualifier))
+	parts := []string{functionName, qualifier}
+	id, err := flex.FlattenResourceId(parts, ProvisionedConcurrencyIDPartCount, false)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting Lambda Provisioned Concurrency Config ID (%s,%s): %s", functionName, qualifier, err)
+	}
+	d.SetId(id)
 
 	if err := waitForProvisionedConcurrencyConfigStatusReady(ctx, conn, functionName, qualifier, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for Lambda Provisioned Concurrency Config (%s) to be ready: %s", d.Id(), err)
@@ -91,11 +111,12 @@ func resourceProvisionedConcurrencyConfigRead(ctx context.Context, d *schema.Res
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaConn(ctx)
 
-	functionName, qualifier, err := ProvisionedConcurrencyConfigParseID(d.Id())
-
+	parts, err := flex.ExpandResourceId(d.Id(), ProvisionedConcurrencyIDPartCount, false)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading Lambda Provisioned Concurrency Config (%s): %s", d.Id(), err)
 	}
+	functionName := parts[0]
+	qualifier := parts[1]
 
 	input := &lambda.GetProvisionedConcurrencyConfigInput{
 		FunctionName: aws.String(functionName),
@@ -125,11 +146,12 @@ func resourceProvisionedConcurrencyConfigUpdate(ctx context.Context, d *schema.R
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaConn(ctx)
 
-	functionName, qualifier, err := ProvisionedConcurrencyConfigParseID(d.Id())
-
+	parts, err := flex.ExpandResourceId(d.Id(), ProvisionedConcurrencyIDPartCount, false)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating Lambda Provisioned Concurrency Config (%s): %s", d.Id(), err)
 	}
+	functionName := parts[0]
+	qualifier := parts[1]
 
 	input := &lambda.PutProvisionedConcurrencyConfigInput{
 		FunctionName:                    aws.String(functionName),
@@ -159,15 +181,14 @@ func resourceProvisionedConcurrencyConfigDelete(ctx context.Context, d *schema.R
 
 	conn := meta.(*conns.AWSClient).LambdaConn(ctx)
 
-	functionName, qualifier, err := ProvisionedConcurrencyConfigParseID(d.Id())
-
+	parts, err := flex.ExpandResourceId(d.Id(), ProvisionedConcurrencyIDPartCount, false)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting Lambda Provisioned Concurrency Config (%s): %s", d.Id(), err)
 	}
 
 	input := &lambda.DeleteProvisionedConcurrencyConfigInput{
-		FunctionName: aws.String(functionName),
-		Qualifier:    aws.String(qualifier),
+		FunctionName: aws.String(parts[0]),
+		Qualifier:    aws.String(parts[1]),
 	}
 
 	_, err = conn.DeleteProvisionedConcurrencyConfigWithContext(ctx, input)
@@ -181,16 +202,6 @@ func resourceProvisionedConcurrencyConfigDelete(ctx context.Context, d *schema.R
 	}
 
 	return diags
-}
-
-func ProvisionedConcurrencyConfigParseID(id string) (string, string, error) {
-	parts := strings.SplitN(id, ":", 2)
-
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("unexpected format of ID (%s), expected FUNCTION_NAME:QUALIFIER", id)
-	}
-
-	return parts[0], parts[1], nil
 }
 
 func refreshProvisionedConcurrencyConfigStatus(ctx context.Context, conn *lambda.Lambda, functionName, qualifier string) retry.StateRefreshFunc {

--- a/internal/service/lambda/provisioned_concurrency_config_migrate.go
+++ b/internal/service/lambda/provisioned_concurrency_config_migrate.go
@@ -1,0 +1,59 @@
+package lambda
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+)
+
+func resourceProvisionedConcurrencyConfigV0() *schema.Resource {
+	// Resource with v0 schema (provider v5.3.0 and below)
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"function_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"provisioned_concurrent_executions": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntAtLeast(1),
+			},
+			"qualifier": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"skip_destroy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func provisionedConcurrencyConfigStateUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	if rawState == nil {
+		rawState = map[string]interface{}{}
+	}
+
+	// Convert id separator from ":" to ","
+	parts := []string{
+		rawState["function_name"].(string),
+		rawState["qualifier"].(string),
+	}
+
+	id, err := flex.FlattenResourceId(parts, ProvisionedConcurrencyIDPartCount, false)
+	if err != nil {
+		return rawState, err
+	}
+	rawState["id"] = id
+
+	return rawState, nil
+}

--- a/website/docs/r/lambda_provisioned_concurrency_config.html.markdown
+++ b/website/docs/r/lambda_provisioned_concurrency_config.html.markdown
@@ -50,7 +50,7 @@ The following arguments are optional:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Lambda Function name and qualifier separated by a colon (`:`).
+* `id` - Lambda Function name and qualifier separated by a comma (`,`).
 
 ## Timeouts
 
@@ -61,8 +61,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Lambda Provisioned Concurrency Configs can be imported using the `function_name` and `qualifier` separated by a colon (`:`), e.g.,
+A Lambda Provisioned Concurrency Configuration can be imported using the `function_name` and `qualifier` separated by a comma (`,`), e.g.,
 
 ```
-$ terraform import aws_lambda_provisioned_concurrency_config.example my_function:production
+$ terraform import aws_lambda_provisioned_concurrency_config.example my_function,production
 ```


### PR DESCRIPTION
### Description
Updates the resource `id` to a comma-separated string, joining `function_name` and `qualifier`. This allows the `function_name` argument to reliably accept ARN values which previously caused Read operations to fail, and migrates this resource to the preferred ID separator.


### Relations
Fixes #11152
Fixes #12923
Fixes #22392
Closes #19868
Closes #11679
Closes #22808
Relates #27843



### Output from Acceptance Testing
```console
$ make testacc PKG=lambda TESTS=TestAccLambdaProvisionedConcurrencyConfig_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaProvisionedConcurrencyConfig_'  -timeout 180m

--- PASS: TestAccLambdaProvisionedConcurrencyConfig_Qualifier_aliasName (190.12s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_Disappears_lambdaProvisionedConcurrency (232.09s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_idMigration530 (243.59s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_Disappears_lambdaFunction (248.04s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_basic (307.14s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_provisionedConcurrentExecutions (310.16s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_skipDestroy (412.08s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_FunctionName_arn (495.91s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     499.303s
```
