### PR TITLE
Add support for updating release label on EMR Serverless applications

### DIFF
--- a/.changelog/32278.txt
+++ b/.changelog/32278.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_emrserverless_application: Mark `release_label` as not requiring a new resource
+resource/aws_emrserverless_application: Do not recreate the resource if `release_label` changes
 ```

--- a/.changelog/32278.txt
+++ b/.changelog/32278.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_emrserverless_application: Mark `release_label` as not requiring a new resource
+```

--- a/internal/service/emrserverless/application.go
+++ b/internal/service/emrserverless/application.go
@@ -201,7 +201,6 @@ func ResourceApplication() *schema.Resource {
 			"release_label": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
@@ -332,6 +331,10 @@ func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta
 		input := &emrserverless.UpdateApplicationInput{
 			ApplicationId: aws.String(d.Id()),
 			ClientToken:   aws.String(id.UniqueId()),
+		}
+
+		if v, ok := d.GetOk("release_label"); ok {
+			input.ReleaseLabel = aws.String(v.(string))
 		}
 
 		if v, ok := d.GetOk("architecture"); ok {

--- a/internal/service/emrserverless/application_test.go
+++ b/internal/service/emrserverless/application_test.go
@@ -91,6 +91,41 @@ func TestAccEMRServerlessApplication_arch(t *testing.T) {
 	})
 }
 
+func TestAccEMRServerlessApplication_releaseLabel(t *testing.T) {
+	ctx := acctest.Context(t)
+	var application emrserverless.Application
+	resourceName := "aws_emrserverless_application.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, emrserverless.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationConfig_releaseLabel(rName, "emr-6.10.0"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationExists(ctx, resourceName, &application),
+					resource.TestCheckResourceAttr(resourceName, "release_label", "emr-6.10.0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccApplicationConfig_releaseLabel(rName, "emr-6.11.0"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationExists(ctx, resourceName, &application),
+					resource.TestCheckResourceAttr(resourceName, "release_label", "emr-6.11.0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEMRServerlessApplication_initialCapacity(t *testing.T) {
 	ctx := acctest.Context(t)
 	var application emrserverless.Application
@@ -386,6 +421,16 @@ resource "aws_emrserverless_application" "test" {
   type          = "hive"
 }
 `, rName)
+}
+
+func testAccApplicationConfig_releaseLabel(rName string, rl string) string {
+	return fmt.Sprintf(`
+resource "aws_emrserverless_application" "test" {
+  name          = %[1]q
+  release_label = %[2]q
+  type          = "spark"
+}
+`, rName, rl)
 }
 
 func testAccApplicationConfig_initialCapacity(rName, cpu string) string {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
EMR Serverless now supports the ability to update the release label of an application without destroying and creating a new application. This change adds support for that functionality.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32275

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Created a new test for this change.

```
make testacc PKG=emrserverless TESTS=TestAccEMRServerlessApplication_releaseLabel

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/emrserverless/... -v -count 1 -parallel 20 -run='TestAccEMRServerlessApplication_releaseLabel'  -timeout 180m
=== RUN   TestAccEMRServerlessApplication_releaseLabel
=== PAUSE TestAccEMRServerlessApplication_releaseLabel
=== CONT  TestAccEMRServerlessApplication_releaseLabel
--- PASS: TestAccEMRServerlessApplication_releaseLabel (107.93s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/emrserverless      113.035s
```
