### PR TITLE
internal/tags: Used shared memory allocation for shared tag schemas

### DIFF
--- a/internal/service/ec2/ec2_spot_instance_request.go
+++ b/internal/service/ec2/ec2_spot_instance_request.go
@@ -49,7 +49,7 @@ func ResourceSpotInstanceRequest() *schema.Resource {
 				if v.Computed && !v.Optional {
 					continue
 				}
-				if k == names.AttrTags {
+				if k == names.AttrTags || k == "volume_tags" {
 					continue
 				}
 				v.ForceNew = true

--- a/internal/service/ec2/tags.go
+++ b/internal/service/ec2/tags.go
@@ -111,8 +111,10 @@ func tagsFromTagDescriptions(tds []*ec2.TagDescription) []*ec2.Tag {
 }
 
 func tagsSchemaConflictsWith(conflictsWith []string) *schema.Schema {
-	v := tftags.TagsSchema()
-	v.ConflictsWith = conflictsWith
-
-	return v
+	return &schema.Schema{
+		Type:          schema.TypeMap,
+		Optional:      true,
+		Elem:          &schema.Schema{Type: schema.TypeString},
+		ConflictsWith: conflictsWith,
+	}
 }

--- a/internal/tags/tags.go
+++ b/internal/tags/tags.go
@@ -4,29 +4,35 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// TagsSchema returns the schema to use for tags.
-func TagsSchema() *schema.Schema {
-	return &schema.Schema{
+var (
+	tagsSchema *schema.Schema = &schema.Schema{
 		Type:     schema.TypeMap,
 		Optional: true,
 		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
-}
-
-func TagsSchemaComputed() *schema.Schema {
-	return &schema.Schema{
+	tagsSchemaComputed *schema.Schema = &schema.Schema{
 		Type:     schema.TypeMap,
 		Optional: true,
 		Computed: true,
 		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
-}
-
-func TagsSchemaForceNew() *schema.Schema {
-	return &schema.Schema{
+	tagsSchemaForceNew *schema.Schema = &schema.Schema{
 		Type:     schema.TypeMap,
 		Optional: true,
 		ForceNew: true,
 		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
+)
+
+// TagsSchema returns the schema to use for tags.
+func TagsSchema() *schema.Schema {
+	return tagsSchema
+}
+
+func TagsSchemaComputed() *schema.Schema {
+	return tagsSchemaComputed
+}
+
+func TagsSchemaForceNew() *schema.Schema {
+	return tagsSchemaForceNew
 }


### PR DESCRIPTION
### Description

Rather than allocating memory for each shared tag schema, reference the same schema data. Each `schema.Schema` struct allocation is ~304 bytes, which adds up when multiplied times a few hundred resources using it. Not a big reduction by any means, but seems like a quick way to reduce some unnecessary memory usage.

Updated the two code locations which were directly mutating the result of shared tag schemas.

### References

Reference: https://github.com/hashicorp/terraform-provider-aws/issues/31722

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
