### PR TITLE
r/aws_redshiftserverless_workgroup: Workgroup may be `AVAILABLE` when deletion starts

### DIFF
--- a/.changelog/32067.txt
+++ b/.changelog/32067.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_redshiftserverless_workgroup: Fix `waiting for completion: unexpected state 'AVAILABLE'` errors when deleting resource
+```

--- a/internal/service/redshiftserverless/find.go
+++ b/internal/service/redshiftserverless/find.go
@@ -35,31 +35,6 @@ func FindNamespaceByName(ctx context.Context, conn *redshiftserverless.RedshiftS
 	return output.Namespace, nil
 }
 
-func FindWorkgroupByName(ctx context.Context, conn *redshiftserverless.RedshiftServerless, name string) (*redshiftserverless.Workgroup, error) {
-	input := &redshiftserverless.GetWorkgroupInput{
-		WorkgroupName: aws.String(name),
-	}
-
-	output, err := conn.GetWorkgroupWithContext(ctx, input)
-
-	if tfawserr.ErrCodeEquals(err, redshiftserverless.ErrCodeResourceNotFoundException) {
-		return nil, &retry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
-		}
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	if output == nil {
-		return nil, tfresource.NewEmptyResultError(input)
-	}
-
-	return output.Workgroup, nil
-}
-
 func FindEndpointAccessByName(ctx context.Context, conn *redshiftserverless.RedshiftServerless, name string) (*redshiftserverless.EndpointAccess, error) {
 	input := &redshiftserverless.GetEndpointAccessInput{
 		EndpointName: aws.String(name),

--- a/internal/service/redshiftserverless/status.go
+++ b/internal/service/redshiftserverless/status.go
@@ -25,22 +25,6 @@ func statusNamespace(ctx context.Context, conn *redshiftserverless.RedshiftServe
 	}
 }
 
-func statusWorkgroup(ctx context.Context, conn *redshiftserverless.RedshiftServerless, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		output, err := FindWorkgroupByName(ctx, conn, name)
-
-		if tfresource.NotFound(err) {
-			return nil, "", nil
-		}
-
-		if err != nil {
-			return nil, "", err
-		}
-
-		return output, aws.StringValue(output.Status), nil
-	}
-}
-
 func statusEndpointAccess(ctx context.Context, conn *redshiftserverless.RedshiftServerless, name string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindEndpointAccessByName(ctx, conn, name)

--- a/internal/service/redshiftserverless/wait.go
+++ b/internal/service/redshiftserverless/wait.go
@@ -48,48 +48,6 @@ func waitNamespaceUpdated(ctx context.Context, conn *redshiftserverless.Redshift
 	return nil, err
 }
 
-func waitWorkgroupAvailable(ctx context.Context, conn *redshiftserverless.RedshiftServerless, name string, wait time.Duration) (*redshiftserverless.Workgroup, error) { //nolint:unparam
-	stateConf := &retry.StateChangeConf{
-		Pending: []string{
-			redshiftserverless.WorkgroupStatusCreating,
-			redshiftserverless.WorkgroupStatusModifying,
-		},
-		Target: []string{
-			redshiftserverless.WorkgroupStatusAvailable,
-		},
-		Refresh: statusWorkgroup(ctx, conn, name),
-		Timeout: wait,
-	}
-
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-
-	if output, ok := outputRaw.(*redshiftserverless.Workgroup); ok {
-		return output, err
-	}
-
-	return nil, err
-}
-
-func waitWorkgroupDeleted(ctx context.Context, conn *redshiftserverless.RedshiftServerless, name string, wait time.Duration) (*redshiftserverless.Workgroup, error) {
-	stateConf := &retry.StateChangeConf{
-		Pending: []string{
-			redshiftserverless.WorkgroupStatusModifying,
-			redshiftserverless.WorkgroupStatusDeleting,
-		},
-		Target:  []string{},
-		Refresh: statusWorkgroup(ctx, conn, name),
-		Timeout: wait,
-	}
-
-	outputRaw, err := stateConf.WaitForStateContext(ctx)
-
-	if output, ok := outputRaw.(*redshiftserverless.Workgroup); ok {
-		return output, err
-	}
-
-	return nil, err
-}
-
 func waitEndpointAccessActive(ctx context.Context, conn *redshiftserverless.RedshiftServerless, name string) (*redshiftserverless.EndpointAccess, error) { //nolint:unparam
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{

--- a/internal/service/redshiftserverless/workgroup.go
+++ b/internal/service/redshiftserverless/workgroup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/redshiftserverless"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -391,6 +392,81 @@ func updateWorkgroup(ctx context.Context, conn *redshiftserverless.RedshiftServe
 	}
 
 	return nil
+}
+
+func FindWorkgroupByName(ctx context.Context, conn *redshiftserverless.RedshiftServerless, name string) (*redshiftserverless.Workgroup, error) {
+	input := &redshiftserverless.GetWorkgroupInput{
+		WorkgroupName: aws.String(name),
+	}
+
+	output, err := conn.GetWorkgroupWithContext(ctx, input)
+
+	if tfawserr.ErrCodeEquals(err, redshiftserverless.ErrCodeResourceNotFoundException) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.Workgroup, nil
+}
+
+func statusWorkgroup(ctx context.Context, conn *redshiftserverless.RedshiftServerless, name string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindWorkgroupByName(ctx, conn, name)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, aws.StringValue(output.Status), nil
+	}
+}
+
+func waitWorkgroupAvailable(ctx context.Context, conn *redshiftserverless.RedshiftServerless, name string, wait time.Duration) (*redshiftserverless.Workgroup, error) { //nolint:unparam
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{redshiftserverless.WorkgroupStatusCreating, redshiftserverless.WorkgroupStatusModifying},
+		Target:  []string{redshiftserverless.WorkgroupStatusAvailable},
+		Refresh: statusWorkgroup(ctx, conn, name),
+		Timeout: wait,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*redshiftserverless.Workgroup); ok {
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitWorkgroupDeleted(ctx context.Context, conn *redshiftserverless.RedshiftServerless, name string, wait time.Duration) (*redshiftserverless.Workgroup, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{redshiftserverless.WorkgroupStatusAvailable, redshiftserverless.WorkgroupStatusModifying, redshiftserverless.WorkgroupStatusDeleting},
+		Target:  []string{},
+		Refresh: statusWorkgroup(ctx, conn, name),
+		Timeout: wait,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*redshiftserverless.Workgroup); ok {
+		return output, err
+	}
+
+	return nil, err
 }
 
 func expandConfigParameter(tfMap map[string]interface{}) *redshiftserverless.ConfigParameter {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds `AVAILABLE` as a valid pending state during resource deletion.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/29962.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccRedshiftServerlessWorkgroup_basic' PKG=redshiftserverless
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/redshiftserverless/... -v -count 1 -parallel 20  -run=TestAccRedshiftServerlessWorkgroup_basic -timeout 180m
=== RUN   TestAccRedshiftServerlessWorkgroup_basic
=== PAUSE TestAccRedshiftServerlessWorkgroup_basic
=== CONT  TestAccRedshiftServerlessWorkgroup_basic
--- PASS: TestAccRedshiftServerlessWorkgroup_basic (675.04s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshiftserverless	680.810s
```
