### PR TITLE
aws_lakeformation_resource_lf_tags: Correctly reads table column tags with inheritance

### DIFF
--- a/internal/create/errors.go
+++ b/internal/create/errors.go
@@ -49,14 +49,24 @@ func Error(service, action, resource, id string, gotError error) error {
 	return errors.New(ProblemStandardMessage(service, action, resource, id, gotError))
 }
 
+// AddError returns diag.Diagnostics with an additional diag.Diagnostic containing
+// an error using a standardized problem message
+func AddError(diags diag.Diagnostics, service, action, resource, id string, gotError error) diag.Diagnostics {
+	return append(diags, newError(service, action, resource, id, gotError))
+}
+
 // DiagError returns a 1-length diag.Diagnostics with a diag.Error-level diag.Diagnostic
 // with a standardized error message
 func DiagError(service, action, resource, id string, gotError error) diag.Diagnostics {
 	return diag.Diagnostics{
-		diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  ProblemStandardMessage(service, action, resource, id, gotError),
-		},
+		newError(service, action, resource, id, gotError),
+	}
+}
+
+func newError(service, action, resource, id string, gotError error) diag.Diagnostic {
+	return diag.Diagnostic{
+		Severity: diag.Error,
+		Summary:  ProblemStandardMessage(service, action, resource, id, gotError),
 	}
 }
 
@@ -95,6 +105,15 @@ func AddWarning(diags diag.Diagnostics, service, action, resource, id string, go
 		diag.Diagnostic{
 			Severity: diag.Warning,
 			Summary:  ProblemStandardMessage(service, action, resource, id, gotError),
+		},
+	)
+}
+
+func AddWarningMessage(diags diag.Diagnostics, service, action, resource, id, message string) diag.Diagnostics {
+	return append(diags,
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  ProblemStandardMessage(service, action, resource, id, fmt.Errorf(message)),
 		},
 	)
 }

--- a/internal/service/lakeformation/lakeformation_test.go
+++ b/internal/service/lakeformation/lakeformation_test.go
@@ -65,7 +65,7 @@ func TestAccLakeFormation_serial(t *testing.T) {
 			"basic":                testAccResourceLFTags_basic,
 			"database":             testAccResourceLFTags_database,
 			"databaseMultipleTags": testAccResourceLFTags_databaseMultipleTags,
-			"disappears":           TestAccResourceLFTags_disappears,
+			"disappears":           testAccResourceLFTags_disappears,
 			"hierarchy":            testAccResourceLFTags_hierarchy,
 			"table":                testAccResourceLFTags_table,
 			"tableWithColumns":     testAccResourceLFTags_tableWithColumns,

--- a/internal/service/lakeformation/lakeformation_test.go
+++ b/internal/service/lakeformation/lakeformation_test.go
@@ -65,6 +65,7 @@ func TestAccLakeFormation_serial(t *testing.T) {
 			"basic":                testAccResourceLFTags_basic,
 			"database":             testAccResourceLFTags_database,
 			"databaseMultipleTags": testAccResourceLFTags_databaseMultipleTags,
+			"disappears":           TestAccResourceLFTags_disappears,
 			"hierarchy":            testAccResourceLFTags_hierarchy,
 			"table":                testAccResourceLFTags_table,
 			"tableWithColumns":     testAccResourceLFTags_tableWithColumns,

--- a/internal/service/lakeformation/lakeformation_test.go
+++ b/internal/service/lakeformation/lakeformation_test.go
@@ -62,11 +62,12 @@ func TestAccLakeFormation_serial(t *testing.T) {
 			"valuesOverFifty": testAccLFTag_Values_overFifty,
 		},
 		"ResourceLFTags": {
-			"basic":            testAccResourceLFTags_basic,
-			"database":         testAccResourceLFTags_database,
-			"databaseMultiple": testAccResourceLFTags_databaseMultiple,
-			"table":            testAccResourceLFTags_table,
-			"tableWithColumns": testAccResourceLFTags_tableWithColumns,
+			"basic":                testAccResourceLFTags_basic,
+			"database":             testAccResourceLFTags_database,
+			"databaseMultipleTags": testAccResourceLFTags_databaseMultipleTags,
+			"hierarchy":            testAccResourceLFTags_hierarchy,
+			"table":                testAccResourceLFTags_table,
+			"tableWithColumns":     testAccResourceLFTags_tableWithColumns,
 		},
 	}
 

--- a/internal/service/lakeformation/resource_lf_tags.go
+++ b/internal/service/lakeformation/resource_lf_tags.go
@@ -380,7 +380,7 @@ func resourceResourceLFTagsDelete(ctx context.Context, d *schema.ResourceData, m
 		input.Resource.TableWithColumns = expandTableColumnsResource(v.([]interface{})[0].(map[string]interface{}))
 	}
 
-	if input.Resource == nil || reflect.DeepEqual(input.Resource, &lakeformation.Resource{}) {
+	if input.Resource == nil || reflect.DeepEqual(input.Resource, &lakeformation.Resource{}) || len(input.LFTags) == 0 {
 		// if resource is empty, don't delete = it won't delete anything since this is the predicate
 		log.Printf("[WARN] No Lake Formation Resource LF Tags to remove")
 		return nil

--- a/internal/service/lakeformation/resource_lf_tags_test.go
+++ b/internal/service/lakeformation/resource_lf_tags_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tflakeformation "github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation"
 )
 
 func testAccResourceLFTags_basic(t *testing.T) {
@@ -39,6 +40,29 @@ func testAccResourceLFTags_basic(t *testing.T) {
 					}),
 					acctest.CheckResourceAttrAccountID(resourceName, "catalog_id"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccResourceLFTags_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lakeformation_resource_lf_tags.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, lakeformation.EndpointsID) },
+		ErrorCheck:               acctest.ErrorCheck(t, lakeformation.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckResourceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceLFTagsConfig_basic(rName, []string{"copse"}, "copse"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatabaseLFTagsExists(ctx, resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tflakeformation.ResourceResourceLFTags(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/service/lakeformation/resource_lf_tags_test.go
+++ b/internal/service/lakeformation/resource_lf_tags_test.go
@@ -80,7 +80,7 @@ func testAccResourceLFTags_database(t *testing.T) {
 	})
 }
 
-func testAccResourceLFTags_databaseMultiple(t *testing.T) {
+func testAccResourceLFTags_databaseMultipleTags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_lakeformation_resource_lf_tags.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -92,7 +92,7 @@ func testAccResourceLFTags_databaseMultiple(t *testing.T) {
 		CheckDestroy:             testAccCheckDatabaseLFTagsDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config:  testAccResourceLFTagsConfig_databaseMultiple(rName, []string{"abbey", "village", "luffield", "woodcote", "copse", "chapel", "stowe", "club"}, []string{"farm", "theloop", "aintree", "brooklands", "maggotts", "becketts", "vale"}, "woodcote", "theloop"),
+				Config:  testAccResourceLFTagsConfig_databaseMultipleTags(rName, []string{"abbey", "village", "luffield", "woodcote", "copse", "chapel", "stowe", "club"}, []string{"farm", "theloop", "aintree", "brooklands", "maggotts", "becketts", "vale"}, "woodcote", "theloop"),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatabaseLFTagsExists(ctx, resourceName),
@@ -107,7 +107,7 @@ func testAccResourceLFTags_databaseMultiple(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceLFTagsConfig_databaseMultiple(rName, []string{"abbey", "village", "luffield", "woodcote", "copse", "chapel", "stowe", "club"}, []string{"farm", "theloop", "aintree", "brooklands", "maggotts", "becketts", "vale"}, "stowe", "becketts"),
+				Config: testAccResourceLFTagsConfig_databaseMultipleTags(rName, []string{"abbey", "village", "luffield", "woodcote", "copse", "chapel", "stowe", "club"}, []string{"farm", "theloop", "aintree", "brooklands", "maggotts", "becketts", "vale"}, "stowe", "becketts"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatabaseLFTagsExists(ctx, resourceName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "lf_tag.*", map[string]string{
@@ -172,7 +172,7 @@ func testAccResourceLFTags_tableWithColumns(t *testing.T) {
 		CheckDestroy:             testAccCheckDatabaseLFTagsDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config:  testAccResourceLFTagsConfig_tableWithColumnsMultiple(rName, []string{"abbey", "village", "luffield", "woodcote", "copse", "chapel", "stowe", "club"}, []string{"farm", "theloop", "aintree", "brooklands", "maggotts", "becketts", "vale"}, "luffield", "vale"),
+				Config:  testAccResourceLFTagsConfig_tableWithColumnsMultipleTags(rName, []string{"abbey", "village", "luffield", "woodcote", "copse", "chapel", "stowe", "club"}, []string{"farm", "theloop", "aintree", "brooklands", "maggotts", "becketts", "vale"}, "luffield", "vale"),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatabaseLFTagsExists(ctx, resourceName),
@@ -187,7 +187,7 @@ func testAccResourceLFTags_tableWithColumns(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceLFTagsConfig_tableWithColumnsMultiple(rName, []string{"abbey", "village", "luffield", "woodcote", "copse", "chapel", "stowe", "club"}, []string{"farm", "theloop", "aintree", "brooklands", "maggotts", "becketts", "vale"}, "copse", "aintree"),
+				Config: testAccResourceLFTagsConfig_tableWithColumnsMultipleTags(rName, []string{"abbey", "village", "luffield", "woodcote", "copse", "chapel", "stowe", "club"}, []string{"farm", "theloop", "aintree", "brooklands", "maggotts", "becketts", "vale"}, "copse", "aintree"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatabaseLFTagsExists(ctx, resourceName),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "lf_tag.*", map[string]string{
@@ -482,7 +482,7 @@ resource "aws_lakeformation_resource_lf_tags" "test" {
 `, rName, fmt.Sprintf(`"%s"`, strings.Join(values, `", "`)), value)
 }
 
-func testAccResourceLFTagsConfig_databaseMultiple(rName string, values1, values2 []string, value1, value2 string) string {
+func testAccResourceLFTagsConfig_databaseMultipleTags(rName string, values1, values2 []string, value1, value2 string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
@@ -598,7 +598,7 @@ resource "aws_lakeformation_resource_lf_tags" "test" {
 `, rName, fmt.Sprintf(`"%s"`, strings.Join(values, `", "`)), value)
 }
 
-func testAccResourceLFTagsConfig_tableWithColumnsMultiple(rName string, values1, values2 []string, value1 string, value2 string) string {
+func testAccResourceLFTagsConfig_tableWithColumnsMultipleTags(rName string, values1, values2 []string, value1 string, value2 string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 

--- a/internal/service/lakeformation/resource_lf_tags_test.go
+++ b/internal/service/lakeformation/resource_lf_tags_test.go
@@ -420,7 +420,7 @@ resource "aws_lakeformation_lf_tag" "test" {
   key    = %[1]q
   values = [%[2]s]
 
-  # for consistency, ensure that admins are setup before testing
+  # for consistency, ensure that admins are set up before testing
   depends_on = [aws_lakeformation_data_lake_settings.test]
 }
 
@@ -436,7 +436,7 @@ resource "aws_lakeformation_resource_lf_tags" "test" {
     value = %[3]q
   }
 
-  # for consistency, ensure that admins are setup before testing
+  # for consistency, ensure that admins are set up before testing
   depends_on = [aws_lakeformation_data_lake_settings.test]
 }
 `, rName, fmt.Sprintf(`"%s"`, strings.Join(values, `", "`)), value)
@@ -462,7 +462,7 @@ resource "aws_lakeformation_lf_tag" "test" {
   key    = %[1]q
   values = [%[2]s]
 
-  # for consistency, ensure that admins are setup before testing
+  # for consistency, ensure that admins are set up before testing
   depends_on = [aws_lakeformation_data_lake_settings.test]
 }
 
@@ -476,7 +476,7 @@ resource "aws_lakeformation_resource_lf_tags" "test" {
     value = %[3]q
   }
 
-  # for consistency, ensure that admins are setup before testing
+  # for consistency, ensure that admins are set up before testing
   depends_on = [aws_lakeformation_data_lake_settings.test]
 }
 `, rName, fmt.Sprintf(`"%s"`, strings.Join(values, `", "`)), value)
@@ -502,7 +502,7 @@ resource "aws_lakeformation_lf_tag" "test" {
   key    = %[1]q
   values = [%[2]s]
 
-  # for consistency, ensure that admins are setup before testing
+  # for consistency, ensure that admins are set up before testing
   depends_on = [aws_lakeformation_data_lake_settings.test]
 }
 
@@ -510,7 +510,7 @@ resource "aws_lakeformation_lf_tag" "test2" {
   key    = "%[1]s-2"
   values = [%[3]s]
 
-  # for consistency, ensure that admins are setup before testing
+  # for consistency, ensure that admins are set up before testing
   depends_on = [aws_lakeformation_data_lake_settings.test]
 }
 
@@ -529,7 +529,7 @@ resource "aws_lakeformation_resource_lf_tags" "test" {
     value = %[5]q
   }
 
-  # for consistency, ensure that admins are setup before testing
+  # for consistency, ensure that admins are set up before testing
   depends_on = [aws_lakeformation_data_lake_settings.test]
 }
 `, rName, fmt.Sprintf(`"%s"`, strings.Join(values1, `", "`)), fmt.Sprintf(`"%s"`, strings.Join(values2, `", "`)), value1, value2)
@@ -577,7 +577,7 @@ resource "aws_lakeformation_lf_tag" "test" {
   key    = %[1]q
   values = [%[2]s]
 
-  # for consistency, ensure that admins are setup before testing
+  # for consistency, ensure that admins are set up before testing
   depends_on = [aws_lakeformation_data_lake_settings.test]
 }
 
@@ -592,7 +592,7 @@ resource "aws_lakeformation_resource_lf_tags" "test" {
     value = %[3]q
   }
 
-  # for consistency, ensure that admins are setup before testing
+  # for consistency, ensure that admins are set up before testing
   depends_on = [aws_lakeformation_data_lake_settings.test]
 }
 `, rName, fmt.Sprintf(`"%s"`, strings.Join(values, `", "`)), value)
@@ -640,7 +640,7 @@ resource "aws_lakeformation_lf_tag" "test" {
   key    = %[1]q
   values = [%[2]s]
 
-  # for consistency, ensure that admins are setup before testing
+  # for consistency, ensure that admins are set up before testing
   depends_on = [aws_lakeformation_data_lake_settings.test]
 }
 
@@ -648,7 +648,7 @@ resource "aws_lakeformation_lf_tag" "test2" {
   key    = "%[1]s-2"
   values = [%[3]s]
 
-  # for consistency, ensure that admins are setup before testing
+  # for consistency, ensure that admins are set up before testing
   depends_on = [aws_lakeformation_data_lake_settings.test]
 }
 
@@ -669,7 +669,7 @@ resource "aws_lakeformation_resource_lf_tags" "test" {
     value = %[5]q
   }
 
-  # for consistency, ensure that admins are setup before testing
+  # for consistency, ensure that admins are set up before testing
   depends_on = [aws_lakeformation_data_lake_settings.test]
 }
 `, rName, fmt.Sprintf(`"%s"`, strings.Join(values1, `", "`)), fmt.Sprintf(`"%s"`, strings.Join(values2, `", "`)), value1, value2)

--- a/internal/service/lakeformation/resource_lf_tags_test.go
+++ b/internal/service/lakeformation/resource_lf_tags_test.go
@@ -148,7 +148,7 @@ func testAccResourceLFTags_databaseMultipleTags(t *testing.T) {
 	})
 }
 
-func TestAccResourceLFTags_hierarchy(t *testing.T) {
+func testAccResourceLFTags_hierarchy(t *testing.T) {
 	ctx := acctest.Context(t)
 	databaseResourceName := "aws_lakeformation_resource_lf_tags.database_tags"
 	tableResourceName := "aws_lakeformation_resource_lf_tags.table_tags"
@@ -224,12 +224,6 @@ func TestAccResourceLFTags_hierarchy(t *testing.T) {
 		},
 	})
 }
-
-// TODO: test table columns with differences
-
-// TODO: test wildcard table
-
-// TODO: test wildcard table columns
 
 func testAccResourceLFTags_table(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -697,13 +691,13 @@ resource "aws_lakeformation_lf_tag" "test2" {
 }
 
 resource "aws_lakeformation_lf_tag" "column_tags" {
-	key    = "%[1]s-3"
-	values = [%[6]s]
-  
-	# for consistency, ensure that admins are set up before testing
-	depends_on = [aws_lakeformation_data_lake_settings.test]
-  }
-  
+  key    = "%[1]s-3"
+  values = [%[6]s]
+
+  # for consistency, ensure that admins are set up before testing
+  depends_on = [aws_lakeformation_data_lake_settings.test]
+}
+
 resource "aws_lakeformation_resource_lf_tags" "database_tags" {
   database {
     name = aws_glue_catalog_database.test.name
@@ -721,7 +715,7 @@ resource "aws_lakeformation_resource_lf_tags" "database_tags" {
 resource "aws_lakeformation_resource_lf_tags" "table_tags" {
   table {
     database_name = aws_glue_catalog_database.test.name
-	name = aws_glue_catalog_table.test.name
+    name          = aws_glue_catalog_table.test.name
   }
 
   lf_tag {
@@ -734,21 +728,21 @@ resource "aws_lakeformation_resource_lf_tags" "table_tags" {
 }
 
 resource "aws_lakeformation_resource_lf_tags" "column_tags" {
-	table_with_columns {
-	  database_name = aws_glue_catalog_database.test.name
-	  name = aws_glue_catalog_table.test.name
-	  column_names  = ["event", "timestamp"]
-	}
-  
-	lf_tag {
-	  key   = aws_lakeformation_lf_tag.column_tags.key
-	  value = %[7]q
-	}
-  
-	# for consistency, ensure that admins are set up before testing
-	depends_on = [aws_lakeformation_data_lake_settings.test]
+  table_with_columns {
+    database_name = aws_glue_catalog_database.test.name
+    name          = aws_glue_catalog_table.test.name
+    column_names  = ["event", "timestamp"]
   }
-  `, rName, fmt.Sprintf(`"%s"`, strings.Join(values1, `", "`)), fmt.Sprintf(`"%s"`, strings.Join(values2, `", "`)), value1, value2, fmt.Sprintf(`"%s"`, strings.Join(values3, `", "`)), value3)
+
+  lf_tag {
+    key   = aws_lakeformation_lf_tag.column_tags.key
+    value = %[7]q
+  }
+
+  # for consistency, ensure that admins are set up before testing
+  depends_on = [aws_lakeformation_data_lake_settings.test]
+}
+`, rName, fmt.Sprintf(`"%s"`, strings.Join(values1, `", "`)), fmt.Sprintf(`"%s"`, strings.Join(values2, `", "`)), value1, value2, fmt.Sprintf(`"%s"`, strings.Join(values3, `", "`)), value3)
 }
 
 func testAccResourceLFTagsConfig_table(rName string, values []string, value string) string {

--- a/internal/service/lakeformation/resource_lf_tags_test.go
+++ b/internal/service/lakeformation/resource_lf_tags_test.go
@@ -148,6 +148,8 @@ func TestAccResourceLFTags_hierarchy(t *testing.T) {
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDatabaseLFTagsExists(ctx, databaseResourceName),
+					testAccCheckDatabaseLFTagsExists(ctx, tableResourceName),
+					testAccCheckDatabaseLFTagsExists(ctx, columnResourceName),
 					resource.TestCheckResourceAttr(databaseResourceName, "lf_tag.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(databaseResourceName, "lf_tag.*", map[string]string{
 						"key":   rName,
@@ -165,9 +167,45 @@ func TestAccResourceLFTags_hierarchy(t *testing.T) {
 					}),
 				),
 			},
+			{
+				Config: testAccResourceLFTagsConfig_hierarchy(rName,
+					[]string{"abbey", "village", "luffield", "woodcote", "copse", "chapel", "stowe", "club"},
+					[]string{"farm", "theloop", "aintree", "brooklands", "maggotts", "becketts", "vale"},
+					[]string{"one", "two", "three"},
+					"stowe",
+					"becketts",
+					"three",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatabaseLFTagsExists(ctx, databaseResourceName),
+					testAccCheckDatabaseLFTagsExists(ctx, tableResourceName),
+					testAccCheckDatabaseLFTagsExists(ctx, columnResourceName),
+					resource.TestCheckResourceAttr(databaseResourceName, "lf_tag.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(databaseResourceName, "lf_tag.*", map[string]string{
+						"key":   rName,
+						"value": "stowe",
+					}),
+					resource.TestCheckResourceAttr(tableResourceName, "lf_tag.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(tableResourceName, "lf_tag.*", map[string]string{
+						"key":   fmt.Sprintf("%s-2", rName),
+						"value": "becketts",
+					}),
+					resource.TestCheckResourceAttr(columnResourceName, "lf_tag.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(columnResourceName, "lf_tag.*", map[string]string{
+						"key":   fmt.Sprintf("%s-3", rName),
+						"value": "three",
+					}),
+				),
+			},
 		},
 	})
 }
+
+// TODO: test table columns with differences
+
+// TODO: test wildcard table
+
+// TODO: test wildcard table columns
 
 func testAccResourceLFTags_table(t *testing.T) {
 	ctx := acctest.Context(t)

--- a/internal/service/lakeformation/resource_lf_tags_test.go
+++ b/internal/service/lakeformation/resource_lf_tags_test.go
@@ -45,7 +45,7 @@ func testAccResourceLFTags_basic(t *testing.T) {
 	})
 }
 
-func TestAccResourceLFTags_disappears(t *testing.T) {
+func testAccResourceLFTags_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lakeformation_resource_lf_tags.test"


### PR DESCRIPTION
### Description

When LF-Tags were defined on table columns as well as either database or table, the incorrect tags were returned for the table columns

### Relations

Closes #31909

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=lakeformation TESTS=TestAccLakeFormation_serial/ResourceLFTags

--- PASS: TestAccLakeFormation_serial (202.59s)
    --- PASS: TestAccLakeFormation_serial/ResourceLFTags (202.58s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/table (33.85s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/tableWithColumns (37.04s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/basic (16.65s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/database (31.39s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/databaseMultipleTags (30.63s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/disappears (16.99s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/hierarchy (36.02s)
```
