### PR TITLE
Deprecate "legacy" behaviour when parsing nullable Bool values

### DIFF
--- a/internal/experimental/nullable/bool.go
+++ b/internal/experimental/nullable/bool.go
@@ -48,6 +48,11 @@ func ValidateTypeStringNullableBool(v interface{}, k string) (ws []string, es []
 
 	if _, err := strconv.ParseBool(value); err != nil {
 		es = append(es, fmt.Errorf("%s: cannot parse '%s' as boolean: %w", k, value, err))
+		return
+	}
+
+	if value != "true" && value != "false" {
+		ws = append(ws, fmt.Sprintf(`%s: the use of values other than "true" and "false" is deprecated and will be removed in a future version of the provider`, k))
 	}
 
 	return

--- a/internal/experimental/nullable/bool_test.go
+++ b/internal/experimental/nullable/bool_test.go
@@ -83,8 +83,9 @@ func TestValidationBool(t *testing.T) {
 			f:   ValidateTypeStringNullableBool,
 		},
 		{
-			val: "1",
-			f:   ValidateTypeStringNullableBool,
+			val:             "1",
+			f:               ValidateTypeStringNullableBool,
+			expectedWarning: regexp.MustCompile(`^\w+: the use of values other than "true" and "false" is deprecated and will be removed in a future version of the provider$`),
 		},
 		{
 			val:         "A",

--- a/internal/experimental/nullable/bool_test.go
+++ b/internal/experimental/nullable/bool_test.go
@@ -90,12 +90,12 @@ func TestValidationBool(t *testing.T) {
 		{
 			val:         "A",
 			f:           ValidateTypeStringNullableBool,
-			expectedErr: regexp.MustCompile(`[\w]+: cannot parse 'A' as boolean`),
+			expectedErr: regexp.MustCompile(`^\w+: cannot parse 'A' as boolean: .+$`),
 		},
 		{
 			val:         1,
 			f:           ValidateTypeStringNullableBool,
-			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be string`),
+			expectedErr: regexp.MustCompile(`^expected type of \w+ to be string$`),
 		},
 	})
 }

--- a/internal/experimental/nullable/float_test.go
+++ b/internal/experimental/nullable/float_test.go
@@ -88,12 +88,12 @@ func TestValidationFloat(t *testing.T) {
 		{
 			val:         "A",
 			f:           ValidateTypeStringNullableFloat,
-			expectedErr: regexp.MustCompile(`[\w]+: cannot parse 'A' as float: .*`),
+			expectedErr: regexp.MustCompile(`^\w+: cannot parse 'A' as float: .+$`),
 		},
 		{
 			val:         1,
 			f:           ValidateTypeStringNullableFloat,
-			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be string`),
+			expectedErr: regexp.MustCompile(`^expected type of \w+ to be string$`),
 		},
 	})
 }

--- a/internal/experimental/nullable/int_test.go
+++ b/internal/experimental/nullable/int_test.go
@@ -70,12 +70,12 @@ func TestValidationInt(t *testing.T) {
 		{
 			val:         "A",
 			f:           ValidateTypeStringNullableInt,
-			expectedErr: regexp.MustCompile(`[\w]+: cannot parse 'A' as int: .*`),
+			expectedErr: regexp.MustCompile(`^\w+: cannot parse 'A' as int: .*`),
 		},
 		{
 			val:         1,
 			f:           ValidateTypeStringNullableInt,
-			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be string`),
+			expectedErr: regexp.MustCompile(`^expected type of \w+ to be string`),
 		},
 	})
 }
@@ -95,12 +95,12 @@ func TestValidationIntAtLeast(t *testing.T) {
 		{
 			val:         "1",
 			f:           ValidateTypeStringNullableIntAtLeast(2),
-			expectedErr: regexp.MustCompile(`expected [\w]+ to be at least \(2\), got 1`),
+			expectedErr: regexp.MustCompile(`expected \w+ to be at least \(2\), got 1`),
 		},
 		{
 			val:         1,
 			f:           ValidateTypeStringNullableIntAtLeast(2),
-			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be string`),
+			expectedErr: regexp.MustCompile(`expected type of \w+ to be string`),
 		},
 	})
 }

--- a/internal/experimental/nullable/testing.go
+++ b/internal/experimental/nullable/testing.go
@@ -8,9 +8,10 @@ import (
 )
 
 type testCase struct {
-	val         interface{}
-	f           schema.SchemaValidateFunc
-	expectedErr *regexp.Regexp
+	val             interface{}
+	f               schema.SchemaValidateFunc
+	expectedErr     *regexp.Regexp
+	expectedWarning *regexp.Regexp
 }
 
 func runValidationTestCases(t *testing.T, cases []testCase) {
@@ -27,19 +28,32 @@ func runValidationTestCases(t *testing.T, cases []testCase) {
 		return false
 	}
 
+	matchWarning := func(warnings []string, r *regexp.Regexp) bool {
+		// warning must match one provided
+		for _, warning := range warnings {
+			if r.MatchString(warning) {
+				return true
+			}
+		}
+
+		return false
+	}
+
 	for i, tc := range cases {
-		_, errs := tc.f(tc.val, "test_property")
+		warnings, errs := tc.f(tc.val, "test_property")
 
-		if len(errs) == 0 && tc.expectedErr == nil {
-			continue
+		if tc.expectedErr == nil && len(errs) != 0 {
+			t.Errorf("expected test case %d to produce no errors, got %v", i, errs)
+		}
+		if tc.expectedErr != nil && !matchErr(errs, tc.expectedErr) {
+			t.Errorf("expected test case %d to produce error matching \"%s\", got %v", i, tc.expectedErr, errs)
 		}
 
-		if len(errs) != 0 && tc.expectedErr == nil {
-			t.Fatalf("expected test case %d to produce no errors, got %v", i, errs)
+		if tc.expectedWarning == nil && len(warnings) != 0 {
+			t.Errorf("expected test case %d to produce no warnings, got %v", i, warnings)
 		}
-
-		if !matchErr(errs, tc.expectedErr) {
-			t.Fatalf("expected test case %d to produce error matching \"%s\", got %v", i, tc.expectedErr, errs)
+		if tc.expectedWarning != nil && !matchWarning(warnings, tc.expectedWarning) {
+			t.Errorf("expected test case %d to produce warning matching \"%s\", got %v", i, tc.expectedWarning, warnings)
 		}
 	}
 }


### PR DESCRIPTION
### Description

The parsing rules for `TypeNullableBool` currently allow `0` and `1` as valid values, matching behaviour of very old versions of Terraform. This PR deprecates this behaviour and return a warning in the validation function.

Note: The ideal solution is to update the resources to use `terraform-plugin-framework` instead of `terraform-plugin-sdk/v2`. `terraform-plugin-framework` allows typed nullable values.

The parsing behaviour will be removed by #29379.

### Relations

Closes #29378

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ go test ./internal/experimental/nullable/... -v

--- PASS: TestNullableBool (0.00s)
--- PASS: TestNullableFloat (0.00s)
--- PASS: TestDiffSuppressBoolFalseAsNull (0.00s)
--- PASS: TestDiffSuppressBool (0.00s)
--- PASS: TestValidationBool (0.00s)
--- PASS: TestValidationFloat (0.00s)
--- PASS: TestNullableInt (0.00s)
--- PASS: TestValidationInt (0.00s)
--- PASS: TestValidationIntAtLeast (0.00s)
```
