### PR TITLE
[data source]: aws_opensearchserverless_access_policy

### DIFF
--- a/.changelog/32231.txt
+++ b/.changelog/32231.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_opensearchserverless_access_policy
+```

--- a/internal/service/opensearchserverless/access_policy_data_source.go
+++ b/internal/service/opensearchserverless/access_policy_data_source.go
@@ -1,0 +1,110 @@
+package opensearchserverless
+
+import (
+	"context"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opensearchserverless/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource(name="Access Policy")
+func newDataSourceAccessPolicy(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceAccessPolicy{}, nil
+}
+
+const (
+	DSNameAccessPolicy = "Access Policy Data Source"
+)
+
+type dataSourceAccessPolicy struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceAccessPolicy) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
+	resp.TypeName = "aws_opensearchserverless_access_policy"
+}
+
+func (d *dataSourceAccessPolicy) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"description": schema.StringAttribute{
+				Computed: true,
+			},
+			"id": framework.IDAttribute(),
+			"name": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(3, 32),
+				},
+			},
+			"policy": schema.StringAttribute{
+				Computed: true,
+			},
+			"policy_version": schema.StringAttribute{
+				Computed: true,
+			},
+			"type": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					enum.FrameworkValidate[awstypes.AccessPolicyType](),
+				},
+			},
+		},
+	}
+}
+func (d *dataSourceAccessPolicy) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().OpenSearchServerlessClient(ctx)
+
+	var data dataSourceAccessPolicyData
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := FindAccessPolicyByNameAndType(ctx, conn, data.Name.ValueString(), data.Type.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, DSNameAccessPolicy, data.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	data.ID = flex.StringToFramework(ctx, out.Name)
+	data.Description = flex.StringToFramework(ctx, out.Description)
+	data.Name = flex.StringToFramework(ctx, out.Name)
+	data.Type = flex.StringValueToFramework(ctx, out.Type)
+	data.PolicyVersion = flex.StringToFramework(ctx, out.PolicyVersion)
+
+	policyBytes, err := out.Policy.MarshalSmithyDocument()
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, DSNameAccessPolicy, data.Name.String(), err),
+			err.Error(),
+		)
+	}
+
+	pb := string(policyBytes)
+	data.Policy = flex.StringToFramework(ctx, &pb)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+type dataSourceAccessPolicyData struct {
+	Description   types.String `tfsdk:"description"`
+	ID            types.String `tfsdk:"id"`
+	Name          types.String `tfsdk:"name"`
+	Policy        types.String `tfsdk:"policy"`
+	PolicyVersion types.String `tfsdk:"policy_version"`
+	Type          types.String `tfsdk:"type"`
+}

--- a/internal/service/opensearchserverless/access_policy_data_source_test.go
+++ b/internal/service/opensearchserverless/access_policy_data_source_test.go
@@ -1,0 +1,84 @@
+package opensearchserverless_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccOpenSearchServerlessAccessPolicyDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var accesspolicy types.AccessPolicyDetail
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_opensearchserverless_access_policy.test"
+	resourceName := "aws_opensearchserverless_access_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.OpenSearchServerlessEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.OpenSearchServerlessEndpointID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAccessPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccessPolicyDataSourceConfig_basic(rName, "data"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccessPolicyExists(ctx, dataSourceName, &accesspolicy),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "policy", resourceName, "policy"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "policy_version", resourceName, "policy_version"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAccessPolicyDataSourceConfig_basic(rName, policyType string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_opensearchserverless_access_policy" "test" {
+  name = %[1]q
+  type = %[2]q
+  description = %[1]q
+  policy = jsonencode([
+    {
+      "Rules" : [
+        {
+          "ResourceType" : "index",
+          "Resource" : [
+            "index/books/*"
+          ],
+          "Permission" : [
+            "aoss:CreateIndex",
+            "aoss:ReadDocument",
+            "aoss:UpdateIndex",
+            "aoss:DeleteIndex",
+            "aoss:WriteDocument"
+          ]
+        }
+      ],
+      "Principal" : [
+        "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:user/admin"
+      ]
+    }
+  ])
+}
+
+data "aws_opensearchserverless_access_policy" "test" {
+  name = aws_opensearchserverless_access_policy.test.name
+  type = aws_opensearchserverless_access_policy.test.type
+}
+`, rName, policyType)
+}

--- a/internal/service/opensearchserverless/access_policy_data_source_test.go
+++ b/internal/service/opensearchserverless/access_policy_data_source_test.go
@@ -49,8 +49,8 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_opensearchserverless_access_policy" "test" {
-  name = %[1]q
-  type = %[2]q
+  name        = %[1]q
+  type        = %[2]q
   description = %[1]q
   policy = jsonencode([
     {

--- a/internal/service/opensearchserverless/service_package_gen.go
+++ b/internal/service/opensearchserverless/service_package_gen.go
@@ -15,7 +15,12 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
-	return []*types.ServicePackageFrameworkDataSource{}
+	return []*types.ServicePackageFrameworkDataSource{
+		{
+			Factory: newDataSourceAccessPolicy,
+			Name:    "Access Policy",
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {

--- a/website/docs/d/opensearchserverless_access_policy.html.markdown
+++ b/website/docs/d/opensearchserverless_access_policy.html.markdown
@@ -1,0 +1,37 @@
+---
+subcategory: "OpenSearch Serverless"
+layout: "aws"
+page_title: "AWS: aws_opensearchserverless_access_policy"
+description: |-
+  Terraform data source for managing an AWS OpenSearch Serverless Access Policy.
+---
+
+# Data Source: aws_opensearchserverless_access_policy
+
+Terraform data source for managing an AWS OpenSearch Serverless Access Policy.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_opensearchserverless_access_policy" "example" {
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `example_arg` - (Required) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+The following arguments are optional:
+
+* `optional_arg` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the Access Policy. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.

--- a/website/docs/d/opensearchserverless_access_policy.html.markdown
+++ b/website/docs/d/opensearchserverless_access_policy.html.markdown
@@ -16,6 +16,8 @@ Terraform data source for managing an AWS OpenSearch Serverless Access Policy.
 
 ```terraform
 data "aws_opensearchserverless_access_policy" "example" {
+  name = aws_opensearchserverless_access_policy.example.name
+  type = aws_opensearchserverless_access_policy.example.type
 }
 ```
 
@@ -23,15 +25,13 @@ data "aws_opensearchserverless_access_policy" "example" {
 
 The following arguments are required:
 
-* `example_arg` - (Required) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
-
-The following arguments are optional:
-
-* `optional_arg` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `name` - (Required) Name of the policy.
+* `type` - (Required) Type of access policy. Must be `data`.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `arn` - ARN of the Access Policy. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
-* `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `description` - Description of the policy. Typically used to store information about the permissions defined in the policy.
+* `policy` - JSON policy document to use as the content for the new policy.
+* `policy_version` - Version of the policy.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds data source for `aws_opensearchserverless_access_policy`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #28460

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccOpenSearchServerlessAccessPolicyDataSource_' PKG=opensearchserverless

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opensearchserverless/... -v -count 1 -parallel 20  -run=TestAccOpenSearchServerlessAccessPolicyDataSource_ -timeout 180m
--- PASS: TestAccOpenSearchServerlessAccessPolicyDataSource_basic (16.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opensearchserverless	19.532s
```
