### PR TITLE
r/aws_configservice_config_rule: fix nil output handling

### DIFF
--- a/.changelog/32439.txt
+++ b/.changelog/32439.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_config_config_rule: Prevent crash on nil describe output
+```

--- a/internal/service/configservice/find.go
+++ b/internal/service/configservice/find.go
@@ -26,10 +26,6 @@ func FindConfigRule(ctx context.Context, conn *configservice.ConfigService, name
 		}
 	}
 
-	if output == nil {
-		return nil, nil
-	}
-
 	if output == nil || output.ConfigRules == nil || len(output.ConfigRules) == 0 || output.ConfigRules[0] == nil {
 		return nil, tfresource.NewEmptyResultError(input)
 	}


### PR DESCRIPTION
### Description
Properly returns an error when the describe config rule API call returns a nil response.


### Relations
Closes #31559


### Output from Acceptance Testing


```console
$ make testacc PKG=configservice TESTARGS='-run=TestAccConfigService_serial/Config'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/configservice/... -v -count 1 -parallel 20  -run=TestAccConfigService_serial/Config -timeout 180m

--- PASS: TestAccConfigService_serial (1763.38s)
    --- PASS: TestAccConfigService_serial/RemediationConfiguration (643.82s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/updates (98.11s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/values (86.53s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/basic (86.28s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/basicBackward (86.26s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/disappears (84.06s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/migrateParameters (102.08s)
        --- PASS: TestAccConfigService_serial/RemediationConfiguration/recreates (100.49s)
    --- PASS: TestAccConfigService_serial/Config (850.48s)
        --- PASS: TestAccConfigService_serial/Config/basic (83.78s)
        --- PASS: TestAccConfigService_serial/Config/ownerAws (85.88s)
        --- PASS: TestAccConfigService_serial/Config/scopeTagValue (96.52s)
        --- PASS: TestAccConfigService_serial/Config/tags (113.23s)
        --- PASS: TestAccConfigService_serial/Config/disappears (83.18s)
        --- PASS: TestAccConfigService_serial/Config/customlambda (122.09s)
        --- PASS: TestAccConfigService_serial/Config/customPolicy (86.03s)
        --- PASS: TestAccConfigService_serial/Config/scopeTagKey (96.49s)
        --- PASS: TestAccConfigService_serial/Config/scopeTagKeyEmpty (83.28s)
    --- PASS: TestAccConfigService_serial/ConfigurationRecorderStatus (135.74s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorderStatus/basic (33.68s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorderStatus/startEnabled (65.33s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorderStatus/importBasic (36.72s)
    --- PASS: TestAccConfigService_serial/ConfigurationRecorder (133.34s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/basic (35.11s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/allParams (32.25s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/recordStrategy (32.91s)
        --- PASS: TestAccConfigService_serial/ConfigurationRecorder/disappears (33.07s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/configservice      1766.651s
```
