### PR TITLE
r/aws_lambda_provisioned_concurrency_config: add `skip_waiting` argument

### DIFF
--- a/internal/service/lambda/provisioned_concurrency_config.go
+++ b/internal/service/lambda/provisioned_concurrency_config.go
@@ -67,6 +67,11 @@ func ResourceProvisionedConcurrencyConfig() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"skip_waiting": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -100,8 +105,10 @@ func resourceProvisionedConcurrencyConfigCreate(ctx context.Context, d *schema.R
 	}
 	d.SetId(id)
 
-	if err := waitForProvisionedConcurrencyConfigStatusReady(ctx, conn, functionName, qualifier, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "waiting for Lambda Provisioned Concurrency Config (%s) to be ready: %s", d.Id(), err)
+	if !d.Get("skip_waiting").(bool) {
+		if err := waitForProvisionedConcurrencyConfigStatusReady(ctx, conn, functionName, qualifier, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for Lambda Provisioned Concurrency Config (%s) to be ready: %s", d.Id(), err)
+		}
 	}
 
 	return append(diags, resourceProvisionedConcurrencyConfigRead(ctx, d, meta)...)
@@ -165,8 +172,10 @@ func resourceProvisionedConcurrencyConfigUpdate(ctx context.Context, d *schema.R
 		return sdkdiag.AppendErrorf(diags, "updating Lambda Provisioned Concurrency Config (%s): %s", d.Id(), err)
 	}
 
-	if err := waitForProvisionedConcurrencyConfigStatusReady(ctx, conn, functionName, qualifier, d.Timeout(schema.TimeoutUpdate)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "updating Lambda Provisioned Concurrency Config (%s): waiting for completion: %s", d.Id(), err)
+	if !d.Get("skip_waiting").(bool) {
+		if err := waitForProvisionedConcurrencyConfigStatusReady(ctx, conn, functionName, qualifier, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating Lambda Provisioned Concurrency Config (%s): waiting for completion: %s", d.Id(), err)
+		}
 	}
 
 	return append(diags, resourceProvisionedConcurrencyConfigRead(ctx, d, meta)...)

--- a/website/docs/r/lambda_provisioned_concurrency_config.html.markdown
+++ b/website/docs/r/lambda_provisioned_concurrency_config.html.markdown
@@ -45,6 +45,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `skip_destroy` - (Optional) Whether to retain the provisoned concurrency configuration upon destruction. Defaults to `false`. If set to `true`, the resource in simply removed from state instead.
+* `skip_waiting` - (Optional) Whether to skip waiting for a provisoned concurrency configuration to reach a `READY` status. Defaults to `false`.
 
 ## Attributes Reference
 


### PR DESCRIPTION

### Description
Adds an optional `skip_waiting` argument, allowing apply to return prior to the provisioned concurrency configuration reaching a `READY` status.

**Note:** Subsequent plans will be non-empty until provisioning has completed, as the function/qualifier combination will have a provisioned concurrency count less than what is configured. Due to the potential complexity around these situations, adoption of this feature should be considered carefully.


### Relations
Closes #31981

### Output from Acceptance Testing

```console
$ make testacc PKG=lambda TESTS=TestAccLambdaProvisionedConcurrencyConfig_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaProvisionedConcurrencyConfig_'  -timeout 180m

--- PASS: TestAccLambdaProvisionedConcurrencyConfig_skipWaiting (67.00s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_Qualifier_aliasName (183.67s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_idMigration530 (186.45s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_Disappears_lambdaProvisionedConcurrency (200.04s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_basic (224.71s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_Disappears_lambdaFunction (233.46s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_FunctionName_arn (342.35s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_skipDestroy (358.91s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_provisionedConcurrentExecutions (376.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     379.808s
```
