### PR TITLE
rds/instance: Fix create returns unready instances

### DIFF
--- a/.changelog/32287.txt
+++ b/.changelog/32287.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/rds: Fix create returns unready instances
+resource/aws_db_instance: Fix resource Create returning instance not in the `available` state
 ```

--- a/.changelog/32287.txt
+++ b/.changelog/32287.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/rds: Fix create returns unready instances
+```

--- a/.changelog/32287.txt
+++ b/.changelog/32287.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_db_instance: Fix resource Create returning instance not in the `available` state
+resource/aws_db_instance: Fix resource Create returning instances not in the `available` state when `identifier_prefix` is specified
 ```

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -1563,7 +1563,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	var instance *rds.DBInstance
 	var err error
-	if instance, err = waitDBInstanceAvailableSDKv1(ctx, conn, d.Get("identifier").(string), d.Timeout(schema.TimeoutCreate)); err != nil {
+	if instance, err = waitDBInstanceAvailableSDKv1(ctx, conn, identifier, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Instance (%s) create: %s", identifier, err)
 	}
 

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -2373,17 +2373,16 @@ func findDBInstanceByIDSDKv1(ctx context.Context, conn *rds.RDS, id string) (*rd
 			LastRequest: input,
 		}
 	}
+
 	if err != nil {
 		return nil, err
 	}
 
-	if output == nil || len(output.DBInstances) == 0 || output.DBInstances[0] == nil {
+	if output == nil {
 		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	dbInstance := output.DBInstances[0]
-
-	return dbInstance, nil
+	return tfresource.AssertSinglePtrResult(output.DBInstances)
 }
 
 // findDBInstanceByIDSDKv2 in general should be called with a DbiResourceId of the form
@@ -2419,15 +2418,16 @@ func findDBInstanceByIDSDKv2(ctx context.Context, conn *rds_sdkv2.Client, id str
 			LastRequest: input,
 		}
 	}
+
 	if err != nil {
 		return nil, err
 	}
 
-	if output == nil || len(output.DBInstances) == 0 {
+	if output == nil {
 		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	return &output.DBInstances[0], nil
+	return tfresource.AssertSingleValueResult(output.DBInstances)
 }
 
 func statusDBInstanceSDKv1(ctx context.Context, conn *rds.RDS, id string) retry.StateRefreshFunc {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The RDS instance `identifier` argument is optional and might be empty when `identifier_prefix` is used. Using the  `identifier` variable ensures that the same name is polled, that is also used when creating the instance.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32179.
Closes #31594.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccRDSInstance PKG=rds

...
```
