### PR TITLE
r/vpc_nat_gateway: Add support for secondary IP addresses

### DIFF
--- a/.changelog/32191.txt
+++ b/.changelog/32191.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/vpc_nat_gateway: Add `secondary_private_ips` for specifying additional secondary private addresses.
+```

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -347,7 +347,7 @@ func StatusNATGatewaySecondaryIPState(ctx context.Context, conn *ec2.EC2, id str
 		}
 
 		for _, addr := range output.NatGatewayAddresses {
-			if addr.PrivateIp != nil && *addr.PrivateIp == address {
+			if aws.StringValue(addr.PrivateIp) == address {
 				return addr, aws.StringValue(addr.Status), nil
 			}
 		}

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -334,6 +334,28 @@ func StatusInstanceRootBlockDeviceDeleteOnTermination(ctx context.Context, conn 
 	}
 }
 
+func StatusNATGatewaySecondaryIPState(ctx context.Context, conn *ec2.EC2, id string, address string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := FindNATGatewayByID(ctx, conn, id)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		for _, addr := range output.NatGatewayAddresses {
+			if addr.PrivateIp != nil && *addr.PrivateIp == address {
+				return addr, aws.StringValue(addr.Status), nil
+			}
+		}
+
+		return nil, "", nil
+	}
+}
+
 func StatusNATGatewayState(ctx context.Context, conn *ec2.EC2, id string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindNATGatewayByID(ctx, conn, id)

--- a/internal/service/ec2/vpc_nat_gateway.go
+++ b/internal/service/ec2/vpc_nat_gateway.go
@@ -2,6 +2,9 @@ package ec2
 
 import (
 	"context"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"golang.org/x/exp/slices"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -59,6 +62,14 @@ func ResourceNATGateway() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.IsIPv4Address,
 			},
+			"secondary_private_ips": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				ForceNew: false,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
 			"public_ip": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -100,6 +111,10 @@ func resourceNATGatewayCreate(ctx context.Context, d *schema.ResourceData, meta 
 		input.SubnetId = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("secondary_private_ips"); ok {
+		input.SecondaryPrivateIpAddresses = flex.ExpandStringSet(v.(*schema.Set))
+	}
+
 	output, err := conn.CreateNatGatewayWithContext(ctx, input)
 
 	if err != nil {
@@ -130,6 +145,8 @@ func resourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("reading EC2 NAT Gateway (%s): %s", d.Id(), err)
 	}
 
+	log.Printf("[FP] reading")
+	secondaryPrivateAddresses := schema.NewSet(schema.HashString, nil)
 	for _, address := range ng.NatGatewayAddresses {
 		// Length check guarantees the attributes are always set (#30865).
 		if len(ng.NatGatewayAddresses) == 1 || aws.BoolValue(address.IsPrimary) {
@@ -138,10 +155,15 @@ func resourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta in
 			d.Set("network_interface_id", address.NetworkInterfaceId)
 			d.Set("private_ip", address.PrivateIp)
 			d.Set("public_ip", address.PublicIp)
-			break
+		} else if !aws.BoolValue(address.IsPrimary) &&
+			address.PrivateIp != nil &&
+			address.Status != nil &&
+			!slices.Contains([]string{ec2.NatGatewayAddressStatusFailed, ec2.NatGatewayAddressStatusDisassociating, ec2.NatGatewayAddressStatusUnassigning}, *address.Status) {
+			secondaryPrivateAddresses.Add(aws.StringValue(address.PrivateIp))
 		}
 	}
 
+	d.Set("secondary_private_ips", secondaryPrivateAddresses)
 	d.Set("connectivity_type", ng.ConnectivityType)
 	d.Set("subnet_id", ng.SubnetId)
 
@@ -151,7 +173,36 @@ func resourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta in
 }
 
 func resourceNATGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// Tags only.
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).EC2Conn(ctx)
+
+	if d.HasChanges("secondary_private_ips") {
+		oRaw, nRaw := d.GetChange("secondary_private_ips")
+		o, n := oRaw.(*schema.Set), nRaw.(*schema.Set)
+		add := n.Difference(o)
+		del := o.Difference(n)
+
+		if add.Len() > 0 {
+			_, err := conn.AssignPrivateNatGatewayAddress(&ec2.AssignPrivateNatGatewayAddressInput{
+				NatGatewayId:       aws.String(d.Id()),
+				PrivateIpAddresses: flex.ExpandStringSet(add),
+			})
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "adding secondary ip address allocations (%s): %s", d.Id(), err)
+			}
+		}
+
+		if del.Len() > 0 {
+			_, err := conn.UnassignPrivateNatGatewayAddress(&ec2.UnassignPrivateNatGatewayAddressInput{
+				NatGatewayId:       aws.String(d.Id()),
+				PrivateIpAddresses: flex.ExpandStringSet(del),
+			})
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "adding secondary ip address allocations (%s): %s", d.Id(), err)
+			}
+		}
+	}
+
 	return resourceNATGatewayRead(ctx, d, meta)
 }
 

--- a/internal/service/ec2/vpc_nat_gateway.go
+++ b/internal/service/ec2/vpc_nat_gateway.go
@@ -183,22 +183,26 @@ func resourceNATGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		del := o.Difference(n)
 
 		if add.Len() > 0 {
-			_, err := conn.AssignPrivateNatGatewayAddress(&ec2.AssignPrivateNatGatewayAddressInput{
+			_, err := conn.AssignPrivateNatGatewayAddressWithContext(ctx, &ec2.AssignPrivateNatGatewayAddressInput{
 				NatGatewayId:       aws.String(d.Id()),
 				PrivateIpAddresses: flex.ExpandStringSet(add),
 			})
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "adding secondary ip address allocations (%s): %s", d.Id(), err)
 			}
+			err = WaitNATGatewaySecondaryAddresses(ctx, conn, d.Id(), flex.ExpandStringValueSet(add))
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "adding secondary ip address allocations (%s): %s", d.Id(), err)
+			}
 		}
 
 		if del.Len() > 0 {
-			_, err := conn.UnassignPrivateNatGatewayAddress(&ec2.UnassignPrivateNatGatewayAddressInput{
+			_, err := conn.UnassignPrivateNatGatewayAddressWithContext(ctx, &ec2.UnassignPrivateNatGatewayAddressInput{
 				NatGatewayId:       aws.String(d.Id()),
 				PrivateIpAddresses: flex.ExpandStringSet(del),
 			})
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "adding secondary ip address allocations (%s): %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "deleting secondary ip address allocations (%s): %s", d.Id(), err)
 			}
 		}
 	}

--- a/internal/service/ec2/vpc_nat_gateway.go
+++ b/internal/service/ec2/vpc_nat_gateway.go
@@ -2,9 +2,6 @@ package ec2
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
-	"github.com/hashicorp/terraform-provider-aws/internal/flex"
-	"golang.org/x/exp/slices"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -15,10 +12,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
+	"golang.org/x/exp/slices"
 )
 
 // @SDKResource("aws_nat_gateway", name="NAT Gateway")

--- a/internal/service/ec2/vpc_nat_gateway.go
+++ b/internal/service/ec2/vpc_nat_gateway.go
@@ -145,7 +145,6 @@ func resourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("reading EC2 NAT Gateway (%s): %s", d.Id(), err)
 	}
 
-	log.Printf("[FP] reading")
 	secondaryPrivateAddresses := schema.NewSet(schema.HashString, nil)
 	for _, address := range ng.NatGatewayAddresses {
 		// Length check guarantees the attributes are always set (#30865).

--- a/internal/service/ec2/vpc_nat_gateway_test.go
+++ b/internal/service/ec2/vpc_nat_gateway_test.go
@@ -383,7 +383,7 @@ resource "aws_nat_gateway" "test" {
   connectivity_type = "private"
   private_ip        = "10.0.0.8"
   subnet_id         = aws_subnet.test[0].id
-  secondary_private_ips = [ 
+  secondary_private_ips = [
     %[2]q
   ]
 

--- a/internal/service/ec2/vpc_nat_gateway_test.go
+++ b/internal/service/ec2/vpc_nat_gateway_test.go
@@ -37,6 +37,7 @@ func TestAccVPCNATGateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "network_interface_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
 					resource.TestCheckResourceAttrSet(resourceName, "public_ip"),
+					resource.TestCheckResourceAttr(resourceName, "secondary_private_ips.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
 				),
 			},
@@ -95,6 +96,7 @@ func TestAccVPCNATGateway_ConnectivityType_private(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "network_interface_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
 					resource.TestCheckResourceAttr(resourceName, "public_ip", ""),
+					resource.TestCheckResourceAttr(resourceName, "secondary_private_ips.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
 				),
@@ -130,6 +132,57 @@ func TestAccVPCNATGateway_privateIP(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "network_interface_id"),
 					resource.TestCheckResourceAttr(resourceName, "private_ip", "10.0.0.8"),
 					resource.TestCheckResourceAttr(resourceName, "public_ip", ""),
+					resource.TestCheckResourceAttr(resourceName, "secondary_private_ips.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccVPCNATGateway_privateIPWithSecondary(t *testing.T) {
+	ctx := acctest.Context(t)
+	var natGateway ec2.NatGateway
+	resourceName := "aws_nat_gateway.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckNATGatewayDestroy(ctx),
+		Steps: []resource.TestStep{
+			// create with secondary ip
+			{
+				Config: testAccVPCNATGatewayConfig_privateIPWithSecondary(rName, "10.0.0.9"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckNATGatewayExists(ctx, resourceName, &natGateway),
+					resource.TestCheckResourceAttr(resourceName, "allocation_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "association_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "connectivity_type", "private"),
+					resource.TestCheckResourceAttrSet(resourceName, "network_interface_id"),
+					resource.TestCheckResourceAttr(resourceName, "private_ip", "10.0.0.8"),
+					resource.TestCheckResourceAttr(resourceName, "public_ip", ""),
+					resource.TestCheckResourceAttr(resourceName, "secondary_private_ips.0", "10.0.0.9"),
+				),
+			},
+			// delete secondary ip
+			{
+				Config: testAccVPCNATGatewayConfig_privateIPWithSecondary(rName, "10.0.0.10"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckNATGatewayExists(ctx, resourceName, &natGateway),
+					resource.TestCheckResourceAttr(resourceName, "allocation_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "association_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "connectivity_type", "private"),
+					resource.TestCheckResourceAttrSet(resourceName, "network_interface_id"),
+					resource.TestCheckResourceAttr(resourceName, "private_ip", "10.0.0.8"),
+					resource.TestCheckResourceAttr(resourceName, "public_ip", ""),
+					resource.TestCheckResourceAttr(resourceName, "secondary_private_ips.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "secondary_private_ips.0", "10.0.0.10"),
 				),
 			},
 			{
@@ -322,6 +375,22 @@ resource "aws_nat_gateway" "test" {
   }
 }
 `, rName))
+}
+
+func testAccVPCNATGatewayConfig_privateIPWithSecondary(rName string, secondary string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
+resource "aws_nat_gateway" "test" {
+  connectivity_type = "private"
+  private_ip        = "10.0.0.8"
+  subnet_id         = aws_subnet.test[0].id
+
+  secondary_private_ips = [ %[2]q ]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, secondary))
 }
 
 func testAccVPCNATGatewayConfig_tags1(rName, tagKey1, tagValue1 string) string {

--- a/internal/service/ec2/vpc_nat_gateway_test.go
+++ b/internal/service/ec2/vpc_nat_gateway_test.go
@@ -383,8 +383,9 @@ resource "aws_nat_gateway" "test" {
   connectivity_type = "private"
   private_ip        = "10.0.0.8"
   subnet_id         = aws_subnet.test[0].id
-
-  secondary_private_ips = [ %[2]q ]
+  secondary_private_ips = [ 
+    %[2]q
+  ]
 
   tags = {
     Name = %[1]q

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -2047,8 +2047,9 @@ func WaitCustomerGatewayDeleted(ctx context.Context, conn *ec2.EC2, id string) (
 }
 
 const (
-	natGatewayCreatedTimeout = 10 * time.Minute
-	natGatewayDeletedTimeout = 30 * time.Minute
+	natGatewayCreatedTimeout           = 10 * time.Minute
+	natGatewayDeletedTimeout           = 30 * time.Minute
+	natGatewayAddressAssignmentTimeout = 2 * time.Minute
 )
 
 func WaitNATGatewayCreated(ctx context.Context, conn *ec2.EC2, id string) (*ec2.NatGateway, error) {
@@ -2070,6 +2071,30 @@ func WaitNATGatewayCreated(ctx context.Context, conn *ec2.EC2, id string) (*ec2.
 	}
 
 	return nil, err
+}
+
+func WaitNATGatewaySecondaryAddresses(ctx context.Context, conn *ec2.EC2, id string, addresses []string) error {
+	for _, addr := range addresses {
+		stateConf := &retry.StateChangeConf{
+			Pending: []string{ec2.NatGatewayAddressStatusAssigning, ec2.NatGatewayAddressStatusAssociating},
+			Target:  []string{ec2.NatGatewayAddressStatusSucceeded},
+			Refresh: StatusNATGatewaySecondaryIPState(ctx, conn, id, addr),
+			Timeout: natGatewayAddressAssignmentTimeout,
+		}
+
+		outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+		if output, ok := outputRaw.(*ec2.NatGatewayAddress); ok {
+			if state := aws.StringValue(output.Status); state == ec2.NatGatewayAddressStatusFailed {
+				tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.StringValue(output.Status), aws.StringValue(output.FailureMessage)))
+			}
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func WaitNATGatewayDeleted(ctx context.Context, conn *ec2.EC2, id string) (*ec2.NatGateway, error) {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This PR adds support for defining secondary IP addresses to private NAT gateways. 


### Relations

### References
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateNatGateway.html
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssignPrivateNatGatewayAddress.html

### Output from Acceptance Testing
```
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNATGateway_'  -timeout 180m
=== RUN   TestAccVPCNATGateway_basic
=== PAUSE TestAccVPCNATGateway_basic
=== RUN   TestAccVPCNATGateway_disappears
=== PAUSE TestAccVPCNATGateway_disappears
=== RUN   TestAccVPCNATGateway_ConnectivityType_private
=== PAUSE TestAccVPCNATGateway_ConnectivityType_private
=== RUN   TestAccVPCNATGateway_privateIP
=== PAUSE TestAccVPCNATGateway_privateIP
=== RUN   TestAccVPCNATGateway_privateIPWithSecondary
=== PAUSE TestAccVPCNATGateway_privateIPWithSecondary
=== RUN   TestAccVPCNATGateway_tags
=== PAUSE TestAccVPCNATGateway_tags
=== CONT  TestAccVPCNATGateway_basic
=== CONT  TestAccVPCNATGateway_privateIP
=== CONT  TestAccVPCNATGateway_ConnectivityType_private
=== CONT  TestAccVPCNATGateway_disappears
=== CONT  TestAccVPCNATGateway_tags
=== CONT  TestAccVPCNATGateway_privateIPWithSecondary
--- PASS: TestAccVPCNATGateway_ConnectivityType_private (161.78s)
--- PASS: TestAccVPCNATGateway_privateIP (162.02s)
--- PASS: TestAccVPCNATGateway_basic (182.32s)
--- PASS: TestAccVPCNATGateway_privateIPWithSecondary (188.96s)
--- PASS: TestAccVPCNATGateway_tags (210.35s)
--- PASS: TestAccVPCNATGateway_disappears (211.04s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	213.330s

```
