### PR TITLE
deps: group aws-sdk-go dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: "daily"
   - package-ecosystem: "gomod"
     directory: "/"
+    groups:
+      aws-sdk-go:
+        patterns:
+          - "github.com/aws/aws-sdk-go"
+          - "github.com/aws/aws-sdk-go-v2/service/*"
     ignore:
       # hcl/v2 should only be updated via terraform-plugin-sdk
       - dependency-name: "github.com/hashicorp/hcl/v2"


### PR DESCRIPTION
### Description
Github has just released "grouped" dependabot updates in a public beta. This PR groups both v1 and v2 AWS SDK updates together.

[Announcement](https://github.com/dependabot/dependabot-core/issues/1190#issuecomment-1623832701)
[Docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)


### Relations

Closes #28454



### Output from Acceptance Testing
N/a, deps.
