### PR TITLE
Fix retry when reading route table association to deal with eventual consistency

### DIFF
--- a/internal/tfresource/errors.go
+++ b/internal/tfresource/errors.go
@@ -14,6 +14,14 @@ func NotFound(err error) bool {
 	return errors.As(err, &e)
 }
 
+// EmptyResult returns true if the error represents an "empty result" condition.
+// Specifically, EmptyResult returns true if the error or a wrapped error is of type
+// EmptyResultError.
+func EmptyResult(err error) bool {
+	var e *EmptyResultError
+	return errors.As(err, &e)
+}
+
 // TimedOut returns true if the error represents a "wait timed out" condition.
 // Specifically, TimedOut returns true if the error matches all these conditions:
 //   - err is of type retry.TimeoutError


### PR DESCRIPTION
### Description

Sometimes the creation of a `aws_route_table_association` that references a just created `aws_route_table` fails because the `aws_route_table` has not been propagated yet (eventual consistency issues). In that case, the error returned is not `NotFoundError`, but an `EmptyResultError`. This PR fixes the wait cycle to include a retry in the latter case.

### Relations

Closes #32219
