### PR TITLE
Add ap-east-1 to Lambda Signer supported regions

### DIFF
--- a/.changelog/32327.txt
+++ b/.changelog/32327.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lambda_function: Support `code_signing_config_arn` in the `ap-east-1` AWS Region
+```

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -1286,6 +1286,7 @@ func SignerServiceIsAvailable(region string) bool {
 		endpoints.UsWest1RegionID:      {},
 		endpoints.UsWest2RegionID:      {},
 		endpoints.AfSouth1RegionID:     {},
+		endpoints.ApEast1RegionID:      {},
 		endpoints.ApSouth1RegionID:     {},
 		endpoints.ApNortheast2RegionID: {},
 		endpoints.ApSoutheast1RegionID: {},


### PR DESCRIPTION
### Description

The AWS docs indicate this region supports code signing: https://docs.aws.amazon.com/general/latest/gr/signer.html#signer_lambda_region