### PR TITLE
Fix string values in reusable team project automation

### DIFF
--- a/.github/workflows/reusable-team-project.yml
+++ b/.github/workflows/reusable-team-project.yml
@@ -1,49 +1,48 @@
-name: 'Team GitHub Project Automation'
-
+name: "Team GitHub Project Automation"
 on:
   workflow_call:
     inputs:
       status:
-        description: '(Optional) The ID of the value of the Status field to set.'
+        description: "(Optional) The ID of the value of the Status field to set."
         required: false
         type: string
-
 env:
   ITEM_NODE_ID: ${{ github.event.issue.node_id || github.event.pull_request.node_id }}
   GH_TOKEN: ${{ secrets.ORGSCOPED_GITHUB_TOKEN }}
-
 jobs:
   add-to-project:
-    name: 'Add Item to Project and Optionally Set Status'
+    name: "Add Item to Project and Optionally Set Status"
     runs-on: ubuntu-latest
     steps:
-      - name: 'Add Item to Project'
+      - name: "Add Item to Project"
         run: |
           project_item_id="$(gh api graphql -f query='
             mutation (
               $node_id: ID!
+              $project_id: ID!
             ){
-              addProjectV2ItemById(input: {projectId: PVT_kwDOAAuecM4AF-7h, contentId: $node_id}) {
+              addProjectV2ItemById(input: {projectId: $project_id, contentId: $node_id}) {
                 item {
                   id
                 }
               }
-            }' -f node_id=$ITEM_NODE_ID --jq '.data.addProjectV2ItemById.item.id')"
+            }' -f node_id=$ITEM_NODE_ID -f project_id='PVT_kwDOAAuecM4AF-7h' --jq '.data.addProjectV2ItemById.item.id')"
 
           echo 'PROJECT_ITEM_ID='$project_item_id >> $GITHUB_ENV
-
-      - name: 'Set Status Field Value'
+      - name: "Set Status Field Value"
         if: inputs.status != ''
         run: |
           gh api graphql -f query='
             mutation(
+              $field_id: ID!
+              $project_id: ID!
               $project_item: ID!
               $status_value: String!
             ){
               updateProjectV2ItemFieldValue(input: {
-                  projectId: PVT_kwDOAAuecM4AF-7h
+                  projectId: $project_id
                   itemId: $project_item
-                  fieldId: PVTSSF_lADOAAuecM4AF-7hzgDcsQA
+                  fieldId: $field_id
                   value: {
                     singleSelectOptionId: $status_value
                   }
@@ -52,4 +51,4 @@ jobs:
                   id
                 }
               }
-            }' -f project_item=$PROJECT_ITEM_ID -f status_value=${{ inputs.status }} --silent
+            }' -f field_id='PVTSSF_lADOAAuecM4AF-7hzgDcsQA' -f project_id='PVT_kwDOAAuecM4AF-7h' -f project_item=$PROJECT_ITEM_ID -f status_value=${{ inputs.status }} --silent


### PR DESCRIPTION
### Description

Since the newly added reusable workflow for automating the team project did not wrap the IDs of the project, field in quotes, it caused failures. This PR switches to interpolating them so that they may be passed as quote-wrapped strings.

### Relations

### References

- [Failed run](https://github.com/hashicorp/terraform-provider-aws/actions/runs/5335208853/jobs/9668107745)

### Output from Acceptance Testing

N/a, workflow
