### PR TITLE
enhancement(s3_object): add support of KMS alias

### DIFF
--- a/.changelog/24921.txt
+++ b/.changelog/24921.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_object: add support of KMS Key alias for parameter `kms_key_id`
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 5.4.0 (Unreleased)
 
+ENHANCEMENTS:
+
+* resource/aws_glue_data_quality_ruleset: Add `catalog_id` argument to `target_table` block ([#31926](https://github.com/hashicorp/terraform-provider-aws/issues/31926))
+
 BUG FIXES:
 
 * resource/aws_quicksight_data_set: Allow physical table map to be optional ([#31863](https://github.com/hashicorp/terraform-provider-aws/issues/31863))

--- a/internal/service/s3/object.go
+++ b/internal/service/s3/object.go
@@ -122,10 +122,9 @@ func ResourceObject() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 			"kms_key_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: verify.ValidARN,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					// ignore diffs where the user hasn't specified a kms_key_id but the bucket has a default KMS key configured
 					if new == "" && d.Get("server_side_encryption") == s3.ServerSideEncryptionAwsKms {
@@ -485,7 +484,35 @@ func resourceObjectUpload(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if v, ok := d.GetOk("kms_key_id"); ok {
-		input.SSEKMSKeyId = aws.String(v.(string))
+
+		// Check if alias or valid ARN.
+		if strings.HasPrefix(v.(string), "alias/") {
+			log.Printf("[INFO] KMS Key alias given: %s", v.(string))
+			// Alias given, get associated ARN.
+			kmsClient := meta.(*conns.AWSClient).KMSConn()
+
+			kmsKeyMetadata, err := kms.FindKeyByID(ctx, kmsClient, v.(string))
+
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "could not find KMS key based on key alias provided (%s): %s", v.(string), err)
+			}
+
+			log.Printf("[INFO] KMS Key ARN returned: %s", *kmsKeyMetadata.Arn)
+			input.SSEKMSKeyId = aws.String(*kmsKeyMetadata.Arn)
+		} else if strings.HasPrefix(v.(string), "arn:") {
+			log.Printf("[INFO] KMS Key ARN given: %s", v.(string))
+			ValidateARN := verify.ValidARNCheck()
+			warnings, errors := ValidateARN(v.(string), "arn")
+			if len(errors) != 0 {
+				return sdkdiag.AppendErrorf(diags, "%s", errors[0])
+			}
+
+			log.Printf("[INFO] KMS Key ARN compliance errors: %v", errors)
+			log.Printf("[INFO] KMS Key ARN compliance warnings: %v", warnings)
+
+			input.SSEKMSKeyId = aws.String(v.(string))
+		}
+
 		input.ServerSideEncryption = aws.String(s3.ServerSideEncryptionAwsKms)
 	}
 

--- a/website/docs/r/s3_object.html.markdown
+++ b/website/docs/r/s3_object.html.markdown
@@ -129,6 +129,21 @@ resource "aws_s3_object" "examplebucket_object" {
 }
 ```
 
+### Server Side Encryption with KMS Key alias
+
+```terraform
+resource "aws_s3_bucket" "examplebucket" {
+  bucket = "examplebuckettftest"
+}
+
+resource "aws_s3_object" "example" {
+  key                    = "someobject"
+  bucket                 = aws_s3_bucket.examplebucket.id
+  source                 = "index.html"
+  server_side_encryption = "alias/aws/s3"
+}
+```
+
 ## Argument Reference
 
 -> **Note:** If you specify `content_encoding` you are responsible for encoding the body appropriately. `source`, `content`, and `content_base64` all expect already encoded/compressed bytes.
@@ -151,7 +166,7 @@ The following arguments are optional:
 * `content` - (Optional, conflicts with `source` and `content_base64`) Literal string value to use as the object content, which will be uploaded as UTF-8-encoded text.
 * `etag` - (Optional) Triggers updates when the value changes. The only meaningful value is `filemd5("path/to/file")` (Terraform 0.11.12 or later) or `${md5(file("path/to/file"))}` (Terraform 0.11.11 or earlier). This attribute is not compatible with KMS encryption, `kms_key_id` or `server_side_encryption = "aws:kms"`, also if an object is larger than 16 MB, the AWS Management Console will upload or copy that object as a Multipart Upload, and therefore the ETag will not be an MD5 digest (see `source_hash` instead).
 * `force_destroy` - (Optional) Whether to allow the object to be deleted by removing any legal hold on any object version. Default is `false`. This value should be set to `true` only if the bucket has S3 object lock enabled.
-* `kms_key_id` - (Optional) ARN of the KMS Key to use for object encryption. If the S3 Bucket has server-side encryption enabled, that value will automatically be used. If referencing the `aws_kms_key` resource, use the `arn` attribute. If referencing the `aws_kms_alias` data source or resource, use the `target_key_arn` attribute. Terraform will only perform drift detection if a configuration value is provided.
+* `kms_key_id` - (Optional) ARN or alias of the KMS Key to use for object encryption. If the S3 Bucket has server-side encryption enabled, that value will automatically be used. If referencing the `aws_kms_key` resource, use the `arn` attribute. If referencing the `aws_kms_alias` data source or resource, use the `target_key_arn` attribute. Terraform will only perform drift detection if a configuration value is provided.
 * `metadata` - (Optional) Map of keys/values to provision metadata (will be automatically prefixed by `x-amz-meta-`, note that only lowercase label are currently supported by the AWS Go API).
 * `object_lock_legal_hold_status` - (Optional) [Legal hold](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-legal-holds) status that you want to apply to the specified object. Valid values are `ON` and `OFF`.
 * `object_lock_mode` - (Optional) Object lock [retention mode](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-retention-modes) that you want to apply to this object. Valid values are `GOVERNANCE` and `COMPLIANCE`.


### PR DESCRIPTION
### Description
This PR adds support of KMS Key alias when uploading an object to an S3 bucket.

### Relations
Closes #24921

### References
https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html

### Output from Acceptance Testing
```
make testacc TESTS=TestAccS3Object_kmsAlias PKG=s3
[In progress]

make testacc TESTS=TestAccS3Object_kmsID PKG=s3
[In progress]
...