### PR TITLE
[Bug]: Fix map arguments with incorrect `Elem` types

### DIFF
--- a/.ci/.semgrep.yml
+++ b/.ci/.semgrep.yml
@@ -67,6 +67,19 @@ rules:
           - pattern: var $VAR = fmt.Sprintf(..., <... acctest.RandomWithPrefix(...) ...>, ...)
     severity: WARNING
 
+  - id: helper-schema-Elem-check-valid-type
+    languages: [go]
+    message: Elem must be either a *schema.Schema or *schema.Resource type
+    paths:
+      include:
+        - internal/service/**/*.go
+      exclude:
+        - internal/service/**/*_data_source.go
+    patterns:
+      - pattern-inside: "Schema: map[string]*schema.Schema{ ... }"
+      - pattern-regex: "Elem:[ ]*schema.Type[a-zA-Z]*,"
+    severity: WARNING
+
   - id: helper-schema-Set-extraneous-NewSet-with-flattenStringList
     languages: [go]
     message: Prefer `flex.FlattenStringSet()` or `flex.FlattenStringValueSet()`

--- a/internal/service/apigateway/stage.go
+++ b/internal/service/apigateway/stage.go
@@ -92,7 +92,7 @@ func ResourceStage() *schema.Resource {
 						},
 						"stage_variable_overrides": {
 							Type:     schema.TypeMap,
-							Elem:     schema.TypeString,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 							Optional: true,
 						},
 						"use_stage_cache": {

--- a/internal/service/emr/cluster.go
+++ b/internal/service/emr/cluster.go
@@ -621,7 +621,7 @@ func instanceFleetConfigSchema() *schema.Resource {
 										Type:     schema.TypeMap,
 										Optional: true,
 										ForceNew: true,
-										Elem:     schema.TypeString,
+										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 								},
 							},

--- a/internal/service/emr/instance_fleet.go
+++ b/internal/service/emr/instance_fleet.go
@@ -79,7 +79,7 @@ func ResourceInstanceFleet() *schema.Resource {
 										Type:     schema.TypeMap,
 										Optional: true,
 										ForceNew: true,
-										Elem:     schema.TypeString,
+										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
 								},
 							},

--- a/internal/service/glue/dev_endpoint.go
+++ b/internal/service/glue/dev_endpoint.go
@@ -43,7 +43,7 @@ func ResourceDevEndpoint() *schema.Resource {
 			"arguments": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"arn": {
 				Type:     schema.TypeString,

--- a/internal/service/glue/workflow.go
+++ b/internal/service/glue/workflow.go
@@ -42,7 +42,7 @@ func ResourceWorkflow() *schema.Resource {
 			"default_run_properties": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     schema.TypeString,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"description": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
### Description
The `Elem` field must be a `*Schema` type for `TypeMap` arguments. Fixes various cases where `Elem` was incorrectly set directly to `TypeString`.

```console
$ rg "Elem:[ ]*schema.Type"
internal/service/apigateway/stage.go
95:                                                     Elem:     schema.TypeString,

internal/service/emr/instance_fleet.go
82:                                                                             Elem:     schema.TypeString,

internal/service/emr/cluster.go
624:                                                                            Elem:     schema.TypeString,

internal/service/glue/workflow.go
45:                             Elem:     schema.TypeString,

internal/service/glue/dev_endpoint.go
46:                             Elem:     schema.TypeString,
```

### Relations
No bug reports found for these arguments, I suspect because they are not frequently used.

### References
- https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-types#typemap
- https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2@v2.26.1/helper/schema#Schema.Elem


### Output from Acceptance Testing


