### PR TITLE
r/aws_eip: use retry logic when creating new resources

### DIFF
--- a/.changelog/32016.txt
+++ b/.changelog/32016.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_eip: Fix `reading EC2 EIP (eipalloc-abcd1234): couldn't find resource` errors when reading new resource
+```

--- a/internal/service/ec2/ec2_eip.go
+++ b/internal/service/ec2/ec2_eip.go
@@ -205,7 +205,6 @@ func resourceEIPRead(ctx context.Context, d *schema.ResourceData, meta interface
 	res, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
 		return FindEIPByAllocationID(ctx, conn, d.Id())
 	}, d.IsNewResource())
-	address := res.(*ec2.Address)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] EC2 EIP (%s) not found, removing from state", d.Id())
@@ -216,6 +215,8 @@ func resourceEIPRead(ctx context.Context, d *schema.ResourceData, meta interface
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading EC2 EIP (%s): %s", d.Id(), err)
 	}
+
+	address := res.(*ec2.Address)
 
 	d.Set("allocation_id", address.AllocationId)
 	d.Set("association_id", address.AssociationId)


### PR DESCRIPTION
### Description
No retry logic on this resource results in sometimes intermittent errored runs.


### Relations

Closes https://github.com/hashicorp/terraform-provider-aws/issues/29604.

### References



### Output from Acceptance Testing
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2EIP_'  -timeout 180m
=== RUN   TestAccEC2EIP_basic
=== PAUSE TestAccEC2EIP_basic
=== RUN   TestAccEC2EIP_disappears
=== PAUSE TestAccEC2EIP_disappears
=== RUN   TestAccEC2EIP_migrateVPCToDomain
=== PAUSE TestAccEC2EIP_migrateVPCToDomain
=== RUN   TestAccEC2EIP_noVPC
=== PAUSE TestAccEC2EIP_noVPC
=== RUN   TestAccEC2EIP_tags
=== PAUSE TestAccEC2EIP_tags
=== RUN   TestAccEC2EIP_instance
=== PAUSE TestAccEC2EIP_instance
=== RUN   TestAccEC2EIP_Instance_reassociate
=== PAUSE TestAccEC2EIP_Instance_reassociate
=== RUN   TestAccEC2EIP_Instance_associatedUserPrivateIP
=== PAUSE TestAccEC2EIP_Instance_associatedUserPrivateIP
=== RUN   TestAccEC2EIP_Instance_notAssociated
=== PAUSE TestAccEC2EIP_Instance_notAssociated
=== RUN   TestAccEC2EIP_networkInterface
=== PAUSE TestAccEC2EIP_networkInterface
=== RUN   TestAccEC2EIP_NetworkInterface_twoEIPsOneInterface
=== PAUSE TestAccEC2EIP_NetworkInterface_twoEIPsOneInterface
=== RUN   TestAccEC2EIP_association
=== PAUSE TestAccEC2EIP_association
=== RUN   TestAccEC2EIP_PublicIPv4Pool_default
=== PAUSE TestAccEC2EIP_PublicIPv4Pool_default
=== RUN   TestAccEC2EIP_PublicIPv4Pool_custom
    ec2_eip_test.go:470: Environment variable AWS_EC2_EIP_PUBLIC_IPV4_POOL is not set
--- SKIP: TestAccEC2EIP_PublicIPv4Pool_custom (0.00s)
=== RUN   TestAccEC2EIP_customerOwnedIPv4Pool
=== PAUSE TestAccEC2EIP_customerOwnedIPv4Pool
=== RUN   TestAccEC2EIP_networkBorderGroup
=== PAUSE TestAccEC2EIP_networkBorderGroup
=== RUN   TestAccEC2EIP_carrierIP
=== PAUSE TestAccEC2EIP_carrierIP
=== RUN   TestAccEC2EIP_BYOIPAddress_default
=== PAUSE TestAccEC2EIP_BYOIPAddress_default
=== RUN   TestAccEC2EIP_BYOIPAddress_custom
    ec2_eip_test.go:617: Environment variable AWS_EC2_EIP_BYOIP_ADDRESS is not set
--- SKIP: TestAccEC2EIP_BYOIPAddress_custom (0.00s)
=== RUN   TestAccEC2EIP_BYOIPAddress_customWithPublicIPv4Pool
    ec2_eip_test.go:646: Environment variable AWS_EC2_EIP_BYOIP_ADDRESS is not set
--- SKIP: TestAccEC2EIP_BYOIPAddress_customWithPublicIPv4Pool (0.00s)
=== CONT  TestAccEC2EIP_basic
=== CONT  TestAccEC2EIP_networkInterface
=== CONT  TestAccEC2EIP_instance
=== CONT  TestAccEC2EIP_customerOwnedIPv4Pool
=== CONT  TestAccEC2EIP_NetworkInterface_twoEIPsOneInterface
=== CONT  TestAccEC2EIP_noVPC
=== CONT  TestAccEC2EIP_Instance_notAssociated
=== CONT  TestAccEC2EIP_BYOIPAddress_default
=== CONT  TestAccEC2EIP_association
=== CONT  TestAccEC2EIP_PublicIPv4Pool_default
=== CONT  TestAccEC2EIP_Instance_associatedUserPrivateIP
=== CONT  TestAccEC2EIP_Instance_reassociate
=== CONT  TestAccEC2EIP_tags
=== CONT  TestAccEC2EIP_networkBorderGroup
=== CONT  TestAccEC2EIP_migrateVPCToDomain
=== CONT  TestAccEC2EIP_disappears
=== CONT  TestAccEC2EIP_carrierIP
    wavelength_carrier_gateway_test.go:193: skipping since no Wavelength Zones are available
--- SKIP: TestAccEC2EIP_carrierIP (0.30s)
=== NAME  TestAccEC2EIP_customerOwnedIPv4Pool
    acctest.go:1061: skipping since no Outposts found
--- SKIP: TestAccEC2EIP_customerOwnedIPv4Pool (0.39s)
--- PASS: TestAccEC2EIP_disappears (18.87s)
--- PASS: TestAccEC2EIP_BYOIPAddress_default (20.35s)
--- PASS: TestAccEC2EIP_networkBorderGroup (23.00s)
--- PASS: TestAccEC2EIP_PublicIPv4Pool_default (24.00s)
--- PASS: TestAccEC2EIP_noVPC (24.28s)
--- PASS: TestAccEC2EIP_basic (24.29s)
=== NAME  TestAccEC2EIP_Instance_reassociate
    ec2_eip_test.go:219: Step 1/2 error: Check failed: Check 2/2 error: aws_eip.test: Attribute 'instance' expected "i-0eb7bc43fc81d0d83", got ""
--- PASS: TestAccEC2EIP_NetworkInterface_twoEIPsOneInterface (28.19s)
--- PASS: TestAccEC2EIP_migrateVPCToDomain (29.94s)
--- PASS: TestAccEC2EIP_networkInterface (31.86s)
--- PASS: TestAccEC2EIP_tags (43.74s)
--- PASS: TestAccEC2EIP_instance (80.71s)
--- PASS: TestAccEC2EIP_Instance_associatedUserPrivateIP (116.48s)
--- PASS: TestAccEC2EIP_Instance_notAssociated (123.96s)
--- PASS: TestAccEC2EIP_association (127.53s)
=== NAME  TestAccEC2EIP_Instance_reassociate
    testing_new.go:88: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting EC2 Internet Gateway (igw-0e949f2aa8b80f122): detaching EC2 Internet Gateway (igw-0e949f2aa8b80f122) from VPC (vpc-0c0b57b6f7c3b353e): DependencyViolation: Network vpc-0c0b57b6f7c3b353e has some mapped public address(es). Please unmap those public address(es) before detaching the gateway.
        	status code: 400, request id: 1bbdc492-a562-42f2-87c8-eaedd01a507c
        
        
        Error: deleting EC2 EIP (eipalloc-036a42dd1eb120344): InvalidIPAddress.InUse: Address 18.204.85.245 is in use.
        	status code: 400, request id: fb160893-ce69-491c-bb9d-a87572a54340
        
--- FAIL: TestAccEC2EIP_Instance_reassociate (1229.50s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	1229.707s
FAIL
make: *** [testacc] Error 1

```
