### PR TITLE
Tech debt: Migrate `pricing` resources to AWS SDK for Go v2 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/oam v1.1.13
 	github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.2.6
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.2.8
+	github.com/aws/aws-sdk-go-v2/service/pricing v1.20.0
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.8.14
 	github.com/aws/aws-sdk-go-v2/service/rds v1.45.2
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.2.15

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.2.6 h1:tADh6fIpsh0X
 github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.2.6/go.mod h1:Ju/rPQaOhCUQAFIZlf+drYB+YJQSuwbCYlAzfCGQVQc=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.2.8 h1:TPr7uAucpAvgE0ac9zMs/LTx9O0dmLWHWr2mkZjL4iY=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.2.8/go.mod h1:T8pM2eiirH5Ld58Ek+t7tK3SqQNUwp9zkqkslW1v8sM=
+github.com/aws/aws-sdk-go-v2/service/pricing v1.20.0 h1:x5gKeerbKIQ/tdhmaAGNpivSfmb+p2rdt0wyjCGz+4Q=
+github.com/aws/aws-sdk-go-v2/service/pricing v1.20.0/go.mod h1:JjpnqJdEW/5An429Ou+5Kb3UkwjXv16gRD2ZdGA2Gw8=
 github.com/aws/aws-sdk-go-v2/service/rbin v1.8.14 h1:oEeNqSze4JYbhsDg7udtz+AtLwrIXlvjItAd09Z2zTw=
 github.com/aws/aws-sdk-go-v2/service/rbin v1.8.14/go.mod h1:JehbzDgwXYQi1wqKKFLstaNqsRPgPu9Kd6DiwhtFxoA=
 github.com/aws/aws-sdk-go-v2/service/rds v1.45.2 h1:tKZ+n9/BTnNYXZo80nIoFes7QEbOd/lnbp0EkPbHfUU=

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -3,6 +3,7 @@ package acctest
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -2290,6 +2291,22 @@ func CheckResourceAttrGreaterThanOrEqualValue(n, key string, val int) resource.T
 
 		if v < val {
 			return fmt.Errorf("got %d, want >= %d", v, val)
+		}
+
+		return nil
+	})
+}
+
+func CheckResourceAttrIsJSONString(n, key string) resource.TestCheckFunc {
+	return resource.TestCheckResourceAttrWith(n, key, func(value string) error {
+		var m map[string]*json.RawMessage
+
+		if err := json.Unmarshal([]byte(value), &m); err != nil {
+			return err
+		}
+
+		if len(m) == 0 {
+			return errors.New(`empty JSON string`)
 		}
 
 		return nil

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -31,6 +31,7 @@ import (
 	oam_sdkv2 "github.com/aws/aws-sdk-go-v2/service/oam"
 	opensearchserverless_sdkv2 "github.com/aws/aws-sdk-go-v2/service/opensearchserverless"
 	pipes_sdkv2 "github.com/aws/aws-sdk-go-v2/service/pipes"
+	pricing_sdkv2 "github.com/aws/aws-sdk-go-v2/service/pricing"
 	rbin_sdkv2 "github.com/aws/aws-sdk-go-v2/service/rbin"
 	rds_sdkv2 "github.com/aws/aws-sdk-go-v2/service/rds"
 	resourceexplorer2_sdkv2 "github.com/aws/aws-sdk-go-v2/service/resourceexplorer2"
@@ -256,7 +257,6 @@ import (
 	pinpointemail_sdkv1 "github.com/aws/aws-sdk-go/service/pinpointemail"
 	pinpointsmsvoice_sdkv1 "github.com/aws/aws-sdk-go/service/pinpointsmsvoice"
 	polly_sdkv1 "github.com/aws/aws-sdk-go/service/polly"
-	pricing_sdkv1 "github.com/aws/aws-sdk-go/service/pricing"
 	prometheusservice_sdkv1 "github.com/aws/aws-sdk-go/service/prometheusservice"
 	proton_sdkv1 "github.com/aws/aws-sdk-go/service/proton"
 	qldb_sdkv1 "github.com/aws/aws-sdk-go/service/qldb"
@@ -1264,8 +1264,8 @@ func (c *AWSClient) PollyConn(ctx context.Context) *polly_sdkv1.Polly {
 	return errs.Must(conn[*polly_sdkv1.Polly](ctx, c, names.Polly))
 }
 
-func (c *AWSClient) PricingConn(ctx context.Context) *pricing_sdkv1.Pricing {
-	return errs.Must(conn[*pricing_sdkv1.Pricing](ctx, c, names.Pricing))
+func (c *AWSClient) PricingClient(ctx context.Context) *pricing_sdkv2.Client {
+	return errs.Must(client[*pricing_sdkv2.Client](ctx, c, names.Pricing))
 }
 
 func (c *AWSClient) ProtonConn(ctx context.Context) *proton_sdkv1.Proton {

--- a/internal/service/pricing/product_data_source_test.go
+++ b/internal/service/pricing/product_data_source_test.go
@@ -1,9 +1,6 @@
 package pricing_test
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -27,7 +24,7 @@ func TestAccPricingProductDataSource_ec2(t *testing.T) {
 			{
 				Config: testAccProductDataSourceConfig_ec2,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrWith(dataSourceName, "result", testAccCheckValueIsJSON),
+					acctest.CheckResourceAttrIsJSONString(dataSourceName, "result"),
 				),
 			},
 		},
@@ -49,7 +46,7 @@ func TestAccPricingProductDataSource_redshift(t *testing.T) {
 			{
 				Config: testAccProductDataSourceConfig_redshift,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrWith(dataSourceName, "result", testAccCheckValueIsJSON),
+					acctest.CheckResourceAttrIsJSONString(dataSourceName, "result"),
 				),
 			},
 		},
@@ -129,17 +126,3 @@ data "aws_pricing_product" "test" {
   }
 }
 `
-
-func testAccCheckValueIsJSON(v string) error {
-	var m map[string]*json.RawMessage
-
-	if err := json.Unmarshal([]byte(v), &m); err != nil {
-		return fmt.Errorf("parsing JSON: %s", err)
-	}
-
-	if len(m) == 0 {
-		return errors.New(`empty JSON`)
-	}
-
-	return nil
-}

--- a/internal/service/pricing/product_data_source_test.go
+++ b/internal/service/pricing/product_data_source_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/aws/aws-sdk-go/service/pricing"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccPricingProductDataSource_ec2(t *testing.T) {
@@ -21,7 +21,7 @@ func TestAccPricingProductDataSource_ec2(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApSouth1RegionID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, pricing.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.PricingEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -43,7 +43,7 @@ func TestAccPricingProductDataSource_redshift(t *testing.T) {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApSouth1RegionID)
 		},
-		ErrorCheck:               acctest.ErrorCheck(t, pricing.EndpointsID),
+		ErrorCheck:               acctest.ErrorCheck(t, names.PricingEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/pricing/service_package_gen.go
+++ b/internal/service/pricing/service_package_gen.go
@@ -24,7 +24,7 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {
 	return []*types.ServicePackageSDKDataSource{
 		{
-			Factory:  DataSourceProduct,
+			Factory:  dataSourceProduct,
 			TypeName: "aws_pricing_product",
 		},
 	}

--- a/internal/service/pricing/service_package_gen.go
+++ b/internal/service/pricing/service_package_gen.go
@@ -5,9 +5,8 @@ package pricing
 import (
 	"context"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	pricing_sdkv1 "github.com/aws/aws-sdk-go/service/pricing"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	pricing_sdkv2 "github.com/aws/aws-sdk-go-v2/service/pricing"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -39,11 +38,15 @@ func (p *servicePackage) ServicePackageName() string {
 	return names.Pricing
 }
 
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*pricing_sdkv1.Pricing, error) {
-	sess := config["session"].(*session_sdkv1.Session)
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*pricing_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
-	return pricing_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
+	return pricing_sdkv2.NewFromConfig(cfg, func(o *pricing_sdkv2.Options) {
+		if endpoint := config["endpoint"].(string); endpoint != "" {
+			o.EndpointResolver = pricing_sdkv2.EndpointResolverFromURL(endpoint)
+		}
+	}), nil
 }
 
 var ServicePackage = &servicePackage{}

--- a/names/names.go
+++ b/names/names.go
@@ -40,6 +40,7 @@ const (
 	ObservabilityAccessManagerEndpointID = "oam"
 	OpenSearchServerlessEndpointID       = "aoss"
 	PipesEndpointID                      = "pipes"
+	PricingEndpointID                    = "pricing"
 	ResourceExplorer2EndpointID          = "resource-explorer-2"
 	RolesAnywhereEndpointID              = "rolesanywhere"
 	Route53DomainsEndpointID             = "route53domains"

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -275,7 +275,7 @@ pinpoint-sms-voice,pinpointsmsvoice,pinpointsmsvoice,pinpointsmsvoice,,pinpoints
 pipes,pipes,pipes,pipes,,pipes,,,Pipes,Pipes,,,2,,aws_pipes_,,pipes_,EventBridge Pipes,Amazon,,,,,
 polly,polly,polly,polly,,polly,,,Polly,Polly,,1,,,aws_polly_,,polly_,Polly,Amazon,,,,,
 ,,,,,,,,,,,,,,,,,Porting Assistant for .NET,,x,,,,No SDK support
-pricing,pricing,pricing,pricing,,pricing,,,Pricing,Pricing,,1,,,aws_pricing_,,pricing_,Pricing Calculator,AWS,,,,,
+pricing,pricing,pricing,pricing,,pricing,,,Pricing,Pricing,,,2,,aws_pricing_,,pricing_,Pricing Calculator,AWS,,,,,
 proton,proton,proton,proton,,proton,,,Proton,Proton,,1,,,aws_proton_,,proton_,Proton,AWS,,,,,
 qldb,qldb,qldb,qldb,,qldb,,,QLDB,QLDB,,1,,,aws_qldb_,,qldb_,QLDB (Quantum Ledger Database),Amazon,,,,,
 qldb-session,qldbsession,qldbsession,qldbsession,,qldbsession,,,QLDBSession,QLDBSession,,1,,,aws_qldbsession_,,qldbsession_,QLDB Session,Amazon,,,,,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Ibid.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% AWS_DEFAULT_REGION=us-east-1 make testacc TESTARGS='-run=TestAccPricingProductDataSource_' PKG=pricing 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/pricing/... -v -count 1 -parallel 20  -run=TestAccPricingProductDataSource_ -timeout 180m
=== RUN   TestAccPricingProductDataSource_ec2
=== PAUSE TestAccPricingProductDataSource_ec2
=== RUN   TestAccPricingProductDataSource_redshift
=== PAUSE TestAccPricingProductDataSource_redshift
=== CONT  TestAccPricingProductDataSource_ec2
=== CONT  TestAccPricingProductDataSource_redshift
--- PASS: TestAccPricingProductDataSource_redshift (15.65s)
--- PASS: TestAccPricingProductDataSource_ec2 (15.72s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/pricing	21.665s
```
