### PR TITLE
KMS Keys: Fixes timeout when removing all tags

### DIFF
--- a/.changelog/32371.txt
+++ b/.changelog/32371.txt
@@ -1,0 +1,15 @@
+```release-note:bug
+resource/aws_kms_external_key: Correctly remove all tags
+```
+
+```release-note:bug
+resource/aws_kms_key: Correctly remove all tags
+```
+
+```release-note:bug
+resource/aws_kms_replica_external_key: Correctly remove all tags
+```
+
+```release-note:bug
+resource/aws_kms_replica_key: Correctly remove all tags
+```

--- a/internal/generate/tags/main.go
+++ b/internal/generate/tags/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-provider-aws/internal/generate/common"
 	v1 "github.com/hashicorp/terraform-provider-aws/internal/generate/tags/templates/v1"
@@ -25,8 +26,9 @@ const (
 )
 
 const (
-	defaultListTagsFunc   = "listTags"
-	defaultUpdateTagsFunc = "updateTags"
+	defaultListTagsFunc           = "listTags"
+	defaultUpdateTagsFunc         = "updateTags"
+	defaultWaitTagsPropagatedFunc = "waitTagsPropagated"
 )
 
 var (
@@ -38,38 +40,45 @@ var (
 	untagInNeedTagType       = flag.Bool("UntagInNeedTagType", false, "whether Untag input needs tag type")
 	updateTags               = flag.Bool("UpdateTags", false, "whether to generate UpdateTags")
 	updateTagsNoIgnoreSystem = flag.Bool("UpdateTagsNoIgnoreSystem", false, "whether to not ignore system tags in UpdateTags")
+	waitForPropagation       = flag.Bool("Wait", false, "whether to generate WaitTagsPropagated")
 
-	createTagsFunc        = flag.String("CreateTagsFunc", "createTags", "createTagsFunc")
-	getTagFunc            = flag.String("GetTagFunc", "GetTag", "getTagFunc")
-	getTagsInFunc         = flag.String("GetTagsInFunc", "getTagsIn", "getTagsInFunc")
-	keyValueTagsFunc      = flag.String("KeyValueTagsFunc", "KeyValueTags", "keyValueTagsFunc")
-	listTagsFunc          = flag.String("ListTagsFunc", defaultListTagsFunc, "listTagsFunc")
-	listTagsInFiltIDName  = flag.String("ListTagsInFiltIDName", "", "listTagsInFiltIDName")
-	listTagsInIDElem      = flag.String("ListTagsInIDElem", "ResourceArn", "listTagsInIDElem")
-	listTagsInIDNeedSlice = flag.String("ListTagsInIDNeedSlice", "", "listTagsInIDNeedSlice")
-	listTagsOp            = flag.String("ListTagsOp", "ListTagsForResource", "listTagsOp")
-	listTagsOutTagsElem   = flag.String("ListTagsOutTagsElem", "Tags", "listTagsOutTagsElem")
-	setTagsOutFunc        = flag.String("SetTagsOutFunc", "setTagsOut", "setTagsOutFunc")
-	tagInCustomVal        = flag.String("TagInCustomVal", "", "tagInCustomVal")
-	tagInIDElem           = flag.String("TagInIDElem", "ResourceArn", "tagInIDElem")
-	tagInIDNeedSlice      = flag.String("TagInIDNeedSlice", "", "tagInIDNeedSlice")
-	tagInTagsElem         = flag.String("TagInTagsElem", "Tags", "tagInTagsElem")
-	tagKeyType            = flag.String("TagKeyType", "", "tagKeyType")
-	tagOp                 = flag.String("TagOp", "TagResource", "tagOp")
-	tagOpBatchSize        = flag.String("TagOpBatchSize", "", "tagOpBatchSize")
-	tagResTypeElem        = flag.String("TagResTypeElem", "", "tagResTypeElem")
-	tagType               = flag.String("TagType", "Tag", "tagType")
-	tagType2              = flag.String("TagType2", "", "tagType")
-	tagTypeAddBoolElem    = flag.String("TagTypeAddBoolElem", "", "TagTypeAddBoolElem")
-	tagTypeIDElem         = flag.String("TagTypeIDElem", "", "tagTypeIDElem")
-	tagTypeKeyElem        = flag.String("TagTypeKeyElem", "Key", "tagTypeKeyElem")
-	tagTypeValElem        = flag.String("TagTypeValElem", "Value", "tagTypeValElem")
-	tagsFunc              = flag.String("TagsFunc", "Tags", "tagsFunc")
-	untagInCustomVal      = flag.String("UntagInCustomVal", "", "untagInCustomVal")
-	untagInNeedTagKeyType = flag.String("UntagInNeedTagKeyType", "", "untagInNeedTagKeyType")
-	untagInTagsElem       = flag.String("UntagInTagsElem", "TagKeys", "untagInTagsElem")
-	untagOp               = flag.String("UntagOp", "UntagResource", "untagOp")
-	updateTagsFunc        = flag.String("UpdateTagsFunc", defaultUpdateTagsFunc, "updateTagsFunc")
+	createTagsFunc          = flag.String("CreateTagsFunc", "createTags", "createTagsFunc")
+	getTagFunc              = flag.String("GetTagFunc", "GetTag", "getTagFunc")
+	getTagsInFunc           = flag.String("GetTagsInFunc", "getTagsIn", "getTagsInFunc")
+	keyValueTagsFunc        = flag.String("KeyValueTagsFunc", "KeyValueTags", "keyValueTagsFunc")
+	listTagsFunc            = flag.String("ListTagsFunc", defaultListTagsFunc, "listTagsFunc")
+	listTagsInFiltIDName    = flag.String("ListTagsInFiltIDName", "", "listTagsInFiltIDName")
+	listTagsInIDElem        = flag.String("ListTagsInIDElem", "ResourceArn", "listTagsInIDElem")
+	listTagsInIDNeedSlice   = flag.String("ListTagsInIDNeedSlice", "", "listTagsInIDNeedSlice")
+	listTagsOp              = flag.String("ListTagsOp", "ListTagsForResource", "listTagsOp")
+	listTagsOutTagsElem     = flag.String("ListTagsOutTagsElem", "Tags", "listTagsOutTagsElem")
+	setTagsOutFunc          = flag.String("SetTagsOutFunc", "setTagsOut", "setTagsOutFunc")
+	tagInCustomVal          = flag.String("TagInCustomVal", "", "tagInCustomVal")
+	tagInIDElem             = flag.String("TagInIDElem", "ResourceArn", "tagInIDElem")
+	tagInIDNeedSlice        = flag.String("TagInIDNeedSlice", "", "tagInIDNeedSlice")
+	tagInTagsElem           = flag.String("TagInTagsElem", "Tags", "tagInTagsElem")
+	tagKeyType              = flag.String("TagKeyType", "", "tagKeyType")
+	tagOp                   = flag.String("TagOp", "TagResource", "tagOp")
+	tagOpBatchSize          = flag.String("TagOpBatchSize", "", "tagOpBatchSize")
+	tagResTypeElem          = flag.String("TagResTypeElem", "", "tagResTypeElem")
+	tagType                 = flag.String("TagType", "Tag", "tagType")
+	tagType2                = flag.String("TagType2", "", "tagType")
+	tagTypeAddBoolElem      = flag.String("TagTypeAddBoolElem", "", "TagTypeAddBoolElem")
+	tagTypeIDElem           = flag.String("TagTypeIDElem", "", "tagTypeIDElem")
+	tagTypeKeyElem          = flag.String("TagTypeKeyElem", "Key", "tagTypeKeyElem")
+	tagTypeValElem          = flag.String("TagTypeValElem", "Value", "tagTypeValElem")
+	tagsFunc                = flag.String("TagsFunc", "Tags", "tagsFunc")
+	untagInCustomVal        = flag.String("UntagInCustomVal", "", "untagInCustomVal")
+	untagInNeedTagKeyType   = flag.String("UntagInNeedTagKeyType", "", "untagInNeedTagKeyType")
+	untagInTagsElem         = flag.String("UntagInTagsElem", "TagKeys", "untagInTagsElem")
+	untagOp                 = flag.String("UntagOp", "UntagResource", "untagOp")
+	updateTagsFunc          = flag.String("UpdateTagsFunc", defaultUpdateTagsFunc, "updateTagsFunc")
+	waitTagsPropagatedFunc  = flag.String("WaitFunc", defaultWaitTagsPropagatedFunc, "waitFunc")
+	waitContinuousOccurence = flag.Int("WaitContinuousOccurence", 0, "ContinuousTargetOccurence for Wait function")
+	waitDelay               = flag.Duration("WaitDelay", 0, "Delay for Wait function")
+	waitMinTimeout          = flag.Duration("WaitMinTimeout", 0, `"MinTimeout" (minimum poll interval) for Wait function`)
+	waitPollInterval        = flag.Duration("WaitPollInterval", 0, "PollInterval for Wait function")
+	waitTimeout             = flag.Duration("WaitTimeout", 0, "Timeout for Wait function")
 
 	parentNotFoundErrCode = flag.String("ParentNotFoundErrCode", "", "Parent 'NotFound' Error Code")
 	parentNotFoundErrMsg  = flag.String("ParentNotFoundErrMsg", "", "Parent 'NotFound' Error Message")
@@ -90,12 +99,13 @@ func usage() {
 }
 
 type TemplateBody struct {
-	getTag           string
-	header           string
-	listTags         string
-	serviceTagsMap   string
-	serviceTagsSlice string
-	updateTags       string
+	getTag             string
+	header             string
+	listTags           string
+	serviceTagsMap     string
+	serviceTagsSlice   string
+	updateTags         string
+	waitTagsPropagated string
 }
 
 func newTemplateBody(version int, kvtValues bool) *TemplateBody {
@@ -108,6 +118,7 @@ func newTemplateBody(version int, kvtValues bool) *TemplateBody {
 			"\n" + v1.ServiceTagsMapBody,
 			"\n" + v1.ServiceTagsSliceBody,
 			"\n" + v1.UpdateTagsBody,
+			"\n" + v1.WaitTagsPropagatedBody,
 		}
 	case sdkV2:
 		if kvtValues {
@@ -118,6 +129,7 @@ func newTemplateBody(version int, kvtValues bool) *TemplateBody {
 				"\n" + v2.ServiceTagsValueMapBody,
 				"\n" + v2.ServiceTagsSliceBody,
 				"\n" + v2.UpdateTagsBody,
+				"\n" + v2.WaitTagsPropagatedBody,
 			}
 		}
 		return &TemplateBody{
@@ -127,6 +139,7 @@ func newTemplateBody(version int, kvtValues bool) *TemplateBody {
 			"\n" + v2.ServiceTagsMapBody,
 			"\n" + v2.ServiceTagsSliceBody,
 			"\n" + v2.UpdateTagsBody,
+			"\n" + v2.WaitTagsPropagatedBody,
 		}
 	default:
 		return nil
@@ -178,6 +191,13 @@ type TemplateData struct {
 	UntagOp                 string
 	UpdateTagsFunc          string
 	UpdateTagsIgnoreSystem  bool
+	WaitForPropagation      bool
+	WaitTagsPropagatedFunc  string
+	WaitContinuousOccurence int
+	WaitDelay               string
+	WaitMinTimeout          string
+	WaitPollInterval        string
+	WaitTimeout             string
 
 	// The following are specific to writing import paths in the `headerBody`;
 	// to include the package, set the corresponding field's value to true
@@ -189,6 +209,7 @@ type TemplateData struct {
 	SkipServiceImp   bool
 	SkipTypesImp     bool
 	TfResourcePkg    bool
+	TimePkg          bool
 
 	IsDefaultListTags   bool
 	IsDefaultUpdateTags bool
@@ -276,7 +297,8 @@ func main() {
 		NamesPkg:         *updateTags && !*skipNamesImp,
 		SkipServiceImp:   *skipServiceImp,
 		SkipTypesImp:     *skipTypesImp,
-		TfResourcePkg:    *getTag,
+		TfResourcePkg:    (*getTag || *waitForPropagation),
+		TimePkg:          *waitForPropagation,
 
 		CreateTagsFunc:          createTagsFunc,
 		GetTagFunc:              *getTagFunc,
@@ -315,6 +337,13 @@ func main() {
 		UntagOp:                 *untagOp,
 		UpdateTagsFunc:          *updateTagsFunc,
 		UpdateTagsIgnoreSystem:  !*updateTagsNoIgnoreSystem,
+		WaitForPropagation:      *waitForPropagation,
+		WaitTagsPropagatedFunc:  *waitTagsPropagatedFunc,
+		WaitContinuousOccurence: *waitContinuousOccurence,
+		WaitDelay:               formatDuration(*waitDelay),
+		WaitMinTimeout:          formatDuration(*waitMinTimeout),
+		WaitPollInterval:        formatDuration(*waitPollInterval),
+		WaitTimeout:             formatDuration(*waitTimeout),
 
 		IsDefaultListTags:   *listTagsFunc == defaultListTagsFunc,
 		IsDefaultUpdateTags: *updateTagsFunc == defaultUpdateTagsFunc,
@@ -366,6 +395,12 @@ func main() {
 		}
 	}
 
+	if *waitForPropagation {
+		if err := d.WriteTemplate("waittagspropagated", templateBody.waitTagsPropagated, templateData); err != nil {
+			g.Fatalf("generating file (%s): %s", filename, err)
+		}
+	}
+
 	if err := d.Write(); err != nil {
 		g.Fatalf("generating file (%s): %s", filename, err)
 	}
@@ -375,4 +410,30 @@ func toSnakeCase(str string) string {
 	result := regexp.MustCompile("(.)([A-Z][a-z]+)").ReplaceAllString(str, "${1}_${2}")
 	result = regexp.MustCompile("([a-z0-9])([A-Z])").ReplaceAllString(result, "${1}_${2}")
 	return strings.ToLower(result)
+}
+
+func formatDuration(d time.Duration) string {
+	if d == 0 {
+		return ""
+	}
+
+	var buf []string
+	if h := d.Hours(); h >= 1 {
+		buf = append(buf, fmt.Sprintf("%d * time.Hour", int64(h)))
+		d = d - time.Duration(int64(h)*int64(time.Hour))
+	}
+	if m := d.Minutes(); m >= 1 {
+		buf = append(buf, fmt.Sprintf("%d * time.Minute", int64(m)))
+		d = d - time.Duration(int64(m)*int64(time.Minute))
+	}
+	if s := d.Seconds(); s >= 1 {
+		buf = append(buf, fmt.Sprintf("%d * time.Second", int64(s)))
+		d = d - time.Duration(int64(s)*int64(time.Second))
+	}
+	if ms := d.Milliseconds(); ms >= 1 {
+		buf = append(buf, fmt.Sprintf("%d * time.Millisecond", int64(ms)))
+	}
+	// Ignoring anything below milliseconds
+
+	return strings.Join(buf, " + ")
 }

--- a/internal/generate/tags/templates/v1/header_body.tmpl
+++ b/internal/generate/tags/templates/v1/header_body.tmpl
@@ -6,6 +6,9 @@ import (
 	{{- if .FmtPkg }}
 	"fmt"
 	{{- end }}
+	{{- if .TimePkg }}
+	"time"
+	{{- end }}
 
 	"github.com/aws/aws-sdk-go/aws"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"

--- a/internal/generate/tags/templates/v1/update_tags_body.tmpl
+++ b/internal/generate/tags/templates/v1/update_tags_body.tmpl
@@ -140,6 +140,14 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 
 	{{- end }}
 
+	{{ if .WaitForPropagation }}
+	if len(removedTags) > 0 || len(updatedTags) > 0 {
+		if err := {{ .WaitTagsPropagatedFunc }}(ctx, conn, identifier, newTags); err != nil {
+			return fmt.Errorf("waiting for resource (%s) tag propagation: %w", identifier, err)
+		}
+	}
+	{{- end }}
+
 	return nil
 }
 

--- a/internal/generate/tags/templates/v1/v1.go
+++ b/internal/generate/tags/templates/v1/v1.go
@@ -24,3 +24,6 @@ var ServiceTagsSliceBody string
 
 //go:embed update_tags_body.tmpl
 var UpdateTagsBody string
+
+//go:embed wait_tags_propagated_body.tmpl
+var WaitTagsPropagatedBody string

--- a/internal/generate/tags/templates/v1/wait_tags_propagated_body.tmpl
+++ b/internal/generate/tags/templates/v1/wait_tags_propagated_body.tmpl
@@ -1,0 +1,34 @@
+// {{ .WaitTagsPropagatedFunc }} waits for {{ .ServicePackage }} service tags to be propagated.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func {{ .WaitTagsPropagatedFunc }}(ctx context.Context, conn {{ .ClientType }}, id string, tags tftags.KeyValueTags) error {
+	checkFunc := func() (bool, error) {
+		output, err := listTags(ctx, conn, id)
+
+		if tfresource.NotFound(err) {
+			return false, nil
+		}
+
+		if err != nil {
+			return false, err
+		}
+
+		return output.Equal(tags), nil
+	}
+	opts := tfresource.WaitOpts{
+		{{- if ne .WaitContinuousOccurence 0 }}
+		ContinuousTargetOccurence: {{ .WaitContinuousOccurence }},
+		{{- end }}
+		{{- if ne .WaitDelay "" }}
+		Delay: {{ .WaitDelay }},
+		{{- end }}
+		{{- if ne .WaitMinTimeout "" }}
+		MinTimeout: {{ .WaitMinTimeout }},
+		{{- end }}
+		{{- if ne .WaitPollInterval "" }}
+		PollInterval: {{ .WaitPollInterval }},
+		{{- end }}
+	}
+
+	return tfresource.WaitUntil(ctx, {{ .WaitTimeout }}, checkFunc, opts)
+}

--- a/internal/generate/tags/templates/v2/header_body.tmpl
+++ b/internal/generate/tags/templates/v2/header_body.tmpl
@@ -6,6 +6,9 @@ import (
 	{{- if .FmtPkg }}
 	"fmt"
 	{{- end }}
+	{{- if .TimePkg }}
+	"time"
+	{{- end }}
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"

--- a/internal/generate/tags/templates/v2/update_tags_body.tmpl
+++ b/internal/generate/tags/templates/v2/update_tags_body.tmpl
@@ -140,6 +140,14 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 
 	{{- end }}
 
+	{{ if .WaitForPropagation }}
+	if len(removedTags) > 0 || len(updatedTags) > 0 {
+		if err := {{ .WaitTagsPropagatedFunc }}(ctx, conn, identifier, newTags); err != nil {
+			return fmt.Errorf("waiting for resource (%s) tag propagation: %w", identifier, err)
+		}
+	}
+	{{- end }}
+
 	return nil
 }
 

--- a/internal/generate/tags/templates/v2/v2.go
+++ b/internal/generate/tags/templates/v2/v2.go
@@ -30,3 +30,6 @@ var ServiceTagsSliceBody string
 
 //go:embed update_tags_body.tmpl
 var UpdateTagsBody string
+
+//go:embed wait_tags_propagated_body.tmpl
+var WaitTagsPropagatedBody string

--- a/internal/generate/tags/templates/v2/wait_tags_propagated_body.tmpl
+++ b/internal/generate/tags/templates/v2/wait_tags_propagated_body.tmpl
@@ -1,0 +1,34 @@
+// {{ .WaitTagsPropagatedFunc }} waits for {{ .ServicePackage }} service tags to be propagated.
+// The identifier is typically the Amazon Resource Name (ARN), although
+// it may also be a different identifier depending on the service.
+func {{ .WaitTagsPropagatedFunc }}(ctx context.Context, conn {{ .ClientType }}, id string, tags tftags.KeyValueTags) error {
+	checkFunc := func() (bool, error) {
+		output, err := listTags(ctx, conn, id)
+
+		if tfresource.NotFound(err) {
+			return false, nil
+		}
+
+		if err != nil {
+			return false, err
+		}
+
+		return output.Equal(tags), nil
+	}
+	opts := tfresource.WaitOpts{
+		{{- if ne .WaitContinuousOccurence 0 }}
+		ContinuousTargetOccurence: {{ .WaitContinuousOccurence }},
+		{{- end }}
+		{{- if ne .WaitDelay "" }}
+		Delay: {{ .WaitDelay }},
+		{{- end }}
+		{{- if ne .WaitMinTimeout "" }}
+		MinTimeout: {{ .WaitMinTimeout }},
+		{{- end }}
+		{{- if ne .WaitPollInterval "" }}
+		PollInterval: {{ .WaitPollInterval }},
+		{{- end }}
+	}
+
+	return tfresource.WaitUntil(ctx, {{ .WaitTimeout }}, checkFunc, opts)
+}

--- a/internal/service/kms/external_key.go
+++ b/internal/service/kms/external_key.go
@@ -195,7 +195,7 @@ func resourceExternalKeyCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if tags := KeyValueTags(ctx, getTagsIn(ctx)); len(tags) > 0 {
-		if err := WaitTagsPropagated(ctx, conn, d.Id(), tags); err != nil {
+		if err := waitTagsPropagated(ctx, conn, d.Id(), tags); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for KMS External Key (%s) tag propagation: %s", d.Id(), err)
 		}
 	}
@@ -301,12 +301,6 @@ func resourceExternalKeyUpdate(ctx context.Context, d *schema.ResourceData, meta
 		// Only disable after all attributes have been modified because we cannot modify disabled keys.
 		if err := updateKeyEnabled(ctx, conn, d.Id(), enabled); err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating KMS External Key (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		if err := WaitTagsPropagated(ctx, conn, d.Id(), tftags.New(ctx, d.Get("tags_all").(map[string]interface{}))); err != nil {
-			return sdkdiag.AppendErrorf(diags, "waiting for KMS External Key (%s) tag propagation: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/kms/external_key_test.go
+++ b/internal/service/kms/external_key_test.go
@@ -58,7 +58,6 @@ func TestAccKMSExternalKey_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"bypass_policy_lockout_safety_check",
 					"deletion_window_in_days",
-					"key_material_base64",
 				},
 			},
 		},
@@ -114,7 +113,6 @@ func TestAccKMSExternalKey_multiRegion(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"bypass_policy_lockout_safety_check",
 					"deletion_window_in_days",
-					"key_material_base64",
 				},
 			},
 		},
@@ -147,7 +145,6 @@ func TestAccKMSExternalKey_deletionWindowInDays(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"bypass_policy_lockout_safety_check",
 					"deletion_window_in_days",
-					"key_material_base64",
 				},
 			},
 			{
@@ -188,7 +185,6 @@ func TestAccKMSExternalKey_description(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"bypass_policy_lockout_safety_check",
 					"deletion_window_in_days",
-					"key_material_base64",
 				},
 			},
 			{
@@ -229,7 +225,6 @@ func TestAccKMSExternalKey_enabled(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"bypass_policy_lockout_safety_check",
 					"deletion_window_in_days",
-					"key_material_base64",
 				},
 			},
 			{
@@ -279,7 +274,6 @@ func TestAccKMSExternalKey_keyMaterialBase64(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"bypass_policy_lockout_safety_check",
 					"deletion_window_in_days",
-					"key_material_base64",
 				},
 			},
 			{
@@ -323,7 +317,6 @@ func TestAccKMSExternalKey_policy(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"bypass_policy_lockout_safety_check",
 					"deletion_window_in_days",
-					"key_material_base64",
 				},
 			},
 			{
@@ -366,7 +359,6 @@ func TestAccKMSExternalKey_policyBypass(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"bypass_policy_lockout_safety_check",
 					"deletion_window_in_days",
-					"key_material_base64",
 				},
 			},
 		},
@@ -400,7 +392,6 @@ func TestAccKMSExternalKey_tags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"bypass_policy_lockout_safety_check",
 					"deletion_window_in_days",
-					"key_material_base64",
 				},
 			},
 			{
@@ -421,6 +412,23 @@ func TestAccKMSExternalKey_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
+			},
+			{
+				Config: testAccExternalKeyConfig_tags0(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExternalKeyExists(ctx, resourceName, &key3),
+					testAccCheckExternalKeyNotRecreated(&key2, &key3),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"bypass_policy_lockout_safety_check",
+					"deletion_window_in_days",
+				},
 			},
 		},
 	})
@@ -455,7 +463,6 @@ func TestAccKMSExternalKey_validTo(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"bypass_policy_lockout_safety_check",
 					"deletion_window_in_days",
-					"key_material_base64",
 				},
 			},
 			{
@@ -702,6 +709,15 @@ resource "aws_kms_external_key" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccExternalKeyConfig_tags0(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_external_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+}
+`, rName)
 }
 
 func testAccExternalKeyConfig_validTo(rName, validTo string) string {

--- a/internal/service/kms/generate.go
+++ b/internal/service/kms/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListResourceTags -ListTagsInIDElem=KeyId -ServiceTagsSlice -TagInIDElem=KeyId -TagTypeKeyElem=TagKey -TagTypeValElem=TagValue -UpdateTags
+//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListResourceTags -ListTagsInIDElem=KeyId -ServiceTagsSlice -TagInIDElem=KeyId -TagTypeKeyElem=TagKey -TagTypeValElem=TagValue -UpdateTags -Wait -WaitContinuousOccurence 5 -WaitMinTimeout 1s -WaitTimeout 10m -ParentNotFoundErrCode=NotFoundException
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/kms/key.go
+++ b/internal/service/kms/key.go
@@ -185,7 +185,7 @@ func resourceKeyCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	if tags := KeyValueTags(ctx, getTagsIn(ctx)); len(tags) > 0 {
-		if err := WaitTagsPropagated(ctx, conn, d.Id(), tags); err != nil {
+		if err := waitTagsPropagated(ctx, conn, d.Id(), tags); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for KMS Key (%s) tag propagation: %s", d.Id(), err)
 		}
 	}
@@ -268,12 +268,6 @@ func resourceKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 		// Only disable after all attributes have been modified because we cannot modify disabled keys.
 		if err := updateKeyEnabled(ctx, conn, d.Id(), enabled); err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating KMS Key (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		if err := WaitTagsPropagated(ctx, conn, d.Id(), tftags.New(ctx, d.Get("tags_all").(map[string]interface{}))); err != nil {
-			return sdkdiag.AppendErrorf(diags, "waiting for KMS Key (%s) tag propagation: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/kms/key_test.go
+++ b/internal/service/kms/key_test.go
@@ -492,6 +492,19 @@ func TestAccKMSKey_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
+			{
+				Config: testAccKeyConfig_tags0(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeyExists(ctx, resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_window_in_days", "bypass_policy_lockout_safety_check"},
+			},
 		},
 	})
 }
@@ -1051,4 +1064,12 @@ resource "aws_kms_key" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccKeyConfig_tags0(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  description = %[1]q
+}
+`, rName)
 }

--- a/internal/service/kms/replica_external_key.go
+++ b/internal/service/kms/replica_external_key.go
@@ -195,7 +195,7 @@ func resourceReplicaExternalKeyCreate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if tags := KeyValueTags(ctx, getTagsIn(ctx)); len(tags) > 0 {
-		if err := WaitTagsPropagated(ctx, conn, d.Id(), tags); err != nil {
+		if err := waitTagsPropagated(ctx, conn, d.Id(), tags); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for KMS Replica External Key (%s) tag propagation: %s", d.Id(), err)
 		}
 	}
@@ -302,12 +302,6 @@ func resourceReplicaExternalKeyUpdate(ctx context.Context, d *schema.ResourceDat
 		// Only disable after all attributes have been modified because we cannot modify disabled keys.
 		if err := updateKeyEnabled(ctx, conn, d.Id(), enabled); err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating KMS Replica External Key (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		if err := WaitTagsPropagated(ctx, conn, d.Id(), tftags.New(ctx, d.Get("tags_all").(map[string]interface{}))); err != nil {
-			return sdkdiag.AppendErrorf(diags, "waiting for KMS Replica External Key (%s) tag propagation: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/kms/replica_external_key_test.go
+++ b/internal/service/kms/replica_external_key_test.go
@@ -216,6 +216,23 @@ func TestAccKMSReplicaExternalKey_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
 			},
+			{
+				Config: testAccReplicaExternalKeyConfig_tags0(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeyExists(ctx, resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"bypass_policy_lockout_safety_check",
+					"deletion_window_in_days",
+					"key_material_base64",
+				},
+			},
 		},
 	})
 }
@@ -317,7 +334,7 @@ resource "aws_kms_external_key" "test" {
 }
 
 resource "aws_kms_replica_external_key" "test" {
-  description     = %[2]q
+  description     = "%[1]s-Replica"
   enabled         = true
   primary_key_arn = aws_kms_external_key.test.arn
 
@@ -352,7 +369,7 @@ resource "aws_kms_external_key" "test" {
 }
 
 resource "aws_kms_replica_external_key" "test" {
-  description     = %[2]q
+  description     = "%[1]s-Replica"
   enabled         = true
   primary_key_arn = aws_kms_external_key.test.arn
 
@@ -366,4 +383,31 @@ resource "aws_kms_replica_external_key" "test" {
   deletion_window_in_days = 7
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
+}
+
+func testAccReplicaExternalKeyConfig_tags0(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), fmt.Sprintf(`
+# ACCEPTANCE TESTING ONLY -- NEVER EXPOSE YOUR KEY MATERIAL
+resource "aws_kms_external_key" "test" {
+  provider = awsalternate
+
+  description  = %[1]q
+  multi_region = true
+  enabled      = true
+
+  key_material_base64 = "Wblj06fduthWggmsT0cLVoIMOkeLbc2kVfMud77i/JY="
+
+  deletion_window_in_days = 7
+}
+
+resource "aws_kms_replica_external_key" "test" {
+  description     = "%[1]s-Replica"
+  enabled         = true
+  primary_key_arn = aws_kms_external_key.test.arn
+
+  key_material_base64 = "Wblj06fduthWggmsT0cLVoIMOkeLbc2kVfMud77i/JY="
+
+  deletion_window_in_days = 7
+}
+`, rName))
 }

--- a/internal/service/kms/replica_key.go
+++ b/internal/service/kms/replica_key.go
@@ -167,7 +167,7 @@ func resourceReplicaKeyCreate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	if tags := KeyValueTags(ctx, getTagsIn(ctx)); len(tags) > 0 {
-		if err := WaitTagsPropagated(ctx, conn, d.Id(), tags); err != nil {
+		if err := waitTagsPropagated(ctx, conn, d.Id(), tags); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for KMS Replica Key (%s) tag propagation: %s", d.Id(), err)
 		}
 	}
@@ -252,12 +252,6 @@ func resourceReplicaKeyUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		// Only disable after all attributes have been modified because we cannot modify disabled keys.
 		if err := updateKeyEnabled(ctx, conn, d.Id(), enabled); err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating KMS Replica Key (%s): %s", d.Id(), err)
-		}
-	}
-
-	if d.HasChange("tags_all") {
-		if err := WaitTagsPropagated(ctx, conn, d.Id(), tftags.New(ctx, d.Get("tags_all").(map[string]interface{}))); err != nil {
-			return sdkdiag.AppendErrorf(diags, "waiting for KMS Replica Key (%s) tag propagation: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/kms/replica_key_test.go
+++ b/internal/service/kms/replica_key_test.go
@@ -203,10 +203,13 @@ func TestAccKMSReplicaKey_tags(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_window_in_days", "bypass_policy_lockout_safety_check"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deletion_window_in_days",
+					"bypass_policy_lockout_safety_check",
+				},
 			},
 			{
 				Config: testAccReplicaKeyConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
@@ -224,6 +227,22 @@ func TestAccKMSReplicaKey_tags(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 				),
+			},
+			{
+				Config: testAccReplicaKeyConfig_tags0(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeyExists(ctx, resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deletion_window_in_days",
+					"bypass_policy_lockout_safety_check",
+				},
 			},
 		},
 	})
@@ -369,6 +388,26 @@ resource "aws_kms_replica_key" "test" {
   deletion_window_in_days = 7
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2))
+}
+
+func testAccReplicaKeyConfig_tags0(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigAlternateRegionProvider(), fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  provider = awsalternate
+
+  description  = %[1]q
+  multi_region = true
+
+  deletion_window_in_days = 7
+}
+
+resource "aws_kms_replica_key" "test" {
+  description     = %[1]q
+  primary_key_arn = aws_kms_key.test.arn
+
+  deletion_window_in_days = 7
+}
+`, rName))
 }
 
 func testAccReplicaKeyConfig_two(rName string) string {

--- a/internal/service/kms/wait.go
+++ b/internal/service/kms/wait.go
@@ -9,10 +9,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -203,28 +201,6 @@ func WaitKeyValidToPropagated(ctx context.Context, conn *kms.KMS, id string, val
 	}
 
 	return tfresource.WaitUntil(ctx, KeyValidToPropagationTimeout, checkFunc, opts)
-}
-
-func WaitTagsPropagated(ctx context.Context, conn *kms.KMS, id string, tags tftags.KeyValueTags) error {
-	checkFunc := func() (bool, error) {
-		output, err := listTags(ctx, conn, id)
-
-		if tfawserr.ErrCodeEquals(err, kms.ErrCodeNotFoundException) {
-			return false, nil
-		}
-
-		if err != nil {
-			return false, err
-		}
-
-		return output.Equal(tags), nil
-	}
-	opts := tfresource.WaitOpts{
-		ContinuousTargetOccurence: 5,
-		MinTimeout:                1 * time.Second,
-	}
-
-	return tfresource.WaitUntil(ctx, KeyTagsPropagationTimeout, checkFunc, opts)
 }
 
 func WaitReplicaExternalKeyCreated(ctx context.Context, conn *kms.KMS, id string) (*kms.KeyMetadata, error) {


### PR DESCRIPTION
### Description

Fixes timeout error when removing all tags from

* aws_kms_key
* aws_kms_external_key
* aws_kms_replica_external_key
* aws_kms_replica_key

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=kms TESTS=TestAccKMSKey

--- PASS: TestAccKMSKey_disappears (107.03s)
--- PASS: TestAccKMSKeyDataSource_byKeyARN (115.68s)
--- PASS: TestAccKMSKeyPolicy_disappears (120.03s)
--- PASS: TestAccKMSKey_hmacKey (127.22s)
--- PASS: TestAccKMSKey_asymmetricKey (130.71s)
--- PASS: TestAccKMSKey_Policy_booleanCondition (140.26s)
--- PASS: TestAccKMSKey_basic (152.11s)
--- PASS: TestAccKMSKey_multiRegion (152.28s)
--- PASS: TestAccKMSKeyPolicy_booleanCondition (156.69s)
--- PASS: TestAccKMSKey_Policy_iamRole (201.02s)
--- PASS: TestAccKMSKey_Policy_iamServiceLinkedRole (201.08s)
--- PASS: TestAccKMSKeyPolicy_iamServiceLinkedRole (211.75s)
--- PASS: TestAccKMSKey_Policy_bypassUpdate (267.76s)
--- PASS: TestAccKMSKey_Policy_basic (279.99s)
--- PASS: TestAccKMSKey_Policy_iamRoleUpdate (287.37s)
--- PASS: TestAccKMSKeyDataSource_multiRegionConfigurationByID (143.72s)
--- PASS: TestAccKMSKeyDataSource_grantToken (162.89s)
--- PASS: TestAccKMSKeyDataSource_multiRegionConfigurationByARN (150.21s)
--- PASS: TestAccKMSKeyPolicy_iamRole (202.09s)
--- PASS: TestAccKMSKeyDataSource_byAliasARN (118.89s)
--- PASS: TestAccKMSKeyDataSource_byAliasID (119.11s)
--- PASS: TestAccKMSKey_Policy_bypass (322.10s)
--- PASS: TestAccKMSKeyDataSource_byKeyID (114.17s)
--- PASS: TestAccKMSKey_Policy_iamRoleOrder (345.79s)
--- PASS: TestAccKMSKeyPolicy_bypassUpdate (222.43s)
--- PASS: TestAccKMSKeyPolicy_iamRoleUpdate (244.52s)
--- PASS: TestAccKMSKeyPolicy_iamRoleOrder (351.56s)
--- PASS: TestAccKMSKeyPolicy_keyIsEnabled (244.08s)
--- PASS: TestAccKMSKeyPolicy_basic (213.69s)
--- PASS: TestAccKMSKeyPolicy_bypass (243.15s)
--- PASS: TestAccKMSKey_isEnabled (378.11s)
--- PASS: TestAccKMSKey_tags (385.73s)
```
