### PR TITLE
waf: up aws_wafregional_web_acl_association create timeout to 5 minutes

### DIFF
--- a/.changelog/32329.txt
+++ b/.changelog/32329.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_wafregional_web_acl_association: Increase creation timeout value from 2 to 5 minutes to prevent WAFUnavailableEntityException
+```

--- a/internal/service/wafregional/web_acl_association.go
+++ b/internal/service/wafregional/web_acl_association.go
@@ -60,7 +60,7 @@ func resourceWebACLAssociationCreate(ctx context.Context, d *schema.ResourceData
 	// create association and wait on retryable error
 	// no response body
 	var err error
-	err = retry.RetryContext(ctx, 2*time.Minute, func() *retry.RetryError {
+	err = retry.RetryContext(ctx, 5*time.Minute, func() *retry.RetryError {
 		_, err = conn.AssociateWebACLWithContext(ctx, params)
 		if err != nil {
 			if tfawserr.ErrCodeEquals(err, wafregional.ErrCodeWAFUnavailableEntityException) {


### PR DESCRIPTION
### Description
Increase creation timeout value from 2 to 5 minutes to prevent WAFUnavailableEntityException for WAFClassic ACL association.

### Relations
Closes #32103

### References
The same as #17545 but for wafregional.

### Output from Acceptance Testing
```
$ make testacc TESTS=TestAccWAFRegionalWebACLAssociation_ PKG=wafregional

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/wafregional/... -v -count 1 -parallel 20 -run='TestAccWAFRegionalWebACLAssociation_'  -timeout 180m
=== RUN   TestAccWAFRegionalWebACLAssociation_basic
=== PAUSE TestAccWAFRegionalWebACLAssociation_basic
=== RUN   TestAccWAFRegionalWebACLAssociation_disappears
=== PAUSE TestAccWAFRegionalWebACLAssociation_disappears
=== RUN   TestAccWAFRegionalWebACLAssociation_multipleAssociations
=== PAUSE TestAccWAFRegionalWebACLAssociation_multipleAssociations
=== RUN   TestAccWAFRegionalWebACLAssociation_ResourceARN_apiGatewayStage
=== PAUSE TestAccWAFRegionalWebACLAssociation_ResourceARN_apiGatewayStage
=== CONT  TestAccWAFRegionalWebACLAssociation_basic
=== CONT  TestAccWAFRegionalWebACLAssociation_multipleAssociations
=== CONT  TestAccWAFRegionalWebACLAssociation_ResourceARN_apiGatewayStage
=== CONT  TestAccWAFRegionalWebACLAssociation_disappears
--- PASS: TestAccWAFRegionalWebACLAssociation_ResourceARN_apiGatewayStage (74.01s)
--- PASS: TestAccWAFRegionalWebACLAssociation_disappears (187.69s)
--- PASS: TestAccWAFRegionalWebACLAssociation_multipleAssociations (197.08s)
--- PASS: TestAccWAFRegionalWebACLAssociation_basic (199.73s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafregional        199.843s
```
