### PR TITLE
Don't manually set `Status` field to `To Do` for new Projects automation

### DIFF
--- a/.github/workflows/new-project-automation.yml
+++ b/.github/workflows/new-project-automation.yml
@@ -1,16 +1,13 @@
 name: 'Team GitHub Projects (new) Automation'
-
 on:
   issues:
     types: ["labeled", "milestoned", "opened"]
   pull_request_target:
     types: ["labeled", "opened", "ready_for_review"]
-
 jobs:
   community_check:
     uses: ./.github/workflows/community-check.yml
     secrets: inherit
-
   maintainer_prs:
     name: 'Add Maintainer PRs that are Ready for Review'
     needs: community_check
@@ -19,27 +16,18 @@ jobs:
     secrets: inherit
     with:
       status: ${{ vars.team_project_status_maintainer_pr }}
-
   partner_prs:
     name: 'Add Partner PRs that are Ready for Review'
     if: github.event_name == 'pull_request_target' && !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'partner')
     uses: ./.github/workflows/reusable-team-project.yml
     secrets: inherit
-    with:
-      status: ${{ vars.team_project_status_to_do }}
-
   roadmap:
     name: 'Add Roadmap Items'
     if: github.event.label.name == 'roadmap' || github.event.*.milestone.title == 'Roadmap'
     uses: ./.github/workflows/reusable-team-project.yml
     secrets: inherit
-    with:
-      status: ${{ vars.team_project_status_to_do }}
-
   regressions:
     name: 'Add Regressions'
     if: github.event.label.name == 'regression'
     uses: ./.github/workflows/reusable-team-project.yml
     secrets: inherit
-    with:
-      status: ${{ vars.team_project_status_to_do }}


### PR DESCRIPTION
### Description

Previously, this workflow called the [reusable workflow](https://github.com/hashicorp/terraform-provider-aws/blob/main/.github/workflows/reusable-team-project.yml) that adds items to the new style of GitHub Project and also passed the requisite input to set the `Status` field to `To Do`. This Project, however, uses the built-in Projects workflow (reference below) to automatically set the `Status` field to `To Do` for newly added items. Removing this means that we save an API call (and associated time, rate-limiting) for every item that gets added.

YAML formatter also removed the extraneous newlines; figured I'd leave that be to try to maintain consistency. 🤷 

### References

- [GitHub Projects Automated Workflows](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/using-the-built-in-automations)


### Output from Acceptance Testing

N/a, Actions
