### PR TITLE
Tech debt: Migrate`qldb` resources to AWS SDK for Go v2

### DIFF
--- a/.changelog/32345.txt
+++ b/.changelog/32345.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_qldb_stream: Add configurable Create and Delete timeouts
+```

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.2.6
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.2.8
 	github.com/aws/aws-sdk-go-v2/service/pricing v1.20.0
+	github.com/aws/aws-sdk-go-v2/service/qldb v1.15.13
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.8.14
 	github.com/aws/aws-sdk-go-v2/service/rds v1.46.0
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.2.15

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/aws/aws-sdk-go-v2/service/pipes v1.2.8 h1:TPr7uAucpAvgE0ac9zMs/LTx9O0
 github.com/aws/aws-sdk-go-v2/service/pipes v1.2.8/go.mod h1:T8pM2eiirH5Ld58Ek+t7tK3SqQNUwp9zkqkslW1v8sM=
 github.com/aws/aws-sdk-go-v2/service/pricing v1.20.0 h1:x5gKeerbKIQ/tdhmaAGNpivSfmb+p2rdt0wyjCGz+4Q=
 github.com/aws/aws-sdk-go-v2/service/pricing v1.20.0/go.mod h1:JjpnqJdEW/5An429Ou+5Kb3UkwjXv16gRD2ZdGA2Gw8=
+github.com/aws/aws-sdk-go-v2/service/qldb v1.15.13 h1:iwKtlmYoS0wXm8VaCMnEpLjLrnyW3rT7YBsr9VlACCA=
+github.com/aws/aws-sdk-go-v2/service/qldb v1.15.13/go.mod h1:AVsFo7PSMNr+/LvWa3YjXnP3poj5UJHDFVbCWkz6rJw=
 github.com/aws/aws-sdk-go-v2/service/rbin v1.8.14 h1:oEeNqSze4JYbhsDg7udtz+AtLwrIXlvjItAd09Z2zTw=
 github.com/aws/aws-sdk-go-v2/service/rbin v1.8.14/go.mod h1:JehbzDgwXYQi1wqKKFLstaNqsRPgPu9Kd6DiwhtFxoA=
 github.com/aws/aws-sdk-go-v2/service/rds v1.46.0 h1:uv2LAciZRd5lEXzJo2u92tdZh/JxcVL7YLC51D4NLG4=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -32,6 +32,7 @@ import (
 	opensearchserverless_sdkv2 "github.com/aws/aws-sdk-go-v2/service/opensearchserverless"
 	pipes_sdkv2 "github.com/aws/aws-sdk-go-v2/service/pipes"
 	pricing_sdkv2 "github.com/aws/aws-sdk-go-v2/service/pricing"
+	qldb_sdkv2 "github.com/aws/aws-sdk-go-v2/service/qldb"
 	rbin_sdkv2 "github.com/aws/aws-sdk-go-v2/service/rbin"
 	rds_sdkv2 "github.com/aws/aws-sdk-go-v2/service/rds"
 	resourceexplorer2_sdkv2 "github.com/aws/aws-sdk-go-v2/service/resourceexplorer2"
@@ -259,7 +260,6 @@ import (
 	polly_sdkv1 "github.com/aws/aws-sdk-go/service/polly"
 	prometheusservice_sdkv1 "github.com/aws/aws-sdk-go/service/prometheusservice"
 	proton_sdkv1 "github.com/aws/aws-sdk-go/service/proton"
-	qldb_sdkv1 "github.com/aws/aws-sdk-go/service/qldb"
 	qldbsession_sdkv1 "github.com/aws/aws-sdk-go/service/qldbsession"
 	quicksight_sdkv1 "github.com/aws/aws-sdk-go/service/quicksight"
 	ram_sdkv1 "github.com/aws/aws-sdk-go/service/ram"
@@ -1272,8 +1272,8 @@ func (c *AWSClient) ProtonConn(ctx context.Context) *proton_sdkv1.Proton {
 	return errs.Must(conn[*proton_sdkv1.Proton](ctx, c, names.Proton))
 }
 
-func (c *AWSClient) QLDBConn(ctx context.Context) *qldb_sdkv1.QLDB {
-	return errs.Must(conn[*qldb_sdkv1.QLDB](ctx, c, names.QLDB))
+func (c *AWSClient) QLDBClient(ctx context.Context) *qldb_sdkv2.Client {
+	return errs.Must(client[*qldb_sdkv2.Client](ctx, c, names.QLDB))
 }
 
 func (c *AWSClient) QLDBSessionConn(ctx context.Context) *qldbsession_sdkv1.QLDBSession {

--- a/internal/service/qldb/exports_test.go
+++ b/internal/service/qldb/exports_test.go
@@ -2,7 +2,9 @@ package qldb
 
 // Exports for use in tests only.
 var (
-	FindLedgerByName = findLedgerByName
+	FindLedgerByName       = findLedgerByName
+	FindStreamByTwoPartKey = findStreamByTwoPartKey
 
 	ResourceLedger = resourceLedger
+	ResourceStream = resourceStream
 )

--- a/internal/service/qldb/exports_test.go
+++ b/internal/service/qldb/exports_test.go
@@ -1,0 +1,8 @@
+package qldb
+
+// Exports for use in tests only.
+var (
+	FindLedgerByName = findLedgerByName
+
+	ResourceLedger = resourceLedger
+)

--- a/internal/service/qldb/generate.go
+++ b/internal/service/qldb/generate.go
@@ -1,4 +1,4 @@
-//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ListTags -ServiceTagsMap -UpdateTags
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ListTags -ServiceTagsMap -UpdateTags -SkipTypesImp
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/qldb/generate.go
+++ b/internal/service/qldb/generate.go
@@ -1,4 +1,4 @@
-//go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ListTags -ServiceTagsMap -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/qldb/ledger.go
+++ b/internal/service/qldb/ledger.go
@@ -6,15 +6,17 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/qldb"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/qldb"
+	"github.com/aws/aws-sdk-go-v2/service/qldb/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -23,7 +25,7 @@ import (
 
 // @SDKResource("aws_qldb_ledger", name="Ledger")
 // @Tags(identifierAttribute="arn")
-func ResourceLedger() *schema.Resource {
+func resourceLedger() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceLedgerCreate,
 		ReadWithoutTimeout:   resourceLedgerRead,
@@ -69,9 +71,9 @@ func ResourceLedger() *schema.Resource {
 				),
 			},
 			"permissions_mode": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringInSlice(qldb.PermissionsMode_Values(), false),
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: enum.Validate[types.PermissionsMode](),
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
@@ -82,13 +84,13 @@ func ResourceLedger() *schema.Resource {
 }
 
 func resourceLedgerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).QLDBConn(ctx)
+	conn := meta.(*conns.AWSClient).QLDBClient(ctx)
 
 	name := create.Name(d.Get("name").(string), "tf")
 	input := &qldb.CreateLedgerInput{
 		DeletionProtection: aws.Bool(d.Get("deletion_protection").(bool)),
 		Name:               aws.String(name),
-		PermissionsMode:    aws.String(d.Get("permissions_mode").(string)),
+		PermissionsMode:    types.PermissionsMode(d.Get("permissions_mode").(string)),
 		Tags:               getTagsIn(ctx),
 	}
 
@@ -96,14 +98,13 @@ func resourceLedgerCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		input.KmsKey = aws.String(v.(string))
 	}
 
-	log.Printf("[DEBUG] Creating QLDB Ledger: %s", input)
-	output, err := conn.CreateLedgerWithContext(ctx, input)
+	output, err := conn.CreateLedger(ctx, input)
 
 	if err != nil {
 		return diag.Errorf("creating QLDB Ledger (%s): %s", name, err)
 	}
 
-	d.SetId(aws.StringValue(output.Name))
+	d.SetId(aws.ToString(output.Name))
 
 	if _, err := waitLedgerCreated(ctx, conn, d.Timeout(schema.TimeoutCreate), d.Id()); err != nil {
 		return diag.Errorf("waiting for QLDB Ledger (%s) create: %s", d.Id(), err)
@@ -113,9 +114,9 @@ func resourceLedgerCreate(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func resourceLedgerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).QLDBConn(ctx)
+	conn := meta.(*conns.AWSClient).QLDBClient(ctx)
 
-	ledger, err := FindLedgerByName(ctx, conn, d.Id())
+	ledger, err := findLedgerByName(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] QLDB Ledger %s not found, removing from state", d.Id())
@@ -141,16 +142,15 @@ func resourceLedgerRead(ctx context.Context, d *schema.ResourceData, meta interf
 }
 
 func resourceLedgerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).QLDBConn(ctx)
+	conn := meta.(*conns.AWSClient).QLDBClient(ctx)
 
 	if d.HasChange("permissions_mode") {
 		input := &qldb.UpdateLedgerPermissionsModeInput{
 			Name:            aws.String(d.Id()),
-			PermissionsMode: aws.String(d.Get("permissions_mode").(string)),
+			PermissionsMode: types.PermissionsMode(d.Get("permissions_mode").(string)),
 		}
 
-		log.Printf("[INFO] Updating QLDB Ledger permissions mode: %s", input)
-		if _, err := conn.UpdateLedgerPermissionsModeWithContext(ctx, input); err != nil {
+		if _, err := conn.UpdateLedgerPermissionsMode(ctx, input); err != nil {
 			return diag.Errorf("updating QLDB Ledger (%s) permissions mode: %s", d.Id(), err)
 		}
 	}
@@ -165,8 +165,7 @@ func resourceLedgerUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			input.KmsKey = aws.String(d.Get("kms_key").(string))
 		}
 
-		log.Printf("[INFO] Updating QLDB Ledger: %s", input)
-		if _, err := conn.UpdateLedgerWithContext(ctx, input); err != nil {
+		if _, err := conn.UpdateLedger(ctx, input); err != nil {
 			return diag.Errorf("updating QLDB Ledger (%s): %s", d.Id(), err)
 		}
 	}
@@ -175,19 +174,18 @@ func resourceLedgerUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func resourceLedgerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).QLDBConn(ctx)
+	conn := meta.(*conns.AWSClient).QLDBClient(ctx)
 
 	input := &qldb.DeleteLedgerInput{
 		Name: aws.String(d.Id()),
 	}
 
 	log.Printf("[INFO] Deleting QLDB Ledger: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute,
-		func() (interface{}, error) {
-			return conn.DeleteLedgerWithContext(ctx, input)
-		}, qldb.ErrCodeResourceInUseException)
+	_, err := tfresource.RetryWhenIsA[*types.ResourceInUseException](ctx, 5*time.Minute, func() (interface{}, error) {
+		return conn.DeleteLedger(ctx, input)
+	})
 
-	if tfawserr.ErrCodeEquals(err, qldb.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil
 	}
 
@@ -202,14 +200,14 @@ func resourceLedgerDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	return nil
 }
 
-func FindLedgerByName(ctx context.Context, conn *qldb.QLDB, name string) (*qldb.DescribeLedgerOutput, error) {
+func findLedgerByName(ctx context.Context, conn *qldb.Client, name string) (*qldb.DescribeLedgerOutput, error) {
 	input := &qldb.DescribeLedgerInput{
 		Name: aws.String(name),
 	}
 
-	output, err := conn.DescribeLedgerWithContext(ctx, input)
+	output, err := conn.DescribeLedger(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, qldb.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
@@ -224,9 +222,9 @@ func FindLedgerByName(ctx context.Context, conn *qldb.QLDB, name string) (*qldb.
 		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	if state := aws.StringValue(output.State); state == qldb.LedgerStateDeleted {
+	if state := output.State; state == types.LedgerStateDeleted {
 		return nil, &retry.NotFoundError{
-			Message:     state,
+			Message:     string(state),
 			LastRequest: input,
 		}
 	}
@@ -234,9 +232,9 @@ func FindLedgerByName(ctx context.Context, conn *qldb.QLDB, name string) (*qldb.
 	return output, nil
 }
 
-func statusLedgerState(ctx context.Context, conn *qldb.QLDB, name string) retry.StateRefreshFunc {
+func statusLedgerState(ctx context.Context, conn *qldb.Client, name string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		output, err := FindLedgerByName(ctx, conn, name)
+		output, err := findLedgerByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil
@@ -246,14 +244,14 @@ func statusLedgerState(ctx context.Context, conn *qldb.QLDB, name string) retry.
 			return nil, "", err
 		}
 
-		return output, aws.StringValue(output.State), nil
+		return output, string(output.State), nil
 	}
 }
 
-func waitLedgerCreated(ctx context.Context, conn *qldb.QLDB, timeout time.Duration, name string) (*qldb.DescribeLedgerOutput, error) {
+func waitLedgerCreated(ctx context.Context, conn *qldb.Client, timeout time.Duration, name string) (*qldb.DescribeLedgerOutput, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{qldb.LedgerStateCreating},
-		Target:     []string{qldb.LedgerStateActive},
+		Pending:    enum.Slice(types.LedgerStateCreating),
+		Target:     enum.Slice(types.LedgerStateActive),
 		Refresh:    statusLedgerState(ctx, conn, name),
 		Timeout:    timeout,
 		MinTimeout: 3 * time.Second,
@@ -268,9 +266,9 @@ func waitLedgerCreated(ctx context.Context, conn *qldb.QLDB, timeout time.Durati
 	return nil, err
 }
 
-func waitLedgerDeleted(ctx context.Context, conn *qldb.QLDB, timeout time.Duration, name string) (*qldb.DescribeLedgerOutput, error) {
+func waitLedgerDeleted(ctx context.Context, conn *qldb.Client, timeout time.Duration, name string) (*qldb.DescribeLedgerOutput, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{qldb.LedgerStateActive, qldb.LedgerStateDeleting},
+		Pending:    enum.Slice(types.LedgerStateActive, types.LedgerStateDeleting),
 		Target:     []string{},
 		Refresh:    statusLedgerState(ctx, conn, name),
 		Timeout:    timeout,

--- a/internal/service/qldb/ledger_data_source.go
+++ b/internal/service/qldb/ledger_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"regexp"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -13,7 +13,7 @@ import (
 )
 
 // @SDKDataSource("aws_qldb_ledger")
-func DataSourceLedger() *schema.Resource {
+func dataSourceLedger() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceLedgerRead,
 
@@ -48,17 +48,17 @@ func DataSourceLedger() *schema.Resource {
 }
 
 func dataSourceLedgerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).QLDBConn(ctx)
+	conn := meta.(*conns.AWSClient).QLDBClient(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	name := d.Get("name").(string)
-	ledger, err := FindLedgerByName(ctx, conn, name)
+	ledger, err := findLedgerByName(ctx, conn, name)
 
 	if err != nil {
 		return diag.Errorf("reading QLDB Ledger (%s): %s", name, err)
 	}
 
-	d.SetId(aws.StringValue(ledger.Name))
+	d.SetId(aws.ToString(ledger.Name))
 	d.Set("arn", ledger.Arn)
 	d.Set("deletion_protection", ledger.DeletionProtection)
 	if ledger.EncryptionDescription != nil {

--- a/internal/service/qldb/ledger_data_source_test.go
+++ b/internal/service/qldb/ledger_data_source_test.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/qldb"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccQLDBLedgerDataSource_basic(t *testing.T) {
@@ -17,8 +17,8 @@ func TestAccQLDBLedgerDataSource_basic(t *testing.T) {
 	datasourceName := "data.aws_qldb_ledger.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, qldb.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, qldb.EndpointsID),
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.QLDBEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.QLDBEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -44,7 +44,7 @@ resource "aws_qldb_ledger" "test" {
   deletion_protection = false
 
   tags = {
-    Env = "test"
+    Name = %[1]q
   }
 }
 

--- a/internal/service/qldb/ledger_test.go
+++ b/internal/service/qldb/ledger_test.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/qldb"
+	"github.com/aws/aws-sdk-go-v2/service/qldb"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfqldb "github.com/hashicorp/terraform-provider-aws/internal/service/qldb"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccQLDBLedger_basic(t *testing.T) {
@@ -23,8 +24,8 @@ func TestAccQLDBLedger_basic(t *testing.T) {
 	resourceName := "aws_qldb_ledger.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, qldb.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, qldb.EndpointsID),
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.QLDBEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.QLDBEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckLedgerDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -56,8 +57,8 @@ func TestAccQLDBLedger_disappears(t *testing.T) {
 	resourceName := "aws_qldb_ledger.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, qldb.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, qldb.EndpointsID),
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.QLDBEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.QLDBEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckLedgerDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -79,8 +80,8 @@ func TestAccQLDBLedger_nameGenerated(t *testing.T) {
 	resourceName := "aws_qldb_ledger.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, qldb.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, qldb.EndpointsID),
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.QLDBEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.QLDBEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckLedgerDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -107,8 +108,8 @@ func TestAccQLDBLedger_update(t *testing.T) {
 	resourceName := "aws_qldb_ledger.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, qldb.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, qldb.EndpointsID),
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.QLDBEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.QLDBEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckLedgerDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -153,8 +154,8 @@ func TestAccQLDBLedger_kmsKey(t *testing.T) {
 	kmsKeyResourceName := "aws_kms_key.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, qldb.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, qldb.EndpointsID),
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.QLDBEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.QLDBEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckLedgerDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -188,8 +189,8 @@ func TestAccQLDBLedger_tags(t *testing.T) {
 	resourceName := "aws_qldb_ledger.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, qldb.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, qldb.EndpointsID),
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.QLDBEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.QLDBEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckLedgerDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -229,7 +230,7 @@ func TestAccQLDBLedger_tags(t *testing.T) {
 
 func testAccCheckLedgerDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).QLDBConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).QLDBClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_qldb_ledger" {
@@ -264,7 +265,7 @@ func testAccCheckLedgerExists(ctx context.Context, n string, v *qldb.DescribeLed
 			return fmt.Errorf("No QLDB Ledger ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).QLDBConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).QLDBClient(ctx)
 
 		output, err := tfqldb.FindLedgerByName(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/qldb/service_package_gen.go
+++ b/internal/service/qldb/service_package_gen.go
@@ -25,7 +25,7 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {
 	return []*types.ServicePackageSDKDataSource{
 		{
-			Factory:  DataSourceLedger,
+			Factory:  dataSourceLedger,
 			TypeName: "aws_qldb_ledger",
 		},
 	}

--- a/internal/service/qldb/service_package_gen.go
+++ b/internal/service/qldb/service_package_gen.go
@@ -42,7 +42,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceStream,
+			Factory:  resourceStream,
 			TypeName: "aws_qldb_stream",
 			Name:     "Stream",
 			Tags: &types.ServicePackageResourceTags{

--- a/internal/service/qldb/service_package_gen.go
+++ b/internal/service/qldb/service_package_gen.go
@@ -34,7 +34,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
 		{
-			Factory:  ResourceLedger,
+			Factory:  resourceLedger,
 			TypeName: "aws_qldb_ledger",
 			Name:     "Ledger",
 			Tags: &types.ServicePackageResourceTags{

--- a/internal/service/qldb/service_package_gen.go
+++ b/internal/service/qldb/service_package_gen.go
@@ -5,9 +5,8 @@ package qldb
 import (
 	"context"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	qldb_sdkv1 "github.com/aws/aws-sdk-go/service/qldb"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	qldb_sdkv2 "github.com/aws/aws-sdk-go-v2/service/qldb"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -57,11 +56,15 @@ func (p *servicePackage) ServicePackageName() string {
 	return names.QLDB
 }
 
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*qldb_sdkv1.QLDB, error) {
-	sess := config["session"].(*session_sdkv1.Session)
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*qldb_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
-	return qldb_sdkv1.New(sess.Copy(&aws_sdkv1.Config{Endpoint: aws_sdkv1.String(config["endpoint"].(string))})), nil
+	return qldb_sdkv2.NewFromConfig(cfg, func(o *qldb_sdkv2.Options) {
+		if endpoint := config["endpoint"].(string); endpoint != "" {
+			o.EndpointResolver = qldb_sdkv2.EndpointResolverFromURL(endpoint)
+		}
+	}), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/internal/service/qldb/stream.go
+++ b/internal/service/qldb/stream.go
@@ -6,14 +6,16 @@ import (
 	"log"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/qldb"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/qldb"
+	"github.com/aws/aws-sdk-go-v2/service/qldb/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -22,7 +24,7 @@ import (
 
 // @SDKResource("aws_qldb_stream", name="Stream")
 // @Tags(identifierAttribute="arn")
-func ResourceStream() *schema.Resource {
+func resourceStream() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceStreamCreate,
 		ReadWithoutTimeout:   resourceStreamRead,
@@ -99,7 +101,7 @@ func ResourceStream() *schema.Resource {
 }
 
 func resourceStreamCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).QLDBConn(ctx)
+	conn := meta.(*conns.AWSClient).QLDBClient(ctx)
 
 	ledgerName := d.Get("ledger_name").(string)
 	name := d.Get("stream_name").(string)
@@ -124,14 +126,13 @@ func resourceStreamCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		input.KinesisConfiguration = expandKinesisConfiguration(v.([]interface{})[0].(map[string]interface{}))
 	}
 
-	log.Printf("[DEBUG] Creating QLDB Stream: %s", input)
-	output, err := conn.StreamJournalToKinesisWithContext(ctx, input)
+	output, err := conn.StreamJournalToKinesis(ctx, input)
 
 	if err != nil {
 		return diag.Errorf("creating QLDB Stream (%s): %s", name, err)
 	}
 
-	d.SetId(aws.StringValue(output.StreamId))
+	d.SetId(aws.ToString(output.StreamId))
 
 	if _, err := waitStreamCreated(ctx, conn, ledgerName, d.Id()); err != nil {
 		return diag.Errorf("waiting for QLDB Stream (%s) create: %s", d.Id(), err)
@@ -141,10 +142,10 @@ func resourceStreamCreate(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func resourceStreamRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).QLDBConn(ctx)
+	conn := meta.(*conns.AWSClient).QLDBClient(ctx)
 
 	ledgerName := d.Get("ledger_name").(string)
-	stream, err := FindStream(ctx, conn, ledgerName, d.Id())
+	stream, err := findStreamByTwoPartKey(ctx, conn, ledgerName, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] QLDB Stream %s not found, removing from state", d.Id())
@@ -158,12 +159,12 @@ func resourceStreamRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	d.Set("arn", stream.Arn)
 	if stream.ExclusiveEndTime != nil {
-		d.Set("exclusive_end_time", aws.TimeValue(stream.ExclusiveEndTime).Format(time.RFC3339))
+		d.Set("exclusive_end_time", aws.ToTime(stream.ExclusiveEndTime).Format(time.RFC3339))
 	} else {
 		d.Set("exclusive_end_time", nil)
 	}
 	if stream.InclusiveStartTime != nil {
-		d.Set("inclusive_start_time", aws.TimeValue(stream.InclusiveStartTime).Format(time.RFC3339))
+		d.Set("inclusive_start_time", aws.ToTime(stream.InclusiveStartTime).Format(time.RFC3339))
 	} else {
 		d.Set("inclusive_start_time", nil)
 	}
@@ -187,7 +188,7 @@ func resourceStreamUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func resourceStreamDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conn := meta.(*conns.AWSClient).QLDBConn(ctx)
+	conn := meta.(*conns.AWSClient).QLDBClient(ctx)
 
 	ledgerName := d.Get("ledger_name").(string)
 	input := &qldb.CancelJournalKinesisStreamInput{
@@ -196,12 +197,11 @@ func resourceStreamDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	log.Printf("[INFO] Deleting QLDB Stream: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute,
-		func() (interface{}, error) {
-			return conn.CancelJournalKinesisStreamWithContext(ctx, input)
-		}, qldb.ErrCodeResourceInUseException)
+	_, err := tfresource.RetryWhenIsA[*types.ResourceInUseException](ctx, 5*time.Minute, func() (interface{}, error) {
+		return conn.CancelJournalKinesisStream(ctx, input)
+	})
 
-	if tfawserr.ErrCodeEquals(err, qldb.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil
 	}
 
@@ -216,7 +216,7 @@ func resourceStreamDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	return nil
 }
 
-func FindStream(ctx context.Context, conn *qldb.QLDB, ledgerName, streamID string) (*qldb.JournalKinesisStreamDescription, error) {
+func findStreamByTwoPartKey(ctx context.Context, conn *qldb.Client, ledgerName, streamID string) (*types.JournalKinesisStreamDescription, error) {
 	input := &qldb.DescribeJournalKinesisStreamInput{
 		LedgerName: aws.String(ledgerName),
 		StreamId:   aws.String(streamID),
@@ -229,10 +229,10 @@ func FindStream(ctx context.Context, conn *qldb.QLDB, ledgerName, streamID strin
 	}
 
 	// See https://docs.aws.amazon.com/qldb/latest/developerguide/streams.create.html#streams.create.states.
-	switch status := aws.StringValue(output.Status); status {
-	case qldb.StreamStatusCompleted, qldb.StreamStatusCanceled, qldb.StreamStatusFailed:
+	switch status := output.Status; status {
+	case types.StreamStatusCompleted, types.StreamStatusCanceled, types.StreamStatusFailed:
 		return nil, &retry.NotFoundError{
-			Message:     status,
+			Message:     string(status),
 			LastRequest: input,
 		}
 	}
@@ -240,10 +240,10 @@ func FindStream(ctx context.Context, conn *qldb.QLDB, ledgerName, streamID strin
 	return output, nil
 }
 
-func findJournalKinesisStream(ctx context.Context, conn *qldb.QLDB, input *qldb.DescribeJournalKinesisStreamInput) (*qldb.JournalKinesisStreamDescription, error) {
-	output, err := conn.DescribeJournalKinesisStreamWithContext(ctx, input)
+func findJournalKinesisStream(ctx context.Context, conn *qldb.Client, input *qldb.DescribeJournalKinesisStreamInput) (*types.JournalKinesisStreamDescription, error) {
+	output, err := conn.DescribeJournalKinesisStream(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, qldb.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
@@ -261,7 +261,7 @@ func findJournalKinesisStream(ctx context.Context, conn *qldb.QLDB, input *qldb.
 	return output.Stream, nil
 }
 
-func statusStreamCreated(ctx context.Context, conn *qldb.QLDB, ledgerName, streamID string) retry.StateRefreshFunc {
+func statusStreamCreated(ctx context.Context, conn *qldb.Client, ledgerName, streamID string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		// Don't call FindStream as it maps useful statuses to NotFoundError.
 		output, err := findJournalKinesisStream(ctx, conn, &qldb.DescribeJournalKinesisStreamInput{
@@ -277,14 +277,14 @@ func statusStreamCreated(ctx context.Context, conn *qldb.QLDB, ledgerName, strea
 			return nil, "", err
 		}
 
-		return output, aws.StringValue(output.Status), nil
+		return output, string(output.Status), nil
 	}
 }
 
-func waitStreamCreated(ctx context.Context, conn *qldb.QLDB, ledgerName, streamID string) (*qldb.JournalKinesisStreamDescription, error) {
+func waitStreamCreated(ctx context.Context, conn *qldb.Client, ledgerName, streamID string) (*types.JournalKinesisStreamDescription, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{qldb.StreamStatusImpaired},
-		Target:     []string{qldb.StreamStatusActive},
+		Pending:    enum.Slice(types.StreamStatusImpaired),
+		Target:     enum.Slice(types.StreamStatusActive),
 		Refresh:    statusStreamCreated(ctx, conn, ledgerName, streamID),
 		Timeout:    8 * time.Minute,
 		MinTimeout: 3 * time.Second,
@@ -292,8 +292,8 @@ func waitStreamCreated(ctx context.Context, conn *qldb.QLDB, ledgerName, streamI
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-	if output, ok := outputRaw.(*qldb.JournalKinesisStreamDescription); ok {
-		tfresource.SetLastError(err, errors.New(aws.StringValue(output.ErrorCause)))
+	if output, ok := outputRaw.(*types.JournalKinesisStreamDescription); ok {
+		tfresource.SetLastError(err, errors.New(string(output.ErrorCause)))
 
 		return output, err
 	}
@@ -301,9 +301,9 @@ func waitStreamCreated(ctx context.Context, conn *qldb.QLDB, ledgerName, streamI
 	return nil, err
 }
 
-func statusStreamDeleted(ctx context.Context, conn *qldb.QLDB, ledgerName, streamID string) retry.StateRefreshFunc {
+func statusStreamDeleted(ctx context.Context, conn *qldb.Client, ledgerName, streamID string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		output, err := FindStream(ctx, conn, ledgerName, streamID)
+		output, err := findStreamByTwoPartKey(ctx, conn, ledgerName, streamID)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil
@@ -313,13 +313,13 @@ func statusStreamDeleted(ctx context.Context, conn *qldb.QLDB, ledgerName, strea
 			return nil, "", err
 		}
 
-		return output, aws.StringValue(output.Status), nil
+		return output, string(output.Status), nil
 	}
 }
 
-func waitStreamDeleted(ctx context.Context, conn *qldb.QLDB, ledgerName, streamID string) (*qldb.JournalKinesisStreamDescription, error) {
+func waitStreamDeleted(ctx context.Context, conn *qldb.Client, ledgerName, streamID string) (*types.JournalKinesisStreamDescription, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{qldb.StreamStatusActive, qldb.StreamStatusImpaired},
+		Pending:    enum.Slice(types.StreamStatusActive, types.StreamStatusImpaired),
 		Target:     []string{},
 		Refresh:    statusStreamDeleted(ctx, conn, ledgerName, streamID),
 		Timeout:    5 * time.Minute,
@@ -328,8 +328,8 @@ func waitStreamDeleted(ctx context.Context, conn *qldb.QLDB, ledgerName, streamI
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-	if output, ok := outputRaw.(*qldb.JournalKinesisStreamDescription); ok {
-		tfresource.SetLastError(err, errors.New(aws.StringValue(output.ErrorCause)))
+	if output, ok := outputRaw.(*types.JournalKinesisStreamDescription); ok {
+		tfresource.SetLastError(err, errors.New(string(output.ErrorCause)))
 
 		return output, err
 	}
@@ -337,12 +337,12 @@ func waitStreamDeleted(ctx context.Context, conn *qldb.QLDB, ledgerName, streamI
 	return nil, err
 }
 
-func expandKinesisConfiguration(tfMap map[string]interface{}) *qldb.KinesisConfiguration {
+func expandKinesisConfiguration(tfMap map[string]interface{}) *types.KinesisConfiguration {
 	if tfMap == nil {
 		return nil
 	}
 
-	apiObject := &qldb.KinesisConfiguration{}
+	apiObject := &types.KinesisConfiguration{}
 
 	if v, ok := tfMap["aggregation_enabled"].(bool); ok {
 		apiObject.AggregationEnabled = aws.Bool(v)
@@ -355,7 +355,7 @@ func expandKinesisConfiguration(tfMap map[string]interface{}) *qldb.KinesisConfi
 	return apiObject
 }
 
-func flattenKinesisConfiguration(apiObject *qldb.KinesisConfiguration) map[string]interface{} {
+func flattenKinesisConfiguration(apiObject *types.KinesisConfiguration) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -363,11 +363,11 @@ func flattenKinesisConfiguration(apiObject *qldb.KinesisConfiguration) map[strin
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.AggregationEnabled; v != nil {
-		tfMap["aggregation_enabled"] = aws.BoolValue(v)
+		tfMap["aggregation_enabled"] = aws.ToBool(v)
 	}
 
 	if v := apiObject.StreamArn; v != nil {
-		tfMap["stream_arn"] = aws.StringValue(v)
+		tfMap["stream_arn"] = aws.ToString(v)
 	}
 
 	return tfMap

--- a/internal/service/qldb/stream_test.go
+++ b/internal/service/qldb/stream_test.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/qldb"
+	"github.com/aws/aws-sdk-go-v2/service/qldb/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -14,17 +14,18 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfqldb "github.com/hashicorp/terraform-provider-aws/internal/service/qldb"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccQLDBStream_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v qldb.JournalKinesisStreamDescription
+	var v types.JournalKinesisStreamDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_qldb_stream.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, qldb.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, qldb.EndpointsID),
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.QLDBEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.QLDBEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckStreamDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -50,13 +51,13 @@ func TestAccQLDBStream_basic(t *testing.T) {
 
 func TestAccQLDBStream_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v qldb.JournalKinesisStreamDescription
+	var v types.JournalKinesisStreamDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_qldb_stream.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, qldb.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, qldb.EndpointsID),
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.QLDBEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.QLDBEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckStreamDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -74,13 +75,13 @@ func TestAccQLDBStream_disappears(t *testing.T) {
 
 func TestAccQLDBStream_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v qldb.JournalKinesisStreamDescription
+	var v types.JournalKinesisStreamDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_qldb_stream.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, qldb.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, qldb.EndpointsID),
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.QLDBEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.QLDBEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckStreamDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -115,13 +116,13 @@ func TestAccQLDBStream_tags(t *testing.T) {
 
 func TestAccQLDBStream_withEndTime(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v qldb.JournalKinesisStreamDescription
+	var v types.JournalKinesisStreamDescription
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_qldb_stream.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, qldb.EndpointsID) },
-		ErrorCheck:               acctest.ErrorCheck(t, qldb.EndpointsID),
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.QLDBEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.QLDBEndpointID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckStreamDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -140,7 +141,7 @@ func TestAccQLDBStream_withEndTime(t *testing.T) {
 	})
 }
 
-func testAccCheckStreamExists(ctx context.Context, n string, v *qldb.JournalKinesisStreamDescription) resource.TestCheckFunc {
+func testAccCheckStreamExists(ctx context.Context, n string, v *types.JournalKinesisStreamDescription) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -151,9 +152,9 @@ func testAccCheckStreamExists(ctx context.Context, n string, v *qldb.JournalKine
 			return fmt.Errorf("No QLDB Stream ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).QLDBConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).QLDBClient(ctx)
 
-		output, err := tfqldb.FindStream(ctx, conn, rs.Primary.Attributes["ledger_name"], rs.Primary.ID)
+		output, err := tfqldb.FindStreamByTwoPartKey(ctx, conn, rs.Primary.Attributes["ledger_name"], rs.Primary.ID)
 
 		if err != nil {
 			return err
@@ -167,14 +168,14 @@ func testAccCheckStreamExists(ctx context.Context, n string, v *qldb.JournalKine
 
 func testAccCheckStreamDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).QLDBConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).QLDBClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_qldb_stream" {
 				continue
 			}
 
-			_, err := tfqldb.FindStream(ctx, conn, rs.Primary.Attributes["ledger_name"], rs.Primary.ID)
+			_, err := tfqldb.FindStreamByTwoPartKey(ctx, conn, rs.Primary.Attributes["ledger_name"], rs.Primary.ID)
 
 			if tfresource.NotFound(err) {
 				continue

--- a/internal/service/qldb/sweep.go
+++ b/internal/service/qldb/sweep.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/qldb"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/qldb"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
@@ -36,33 +36,30 @@ func sweepLedgers(region string) error {
 	if err != nil {
 		return fmt.Errorf("error getting client: %w", err)
 	}
-	conn := client.QLDBConn(ctx)
+	conn := client.QLDBClient(ctx)
 	input := &qldb.ListLedgersInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	err = conn.ListLedgersPagesWithContext(ctx, input, func(page *qldb.ListLedgersOutput, lastPage bool) bool {
-		if page == nil {
-			return !lastPage
+	pages := qldb.NewListLedgersPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if sweep.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping QLDB Ledger sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("error listing QLDB Ledgers (%s): %w", region, err)
 		}
 
 		for _, v := range page.Ledgers {
-			r := ResourceLedger()
+			r := resourceLedger()
 			d := r.Data(nil)
-			d.SetId(aws.StringValue(v.Name))
+			d.SetId(aws.ToString(v.Name))
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
-
-		return !lastPage
-	})
-
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping QLDB Ledger sweep for %s: %s", region, err)
-		return nil
-	}
-
-	if err != nil {
-		return fmt.Errorf("error listing QLDB Ledgers (%s): %w", region, err)
 	}
 
 	err = sweep.SweepOrchestratorWithContext(ctx, sweepResources)
@@ -80,14 +77,22 @@ func sweepStreams(region string) error {
 	if err != nil {
 		return fmt.Errorf("error getting client: %w", err)
 	}
-	conn := client.QLDBConn(ctx)
+	conn := client.QLDBClient(ctx)
 	input := &qldb.ListLedgersInput{}
 	var sweeperErrs *multierror.Error
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	err = conn.ListLedgersPagesWithContext(ctx, input, func(page *qldb.ListLedgersOutput, lastPage bool) bool {
-		if page == nil {
-			return !lastPage
+	pages := qldb.NewListLedgersPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if sweep.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping QLDB Stream sweep for %s: %s", region, err)
+			return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+		}
+
+		if err != nil {
+			sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing QLDB Ledgers (%s): %w", region, err))
 		}
 
 		for _, v := range page.Ledgers {
@@ -95,42 +100,28 @@ func sweepStreams(region string) error {
 				LedgerName: v.Name,
 			}
 
-			err := conn.ListJournalKinesisStreamsForLedgerPagesWithContext(ctx, input, func(page *qldb.ListJournalKinesisStreamsForLedgerOutput, lastPage bool) bool {
-				if page == nil {
-					return !lastPage
+			pages := qldb.NewListJournalKinesisStreamsForLedgerPaginator(conn, input)
+			for pages.HasMorePages() {
+				page, err := pages.NextPage(ctx)
+
+				if sweep.SkipSweepError(err) {
+					continue
+				}
+
+				if err != nil {
+					sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing QLDB Streams (%s): %w", region, err))
 				}
 
 				for _, v := range page.Streams {
-					r := ResourceStream()
+					r := resourceStream()
 					d := r.Data(nil)
-					d.SetId(aws.StringValue(v.StreamId))
+					d.SetId(aws.ToString(v.StreamId))
 					d.Set("ledger_name", v.LedgerName)
 
 					sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 				}
-
-				return !lastPage
-			})
-
-			if sweep.SkipSweepError(err) {
-				continue
-			}
-
-			if err != nil {
-				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing QLDB Streams (%s): %w", region, err))
 			}
 		}
-
-		return !lastPage
-	})
-
-	if sweep.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping QLDB Stream sweep for %s: %s", region, err)
-		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
-	}
-
-	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing QLDB Ledgers (%s): %w", region, err))
 	}
 
 	err = sweep.SweepOrchestratorWithContext(ctx, sweepResources)

--- a/internal/service/qldb/tags_gen.go
+++ b/internal/service/qldb/tags_gen.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/qldb"
-	"github.com/aws/aws-sdk-go/service/qldb/qldbiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/qldb"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/qldb/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
@@ -17,12 +17,12 @@ import (
 // listTags lists qldb service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn qldbiface.QLDBAPI, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *qldb.Client, identifier string) (tftags.KeyValueTags, error) {
 	input := &qldb.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResourceWithContext(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -34,7 +34,7 @@ func listTags(ctx context.Context, conn qldbiface.QLDBAPI, identifier string) (t
 // ListTags lists qldb service tags and set them in Context.
 // It is called from outside this package.
 func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier string) error {
-	tags, err := listTags(ctx, meta.(*conns.AWSClient).QLDBConn(ctx), identifier)
+	tags, err := listTags(ctx, meta.(*conns.AWSClient).QLDBClient(ctx), identifier)
 
 	if err != nil {
 		return err
@@ -81,7 +81,7 @@ func setTagsOut(ctx context.Context, tags map[string]*string) {
 // updateTags updates qldb service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn qldbiface.QLDBAPI, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *qldb.Client, identifier string, oldTagsMap, newTagsMap any) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -90,10 +90,10 @@ func updateTags(ctx context.Context, conn qldbiface.QLDBAPI, identifier string, 
 	if len(removedTags) > 0 {
 		input := &qldb.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.Keys()),
+			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResourceWithContext(ctx, input)
+		_, err := conn.UntagResource(ctx, input)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -108,7 +108,7 @@ func updateTags(ctx context.Context, conn qldbiface.QLDBAPI, identifier string, 
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResourceWithContext(ctx, input)
+		_, err := conn.TagResource(ctx, input)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)
@@ -121,5 +121,5 @@ func updateTags(ctx context.Context, conn qldbiface.QLDBAPI, identifier string, 
 // UpdateTags updates qldb service tags.
 // It is called from outside this package.
 func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
-	return updateTags(ctx, meta.(*conns.AWSClient).QLDBConn(ctx), identifier, oldTags, newTags)
+	return updateTags(ctx, meta.(*conns.AWSClient).QLDBClient(ctx), identifier, oldTags, newTags)
 }

--- a/internal/service/qldb/tags_gen.go
+++ b/internal/service/qldb/tags_gen.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/qldb"
-	awstypes "github.com/aws/aws-sdk-go-v2/service/qldb/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"

--- a/names/names.go
+++ b/names/names.go
@@ -41,6 +41,7 @@ const (
 	OpenSearchServerlessEndpointID       = "aoss"
 	PipesEndpointID                      = "pipes"
 	PricingEndpointID                    = "pricing"
+	QLDBEndpointID                       = "qldb"
 	ResourceExplorer2EndpointID          = "resource-explorer-2"
 	RolesAnywhereEndpointID              = "rolesanywhere"
 	Route53DomainsEndpointID             = "route53domains"

--- a/names/names_data.csv
+++ b/names/names_data.csv
@@ -277,7 +277,7 @@ polly,polly,polly,polly,,polly,,,Polly,Polly,,1,,,aws_polly_,,polly_,Polly,Amazo
 ,,,,,,,,,,,,,,,,,Porting Assistant for .NET,,x,,,,No SDK support
 pricing,pricing,pricing,pricing,,pricing,,,Pricing,Pricing,,,2,,aws_pricing_,,pricing_,Pricing Calculator,AWS,,,,,
 proton,proton,proton,proton,,proton,,,Proton,Proton,,1,,,aws_proton_,,proton_,Proton,AWS,,,,,
-qldb,qldb,qldb,qldb,,qldb,,,QLDB,QLDB,,1,,,aws_qldb_,,qldb_,QLDB (Quantum Ledger Database),Amazon,,,,,
+qldb,qldb,qldb,qldb,,qldb,,,QLDB,QLDB,,,2,,aws_qldb_,,qldb_,QLDB (Quantum Ledger Database),Amazon,,,,,
 qldb-session,qldbsession,qldbsession,qldbsession,,qldbsession,,,QLDBSession,QLDBSession,,1,,,aws_qldbsession_,,qldbsession_,QLDB Session,Amazon,,,,,
 quicksight,quicksight,quicksight,quicksight,,quicksight,,,QuickSight,QuickSight,,1,,,aws_quicksight_,,quicksight_,QuickSight,Amazon,,,,,
 ram,ram,ram,ram,,ram,,,RAM,RAM,,1,,,aws_ram_,,ram_,RAM (Resource Access Manager),AWS,,,,,

--- a/website/docs/r/qldb_stream.html.markdown
+++ b/website/docs/r/qldb_stream.html.markdown
@@ -56,3 +56,10 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The ID of the QLDB Stream.
 * `arn` - The ARN of the QLDB Stream.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `create` - (Default `8m`)
+- `delete` - (Default `5m`)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Ibid.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccQLDB' PKG=qldb ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/qldb/... -v -count 1 -parallel 2  -run=TestAccQLDB -timeout 180m
=== RUN   TestAccQLDBLedgerDataSource_basic
=== PAUSE TestAccQLDBLedgerDataSource_basic
=== RUN   TestAccQLDBLedger_basic
=== PAUSE TestAccQLDBLedger_basic
=== RUN   TestAccQLDBLedger_disappears
=== PAUSE TestAccQLDBLedger_disappears
=== RUN   TestAccQLDBLedger_nameGenerated
=== PAUSE TestAccQLDBLedger_nameGenerated
=== RUN   TestAccQLDBLedger_update
=== PAUSE TestAccQLDBLedger_update
=== RUN   TestAccQLDBLedger_kmsKey
=== PAUSE TestAccQLDBLedger_kmsKey
=== RUN   TestAccQLDBLedger_tags
=== PAUSE TestAccQLDBLedger_tags
=== RUN   TestAccQLDBStream_basic
=== PAUSE TestAccQLDBStream_basic
=== RUN   TestAccQLDBStream_disappears
=== PAUSE TestAccQLDBStream_disappears
=== RUN   TestAccQLDBStream_tags
=== PAUSE TestAccQLDBStream_tags
=== RUN   TestAccQLDBStream_withEndTime
=== PAUSE TestAccQLDBStream_withEndTime
=== CONT  TestAccQLDBLedgerDataSource_basic
=== CONT  TestAccQLDBLedger_tags
--- PASS: TestAccQLDBLedger_tags (353.54s)
=== CONT  TestAccQLDBStream_tags
--- PASS: TestAccQLDBLedgerDataSource_basic (360.53s)
=== CONT  TestAccQLDBStream_withEndTime
--- PASS: TestAccQLDBStream_withEndTime (326.34s)
=== CONT  TestAccQLDBStream_disappears
--- PASS: TestAccQLDBStream_tags (486.99s)
=== CONT  TestAccQLDBStream_basic
--- PASS: TestAccQLDBStream_disappears (358.00s)
=== CONT  TestAccQLDBLedger_nameGenerated
--- PASS: TestAccQLDBStream_basic (348.57s)
=== CONT  TestAccQLDBLedger_update
--- PASS: TestAccQLDBLedger_nameGenerated (328.04s)
=== CONT  TestAccQLDBLedger_disappears
--- PASS: TestAccQLDBLedger_update (352.20s)
=== CONT  TestAccQLDBLedger_basic
--- PASS: TestAccQLDBLedger_disappears (301.45s)
=== CONT  TestAccQLDBLedger_kmsKey
--- PASS: TestAccQLDBLedger_basic (276.97s)
--- PASS: TestAccQLDBLedger_kmsKey (327.96s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/qldb	2008.017s
```
```console
% make sweep SWEEPARGS=-sweep-run=aws_qldb_ledger
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./internal/sweep -v -tags=sweep -sweep=us-west-2,us-east-1,us-east-2 -sweep-run=aws_qldb_ledger -timeout 60m
2023/06/30 17:47:54 [DEBUG] Running Sweepers for region (us-west-2):
2023/06/30 17:47:54 [DEBUG] Sweeper (aws_qldb_ledger) has dependency (aws_qldb_stream), running..
2023/06/30 17:47:54 [DEBUG] Running Sweeper (aws_qldb_stream) in region (us-west-2)
2023/06/30 17:47:54 [DEBUG] Completed Sweeper (aws_qldb_stream) in region (us-west-2) in 824.355582ms
2023/06/30 17:47:54 [DEBUG] Running Sweeper (aws_qldb_ledger) in region (us-west-2)
2023/06/30 17:47:55 [DEBUG] Completed Sweeper (aws_qldb_ledger) in region (us-west-2) in 254.473685ms
2023/06/30 17:47:55 [DEBUG] Sweeper (aws_qldb_stream) already ran in region (us-west-2)
2023/06/30 17:47:55 Completed Sweepers for region (us-west-2) in 1.079129436s
2023/06/30 17:47:55 Sweeper Tests for region (us-west-2) ran successfully:
	- aws_qldb_stream
	- aws_qldb_ledger
2023/06/30 17:47:55 [DEBUG] Running Sweepers for region (us-east-1):
2023/06/30 17:47:55 [DEBUG] Sweeper (aws_qldb_ledger) has dependency (aws_qldb_stream), running..
2023/06/30 17:47:55 [DEBUG] Running Sweeper (aws_qldb_stream) in region (us-east-1)
2023/06/30 17:47:55 [DEBUG] Completed Sweeper (aws_qldb_stream) in region (us-east-1) in 540.03341ms
2023/06/30 17:47:55 [DEBUG] Running Sweeper (aws_qldb_ledger) in region (us-east-1)
2023/06/30 17:47:55 [DEBUG] Completed Sweeper (aws_qldb_ledger) in region (us-east-1) in 85.779903ms
2023/06/30 17:47:55 [DEBUG] Sweeper (aws_qldb_stream) already ran in region (us-east-1)
2023/06/30 17:47:55 Completed Sweepers for region (us-east-1) in 625.933558ms
2023/06/30 17:47:55 Sweeper Tests for region (us-east-1) ran successfully:
	- aws_qldb_stream
	- aws_qldb_ledger
2023/06/30 17:47:55 [DEBUG] Running Sweepers for region (us-east-2):
2023/06/30 17:47:55 [DEBUG] Sweeper (aws_qldb_ledger) has dependency (aws_qldb_stream), running..
2023/06/30 17:47:55 [DEBUG] Running Sweeper (aws_qldb_stream) in region (us-east-2)
2023/06/30 17:47:56 [DEBUG] Completed Sweeper (aws_qldb_stream) in region (us-east-2) in 488.409682ms
2023/06/30 17:47:56 [DEBUG] Running Sweeper (aws_qldb_ledger) in region (us-east-2)
2023/06/30 17:47:56 [DEBUG] Completed Sweeper (aws_qldb_ledger) in region (us-east-2) in 143.006109ms
2023/06/30 17:47:56 [DEBUG] Sweeper (aws_qldb_stream) already ran in region (us-east-2)
2023/06/30 17:47:56 Completed Sweepers for region (us-east-2) in 631.540509ms
2023/06/30 17:47:56 Sweeper Tests for region (us-east-2) ran successfully:
	- aws_qldb_stream
	- aws_qldb_ledger
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	8.056s
```
