### PR TITLE
r/vpc_endpoint: fix private_dns_only_for_inbound_resolver_endpoint

### DIFF
--- a/.changelog/32021.txt
+++ b/.changelog/32021.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpc_endpoint: Fix error creating S3 _Interface_ VPC endpoint
+```

--- a/internal/service/ec2/vpc_endpoint.go
+++ b/internal/service/ec2/vpc_endpoint.go
@@ -492,7 +492,7 @@ func expandDNSOptionsSpecification(tfMap map[string]interface{}) *ec2.DnsOptions
 		apiObject.DnsRecordIpType = aws.String(v)
 	}
 
-	if v, ok := tfMap["private_dns_only_for_inbound_resolver_endpoint"].(bool); ok && v {
+	if v, ok := tfMap["private_dns_only_for_inbound_resolver_endpoint"].(bool); ok {
 		apiObject.PrivateDnsOnlyForInboundResolverEndpoint = aws.Bool(v)
 	}
 

--- a/internal/service/ec2/vpc_endpoint_test.go
+++ b/internal/service/ec2/vpc_endpoint_test.go
@@ -117,14 +117,14 @@ func TestAccVPCEndpoint_interfacePrivateDNS(t *testing.T) {
 		CheckDestroy:             testAccCheckVPCEndpointDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPCEndpointConfig_interfacePrivateDNS(rName, true),
+				Config: testAccVPCEndpointConfig_interfacePrivateDNS(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVPCEndpointExists(ctx, resourceName, &endpoint),
 					acctest.CheckResourceAttrGreaterThanValue(resourceName, "cidr_blocks.#", 0),
 					resource.TestCheckResourceAttr(resourceName, "dns_entry.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "dns_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "dns_options.0.dns_record_ip_type", "ipv4"),
-					resource.TestCheckResourceAttr(resourceName, "dns_options.0.private_dns_only_for_inbound_resolver_endpoint", "true"),
+					resource.TestCheckResourceAttr(resourceName, "dns_options.0.private_dns_only_for_inbound_resolver_endpoint", "false"),
 					resource.TestCheckResourceAttr(resourceName, "private_dns_enabled", "true"),
 				),
 			},
@@ -134,14 +134,14 @@ func TestAccVPCEndpoint_interfacePrivateDNS(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccVPCEndpointConfig_interfacePrivateDNS(rName, false),
+				Config: testAccVPCEndpointConfig_interfacePrivateDNSWithGateway(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVPCEndpointExists(ctx, resourceName, &endpoint),
 					acctest.CheckResourceAttrGreaterThanValue(resourceName, "cidr_blocks.#", 0),
 					resource.TestCheckResourceAttr(resourceName, "dns_entry.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "dns_options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "dns_options.0.dns_record_ip_type", "ipv4"),
-					resource.TestCheckResourceAttr(resourceName, "dns_options.0.private_dns_only_for_inbound_resolver_endpoint", "false"),
+					resource.TestCheckResourceAttr(resourceName, "dns_options.0.private_dns_only_for_inbound_resolver_endpoint", "true"),
 					resource.TestCheckResourceAttr(resourceName, "private_dns_enabled", "true"),
 				),
 			},
@@ -742,7 +742,40 @@ resource "aws_vpc_endpoint" "test" {
 `, rName)
 }
 
-func testAccVPCEndpointConfig_interfacePrivateDNS(rName string, privateDNSOnlyForInboundResolverEndpoint bool) string {
+func testAccVPCEndpointConfig_interfacePrivateDNS(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_region" "current" {}
+
+resource "aws_vpc_endpoint" "test" {
+  vpc_id              = aws_vpc.test.id
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.s3"
+  private_dns_enabled = true
+  vpc_endpoint_type   = "Interface"
+  ip_address_type     = "ipv4"
+
+  dns_options {
+    dns_record_ip_type                             = "ipv4"
+    private_dns_only_for_inbound_resolver_endpoint = false
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName)
+}
+
+func testAccVPCEndpointConfig_interfacePrivateDNSWithGateway(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block           = "10.0.0.0/16"
@@ -759,7 +792,6 @@ data "aws_region" "current" {}
 resource "aws_vpc_endpoint" "gateway" {
   vpc_id       = aws_vpc.test.id
   service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
-
   tags = {
     Name = %[1]q
   }
@@ -774,7 +806,7 @@ resource "aws_vpc_endpoint" "test" {
 
   dns_options {
     dns_record_ip_type                             = "ipv4"
-    private_dns_only_for_inbound_resolver_endpoint = %[2]t
+    private_dns_only_for_inbound_resolver_endpoint = true
   }
 
   tags = {
@@ -784,7 +816,7 @@ resource "aws_vpc_endpoint" "test" {
   # To set PrivateDnsOnlyForInboundResolverEndpoint to true, the VPC vpc-abcd1234 must have a Gateway endpoint for the service.
   depends_on = [aws_vpc_endpoint.gateway]
 }
-`, rName, privateDNSOnlyForInboundResolverEndpoint)
+`, rName)
 }
 
 func testAccVPCEndpointConfig_ipAddressType(rName, addressType string) string {


### PR DESCRIPTION
### Description
This PR is a follow-on from #31873 , which seems to have a defect. In order to create a VPC Endpoint for S3 in Interface mode, the field `private_dns_only_for_inbound_resolver_endpoint` MUST be set to `false`. 

In the previous PR, the value was only sent when `true`, otherwise as `nil`. AWS interprets the `nil` option the same as if it were set to `true`, which is odd.

In any case, it was impossible to set this value to `false`. 

In the case of this value being set to `false`, the test should have no dependency on a VPC Endpoint of GATEWAY type. The test passed in the previous PR because the gateway was created and the value was interpreted as `true`. 

In the case of this value being set to `true`, this test continues to have a dependency on the VPC Endpoint of GATEWAY type.

### Relations

Closes https://github.com/hashicorp/terraform-provider-aws/issues/30041.
Relates #31873.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
make testacc TESTS=TestAccVPCEndpoint_interfacePrivateDNS PKG=ec2  2 ↵  6578  16:12:03 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCEndpoint_interfacePrivateDNS'  -timeout 180m
=== RUN   TestAccVPCEndpoint_interfacePrivateDNS
=== PAUSE TestAccVPCEndpoint_interfacePrivateDNS
=== CONT  TestAccVPCEndpoint_interfacePrivateDNS
--- PASS: TestAccVPCEndpoint_interfacePrivateDNS (449.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	450.003s

...
```
