### PR TITLE
Add EventBridge example to S3 Bucket Notification docs

### DIFF
--- a/website/docs/r/s3_bucket_notification.html.markdown
+++ b/website/docs/r/s3_bucket_notification.html.markdown
@@ -305,6 +305,19 @@ For Terraform's [JSON syntax](https://www.terraform.io/docs/configuration/syntax
 }
 ```
 
+### Emit events to EventBridge
+
+```terraform
+resource "aws_s3_bucket" "bucket" {
+  bucket = "your-bucket-name"
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  bucket      = aws_s3_bucket.bucket.id
+  eventbridge = true
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -313,7 +326,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `eventbridge` - (Optional) Whether to enable Amazon EventBridge notifications.
+* `eventbridge` - (Optional) Whether to enable Amazon EventBridge notifications. Defaults to `false`.
 * `lambda_function` - (Optional, Multiple) Used to configure notifications to a Lambda Function. See below.
 * `queue` - (Optional) Notification configuration to SQS Queue. See below.
 * `topic` - (Optional) Notification configuration to SNS Topic. See below.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR adds an EventBridge example to S3 Bucket Notification docs and explicitly indicates the default value and type of the `eventbridge` argument. This was previously unclear as to what the type of this argument was and whether it followed the the same pattern as existing other nested argument object types.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #25118

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

N/A
