### PR TITLE
Improve doc accuracy for `aws_vpc_security_group_ingress_rule` and `a…

### DIFF
--- a/.changelog/32148.txt
+++ b/.changelog/32148.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+resource/aws_vpc_security_group_egress_rule: Make `security_group_id` a required argument
+resource/aws_vpc_security_group_ingress_rule: Make `security_group_id` a required argument
+```

--- a/internal/service/ec2/vpc_security_group_ingress_rule.go
+++ b/internal/service/ec2/vpc_security_group_ingress_rule.go
@@ -134,7 +134,7 @@ func (r *resourceSecurityGroupRule) Schema(ctx context.Context, req resource.Sch
 				Optional: true,
 			},
 			"security_group_id": schema.StringAttribute{
-				Optional: true,
+				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -236,6 +236,8 @@ The following arguments are required:
 
 The following arguments are optional:
 
+~> **Note** Although `cidr_blocks`, `ipv6_cidr_blocks`, `prefix_list_ids`, and `security_groups` are all marked as optional, you _must_ provide one of them in order to configure the source of the traffic.
+
 * `cidr_blocks` - (Optional) List of CIDR blocks.
 * `description` - (Optional) Description of this ingress rule.
 * `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
@@ -253,6 +255,8 @@ The following arguments are required:
 * `to_port` - (Required) End range port (or ICMP code if protocol is `icmp`).
 
 The following arguments are optional:
+
+~> **Note** Although `cidr_blocks`, `ipv6_cidr_blocks`, `prefix_list_ids`, and `security_groups` are all marked as optional, you _must_ provide one of them in order to configure the destination of the traffic.
 
 * `cidr_blocks` - (Optional) List of CIDR blocks.
 * `description` - (Optional) Description of this egress rule.

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -99,6 +99,8 @@ or `egress` (outbound).
 
 The following arguments are optional:
 
+~> **Note** Although `cidr_blocks`, `ipv6_cidr_blocks`, `prefix_list_ids`, and `source_security_group_id` are all marked as optional, you _must_ provide one of them in order to configure the source of the traffic.
+
 * `cidr_blocks` - (Optional) List of CIDR blocks. Cannot be specified with `source_security_group_id` or `self`.
 * `description` - (Optional) Description of the rule.
 * `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks. Cannot be specified with `source_security_group_id` or `self`.

--- a/website/docs/r/vpc_security_group_egress_rule.html.markdown
+++ b/website/docs/r/vpc_security_group_egress_rule.html.markdown
@@ -26,11 +26,14 @@ resource "aws_vpc_security_group_egress_rule" "example" {
   cidr_ipv4   = "10.0.0.0/8"
   from_port   = 80
   ip_protocol = "tcp"
-  to_port     = 8080
+  to_port     = 80
 }
 ```
 
 ## Argument Reference
+
+~> **NOTE on optional/required attributes:** Although `cidr_ipv4`, `cidr_ipv6`, `prefix_list_id`, and `referenced_security_group_id` are all marked as optional, you *must* provide one of them in order to configure the destination of the traffic.
+`from_port` and `to_port` are required, unless `ip_protocol` is set to `-1` or `icmpv6`.
 
 The following arguments are supported:
 

--- a/website/docs/r/vpc_security_group_egress_rule.html.markdown
+++ b/website/docs/r/vpc_security_group_egress_rule.html.markdown
@@ -32,8 +32,7 @@ resource "aws_vpc_security_group_egress_rule" "example" {
 
 ## Argument Reference
 
-~> **NOTE on optional/required attributes:** Although `cidr_ipv4`, `cidr_ipv6`, `prefix_list_id`, and `referenced_security_group_id` are all marked as optional, you *must* provide one of them in order to configure the destination of the traffic.
-`from_port` and `to_port` are required, unless `ip_protocol` is set to `-1` or `icmpv6`.
+~> **Note** Although `cidr_ipv4`, `cidr_ipv6`, `prefix_list_id`, and `referenced_security_group_id` are all marked as optional, you *must* provide one of them in order to configure the destination of the traffic. The `from_port` and `to_port` arguments are required unless `ip_protocol` is set to `-1` or `icmpv6`.
 
 The following arguments are supported:
 

--- a/website/docs/r/vpc_security_group_ingress_rule.html.markdown
+++ b/website/docs/r/vpc_security_group_ingress_rule.html.markdown
@@ -34,8 +34,7 @@ resource "aws_vpc_security_group_ingress_rule" "example" {
 
 The following arguments are supported:
 
-~> **NOTE on optional/required attributes:** Although `cidr_ipv4`, `cidr_ipv6`, `prefix_list_id`, and `referenced_security_group_id` are all marked as optional, you *must* provide one of them in order to configure the source of the traffic.
-`from_port` and `to_port` are required, unless `ip_protocol` is set to `-1` or `icmpv6`.
+~> **Note** Although `cidr_ipv4`, `cidr_ipv6`, `prefix_list_id`, and `referenced_security_group_id` are all marked as optional, you *must* provide one of them in order to configure the destination of the traffic. The `from_port` and `to_port` arguments are required unless `ip_protocol` is set to `-1` or `icmpv6`.
 
 * `cidr_ipv4` - (Optional) The source IPv4 CIDR range.
 * `cidr_ipv6` - (Optional) The source IPv6 CIDR range.

--- a/website/docs/r/vpc_security_group_ingress_rule.html.markdown
+++ b/website/docs/r/vpc_security_group_ingress_rule.html.markdown
@@ -26,7 +26,7 @@ resource "aws_vpc_security_group_ingress_rule" "example" {
   cidr_ipv4   = "10.0.0.0/8"
   from_port   = 80
   ip_protocol = "tcp"
-  to_port     = 8080
+  to_port     = 80
 }
 ```
 
@@ -34,11 +34,14 @@ resource "aws_vpc_security_group_ingress_rule" "example" {
 
 The following arguments are supported:
 
+~> **NOTE on optional/required attributes:** Although `cidr_ipv4`, `cidr_ipv6`, `prefix_list_id`, and `referenced_security_group_id` are all marked as optional, you *must* provide one of them in order to configure the source of the traffic.
+`from_port` and `to_port` are required, unless `ip_protocol` is set to `-1` or `icmpv6`.
+
 * `cidr_ipv4` - (Optional) The source IPv4 CIDR range.
 * `cidr_ipv6` - (Optional) The source IPv6 CIDR range.
 * `description` - (Optional) The security group rule description.
 * `from_port` - (Optional) The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 type.
-* `ip_protocol` - (Optional) The IP protocol name or number. Use `-1` to specify all protocols. Note that if `ip_protocol` is set to `-1`, it translates to all protocols, all port ranges, and `from_port` and `to_port` values should not be defined.
+* `ip_protocol` - (Required) The IP protocol name or number. Use `-1` to specify all protocols. Note that if `ip_protocol` is set to `-1`, it translates to all protocols, all port ranges, and `from_port` and `to_port` values should not be defined.
 * `prefix_list_id` - (Optional) The ID of the source prefix list.
 * `referenced_security_group_id` - (Optional) The source security group that is referenced in the rule.
 * `security_group_id` - (Required) The ID of the security group.


### PR DESCRIPTION
…ws_vpc_security_group_egress_rule`

* `ip_protocol` was marked as `Required` in the schema but `Optional` in the docs
* `security_group_id` is `Required` but was `Optional` in the schema
* Try to clarify the situations where `Optional` arguments are actually `Required`

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29895
Closes #32089
Relates #29893

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Note that although this technically includes what looks like a breaking change, it's impossible for practitioners to create security group rules without specifying a security group ID so this is actually just a quality-of-life improvement by getting early validation feedback without waiting for the AWS API call to be made. 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
