### PR TITLE
Add Timestamp type for Framework

### DIFF
--- a/internal/framework/types/timestamp_type.go
+++ b/internal/framework/types/timestamp_type.go
@@ -1,0 +1,125 @@
+package types
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+type TimestampType struct {
+	basetypes.StringType
+}
+
+var (
+	_ basetypes.StringTypable = TimestampType{}
+	_ xattr.TypeWithValidate  = TimestampType{}
+)
+
+func (typ TimestampType) ValueFromString(_ context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	if in.IsUnknown() {
+		return NewTimestampUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewTimestampNull(), nil
+	}
+
+	s := in.ValueString()
+
+	var diags diag.Diagnostics
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		diags.AddError(
+			"Timestamp Type Validation Error",
+			fmt.Sprintf("Value %q cannot be parsed as a Timestamp.", s),
+		)
+		return nil, diags
+	}
+
+	return newTimestampValue(s, t), nil
+}
+
+func (typ TimestampType) ValueFromTerraform(_ context.Context, in tftypes.Value) (attr.Value, error) {
+	if !in.IsKnown() {
+		return NewTimestampUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewTimestampNull(), nil
+	}
+
+	var s string
+	err := in.As(&s)
+	if err != nil {
+		return nil, err
+	}
+
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return NewTimestampUnknown(), nil //nolint: nilerr // Must not return validation errors
+	}
+
+	return newTimestampValue(s, t), nil
+}
+
+func (typ TimestampType) ValueType(context.Context) attr.Value {
+	return TimestampValue{}
+}
+
+func (typ TimestampType) Equal(o attr.Type) bool {
+	other, ok := o.(TimestampType)
+	if !ok {
+		return false
+	}
+
+	return typ.StringType.Equal(other.StringType)
+}
+
+// String returns a human-friendly description of the TimestampType.
+func (typ TimestampType) String() string {
+	return "types.TimestampType"
+}
+
+func (typ TimestampType) Validate(ctx context.Context, in tftypes.Value, path path.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if !in.IsKnown() || in.IsNull() {
+		return diags
+	}
+
+	var s string
+	err := in.As(&s)
+	if err != nil {
+		diags.AddAttributeError(
+			path,
+			"Invalid Terraform Value",
+			"An unexpected error occurred while attempting to convert a Terraform value to a string. "+
+				"This is generally an issue with the provider schema implementation. "+
+				"Please report the following to the provider developer:\n\n"+
+				"Path: "+path.String()+"\n"+
+				"Error: "+err.Error(),
+		)
+		return diags
+	}
+
+	_, err = time.Parse(time.RFC3339, s)
+	if err != nil {
+		diags.AddAttributeError(
+			path,
+			"Invalid Timestamp Value",
+			fmt.Sprintf("Value %q cannot be parsed as an RFC 3339 Timestamp.\n\n"+
+				"Path: %s\n"+
+				"Error: %s", s, path, err),
+		)
+		return diags
+	}
+
+	return diags
+}

--- a/internal/framework/types/timestamp_type_test.go
+++ b/internal/framework/types/timestamp_type_test.go
@@ -1,0 +1,135 @@
+package types_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+)
+
+func TestTimestampTypeValueFromTerraform(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		val      tftypes.Value
+		expected attr.Value
+	}{
+		"null value": {
+			val:      tftypes.NewValue(tftypes.String, nil),
+			expected: fwtypes.NewTimestampNull(),
+		},
+		"unknown value": {
+			val:      tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			expected: fwtypes.NewTimestampUnknown(),
+		},
+		"valid timestamp UTC": {
+			val:      tftypes.NewValue(tftypes.String, "2023-06-07T15:11:34Z"),
+			expected: fwtypes.NewTimestampValue(time.Date(2023, time.June, 7, 15, 11, 34, 0, time.UTC)),
+		},
+		"valid timestamp zone": {
+			val:      tftypes.NewValue(tftypes.String, "2023-06-07T15:11:34-06:00"),
+			expected: fwtypes.NewTimestampValue(time.Date(2023, time.June, 7, 15, 11, 34, 0, locationFromString(t, "America/Regina"))), // No DST
+		},
+		"invalid value": {
+			val:      tftypes.NewValue(tftypes.String, "not ok"),
+			expected: fwtypes.NewTimestampUnknown(),
+		},
+		"invalid no zone": {
+			val:      tftypes.NewValue(tftypes.String, "2023-06-07T15:11:34"),
+			expected: fwtypes.NewTimestampUnknown(),
+		},
+		"invalid date only": {
+			val:      tftypes.NewValue(tftypes.String, "2023-06-07Z"),
+			expected: fwtypes.NewTimestampUnknown(),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			val, err := fwtypes.TimestampType{}.ValueFromTerraform(ctx, test.val)
+
+			if err != nil {
+				t.Fatalf("got unexpected error: %s", err)
+			}
+
+			if !test.expected.Equal(val) {
+				t.Errorf("unexpected diff\nwanted: %s\ngot:    %s", test.expected, val)
+			}
+		})
+	}
+}
+
+func TestTimestampTypeValidate(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		val         tftypes.Value
+		expectError bool
+	}
+	tests := map[string]testCase{
+		"not a string": {
+			val:         tftypes.NewValue(tftypes.Bool, true),
+			expectError: true,
+		},
+		"unknown string": {
+			val: tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+		},
+		"null string": {
+			val: tftypes.NewValue(tftypes.String, nil),
+		},
+		"valid timestamp UTC": {
+			val: tftypes.NewValue(tftypes.String, "2023-06-07T15:11:34Z"),
+		},
+		"valid timestamp zone": {
+			val: tftypes.NewValue(tftypes.String, "2023-06-07T15:11:34-06:00"),
+		},
+		"invalid string": {
+			val:         tftypes.NewValue(tftypes.String, "not ok"),
+			expectError: true,
+		},
+		"invalid no zone": {
+			val:         tftypes.NewValue(tftypes.String, "2023-06-07T15:11:34"),
+			expectError: true,
+		},
+		"invalid date only": {
+			val:         tftypes.NewValue(tftypes.String, "2023-06-07Z"),
+			expectError: true,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			diags := fwtypes.TimestampType{}.Validate(ctx, test.val, path.Root("test"))
+
+			if !diags.HasError() && test.expectError {
+				t.Fatal("expected error, got no error")
+			}
+
+			if diags.HasError() && !test.expectError {
+				t.Fatalf("got unexpected error: %#v", diags)
+			}
+		})
+	}
+}
+
+func locationFromString(t *testing.T, s string) *time.Location {
+	location, err := time.LoadLocation(s)
+	if err != nil {
+		t.Fatalf("loading time.Location %q: %s", s, err)
+	}
+
+	return location
+}

--- a/internal/framework/types/timestamp_value.go
+++ b/internal/framework/types/timestamp_value.go
@@ -1,0 +1,80 @@
+package types
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+func NewTimestampNull() TimestampValue {
+	return TimestampValue{
+		StringValue: types.StringNull(),
+	}
+}
+
+func NewTimestampUnknown() TimestampValue {
+	return TimestampValue{
+		StringValue: types.StringUnknown(),
+	}
+}
+
+func NewTimestampValue(t time.Time) TimestampValue {
+	return newTimestampValue(t.Format(time.RFC3339), t)
+}
+
+func NewTimestampValueString(s string) (TimestampValue, error) {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return TimestampValue{}, err
+	}
+	return newTimestampValue(s, t), nil
+}
+
+func newTimestampValue(s string, t time.Time) TimestampValue {
+	return TimestampValue{
+		StringValue: types.StringValue(s),
+		value:       t,
+	}
+}
+
+var (
+	_ basetypes.StringValuable = TimestampValue{}
+)
+
+type TimestampValue struct {
+	basetypes.StringValue
+
+	// value contains the parsed value, if not Null or Unknown.
+	value time.Time
+}
+
+func (val TimestampValue) Type(_ context.Context) attr.Type {
+	return TimestampType{}
+}
+
+func (val TimestampValue) Equal(other attr.Value) bool {
+	o, ok := other.(TimestampValue)
+
+	if !ok {
+		return false
+	}
+
+	if val.StringValue.IsUnknown() {
+		return o.StringValue.IsUnknown()
+	}
+
+	if val.StringValue.IsNull() {
+		return o.StringValue.IsNull()
+	}
+
+	return val.value.Equal(o.value)
+}
+
+// ValueTimestamp returns the known time.Time value. If Timestamp is null or unknown, returns 0.
+// To get the value as a string, use ValueString.
+func (val TimestampValue) ValueTimestamp() time.Time {
+	return val.value
+}

--- a/internal/framework/types/timestamp_value_test.go
+++ b/internal/framework/types/timestamp_value_test.go
@@ -1,0 +1,345 @@
+package types_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+)
+
+func TestTimestampValueToTerraformValue(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		timestamp fwtypes.TimestampValue
+		expected  tftypes.Value
+	}{
+		"value": {
+			timestamp: errs.Must(fwtypes.NewTimestampValueString("2023-06-07T15:11:34Z")),
+			expected:  tftypes.NewValue(tftypes.String, "2023-06-07T15:11:34Z"),
+		},
+		"null": {
+			timestamp: fwtypes.NewTimestampNull(),
+			expected:  tftypes.NewValue(tftypes.String, nil),
+		},
+		"unknown": {
+			timestamp: fwtypes.NewTimestampUnknown(),
+			expected:  tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			got, err := test.timestamp.ToTerraformValue(ctx)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+
+			if !test.expected.Equal(got) {
+				t.Fatalf("expected %#v to equal %#v", got, test.expected)
+			}
+		})
+	}
+}
+
+func TestTimestampValueToStringValue(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		timestamp fwtypes.TimestampValue
+		expected  types.String
+	}{
+		"value": {
+			timestamp: errs.Must(fwtypes.NewTimestampValueString("2023-06-07T15:11:34Z")),
+			expected:  types.StringValue("2023-06-07T15:11:34Z"),
+		},
+		"null": {
+			timestamp: fwtypes.NewTimestampNull(),
+			expected:  types.StringNull(),
+		},
+		"unknown": {
+			timestamp: fwtypes.NewTimestampUnknown(),
+			expected:  types.StringUnknown(),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			s, _ := test.timestamp.ToStringValue(ctx)
+
+			if !test.expected.Equal(s) {
+				t.Fatalf("expected %#v to equal %#v", s, test.expected)
+			}
+		})
+	}
+}
+
+func TestTimestampValueEqual(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		input     fwtypes.TimestampValue
+		candidate attr.Value
+		expected  bool
+	}{
+		"known-known-same": {
+			input:     errs.Must(fwtypes.NewTimestampValueString("2023-06-07T15:11:34Z")),
+			candidate: errs.Must(fwtypes.NewTimestampValueString("2023-06-07T15:11:34Z")),
+			expected:  true,
+		},
+		"known-known-diff": {
+			input:     errs.Must(fwtypes.NewTimestampValueString("2023-06-07T15:11:34Z")),
+			candidate: errs.Must(fwtypes.NewTimestampValueString("1999-06-07T15:11:34Z")),
+			expected:  false,
+		},
+		"known-unknown": {
+			input:     errs.Must(fwtypes.NewTimestampValueString("2023-06-07T15:11:34Z")),
+			candidate: fwtypes.NewTimestampUnknown(),
+			expected:  false,
+		},
+		"known-null": {
+			input:     errs.Must(fwtypes.NewTimestampValueString("2023-06-07T15:11:34Z")),
+			candidate: fwtypes.NewTimestampNull(),
+			expected:  false,
+		},
+		"unknown-known": {
+			input:     fwtypes.NewTimestampUnknown(),
+			candidate: errs.Must(fwtypes.NewTimestampValueString("2023-06-07T15:11:34Z")),
+			expected:  false,
+		},
+		"unknown-unknown": {
+			input:     fwtypes.NewTimestampUnknown(),
+			candidate: fwtypes.NewTimestampUnknown(),
+			expected:  true,
+		},
+		"unknown-null": {
+			input:     fwtypes.NewTimestampUnknown(),
+			candidate: fwtypes.NewTimestampNull(),
+			expected:  false,
+		},
+		"null-known": {
+			input:     fwtypes.NewTimestampNull(),
+			candidate: errs.Must(fwtypes.NewTimestampValueString("2023-06-07T15:11:34Z")),
+			expected:  false,
+		},
+		"null-unknown": {
+			input:     fwtypes.NewTimestampNull(),
+			candidate: fwtypes.NewTimestampUnknown(),
+			expected:  false,
+		},
+		"null-null": {
+			input:     fwtypes.NewTimestampNull(),
+			candidate: fwtypes.NewTimestampNull(),
+			expected:  true,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := test.input.Equal(test.candidate)
+			if got != test.expected {
+				t.Errorf("expected %t, got %t", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimestampValueIsNull(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    fwtypes.TimestampValue
+		expected bool
+	}{
+		"known": {
+			input:    errs.Must(fwtypes.NewTimestampValueString("2023-06-07T15:11:34Z")),
+			expected: false,
+		},
+		"null": {
+			input:    fwtypes.NewTimestampNull(),
+			expected: true,
+		},
+		"unknown": {
+			input:    fwtypes.NewTimestampUnknown(),
+			expected: false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.input.IsNull()
+
+			if got != testCase.expected {
+				t.Error("expected Null")
+			}
+		})
+	}
+}
+
+func TestTimestampValueIsUnknown(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    fwtypes.TimestampValue
+		expected bool
+	}{
+		"known": {
+			input:    errs.Must(fwtypes.NewTimestampValueString("2023-06-07T15:11:34Z")),
+			expected: false,
+		},
+		"null": {
+			input:    fwtypes.NewTimestampNull(),
+			expected: false,
+		},
+		"unknown": {
+			input:    fwtypes.NewTimestampUnknown(),
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.input.IsUnknown()
+
+			if got != testCase.expected {
+				t.Error("expected Unknown")
+			}
+		})
+	}
+}
+
+func TestTimestampValueString(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    fwtypes.TimestampValue
+		expected string
+	}
+	tests := map[string]testCase{
+		"known-non-empty": {
+			input:    errs.Must(fwtypes.NewTimestampValueString("2023-06-07T15:11:34Z")),
+			expected: `"2023-06-07T15:11:34Z"`,
+		},
+		"unknown": {
+			input:    fwtypes.NewTimestampUnknown(),
+			expected: "<unknown>",
+		},
+		"null": {
+			input:    fwtypes.NewTimestampNull(),
+			expected: "<null>",
+		},
+		"zero-value": {
+			input:    fwtypes.TimestampValue{},
+			expected: `<null>`,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := test.input.String()
+			if got != test.expected {
+				t.Errorf("Expected %q, got %q", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimestampValueValueString(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    fwtypes.TimestampValue
+		expected string
+	}{
+		"known": {
+			input:    errs.Must(fwtypes.NewTimestampValueString("2023-06-07T15:11:34Z")),
+			expected: "2023-06-07T15:11:34Z",
+		},
+		"null": {
+			input:    fwtypes.NewTimestampNull(),
+			expected: "",
+		},
+		"unknown": {
+			input:    fwtypes.NewTimestampUnknown(),
+			expected: "",
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.input.ValueString()
+
+			if got != testCase.expected {
+				t.Errorf("Expected %q, got %q", testCase.expected, got)
+			}
+		})
+	}
+}
+
+func TestTimestampValueValueTimestamp(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    fwtypes.TimestampValue
+		expected time.Time
+	}{
+		"known": {
+			input:    errs.Must(fwtypes.NewTimestampValueString("2023-06-07T15:11:34Z")),
+			expected: errs.Must(time.Parse(time.RFC3339, "2023-06-07T15:11:34Z")),
+		},
+		"null": {
+			input:    fwtypes.NewTimestampNull(),
+			expected: time.Time{},
+		},
+		"unknown": {
+			input:    fwtypes.NewTimestampUnknown(),
+			expected: time.Time{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.input.ValueTimestamp()
+
+			if !testCase.expected.Equal(got) {
+				t.Errorf("Expected %q, got %q", testCase.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description

Adds `TimestampType` and `TimestampValue` for Framework RFC 3339 custom type

### Output from Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ go test ./internal/framework/types/... -v -run=TestTimestamp

--- PASS: TestTimestampValueIsNull (0.00s)
    --- PASS: TestTimestampValueIsNull/unknown (0.00s)
    --- PASS: TestTimestampValueIsNull/known (0.00s)
    --- PASS: TestTimestampValueIsNull/null (0.00s)
--- PASS: TestTimestampValueToStringValue (0.00s)
    --- PASS: TestTimestampValueToStringValue/unknown (0.00s)
    --- PASS: TestTimestampValueToStringValue/value (0.00s)
    --- PASS: TestTimestampValueToStringValue/null (0.00s)
--- PASS: TestTimestampValueToTerraformValue (0.00s)
    --- PASS: TestTimestampValueToTerraformValue/value (0.00s)
    --- PASS: TestTimestampValueToTerraformValue/null (0.00s)
    --- PASS: TestTimestampValueToTerraformValue/unknown (0.00s)
--- PASS: TestTimestampValueValueTimestamp (0.00s)
    --- PASS: TestTimestampValueValueTimestamp/unknown (0.00s)
    --- PASS: TestTimestampValueValueTimestamp/null (0.00s)
    --- PASS: TestTimestampValueValueTimestamp/known (0.00s)
--- PASS: TestTimestampValueIsUnknown (0.00s)
    --- PASS: TestTimestampValueIsUnknown/known (0.00s)
    --- PASS: TestTimestampValueIsUnknown/unknown (0.00s)
    --- PASS: TestTimestampValueIsUnknown/null (0.00s)
--- PASS: TestTimestampValueValueString (0.00s)
    --- PASS: TestTimestampValueValueString/null (0.00s)
    --- PASS: TestTimestampValueValueString/unknown (0.00s)
    --- PASS: TestTimestampValueValueString/known (0.00s)
--- PASS: TestTimestampTypeValidate (0.00s)
    --- PASS: TestTimestampTypeValidate/invalid_string (0.00s)
    --- PASS: TestTimestampTypeValidate/valid_timestamp_zone (0.00s)
    --- PASS: TestTimestampTypeValidate/not_a_string (0.00s)
    --- PASS: TestTimestampTypeValidate/valid_timestamp_UTC (0.00s)
    --- PASS: TestTimestampTypeValidate/null_string (0.00s)
    --- PASS: TestTimestampTypeValidate/invalid_no_zone (0.00s)
    --- PASS: TestTimestampTypeValidate/invalid_date_only (0.00s)
    --- PASS: TestTimestampTypeValidate/unknown_string (0.00s)
--- PASS: TestTimestampValueString (0.00s)
    --- PASS: TestTimestampValueString/zero-value (0.00s)
    --- PASS: TestTimestampValueString/unknown (0.00s)
    --- PASS: TestTimestampValueString/known-non-empty (0.00s)
    --- PASS: TestTimestampValueString/null (0.00s)
--- PASS: TestTimestampValueEqual (0.00s)
    --- PASS: TestTimestampValueEqual/known-known-same (0.00s)
    --- PASS: TestTimestampValueEqual/known-known-diff (0.00s)
    --- PASS: TestTimestampValueEqual/known-unknown (0.00s)
    --- PASS: TestTimestampValueEqual/null-null (0.00s)
    --- PASS: TestTimestampValueEqual/null-known (0.00s)
    --- PASS: TestTimestampValueEqual/unknown-null (0.00s)
    --- PASS: TestTimestampValueEqual/unknown-unknown (0.00s)
    --- PASS: TestTimestampValueEqual/unknown-known (0.00s)
    --- PASS: TestTimestampValueEqual/known-null (0.00s)
    --- PASS: TestTimestampValueEqual/null-unknown (0.00s)
--- PASS: TestTimestampTypeValueFromTerraform (0.00s)
    --- PASS: TestTimestampTypeValueFromTerraform/null_value (0.00s)
    --- PASS: TestTimestampTypeValueFromTerraform/valid_timestamp_UTC (0.00s)
    --- PASS: TestTimestampTypeValueFromTerraform/invalid_value (0.00s)
    --- PASS: TestTimestampTypeValueFromTerraform/unknown_value (0.00s)
    --- PASS: TestTimestampTypeValueFromTerraform/invalid_no_zone (0.00s)
    --- PASS: TestTimestampTypeValueFromTerraform/valid_timestamp_zone (0.00s)
    --- PASS: TestTimestampTypeValueFromTerraform/invalid_date_only (0.00s)
```
