### PR TITLE
Correct example on `aws_appflow_flow`

### DIFF
--- a/website/docs/r/appflow_flow.html.markdown
+++ b/website/docs/r/appflow_flow.html.markdown
@@ -14,7 +14,7 @@ Provides an AppFlow flow resource.
 
 ```terraform
 resource "aws_s3_bucket" "example_source" {
-  bucket = "example_source"
+  bucket = "example-source"
 }
 
 data "aws_iam_policy_document" "example_source" {
@@ -51,31 +51,33 @@ resource "aws_s3_object" "example" {
 }
 
 resource "aws_s3_bucket" "example_destination" {
-  bucket = "example_destination"
+  bucket = "example-destination"
 }
 
 data "aws_iam_policy_document" "example_destination" {
-  sid    = "AllowAppFlowDestinationActions"
-  effect = "Allow"
+  statement {
+    sid    = "AllowAppFlowDestinationActions"
+    effect = "Allow"
 
-  principals {
-    type        = "Service"
-    identifiers = ["appflow.amazonaws.com"]
+    principals {
+      type        = "Service"
+      identifiers = ["appflow.amazonaws.com"]
+    }
+
+    actions = [
+      "s3:PutObject",
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts",
+      "s3:ListBucketMultipartUploads",
+      "s3:GetBucketAcl",
+      "s3:PutObjectAcl",
+    ]
+
+    resources = [
+      "arn:aws:s3:::example_destination",
+      "arn:aws:s3:::example_destination/*",
+    ]
   }
-
-  actions = [
-    "s3:PutObject",
-    "s3:AbortMultipartUpload",
-    "s3:ListMultipartUploadParts",
-    "s3:ListBucketMultipartUploads",
-    "s3:GetBucketAcl",
-    "s3:PutObjectAcl",
-  ]
-
-  resources = [
-    "arn:aws:s3:::example_destination",
-    "arn:aws:s3:::example_destination/*",
-  ]
 }
 
 resource "aws_s3_bucket_policy" "example_destination" {


### PR DESCRIPTION
### Description

This PR updates the example within the `aws_appflow_flow` documentation, which had the following issues:

- `aws_s3_bucket.example_source` had a `bucket` argument of `example_source`, while S3 bucket naming conventions do not allow underscores.
- `aws_s3_bucket.example_destination` had a `bucket` argument of `example_destination`, while S3 bucket naming conventions do not allow underscores.
- `aws_iam_policy_document.example_destination` was missing the top-level `statement` block that contains the other arguments.

### Relations

Closes #29878

### References

- [S3 bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)
- [`aws_iam_policy_document` data source reference](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)


### Output from Acceptance Testing

N/a, docs
