### PR TITLE
provider: Prevent resource recreation if `tags` or `tags_all` change

### DIFF
--- a/.changelog/32297.txt
+++ b/.changelog/32297.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+provider: Prevent resource recreation if `tags` or `tags_all` are updated
+```

--- a/internal/service/ec2/ec2_spot_instance_request.go
+++ b/internal/service/ec2/ec2_spot_instance_request.go
@@ -49,7 +49,7 @@ func ResourceSpotInstanceRequest() *schema.Resource {
 				if v.Computed && !v.Optional {
 					continue
 				}
-				if k == names.AttrTags || k == "volume_tags" {
+				if k == names.AttrTags {
 					continue
 				}
 				v.ForceNew = true

--- a/internal/service/ec2/tags.go
+++ b/internal/service/ec2/tags.go
@@ -111,10 +111,8 @@ func tagsFromTagDescriptions(tds []*ec2.TagDescription) []*ec2.Tag {
 }
 
 func tagsSchemaConflictsWith(conflictsWith []string) *schema.Schema {
-	return &schema.Schema{
-		Type:          schema.TypeMap,
-		Optional:      true,
-		Elem:          &schema.Schema{Type: schema.TypeString},
-		ConflictsWith: conflictsWith,
-	}
+	v := tftags.TagsSchema()
+	v.ConflictsWith = conflictsWith
+
+	return v
 }

--- a/internal/service/ec2/vpc_test.go
+++ b/internal/service/ec2/vpc_test.go
@@ -91,7 +91,7 @@ func TestAccVPC_disappears(t *testing.T) {
 
 func TestAccVPC_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var vpc ec2.Vpc
+	var vpc1, vpc2, vpc3 ec2.Vpc
 	resourceName := "aws_vpc.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -103,7 +103,7 @@ func TestAccVPC_tags(t *testing.T) {
 			{
 				Config: testAccVPCConfig_tags1("key1", "value1"),
 				Check: resource.ComposeTestCheckFunc(
-					acctest.CheckVPCExists(ctx, resourceName, &vpc),
+					acctest.CheckVPCExists(ctx, resourceName, &vpc1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
@@ -116,7 +116,8 @@ func TestAccVPC_tags(t *testing.T) {
 			{
 				Config: testAccVPCConfig_tags2("key1", "value1updated", "key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					acctest.CheckVPCExists(ctx, resourceName, &vpc),
+					acctest.CheckVPCExists(ctx, resourceName, &vpc2),
+					testAccCheckVPCIDsEqual(&vpc2, &vpc1),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -125,7 +126,8 @@ func TestAccVPC_tags(t *testing.T) {
 			{
 				Config: testAccVPCConfig_tags1("key2", "value2"),
 				Check: resource.ComposeTestCheckFunc(
-					acctest.CheckVPCExists(ctx, resourceName, &vpc),
+					acctest.CheckVPCExists(ctx, resourceName, &vpc3),
+					testAccCheckVPCIDsEqual(&vpc3, &vpc2),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),

--- a/internal/tags/tags.go
+++ b/internal/tags/tags.go
@@ -4,35 +4,29 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var (
-	tagsSchema *schema.Schema = &schema.Schema{
+// TagsSchema returns the schema to use for tags.
+func TagsSchema() *schema.Schema {
+	return &schema.Schema{
 		Type:     schema.TypeMap,
 		Optional: true,
 		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
-	tagsSchemaComputed *schema.Schema = &schema.Schema{
+}
+
+func TagsSchemaComputed() *schema.Schema {
+	return &schema.Schema{
 		Type:     schema.TypeMap,
 		Optional: true,
 		Computed: true,
 		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
-	tagsSchemaForceNew *schema.Schema = &schema.Schema{
+}
+
+func TagsSchemaForceNew() *schema.Schema {
+	return &schema.Schema{
 		Type:     schema.TypeMap,
 		Optional: true,
 		ForceNew: true,
 		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
-)
-
-// TagsSchema returns the schema to use for tags.
-func TagsSchema() *schema.Schema {
-	return tagsSchema
-}
-
-func TagsSchemaComputed() *schema.Schema {
-	return tagsSchemaComputed
-}
-
-func TagsSchemaForceNew() *schema.Schema {
-	return tagsSchemaForceNew
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Reverts the change made in #32250 to share `tags` (and `tags_all`) schema objects.
Somewhere the `ForceNew` flag is being set and affecting all resources that use tagging.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/32296.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

#### Before

```console
% make testacc TESTARGS='-run=TestAccVPC_tags$$' PKG=ec2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPC_tags$ -timeout 180m
=== RUN   TestAccVPC_tags
=== PAUSE TestAccVPC_tags
=== CONT  TestAccVPC_tags
    vpc_test.go:97: Step 3/4 error: Check failed: Check 2/5 error: VPC IDs are not equal
--- FAIL: TestAccVPC_tags (38.01s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	43.766s
FAIL
make: *** [testacc] Error 1
```

#### After

```console
% make testacc TESTARGS='-run=TestAccVPC_tags$$' PKG=ec2                     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPC_tags$ -timeout 180m
=== RUN   TestAccVPC_tags
=== PAUSE TestAccVPC_tags
=== CONT  TestAccVPC_tags
--- PASS: TestAccVPC_tags (59.53s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	65.069s
```