### PR TITLE
Sweepers: Fixes failures in `aws_iam_policy` sweeper

### DIFF
--- a/internal/service/iam/sweep.go
+++ b/internal/service/iam/sweep.go
@@ -469,15 +469,8 @@ func newPolicySweeper(resource *schema.Resource, d *schema.ResourceData, client 
 func (ps policySweeper) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
 	err := ps.sweepable.Delete(ctx, timeout, optFns...)
 
-	errStr := err.Error()
-
-	if strings.Contains(errStr, iam.ErrCodeDeleteConflictException) {
-		log.Printf("[WARN] Ignoring IAM Policy (%s) deletion error: %s", ps.d.Id(), err)
-		return nil
-	}
-
 	accessDenied := regexp.MustCompile(`AccessDenied: .+ with an explicit deny`)
-	if accessDenied.MatchString(errStr) {
+	if accessDenied.MatchString(err.Error()) {
 		log.Printf("[DEBUG] Skipping IAM Policy (%s): %s", ps.d.Id(), err)
 		return nil
 	}

--- a/internal/service/iam/sweep.go
+++ b/internal/service/iam/sweep.go
@@ -846,9 +846,11 @@ func roleNameFilter(name string) bool {
 	// exhaustive list.
 	prefixes := []string{
 		"another_rds",
+		"AmazonComprehendServiceRole-",
 		"aws_batch_service_role",
 		"aws_elastictranscoder_pipeline_tf_test",
 		"batch_tf_batch_target-",
+		"codebuild-",
 		"codepipeline-",
 		"cognito_authenticated_",
 		"cognito_unauthenticated_",

--- a/internal/service/iam/sweep.go
+++ b/internal/service/iam/sweep.go
@@ -4,18 +4,23 @@
 package iam
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/sdk"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func init() {
@@ -407,11 +412,13 @@ func sweepPolicies(region string) error {
 	if err != nil {
 		return fmt.Errorf("error getting client: %w", err)
 	}
+
 	conn := client.IAMConn(ctx)
 	input := &iam.ListPoliciesInput{
 		Scope: aws.String(iam.PolicyScopeTypeLocal),
 	}
-	var sweeperErrs *multierror.Error
+
+	var sweepResources []sweep.Sweepable
 
 	err = conn.ListPoliciesPagesWithContext(ctx, input, func(page *iam.ListPoliciesOutput, lastPage bool) bool {
 		if page == nil {
@@ -424,25 +431,7 @@ func sweepPolicies(region string) error {
 			d := r.Data(nil)
 			d.SetId(arn)
 
-			err := sweep.NewSweepResource(r, d, client).Delete(ctx, sweep.ThrottlingRetryTimeout) // nosemgrep:ci.semgrep.migrate.direct-CRUD-calls
-
-			// Treat this sweeper as best effort for now. There are a lot of edge cases
-			// with lingering aws_iam_role resources in the HashiCorp testing accounts.
-			if tfawserr.ErrCodeEquals(err, iam.ErrCodeDeleteConflictException) {
-				log.Printf("[WARN] Ignoring IAM Policy (%s) deletion error: %s", arn, err)
-				continue
-			}
-
-			if tfawserr.ErrMessageContains(err, "AccessDenied", "with an explicit deny") {
-				continue
-			}
-
-			if err != nil {
-				sweeperErr := fmt.Errorf("error deleting IAM Policy (%s): %w", arn, err)
-				log.Printf("[ERROR] %s", sweeperErr)
-				sweeperErrs = multierror.Append(sweeperErrs, sweeperErr)
-				continue
-			}
+			sweepResources = append(sweepResources, newPolicySweeper(r, d, client))
 		}
 
 		return !lastPage
@@ -450,14 +439,50 @@ func sweepPolicies(region string) error {
 
 	if sweep.SkipSweepError(err) {
 		log.Printf("[WARN] Skipping IAM Policy sweep for %s: %s", region, err)
-		return sweeperErrs.ErrorOrNil()
+		return nil
 	}
 
 	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving IAM Policies: %w", err))
+		return fmt.Errorf("retrieving IAM Policies: %w", err)
 	}
 
-	return sweeperErrs.ErrorOrNil()
+	err = sweep.SweepOrchestratorWithContext(ctx, sweepResources)
+	if err != nil {
+		return fmt.Errorf("sweeping IAM Policies (%s): %w", region, err)
+	}
+
+	return nil
+}
+
+type policySweeper struct {
+	d         *schema.ResourceData
+	sweepable sweep.Sweepable
+}
+
+func newPolicySweeper(resource *schema.Resource, d *schema.ResourceData, client *conns.AWSClient) *policySweeper {
+	return &policySweeper{
+		d:         d,
+		sweepable: sdk.NewSweepResource(resource, d, client),
+	}
+}
+
+func (ps policySweeper) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
+	err := ps.sweepable.Delete(ctx, timeout, optFns...)
+
+	errStr := err.Error()
+
+	if strings.Contains(errStr, iam.ErrCodeDeleteConflictException) {
+		log.Printf("[WARN] Ignoring IAM Policy (%s) deletion error: %s", ps.d.Id(), err)
+		return nil
+	}
+
+	accessDenied := regexp.MustCompile(`AccessDenied: .+ with an explicit deny`)
+	if accessDenied.MatchString(errStr) {
+		log.Printf("[DEBUG] Skipping IAM Policy (%s): %s", ps.d.Id(), err)
+		return nil
+	}
+
+	return err
 }
 
 func sweepRoles(region string) error {


### PR DESCRIPTION
### Description

Adds `AmazonComprehendServiceRole-` and `codebuild-` to role sweeper.

Restores skip on `AccessDenied` errors for policy sweeper.

### Output from Acceptance Testing

Previously:

>	- aws_iam_policy: 5 errors occurred:
	* error deleting IAM Policy (\*****): 1 error occurred:
	* deleting IAM Policy (*****): DeleteConflict: Cannot delete a policy attached to entities.
	status code: 409, request id: *****
>
>
>	* error deleting IAM Policy (\*****): 1 error occurred:
	* deleting IAM Policy (*****): DeleteConflict: Cannot delete a policy attached to entities.
	status code: 409, request id: *****
>
>
>	* error deleting IAM Policy (\*****): 1 error occurred:
	* deleting IAM Policy (*****): DeleteConflict: Cannot delete a policy attached to entities.
	status code: 409, request id: *****
>
>
>	* error deleting IAM Policy (\*****): 1 error occurred:
>	* deleting IAM Policy (*****): AccessDenied: User: ***** is not authorized to perform: iam:DeletePolicy on resource: policy *****with an explicit deny in a service control policy
	status code: 403, request id: *****
>
>
>	* error deleting IAM Policy (\*****): 1 error occurred:
	* deleting IAM Policy (*****): DeleteConflict: Cannot delete a policy attached to entities.
	status code: 409, request id: *****

Now:

> [DEBUG] Skipping IAM Policy (\*****): 1 error occurred:
	* deleting IAM Policy (*****): AccessDenied: User: ***** is not authorized to perform: iam:DeletePolicy on resource: policy ***** with an explicit deny in a service control policy