### PR TITLE
Update cognito_user_pool.markdown

### DIFF
--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -118,7 +118,7 @@ The following arguments are optional:
 ### email_configuration
 
 * `configuration_set` - (Optional) Email configuration set name from SES.
-* `email_sending_account` - (Optional) Email delivery method to use. `COGNITO_DEFAULT` for the default email functionality built into Cognito or `DEVELOPER` to use your Amazon SES configuration.
+* `email_sending_account` - (Optional) Email delivery method to use. `COGNITO_DEFAULT` for the default email functionality built into Cognito or `DEVELOPER` to use your Amazon SES configuration. Required to be `DEVELOPER` if `from_email_address` is set.
 * `from_email_address` - (Optional) Sender’s email address or sender’s display name with their email address (e.g., `john@example.com`, `John Smith <john@example.com>` or `\"John Smith Ph.D.\" <john@example.com>`). Escaped double quotes are required around display names that contain certain characters as specified in [RFC 5322](https://tools.ietf.org/html/rfc5322).
 * `reply_to_email_address` - (Optional) REPLY-TO email address.
 * `source_arn` - (Optional) ARN of the SES verified email identity to use. Required if `email_sending_account` is set to `DEVELOPER`.


### PR DESCRIPTION
Hi Hashicorp!
I spent a lot of yesterday struggling with updating my Cognito userpool email_configuration settings, and I believe that this documentation change will save others the struggle I went through. (In fairness, AWS's documentation on this point is also not great.)

### Description
Adds one line to the `email_provider` documentation block.