### PR TITLE
service/wafv2: Allocate memory once for emptySchema()

### DIFF
--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -10,15 +10,17 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
+var listOfEmptyObjectSchema *schema.Schema = &schema.Schema{
+	Type:     schema.TypeList,
+	Optional: true,
+	MaxItems: 1,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{},
+	},
+}
+
 func emptySchema() *schema.Schema {
-	return &schema.Schema{
-		Type:     schema.TypeList,
-		Optional: true,
-		MaxItems: 1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{},
-		},
-	}
+	return listOfEmptyObjectSchema
 }
 
 func ruleLabelsSchema() *schema.Schema {


### PR DESCRIPTION
### Description

Happened to notice this was generating a decent number of memory allocations while profiling and its a small change.

### References

Reference: https://github.com/hashicorp/terraform-provider-aws/issues/31722

### Output from Acceptance Testing

```
$ TF_ACC=1 go test -count=1 -run='TestAccWAFV2RuleGroup_' -timeout=10m -v ./internal/service/wafv2
...
--- PASS: TestAccWAFV2RuleGroup_basic (30.05s)
--- PASS: TestAccWAFV2RuleGroup_disappears (32.14s)
--- PASS: TestAccWAFV2RuleGroup_Operators_maxNested (34.74s)
--- PASS: TestAccWAFV2RuleGroup_changeMetricNameForceNew (58.55s)
--- PASS: TestAccWAFV2RuleGroup_changeNameForceNew (60.83s)
--- PASS: TestAccWAFV2RuleGroup_changeCapacityForceNew (65.89s)
--- PASS: TestAccWAFV2RuleGroup_updateRule (68.22s)
--- PASS: TestAccWAFV2RuleGroup_logicalRuleStatements (85.48s)
--- PASS: TestAccWAFV2RuleGroup_LabelMatchStatement (58.55s)
--- PASS: TestAccWAFV2RuleGroup_byteMatchStatement (60.96s)
--- PASS: TestAccWAFV2RuleGroup_ipSetReferenceStatement (35.66s)
--- PASS: TestAccWAFV2RuleGroup_RateBased_maxNested (35.63s)
--- PASS: TestAccWAFV2RuleGroup_updateRuleProperties (105.28s)
--- PASS: TestAccWAFV2RuleGroup_sizeConstraintStatement (59.81s)
--- PASS: TestAccWAFV2RuleGroup_xssMatchStatement (59.43s)
--- PASS: TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP (112.62s)
--- PASS: TestAccWAFV2RuleGroup_sqliMatchStatement (58.73s)
--- PASS: TestAccWAFV2RuleGroup_geoMatchStatement (58.94s)
--- PASS: TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP (58.18s)
--- PASS: TestAccWAFV2RuleGroup_RuleLabels (58.66s)
--- PASS: TestAccWAFV2RuleGroup_tags (83.04s)
--- PASS: TestAccWAFV2RuleGroup_rateBasedStatement (109.78s)
--- PASS: TestAccWAFV2RuleGroup_regexMatchStatement (32.72s)
--- PASS: TestAccWAFV2RuleGroup_minimal (25.63s)
--- PASS: TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement (32.67s)
--- PASS: TestAccWAFV2RuleGroup_ruleAction (75.28s)
--- PASS: TestAccWAFV2RuleGroup_RuleAction_customRequestHandling (50.20s)
--- PASS: TestAccWAFV2RuleGroup_RuleAction_customResponse (65.41s)
--- PASS: TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch (264.78s)
```
