### PR TITLE
dependabot: Groups together `aws-sdk-go-base` and `awsv1shim` modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,12 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - directory: "/"
+    package-ecosystem: "github-actions"
     schedule:
       interval: "daily"
-  - package-ecosystem: "gomod"
-    directory: "/"
+
+  - directory: "/"
+    package-ecosystem: "gomod"
     groups:
       aws-sdk-go:
         patterns:
@@ -25,28 +26,32 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 30
-  - package-ecosystem: "gomod"
-    directory: "/.ci/providerlint"
+
+  - directory: "/.ci/providerlint"
+    package-ecosystem: "gomod"
     ignore:
       - dependency-name: "golang.org/x/tools"
       - dependency-name: "google.golang.org/grpc"
     schedule:
       interval: "daily"
-  - package-ecosystem: "gomod"
-    directory: "/.ci/tools"
+
+  - directory: "/.ci/tools"
+    package-ecosystem: "gomod"
     ignore:
       - dependency-name: "golang.org/x/tools"
       - dependency-name: "google.golang.org/grpc"
     schedule:
       interval: "daily"
-  - package-ecosystem: "gomod"
-    directory: "/skaff"
+
+  - directory: "/skaff"
+    package-ecosystem: "gomod"
     ignore:
       - dependency-name: "golang.org/x/tools"
       - dependency-name: "google.golang.org/grpc"
     schedule:
       interval: "daily"
-  - package-ecosystem: "terraform"
-    directory: "/infrastructure/repository"
+
+  - directory: "/infrastructure/repository"
+    package-ecosystem: "terraform"
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
         patterns:
           - "github.com/aws/aws-sdk-go"
           - "github.com/aws/aws-sdk-go-v2/*"
+      aws-sdk-go-base:
+        patterns:
+          - "github.com/hashicorp/aws-sdk-go-base/v2"
+          - "github.com/hashicorp/aws-sdk-go-base/v2/*"
     ignore:
       # hcl/v2 should only be updated via terraform-plugin-sdk
       - dependency-name: "github.com/hashicorp/hcl/v2"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       aws-sdk-go:
         patterns:
           - "github.com/aws/aws-sdk-go"
-          - "github.com/aws/aws-sdk-go-v2/service/*"
+          - "github.com/aws/aws-sdk-go-v2/*"
     ignore:
       # hcl/v2 should only be updated via terraform-plugin-sdk
       - dependency-name: "github.com/hashicorp/hcl/v2"


### PR DESCRIPTION
### Description

Groups together `aws-sdk-go-base` and `awsv1shim` modules for `dependabot` updates

Also includes more `aws-sdk-go-v2` modules in `aws-sdk-go` group

