### PR TITLE
opensearch update delay: 10 min -> 1 min

### DIFF
--- a/internal/service/opensearch/wait.go
+++ b/internal/service/opensearch/wait.go
@@ -83,7 +83,7 @@ func waitForDomainUpdate(ctx context.Context, conn *opensearchservice.OpenSearch
 
 		return retry.RetryableError(
 			fmt.Errorf("%q: Timeout while waiting for changes to be processed", domainName))
-	}, tfresource.WithDelay(10*time.Minute), tfresource.WithPollInterval(10*time.Second))
+	}, tfresource.WithDelay(1*time.Minute), tfresource.WithPollInterval(10*time.Second))
 
 	if tfresource.TimedOut(err) {
 		out, err = FindDomainByName(ctx, conn, domainName)


### PR DESCRIPTION
### Description
https://github.com/hashicorp/terraform-provider-aws/issues/32189

Pragmatic option: reduce minimum OpenSearch update to 1 minute (from 10 minutes).

### Relations
Closes #32189

### References
https://github.com/hashicorp/terraform-provider-aws/issues/32189


### Output from Acceptance Testing
Not sure about tests for this one. No prior delay-specific tests exist for this.