### PR TITLE
aws_api_gateway_rest_api: fix crash on `binary_media_types` attribute

### DIFF
--- a/.changelog/32169.txt
+++ b/.changelog/32169.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_api_gateway_rest_api: Fix crash when `binary_media_types` is `null`
+```

--- a/internal/service/apigateway/rest_api.go
+++ b/internal/service/apigateway/rest_api.go
@@ -395,19 +395,23 @@ func resourceRestAPIUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			// Remove every binary media types. Simpler to remove and add new ones,
 			// since there are no replacings.
 			for _, v := range old {
-				operations = append(operations, &apigateway.PatchOperation{
-					Op:   aws.String(apigateway.OpRemove),
-					Path: aws.String(fmt.Sprintf("/%s/%s", prefix, escapeJSONPointer(v.(string)))),
-				})
+				if e, ok := v.(string); ok {
+					operations = append(operations, &apigateway.PatchOperation{
+						Op:   aws.String(apigateway.OpRemove),
+						Path: aws.String(fmt.Sprintf("/%s/%s", prefix, escapeJSONPointer(e))),
+					})
+				}
 			}
 
 			// Handle additions
 			if len(new) > 0 {
 				for _, v := range new {
-					operations = append(operations, &apigateway.PatchOperation{
-						Op:   aws.String(apigateway.OpAdd),
-						Path: aws.String(fmt.Sprintf("/%s/%s", prefix, escapeJSONPointer(v.(string)))),
-					})
+					if e, ok := v.(string); ok {
+						operations = append(operations, &apigateway.PatchOperation{
+							Op:   aws.String(apigateway.OpAdd),
+							Path: aws.String(fmt.Sprintf("/%s/%s", prefix, escapeJSONPointer(e))),
+						})
+					}
 				}
 			}
 		}
@@ -626,18 +630,22 @@ func resourceRestAPIWithBodyUpdateOperations(d *schema.ResourceData, output *api
 	}
 
 	if v, ok := d.GetOk("binary_media_types"); ok && len(v.([]interface{})) > 0 {
-		for _, elem := range aws.StringValueSlice(output.BinaryMediaTypes) {
-			operations = append(operations, &apigateway.PatchOperation{
-				Op:   aws.String(apigateway.OpRemove),
-				Path: aws.String("/binaryMediaTypes/" + escapeJSONPointer(elem)),
-			})
+		if len(output.BinaryMediaTypes) > 0 {
+			for _, elem := range aws.StringValueSlice(output.BinaryMediaTypes) {
+				operations = append(operations, &apigateway.PatchOperation{
+					Op:   aws.String(apigateway.OpRemove),
+					Path: aws.String("/binaryMediaTypes/" + escapeJSONPointer(elem)),
+				})
+			}
 		}
 
 		for _, elem := range v.([]interface{}) {
-			operations = append(operations, &apigateway.PatchOperation{
-				Op:   aws.String(apigateway.OpAdd),
-				Path: aws.String("/binaryMediaTypes/" + escapeJSONPointer(elem.(string))),
-			})
+			if el, ok := elem.(string); ok {
+				operations = append(operations, &apigateway.PatchOperation{
+					Op:   aws.String(apigateway.OpAdd),
+					Path: aws.String("/binaryMediaTypes/" + escapeJSONPointer(el)),
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Crash on resource

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #31827

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccAPIGatewayRestAPI_' PKG=apigateway

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apigateway/... -v -count 1 -parallel 20  -run=TestAccAPIGatewayRestAPI_ -timeout 180m
--- PASS: TestAccAPIGatewayRestAPI_basic (32.63s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_basic (70.20s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_setByBody (139.79s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_overrideBody (216.69s)
--- PASS: TestAccAPIGatewayRestAPI_MinimumCompressionSize_setByBody (246.42s)
--- PASS: TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_setByBody (258.52s)
--- PASS: TestAccAPIGatewayRestAPI_Policy_order (22.00s)
--- PASS: TestAccAPIGatewayRestAPI_FailOnWarnings (356.82s)
--- PASS: TestAccAPIGatewayRestAPI_Description_overrideBody (400.04s)
--- PASS: TestAccAPIGatewayRestAPI_APIKeySource_overrideBody (40.97s)
--- PASS: TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideToMergeBody (183.88s)
--- PASS: TestAccAPIGatewayRestAPI_apiKeySource (39.75s)
--- PASS: TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_mergeBody (146.97s)
--- PASS: TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_setByBody (93.62s)
--- PASS: TestAccAPIGatewayRestAPI_DisableExecuteAPIEndpoint_overrideBody (66.77s)
--- PASS: TestAccAPIGatewayRestAPI_Description_setByBody (615.29s)
--- PASS: TestAccAPIGatewayRestAPI_BinaryMediaTypes_overrideBody (647.43s)
--- PASS: TestAccAPIGatewayRestAPI_APIKeySource_setByBody (708.11s)
--- PASS: TestAccAPIGatewayRestAPI_binaryMediaTypes (733.15s)
--- PASS: TestAccAPIGatewayRestAPI_disableExecuteAPIEndpoint (799.31s)
--- PASS: TestAccAPIGatewayRestAPI_parameters (887.46s)
--- PASS: TestAccAPIGatewayRestAPI_Endpoint_vpcEndpointIDs (445.51s)
--- PASS: TestAccAPIGatewayRestAPI_endpoint (859.67s)
--- PASS: TestAccAPIGatewayRestAPI_Name_overrideBody (997.50s)
--- PASS: TestAccAPIGatewayRestAPI_body (1072.88s)
--- PASS: TestAccAPIGatewayRestAPI_disappears (1093.21s)
--- PASS: TestAccAPIGatewayRestAPI_EndpointVPCEndpointIDs_overrideBody (883.94s)
--- PASS: TestAccAPIGatewayRestAPI_MinimumCompressionSize_overrideBody (1183.83s)
--- PASS: TestAccAPIGatewayRestAPI_Endpoint_private (1240.13s)
--- PASS: TestAccAPIGatewayRestAPI_tags (1142.05s)
--- PASS: TestAccAPIGatewayRestAPI_description (1350.87s)
--- PASS: TestAccAPIGatewayRestAPI_minimumCompressionSize (1234.03s)
--- PASS: TestAccAPIGatewayRestAPI_BinaryMediaTypes_setByBody (1679.84s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigateway	1683.281s
```
