### PR TITLE
resource/aws_ssm_parameter: Ignore Update if only `overwrite` parameter changes

### DIFF
--- a/.changelog/32372.txt
+++ b/.changelog/32372.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ssm_parameter: Skip Update if only `overwrite` parameter changes
+```

--- a/internal/service/ssm/parameter.go
+++ b/internal/service/ssm/parameter.go
@@ -303,7 +303,7 @@ func resourceParameterUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SSMConn(ctx)
 
-	if d.HasChangesExcept("tags", "tags_all") {
+	if d.HasChangesExcept("overwrite", "tags", "tags_all") {
 		value := d.Get("value").(string)
 
 		if v, ok := d.Get("insecure_value").(string); ok && v != "" {

--- a/internal/service/ssm/parameter_test.go
+++ b/internal/service/ssm/parameter_test.go
@@ -43,6 +43,101 @@ func TestAccSSMParameter_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "version"),
 					resource.TestCheckResourceAttr(resourceName, "data_type", "text"),
+					resource.TestCheckNoResourceAttr(resourceName, "overwrite"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"overwrite"},
+			},
+		},
+	})
+}
+
+func TestAccSSMParameter_updateValue(t *testing.T) {
+	ctx := acctest.Context(t)
+	var param ssm.Parameter
+	name := fmt.Sprintf("%s_%s", t.Name(), sdkacctest.RandString(10))
+	resourceName := "aws_ssm_parameter.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ssm.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckParameterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccParameterConfig_basic(name, "String", "test"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckParameterExists(ctx, resourceName, &param),
+					resource.TestCheckResourceAttr(resourceName, "type", "String"),
+					resource.TestCheckResourceAttr(resourceName, "value", "test"),
+					resource.TestCheckNoResourceAttr(resourceName, "overwrite"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"overwrite"},
+			},
+			{
+				Config: testAccParameterConfig_basic(name, "String", "test2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckParameterExists(ctx, resourceName, &param),
+					resource.TestCheckResourceAttr(resourceName, "type", "String"),
+					resource.TestCheckResourceAttr(resourceName, "value", "test2"),
+					resource.TestCheckNoResourceAttr(resourceName, "overwrite"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"overwrite"},
+			},
+		},
+	})
+}
+
+func TestAccSSMParameter_updateDescription(t *testing.T) {
+	ctx := acctest.Context(t)
+	var param ssm.Parameter
+	name := fmt.Sprintf("%s_%s", t.Name(), sdkacctest.RandString(10))
+	resourceName := "aws_ssm_parameter.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ssm.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckParameterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccParameterConfig_description(name, "description", "String", "test"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckParameterExists(ctx, resourceName, &param),
+					resource.TestCheckResourceAttr(resourceName, "description", "description"),
+					resource.TestCheckResourceAttr(resourceName, "type", "String"),
+					resource.TestCheckResourceAttr(resourceName, "value", "test"),
+					resource.TestCheckNoResourceAttr(resourceName, "overwrite"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"overwrite"},
+			},
+			{
+				Config: testAccParameterConfig_description(name, "updated description", "String", "test"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckParameterExists(ctx, resourceName, &param),
+					resource.TestCheckResourceAttr(resourceName, "description", "updated description"),
+					resource.TestCheckResourceAttr(resourceName, "type", "String"),
+					resource.TestCheckResourceAttr(resourceName, "value", "test"),
+					resource.TestCheckNoResourceAttr(resourceName, "overwrite"),
 				),
 			},
 			{
@@ -316,12 +411,14 @@ func TestAccSSMParameter_Overwrite_basic(t *testing.T) {
 				Config: testAccParameterConfig_basicOverwrite(name, "String", "This value is set using Terraform"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "version", "2"),
+					resource.TestCheckResourceAttr(resourceName, "overwrite", "true"),
 				),
 			},
 			{
 				Config: testAccParameterConfig_basicOverwrite(name, "String", "test2"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "version", "3"),
+					resource.TestCheckResourceAttr(resourceName, "overwrite", "true"),
 				),
 			},
 			{
@@ -337,6 +434,7 @@ func TestAccSSMParameter_Overwrite_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "value", "test3"),
 					resource.TestCheckResourceAttr(resourceName, "type", "String"),
 					resource.TestCheckResourceAttr(resourceName, "version", "4"),
+					resource.TestCheckResourceAttr(resourceName, "overwrite", "true"),
 				),
 			},
 		},
@@ -463,6 +561,41 @@ func TestAccSSMParameter_Overwrite_updateToTags(t *testing.T) {
 					testAccCheckParameterExists(ctx, resourceName, &param),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value2"),
+				),
+			},
+		},
+	})
+}
+func TestAccSSMParameter_Overwrite_removeAttribute(t *testing.T) {
+	ctx := acctest.Context(t)
+	var param ssm.Parameter
+	rName := fmt.Sprintf("%s_%s", t.Name(), sdkacctest.RandString(10))
+	resourceName := "aws_ssm_parameter.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, ssm.EndpointsID),
+		CheckDestroy: testAccCheckParameterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "4.67.0",
+					},
+				},
+				Config: testAccParameterConfig_overwriteRemove_Setup(rName, "String", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckParameterExists(ctx, resourceName, &param),
+					resource.TestCheckResourceAttr(resourceName, "overwrite", "true"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccParameterConfig_overwriteRemove_Remove(rName, "String", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckParameterExists(ctx, resourceName, &param),
+					resource.TestCheckResourceAttr(resourceName, "overwrite", "false"),
 				),
 			},
 		},
@@ -983,6 +1116,17 @@ resource "aws_ssm_parameter" "test" {
 `, rName, pType, value)
 }
 
+func testAccParameterConfig_description(rName, description, pType, value string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_parameter" "test" {
+  name        = %[1]q
+  description = %[2]q
+  type        = %[3]q
+  value       = %[4]q
+}
+`, rName, description, pType, value)
+}
+
 func testAccParameterConfig_insecure(rName, pType, value string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_parameter" "test" {
@@ -1122,6 +1266,29 @@ resource "aws_ssm_parameter" "test_downstream" {
   overwrite = true
 }
 `, rName, value)
+}
+
+func testAccParameterConfig_overwriteRemove_Setup(rName, pType, value string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_parameter" "test" {
+  name        = "test_parameter-%[1]s"
+  description = "description for parameter %[1]s"
+  type        = "%[2]s"
+  value       = "%[3]s"
+  overwrite   = true
+}
+`, rName, pType, value)
+}
+
+func testAccParameterConfig_overwriteRemove_Remove(rName, pType, value string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_parameter" "test" {
+  name        = "test_parameter-%[1]s"
+  description = "description for parameter %[1]s"
+  type        = "%[2]s"
+  value       = "%[3]s"
+}
+`, rName, pType, value)
 }
 
 func testAccParameterConfig_secure(rName string, value string) string {


### PR DESCRIPTION
### Description

Ignores Update if only `overwrite` parameter changes. Prevents the error

> Error: updating SSM Parameter (example): ParameterAlreadyExists: The parameter already exists. To overwrite this value, set the overwrite option in the request to true.

when removing parameter.

Closes https://github.com/hashicorp/terraform-provider-aws/issues/31655.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=ssm TESTS=TestAccSSMParameter_

--- PASS: TestAccSSMParameter_disappears (64.78s)
--- PASS: TestAccSSMParameter_Secure_basic (83.54s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringOnCreation (83.55s)
--- PASS: TestAccSSMParameter_basic (83.62s)
--- PASS: TestAccSSMParameter_Overwrite_noOverwriteTags (85.51s)
--- PASS: TestAccSSMParameter_fullPath (85.62s)
--- PASS: TestAccSSMParameter_DataType_ssmIntegration (85.95s)
--- PASS: TestAccSSMParameter_Overwrite_tags (88.79s)
--- PASS: TestAccSSMParameter_Secure_key (90.50s)
--- PASS: TestAccSSMParameter_DataType_ec2Image (91.05s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringOnUpdate (125.59s)
--- PASS: TestAccSSMParameter_Overwrite_updateDescription (132.63s)
--- PASS: TestAccSSMParameter_Overwrite_updateToTags (133.14s)
--- PASS: TestAccSSMParameter_changeNameForcesNew (134.67s)
--- PASS: TestAccSSMParameter_Secure_keyUpdate (137.96s)
--- PASS: TestAccSSMParameter_updateDescription (141.88s)
--- PASS: TestAccSSMParameter_Overwrite_cascade (149.95s)
--- PASS: TestAccSSMParameter_Overwrite_removeAttribute (72.31s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringToStandard (159.41s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringToAdvanced (162.87s)
--- PASS: TestAccSSMParameter_Overwrite_basic (163.30s)
--- PASS: TestAccSSMParameter_updateType (84.28s)
--- PASS: TestAccSSMParameter_updateValue (89.34s)
--- PASS: TestAccSSMParameter_tier (115.34s)
--- PASS: TestAccSSMParameter_Secure_insecureChangeSecure (96.61s)
--- PASS: TestAccSSMParameter_Secure_insecure (97.95s)
--- PASS: TestAccSSMParameter_tags (97.43s)
```
