### PR TITLE
r/glue_crawler -  add `iceberg_target` + fix `enable_additional_metadata` on `jdbc_target`

### DIFF
--- a/.changelog/32332.txt
+++ b/.changelog/32332.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_glue_crawler: Add `iceberg_target` configuration block
+```

--- a/internal/service/glue/crawler.go
+++ b/internal/service/glue/crawler.go
@@ -863,7 +863,7 @@ func expandJDBCTarget(cfg map[string]interface{}) *glue.JdbcTarget {
 	}
 
 	if v, ok := cfg["enable_additional_metadata"].([]interface{}); ok {
-		target.Exclusions = flex.ExpandStringList(v)
+		target.EnableAdditionalMetadata = flex.ExpandStringList(v)
 	}
 
 	if v, ok := cfg["exclusions"].([]interface{}); ok {

--- a/internal/service/glue/crawler.go
+++ b/internal/service/glue/crawler.go
@@ -561,6 +561,11 @@ func resourceCrawlerUpdate(ctx context.Context, d *schema.ResourceData, meta int
 					return retry.RetryableError(err)
 				}
 
+				// InvalidInputException: com.amazonaws.services.glue.model.AccessDeniedException: You need to enable AWS Security Token Service for this region. . Please verify the role's TrustPolicy.
+				if tfawserr.ErrMessageContains(err, glue.ErrCodeInvalidInputException, "Please verify the role's TrustPolicy") {
+					return retry.RetryableError(err)
+				}
+
 				// InvalidInputException: Unable to retrieve connection tf-acc-test-8656357591012534997: User: arn:aws:sts::*******:assumed-role/tf-acc-test-8656357591012534997/AWS-Crawler is not authorized to perform: glue:GetConnection on resource: * (Service: AmazonDataCatalog; Status Code: 400; Error Code: AccessDeniedException; Request ID: 4d72b66f-9c75-11e8-9faf-5b526c7be968)
 				if tfawserr.ErrMessageContains(err, glue.ErrCodeInvalidInputException, "is not authorized") {
 					return retry.RetryableError(err)

--- a/internal/service/glue/crawler.go
+++ b/internal/service/glue/crawler.go
@@ -26,7 +26,7 @@ import (
 )
 
 func targets() []string {
-	return []string{"s3_target", "dynamodb_target", "mongodb_target", "jdbc_target", "catalog_target", "delta_target"}
+	return []string{"s3_target", "dynamodb_target", "mongodb_target", "jdbc_target", "catalog_target", "delta_target", "iceberg_target"}
 }
 
 // @SDKResource("aws_glue_crawler", name="Crawler")
@@ -154,6 +154,35 @@ func ResourceCrawler() *schema.Resource {
 							Type:         schema.TypeFloat,
 							Optional:     true,
 							ValidateFunc: validation.FloatBetween(0.1, 1.5),
+						},
+					},
+				},
+			},
+			"iceberg_target": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				MinItems:     1,
+				AtLeastOneOf: targets(),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"connection_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"exclusions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"maximum_traversal_depth": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntBetween(1, 20),
+						},
+						"paths": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},
 				},
@@ -389,6 +418,11 @@ func resourceCrawlerCreate(ctx context.Context, d *schema.ResourceData, meta int
 				return retry.RetryableError(err)
 			}
 
+			// InvalidInputException: com.amazonaws.services.glue.model.AccessDeniedException: You need to enable AWS Security Token Service for this region. . Please verify the role's TrustPolicy.
+			if tfawserr.ErrMessageContains(err, glue.ErrCodeInvalidInputException, "Please verify the role's TrustPolicy") {
+				return retry.RetryableError(err)
+			}
+
 			// InvalidInputException: Unable to retrieve connection tf-acc-test-8656357591012534997: User: arn:aws:sts::*******:assumed-role/tf-acc-test-8656357591012534997/AWS-Crawler is not authorized to perform: glue:GetConnection on resource: * (Service: AmazonDataCatalog; Status Code: 400; Error Code: AccessDeniedException; Request ID: 4d72b66f-9c75-11e8-9faf-5b526c7be968)
 			if tfawserr.ErrMessageContains(err, glue.ErrCodeInvalidInputException, "is not authorized") {
 				return retry.RetryableError(err)
@@ -481,6 +515,10 @@ func resourceCrawlerRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 		if err := d.Set("delta_target", flattenDeltaTargets(crawler.Targets.DeltaTargets)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting delta_target: %s", err)
+		}
+
+		if err := d.Set("iceberg_target", flattenIcebergTargets(crawler.Targets.IcebergTargets)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting iceberg_target: %s", err)
 		}
 	}
 
@@ -726,6 +764,10 @@ func expandCrawlerTargets(d *schema.ResourceData) *glue.CrawlerTargets {
 		crawlerTargets.DeltaTargets = expandDeltaTargets(v.([]interface{}))
 	}
 
+	if v, ok := d.GetOk("iceberg_target"); ok {
+		crawlerTargets.IcebergTargets = expandIcebergTargets(v.([]interface{}))
+	}
+
 	return crawlerTargets
 }
 
@@ -910,6 +952,36 @@ func expandDeltaTarget(cfg map[string]interface{}) *glue.DeltaTarget {
 	return target
 }
 
+func expandIcebergTargets(targets []interface{}) []*glue.IcebergTarget {
+	if len(targets) < 1 {
+		return []*glue.IcebergTarget{}
+	}
+
+	perms := make([]*glue.IcebergTarget, len(targets))
+	for i, rawCfg := range targets {
+		cfg := rawCfg.(map[string]interface{})
+		perms[i] = expandIcebergTarget(cfg)
+	}
+	return perms
+}
+
+func expandIcebergTarget(cfg map[string]interface{}) *glue.IcebergTarget {
+	target := &glue.IcebergTarget{
+		Paths:                 flex.ExpandStringSet(cfg["paths"].(*schema.Set)),
+		MaximumTraversalDepth: aws.Int64(int64(cfg["maximum_traversal_depth"].(int))),
+	}
+
+	if v, ok := cfg["exclusions"]; ok {
+		target.Exclusions = flex.ExpandStringList(v.([]interface{}))
+	}
+
+	if v, ok := cfg["connection_name"].(string); ok {
+		target.ConnectionName = aws.String(v)
+	}
+
+	return target
+}
+
 func flattenS3Targets(s3Targets []*glue.S3Target) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0)
 
@@ -999,6 +1071,21 @@ func flattenDeltaTargets(deltaTargets []*glue.DeltaTarget) []map[string]interfac
 		attrs["create_native_delta_table"] = aws.BoolValue(deltaTarget.CreateNativeDeltaTable)
 		attrs["delta_tables"] = flex.FlattenStringSet(deltaTarget.DeltaTables)
 		attrs["write_manifest"] = aws.BoolValue(deltaTarget.WriteManifest)
+
+		result = append(result, attrs)
+	}
+	return result
+}
+
+func flattenIcebergTargets(icebergTargets []*glue.IcebergTarget) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0)
+
+	for _, icebergTarget := range icebergTargets {
+		attrs := make(map[string]interface{})
+		attrs["connection_name"] = aws.StringValue(icebergTarget.ConnectionName)
+		attrs["maximum_traversal_depth"] = aws.Int64Value(icebergTarget.MaximumTraversalDepth)
+		attrs["paths"] = flex.FlattenStringSet(icebergTarget.Paths)
+		attrs["exclusions"] = flex.FlattenStringList(icebergTarget.Exclusions)
 
 		result = append(result, attrs)
 	}

--- a/internal/service/glue/crawler_test.go
+++ b/internal/service/glue/crawler_test.go
@@ -3120,7 +3120,7 @@ resource "aws_glue_crawler" "test" {
   iceberg_target {
     connection_name           = aws_glue_connection.test.name
     paths                     = [%[3]q]
-	maximum_traversal_depth   = %[4]d
+    maximum_traversal_depth   = %[4]d
   }
 }
 `, rName, connectionUrl, tableName, depth))

--- a/internal/service/glue/crawler_test.go
+++ b/internal/service/glue/crawler_test.go
@@ -625,7 +625,7 @@ func TestAccGlueCrawler_icebergTarget(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "iceberg_target.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "iceberg_target.0.connection_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "iceberg_target.0.maximum_traversal_depth", "2"),
-					resource.TestCheckResourceAttr(resourceName, "iceberg_target.0.paths.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "iceberg_target.0.paths.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "iceberg_target.0.paths.*", "s3://table2"),
 				),
 			},

--- a/internal/service/glue/crawler_test.go
+++ b/internal/service/glue/crawler_test.go
@@ -624,7 +624,7 @@ func TestAccGlueCrawler_icebergTarget(t *testing.T) {
 					testAccCheckCrawlerExists(ctx, resourceName, &crawler),
 					resource.TestCheckResourceAttr(resourceName, "iceberg_target.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "iceberg_target.0.connection_name", rName),
-					resource.TestCheckResourceAttr(resourceName, "iceberg_target.0.maximum_traversal_depth", "1"),
+					resource.TestCheckResourceAttr(resourceName, "iceberg_target.0.maximum_traversal_depth", "2"),
 					resource.TestCheckResourceAttr(resourceName, "iceberg_target.0.paths.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "iceberg_target.0.paths.*", "s3://table2"),
 				),
@@ -3091,7 +3091,7 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_glue_catalog_database" "test" {
-  name = "%[1]s"
+  name = %[1]q
 }
 
 resource "aws_glue_connection" "test" {
@@ -3101,7 +3101,7 @@ resource "aws_glue_connection" "test" {
 
   connection_type = "NETWORK"
 
-  name = "%[1]s"
+  name = %[1]q
 
   physical_connection_requirements {
     availability_zone      = aws_subnet.test[0].availability_zone

--- a/internal/service/glue/crawler_test.go
+++ b/internal/service/glue/crawler_test.go
@@ -560,6 +560,51 @@ func TestAccGlueCrawler_deltaTarget(t *testing.T) {
 	})
 }
 
+func TestAccGlueCrawler_icebergTarget(t *testing.T) {
+	ctx := acctest.Context(t)
+	var crawler glue.Crawler
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_glue_crawler.test"
+
+	connectionUrl := fmt.Sprintf("mongodb://%s:27017/testdatabase", acctest.RandomDomainName())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, glue.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCrawlerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCrawlerConfig_icebergTarget(rName, connectionUrl, "s3://table1", 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCrawlerExists(ctx, resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "iceberg_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "iceberg_target.0.connection_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "iceberg_target.0.maximum_traversal_depth", "1"),
+					resource.TestCheckResourceAttr(resourceName, "iceberg_target.0.paths.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "iceberg_target.0.paths.*", "s3://table1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCrawlerConfig_icebergTarget(rName, connectionUrl, "s3://table2", 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCrawlerExists(ctx, resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "iceberg_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "iceberg_target.0.connection_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "iceberg_target.0.maximum_traversal_depth", "1"),
+					resource.TestCheckResourceAttr(resourceName, "iceberg_target.0.paths.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "iceberg_target.0.paths.*", "s3://table2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccGlueCrawler_s3Target(t *testing.T) {
 	ctx := acctest.Context(t)
 	var crawler glue.Crawler
@@ -2965,6 +3010,60 @@ resource "aws_glue_crawler" "test" {
   }
 }
 `, rName, connectionUrl, tableName, createNativeDeltaTable))
+}
+
+func testAccCrawlerConfig_icebergTarget(rName, connectionUrl, tableName string, depth int) string {
+	return acctest.ConfigCompose(testAccCrawlerConfig_base(rName), acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name   = %[1]q
+  vpc_id = aws_vpc.test.id
+
+  ingress {
+    from_port = 1
+    protocol  = "tcp"
+    self      = true
+    to_port   = 65535
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_glue_catalog_database" "test" {
+  name = "%[1]s"
+}
+
+resource "aws_glue_connection" "test" {
+  connection_properties = {
+    JDBC_ENFORCE_SSL = false
+  }
+
+  connection_type = "NETWORK"
+
+  name = "%[1]s"
+
+  physical_connection_requirements {
+    availability_zone      = aws_subnet.test[0].availability_zone
+    security_group_id_list = [aws_security_group.test.id]
+    subnet_id              = aws_subnet.test[0].id
+  }
+}
+
+resource "aws_glue_crawler" "test" {
+  depends_on = [aws_iam_role_policy_attachment.test-AWSGlueServiceRole]
+
+  database_name = aws_glue_catalog_database.test.name
+  name          = %[1]q
+  role          = aws_iam_role.test.name
+
+  iceberg_target {
+    connection_name           = aws_glue_connection.test.name
+    paths                     = [%[3]q]
+	maximum_traversal_depth   = %[4]d
+  }
+}
+`, rName, connectionUrl, tableName, depth))
 }
 
 func testAccCrawlerConfig_lakeformation(rName string, use bool) string {

--- a/internal/service/glue/crawler_test.go
+++ b/internal/service/glue/crawler_test.go
@@ -3118,9 +3118,9 @@ resource "aws_glue_crawler" "test" {
   role          = aws_iam_role.test.name
 
   iceberg_target {
-    connection_name           = aws_glue_connection.test.name
-    paths                     = [%[3]q]
-    maximum_traversal_depth   = %[4]d
+    connection_name         = aws_glue_connection.test.name
+    paths                   = [%[3]q]
+    maximum_traversal_depth = %[4]d
   }
 }
 `, rName, connectionUrl, tableName, depth))

--- a/internal/service/glue/crawler_test.go
+++ b/internal/service/glue/crawler_test.go
@@ -2041,7 +2041,7 @@ resource "aws_glue_crawler" "test" {
   jdbc_target {
     connection_name            = aws_glue_connection.test.name
     path                       = %[3]q
-	enable_additional_metadata = ["COMMENTS"]
+    enable_additional_metadata = ["COMMENTS"]
   }
 }
 `, rName, jdbcConnectionUrl, path))

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -143,6 +143,7 @@ The following arguments are supported:
 * `jdbc_target` (Optional) List of nested JBDC target arguments. See [JDBC Target](#jdbc-target) below.
 * `s3_target` (Optional) List nested Amazon S3 target arguments. See [S3 Target](#s3-target) below.
 * `mongodb_target` (Optional) List nested MongoDB target arguments. See [MongoDB Target](#mongodb-target) below.
+* `iceberg_target` (Optional) List nested Iceberg target arguments. See [Iceberg Target](#iceberg-target) below.
 * `schedule` (Optional) A cron expression used to specify the schedule. For more information, see [Time-Based Schedules for Jobs and Crawlers](https://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html). For example, to run something every day at 12:15 UTC, you would specify: `cron(15 12 * * ? *)`.
 * `schema_change_policy` (Optional) Policy for the crawler's update and deletion behavior. See [Schema Change Policy](#schema-change-policy) below.
 * `lake_formation_configuration` (Optional) Specifies Lake Formation configuration settings for the crawler. See [Lake Formation Configuration](#lake-formation-configuration) below.
@@ -191,6 +192,13 @@ The following arguments are supported:
 * `connection_name` - (Required) The name of the connection to use to connect to the Amazon DocumentDB or MongoDB target.
 * `path` - (Required) The path of the Amazon DocumentDB or MongoDB target (database/collection).
 * `scan_all` - (Optional) Indicates whether to scan all the records, or to sample rows from the table. Scanning all the records can take a long time when the table is not a high throughput table. Default value is `true`.
+
+### Iceberg Target
+
+* `connection_name` - (Optional) The name of the connection to use to connect to the Iceberg target.
+* `paths` - (Required) One or more Amazon S3 paths that contains Iceberg metadata folders as s3://bucket/prefix.
+* `exclusions` - (Optional) A list of glob patterns used to exclude from the crawl.
+* `maximum_traversal_depth` - (Required) The maximum depth of Amazon S3 paths that the crawler can traverse to discover the Iceberg metadata folder in your Amazon S3 path. Used to limit the crawler run time. Valid values are between `1` and `20`.
 
 ### Delta Target
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32110

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccGlueCrawler_icebergTarget  PKG=glue
$ make testacc TESTS=TestAccGlueCrawler_jdbcTarget  PKG=glue
--- PASS: TestAccGlueCrawler_jdbcTarget (96.06s)
--- PASS: TestAccGlueCrawler_icebergTarget (83.63s)
```
