### PR TITLE
aws_security_group - remove all managed ingress & egress rules

### DIFF
--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -93,7 +93,7 @@ resource "aws_vpc_endpoint" "my_endpoint" {
 
 You can also find a specific Prefix List using the `aws_prefix_list` data source.
 
-### Removing All Rules
+### Removing All Ingress and Egress Rules
 
 The `ingress` and `egress` arguments are processed in [attribute-as-blocks](https://developer.hashicorp.com/terraform/language/attr-as-blocks) mode. Due to this, removing these arguments from the configuration will **not** cause Terraform to destroy the managed rules. To subsequently remove all managed ingress and egress rules:
 

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -95,7 +95,7 @@ You can also find a specific Prefix List using the `aws_prefix_list` data source
 
 ### Removing All Ingress and Egress Rules
 
-The `ingress` and `egress` arguments are processed in [attribute-as-blocks](https://developer.hashicorp.com/terraform/language/attr-as-blocks) mode. Due to this, removing these arguments from the configuration will **not** cause Terraform to destroy the managed rules. To subsequently remove all managed ingress and egress rules:
+The `ingress` and `egress` arguments are processed in [attributes-as-blocks](https://developer.hashicorp.com/terraform/language/attr-as-blocks) mode. Due to this, removing these arguments from the configuration will **not** cause Terraform to destroy the managed rules. To subsequently remove all managed ingress and egress rules:
 
 ```terraform
 resource "aws_security_group" "example" {

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -211,6 +211,18 @@ resource "null_resource" "example" {
 }
 ```
 
+To subsequently remove all managed ingress & egress rules:
+
+```terraform
+resource "aws_security_group" "example" {
+  name   = "sg"
+  vpc_id = aws_vpc.example.id
+
+  ingress = []
+  egress  = []
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -93,6 +93,20 @@ resource "aws_vpc_endpoint" "my_endpoint" {
 
 You can also find a specific Prefix List using the `aws_prefix_list` data source.
 
+### Removing All Rules
+
+The `ingress` and `egress` arguments are processed in [attribute-as-blocks](https://developer.hashicorp.com/terraform/language/attr-as-blocks) mode. Due to this, removing these arguments from the configuration will **not** cause Terraform to destroy the managed rules. To subsequently remove all managed ingress and egress rules:
+
+```terraform
+resource "aws_security_group" "example" {
+  name   = "sg"
+  vpc_id = aws_vpc.example.id
+
+  ingress = []
+  egress  = []
+}
+```
+
 ### Recreating a Security Group
 
 A simple security group `name` change "forces new" the security group--Terraform destroys the security group and creates a new one. (Likewise, `description`, `name_prefix`, or `vpc_id` [cannot be changed](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/working-with-security-groups.html#creating-security-group).) Attempting to recreate the security group leads to a variety of complications depending on how it is used.
@@ -208,18 +222,6 @@ resource "null_resource" "example" {
   triggers = {
     rerun_upon_change_of = join(",", aws_vpc_endpoint.example.security_group_ids)
   }
-}
-```
-
-To subsequently remove all managed ingress & egress rules:
-
-```terraform
-resource "aws_security_group" "example" {
-  name   = "sg"
-  vpc_id = aws_vpc.example.id
-
-  ingress = []
-  egress  = []
 }
 ```
 


### PR DESCRIPTION
### Description

* Document how to remove all managed ingress & egress rules from the `aws_security_group` resource https://github.com/hashicorp/terraform-provider-aws/issues/4399#issuecomment-488627152
* Mirrored documentation from `aws_route_table` resource https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table.html#example-usage

### Relations

Closes #660
Closes #1555
Closes #4399
Closes #11059
Closes #20046

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
