### PR TITLE
Replace NormalizeJsonString with local helper func

### DIFF
--- a/internal/service/events/rule.go
+++ b/internal/service/events/rule.go
@@ -296,7 +296,7 @@ func FindRuleByTwoPartKey(ctx context.Context, conn *eventbridge.EventBridge, ev
 	return output, nil
 }
 
-// Decodes unicode translation of <,>,&
+// RuleEventPatternJSONDecoder decodes unicode translation of <,>,&
 func RuleEventPatternJSONDecoder(jsonString interface{}) (string, error) {
 	var j interface{}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The unicode conversion of `<` `>` `&` currently is causing issues for EventBridge rules.  Instead of `NormalizeJsonString` we'll use a local helper function that will escape those characters.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
