### PR TITLE
Add Network Firewall policy variable support (HOME_NET override)

### DIFF
--- a/internal/service/networkfirewall/firewall_policy.go
+++ b/internal/service/networkfirewall/firewall_policy.go
@@ -383,13 +383,8 @@ func expandPolicyVariables(tfMap map[string]interface{}) *networkfirewall.Policy
 
 	policyVariables := &networkfirewall.PolicyVariables{}
 
-	if tfList, ok := tfMap["rule_variables"].([]interface{}); ok && len(tfList) > 0 && tfList[0] != nil {
-		pvMap, ok := tfList[0].(map[string]interface{})
-		if ok {
-			if v, ok := pvMap["ip_sets"].(*schema.Set); ok && v.Len() > 0 {
-				policyVariables.RuleVariables = expandIPSets(v.List())
-			}
-		}
+	if rvMap, ok := tfMap["rule_variables"].(*schema.Set); ok && rvMap.Len() > 0 {
+		policyVariables.RuleVariables = expandIPSets(rvMap.List())
 	}
 
 	return policyVariables

--- a/internal/service/networkfirewall/firewall_policy.go
+++ b/internal/service/networkfirewall/firewall_policy.go
@@ -63,6 +63,7 @@ func ResourceFirewallPolicy() *schema.Resource {
 									"rule_variables": {
 										Type:     schema.TypeSet,
 										Optional: true,
+										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"key": {

--- a/internal/service/networkfirewall/firewall_policy.go
+++ b/internal/service/networkfirewall/firewall_policy.go
@@ -63,7 +63,6 @@ func ResourceFirewallPolicy() *schema.Resource {
 									"rule_variables": {
 										Type:     schema.TypeSet,
 										Optional: true,
-										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"key": {
@@ -559,7 +558,6 @@ func flattenPolicyVariables(variables *networkfirewall.PolicyVariables) []interf
 	}
 
 	return []interface{}{m}
-
 }
 
 func flattenStatefulEngineOptions(options *networkfirewall.StatefulEngineOptions) []interface{} {

--- a/internal/service/networkfirewall/firewall_policy_test.go
+++ b/internal/service/networkfirewall/firewall_policy_test.go
@@ -116,6 +116,59 @@ func TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration(t *testing.T) 
 	})
 }
 
+func TestAccNetworkFirewallFirewallPolicy_policyVariables(t *testing.T) {
+	ctx := acctest.Context(t)
+	var firewallPolicy networkfirewall.DescribeFirewallPolicyOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_networkfirewall_firewall_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, networkfirewall.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFirewallPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirewallPolicyConfig_policyVariables(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFirewallPolicyExists(ctx, resourceName, &firewallPolicy),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.policy_variables.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.policy_variables.0.rule_variables.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "firewall_policy.0.policy_variables.0.rule_variables.*", map[string]string{
+						"key":                   "HOME_NET",
+						"ip_set.#":              "1",
+						"ip_set.0.definition.#": "2",
+					}),
+					resource.TestCheckTypeSetElemAttr(resourceName, "firewall_policy.0.policy_variables.0.rule_variables.*.ip_set.0.definition.*", "10.0.0.0/16"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "firewall_policy.0.policy_variables.0.rule_variables.*.ip_set.0.definition.*", "10.0.1.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateless_fragment_default_actions.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "firewall_policy.0.stateless_fragment_default_actions.*", "aws:drop"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateless_default_actions.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "firewall_policy.0.stateless_default_actions.*", "aws:pass"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccFirewallPolicyConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFirewallPolicyExists(ctx, resourceName, &firewallPolicy),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.policy_variables.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateless_fragment_default_actions.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "firewall_policy.0.stateless_fragment_default_actions.*", "aws:drop"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateless_default_actions.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "firewall_policy.0.stateless_default_actions.*", "aws:pass"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNetworkFirewallFirewallPolicy_statefulDefaultActions(t *testing.T) {
 	ctx := acctest.Context(t)
 	var firewallPolicy networkfirewall.DescribeFirewallPolicyOutput
@@ -1173,6 +1226,27 @@ resource "aws_networkfirewall_firewall_policy" "test" {
   }
 }
 `, rName, ruleOrder, streamExceptionPolicy)
+}
+
+func testAccFirewallPolicyConfig_policyVariables(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_networkfirewall_firewall_policy" "test" {
+  name = %[1]q
+
+  firewall_policy {
+    policy_variables {
+      rule_variables {
+        key = "HOME_NET"
+        ip_set {
+          definition = ["10.0.0.0/16", "10.0.1.0/24"]
+        }
+      }
+    }
+    stateless_fragment_default_actions = ["aws:drop"]
+    stateless_default_actions          = ["aws:pass"]
+  }
+}
+`, rName)
 }
 
 func testAccFirewallPolicyConfig_ruleOrderOnly(rName, ruleOrder string) string {

--- a/website/docs/r/networkfirewall_firewall_policy.html.markdown
+++ b/website/docs/r/networkfirewall_firewall_policy.html.markdown
@@ -32,6 +32,36 @@ resource "aws_networkfirewall_firewall_policy" "example" {
 }
 ```
 
+## Policy with a HOME_NET Override
+
+```terraform
+resource "aws_networkfirewall_firewall_policy" "example" {
+  name = "example"
+
+  firewall_policy {
+    policy_variables {
+      rule_variables {
+        key = "HOME_NET"
+        ip_set {
+          definition = ["10.0.0.0/16", "10.1.0.0/24"]
+        }
+      }
+    }
+    stateless_default_actions          = ["aws:pass"]
+    stateless_fragment_default_actions = ["aws:drop"]
+    stateless_rule_group_reference {
+      priority     = 1
+      resource_arn = aws_networkfirewall_rule_group.example.arn
+    }
+  }
+
+  tags = {
+    Tag1 = "Value1"
+    Tag2 = "Value2"
+  }
+}
+```
+
 ## Policy with a Custom Action for Stateless Inspection
 
 ```terraform
@@ -81,6 +111,8 @@ The following arguments are supported:
 
 The `firewall_policy` block supports the following arguments:
 
+* `policy_variables` - (Optional). Contains variables that you can use to override default Suricata settings in your firewall policy. See [Rule Variables](#rule-variables) for details.
+
 * `stateful_default_actions` - (Optional) Set of actions to take on a packet if it does not match any stateful rules in the policy. This can only be specified if the policy has a `stateful_engine_options` block with a `rule_order` value of `STRICT_ORDER`. You can specify one of either or neither values of `aws:drop_strict` or `aws:drop_established`, as well as any combination of `aws:alert_strict` and `aws:alert_established`.
 
 * `stateful_engine_options` - (Optional) A configuration block that defines options on how the policy handles stateful rules. See [Stateful Engine Options](#stateful-engine-options) below for details.
@@ -96,6 +128,18 @@ In addition, you can specify custom actions that are compatible with your standa
 In addition, you can specify custom actions that are compatible with your standard action choice. If you want non-matching packets to be forwarded for stateful inspection, specify `aws:forward_to_sfe`.
 
 * `stateless_rule_group_reference` - (Optional) Set of configuration blocks containing references to the stateless rule groups that are used in the policy. See [Stateless Rule Group Reference](#stateless-rule-group-reference) below for details.
+
+### Rule Variables
+The `rule_variables` block supports the following arguments:
+
+* `key` - (Required) An alphanumeric string to identify the `ip_set`. Valid values: `HOME_NET`
+
+* `ip_set` - (Required) A configuration block that defines a set of IP addresses. See [IP Set](#ip-set) below for details.
+
+### IP Set
+The `ip_set` block supports the following arguement:
+
+* `definition` - (Required) Set of IPv4 or IPv6 addresses in CIDR notation to use for the Suricata `HOME_NET` variable.
 
 ### Stateful Engine Options
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Adds support for policy variables in the `networkfirewall_firewall_policy` resource. This will enable overriding the default `HOME_NET` Suricata variable, e.g. when using Network Firewall in a centralized inspection VPC.

- `HOME_NET` is the only valid value for the `key` attribute - any other value will return an InvalidRequestException, e.g. when calling the CreateFirewallPolicy operation: `RuleVariables is invalid, parameter: [foo]`

### Relations
Closes #31249

### References
- API: `FirewallPolicy`: https://docs.aws.amazon.com/network-firewall/latest/APIReference/API_FirewallPolicy.html
- API: `PolicyVariables`: https://docs.aws.amazon.com/network-firewall/latest/APIReference/API_PolicyVariables.html#networkfirewall-Type-PolicyVariables-RuleVariables
- SDK: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/networkfirewall@v1.28.2/types#PolicyVariables
- What's New announcement: https://aws.amazon.com/about-aws/whats-new/2023/05/aws-network-firewall-suricata-home-net-variable-override/


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTARGS='-run=TestAccNetworkFirewallFirewallPolicy_policyVariables' PKG=networkfirewall
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkfirewall/... -v -count 1 -parallel 20  -run=TestAccNetworkFirewallFirewallPolicy_policyVariables -timeout 180m
=== RUN   TestAccNetworkFirewallFirewallPolicy_policyVariables
=== PAUSE TestAccNetworkFirewallFirewallPolicy_policyVariables
=== CONT  TestAccNetworkFirewallFirewallPolicy_policyVariables
--- PASS: TestAccNetworkFirewallFirewallPolicy_policyVariables (174.24s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall    177.540s
$ make testacc TESTARGS='-run=TestAccNetworkFirewallFirewallPolicy_' PKG=networkfirewall
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/networkfirewall/... -v -count 1 -parallel 20  -run=TestAccNetworkFirewallFirewallPolicy_ -timeout 180m
=== RUN   TestAccNetworkFirewallFirewallPolicy_basic
=== PAUSE TestAccNetworkFirewallFirewallPolicy_basic
=== RUN   TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration
=== PAUSE TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration
=== RUN   TestAccNetworkFirewallFirewallPolicy_policyVariables
=== PAUSE TestAccNetworkFirewallFirewallPolicy_policyVariables
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulDefaultActions
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulDefaultActions
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulEngineOption
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulEngineOption
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsSingle
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsSingle
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceManaged
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceManaged
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_multipleStatefulRuleGroupReferences
=== PAUSE TestAccNetworkFirewallFirewallPolicy_multipleStatefulRuleGroupReferences
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupPriorityReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupPriorityReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupOverrideActionReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupOverrideActionReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupPriorityReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupPriorityReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_statelessRuleGroupReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statelessRuleGroupReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatelessRuleGroupReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatelessRuleGroupReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_multipleStatelessRuleGroupReferences
=== PAUSE TestAccNetworkFirewallFirewallPolicy_multipleStatelessRuleGroupReferences
=== RUN   TestAccNetworkFirewallFirewallPolicy_statelessCustomAction
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statelessCustomAction
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatelessCustomAction
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatelessCustomAction
=== RUN   TestAccNetworkFirewallFirewallPolicy_multipleStatelessCustomActions
=== PAUSE TestAccNetworkFirewallFirewallPolicy_multipleStatelessCustomActions
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAction
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAction
=== RUN   TestAccNetworkFirewallFirewallPolicy_tags
=== PAUSE TestAccNetworkFirewallFirewallPolicy_tags
=== RUN   TestAccNetworkFirewallFirewallPolicy_disappears
=== PAUSE TestAccNetworkFirewallFirewallPolicy_disappears
=== CONT  TestAccNetworkFirewallFirewallPolicy_basic
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupOverrideActionReference
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsSingle
=== CONT  TestAccNetworkFirewallFirewallPolicy_statelessCustomAction
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupPriorityReference
=== CONT  TestAccNetworkFirewallFirewallPolicy_multipleStatelessRuleGroupReferences
=== CONT  TestAccNetworkFirewallFirewallPolicy_multipleStatefulRuleGroupReferences
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupPriorityReference
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupReference
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulDefaultActions
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatelessCustomAction
=== CONT  TestAccNetworkFirewallFirewallPolicy_statelessRuleGroupReference
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceManaged
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReference
=== CONT  TestAccNetworkFirewallFirewallPolicy_tags
=== CONT  TestAccNetworkFirewallFirewallPolicy_disappears
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatelessRuleGroupReference
=== CONT  TestAccNetworkFirewallFirewallPolicy_policyVariables
=== CONT  TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulEngineOption
--- PASS: TestAccNetworkFirewallFirewallPolicy_statelessCustomAction (191.90s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulDefaultActions (204.50s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAction
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceManaged (205.99s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_multipleStatelessCustomActions
--- PASS: TestAccNetworkFirewallFirewallPolicy_basic (208.78s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupOverrideActionReference (209.52s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_disappears (223.92s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_tags (237.86s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReference (239.35s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupPriorityReference (241.77s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsSingle (266.11s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_policyVariables (270.75s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupPriorityReference (304.71s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_multipleStatelessRuleGroupReferences (305.04s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatelessRuleGroupReference (325.33s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_statelessRuleGroupReference (326.63s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_multipleStatefulRuleGroupReferences (331.54s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulEngineOption (144.87s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupReference (337.29s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration (359.44s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption (430.02s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_multipleStatelessCustomActions (285.26s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAction (347.38s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatelessCustomAction (625.38s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall    628.699s
```
