### PR TITLE
Update index.html.markdown to match provider version 5

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -27,7 +27,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }
@@ -48,7 +48,7 @@ Terraform 0.12 and earlier:
 ```terraform
 # Configure the AWS Provider
 provider "aws" {
-  version = "~> 4.0"
+  version = "~> 5.0"
   region  = "us-east-1"
 }
 
@@ -254,7 +254,7 @@ See the [assume role documentation](https://docs.aws.amazon.com/cli/latest/userg
 |Setting|Provider|[Environment Variable][envvars]|[Shared Config][config]|
 |-------|--------|--------|-----------------------|
 |Role ARN|`role_arn`|`AWS_ROLE_ARN`|`role_arn`|
-|Duration|`duration` or `duration_seconds`|N/A|`duration_seconds`|
+|Duration|`duration`|N/A|`duration_seconds`|
 |External ID|`external_id`|N/A|`external_id`|
 |Policy|`policy`|N/A|N/A|
 |Policy ARNs|`policy_arns`|N/A|N/A|
@@ -458,11 +458,7 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 
 The `assume_role` configuration block supports the following arguments:
 
-* `duration` - (Optional, Conflicts with `duration_seconds`) Duration of the assume role session.
-  You can provide a value from 15 minutes up to the maximum session duration setting for the role.
-  Represented by a string such as `1h`, `2h45m`, or `30m15s`.
-* `duration_seconds` - (Optional, **Deprecated** use `duration` instead) Number of seconds to restrict the assume role session duration.
-  You can provide a value from 900 seconds (15 minutes) up to the maximum session duration setting for the role.
+* `duration` - (Optional) Duration of the assume role session. You can provide a value from 15 minutes up to the maximum session duration setting for the role. Represented by a string such as `1h`, `2h45m`, or `30m15s`.
 * `external_id` - (Optional) External identifier to use when assuming the role.
 * `policy` - (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
 * `policy_arns` - (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.


### PR DESCRIPTION
### Description

The main index page of the provider had a couple of leftover things from v4 of the provider. This PR aims to correct them:

- Updated version pinning in example to be `~> 5.0` rather than `~> 4.0`
- Removed `duration_seconds` from `assume_role` reference
- Concatenated `assume_role.duration` line

### Relations

Closes #32131

### Output from Acceptance Testing

N/a, docs
