### PR TITLE
Move `reusable-team-project` to Project scoped token

### DIFF
--- a/.github/workflows/reusable-team-project.yml
+++ b/.github/workflows/reusable-team-project.yml
@@ -8,7 +8,7 @@ on:
         type: string
 env:
   ITEM_NODE_ID: ${{ github.event.issue.node_id || github.event.pull_request.node_id }}
-  GH_TOKEN: ${{ secrets.ORGSCOPED_GITHUB_TOKEN }}
+  GH_TOKEN: ${{ secrets.PROJECT_SCOPED_TOKEN }}
 jobs:
   add-to-project:
     name: "Add Item to Project and Optionally Set Status"


### PR DESCRIPTION
### Description

The reusable workflow for automating the new style GitHub Projects was previously failing due to the token being passed not having the correct permissions. This PR moves the workflow to a newly created `PROJECT_SCOPED_TOKEN` secret to correct this.

### Output from Acceptance Testing

N/a, Actions