### PR TITLE
docs: Correct documentation for EKS add-on supported values

### DIFF
--- a/website/docs/r/eks_addon.html.markdown
+++ b/website/docs/r/eks_addon.html.markdown
@@ -10,11 +10,6 @@ description: |-
 
 Manages an EKS add-on.
 
-~> **Note:** Amazon EKS add-on can only be used with Amazon EKS Clusters
-running version 1.18 with platform version eks.3 or later
-because add-ons rely on the Server-side Apply Kubernetes feature,
-which is only available in Kubernetes 1.18 and later.
-
 ## Example Usage
 
 ```terraform
@@ -32,7 +27,7 @@ resource "aws_eks_addon" "example" {
 resource "aws_eks_addon" "example" {
   cluster_name                = aws_eks_cluster.example.name
   addon_name                  = "coredns"
-  addon_version               = "v1.8.7-eksbuild.3" #e.g., previous version v1.8.7-eksbuild.2 and the new version is v1.8.7-eksbuild.3
+  addon_version               = "v1.10.1-eksbuild.1" #e.g., previous version v1.9.3-eksbuild.3 and the new version is v1.10.1-eksbuild.1
   resolve_conflicts_on_update = "PRESERVE"
 }
 ```
@@ -49,7 +44,7 @@ This below is an example for extracting the `configuration_values` schema for `c
 ```bash
  aws eks describe-addon-configuration \
  --addon-name coredns \
- --addon-version v1.8.7-eksbuild.2
+ --addon-version v1.10.1-eksbuild.1
 ```
 
 Example to create a `coredns` managed addon with custom `configuration_values`.
@@ -58,7 +53,7 @@ Example to create a `coredns` managed addon with custom `configuration_values`.
 resource "aws_eks_addon" "example" {
   cluster_name                = "mycluster"
   addon_name                  = "coredns"
-  addon_version               = "v1.8.7-eksbuild.3"
+  addon_version               = "v1.10.1-eksbuild.1"
   resolve_conflicts_on_create = "OVERWRITE"
 
   configuration_values = jsonencode({
@@ -137,7 +132,7 @@ The following arguments are optional:
   match one of the versions returned by [describe-addon-versions](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html).
 * `configuration_values` - (Optional) custom configuration values for addons with single JSON string. This JSON string value must match the JSON schema derived from [describe-addon-configuration](https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-configuration.html).
 * `resolve_conflicts_on_create` - (Optional) How to resolve field value conflicts when migrating a self-managed add-on to an Amazon EKS add-on. Valid values are `NONE` and `OVERWRITE`. For more details see the [CreateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_CreateAddon.html) API Docs.
-* `resolve_conflicts_on_update` - (Optional) How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value. Valid values are `NONE` and `OVERWRITE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
+* `resolve_conflicts_on_update` - (Optional) How to resolve field value conflicts for an Amazon EKS add-on if you've changed a value from the Amazon EKS default value. Valid values are `NONE`, `OVERWRITE`, and `PRESERVE`. For more details see the [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
 * `resolve_conflicts` - (**Deprecated** use the `resolve_conflicts_on_create` and `resolve_conflicts_on_update` attributes instead) Define how to resolve parameter value conflicts when migrating an existing add-on to an Amazon EKS add-on or when applying version updates to the add-on. Valid values are `NONE`, `OVERWRITE` and `PRESERVE`. Note that `PRESERVE` is only valid on addon update, not for initial addon creation. If you need to set this to `PRESERVE`, use the `resolve_conflicts_on_create` and `resolve_conflicts_on_update` attributes instead. For more details check [UpdateAddon](https://docs.aws.amazon.com/eks/latest/APIReference/API_UpdateAddon.html) API Docs.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `preserve` - (Optional) Indicates if you want to preserve the created resources when deleting the EKS add-on.
@@ -147,7 +142,7 @@ The following arguments are optional:
   an existing IAM role, then the add-on uses the permissions assigned to the node
   IAM role. For more information, see [Amazon EKS node IAM role](https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html)
   in the Amazon EKS User Guide.
-  
+
   ~> **Note:** To specify an existing IAM role, you must have an IAM OpenID Connect (OIDC)
   provider created for your cluster. For more information, [see Enabling IAM roles
   for service accounts on your cluster](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

### Relations

Closes None

### References

- Adds missing `PRESERVE` value to list of acceptable values for `resolve_conflicts_on_update` argument 
- Removes note regarding 1.18 clusters - no longer relevant since [minimum supported version in EKS is currently 1.23](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar)
- Updates version of CoreDNS addon used to reflect more current version as well as the example of upgrading addons to newer versions https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
