### PR TITLE
Fixes "Cannot delete self" error in OpsWorks User Profile sweeper

### DIFF
--- a/internal/errs/sdkdiag/diags.go
+++ b/internal/errs/sdkdiag/diags.go
@@ -28,16 +28,27 @@ func severityFilter(s diag.Severity) tfslices.FilterFunc[diag.Diagnostic] {
 }
 
 // DiagnosticsError returns an error containing all Diagnostic with SeverityError
-func DiagnosticsError(diags diag.Diagnostics) (errs error) {
+func DiagnosticsError(diags diag.Diagnostics) error {
 	if !diags.HasError() {
-		return
+		return nil
 	}
 
-	for _, d := range Errors(diags) {
-		errs = multierror.Append(errs, errors.New(DiagnosticString(d)))
+	errDiags := Errors(diags)
+
+	if len(errDiags) == 1 {
+		return diagnosticError(errDiags[0])
 	}
 
-	return
+	var errs error
+	for _, d := range errDiags {
+		errs = multierror.Append(errs, diagnosticError(d))
+	}
+
+	return errs
+}
+
+func diagnosticError(diag diag.Diagnostic) error {
+	return errors.New(DiagnosticString(diag))
 }
 
 // DiagnosticString formats a Diagnostic

--- a/internal/service/opsworks/sweep.go
+++ b/internal/service/opsworks/sweep.go
@@ -4,16 +4,21 @@
 package opsworks
 
 import (
-	"errors"
+	"context"
 	"fmt"
 	"log"
+	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/opsworks"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/sdk"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func init() {
@@ -107,7 +112,7 @@ func sweepApplication(region string) error {
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(app.AppId))
 
-			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+			sweepResources = append(sweepResources, sdk.NewSweepResource(r, d, client))
 		}
 	}
 
@@ -160,7 +165,7 @@ func sweepInstance(region string) error {
 			d.SetId(aws.StringValue(instance.InstanceId))
 			d.Set("status", instance.Status)
 
-			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+			sweepResources = append(sweepResources, sdk.NewSweepResource(r, d, client))
 		}
 	}
 
@@ -213,7 +218,7 @@ func sweepRDSDBInstance(region string) error {
 			d.SetId(aws.StringValue(dbInstance.DbInstanceIdentifier))
 			d.Set("rds_db_instance_arn", dbInstance.RdsDbInstanceArn)
 
-			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+			sweepResources = append(sweepResources, sdk.NewSweepResource(r, d, client))
 		}
 	}
 
@@ -257,7 +262,7 @@ func sweepStacks(region string) error {
 			d.Set("use_opsworks_security_groups", true)
 		}
 
-		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		sweepResources = append(sweepResources, sdk.NewSweepResource(r, d, client))
 	}
 
 	return sweep.SweepOrchestratorWithContext(ctx, sweepResources)
@@ -318,7 +323,7 @@ func sweepLayers(region string) error {
 				}
 			}
 
-			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+			sweepResources = append(sweepResources, sdk.NewSweepResource(r, d, client))
 		}
 	}
 
@@ -349,23 +354,29 @@ func sweepUserProfiles(region string) error {
 		r := ResourceUserProfile()
 		d := r.Data(nil)
 		d.SetId(aws.StringValue(profile.IamUserArn))
-		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		sweepResources = append(sweepResources, newUserProfileSweeper(r, d, client))
 	}
 
-	err = sweep.SweepOrchestratorWithContext(ctx, sweepResources)
+	return sweep.SweepOrchestratorWithContext(ctx, sweepResources)
+}
 
-	var errs *multierror.Error
-	if errors.As(err, &errs) {
-		var es *multierror.Error
-		for _, e := range errs.Errors {
-			if tfawserr.ErrMessageContains(err, opsworks.ErrCodeValidationException, "Cannot delete self") {
-				log.Printf("[WARN] Ignoring error: %s", e.Error())
-			} else {
-				es = multierror.Append(es, e)
-			}
-		}
-		return es.ErrorOrNil()
+type userProfileSweeper struct {
+	d         *schema.ResourceData
+	sweepable sweep.Sweepable
+}
+
+func newUserProfileSweeper(resource *schema.Resource, d *schema.ResourceData, client *conns.AWSClient) *userProfileSweeper {
+	return &userProfileSweeper{
+		d:         d,
+		sweepable: sdk.NewSweepResource(resource, d, client),
 	}
+}
 
+func (ups userProfileSweeper) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
+	err := ups.sweepable.Delete(ctx, timeout, optFns...)
+	if strings.Contains(err.Error(), "Cannot delete self") {
+		log.Printf("[WARN] Skipping OpsWorks User Profile (%s): %s", ups.d.Id(), err)
+		return nil
+	}
 	return err
 }


### PR DESCRIPTION
### Description

Fixes "Cannot delete self" error in OpsWorks User Profile sweeper

Previously failed with:

> deleting OpsWorks User Profile (*****): ValidationException: Cannot delete self

Now succeeds with:

> [WARN] Skipping OpsWorks User Profile (*****): deleting OpsWorks User Profile (*****): ValidationException: Cannot delete self