### PR TITLE
r/glue_catalog_database - add region to target_database

### DIFF
--- a/.changelog/32283.txt
+++ b/.changelog/32283.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_glue_catalog_database: Add `target_database.region` argument
+```

--- a/internal/service/glue/catalog_database.go
+++ b/internal/service/glue/catalog_database.go
@@ -118,6 +118,10 @@ func ResourceCatalogDatabase() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"region": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -314,6 +318,10 @@ func expandDatabaseTargetDatabase(tfMap map[string]interface{}) *glue.DatabaseId
 		apiObject.DatabaseName = aws.String(v)
 	}
 
+	if v, ok := tfMap["region"].(string); ok && v != "" {
+		apiObject.Region = aws.String(v)
+	}
+
 	return apiObject
 }
 
@@ -330,6 +338,10 @@ func flattenDatabaseTargetDatabase(apiObject *glue.DatabaseIdentifier) map[strin
 
 	if v := apiObject.DatabaseName; v != nil {
 		tfMap["database_name"] = aws.StringValue(v)
+	}
+
+	if v := apiObject.Region; v != nil {
+		tfMap["region"] = aws.StringValue(v)
 	}
 
 	return tfMap

--- a/internal/service/glue/catalog_database_test.go
+++ b/internal/service/glue/catalog_database_test.go
@@ -135,6 +135,7 @@ func TestAccGlueCatalogDatabase_targetDatabase(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "target_database.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "target_database.0.catalog_id", "aws_glue_catalog_database.test2", "catalog_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "target_database.0.database_name", "aws_glue_catalog_database.test2", "name"),
+					resource.TestCheckResourceAttr(resourceName, "target_database.0.region", ""),
 				),
 			},
 			{
@@ -150,6 +151,7 @@ func TestAccGlueCatalogDatabase_targetDatabase(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "target_database.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "target_database.0.catalog_id", "aws_glue_catalog_database.test2", "catalog_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "target_database.0.database_name", "aws_glue_catalog_database.test2", "name"),
+					resource.TestCheckResourceAttr(resourceName, "target_database.0.region", ""),
 				),
 			},
 		},

--- a/internal/service/glue/catalog_database_test.go
+++ b/internal/service/glue/catalog_database_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -153,6 +154,38 @@ func TestAccGlueCatalogDatabase_targetDatabase(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "target_database.0.database_name", "aws_glue_catalog_database.test2", "name"),
 					resource.TestCheckResourceAttr(resourceName, "target_database.0.region", ""),
 				),
+			},
+		},
+	})
+}
+
+func TestAccGlueCatalogDatabase_targetDatabaseWithRegion(t *testing.T) {
+	ctx := acctest.Context(t)
+	var providers []*schema.Provider
+	resourceName := "aws_glue_catalog_database.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckMultipleRegion(t, 2) },
+		ErrorCheck:               acctest.ErrorCheck(t, glue.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesPlusProvidersAlternate(ctx, t, &providers),
+		CheckDestroy:             testAccCheckDatabaseDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:  testAccCatalogDatabaseConfig_targetWithRegion(rName),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogDatabaseExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "target_database.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_database.0.catalog_id", "aws_glue_catalog_database.test2", "catalog_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_database.0.database_name", "aws_glue_catalog_database.test2", "name"),
+					resource.TestCheckResourceAttr(resourceName, "target_database.0.region", acctest.AlternateRegion()),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -317,6 +350,26 @@ resource "aws_glue_catalog_database" "test2" {
   location_uri = "my-location"
 }
 `, rName)
+}
+
+func testAccCatalogDatabaseConfig_targetWithRegion(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+
+  target_database {
+    catalog_id    = aws_glue_catalog_database.test2.catalog_id
+    database_name = aws_glue_catalog_database.test2.name
+    region        = %[2]q
+  }
+}
+
+resource "aws_glue_catalog_database" "test2" {
+  provider = "awsalternate"
+
+  name = "%[1]s-2"
+}
+`, rName, acctest.AlternateRegion()))
 }
 
 func testAccCatalogDatabaseConfig_permission(rName, permission string) string {

--- a/website/docs/r/glue_catalog_database.html.markdown
+++ b/website/docs/r/glue_catalog_database.html.markdown
@@ -51,6 +51,7 @@ The following arguments are supported:
 
 * `catalog_id` - (Required) ID of the Data Catalog in which the database resides.
 * `database_name` - (Required) Name of the catalog database.
+* `region` - (Optional) Region of the target database.
 
 ### create_table_default_permission
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32099

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccGlueCatalogDatabase_  PKG=glue

--- PASS: TestAccGlueCatalogDatabase_disappears (80.53s)
--- PASS: TestAccGlueCatalogDatabase_createTablePermission (161.43s)
--- PASS: TestAccGlueCatalogDatabase_targetDatabase (163.26s)
--- PASS: TestAccGlueCatalogDatabase_tags (210.84s)
--- PASS: TestAccGlueCatalogDatabase_full (211.01s)
```
