### PR TITLE
Fix community check reusable workflow

### DIFF
--- a/.github/workflows/community-check.yml
+++ b/.github/workflows/community-check.yml
@@ -41,10 +41,8 @@ jobs:
       - name: Determine if user is in lists
         id: determination
         env:
-          IS_CORE_CONTRIBUTOR: ${{ contains(fromJSON(steps.decode.outputs.core_contributors_list), github.event.*.user.login) }}
-          IS_MAINTAINER: ${{ contains(fromJSON(steps.decode.outputs.maintainers_list), github.event.*.user.login) }}
-          IS_PARTNER: ${{ contains(fromJSON(steps.decode.outputs.partners_list), github.event.*.user.login) }}
+          USER_LOGIN: ${{ github.event.issue.user.login || github.event.pull_request.user.login }}
         run: |
-          echo "is_core_contributor=$IS_CORE_CONTRIBUTOR" >> $GITHUB_OUTPUT
-          echo "is_maintainer=$IS_MAINTAINER" >> $GITHUB_OUTPUT
-          echo "is_partner=$IS_PARTNER" >> $GITHUB_OUTPUT
+          echo "is_core_contributor="${{ contains(fromJSON(steps.decode.outputs.core_contributors_list), env.USER_LOGIN) }} >> $GITHUB_OUTPUT
+          echo "is_maintainer="${{ contains(fromJSON(steps.decode.outputs.maintainers_list), env.USER_LOGIN) }} >> $GITHUB_OUTPUT
+          echo "is_partner="${{ contains(fromJSON(steps.decode.outputs.partners_list), env.USER_LOGIN) }} >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Description

A recent change to the community check reusable workflow that was intended to eliminate false positives (see linked issue) introduced a bug that made it so every check evaluated to `false` every time. This PR fixes that bug so that the evaluations are correct.

### Relations

Relates #32139

### Output from Acceptance Testing

**Note:** I created two local files to test this locally with `nektos/act`. So as not to expose anything, I'm omitting these files, but will look into creating files that we can actually use to test this locally more reliably. The files contained:

`prt.json`:
```json
{
  "pull_request": {
    "user": {
      "login": "justinretzolk"
    }
  }
}

```

`my.secrets`:
```plaintext
# these were populated with the base64 encoded values from the Terraform state in TFC
CORE_CONTRIBUTORS=
MAINTAINERS=
PARTNERS=
```

```shell
➜ act pull_request_target --secret-file my.secrets -e prt.json -j community_check -W ./.github/workflows/maintainer-edit.yml
[community_check/Community Check/Check community lists for username] 🚀  Start image=ghcr.io/catthehacker/ubuntu:full-20.04
[community_check/Community Check/Check community lists for username]   🐳  docker pull image=ghcr.io/catthehacker/ubuntu:full-20.04 platform= username= forcePull=true
[community_check/Community Check/Check community lists for username]   🐳  docker create image=ghcr.io/catthehacker/ubuntu:full-20.04 platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[]
[community_check/Community Check/Check community lists for username]   🐳  docker run image=ghcr.io/catthehacker/ubuntu:full-20.04 platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[]
[community_check/Community Check/Check community lists for username] ⭐ Run Main Decode user lists from secrets
[community_check/Community Check/Check community lists for username]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/decode] user= workdir=
[community_check/Community Check/Check community lists for username]   ⚙  ***
[community_check/Community Check/Check community lists for username]   ⚙  ***
[community_check/Community Check/Check community lists for username]   ⚙  ***
[community_check/Community Check/Check community lists for username]   ✅  Success - Main Decode user lists from secrets
[community_check/Community Check/Check community lists for username]   ⚙  ::set-output:: maintainers_list=***
[community_check/Community Check/Check community lists for username]   ⚙  ::set-output:: partners_list=***
[community_check/Community Check/Check community lists for username]   ⚙  ::set-output:: core_contributors_list=***
[community_check/Community Check/Check community lists for username] ⭐ Run Main Determine if user is in lists
[community_check/Community Check/Check community lists for username]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/determination] user= workdir=
[community_check/Community Check/Check community lists for username]   ✅  Success - Main Determine if user is in lists
[community_check/Community Check/Check community lists for username]   ⚙  ::set-output:: is_core_contributor=false
[community_check/Community Check/Check community lists for username]   ⚙  ::set-output:: is_maintainer=true
[community_check/Community Check/Check community lists for username]   ⚙  ::set-output:: is_partner=false
[community_check/Community Check/Check community lists for username] 🏁  Job succeeded

```