### PR TITLE
docs: Quick fix to finspace_kx_cluster documentation

### DIFF
--- a/website/docs/r/finspace_kx_cluster.html.markdown
+++ b/website/docs/r/finspace_kx_cluster.html.markdown
@@ -62,7 +62,7 @@ The following arguments are required:
 * `az_mode` - (Required) The number of availability zones you want to assign per cluster. This can be one of the following:
     * SINGLE - Assigns one availability zone per cluster.
     * MULTI - Assigns all the availability zones per cluster.
-* `capacity_configuration` - (Required) Structure for the metadata of a cluster. Includes information like the CPUs needed, memory of instances, number of instances, and the port used while establishing a connection. See [capacity_configuration](#capacity_configuration).
+* `capacity_configuration` - (Required) Structure for the metadata of a cluster. Includes information like the CPUs needed, memory of instances, and number of instances. See [capacity_configuration](#capacity_configuration).
 * `environment_id` - (Required) Unique identifier for the KX environment.
 * `name` - (Required) Unique name for the cluster that you want to create.
 * `release_label` - (Required) Version of FinSpace Managed kdb to run.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Minor update to finspace_kx_cluster documentation. This resource no longer takes a port as an optional parameter and the parameter was removed from the documentation earlier but hasn't yet been updated in the description for the larger capacity_configuration construct.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/31806

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

AWS user guide documentation for finspace kx cluster: https://docs.aws.amazon.com/finspace/latest/userguide/create-kdb-clusters.html