### PR TITLE
docs: update aws_ecr_repository_policy to be written in jsonencode.

### DIFF
--- a/website/docs/r/ecr_repository_policy.html.markdown
+++ b/website/docs/r/ecr_repository_policy.html.markdown
@@ -19,38 +19,38 @@ resource "aws_ecr_repository" "foo" {
   name = "bar"
 }
 
-data "aws_iam_policy_document" "foopolicy" {
-  statement {
-    sid    = "new policy"
-    effect = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["123456789012"]
-    }
-
-    actions = [
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:PutImage",
-      "ecr:InitiateLayerUpload",
-      "ecr:UploadLayerPart",
-      "ecr:CompleteLayerUpload",
-      "ecr:DescribeRepositories",
-      "ecr:GetRepositoryPolicy",
-      "ecr:ListImages",
-      "ecr:DeleteRepository",
-      "ecr:BatchDeleteImage",
-      "ecr:SetRepositoryPolicy",
-      "ecr:DeleteRepositoryPolicy",
-    ]
-  }
-}
-
 resource "aws_ecr_repository_policy" "foopolicy" {
   repository = aws_ecr_repository.foo.name
-  policy     = data.aws_iam_policy_document.foopolicy.json
+  policy = jsonencode(
+    {
+      Statement = [
+        {
+          Action = [
+            "ecr:GetDownloadUrlForLayer",
+            "ecr:BatchGetImage",
+            "ecr:BatchCheckLayerAvailability",
+            "ecr:PutImage",
+            "ecr:InitiateLayerUpload",
+            "ecr:UploadLayerPart",
+            "ecr:CompleteLayerUpload",
+            "ecr:DescribeRepositories",
+            "ecr:GetRepositoryPolicy",
+            "ecr:ListImages",
+            "ecr:DeleteRepository",
+            "ecr:BatchDeleteImage",
+            "ecr:SetRepositoryPolicy",
+            "ecr:DeleteRepositoryPolicy",
+          ]
+          Effect = "Allow"
+          Principal = {
+            AWS = "arn:aws:iam::123456789012:root"
+          }
+          Sid = "new statement"
+        },
+      ]
+      Version = "2012-10-17"
+    }
+  )
 }
 ```
 


### PR DESCRIPTION
### Description
The resource for creating ECR resource policies, aws_ecr_repository_policy, currently only includes a description of using data source in the examples.
How about putting this one here as it is simpler to write in jsonencode?
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy