### PR TITLE
Properly handle renaming of CodeCommit repository

### DIFF
--- a/.changelog/32207.txt
+++ b/.changelog/32207.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_codecommit_repository: rename repository when repository_name is changed, don't force replacement, causing data loss
+```

--- a/.changelog/32207.txt
+++ b/.changelog/32207.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_codecommit_repository: rename repository when repository_name is changed, don't force replacement, causing data loss
+resource/aws_codecommit_repository: Doesn't force replacement when renaming
 ```

--- a/internal/service/codecommit/repository.go
+++ b/internal/service/codecommit/repository.go
@@ -145,7 +145,7 @@ func resourceRepositoryRead(ctx context.Context, d *schema.ResourceData, meta in
 func resourceRepositoryUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CodeCommitConn(ctx)
-	
+
 	if d.HasChange("repository_name") {
 		if err := resourceUpdateRepositoryName(ctx, conn, d); err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating CodeCommit Repository (%s) name: %s", d.Id(), err)

--- a/internal/service/codecommit/repository.go
+++ b/internal/service/codecommit/repository.go
@@ -187,15 +187,20 @@ func resourceRepositoryDelete(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func resourceUpdateRepositoryName(ctx context.Context, conn *codecommit.CodeCommit, d *schema.ResourceData) error {
+	newName := d.Get("repository_name").(string)
+
 	branchInput := &codecommit.UpdateRepositoryNameInput{
 		OldName: aws.String(d.Id()),
-		NewName: aws.String(d.Get("repository_name").(string)),
+		NewName: aws.String(newName),
 	}
 
 	_, err := conn.UpdateRepositoryNameWithContext(ctx, branchInput)
 	if err != nil {
 		return fmt.Errorf("Updating Repository Name for CodeCommit Repository: %s", err.Error())
 	}
+
+	// The Id is the name
+	d.SetId(newName)
 
 	return nil
 }

--- a/internal/service/codecommit/repository_test.go
+++ b/internal/service/codecommit/repository_test.go
@@ -74,7 +74,9 @@ func TestAccCodeCommitRepository_withChanges(t *testing.T) {
 					testAccCheckRepositoryExists(ctx, "aws_codecommit_repository.test"),
 					resource.TestCheckResourceAttr(
 						"aws_codecommit_repository.test", "description", "This is a test description - with changes"),
-				),
+					resource.TestCheckResourceAttr(
+						"aws_codecommit_repository.test", "repository_name", "renamed_test_repository"),
+					),
 			},
 		},
 	})
@@ -262,7 +264,7 @@ resource "aws_codecommit_repository" "test" {
 func testAccRepositoryConfig_changes(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_codecommit_repository" "test" {
-  repository_name = "test_repository_%d"
+  repository_name = "renamed_test_repository_%d"
   description     = "This is a test description - with changes"
 }
 `, rInt)

--- a/internal/service/codecommit/repository_test.go
+++ b/internal/service/codecommit/repository_test.go
@@ -76,7 +76,7 @@ func TestAccCodeCommitRepository_withChanges(t *testing.T) {
 						"aws_codecommit_repository.test", "description", "This is a test description - with changes"),
 					resource.TestCheckResourceAttr(
 						"aws_codecommit_repository.test", "repository_name", "renamed_test_repository"),
-					),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This pull requests attempts to adjust the CodeCommit repository resource such that attempting to rename it succeeds (as is supported by the API), rather than forcing replacement of the resource (which is undesirable behavior in a resource such as this one that contains data).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32161

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
I'm not currently equipped to run the tests, unfortunately :-(
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
