### PR TITLE
Adding support for ChimeSDKVoice Sip Rule

### DIFF
--- a/.changelog/32070.txt
+++ b/.changelog/32070.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_chime_sdk_voice_sip_rule
+```

--- a/.changelog/32070.txt
+++ b/.changelog/32070.txt
@@ -1,3 +1,3 @@
 ```release-note:new-resource
-aws_chime_sdk_voice_sip_rule
+aws_chimesdkvoice_sip_rule
 ```

--- a/internal/service/chimesdkvoice/service_package_gen.go
+++ b/internal/service/chimesdkvoice/service_package_gen.go
@@ -38,6 +38,11 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
+			Factory:  ResourceSipRule,
+			TypeName: "aws_chimesdkvoice_sip_rule",
+			Name:     "Sip Rule",
+		},
+		{
 			Factory:  ResourceVoiceProfileDomain,
 			TypeName: "aws_chimesdkvoice_voice_profile_domain",
 			Name:     "Voice Profile Domain",

--- a/internal/service/chimesdkvoice/sip_media_application_test.go
+++ b/internal/service/chimesdkvoice/sip_media_application_test.go
@@ -189,7 +189,7 @@ func testAccCheckSipMediaApplicationExists(ctx context.Context, name string, vc 
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("no Chime voice connector ID is set")
+			return fmt.Errorf("no ChimeSdkVoice Sip Media Application ID is set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
@@ -210,7 +210,7 @@ func testAccCheckSipMediaApplicationExists(ctx context.Context, name string, vc 
 func testAccCheckSipMediaApplicationDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "aws_chimesdkvoice_chime_sip_media_application" {
+			if rs.Type != "aws_chimesdkvoice_sip_media_application" {
 				continue
 			}
 			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)

--- a/internal/service/chimesdkvoice/sip_rule.go
+++ b/internal/service/chimesdkvoice/sip_rule.go
@@ -1,0 +1,202 @@
+package chimesdkvoice
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"log"
+)
+
+// @SDKResource("aws_chimesdkvoice_sip_rule", name="Sip Rule")
+func ResourceSipRule() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceSipRuleCreate,
+		ReadWithoutTimeout:   resourceSipRuleRead,
+		UpdateWithoutTimeout: resourceSipRuleUpdate,
+		DeleteWithoutTimeout: resourceSipRuleDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"disabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 256),
+			},
+			"target_applications": {
+				Type:     schema.TypeSet,
+				Required: true,
+				MinItems: 1,
+				MaxItems: 25,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"aws_region": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"priority": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntAtLeast(1),
+						},
+						"sip_media_application_id": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(1, 256),
+						},
+					},
+				},
+			},
+			"trigger_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(chimesdkvoice.SipRuleTriggerType_Values(), false),
+			},
+			"trigger_value": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceSipRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+
+	input := &chimesdkvoice.CreateSipRuleInput{
+		Name:               aws.String(d.Get("name").(string)),
+		TriggerType:        aws.String(d.Get("trigger_type").(string)),
+		TriggerValue:       aws.String(d.Get("trigger_value").(string)),
+		TargetApplications: expandSipRuleTargetApplications(d.Get("target_applications").(*schema.Set).List()),
+	}
+
+	if v, ok := d.GetOk("disabled"); ok {
+		input.Disabled = aws.Bool(v.(bool))
+	}
+
+	resp, err := conn.CreateSipRuleWithContext(ctx, input)
+
+	if err != nil || resp.SipRule == nil {
+		return sdkdiag.AppendErrorf(diags, "creating ChimeSKVoice Sip Rule: %s", err)
+	}
+
+	d.SetId(aws.StringValue(resp.SipRule.SipRuleId))
+
+	return append(diags, resourceSipRuleRead(ctx, d, meta)...)
+}
+
+func resourceSipRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+
+	getInput := &chimesdkvoice.GetSipRuleInput{
+		SipRuleId: aws.String(d.Id()),
+	}
+
+	resp, err := conn.GetSipRuleWithContext(ctx, getInput)
+	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
+		log.Printf("[WARN] ChimeSDKVoice Sip Rule %s not found", d.Id())
+		d.SetId("")
+		return diags
+	}
+
+	if err != nil || resp.SipRule == nil {
+		return sdkdiag.AppendErrorf(diags, "getting Sip Rule (%s): %s", d.Id(), err)
+	}
+
+	d.Set("name", resp.SipRule.Name)
+	d.Set("disabled", resp.SipRule.Disabled)
+	d.Set("trigger_type", resp.SipRule.TriggerType)
+	d.Set("trigger_value", resp.SipRule.TriggerValue)
+	d.Set("target_applications", flattenSipRuleTargetApplications(resp.SipRule.TargetApplications))
+	return diags
+}
+
+func resourceSipRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+
+	updateInput := &chimesdkvoice.UpdateSipRuleInput{
+		SipRuleId: aws.String(d.Id()),
+		Name:      aws.String(d.Get("name").(string)),
+	}
+
+	if d.HasChanges("target_applications") {
+		updateInput.TargetApplications = expandSipRuleTargetApplications(d.Get("target_applications").(*schema.Set).List())
+	}
+
+	if d.HasChanges("disabled") {
+		updateInput.Disabled = aws.Bool(d.Get("disabled").(bool))
+	}
+
+	if _, err := conn.UpdateSipRuleWithContext(ctx, updateInput); err != nil {
+		return sdkdiag.AppendErrorf(diags, "updating Sip Rule (%s): %s", d.Id(), err)
+	}
+
+	return append(diags, resourceSipRuleRead(ctx, d, meta)...)
+}
+
+func resourceSipRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+
+	input := &chimesdkvoice.DeleteSipRuleInput{
+		SipRuleId: aws.String(d.Id()),
+	}
+
+	if _, err := conn.DeleteSipRuleWithContext(ctx, input); err != nil {
+		if tfawserr.ErrCodeEquals(err, chimesdkvoice.ErrCodeNotFoundException) {
+			log.Printf("[WARN] ChimeSDKVoice Sip Rule %s not found", d.Id())
+			return diags
+		}
+		return sdkdiag.AppendErrorf(diags, "deleting Sip Rule (%s)", d.Id())
+	}
+
+	return diags
+}
+
+func expandSipRuleTargetApplications(data []interface{}) []*chimesdkvoice.SipRuleTargetApplication {
+	var targetApplications []*chimesdkvoice.SipRuleTargetApplication
+
+	for _, rItem := range data {
+		item := rItem.(map[string]interface{})
+		application := &chimesdkvoice.SipRuleTargetApplication{
+			SipMediaApplicationId: aws.String(item["sip_media_application_id"].(string)),
+			Priority:              aws.Int64(int64(item["priority"].(int))),
+			AwsRegion:             aws.String(item["aws_region"].(string)),
+		}
+
+		targetApplications = append(targetApplications, application)
+	}
+
+	return targetApplications
+}
+
+func flattenSipRuleTargetApplications(apiObject []*chimesdkvoice.SipRuleTargetApplication) []interface{} {
+	var rawSipRuleTargetApplications []interface{}
+
+	for _, e := range apiObject {
+		rawTargetApplication := map[string]interface{}{
+			"sip_media_application_id": aws.StringValue(e.SipMediaApplicationId),
+			"priority":                 aws.Int64Value(e.Priority),
+			"aws_region":               aws.StringValue(e.AwsRegion),
+		}
+
+		rawSipRuleTargetApplications = append(rawSipRuleTargetApplications, rawTargetApplication)
+	}
+	return rawSipRuleTargetApplications
+}

--- a/internal/service/chimesdkvoice/sip_rule.go
+++ b/internal/service/chimesdkvoice/sip_rule.go
@@ -2,6 +2,8 @@ package chimesdkvoice
 
 import (
 	"context"
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
@@ -10,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
-	"log"
 )
 
 // @SDKResource("aws_chimesdkvoice_sip_rule", name="Sip Rule")

--- a/internal/service/chimesdkvoice/sip_rule_test.go
+++ b/internal/service/chimesdkvoice/sip_rule_test.go
@@ -1,0 +1,263 @@
+package chimesdkvoice_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/service/chime"
+	"github.com/aws/aws-sdk-go/service/chimesdkvoice"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfchimesdkvoice "github.com/hashicorp/terraform-provider-aws/internal/service/chimesdkvoice"
+	"testing"
+)
+
+func TestAccChimeSDKVoiceSipRule_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var chimeSipRule *chimesdkvoice.SipRule
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_chimesdkvoice_sip_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSipRuleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSipRuleConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSipRuleExists(ctx, resourceName, chimeSipRule),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "trigger_type", "RequestUriHostname"),
+					resource.TestCheckResourceAttrSet(resourceName, "trigger_value"),
+					resource.TestCheckResourceAttr(resourceName, "target_applications.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "target_applications.0.priority", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "target_applications.0.sip_media_application_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "target_applications.0.aws_region"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccChimeSDKVoiceSipRule_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	var chimeSipRule *chimesdkvoice.SipRule
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_chimesdkvoice_sip_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, chime.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSipRuleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSipRuleConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSipRuleExists(ctx, resourceName, chimeSipRule),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfchimesdkvoice.ResourceSipRule(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccChimeSDKVoiceSipRule_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	var chimeSipRule *chimesdkvoice.SipRule
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameUpdated := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_chimesdkvoice_sip_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, chimesdkvoice.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSipRuleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSipRuleConfig_update(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSipRuleExists(ctx, resourceName, chimeSipRule),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "trigger_type", "RequestUriHostname"),
+					resource.TestCheckResourceAttrSet(resourceName, "trigger_value"),
+					resource.TestCheckResourceAttr(resourceName, "target_applications.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "target_applications.0.priority", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "target_applications.0.sip_media_application_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "target_applications.0.aws_region"),
+				),
+			},
+			{
+				Config: testAccSipRuleConfig_update(rNameUpdated),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSipRuleExists(ctx, resourceName, chimeSipRule),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "disabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSipRuleConfigBase(rName string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %[1]q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_chime_voice_connector" "test" {
+  name               = %[1]q
+  require_encryption = true
+}
+
+resource "aws_lambda_function" "test" {
+  filename         = "test-fixtures/lambdatest.zip"
+  source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
+  function_name    = %[1]q
+  role             = aws_iam_role.test.arn
+  runtime          = "nodejs16.x"
+  handler          = "index.handler"
+}
+
+resource "aws_chimesdkvoice_sip_media_application" "test" {
+  name       = %[1]q
+  aws_region = data.aws_region.current.name
+  endpoints {
+    lambda_arn = aws_lambda_function.test.arn
+  }
+}
+
+`, rName)
+}
+
+func testAccSipRuleConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSipRuleConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_chimesdkvoice_sip_rule" "test" {
+  name = %[1]q
+  disabled = "false"
+  trigger_type = "RequestUriHostname"
+  trigger_value = aws_chime_voice_connector.test.outbound_host_name
+  target_applications {
+	priority = 1
+    sip_media_application_id = aws_chimesdkvoice_sip_media_application.test.id
+	aws_region = data.aws_region.current.name
+  }
+}
+`, rName))
+}
+
+func testAccSipRuleConfig_update(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSipRuleConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_chimesdkvoice_sip_rule" "test" {
+  name = %[1]q
+  disabled = "true"
+  trigger_type = "RequestUriHostname"
+  trigger_value = aws_chime_voice_connector.test.outbound_host_name
+  target_applications {
+	priority = 1
+    sip_media_application_id = aws_chimesdkvoice_sip_media_application.test.id
+	aws_region = data.aws_region.current.name
+  }
+}
+`, rName))
+}
+
+func testAccCheckSipRuleExists(ctx context.Context, name string, sr *chimesdkvoice.SipRule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ChimeSdkVoice Sip Rule ID is set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+		input := &chimesdkvoice.GetSipRuleInput{
+			SipRuleId: aws.String(rs.Primary.ID),
+		}
+		resp, err := conn.GetSipRuleWithContext(ctx, input)
+		if err != nil {
+			return err
+		}
+
+		sr = resp.SipRule
+
+		return nil
+	}
+}
+
+func testAccCheckSipRuleDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_chimesdkvoice_sip_rule" {
+				continue
+			}
+			conn := acctest.Provider.Meta().(*conns.AWSClient).ChimeSDKVoiceConn(ctx)
+			input := &chimesdkvoice.GetSipRuleInput{
+				SipRuleId: aws.String(rs.Primary.ID),
+			}
+			resp, err := conn.GetSipRuleWithContext(ctx, input)
+			if err == nil {
+				if resp.SipRule != nil && aws.StringValue(resp.SipRule.Name) != "" {
+					return fmt.Errorf("error ChimeSdkVoice Sip Rule still exists")
+				}
+			}
+			return nil
+		}
+		return nil
+	}
+}

--- a/internal/service/chimesdkvoice/sip_rule_test.go
+++ b/internal/service/chimesdkvoice/sip_rule_test.go
@@ -3,6 +3,8 @@ package chimesdkvoice_test
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/chime"
@@ -13,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfchimesdkvoice "github.com/hashicorp/terraform-provider-aws/internal/service/chimesdkvoice"
-	"testing"
 )
 
 func TestAccChimeSDKVoiceSipRule_basic(t *testing.T) {

--- a/internal/service/chimesdkvoice/sip_rule_test.go
+++ b/internal/service/chimesdkvoice/sip_rule_test.go
@@ -183,14 +183,14 @@ func testAccSipRuleConfig_basic(rName string) string {
 		testAccSipRuleConfigBase(rName),
 		fmt.Sprintf(`
 resource "aws_chimesdkvoice_sip_rule" "test" {
-  name = %[1]q
-  disabled = "false"
-  trigger_type = "RequestUriHostname"
+  name          = %[1]q
+  disabled      = "false"
+  trigger_type  = "RequestUriHostname"
   trigger_value = aws_chime_voice_connector.test.outbound_host_name
   target_applications {
-	priority = 1
+    priority                 = 1
     sip_media_application_id = aws_chimesdkvoice_sip_media_application.test.id
-	aws_region = data.aws_region.current.name
+    aws_region               = data.aws_region.current.name
   }
 }
 `, rName))
@@ -201,14 +201,14 @@ func testAccSipRuleConfig_update(rName string) string {
 		testAccSipRuleConfigBase(rName),
 		fmt.Sprintf(`
 resource "aws_chimesdkvoice_sip_rule" "test" {
-  name = %[1]q
-  disabled = "true"
-  trigger_type = "RequestUriHostname"
+  name          = %[1]q
+  disabled      = "true"
+  trigger_type  = "RequestUriHostname"
   trigger_value = aws_chime_voice_connector.test.outbound_host_name
   target_applications {
-	priority = 1
+    priority                 = 1
     sip_media_application_id = aws_chimesdkvoice_sip_media_application.test.id
-	aws_region = data.aws_region.current.name
+    aws_region               = data.aws_region.current.name
   }
 }
 `, rName))

--- a/website/docs/r/chimesdkvoice_sip_rule.html.markdown
+++ b/website/docs/r/chimesdkvoice_sip_rule.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Chime SDK Voice"
 layout: "aws"
 page_title: "AWS: aws_chimesdkvoice_sip_rule"
 description: |-
-A SIP rule associates your SIP media application with a phone number or a Request URI hostname. You can associate a SIP rule with more than one SIP media application. Each application then runs only that rule.
+    A SIP rule associates your SIP media application with a phone number or a Request URI hostname. You can associate a SIP rule with more than one SIP media application. Each application then runs only that rule.
 ---
 # Resource: aws_chimesdkvoice_sip_rule
 

--- a/website/docs/r/chimesdkvoice_sip_rule.html.markdown
+++ b/website/docs/r/chimesdkvoice_sip_rule.html.markdown
@@ -31,9 +31,9 @@ resource "aws_chimesdkvoice_sip_rule" "example" {
 The following arguments are required:
 
 * `name` - (Required) The name of the SIP rule.
-* `target_applications` - (Required) List of SIP media applications with priority and AWS Region. Only one SIP application per AWS Region can be used.
-* `trigger_type` - (Required) The type of trigger assigned to the SIP rule in TriggerValue, currently RequestUriHostname or ToPhoneNumber.
-* `trigger_value` - (Required) If TriggerType is RequestUriHostname, the value can be the outbound host name of an Amazon Chime Voice Connector. If TriggerType is ToPhoneNumber, the value can be a customer-owned phone number in the E164 format. The SipMediaApplication specified in the SipRule is triggered if the request URI in an incoming SIP request matches the RequestUriHostname, or if the To header in the incoming SIP request matches the ToPhoneNumber value.
+* `target_applications` - (Required) List of SIP media applications with priority and AWS Region. Only one SIP application per AWS Region can be used. See [`target_applications`](#target_applications).
+* `trigger_type` - (Required) The type of trigger assigned to the SIP rule in `trigger_value`. Valid values are `RequestUriHostname` or `ToPhoneNumber`.
+* `trigger_value` - (Required) If `trigger_type` is `RequestUriHostname`, the value can be the outbound host name of an Amazon Chime Voice Connector. If `trigger_type` is `ToPhoneNumber`, the value can be a customer-owned phone number in the E164 format. The Sip Media Application specified in the Sip Rule is triggered if the request URI in an incoming SIP request matches the `RequestUriHostname`, or if the "To" header in the incoming SIP request matches the `ToPhoneNumber` value.
 
 The following arguments are optional:
 
@@ -43,9 +43,9 @@ The following arguments are optional:
 
 List of SIP media applications with priority and AWS Region. Only one SIP application per AWS Region can be used.
 
-* `AwsRegion` - (Required) The AWS Region of the target application.
-* `Priority` - (Required) Priority of the SIP media application in the target list.
-* `SipMediaApplicationId` - (Required) The SIP media application ID.
+* `aws_region` - (Required) The AWS Region of the target application.
+* `priority` - (Required) Priority of the SIP media application in the target list.
+* `sip_media_application_id` - (Required) The SIP media application ID.
 
 ## Attributes Reference
 

--- a/website/docs/r/chimesdkvoice_sip_rule.html.markdown
+++ b/website/docs/r/chimesdkvoice_sip_rule.html.markdown
@@ -1,0 +1,62 @@
+---
+subcategory: "Chime SDK Voice"
+layout: "aws"
+page_title: "AWS: aws_chimesdkvoice_sip_rule"
+description: |-
+A SIP rule associates your SIP media application with a phone number or a Request URI hostname. You can associate a SIP rule with more than one SIP media application. Each application then runs only that rule.
+---
+# Resource: aws_chimesdkvoice_sip_rule
+
+A SIP rule associates your SIP media application with a phone number or a Request URI hostname. You can associate a SIP rule with more than one SIP media application. Each application then runs only that rule.
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_chimesdkvoice_sip_rule" "example" {
+  name = "example-sip-rule"
+  trigger_type = "RequestUriHostname"
+  trigger_value = aws_chime_voice_connector.example-voice-connector.outbound_host_name
+  target_applications {
+	priority = 1
+	sip_media_application_id = aws_chimesdkvoice_sip_media_application.example-sma.id
+	aws_region = "us-east-1"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) The name of the SIP rule.
+* `target_applications` - (Required) List of SIP media applications with priority and AWS Region. Only one SIP application per AWS Region can be used.
+* `trigger_type` - (Required) The type of trigger assigned to the SIP rule in TriggerValue, currently RequestUriHostname or ToPhoneNumber.
+* `trigger_value` - (Required) If TriggerType is RequestUriHostname, the value can be the outbound host name of an Amazon Chime Voice Connector. If TriggerType is ToPhoneNumber, the value can be a customer-owned phone number in the E164 format. The SipMediaApplication specified in the SipRule is triggered if the request URI in an incoming SIP request matches the RequestUriHostname, or if the To header in the incoming SIP request matches the ToPhoneNumber value.
+
+The following arguments are optional:
+
+* `disabled` - (Optional) Enables or disables a rule. You must disable rules before you can delete them.
+
+### `target_applications`
+
+List of SIP media applications with priority and AWS Region. Only one SIP application per AWS Region can be used.
+
+* `AwsRegion` - (Required) The AWS Region of the target application.
+* `Priority` - (Required) Priority of the SIP media application in the target list.
+* `SipMediaApplicationId` - (Required) The SIP media application ID.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The SIP rule ID.
+
+## Import
+
+A ChimeSDKVoice SIP Rule can be imported using the `id`, e.g.,
+
+```
+$ terraform import aws_chimesdkvoice_sip_rule.example abcdef123456
+```

--- a/website/docs/r/chimesdkvoice_sip_rule.html.markdown
+++ b/website/docs/r/chimesdkvoice_sip_rule.html.markdown
@@ -8,19 +8,20 @@ A SIP rule associates your SIP media application with a phone number or a Reques
 # Resource: aws_chimesdkvoice_sip_rule
 
 A SIP rule associates your SIP media application with a phone number or a Request URI hostname. You can associate a SIP rule with more than one SIP media application. Each application then runs only that rule.
+
 ## Example Usage
 
 ### Basic Usage
 
 ```terraform
 resource "aws_chimesdkvoice_sip_rule" "example" {
-  name = "example-sip-rule"
-  trigger_type = "RequestUriHostname"
+  name          = "example-sip-rule"
+  trigger_type  = "RequestUriHostname"
   trigger_value = aws_chime_voice_connector.example-voice-connector.outbound_host_name
   target_applications {
-	priority = 1
-	sip_media_application_id = aws_chimesdkvoice_sip_media_application.example-sma.id
-	aws_region = "us-east-1"
+    priority                 = 1
+    sip_media_application_id = aws_chimesdkvoice_sip_media_application.example-sma.id
+    aws_region               = "us-east-1"
   }
 }
 ```
@@ -45,7 +46,6 @@ List of SIP media applications with priority and AWS Region. Only one SIP applic
 * `AwsRegion` - (Required) The AWS Region of the target application.
 * `Priority` - (Required) Priority of the SIP media application in the target list.
 * `SipMediaApplicationId` - (Required) The SIP media application ID.
-
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adding support for ChimeSDKVoice Sip Rule

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32069

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/chime-sdk/latest/APIReference/API_voice-chime_CreateSipRule.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$  export AWS_DEFAULT_REGION="us-east-1" && make testacc TESTS=TestAccChimeSDKVoiceSip PKG=chimesdkvoice
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/chimesdkvoice/... -v -count 1 -parallel 20 -run='TestAccChimeSDKVoiceSip'  -timeout 180m
=== RUN   TestAccChimeSDKVoiceSipMediaApplication_basic
=== PAUSE TestAccChimeSDKVoiceSipMediaApplication_basic
=== RUN   TestAccChimeSDKVoiceSipMediaApplication_disappears
=== PAUSE TestAccChimeSDKVoiceSipMediaApplication_disappears
=== RUN   TestAccChimeSDKVoiceSipMediaApplication_update
=== PAUSE TestAccChimeSDKVoiceSipMediaApplication_update
=== RUN   TestAccChimeSDKVoiceSipMediaApplication_tags
=== PAUSE TestAccChimeSDKVoiceSipMediaApplication_tags
=== RUN   TestAccChimeSDKVoiceSipRule_basic
=== PAUSE TestAccChimeSDKVoiceSipRule_basic
=== RUN   TestAccChimeSDKVoiceSipRule_disappears
=== PAUSE TestAccChimeSDKVoiceSipRule_disappears
=== RUN   TestAccChimeSDKVoiceSipRule_update
=== PAUSE TestAccChimeSDKVoiceSipRule_update
=== CONT  TestAccChimeSDKVoiceSipMediaApplication_basic
=== CONT  TestAccChimeSDKVoiceSipRule_basic
=== CONT  TestAccChimeSDKVoiceSipRule_disappears
=== CONT  TestAccChimeSDKVoiceSipMediaApplication_update
=== CONT  TestAccChimeSDKVoiceSipMediaApplication_disappears
=== CONT  TestAccChimeSDKVoiceSipMediaApplication_tags
=== CONT  TestAccChimeSDKVoiceSipRule_update
--- PASS: TestAccChimeSDKVoiceSipMediaApplication_disappears (53.79s)
--- PASS: TestAccChimeSDKVoiceSipMediaApplication_basic (63.77s)
--- PASS: TestAccChimeSDKVoiceSipRule_disappears (78.28s)
--- PASS: TestAccChimeSDKVoiceSipRule_basic (103.95s)
--- PASS: TestAccChimeSDKVoiceSipRule_update (120.53s)
--- PASS: TestAccChimeSDKVoiceSipMediaApplication_tags (128.13s)
--- PASS: TestAccChimeSDKVoiceSipMediaApplication_update (133.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/chimesdkvoice	139.763s

...
```
