### PR TITLE
docs/r/cloudfront_distribution: Fix example of default_cache_behavior

### DIFF
--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -212,7 +212,6 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     # Using the CachingDisabled managed policy ID:
     cache_policy_id  = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
-    path_pattern     = "/content/*"
     target_origin_id = local.s3_origin_id
   }
 


### PR DESCRIPTION
### Description
`default_cache_behavior` cannot specify `path_pattern`.
