### PR TITLE
Fix headers, anchor links in `aws_wafv2_web_acl docs`

### DIFF
--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -89,7 +89,7 @@ resource "aws_wafv2_web_acl" "example" {
 
 ### Account Takeover Protection
 
-```
+```terraform
 resource "aws_wafv2_web_acl" "atp-example" {
   name        = "managed-atp-example"
   description = "Example of a managed ATP rule."
@@ -349,61 +349,61 @@ resource "aws_wafv2_web_acl" "test" {
 
 The following arguments are supported:
 
-* `custom_response_body` - (Optional) Defines custom response bodies that can be referenced by `custom_response` actions. See [`custom_response_body`](#custom_response_body) below for details.
-* `default_action` - (Required) Action to perform if none of the `rules` contained in the WebACL match. See [`default_ action`](#default_action) below for details.
+* `custom_response_body` - (Optional) Defines custom response bodies that can be referenced by `custom_response` actions. See [`custom_response_body`](#custom_response_body-block) below for details.
+* `default_action` - (Required) Action to perform if none of the `rules` contained in the WebACL match. See [`default_action`](#default_action-block) below for details.
 * `description` - (Optional) Friendly description of the WebACL.
 * `name` - (Required) Friendly name of the WebACL.
-* `rule` - (Optional) Rule blocks used to identify the web requests that you want to `allow`, `block`, or `count`. See [`rule`](#rule) below for details.
+* `rule` - (Optional) Rule blocks used to identify the web requests that you want to `allow`, `block`, or `count`. See [`rule`](#rule-block) below for details.
 * `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the region `us-east-1` (N. Virginia) on the AWS provider.
 * `tags` - (Optional) Map of key-value pairs to associate with the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `token_domains` - (Optional) Specifies the domains that AWS WAF should accept in a web request token. This enables the use of tokens across multiple protected websites. When AWS WAF provides a token, it uses the domain of the AWS resource that the web ACL is protecting. If you don't specify a list of token domains, AWS WAF accepts tokens only for the domain of the protected resource. With a token domain list, AWS WAF accepts the resource's host domain plus all domains in the token domain list, including their prefixed subdomains.
-* `visibility_config` - (Required) Defines and enables Amazon CloudWatch metrics and web request sample collection. See [`visibility_config`](#visibility_config) below for details.
+* `visibility_config` - (Required) Defines and enables Amazon CloudWatch metrics and web request sample collection. See [`visibility_config`](#visibility_config-block) below for details.
 
-### `custom_response_body`
+### `custom_response_body` Block
 
 Each `custom_response_body` block supports the following arguments:
 
-* `key` - (Required) Unique key identifying the custom response body. This is referenced by the `custom_response_body_key` argument in the [`custom_response`](#custom_response) block.
+* `key` - (Required) Unique key identifying the custom response body. This is referenced by the `custom_response_body_key` argument in the [`custom_response`](#custom_response-block) block.
 * `content` - (Required) Payload of the custom response.
 * `content_type` - (Required) Type of content in the payload that you are defining in the `content` argument. Valid values are `TEXT_PLAIN`, `TEXT_HTML`, or `APPLICATION_JSON`.
 
-### `default_action`
+### `default_action` Block
 
 The `default_action` block supports the following arguments:
 
 ~> **NOTE:** One of `allow` or `block`, expressed as an empty configuration block `{}`, is required when specifying a `default_action`
 
-* `allow` - (Optional) Specifies that AWS WAF should allow requests by default. See [`allow`](#allow) below for details.
-* `block` - (Optional) Specifies that AWS WAF should block requests by default. See [`block`](#block) below for details.
+* `allow` - (Optional) Specifies that AWS WAF should allow requests by default. See [`allow`](#allow-block) below for details.
+* `block` - (Optional) Specifies that AWS WAF should block requests by default. See [`block`](#block-block) below for details.
 
-### `rule`
+### `rule` Block
 
 ~> **NOTE:** One of `action` or `override_action` is required when specifying a rule
 
 Each `rule` supports the following arguments:
 
-* `action` - (Optional) Action that AWS WAF should take on a web request when it matches the rule's statement. This is used only for rules whose **statements do not reference a rule group**. See [`action`](#action) below for details.
-* `captcha_config` - (Optional) Specifies how AWS WAF should handle CAPTCHA evaluations. See [Captcha Configuration](#captcha-configuration) below for details.
+* `action` - (Optional) Action that AWS WAF should take on a web request when it matches the rule's statement. This is used only for rules whose **statements do not reference a rule group**. See [`action`](#action-block) for details.
+* `captcha_config` - (Optional) Specifies how AWS WAF should handle CAPTCHA evaluations. See [`captcha_config`](#captcha_config-block) below for details.
 * `name` - (Required) Friendly name of the rule. **NOTE:** The provider assumes that rules with names matching this pattern, `^ShieldMitigationRuleGroup_<account-id>_<web-acl-guid>_.*`, are AWS-added for [automatic application layer DDoS mitigation activities](https://docs.aws.amazon.com/waf/latest/developerguide/ddos-automatic-app-layer-response-rg.html). Such rules will be ignored by the provider unless you explicitly include them in your configuration (for example, by using the AWS CLI to discover their properties and creating matching configuration). However, since these rules are owned and managed by AWS, you may get permission errors.
-* `override_action` - (Optional) Override action to apply to the rules in a rule group. Used only for rule **statements that reference a rule group**, like `rule_group_reference_statement` and `managed_rule_group_statement`. See [`override_action`](#override_action) below for details.
+* `override_action` - (Optional) Override action to apply to the rules in a rule group. Used only for rule **statements that reference a rule group**, like `rule_group_reference_statement` and `managed_rule_group_statement`. See [`override_action`](#override_action-block) below for details.
 * `priority` - (Required) If you define more than one Rule in a WebACL, AWS WAF evaluates each request against the `rules` in order based on the value of `priority`. AWS WAF processes rules with lower priority first.
-* `rule_label` - (Optional) Labels to apply to web requests that match the rule match statement. See [`rule_label`](#rule_label) below for details.
-* `statement` - (Required) The AWS WAF processing statement for the rule, for example `byte_match_statement` or `geo_match_statement`. See [`statement`](#statement) below for details.
-* `visibility_config` - (Required) Defines and enables Amazon CloudWatch metrics and web request sample collection. See [`visibility_config`](#visibility_config) below for details.
+* `rule_label` - (Optional) Labels to apply to web requests that match the rule match statement. See [`rule_label`](#rule_label-block) below for details.
+* `statement` - (Required) The AWS WAF processing statement for the rule, for example `byte_match_statement` or `geo_match_statement`. See [`statement`](#statement-block) below for details.
+* `visibility_config` - (Required) Defines and enables Amazon CloudWatch metrics and web request sample collection. See [`visibility_config`](#visibility_config-block) below for details.
 
-#### `action`
+### `action` Block
 
 The `action` block supports the following arguments:
 
 ~> **NOTE:** One of `allow`, `block`, or `count`, is required when specifying an `action`.
 
-* `allow` - (Optional) Instructs AWS WAF to allow the web request. See [`allow`](#allow) below for details.
-* `block` - (Optional) Instructs AWS WAF to block the web request. See [`block`](#block) below for details.
-* `captcha` - (Optional) Instructs AWS WAF to run a Captcha check against the web request. See [`captcha`](#captcha) below for details.
-* `challenge` - (Optional) Instructs AWS WAF to run a check against the request to verify that the request is coming from a legitimate client session. See [`challenge`](#challenge) below for details.
-* `count` - (Optional) Instructs AWS WAF to count the web request and allow it. See [`count`](#count) below for details.
+* `allow` - (Optional) Instructs AWS WAF to allow the web request. See [`allow`](#allow-block) below for details.
+* `block` - (Optional) Instructs AWS WAF to block the web request. See [`block`](#block-block) below for details.
+* `captcha` - (Optional) Instructs AWS WAF to run a Captcha check against the web request. See [`captcha`](#captcha-block) below for details.
+* `challenge` - (Optional) Instructs AWS WAF to run a check against the request to verify that the request is coming from a legitimate client session. See [`challenge`](#challenge-block) below for details.
+* `count` - (Optional) Instructs AWS WAF to count the web request and allow it. See [`count`](#count-block) below for details.
 
-#### `override_action`
+### `override_action` Block
 
 The `override_action` block supports the following arguments:
 
@@ -412,71 +412,71 @@ The `override_action` block supports the following arguments:
 * `count` - (Optional) Override the rule action setting to count (i.e., only count matches). Configured as an empty block `{}`.
 * `none` - (Optional) Don't override the rule action setting. Configured as an empty block `{}`.
 
-#### `allow`
+### `allow` Block
 
 The `allow` block supports the following arguments:
 
-* `custom_request_handling` - (Optional) Defines custom handling for the web request. See [`custom_request_handling`](#custom_request_handling) below for details.
+* `custom_request_handling` - (Optional) Defines custom handling for the web request. See [`custom_request_handling`](#custom_request_handling-block) below for details.
 
-#### `block`
+### `block` Block
 
 The `block` block supports the following arguments:
 
-* `custom_response` - (Optional) Defines a custom response for the web request. See [`custom_response`](#custom_response) below for details.
+* `custom_response` - (Optional) Defines a custom response for the web request. See [`custom_response`](#custom_response-block) below for details.
 
-#### `captcha`
+### `captcha` Block
 
 The `captcha` block supports the following arguments:
 
-* `custom_request_handling` - (Optional) Defines custom handling for the web request. See [`custom_request_handling`](#custom_request_handling) below for details.
+* `custom_request_handling` - (Optional) Defines custom handling for the web request. See [`custom_request_handling`](#custom_request_handling-block) below for details.
 
-#### `challenge`
+### `challenge` Block
 
 The `challenge` block supports the following arguments:
 
-* `custom_request_handling` - (Optional) Defines custom handling for the web request. See [`custom_request_handling`](#custom_request_handling) below for details.
+* `custom_request_handling` - (Optional) Defines custom handling for the web request. See [`custom_request_handling`](#custom_request_handling-block) below for details.
 
-#### `count`
+### `count` Block
 
 The `count` block supports the following arguments:
 
-* `custom_request_handling` - (Optional) Defines custom handling for the web request. See [`custom_request_handling`](#custom_request_handling) below for details.
+* `custom_request_handling` - (Optional) Defines custom handling for the web request. See [`custom_request_handling`](#custom_request_handling-block) below for details.
 
-#### `custom_request_handling`
+### `custom_request_handling` Block
 
 The `custom_request_handling` block supports the following arguments:
 
-* `insert_header` - (Required) The `insert_header` blocks used to define HTTP headers added to the request. See [`insert_header`](#insert_header) below for details.
+* `insert_header` - (Required) The `insert_header` blocks used to define HTTP headers added to the request. See [`insert_header`](#insert_header-block) below for details.
 
-#### `insert_header`
+### `insert_header` Block
 
 Each `insert_header` block supports the following arguments. Duplicate header names are not allowed:
 
 * `name` - Name of the custom header. For custom request header insertion, when AWS WAF inserts the header into the request, it prefixes this name `x-amzn-waf-`, to avoid confusion with the headers that are already in the request. For example, for the header name `sample`, AWS WAF inserts the header `x-amzn-waf-sample`.
 * `value` - Value of the custom header.
 
-#### `custom_response`
+### `custom_response` Block
 
 The `custom_response` block supports the following arguments:
 
 * `custom_response_body_key` - (Optional) References the response body that you want AWS WAF to return to the web request client. This must reference a `key` defined in a `custom_response_body` block of this resource.
 * `response_code` - (Required) The HTTP status code to return to the client.
-* `response_header` - (Optional) The `response_header` blocks used to define the HTTP response headers added to the response. See [`response_header`](#response_header) below for details.
+* `response_header` - (Optional) The `response_header` blocks used to define the HTTP response headers added to the response. See [`response_header`](#response_header-block) below for details.
 
-#### `response_header`
+### `response_header` Block
 
 Each `response_header` block supports the following arguments. Duplicate header names are not allowed:
 
 * `name` - Name of the custom header. For custom request header insertion, when AWS WAF inserts the header into the request, it prefixes this name `x-amzn-waf-`, to avoid confusion with the headers that are already in the request. For example, for the header name `sample`, AWS WAF inserts the header `x-amzn-waf-sample`.
 * `value` - Value of the custom header.
 
-#### `rule_label`
+### `rule_label` Block
 
 Each block supports the following arguments:
 
 * `name` - Label string.
 
-#### `statement`
+### `statement` Block
 
 The processing guidance for a Rule, used by AWS WAF to determine whether a web request matches the rule. See the [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statements-list.html) for more information.
 
@@ -484,67 +484,65 @@ The processing guidance for a Rule, used by AWS WAF to determine whether a web r
 
 The `statement` block supports the following arguments:
 
-* `and_statement` - (Optional) Logical rule statement used to combine other rule statements with AND logic. See [`and_statement`](#and_statement) below for details.
-* `byte_match_statement` - (Optional) Rule statement that defines a string match search for AWS WAF to apply to web requests. See [`byte_match_statement`](#byte_match_statement) below for details.
-* `geo_match_statement` - (Optional) Rule statement used to identify web requests based on country of origin. See [`geo_match_statement`](#geo_match_statement) below for details.
-* `ip_set_reference_statement` - (Optional) Rule statement used to detect web requests coming from particular IP addresses or address ranges. See [IP Set Reference Statement](#ip_set_reference_statement) below for details.
-* `label_match_statement` - (Optional) Rule statement that defines a string match search against labels that have been added to the web request by rules that have already run in the web ACL. See [`label_match_statement`](#label_match_statement) below for details.
-* `managed_rule_group_statement` - (Optional) Rule statement used to run the rules that are defined in a managed rule group.  This statement can not be nested. See [Managed Rule Group Statement](#managed_rule_group_statement) below for details.
-* `not_statement` - (Optional) Logical rule statement used to negate the results of another rule statement. See [`not_statement`](#not_statement) below for details.
-* `or_statement` - (Optional) Logical rule statement used to combine other rule statements with OR logic. See [`or_statement`](#or_statement) below for details.
-* `rate_based_statement` - (Optional) Rate-based rule tracks the rate of requests for each originating `IP address`, and triggers the rule action when the rate exceeds a limit that you specify on the number of requests in any `5-minute` time span. This statement can not be nested. See [`rate_based_statement`](#rate_based_statement) below for details.
-* `regex_match_statement` - (Optional) Rule statement used to search web request components for a match against a single regular expression. See [`regex_match_statement`](#regex_match_statement) below for details.
-* `regex_pattern_set_reference_statement` - (Optional) Rule statement used to search web request components for matches with regular expressions. See [Regex Pattern Set Reference Statement](#regex_pattern_set_reference_statement) below for details.
-* `rule_group_reference_statement` - (Optional) Rule statement used to run the rules that are defined in an WAFv2 Rule Group. See [Rule Group Reference Statement](#rule_group_reference_statement) below for details.
-* `size_constraint_statement` - (Optional) Rule statement that compares a number of bytes against the size of a request component, using a comparison operator, such as greater than (>) or less than (<). See [`size_constraint_statement`](#size_constraint_statement) below for more details.
-* `sqli_match_statement` - (Optional) An SQL injection match condition identifies the part of web requests, such as the URI or the query string, that you want AWS WAF to inspect. See [`sqli_match_statement`](#sqli_match_statement) below for details.
-* `xss_match_statement` - (Optional) Rule statement that defines a cross-site scripting (XSS) match search for AWS WAF to apply to web requests. See [`xss_match_statement`](#xss_match_statement) below for details.
+* `and_statement` - (Optional) Logical rule statement used to combine other rule statements with AND logic. See [`and_statement`](#and_statement-block) below for details.
+* `byte_match_statement` - (Optional) Rule statement that defines a string match search for AWS WAF to apply to web requests. See [`byte_match_statement`](#byte_match_statement-block) below for details.
+* `geo_match_statement` - (Optional) Rule statement used to identify web requests based on country of origin. See [`geo_match_statement`](#geo_match_statement-block) below for details.
+* `ip_set_reference_statement` - (Optional) Rule statement used to detect web requests coming from particular IP addresses or address ranges. See [`ip_set_reference_statement`](#ip_set_reference_statement-block) below for details.
+* `label_match_statement` - (Optional) Rule statement that defines a string match search against labels that have been added to the web request by rules that have already run in the web ACL. See [`label_match_statement`](#label_match_statement-block) below for details.
+* `managed_rule_group_statement` - (Optional) Rule statement used to run the rules that are defined in a managed rule group.  This statement can not be nested. See [`managed_rule_group_statement`](#managed_rule_group_statement-block) below for details.
+* `not_statement` - (Optional) Logical rule statement used to negate the results of another rule statement. See [`not_statement`](#not_statement-block) below for details.
+* `or_statement` - (Optional) Logical rule statement used to combine other rule statements with OR logic. See [`or_statement`](#or_statement-block) below for details.
+* `rate_based_statement` - (Optional) Rate-based rule tracks the rate of requests for each originating `IP address`, and triggers the rule action when the rate exceeds a limit that you specify on the number of requests in any `5-minute` time span. This statement can not be nested. See [`rate_based_statement`](#rate_based_statement-block) below for details.
+* `regex_match_statement` - (Optional) Rule statement used to search web request components for a match against a single regular expression. See [`regex_match_statement`](#regex_match_statement-block) below for details.
+* `regex_pattern_set_reference_statement` - (Optional) Rule statement used to search web request components for matches with regular expressions. See [`regex_pattern_set_reference_statement`](#regex_pattern_set_reference_statement-block) below for details.
+* `rule_group_reference_statement` - (Optional) Rule statement used to run the rules that are defined in an WAFv2 Rule Group. See [`rule_group_reference_statement`](#rule_group_reference_statement-block) below for details.
+* `size_constraint_statement` - (Optional) Rule statement that compares a number of bytes against the size of a request component, using a comparison operator, such as greater than (>) or less than (<). See [`size_constraint_statement`](#size_constraint_statement-block) below for more details.
+* `sqli_match_statement` - (Optional) An SQL injection match condition identifies the part of web requests, such as the URI or the query string, that you want AWS WAF to inspect. See [`sqli_match_statement`](#sqli_match_statement-block) below for details.
+* `xss_match_statement` - (Optional) Rule statement that defines a cross-site scripting (XSS) match search for AWS WAF to apply to web requests. See [`xss_match_statement`](#xss_match_statement-block) below for details.
 
-#### `and_statement`
+### `and_statement` Block
 
 A logical rule statement used to combine other rule statements with `AND` logic. You provide more than one `statement` within the `and_statement`.
 
 The `and_statement` block supports the following arguments:
 
-* `statement` - (Required) Statements to combine with `AND` logic. You can use any statements that can be nested. See [`statement`](#statement) above for details.
+* `statement` - (Required) Statements to combine with `AND` logic. You can use any statements that can be nested. See [`statement`](#statement-block) above for details.
 
-#### `byte_match_statement`
+### `byte_match_statement` Block
 
 The byte match statement provides the bytes to search for, the location in requests that you want AWS WAF to search, and other settings. The bytes to search for are typically a string that corresponds with ASCII characters.
 
 The `byte_match_statement` block supports the following arguments:
 
-* `field_to_match` - (Optional) Part of a web request that you want AWS WAF to inspect. See [`field_to_match`](#field_to_match) below for details.
+* `field_to_match` - (Optional) Part of a web request that you want AWS WAF to inspect. See [`field_to_match`](#field_to_match-block) below for details.
 * `positional_constraint` - (Required) Area within the portion of a web request that you want AWS WAF to search for `search_string`. Valid values include the following: `EXACTLY`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS`, `CONTAINS_WORD`. See the AWS [documentation](https://docs.aws.amazon.com/waf/latest/APIReference/API_ByteMatchStatement.html) for more information.
 * `search_string` - (Required) String value that you want AWS WAF to search for. AWS WAF searches only in the part of web requests that you designate for inspection in `field_to_match`. The maximum length of the value is 50 bytes.
-* `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection.
-  At least one required.
-  See [`text_transformation`](#text_transformation) below for details.
+* `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection. At least one transformation is required. See [`text_transformation`](#text_transformation-block) below for details.
 
-#### `geo_match_statement`
+### `geo_match_statement` Block
 
 The `geo_match_statement` block supports the following arguments:
 
 * `country_codes` - (Required) Array of two-character country codes, for example, [ "US", "CN" ], from the alpha-2 country ISO codes of the `ISO 3166` international standard. See the [documentation](https://docs.aws.amazon.com/waf/latest/APIReference/API_GeoMatchStatement.html) for valid values.
-* `forwarded_ip_config` - (Optional) Configuration for inspecting IP addresses in an HTTP header that you specify, instead of using the IP address that's reported by the web request origin. See [`forwarded_ip_config`](#forwarded_ip_config) below for details.
+* `forwarded_ip_config` - (Optional) Configuration for inspecting IP addresses in an HTTP header that you specify, instead of using the IP address that's reported by the web request origin. See [`forwarded_ip_config`](#forwarded_ip_config-block) below for details.
 
-#### `ip_set_reference_statement`
+### `ip_set_reference_statement` Block
 
 A rule statement used to detect web requests coming from particular IP addresses or address ranges. To use this, create an `aws_wafv2_ip_set` that specifies the addresses you want to detect, then use the `ARN` of that set in this statement.
 
 The `ip_set_reference_statement` block supports the following arguments:
 
 * `arn` - (Required) The Amazon Resource Name (ARN) of the IP Set that this statement references.
-* `ip_set_forwarded_ip_config` - (Optional) Configuration for inspecting IP addresses in an HTTP header that you specify, instead of using the IP address that's reported by the web request origin. See [`ip_set_forwarded_ip_config`](#ip_set_forwarded_ip_config) below for more details.
+* `ip_set_forwarded_ip_config` - (Optional) Configuration for inspecting IP addresses in an HTTP header that you specify, instead of using the IP address that's reported by the web request origin. See [`ip_set_forwarded_ip_config`](#ip_set_forwarded_ip_config-block) below for more details.
 
-#### `label_match_statement`
+### `label_match_statement` Block
 
 The `label_match_statement` block supports the following arguments:
 
 * `scope` - (Required) Specify whether you want to match using the label name or just the namespace. Valid values are `LABEL` or `NAMESPACE`.
 * `key` - (Required) String to match against.
 
-#### `managed_rule_group_statement`
+### `managed_rule_group_statement` Block
 
 A rule statement used to run the rules that are defined in a managed rule group.
 
@@ -553,29 +551,29 @@ You can't nest a `managed_rule_group_statement`, for example for use inside a `n
 The `managed_rule_group_statement` block supports the following arguments:
 
 * `name` - (Required) Name of the managed rule group.
-* `rule_action_override` - (Optional) Action settings to use in the place of the rule actions that are configured inside the rule group. You specify one override for each rule whose action you want to change. See [`rule_action_override`](#rule_action_override) below for details.
-* `managed_rule_group_configs`- (Optional) Additional information that's used by a managed rule group. Only one rule attribute is allowed in each config. See [Managed Rule Group Configs](#managed_rule_group_configs) for more details
-* `scope_down_statement` - Narrows the scope of the statement to matching web requests. This can be any nestable statement, and you can nest statements at any level below this scope-down statement. See [`statement`](#statement) above for details.
+* `rule_action_override` - (Optional) Action settings to use in the place of the rule actions that are configured inside the rule group. You specify one override for each rule whose action you want to change. See [`rule_action_override`](#rule_action_override-block) below for details.
+* `managed_rule_group_configs`- (Optional) Additional information that's used by a managed rule group. Only one rule attribute is allowed in each config. See [`managed_rule_group_configs`](#managed_rule_group_configs-block) for more details
+* `scope_down_statement` - Narrows the scope of the statement to matching web requests. This can be any nestable statement, and you can nest statements at any level below this scope-down statement. See [`statement`](#statement-block) above for details.
 * `vendor_name` - (Required) Name of the managed rule group vendor.
 * `version` - (Optional) Version of the managed rule group. You can set `Version_1.0` or `Version_1.1` etc. If you want to use the default version, do not set anything.
 
-#### `not_statement`
+### `not_statement` Block
 
 A logical rule statement used to negate the results of another rule statement. You provide one `statement` within the `not_statement`.
 
 The `not_statement` block supports the following arguments:
 
-* `statement` - (Required) Statement to negate. You can use any statement that can be nested. See [`statement`](#statement) above for details.
+* `statement` - (Required) Statement to negate. You can use any statement that can be nested. See [`statement`](#statement-block) above for details.
 
-#### `or_statement`
+### `or_statement` Block
 
 A logical rule statement used to combine other rule statements with `OR` logic. You provide more than one `statement` within the `or_statement`.
 
 The `or_statement` block supports the following arguments:
 
-* `statement` - (Required) Statements to combine with `OR` logic. You can use any statements that can be nested. See [`statement`](#statement) above for details.
+* `statement` - (Required) Statements to combine with `OR` logic. You can use any statements that can be nested. See [`statement`](#statement-block) above for details.
 
-#### `rate_based_statement`
+### `rate_based_statement` Block
 
 A rate-based rule tracks the rate of requests for each originating IP address, and triggers the rule action when the rate exceeds a limit that you specify on the number of requests in any 5-minute time span. You can use this to put a temporary block on requests from an IP address that is sending excessive requests. See the [documentation](https://docs.aws.amazon.com/waf/latest/APIReference/API_RateBasedStatement.html) for more information.
 
@@ -584,35 +582,31 @@ You can't nest a `rate_based_statement`, for example for use inside a `not_state
 The `rate_based_statement` block supports the following arguments:
 
 * `aggregate_key_type` - (Optional) Setting that indicates how to aggregate the request counts. Valid values include: `FORWARDED_IP` or `IP`. Default: `IP`.
-* `forwarded_ip_config` - (Optional) Configuration for inspecting IP addresses in an HTTP header that you specify, instead of using the IP address that's reported by the web request origin. If `aggregate_key_type` is set to `FORWARDED_IP`, this block is required. See [`forwarded_ip_config`](#forwarded_ip_config) below for details.
+* `forwarded_ip_config` - (Optional) Configuration for inspecting IP addresses in an HTTP header that you specify, instead of using the IP address that's reported by the web request origin. If `aggregate_key_type` is set to `FORWARDED_IP`, this block is required. See [`forwarded_ip_config`](#forwarded_ip_config-block) below for details.
 * `limit` - (Required) Limit on requests per 5-minute period for a single originating IP address.
-* `scope_down_statement` - (Optional) Optional nested statement that narrows the scope of the rate-based statement to matching web requests. This can be any nestable statement, and you can nest statements at any level below this scope-down statement. See [`statement`](#statement) above for details.
+* `scope_down_statement` - (Optional) Optional nested statement that narrows the scope of the rate-based statement to matching web requests. This can be any nestable statement, and you can nest statements at any level below this scope-down statement. See [`statement`](#statement-block) above for details.
 
-#### `regex_match_statement`
+### `regex_match_statement` Block
 
 A rule statement used to search web request components for a match against a single regular expression.
 
 The `regex_match_statement` block supports the following arguments:
 
 * `regex_string` - (Required) String representing the regular expression. Minimum of `1` and maximum of `512` characters.
-* `field_to_match` - (Required) The part of a web request that you want AWS WAF to inspect. See [`field_to_match`](#field_to_match) below for details.
-* `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection.
-  At least one required.
-  See [`text_transformation`](#text_transformation) below for details.
+* `field_to_match` - (Required) The part of a web request that you want AWS WAF to inspect. See [`field_to_match`](#field_to_match-block) below for details.
+* `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection. At least one transformation is required. See [`text_transformation`](#text_transformation-block) below for details.
 
-#### `regex_pattern_set_reference_statement`
+### `regex_pattern_set_reference_statement` Block
 
 A rule statement used to search web request components for matches with regular expressions. To use this, create a `aws_wafv2_regex_pattern_set` that specifies the expressions that you want to detect, then use the `ARN` of that set in this statement. A web request matches the pattern set rule statement if the request component matches any of the patterns in the set.
 
 The `regex_pattern_set_reference_statement` block supports the following arguments:
 
 * `arn` - (Required) The Amazon Resource Name (ARN) of the Regex Pattern Set that this statement references.
-* `field_to_match` - (Optional) Part of a web request that you want AWS WAF to inspect. See [`field_to_match`](#field_to_match) below for details.
-* `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection.
-  At least one required.
-  See [`text_transformation`](#text_transformation) below for details.
+* `field_to_match` - (Optional) Part of a web request that you want AWS WAF to inspect. See [`field_to_match`](#field_to_match-block) below for details.
+* `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection. At least one transformation is required. See [`text_transformation`](#text_transformation-block) below for details.
 
-#### `rule_group_reference_statement`
+### `rule_group_reference_statement` Block
 
 A rule statement used to run the rules that are defined in an WAFv2 Rule Group or `aws_wafv2_rule_group` resource.
 
@@ -621,9 +615,9 @@ You can't nest a `rule_group_reference_statement`, for example for use inside a 
 The `rule_group_reference_statement` block supports the following arguments:
 
 * `arn` - (Required) The Amazon Resource Name (ARN) of the `aws_wafv2_rule_group` resource.
-* `rule_action_override` - (Optional) Action settings to use in the place of the rule actions that are configured inside the rule group. You specify one override for each rule whose action you want to change. See [`rule_action_override`](#rule_action_override) below for details.
+* `rule_action_override` - (Optional) Action settings to use in the place of the rule actions that are configured inside the rule group. You specify one override for each rule whose action you want to change. See [`rule_action_override`](#rule_action_override-block) below for details.
 
-#### `size_constraint_statement`
+### `size_constraint_statement` Block
 
 A rule statement that uses a comparison operator to compare a number of bytes against the size of a request component. AWS WAFv2 inspects up to the first 8192 bytes (8 KB) of a request body, and when inspecting the request URI Path, the slash `/` in
 the URI counts as one character.
@@ -631,137 +625,128 @@ the URI counts as one character.
 The `size_constraint_statement` block supports the following arguments:
 
 * `comparison_operator` - (Required) Operator to use to compare the request part to the size setting. Valid values include: `EQ`, `NE`, `LE`, `LT`, `GE`, or `GT`.
-* `field_to_match` - (Optional) Part of a web request that you want AWS WAF to inspect. See [`field_to_match`](#field_to_match) below for details.
+* `field_to_match` - (Optional) Part of a web request that you want AWS WAF to inspect. See [`field_to_match`](#field_to_match-block) below for details.
 * `size` - (Required) Size, in bytes, to compare to the request part, after any transformations. Valid values are integers between 0 and 21474836480, inclusive.
-* `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection.
-  At least one required.
-  See [`text_transformation`](#text_transformation) below for details.
+* `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection. At least one transformation is required. See [`text_transformation`](#text_transformation-block) below for details.
 
-#### `sqli_match_statement`
+### `sqli_match_statement` Block
 
 An SQL injection match condition identifies the part of web requests, such as the URI or the query string, that you want AWS WAF to inspect. Later in the process, when you create a web ACL, you specify whether to allow or block requests that appear to contain malicious SQL code.
 
 The `sqli_match_statement` block supports the following arguments:
 
-* `field_to_match` - (Optional) Part of a web request that you want AWS WAF to inspect. See [`field_to_match`](#field_to_match) below for details.
-* `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection.
-  At least one required.
-  See [`text_transformation`](#text_transformation) below for details.
+* `field_to_match` - (Optional) Part of a web request that you want AWS WAF to inspect. See [`field_to_match`](#field_to_match-block) below for details.
+* `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection. At least one transformation is required. See [`text_transformation`](#text_transformation-block) below for details.
 
-#### `xss_match_statement`
+### `xss_match_statement` Block
 
 The XSS match statement provides the location in requests that you want AWS WAF to search and text transformations to use on the search area before AWS WAF searches for character sequences that are likely to be malicious strings.
 
 The `xss_match_statement` block supports the following arguments:
 
-* `field_to_match` - (Optional) Part of a web request that you want AWS WAF to inspect. See [`field_to_match`](#field_to_match) below for details.
-* `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection.
-  At least one required.
-  See [`text_transformation`](#text_transformation) below for details.
+* `field_to_match` - (Optional) Part of a web request that you want AWS WAF to inspect. See [`field_to_match`](#field_to_match-block) below for details.
+* `text_transformation` - (Required) Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection. At least one transformation is required. See [`text_transformation`](#text_transformation-block) below for details.
 
-#### `rule_action_override`
+### `rule_action_override` Block
 
 The `rule_action_override` block supports the following arguments:
 
-* `action_to_use` - (Required) Override action to use, in place of the configured action of the rule in the rule group. See [`action`](#action) below for details.
+* `action_to_use` - (Required) Override action to use, in place of the configured action of the rule in the rule group. See [`action`](#action-block) for details.
 * `name` - (Required) Name of the rule to override. See the [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html) for a list of names in the appropriate rule group in use.
 
-#### `managed_rule_group_configs`
+### `managed_rule_group_configs` Block
 
 The `managed_rule_group_configs` block support the following arguments:
 
-* `aws_managed_rules_bot_control_rule_set` - (Optional) Additional configuration for using the Bot Control managed rule group. Use this to specify the inspection level that you want to use. See [`aws_managed_rules_bot_control_rule_set`](#aws_managed_rules_bot_control_rule_set) for more details
+* `aws_managed_rules_bot_control_rule_set` - (Optional) Additional configuration for using the Bot Control managed rule group. Use this to specify the inspection level that you want to use. See [`aws_managed_rules_bot_control_rule_set`](#aws_managed_rules_bot_control_rule_set-block) for more details
 * `aws_managed_rules_atp_rule_set` - (Optional) Additional configuration for using the Account Takeover Protection managed rule group. Use this to specify information such as the sign-in page of your application and the type of content to accept or reject from the client.
 * `login_path` - (Optional, **Deprecated**) The path of the login endpoint for your application.
-* `password_field` - (Optional, **Deprecated**) Details about your login page password field. See [`password_field`](#password_field) for more details.
+* `password_field` - (Optional, **Deprecated**) Details about your login page password field. See [`password_field`](#password_field-block) for more details.
 * `payload_type`- (Optional, **Deprecated**) The payload type for your login endpoint, either JSON or form encoded.
-* `username_field` - (Optional, **Deprecated**) Details about your login page username field. See [`username_field`](#username_field) for more details.
+* `username_field` - (Optional, **Deprecated**) Details about your login page username field. See [`username_field`](#username_field-block) for more details.
 
-#### `aws_managed_rules_bot_control_rule_set`
+### `aws_managed_rules_bot_control_rule_set` Block
 
 * `inspection_level` - (Optional) The inspection level to use for the Bot Control rule group.
 
-#### `aws_managed_rules_atp_rule_set`
+### `aws_managed_rules_atp_rule_set` Block
 
 * `login_path` - (Required) The path of the login endpoint for your application.
-* `request_inspection` - (Optional) The criteria for inspecting login requests, used by the ATP rule group to validate credentials usage. See [`request_inspection`](#request_inspection) for more details.
-* `response_inspection` - (Optional) The criteria for inspecting responses to login requests, used by the ATP rule group to track login failure rates. Note that Response Inspection is available only on web ACLs that protect CloudFront distributions. See [`response_inspection`](#response_inspection) for more details.
+* `request_inspection` - (Optional) The criteria for inspecting login requests, used by the ATP rule group to validate credentials usage. See [`request_inspection`](#request_inspection-block) for more details.
+* `response_inspection` - (Optional) The criteria for inspecting responses to login requests, used by the ATP rule group to track login failure rates. Note that Response Inspection is available only on web ACLs that protect CloudFront distributions. See [`response_inspection`](#response_inspection-block) for more details.
 
-#### `request_inspection`
+### `request_inspection` Block
 
 * `payload_type` (Required) The payload type for your login endpoint, either JSON or form encoded.
-* `username_field` (Required) Details about your login page username field. See [`username_field`](#username_field) for more details.
-* `password_field` (Required) Details about your login page password field. See [`password_field`](#password_field) for more details.
+* `username_field` (Required) Details about your login page username field. See [`username_field`](#username_field-block) for more details.
+* `password_field` (Required) Details about your login page password field. See [`password_field`](#password_field-block) for more details.
 
-#### `password_field`
+### `password_field` Block
 
 * `identifier` - (Optional) The name of the password field.
 
-#### `username_field`
+### `username_field` Block
 
 * `identifier` - (Optional) The name of the username field.
 
-#### `response_inspection`
+### `response_inspection` Block
 
-* `body_contains` (Optional) Configures inspection of the response body. See [`body_contains`](#body_contains) for more details.
-* `header` (Optional) Configures inspection of the response header.See [`header`](#header) for more details.
-* `json` (Optional) Configures inspection of the response JSON. See [`json`](#json) for more details.
-* `status_code` (Optional) Configures inspection of the response status code.See [`status_code`](#status_code) for more details.
+* `body_contains` (Optional) Configures inspection of the response body. See [`body_contains`](#body_contains-block) for more details.
+* `header` (Optional) Configures inspection of the response header.See [`header`](#header-block) for more details.
+* `json` (Optional) Configures inspection of the response JSON. See [`json`](#json-block) for more details.
+* `status_code` (Optional) Configures inspection of the response status code.See [`status_code`](#status_code-block) for more details.
 
-#### `body_contains`
+### `body_contains` Block
 
 * `success_strings` (Required) Strings in the body of the response that indicate a successful login attempt.
 * `failure_strings` (Required) Strings in the body of the response that indicate a failed login attempt.
 
-#### `header`
+### `header` Block
 
 * `name` (Required) The name of the header to match against. The name must be an exact match, including case.
 * `success_values` (Required) Values in the response header with the specified name that indicate a successful login attempt.
 * `failure_values` (Required) Values in the response header with the specified name that indicate a failed login attempt.
 
-#### `json`
+### `json` Block
 
 * `identifier` (Required) The identifier for the value to match against in the JSON.
 * `success_strings` (Required) Strings in the body of the response that indicate a successful login attempt.
 * `failure_strings` (Required) Strings in the body of the response that indicate a failed login attempt.
 
-#### `status_code`
+### `status_code` Block
 
 * `success_codes` (Required) Status codes in the response that indicate a successful login attempt.
 * `failure_codes` (Required) Status codes in the response that indicate a failed login attempt.
 
-#### `field_to_match`
+### `field_to_match` Block
 
 The part of a web request that you want AWS WAF to inspect. Include the single `field_to_match` type that you want to inspect, with additional specifications as needed, according to the type. You specify a single request component in `field_to_match` for each rule statement that requires it. To inspect more than one component of a web request, create a separate rule statement for each component. See the [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-fields.html#waf-rule-statement-request-component) for more details.
 
 The `field_to_match` block supports the following arguments:
 
-~> **NOTE:** Only one of `all_query_arguments`, `body`, `cookies`, `headers`, `json_body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified.
-An empty configuration block `{}` should be used when specifying `all_query_arguments`, `method`, or `query_string` attributes.
+~> **NOTE:** Only one of `all_query_arguments`, `body`, `cookies`, `headers`, `json_body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified. An empty configuration block `{}` should be used when specifying `all_query_arguments`, `method`, or `query_string` attributes.
 
 * `all_query_arguments` - (Optional) Inspect all query arguments.
-* `body` - (Optional) Inspect the request body, which immediately follows the request headers. See [`body`](#body) below for details.
-* `cookies` - (Optional) Inspect the cookies in the web request. See [`cookies`](#cookies) below for details.
-* `headers` - (Optional) Inspect the request headers. See [`headers`](#headers) below for details.
-* `json_body` - (Optional) Inspect the request body as JSON. See [`json_body`](#json_body) for details.
+* `body` - (Optional) Inspect the request body, which immediately follows the request headers. See [`body`](#body-block) below for details.
+* `cookies` - (Optional) Inspect the cookies in the web request. See [`cookies`](#cookies-block) below for details.
+* `headers` - (Optional) Inspect the request headers. See [`headers`](#headers-block) below for details.
+* `json_body` - (Optional) Inspect the request body as JSON. See [`json_body`](#json_body-block) for details.
 * `method` - (Optional) Inspect the HTTP method. The method indicates the type of operation that the request is asking the origin to perform.
 * `query_string` - (Optional) Inspect the query string. This is the part of a URL that appears after a `?` character, if any.
-* `single_header` - (Optional) Inspect a single header. See [`single_header`](#single_header) below for details.
-* `single_query_argument` - (Optional) Inspect a single query argument. See [`single_query_argument`](#single_query_argument) below for details.
+* `single_header` - (Optional) Inspect a single header. See [`single_header`](#single_header-block) below for details.
+* `single_query_argument` - (Optional) Inspect a single query argument. See [`single_query_argument`](#single_query_argument-block) below for details.
 * `uri_path` - (Optional) Inspect the request URI path. This is the part of a web request that identifies a resource, for example, `/images/daily-ad.jpg`.
 
-#### `forwarded_ip_config`
+### `forwarded_ip_config` Block
 
-The configuration for inspecting IP addresses in an HTTP header that you specify, instead of using the IP address that's reported by the web request origin. Commonly, this is the X-Forwarded-For (XFF) header, but you can specify
-any header name. If the specified header isn't present in the request, AWS WAFv2 doesn't apply the rule to the web request at all.
-AWS WAFv2 only evaluates the first IP address found in the specified HTTP header.
+The configuration for inspecting IP addresses in an HTTP header that you specify, instead of using the IP address that's reported by the web request origin. Commonly, this is the X-Forwarded-For (XFF) header, but you can specify any header name. If the specified header isn't present in the request, AWS WAFv2 doesn't apply the rule to the web request at all. AWS WAFv2 only evaluates the first IP address found in the specified HTTP header.
 
 The `forwarded_ip_config` block supports the following arguments:
 
 * `fallback_behavior` - (Required) - Match status to assign to the web request if the request doesn't have a valid IP address in the specified position. Valid values include: `MATCH` or `NO_MATCH`.
 * `header_name` - (Required) - Name of the HTTP header to use for the IP address.
 
-#### `ip_set_forwarded_ip_config`
+### `ip_set_forwarded_ip_config` Block
 
 The configuration for inspecting IP addresses in an HTTP header that you specify, instead of using the IP address that's reported by the web request origin. Commonly, this is the X-Forwarded-For (XFF) header, but you can specify any header name.
 
@@ -771,7 +756,7 @@ The `ip_set_forwarded_ip_config` block supports the following arguments:
 * `header_name` - (Required) - Name of the HTTP header to use for the IP address.
 * `position` - (Required) - Position in the header to search for the IP address. Valid values include: `FIRST`, `LAST`, or `ANY`. If `ANY` is specified and the header contains more than 10 IP addresses, AWS WAFv2 inspects the last 10.
 
-#### `headers`
+### `headers` Block
 
 Inspect the request headers.
 
@@ -784,7 +769,7 @@ The `headers` block supports the following arguments:
 * `match_scope` - (Required) The parts of the headers to inspect with the rule inspection criteria. If you specify `All`, AWS WAF inspects both keys and values. Valid values include the following: `ALL`, `Key`, `Value`.
 * `oversize_handling` - (Required) Oversize handling tells AWS WAF what to do with a web request when the request component that the rule inspects is over the limits. Valid values include the following: `CONTINUE`, `MATCH`, `NO_MATCH`. See the AWS [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-oversize-handling.html) for more information.
 
-#### `json_body`
+### `json_body` Block
 
 The `json_body` block supports the following arguments:
 
@@ -793,7 +778,7 @@ The `json_body` block supports the following arguments:
 * `match_scope` - (Required) The parts of the JSON to match against using the `match_pattern`. Valid values are `ALL`, `KEY` and `VALUE`.
 * `oversize_handling` - (Optional) What to do if the body is larger than can be inspected. Valid values are `CONTINUE` (default), `MATCH` and `NO_MATCH`.
 
-#### `single_header`
+### `single_header` Block
 
 Inspect a single header. Provide the name of the header to inspect, for example, `User-Agent` or `Referer` (provided as lowercase strings).
 
@@ -801,7 +786,7 @@ The `single_header` block supports the following arguments:
 
 * `name` - (Optional) Name of the query header to inspect. This setting must be provided as lower case characters.
 
-#### `single_query_argument`
+### `single_query_argument` Block
 
 Inspect a single query argument. Provide the name of the query argument to inspect, such as `UserName` or `SalesRegion` (provided as lowercase strings).
 
@@ -809,16 +794,15 @@ The `single_query_argument` block supports the following arguments:
 
 * `name` - (Optional) Name of the query header to inspect. This setting must be provided as lower case characters.
 
-#### `body`
+### `body` Block
 
 The `body` block supports the following arguments:
 
 * `oversize_handling` - (Optional) What WAF should do if the body is larger than WAF can inspect. WAF does not support inspecting the entire contents of the body of a web request when the body exceeds 8 KB (8192 bytes). Only the first 8 KB of the request body are forwarded to WAF by the underlying host service. Valid values: `CONTINUE`, `MATCH`, `NO_MATCH`.
 
-#### `cookies`
+### `cookies` Block
 
-Inspect the cookies in the web request. You can specify the parts of the cookies to inspect and you can narrow the set of cookies to inspect by including or excluding specific keys.
-This is used to indicate the web request component to inspect, in the [FieldToMatch](https://docs.aws.amazon.com/waf/latest/APIReference/API_FieldToMatch.html) specification.
+Inspect the cookies in the web request. You can specify the parts of the cookies to inspect and you can narrow the set of cookies to inspect by including or excluding specific keys. This is used to indicate the web request component to inspect, in the [FieldToMatch](https://docs.aws.amazon.com/waf/latest/APIReference/API_FieldToMatch.html) specification.
 
 The `cookies` block supports the following arguments:
 
@@ -826,14 +810,14 @@ The `cookies` block supports the following arguments:
 * `match_scope` - (Required) The parts of the cookies to inspect with the rule inspection criteria. If you specify All, AWS WAF inspects both keys and values. Valid values: `ALL`, `KEY`, `VALUE`
 * `oversize_handling` - (Required) What AWS WAF should do if the cookies of the request are larger than AWS WAF can inspect. AWS WAF does not support inspecting the entire contents of request cookies when they exceed 8 KB (8192 bytes) or 200 total cookies. The underlying host service forwards a maximum of 200 cookies and at most 8 KB of cookie contents to AWS WAF. Valid values: `CONTINUE`, `MATCH`, `NO_MATCH`.
 
-#### `text_transformation`
+### `text_transformation` Block
 
 The `text_transformation` block supports the following arguments:
 
 * `priority` - (Required) Relative processing order for multiple transformations that are defined for a rule statement. AWS WAF processes all transformations, from lowest priority to highest, before inspecting the transformed content.
 * `type` - (Required) Transformation to apply, please refer to the Text Transformation [documentation](https://docs.aws.amazon.com/waf/latest/APIReference/API_TextTransformation.html) for more details.
 
-### `visibility_config`
+### `visibility_config` Block
 
 The `visibility_config` block supports the following arguments:
 
@@ -841,13 +825,13 @@ The `visibility_config` block supports the following arguments:
 * `metric_name` - (Required) A friendly name of the CloudWatch metric. The name can contain only alphanumeric characters (A-Z, a-z, 0-9) hyphen(-) and underscore (\_), with length from one to 128 characters. It can't contain whitespace or metric names reserved for AWS WAF, for example `All` and `Default_Action`.
 * `sampled_requests_enabled` - (Required) Whether AWS WAF should store a sampling of the web requests that match the rules. You can view the sampled requests through the AWS WAF console.
 
-### Captcha Configuration
+### `captcha_config` Blocks
 
 The `captcha_config` block supports the following arguments:
 
-* `immunity_time_property` - (Optional) Defines custom immunity time. See [Immunity Time Property](#immunity-time-property) below for details.
+* `immunity_time_property` - (Optional) Defines custom immunity time. See [`immunity_time_property`](#immunity_time_property-block) below for details.
 
-### Immunity Time Property
+### `immunity_time_property` Block
 
 The `immunity_time_property` block supports the following arguments:
 

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Creates a WAFv2 Web ACL resource.
 
-~> **Note:** In `field_to_match` blocks, _e.g._, in `byte_match_statement`, the `body` block includes an optional argument `oversize_handling`. AWS indicates this argument will be required starting February 2023. To avoid configurations breaking when that change happens, treat the `oversize_handling` argument as **required** as soon as possible.
+~> **Note** In `field_to_match` blocks, _e.g._, in `byte_match_statement`, the `body` block includes an optional argument `oversize_handling`. AWS indicates this argument will be required starting February 2023. To avoid configurations breaking when that change happens, treat the `oversize_handling` argument as **required** as soon as possible.
 
 ## Example Usage
 
@@ -371,20 +371,20 @@ Each `custom_response_body` block supports the following arguments:
 
 The `default_action` block supports the following arguments:
 
-~> **NOTE:** One of `allow` or `block`, expressed as an empty configuration block `{}`, is required when specifying a `default_action`
+~> **Note** One of `allow` or `block`, expressed as an empty configuration block `{}`, is required when specifying a `default_action`
 
 * `allow` - (Optional) Specifies that AWS WAF should allow requests by default. See [`allow`](#allow-block) below for details.
 * `block` - (Optional) Specifies that AWS WAF should block requests by default. See [`block`](#block-block) below for details.
 
 ### `rule` Block
 
-~> **NOTE:** One of `action` or `override_action` is required when specifying a rule
+~> **Note** One of `action` or `override_action` is required when specifying a rule
 
 Each `rule` supports the following arguments:
 
 * `action` - (Optional) Action that AWS WAF should take on a web request when it matches the rule's statement. This is used only for rules whose **statements do not reference a rule group**. See [`action`](#action-block) for details.
 * `captcha_config` - (Optional) Specifies how AWS WAF should handle CAPTCHA evaluations. See [`captcha_config`](#captcha_config-block) below for details.
-* `name` - (Required) Friendly name of the rule. **NOTE:** The provider assumes that rules with names matching this pattern, `^ShieldMitigationRuleGroup_<account-id>_<web-acl-guid>_.*`, are AWS-added for [automatic application layer DDoS mitigation activities](https://docs.aws.amazon.com/waf/latest/developerguide/ddos-automatic-app-layer-response-rg.html). Such rules will be ignored by the provider unless you explicitly include them in your configuration (for example, by using the AWS CLI to discover their properties and creating matching configuration). However, since these rules are owned and managed by AWS, you may get permission errors.
+* `name` - (Required) Friendly name of the rule. Note that the provider assumes that rules with names matching this pattern, `^ShieldMitigationRuleGroup_<account-id>_<web-acl-guid>_.*`, are AWS-added for [automatic application layer DDoS mitigation activities](https://docs.aws.amazon.com/waf/latest/developerguide/ddos-automatic-app-layer-response-rg.html). Such rules will be ignored by the provider unless you explicitly include them in your configuration (for example, by using the AWS CLI to discover their properties and creating matching configuration). However, since these rules are owned and managed by AWS, you may get permission errors.
 * `override_action` - (Optional) Override action to apply to the rules in a rule group. Used only for rule **statements that reference a rule group**, like `rule_group_reference_statement` and `managed_rule_group_statement`. See [`override_action`](#override_action-block) below for details.
 * `priority` - (Required) If you define more than one Rule in a WebACL, AWS WAF evaluates each request against the `rules` in order based on the value of `priority`. AWS WAF processes rules with lower priority first.
 * `rule_label` - (Optional) Labels to apply to web requests that match the rule match statement. See [`rule_label`](#rule_label-block) below for details.
@@ -395,7 +395,7 @@ Each `rule` supports the following arguments:
 
 The `action` block supports the following arguments:
 
-~> **NOTE:** One of `allow`, `block`, or `count`, is required when specifying an `action`.
+~> **Note** One of `allow`, `block`, or `count`, is required when specifying an `action`.
 
 * `allow` - (Optional) Instructs AWS WAF to allow the web request. See [`allow`](#allow-block) below for details.
 * `block` - (Optional) Instructs AWS WAF to block the web request. See [`block`](#block-block) below for details.
@@ -407,7 +407,7 @@ The `action` block supports the following arguments:
 
 The `override_action` block supports the following arguments:
 
-~> **NOTE:** One of `count` or `none`, expressed as an empty configuration block `{}`, is required when specifying an `override_action`
+~> **Note** One of `count` or `none`, expressed as an empty configuration block `{}`, is required when specifying an `override_action`
 
 * `count` - (Optional) Override the rule action setting to count (i.e., only count matches). Configured as an empty block `{}`.
 * `none` - (Optional) Don't override the rule action setting. Configured as an empty block `{}`.
@@ -480,7 +480,7 @@ Each block supports the following arguments:
 
 The processing guidance for a Rule, used by AWS WAF to determine whether a web request matches the rule. See the [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statements-list.html) for more information.
 
--> **NOTE:** Although the `statement` block is recursive, currently only 3 levels are supported.
+-> **Note** Although the `statement` block is recursive, currently only 3 levels are supported.
 
 The `statement` block supports the following arguments:
 
@@ -724,7 +724,7 @@ The part of a web request that you want AWS WAF to inspect. Include the single `
 
 The `field_to_match` block supports the following arguments:
 
-~> **NOTE:** Only one of `all_query_arguments`, `body`, `cookies`, `headers`, `json_body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified. An empty configuration block `{}` should be used when specifying `all_query_arguments`, `method`, or `query_string` attributes.
+~> **Note** Only one of `all_query_arguments`, `body`, `cookies`, `headers`, `json_body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified. An empty configuration block `{}` should be used when specifying `all_query_arguments`, `method`, or `query_string` attributes.
 
 * `all_query_arguments` - (Optional) Inspect all query arguments.
 * `body` - (Optional) Inspect the request body, which immediately follows the request headers. See [`body`](#body-block) below for details.

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -825,7 +825,7 @@ The `visibility_config` block supports the following arguments:
 * `metric_name` - (Required) A friendly name of the CloudWatch metric. The name can contain only alphanumeric characters (A-Z, a-z, 0-9) hyphen(-) and underscore (\_), with length from one to 128 characters. It can't contain whitespace or metric names reserved for AWS WAF, for example `All` and `Default_Action`.
 * `sampled_requests_enabled` - (Required) Whether AWS WAF should store a sampling of the web requests that match the rules. You can view the sampled requests through the AWS WAF console.
 
-### `captcha_config` Blocks
+### `captcha_config` Block
 
 The `captcha_config` block supports the following arguments:
 


### PR DESCRIPTION
### Description

This PR fixes a few issues within the `aws_wafv2_web_acl` documentation:

- Added `terraform` tag to one of the example code blocks that was missing it.
- Concatenated a few lines that were broken up for some reason.
- Changed header level of several of the headers from h4 to h3 so that they would properly render as anchors in the Registry.
- Made the `**Note**` callouts consistent with the [Registry Documentation](https://developer.hashicorp.com/terraform/registry/providers/docs#callouts) on callouts
- Changed nested block headers to a uniform style of "`nested_block_name` Block". This accomplishes a couple of things:
  - Consistency across header titles.
  - Consistency in anchor links; underscores, mirroring the block name, a dash to replace the space, and then "block" (`#nested_block_name-block`)
  - Ability to properly link to the argument in a block vs the reference for the nested block (e.g. can properly link to the top level `visibility_config` vs the `visibility_config` nested block section of the docs). This one is small (I don't imagine many people are linking to the top-level argument definition), but ensures that all of the arguments and nested blocks can be linked to for consistency.
- Changed link text for links to anchors so that they were all consistent. 
 
**For the reviewer(s):** I opted to make the link text just the block name (e.g. "See `visibility_config` for details"), rather than what the actual header title is (e.g. "`visibility_config` Block") because it felt like it looked better to my eye. I could see an argument for the link text being exactly what the header actually is (e.g. "See `visibility_config` Block for details), and so would be interested in another opinion.


### Relations

Closes #29510

### References

- [Registry Doc Preview Tool](https://registry.terraform.io/tools/doc-preview) was used to preview changes

### Output from Acceptance Testing

N/a, docs