### PR TITLE
bump go.mod to 1.20

### DIFF
--- a/.changelog/32108.txt
+++ b/.changelog/32108.txt
@@ -1,0 +1,7 @@
+```release-note:note
+provider: Updates to Go 1.20, the last release that will run on macOS 10.13 High Sierra or 10.14 Mojave. A future release will update to Go 1.21, and these platforms will no longer be supported.
+```
+
+```release-note:note
+provider: Updates to Go 1.20, the last release that will run on any release of Windows 7, 8, Server 2008 and Server 2012. A future release will update to Go 1.21, and these platforms will no longer be supported.
+```

--- a/.changelog/32108.txt
+++ b/.changelog/32108.txt
@@ -5,3 +5,7 @@ provider: Updates to Go 1.20, the last release that will run on macOS 10.13 High
 ```release-note:note
 provider: Updates to Go 1.20, the last release that will run on any release of Windows 7, 8, Server 2008 and Server 2012. A future release will update to Go 1.21, and these platforms will no longer be supported.
 ```
+
+```release-note:note
+provider: Updates to Go 1.20. The provider will now notice the `trust-ad` option in `/etc/resolv.conf` and, if set, will set the "authentic data" option in outgoing DNS requests in order to better match the behavior of the GNU libc resolver.
+```

--- a/.ci/providerlint/go.mod
+++ b/.ci/providerlint/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-provider-aws/ci/providerlint
 
-go 1.19
+go 1.20
 
 require (
 	github.com/aws/aws-sdk-go v1.44.286

--- a/.ci/tools/go.mod
+++ b/.ci/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-provider-aws/tools
 
-go 1.19
+go 1.20
 
 require (
 	github.com/bflad/tfproviderdocs v0.11.0

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -60,3 +60,8 @@ jobs:
         with:
           version: "${{ steps.golangci-lint-version.outputs.version }}"
           args: --config .ci/.golangci2.yml
+        env:
+          # Trigger garbage collection more frequently to reduce the likelihood
+          # of OOM errors.
+          # ref: https://golangci-lint.run/usage/performance/#memory-usage
+          GOGC: "50"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-provider-aws
 
-go 1.19
+go 1.20
 
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8

--- a/internal/service/elb/load_balancer_test.go
+++ b/internal/service/elb/load_balancer_test.go
@@ -7,7 +7,6 @@ import ( // nosemgrep:ci.semgrep.aws.multiple-service-imports
 	"reflect"
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elb"
@@ -149,8 +148,6 @@ func TestValidLoadBalancerHealthCheckTarget(t *testing.T) {
 	}
 
 	randomRunes := func(n int) string {
-		rand.Seed(time.Now().UTC().UnixNano())
-
 		// A complete set of modern Katakana characters.
 		runes := []rune("アイウエオ" +
 			"カキクケコガギグゲゴサシスセソザジズゼゾ" +

--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -758,8 +758,6 @@ func ChangeResourceRecordSets(ctx context.Context, conn *route53.Route53, input 
 }
 
 func WaitForRecordSetToSync(ctx context.Context, conn *route53.Route53, requestId string) error {
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	wait := retry.StateChangeConf{
 		Pending:      []string{route53.ChangeStatusPending},
 		Target:       []string{route53.ChangeStatusInsync},

--- a/internal/service/route53/wait.go
+++ b/internal/service/route53/wait.go
@@ -27,8 +27,6 @@ const (
 )
 
 func waitChangeInfoStatusInsync(ctx context.Context, conn *route53.Route53, changeID string) (*route53.ChangeInfo, error) { //nolint:unparam
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	// Route53 is vulnerable to throttling so longer delays, poll intervals helps significantly to avoid
 
 	stateConf := &retry.StateChangeConf{

--- a/internal/service/route53/zone.go
+++ b/internal/service/route53/zone.go
@@ -680,8 +680,6 @@ func hostedZoneVPCHash(v interface{}) int {
 }
 
 func waitForChangeSynchronization(ctx context.Context, conn *route53.Route53, changeID string) error {
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	conf := retry.StateChangeConf{
 		Pending:      []string{route53.ChangeStatusPending},
 		Target:       []string{route53.ChangeStatusInsync},

--- a/skaff/go.mod
+++ b/skaff/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-provider-aws/skaff
 
-go 1.19
+go 1.20
 
 require (
 	github.com/hashicorp/terraform-provider-aws v1.60.1-0.20220322001452-8f7a597d0c24

--- a/tools/tfsdk2fw/go.mod
+++ b/tools/tfsdk2fw/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-provider-aws/tools/tfsdk2fw
 
-go 1.19
+go 1.20
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1


### PR DESCRIPTION
### Description
Updates `go.mod` to Go `1.20`. Also replaces package-scoped calls to `rand.Seed()` with randomized values, as Go 1.20 now seeds the global number generator in `math/rand` with a randomized value by default. From the [1.20 release notes](https://tip.golang.org/doc/go1.20):

> The [math/rand](https://tip.golang.org/pkg/math/rand/) package now automatically seeds the global random number generator (used by top-level functions like Float64 and Int) with a random value, and the top-level Seed function has been deprecated. Programs that need a reproducible sequence of random numbers should prefer to allocate their own random source, using rand.New(rand.NewSource(seed)).


### Relations

Relates #32082 (see [failed checks](https://github.com/hashicorp/terraform-provider-aws/actions/runs/5308865624/jobs/9608821669?pr=32082)).
Closes https://github.com/hashicorp/terraform-provider-aws/issues/30876.

