### PR TITLE
[Enhancement]: add tgw route table in aws_networkmanager_attachment_accepter ✨

### DIFF
--- a/.changelog/32023.txt
+++ b/.changelog/32023.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_networkmanager_attachment_accepter: Added support for Transit Gateway route table attachments
+```

--- a/internal/service/networkmanager/attachment_accepter.go
+++ b/internal/service/networkmanager/attachment_accepter.go
@@ -49,7 +49,7 @@ func ResourceAttachmentAccepter() *schema.Resource {
 					networkmanager.AttachmentTypeSiteToSiteVpn,
 					networkmanager.AttachmentTypeConnect,
 					networkmanager.AttachmentTypeTransitGatewayRouteTable,
-					}, false),
+				}, false),
 			},
 			"core_network_arn": {
 				Type:     schema.TypeString,

--- a/internal/service/networkmanager/attachment_accepter.go
+++ b/internal/service/networkmanager/attachment_accepter.go
@@ -167,7 +167,7 @@ func resourceAttachmentAccepterCreate(ctx context.Context, d *schema.ResourceDat
 			}
 
 		case networkmanager.AttachmentTypeTransitGatewayRouteTable:
-			if _, err := waitTransitGatewayRouteTableAttachmentCreated(ctx, conn, attachmentID, d.Timeout(schema.TimeoutCreate)); err != nil {
+			if _, err := waitTransitGatewayRouteTableAttachmentAvailable(ctx, conn, attachmentID, d.Timeout(schema.TimeoutCreate)); err != nil {
 				return diag.Errorf("waiting for Network Manager Transit Gateway Route Table Attachment (%s) create: %s", attachmentID, err)
 			}
 		}

--- a/internal/service/networkmanager/attachment_accepter.go
+++ b/internal/service/networkmanager/attachment_accepter.go
@@ -41,15 +41,10 @@ func ResourceAttachmentAccepter() *schema.Resource {
 			// querying attachments requires knowing the type ahead of time
 			// therefore type is required in provider, though not on the API
 			"attachment_type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					networkmanager.AttachmentTypeVpc,
-					networkmanager.AttachmentTypeSiteToSiteVpn,
-					networkmanager.AttachmentTypeConnect,
-					networkmanager.AttachmentTypeTransitGatewayRouteTable,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(networkmanager.AttachmentType_Values(), false),
 			},
 			"core_network_arn": {
 				Type:     schema.TypeString,

--- a/internal/service/networkmanager/transit_gateway_peering_test.go
+++ b/internal/service/networkmanager/transit_gateway_peering_test.go
@@ -200,11 +200,15 @@ resource "aws_networkmanager_global_network" "test" {
 
 resource "aws_networkmanager_core_network" "test" {
   global_network_id = aws_networkmanager_global_network.test.id
-  policy_document   = data.aws_networkmanager_core_network_policy_document.test.json
 
   tags = {
     Name = %[1]q
   }
+}
+
+resource "aws_networkmanager_core_network_policy_attachment" "test" {
+  core_network_id = aws_networkmanager_core_network.test.id
+  policy_document = data.aws_networkmanager_core_network_policy_document.test.json
 }
 
 data "aws_networkmanager_core_network_policy_document" "test" {

--- a/internal/service/networkmanager/transit_gateway_route_table_attachment.go
+++ b/internal/service/networkmanager/transit_gateway_route_table_attachment.go
@@ -268,3 +268,20 @@ func waitTransitGatewayRouteTableAttachmentDeleted(ctx context.Context, conn *ne
 
 	return nil, err
 }
+
+func waitTransitGatewayRouteTableAttachmentAvailable(ctx context.Context, conn *networkmanager.NetworkManager, id string, timeout time.Duration) (*networkmanager.TransitGatewayRouteTableAttachment, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{networkmanager.AttachmentStateCreating, networkmanager.AttachmentStatePendingAttachmentAcceptance, networkmanager.AttachmentStatePendingNetworkUpdate},
+		Target:  []string{networkmanager.AttachmentStateAvailable},
+		Timeout: timeout,
+		Refresh: StatusTransitGatewayRouteTableAttachmentState(ctx, conn, id),
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*networkmanager.TransitGatewayRouteTableAttachment); ok {
+		return output, err
+	}
+
+	return nil, err
+}

--- a/internal/service/networkmanager/transit_gateway_route_table_attachment.go
+++ b/internal/service/networkmanager/transit_gateway_route_table_attachment.go
@@ -218,7 +218,7 @@ func FindTransitGatewayRouteTableAttachmentByID(ctx context.Context, conn *netwo
 	return output.TransitGatewayRouteTableAttachment, nil
 }
 
-func StatusTransitGatewayRouteTableAttachmentState(ctx context.Context, conn *networkmanager.NetworkManager, id string) retry.StateRefreshFunc {
+func statusTransitGatewayRouteTableAttachmentState(ctx context.Context, conn *networkmanager.NetworkManager, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindTransitGatewayRouteTableAttachmentByID(ctx, conn, id)
 
@@ -239,7 +239,7 @@ func waitTransitGatewayRouteTableAttachmentCreated(ctx context.Context, conn *ne
 		Pending: []string{networkmanager.AttachmentStateCreating, networkmanager.AttachmentStatePendingNetworkUpdate},
 		Target:  []string{networkmanager.AttachmentStateAvailable, networkmanager.AttachmentStatePendingAttachmentAcceptance},
 		Timeout: timeout,
-		Refresh: StatusTransitGatewayRouteTableAttachmentState(ctx, conn, id),
+		Refresh: statusTransitGatewayRouteTableAttachmentState(ctx, conn, id),
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
@@ -256,7 +256,7 @@ func waitTransitGatewayRouteTableAttachmentDeleted(ctx context.Context, conn *ne
 		Pending:        []string{networkmanager.AttachmentStateDeleting},
 		Target:         []string{},
 		Timeout:        timeout,
-		Refresh:        StatusTransitGatewayRouteTableAttachmentState(ctx, conn, id),
+		Refresh:        statusTransitGatewayRouteTableAttachmentState(ctx, conn, id),
 		NotFoundChecks: 1,
 	}
 
@@ -274,7 +274,7 @@ func waitTransitGatewayRouteTableAttachmentAvailable(ctx context.Context, conn *
 		Pending: []string{networkmanager.AttachmentStateCreating, networkmanager.AttachmentStatePendingAttachmentAcceptance, networkmanager.AttachmentStatePendingNetworkUpdate},
 		Target:  []string{networkmanager.AttachmentStateAvailable},
 		Timeout: timeout,
-		Refresh: StatusTransitGatewayRouteTableAttachmentState(ctx, conn, id),
+		Refresh: statusTransitGatewayRouteTableAttachmentState(ctx, conn, id),
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)

--- a/internal/service/networkmanager/transit_gateway_route_table_attachment_test.go
+++ b/internal/service/networkmanager/transit_gateway_route_table_attachment_test.go
@@ -183,7 +183,7 @@ resource "aws_networkmanager_transit_gateway_peering" "test" {
     Name = %[1]q
   }
 
-  depends_on = [aws_ec2_transit_gateway_policy_table.test]
+  depends_on = [aws_ec2_transit_gateway_policy_table.test, aws_networkmanager_core_network_policy_attachment.test]
 }
 
 resource "aws_ec2_transit_gateway_route_table" "test" {
@@ -209,6 +209,11 @@ resource "aws_networkmanager_transit_gateway_route_table_attachment" "test" {
 
   depends_on = [aws_ec2_transit_gateway_policy_table_association.test]
 }
+
+resource "aws_networkmanager_attachment_accepter" "test" {
+  attachment_id   = aws_networkmanager_transit_gateway_route_table_attachment.test.id
+  attachment_type = aws_networkmanager_transit_gateway_route_table_attachment.test.attachment_type
+}
 `)
 }
 
@@ -223,6 +228,11 @@ resource "aws_networkmanager_transit_gateway_route_table_attachment" "test" {
   }
 
   depends_on = [aws_ec2_transit_gateway_policy_table_association.test]
+}
+
+resource "aws_networkmanager_attachment_accepter" "test" {
+  attachment_id   = aws_networkmanager_transit_gateway_route_table_attachment.test.id
+  attachment_type = aws_networkmanager_transit_gateway_route_table_attachment.test.attachment_type
 }
 `, tagKey1, tagValue1))
 }
@@ -239,6 +249,11 @@ resource "aws_networkmanager_transit_gateway_route_table_attachment" "test" {
   }
 
   depends_on = [aws_ec2_transit_gateway_policy_table_association.test]
+}
+
+resource "aws_networkmanager_attachment_accepter" "test" {
+  attachment_id   = aws_networkmanager_transit_gateway_route_table_attachment.test.id
+  attachment_type = aws_networkmanager_transit_gateway_route_table_attachment.test.attachment_type
 }
 `, tagKey1, tagValue1, tagKey2, tagValue2))
 }

--- a/website/docs/r/networkmanager_attachment_accepter.html.markdown
+++ b/website/docs/r/networkmanager_attachment_accepter.html.markdown
@@ -35,7 +35,7 @@ resource "aws_networkmanager_attachment_accepter" "test" {
 The following arguments are required:
 
 - `attachment_id` - (Required) The ID of the attachment.
-- `attachment_type` - The type of attachment. Valid values can be found in the [AWS Documentation](https://docs.aws.amazon.com/networkmanager/latest/APIReference/API_ListAttachments.html#API_ListAttachments_RequestSyntax)
+- `attachment_type` - (Required) The type of attachment. Valid values can be found in the [AWS Documentation](https://docs.aws.amazon.com/networkmanager/latest/APIReference/API_ListAttachments.html#API_ListAttachments_RequestSyntax)
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Adding the ability to accept Transit Gateway Route Table attachments in the `aws_networkmanager_attachment_accepter` resource. Currently, when trying to accept a Transit Gateway Route Table attachment, the following error is thrown:

`Error: expected attachment_type to be one of [VPC SITE_TO_SITE_VPN CONNECT], got TRANSIT_GATEWAY_ROUTE_TABLE`

### Relations

Closes #26420 (note: I'm closing this issues since this appears to be the only remaining type not supported by the accepter)

### References
https://docs.aws.amazon.com/networkmanager/latest/APIReference/API_ListAttachments.html#API_ListAttachments_RequestSyntax
https://github.com/aws/aws-sdk-go/blob/main/service/networkmanager/api.go#L23525


### Output from Acceptance Testing

**Note to admins/maintainers: I need help with testing this PR.**
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=networkmanager

...
```
