### PR TITLE
Added RuntimeManagement for lambda function

### DIFF
--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -2486,11 +2486,12 @@ resource "aws_security_group" "test" {
 func testAccFunctionConfig_basic(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(acctest.ConfigLambdaBase(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "test" {
-  filename      = "test-fixtures/lambdatest.zip"
-  function_name = "%s"
-  role          = aws_iam_role.iam_for_lambda.arn
-  handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  filename                  = "test-fixtures/lambdatest.zip"
+  function_name             = "%s"
+  role                      = aws_iam_role.iam_for_lambda.arn
+  handler                   = "exports.example"
+  runtime                   = "nodejs16.x"
+  runtime_version_update_on = "FunctionUpdate"
 }
 `, funcName)
 }

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -277,6 +277,8 @@ The following arguments are optional:
 * `replace_security_groups_on_destroy` - (Optional, **Deprecated**) **AWS no longer supports this operation. This attribute now has no effect and will be removed in a future major version.** Whether to replace the security groups on associated lambda network interfaces upon destruction. Removing these security groups from orphaned network interfaces can speed up security group deletion times by avoiding a dependency on AWS's internal cleanup operations. By default, the ENI security groups will be replaced with the `default` security group in the function's VPC. Set the `replacement_security_group_ids` attribute to use a custom list of security groups for replacement.
 * `replacement_security_group_ids` - (Optional, **Deprecated**) List of security group IDs to assign to orphaned Lambda function network interfaces upon destruction. `replace_security_groups_on_destroy` must be set to `true` to use this attribute.
 * `runtime` - (Optional) Identifier of the function's runtime. See [Runtimes][6] for valid values.
+* `runtime_version_arn` - (Optional) The ARN of the runtime version you want the function to use. See [Runtimes-update][13] for details.
+* `runtime_version_update_on` - (Optional) Update strategy for runtime. Valid Values are `Auto`, `Manual`, `FunctionUpdate`. Defaults to `Auto`. You need do set `runtime_version_arn` when set to `Manual`. See [Runtimes-update][13] for details.
 * `s3_bucket` - (Optional) S3 bucket location containing the function's deployment package. This bucket must reside in the same AWS region where you are creating the Lambda function. Exactly one of `filename`, `image_uri`, or `s3_bucket` must be specified. When `s3_bucket` is set, `s3_key` is required.
 * `s3_key` - (Optional) S3 key of an object containing the function's deployment package. When `s3_bucket` is set, `s3_key` is required.
 * `s3_object_version` - (Optional) Object version containing the function's deployment package. Conflicts with `filename` and `image_uri`.
@@ -364,6 +366,7 @@ In addition to all arguments above, the following attributes are exported:
 [10]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
 [11]: https://learn.hashicorp.com/terraform/aws/lambda-api-gateway
 [12]: https://docs.aws.amazon.com/lambda/latest/dg/services-efs.html
+[13]: https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html
 
 ## Timeouts
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This PR add support for lambda runtime update control.
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

None 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$make testacc TESTS=TestAccLambdaFunction_basic PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunction_basic'  -timeout 180m
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== CONT  TestAccLambdaFunction_basic
--- PASS: TestAccLambdaFunction_basic (36.80s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	36.876s

...
```
