### PR TITLE
Fix PrivateDnsOnlyForInboundResolverEndpoint for S3 interface endpoints

### DIFF
--- a/.changelog/32021.txt
+++ b/.changelog/32021.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-resource/aws_vpc_endpoint: Fix error creating S3 _Interface_ VPC endpoint
-```

--- a/.changelog/32355.txt
+++ b/.changelog/32355.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_vpc_endpoint: Fix `PrivateDnsOnlyForInboundResolverEndpoint` on S3 interface endpoint
+resource/aws_vpc_endpoint: Fix `InvalidParameter: PrivateDnsOnlyForInboundResolverEndpoint not supported for this service` errors creating S3 _Interface_ VPC endpoints
 ```

--- a/.changelog/32355.txt
+++ b/.changelog/32355.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpc_endpoint: Fix `PrivateDnsOnlyForInboundResolverEndpoint` on S3 interface endpoint
+```

--- a/internal/service/ec2/vpc_endpoint.go
+++ b/internal/service/ec2/vpc_endpoint.go
@@ -206,11 +206,10 @@ func resourceVPCEndpointCreate(ctx context.Context, d *schema.ResourceData, meta
 		// PrivateDnsOnlyForInboundResolverEndpoint is only supported for services
 		// that support both gateway and interface endpoints, i.e. S3
 		if ok, _ := regexp.MatchString("com\\.amazonaws\\.([a-z]+\\-[a-z]+\\-[0-9])\\.s3", serviceName); ok {
-			input.DnsOptions = expandDNSOptionsSpecificationWithPrivateDnsOnly(v.([]interface{})[0].(map[string]interface{}))
+			input.DnsOptions = expandDNSOptionsSpecificationWithPrivateDNSOnly(v.([]interface{})[0].(map[string]interface{}))
 		} else {
 			input.DnsOptions = expandDNSOptionsSpecification(v.([]interface{})[0].(map[string]interface{}))
 		}
-
 	}
 
 	if v, ok := d.GetOk("ip_address_type"); ok {
@@ -386,7 +385,7 @@ func resourceVPCEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta
 				// PrivateDnsOnlyForInboundResolverEndpoint is only supported for services
 				// that support both gateway and interface endpoints, i.e. S3
 				if ok, _ := regexp.MatchString("com\\.amazonaws\\.([a-z]+\\-[a-z]+\\-[0-9])\\.s3", d.Get("service_name").(string)); ok {
-					input.DnsOptions = expandDNSOptionsSpecificationWithPrivateDnsOnly(tfMap)
+					input.DnsOptions = expandDNSOptionsSpecificationWithPrivateDNSOnly(tfMap)
 				} else {
 					input.DnsOptions = expandDNSOptionsSpecification(tfMap)
 				}
@@ -504,7 +503,7 @@ func expandDNSOptionsSpecification(tfMap map[string]interface{}) *ec2.DnsOptions
 	return apiObject
 }
 
-func expandDNSOptionsSpecificationWithPrivateDnsOnly(tfMap map[string]interface{}) *ec2.DnsOptionsSpecification {
+func expandDNSOptionsSpecificationWithPrivateDNSOnly(tfMap map[string]interface{}) *ec2.DnsOptionsSpecification {
 	if tfMap == nil {
 		return nil
 	}

--- a/internal/service/ec2/vpc_endpoint_test.go
+++ b/internal/service/ec2/vpc_endpoint_test.go
@@ -149,6 +149,39 @@ func TestAccVPCEndpoint_interfacePrivateDNS(t *testing.T) {
 	})
 }
 
+func TestAccVPCEndpoint_interfacePrivateDNSNoGateway(t *testing.T) {
+	ctx := acctest.Context(t)
+	var endpoint ec2.VpcEndpoint
+	resourceName := "aws_vpc_endpoint.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckVPCEndpointDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCEndpointConfig_interfacePrivateDNSNoGateway(rName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVPCEndpointExists(ctx, resourceName, &endpoint),
+					acctest.CheckResourceAttrGreaterThanValue(resourceName, "cidr_blocks.#", 0),
+					resource.TestCheckResourceAttr(resourceName, "dns_entry.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "dns_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dns_options.0.dns_record_ip_type", "ipv4"),
+					resource.TestCheckResourceAttr(resourceName, "dns_options.0.private_dns_only_for_inbound_resolver_endpoint", "false"),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccVPCEndpoint_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var endpoint ec2.VpcEndpoint
@@ -783,6 +816,39 @@ resource "aws_vpc_endpoint" "test" {
 
   # To set PrivateDnsOnlyForInboundResolverEndpoint to true, the VPC vpc-abcd1234 must have a Gateway endpoint for the service.
   depends_on = [aws_vpc_endpoint.gateway]
+}
+`, rName, privateDNSOnlyForInboundResolverEndpoint)
+}
+
+func testAccVPCEndpointConfig_interfacePrivateDNSNoGateway(rName string, privateDNSOnlyForInboundResolverEndpoint bool) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_region" "current" {}
+
+resource "aws_vpc_endpoint" "test" {
+  vpc_id              = aws_vpc.test.id
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.s3"
+  private_dns_enabled = true
+  vpc_endpoint_type   = "Interface"
+  ip_address_type     = "ipv4"
+
+  dns_options {
+    dns_record_ip_type                             = "ipv4"
+    private_dns_only_for_inbound_resolver_endpoint = %[2]t
+  }
+
+  tags = {
+    Name = %[1]q
+  }
 }
 `, rName, privateDNSOnlyForInboundResolverEndpoint)
 }


### PR DESCRIPTION
### Description
* This PR adds logic to check against the service_name attribute provided in the resource. If the service_name matches an S3 service name such as `com.amazonaws.us-west-2.s3`, the CREATE and UPDATE calls will include the `PrivateDnsOnlyForInboundResolverEndpoint` attribute. Otherwise, this attribute will not be included in the API calls. A new acceptance test is included to cover this use case.
    * Existing acceptance tests cover the scenario of enabling/disabling `PrivateDnsOnlyForInboundResolverEndpoint` on an interface endpoint resource with an existing gateway endpoint in the same VPC.

### References
* `PrivateDnsOnlyForInboundResolverEndpoint` is only supported for services that support BOTH gateway and interface endpoints. See: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ec2@v1.102.0/types#DnsOptionsSpecification
* Amazon S3 is the only service that meets these criteria today - DynamoDB supports gateway endpoints but not interface endpoints, and all other services use interface endpoints.
    * It is possible that DynamoDB could one day add support for interface endpoints, but that does not exist today. It’s also possible that additional services could add gateway endpoint support, but the trend for new AWS services since 2017 has been to rely on interface endpoints.
* If you don't specify a value for `PrivateDnsOnlyForInboundResolverEndpoint` when creating an S3 interface endpoint, it will default to true. See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html#s3-creating-vpc
* If you specify a value for `PrivateDnsOnlyForInboundResolverEndpoint` when creating a non-S3 interface endpoint, it will fail with the error: `PrivateDnsOnlyForInboundResolverEndpoint not supported for this service.`
    * In other words, the only practical time this attribute should be used is when creating an S3 interface endpoint.


### Relations

Closes #30041.
Relates #31117.
Closes https://github.com/hashicorp/terraform-provider-aws/pull/32021.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/31873.


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccVPCEndpoint_' PKG=ec2 ACCTEST_PARALLELISM=2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 2  -run=TestAccVPCEndpoint_ -timeout 180m
=== RUN   TestAccVPCEndpoint_gatewayBasic
=== PAUSE TestAccVPCEndpoint_gatewayBasic
=== RUN   TestAccVPCEndpoint_interfaceBasic
=== PAUSE TestAccVPCEndpoint_interfaceBasic
=== RUN   TestAccVPCEndpoint_interfacePrivateDNS
=== PAUSE TestAccVPCEndpoint_interfacePrivateDNS
=== RUN   TestAccVPCEndpoint_interfacePrivateDNSNoGateway
=== PAUSE TestAccVPCEndpoint_interfacePrivateDNSNoGateway
=== RUN   TestAccVPCEndpoint_disappears
=== PAUSE TestAccVPCEndpoint_disappears
=== RUN   TestAccVPCEndpoint_tags
=== PAUSE TestAccVPCEndpoint_tags
=== RUN   TestAccVPCEndpoint_gatewayWithRouteTableAndPolicy
=== PAUSE TestAccVPCEndpoint_gatewayWithRouteTableAndPolicy
=== RUN   TestAccVPCEndpoint_gatewayPolicy
=== PAUSE TestAccVPCEndpoint_gatewayPolicy
=== RUN   TestAccVPCEndpoint_ignoreEquivalent
=== PAUSE TestAccVPCEndpoint_ignoreEquivalent
=== RUN   TestAccVPCEndpoint_ipAddressType
=== PAUSE TestAccVPCEndpoint_ipAddressType
=== RUN   TestAccVPCEndpoint_interfaceWithSubnetAndSecurityGroup
=== PAUSE TestAccVPCEndpoint_interfaceWithSubnetAndSecurityGroup
=== RUN   TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnCreate
=== PAUSE TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnCreate
=== RUN   TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnUpdate
=== PAUSE TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnUpdate
=== RUN   TestAccVPCEndpoint_VPCEndpointType_gatewayLoadBalancer
=== PAUSE TestAccVPCEndpoint_VPCEndpointType_gatewayLoadBalancer
=== CONT  TestAccVPCEndpoint_gatewayBasic
=== CONT  TestAccVPCEndpoint_gatewayPolicy
--- PASS: TestAccVPCEndpoint_gatewayBasic (37.72s)
=== CONT  TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnCreate
--- PASS: TestAccVPCEndpoint_gatewayPolicy (62.81s)
=== CONT  TestAccVPCEndpoint_VPCEndpointType_gatewayLoadBalancer
--- PASS: TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnCreate (283.52s)
=== CONT  TestAccVPCEndpoint_disappears
--- PASS: TestAccVPCEndpoint_disappears (31.88s)
=== CONT  TestAccVPCEndpoint_gatewayWithRouteTableAndPolicy
--- PASS: TestAccVPCEndpoint_gatewayWithRouteTableAndPolicy (58.80s)
=== CONT  TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnUpdate
--- PASS: TestAccVPCEndpoint_VPCEndpointType_gatewayLoadBalancer (396.50s)
=== CONT  TestAccVPCEndpoint_tags
--- PASS: TestAccVPCEndpoint_tags (81.66s)
=== CONT  TestAccVPCEndpoint_ipAddressType
--- PASS: TestAccVPCEndpoint_interfaceNonAWSServiceAcceptOnUpdate (344.07s)
=== CONT  TestAccVPCEndpoint_interfaceWithSubnetAndSecurityGroup
--- PASS: TestAccVPCEndpoint_ipAddressType (467.16s)
=== CONT  TestAccVPCEndpoint_interfacePrivateDNS
--- PASS: TestAccVPCEndpoint_interfaceWithSubnetAndSecurityGroup (326.49s)
=== CONT  TestAccVPCEndpoint_interfacePrivateDNSNoGateway
--- PASS: TestAccVPCEndpoint_interfacePrivateDNSNoGateway (415.36s)
=== CONT  TestAccVPCEndpoint_ignoreEquivalent
--- PASS: TestAccVPCEndpoint_interfacePrivateDNS (582.67s)
=== CONT  TestAccVPCEndpoint_interfaceBasic
--- PASS: TestAccVPCEndpoint_ignoreEquivalent (105.75s)
--- PASS: TestAccVPCEndpoint_interfaceBasic (159.93s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        1754.148s
```
