### PR TITLE
Update `addresses` argument description in `wafv2_ip_set`

### DIFF
--- a/website/docs/d/wafv2_ip_set.html.markdown
+++ b/website/docs/d/wafv2_ip_set.html.markdown
@@ -30,7 +30,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `addresses` - An array of strings that specify one or more IP addresses or blocks of IP addresses in Classless Inter-Domain Routing (CIDR) notation.
+* `addresses` - An array of strings that specifies zero or more IP addresses or blocks of IP addresses in Classless Inter-Domain Routing (CIDR) notation.
 * `arn` - ARN of the entity.
 * `description` - Description of the set that helps with identification.
 * `id` - Unique identifier for the set.

--- a/website/docs/r/wafv2_ip_set.html.markdown
+++ b/website/docs/r/wafv2_ip_set.html.markdown
@@ -35,7 +35,7 @@ The following arguments are supported:
 * `description` - (Optional) A friendly description of the IP set.
 * `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the Region US East (N. Virginia).
 * `ip_address_version` - (Required) Specify IPV4 or IPV6. Valid values are `IPV4` or `IPV6`.
-* `addresses` - (Required) Contains an array of strings that specify one or more IP addresses or blocks of IP addresses in Classless Inter-Domain Routing (CIDR) notation. AWS WAF supports all address ranges for IP versions IPv4 and IPv6.
+* `addresses` - (Required) Contains an array of strings that specifies zero or more IP addresses or blocks of IP addresses. All addresses must be specified using Classless Inter-Domain Routing (CIDR) notation. WAF supports all IPv4 and IPv6 CIDR ranges except for `/0`.
 * `tags` - (Optional) An array of key:value pairs to associate with the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attributes Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
I have updated the `addresses` parameter description in the `wafv2_ip_set` documents to reflect the ability to accept an empty array. The previous description was incorrect, this parameter allows for an empty array as input.

### Relations

Relates #21758


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
* [create-ip-set — AWS CLI 2.12.6 Command Reference](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/wafv2/create-ip-set.html)
    * I referenced this URL for the description.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

N/A
