### PR TITLE
Fixes QuickSight sweepers when account not signed up for QuickSight

### DIFF
--- a/internal/service/quicksight/sweep.go
+++ b/internal/service/quicksight/sweep.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/quicksight"
-	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 )
@@ -57,7 +57,6 @@ func sweepDashboards(region string) error {
 
 	conn := client.QuickSightConn(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
-	var errs *multierror.Error
 
 	awsAccountId := client.AccountID
 
@@ -85,20 +84,19 @@ func sweepDashboards(region string) error {
 		return !lastPage
 	})
 
+	if skipSweepError(err) {
+		log.Printf("[WARN] Skipping QuickSight Dashboard sweep for %s: %s", region, err)
+		return nil
+	}
 	if err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("listing QuickSight Dashboards: %w", err))
+		return fmt.Errorf("listing QuickSight Dashboards: %w", err)
 	}
 
 	if err := sweep.SweepOrchestratorWithContext(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("sweeping QuickSight Dashboards for %s: %w", region, err))
+		return fmt.Errorf("sweeping QuickSight Dashboards for %s: %w", region, err)
 	}
 
-	if sweep.SkipSweepError(errs.ErrorOrNil()) {
-		log.Printf("[WARN] Skipping QuickSight Dashboard sweep for %s: %s", region, errs)
-		return nil
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepDataSets(region string) error {
@@ -111,7 +109,6 @@ func sweepDataSets(region string) error {
 
 	conn := client.QuickSightConn(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
-	var errs *multierror.Error
 
 	awsAccountId := client.AccountID
 
@@ -139,20 +136,19 @@ func sweepDataSets(region string) error {
 		return !lastPage
 	})
 
+	if skipSweepError(err) {
+		log.Printf("[WARN] Skipping QuickSight Data Set sweep for %s: %s", region, err)
+		return nil
+	}
 	if err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("listing QuickSight Data Sets: %w", err))
+		return fmt.Errorf("listing QuickSight Data Sets: %w", err)
 	}
 
 	if err := sweep.SweepOrchestratorWithContext(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("sweeping QuickSight Data Sets for %s: %w", region, err))
+		return fmt.Errorf("sweeping QuickSight Data Sets for %s: %w", region, err)
 	}
 
-	if sweep.SkipSweepError(errs.ErrorOrNil()) {
-		log.Printf("[WARN] Skipping QuickSight Data Set sweep for %s: %s", region, errs)
-		return nil
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepDataSources(region string) error {
@@ -165,7 +161,6 @@ func sweepDataSources(region string) error {
 
 	conn := client.QuickSightConn(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
-	var errs *multierror.Error
 
 	awsAccountId := client.AccountID
 
@@ -193,20 +188,19 @@ func sweepDataSources(region string) error {
 		return !lastPage
 	})
 
+	if skipSweepError(err) {
+		log.Printf("[WARN] Skipping QuickSight Data Source sweep for %s: %s", region, err)
+		return nil
+	}
 	if err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("listing QuickSight Data Sources: %w", err))
+		return fmt.Errorf("listing QuickSight Data Sources: %w", err)
 	}
 
 	if err := sweep.SweepOrchestratorWithContext(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("sweeping QuickSight Data Sources for %s: %w", region, err))
+		return fmt.Errorf("sweeping QuickSight Data Sources for %s: %w", region, err)
 	}
 
-	if sweep.SkipSweepError(errs.ErrorOrNil()) {
-		log.Printf("[WARN] Skipping QuickSight Data Source sweep for %s: %s", region, errs)
-		return nil
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepFolders(region string) error {
@@ -220,7 +214,6 @@ func sweepFolders(region string) error {
 	conn := client.QuickSightConn(ctx)
 	awsAccountId := client.AccountID
 	sweepResources := make([]sweep.Sweepable, 0)
-	var errs *multierror.Error
 
 	input := &quicksight.ListFoldersInput{
 		AwsAccountId: aws.String(awsAccountId),
@@ -239,20 +232,20 @@ func sweepFolders(region string) error {
 		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 	}
 
+	if skipSweepError(err) {
+		log.Printf("[WARN] Skipping QuickSight Folder sweep for %s: %s", region, err)
+		return nil
+	}
 	if err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("listing QuickSight Folder for %s: %w", region, err))
+		return fmt.Errorf("listing QuickSight Folders: %w", err)
 	}
 
 	if err := sweep.SweepOrchestratorWithContext(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("sweeping QuickSight Folder for %s: %w", region, err))
+		return fmt.Errorf("sweeping QuickSight Folders for %s: %w", region, err)
 	}
 
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping QuickSight Folder sweep for %s: %s", region, errs)
-		return nil
-	}
+	return nil
 
-	return errs.ErrorOrNil()
 }
 
 func sweepTemplates(region string) error {
@@ -265,7 +258,6 @@ func sweepTemplates(region string) error {
 
 	conn := client.QuickSightConn(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
-	var errs *multierror.Error
 
 	awsAccountId := client.AccountID
 
@@ -293,20 +285,19 @@ func sweepTemplates(region string) error {
 		return !lastPage
 	})
 
+	if skipSweepError(err) {
+		log.Printf("[WARN] Skipping QuickSight Template sweep for %s: %s", region, err)
+		return nil
+	}
 	if err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("listing QuickSight Templates: %w", err))
+		return fmt.Errorf("listing QuickSight Templates: %w", err)
 	}
 
 	if err := sweep.SweepOrchestratorWithContext(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("sweeping QuickSight Templates for %s: %w", region, err))
+		return fmt.Errorf("sweeping QuickSight Templates for %s: %w", region, err)
 	}
 
-	if sweep.SkipSweepError(errs.ErrorOrNil()) {
-		log.Printf("[WARN] Skipping QuickSight Template sweep for %s: %s", region, errs)
-		return nil
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepUsers(region string) error {
@@ -320,7 +311,6 @@ func sweepUsers(region string) error {
 	conn := client.QuickSightConn(ctx)
 	awsAccountId := client.AccountID
 	sweepResources := make([]sweep.Sweepable, 0)
-	var errs *multierror.Error
 
 	input := &quicksight.ListUsersInput{
 		AwsAccountId: aws.String(awsAccountId),
@@ -341,18 +331,36 @@ func sweepUsers(region string) error {
 		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 	}
 
+	if skipSweepUserError(err) {
+		log.Printf("[WARN] Skipping QuickSight User sweep for %s: %s", region, err)
+		return nil
+	}
 	if err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("listing QuickSight Users for %s: %w", region, err))
+		return fmt.Errorf("listing QuickSight Users: %w", err)
 	}
 
 	if err := sweep.SweepOrchestratorWithContext(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("sweeping QuickSight Users for %s: %w", region, err))
+		return fmt.Errorf("sweeping QuickSight Users for %s: %w", region, err)
 	}
 
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping QuickSight User sweep for %s: %s", region, errs)
-		return nil
+	return nil
+}
+
+// skipSweepError adds an additional skippable error code for listing QuickSight resources other than User
+func skipSweepError(err error) bool {
+	if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeUnsupportedUserEditionException) {
+		return true
 	}
 
-	return errs.ErrorOrNil()
+	return sweep.SkipSweepError(err)
+}
+
+// skipSweepUserError adds an additional skippable error code for listing QuickSight User resources
+func skipSweepUserError(err error) bool {
+	if tfawserr.ErrMessageContains(err, quicksight.ErrCodeResourceNotFoundException, "not signed up with QuickSight") {
+		return true
+	}
+
+	return sweep.SkipSweepError(err)
+
 }


### PR DESCRIPTION
### Description

When an account is not signed up for QuickSight, the sweepers fail with the following error:

> UnsupportedUserEditionException: Account 123456789012 is not subscribed for QuickSight

or the following error for User:

> ResourceNotFoundException: Account 123456789012 is not signed up with QuickSight with namespace default


### Output from Acceptance Testing

Now:

> [WARN] Skipping QuickSight User sweep for us-west-2: ResourceNotFoundException: Account 123456789012 is not signed up with QuickSight with namespace default.
[WARN] Skipping QuickSight Folder sweep for us-west-2: UnsupportedUserEditionException: Account 123456789012 is not subscribed for QuickSight
[WARN] Skipping QuickSight Dashboard sweep for us-west-2: UnsupportedUserEditionException: Account 123456789012 is not subscribed for QuickSight
[WARN] Skipping QuickSight Template sweep for us-west-2: UnsupportedUserEditionException: Account 123456789012 is not subscribed for QuickSight
Sweeper Tests for region (us-west-2) ran successfully:
	- aws_quicksight_template
	- aws_quicksight_data_source
	- aws_quicksight_user
	- aws_quicksight_data_set
	- aws_quicksight_folder
	- aws_quicksight_dashboard
