### PR TITLE
Add link to additional information for `aws_backup_region_settings`

### DIFF
--- a/website/docs/r/backup_region_settings.html.markdown
+++ b/website/docs/r/backup_region_settings.html.markdown
@@ -40,7 +40,7 @@ resource "aws_backup_region_settings" "test" {
 The following arguments are supported:
 
 * `resource_type_opt_in_preference` - (Required) A map of services along with the opt-in preferences for the Region.
-* `resource_type_management_preference` - (Optional) A map of services along with the management preferences for the Region.
+* `resource_type_management_preference` - (Optional) A map of services along with the management preferences for the Region. For more information, see the [AWS Documentation](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_UpdateRegionSettings.html#API_UpdateRegionSettings_RequestSyntax).
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Description

This PR adds a link to the AWS documentation for additional information around the settings available in `aws_backup_region_settings`.

### Relations

Closes #25150

### References


### Output from Acceptance Testing

N/a, docs
