### PR TITLE
Fix community check for label events

### DIFF
--- a/.github/workflows/community-check.yml
+++ b/.github/workflows/community-check.yml
@@ -1,5 +1,4 @@
 name: Community Check
-
 on:
   workflow_call:
     outputs:
@@ -9,7 +8,6 @@ on:
         value: ${{ jobs.community_check.outputs.is_maintainer }}
       partner:
         value: ${{ jobs.community_check.outputs.is_partner }}
-
 jobs:
   community_check:
     name: Check community lists for username
@@ -43,9 +41,9 @@ jobs:
       - name: Determine if user is in lists
         id: determination
         env:
-          IS_CORE_CONTRIBUTOR: ${{ contains(fromJSON(steps.decode.outputs.core_contributors_list), github.actor) }}
-          IS_MAINTAINER: ${{ contains(fromJSON(steps.decode.outputs.maintainers_list), github.actor) }}
-          IS_PARTNER: ${{ contains(fromJSON(steps.decode.outputs.partners_list), github.actor) }}
+          IS_CORE_CONTRIBUTOR: ${{ contains(fromJSON(steps.decode.outputs.core_contributors_list), github.event.*.user.login) }}
+          IS_MAINTAINER: ${{ contains(fromJSON(steps.decode.outputs.maintainers_list), github.event.*.user.login) }}
+          IS_PARTNER: ${{ contains(fromJSON(steps.decode.outputs.partners_list), github.event.*.user.login) }}
         run: |
           echo "is_core_contributor=$IS_CORE_CONTRIBUTOR" >> $GITHUB_OUTPUT
           echo "is_maintainer=$IS_MAINTAINER" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Description

Previously, we were comparing the list of users in our Secrets to the `github.actor`. For events such as labeling an issue or pull request, however, the `github.actor` is the person who labeled the item rather than the actual issue or pull request author. This means that there's false positives when maintainers (or partners, core contributors) label an item. This PR aims to fix that by using `github.event.*.user.login` instead (the `*` means that this will work for `github.event.issue.user.login` as well as `github.event.pull_request.user.login`).

### References

- [False positive result](https://github.com/hashicorp/terraform-provider-aws/actions/runs/5335208853/jobs/9668104459)


### Output from Acceptance Testing

N/a, workflows
