### PR TITLE
aws_storagegateway_smb_file_share: Set `kms_key_arn` when `kms_encrypted` is `true`

### DIFF
--- a/.changelog/32171.txt
+++ b/.changelog/32171.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_storagegateway_smb_file_share: Fix update error when `kms_encrypted` is `true` but `kms_key_arn` is not sent in the request
+```

--- a/internal/service/storagegateway/smb_file_share.go
+++ b/internal/service/storagegateway/smb_file_share.go
@@ -402,6 +402,8 @@ func resourceSMBFileShareUpdate(ctx context.Context, d *schema.ResourceData, met
 		// This value can only be set when KMSEncrypted is true.
 		if d.HasChange("kms_key_arn") && d.Get("kms_encrypted").(bool) {
 			input.KMSKey = aws.String(d.Get("kms_key_arn").(string))
+		} else if d.Get("kms_encrypted").(bool) && d.Get("kms_key_arn").(string) != "" {
+			input.KMSKey = aws.String(d.Get("kms_key_arn").(string))
 		}
 
 		if d.HasChange("notification_policy") {

--- a/internal/service/storagegateway/smb_file_share_test.go
+++ b/internal/service/storagegateway/smb_file_share_test.go
@@ -237,6 +237,38 @@ func TestAccStorageGatewaySMBFileShare_defaultStorageClass(t *testing.T) {
 	})
 }
 
+func TestAccStorageGatewaySMBFileShare_encryptedUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var smbFileShare storagegateway.SMBFileShareInfo
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_storagegateway_smb_file_share.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, storagegateway.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSMBFileShareDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSMBFileShareConfig_encryptedUpdate(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSMBFileShareExists(ctx, resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "kms_encrypted", "true"),
+				),
+			},
+			{
+				Config: testAccSMBFileShareConfig_encryptedUpdate(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSMBFileShareExists(ctx, resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "read_only", "true"),
+					resource.TestCheckResourceAttr(resourceName, "kms_encrypted", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccStorageGatewaySMBFileShare_fileShareName(t *testing.T) {
 	ctx := acctest.Context(t)
 	var smbFileShare storagegateway.SMBFileShareInfo
@@ -1115,6 +1147,26 @@ resource "aws_storagegateway_smb_file_share" "test" {
   role_arn              = aws_iam_role.test.arn
 }
 `, defaultStorageClass))
+}
+
+func testAccSMBFileShareConfig_encryptedUpdate(rName string, readOnly bool) string {
+	return acctest.ConfigCompose(testAcc_SMBFileShare_GuestAccessBase(rName), fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+ deletion_window_in_days = 7
+  description             = "Terraform Acceptance Testing"
+}
+
+resource "aws_storagegateway_smb_file_share" "test" {
+  # Use GuestAccess to simplify testing
+  authentication = "GuestAccess"
+  gateway_arn    = aws_storagegateway_gateway.test.arn
+  kms_encrypted  = true
+  kms_key_arn    = aws_kms_key.test.arn
+  location_arn   = aws_s3_bucket.test.arn
+  role_arn       = aws_iam_role.test.arn
+  read_only      = %t
+}
+`, readOnly))
 }
 
 func testAccSMBFileShareConfig_name(rName, fileShareName string) string {

--- a/internal/service/storagegateway/smb_file_share_test.go
+++ b/internal/service/storagegateway/smb_file_share_test.go
@@ -1164,7 +1164,7 @@ resource "aws_storagegateway_smb_file_share" "test" {
   kms_key_arn    = aws_kms_key.test.arn
   location_arn   = aws_s3_bucket.test.arn
   role_arn       = aws_iam_role.test.arn
-  read_only      = %t
+  read_only      = %[1]t
 }
 `, readOnly))
 }

--- a/internal/service/storagegateway/smb_file_share_test.go
+++ b/internal/service/storagegateway/smb_file_share_test.go
@@ -1152,7 +1152,7 @@ resource "aws_storagegateway_smb_file_share" "test" {
 func testAccSMBFileShareConfig_encryptedUpdate(rName string, readOnly bool) string {
 	return acctest.ConfigCompose(testAcc_SMBFileShare_GuestAccessBase(rName), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
- deletion_window_in_days = 7
+  deletion_window_in_days = 7
   description             = "Terraform Acceptance Testing"
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Resolve error during an update when `kms_encrypted` is `true` but `kms_key_arn` is not sent in the request.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #20766

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccStorageGatewaySMBFileShare_' PKG=storagegateway

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/storagegateway/... -v -count 1 -parallel 20  -run=TestAccStorageGatewaySMBFileShare_ -timeout 180m
--- PASS: TestAccStorageGatewaySMBFileShare_Authentication_guestAccess (345.92s)
--- PASS: TestAccStorageGatewaySMBFileShare_guessMIMETypeEnabled (394.40s)
--- PASS: TestAccStorageGatewaySMBFileShare_disappears (395.55s)
--- PASS: TestAccStorageGatewaySMBFileShare_encryptedUpdate (410.67s)
--- PASS: TestAccStorageGatewaySMBFileShare_audit (411.60s)
--- PASS: TestAccStorageGatewaySMBFileShare_objectACL (424.00s)
--- PASS: TestAccStorageGatewaySMBFileShare_readOnly (434.67s)
--- PASS: TestAccStorageGatewaySMBFileShare_fileShareName (443.06s)
--- PASS: TestAccStorageGatewaySMBFileShare_defaultStorageClass (443.16s)
--- PASS: TestAccStorageGatewaySMBFileShare_accessBasedEnumeration (449.45s)
--- PASS: TestAccStorageGatewaySMBFileShare_kmsKeyARN (449.87s)
--- PASS: TestAccStorageGatewaySMBFileShare_requesterPays (453.36s)
--- PASS: TestAccStorageGatewaySMBFileShare_cacheAttributes (464.34s)
--- PASS: TestAccStorageGatewaySMBFileShare_caseSensitivity (483.75s)
--- PASS: TestAccStorageGatewaySMBFileShare_notificationPolicy (483.95s)
--- PASS: TestAccStorageGatewaySMBFileShare_kmsEncrypted (319.21s)
--- PASS: TestAccStorageGatewaySMBFileShare_tags (371.39s)
--- PASS: TestAccStorageGatewaySMBFileShare_Authentication_activeDirectory (1071.96s)
--- PASS: TestAccStorageGatewaySMBFileShare_SMB_acl (1137.82s)
--- PASS: TestAccStorageGatewaySMBFileShare_validUserList (1151.34s)
--- PASS: TestAccStorageGatewaySMBFileShare_adminUserList (1153.71s)
--- PASS: TestAccStorageGatewaySMBFileShare_invalidUserList (1397.42s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/storagegateway	1400.765s
```
