### PR TITLE
tooling: updating the TeamCity configuration

### DIFF
--- a/.github/workflows/gen-teamcity.yml
+++ b/.github/workflows/gen-teamcity.yml
@@ -17,9 +17,10 @@ jobs:
       - uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # v3.11.0
         with:
           distribution: adopt
-          java-version: 11
+          java-version: 17
           cache: maven
       - name: Build TeamCity Configuration
         run: |
           cd .teamcity
-          mvn org.jetbrains.teamcity:teamcity-configs-maven-plugin:generate
+          make tools
+          make validate

--- a/.teamcity/.java-version
+++ b/.teamcity/.java-version
@@ -1,1 +1,1 @@
-corretto64-11.0.13
+corretto64-17.0.7

--- a/.teamcity/GNUmakefile
+++ b/.teamcity/GNUmakefile
@@ -1,0 +1,7 @@
+default: tools
+
+tools:
+	mvn -U dependency:sources
+
+validate:
+	mvn teamcity-configs:generate

--- a/.teamcity/components/service_build_config.kt
+++ b/.teamcity/components/service_build_config.kt
@@ -1,10 +1,10 @@
 import java.io.File
-import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
-import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
-import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
-import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.notifications
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.AbsoluteId
+import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.DslContext
+import jetbrains.buildServer.configs.kotlin.ParameterDisplay
+import jetbrains.buildServer.configs.kotlin.buildFeatures.notifications
+import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 data class ServiceSpec(
     val readableName: String,

--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <project>
     <modelVersion>4.0.0</modelVersion>
-    <name>AWS TeamCity Config DSL Script</name>
-    <groupId>TeamCity-Config-DSL-Script</groupId>
-    <artifactId>TeamCity-Config-DSL-Script</artifactId>
+    <name>Terraform-Provider-AWS Config DSL Script</name>
+    <groupId>TerraformProviderAWS</groupId>
+    <artifactId>TerraformProviderAWS</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <parent>
@@ -22,7 +22,7 @@
         </repository>
         <repository>
             <id>teamcity-server</id>
-            <url>https://ci-oss.hashicorp.engineering/app/dsl-plugins-repository</url>
+            <url>https://teamcity.jetbrains.com/app/dsl-plugins-repository</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -70,10 +70,12 @@
                     <format>kotlin</format>
                     <dstDir>target/generated-configs</dstDir>
                     <!-- For testing -->
-                    <!--<contextParameters>
+                    <!--
+                    <contextParameters>
                         <run_nightly_build>true</run_nightly_build>
                         <trigger_time>02:05 America/Vancouver</trigger_time>
-                    </contextParameters>-->
+                    </contextParameters>
+                    -->
                 </configuration>
             </plugin>
         </plugins>
@@ -82,13 +84,13 @@
     <dependencies>
         <dependency>
             <groupId>org.jetbrains.teamcity</groupId>
-            <artifactId>configs-dsl-kotlin</artifactId>
+            <artifactId>configs-dsl-kotlin-latest</artifactId>
             <version>${teamcity.dsl.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.teamcity</groupId>
-            <artifactId>configs-dsl-kotlin-plugins</artifactId>
+            <artifactId>configs-dsl-kotlin-plugins-latest</artifactId>
             <version>1.0-SNAPSHOT</version>
             <type>pom</type>
             <scope>compile</scope>

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1,15 +1,15 @@
-import jetbrains.buildServer.configs.kotlin.v2019_2.* // ktlint-disable no-wildcard-imports
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.golang
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.notifications
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
+import jetbrains.buildServer.configs.kotlin.* // ktlint-disable no-wildcard-imports
+import jetbrains.buildServer.configs.kotlin.buildFeatures.golang
+import jetbrains.buildServer.configs.kotlin.buildFeatures.notifications
+import jetbrains.buildServer.configs.kotlin.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.triggers.schedule
 import java.io.File
 import java.time.Duration
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
-version = "2020.2"
+version = "2023.05"
 
 val defaultRegion = DslContext.getParameter("default_region")
 val alternateRegion = DslContext.getParameter("alternate_region", "")


### PR DESCRIPTION
### Description

This PR updates the TeamCity Configuration to use the newer syntax (which is now versionless).

I'm having a little trouble validating the `jenv` setup, but this is the latest version available from the Corretto site for v17, so I think should work fine?