### PR TITLE
r/aws_cognitoidp_user_pool: suppress diff when schema.string_attribute_constraints is omitted

### DIFF
--- a/.changelog/32445.txt
+++ b/.changelog/32445.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cognito_user_pool: Suppress diff when `schema.string_attribute_constraints` is omitted for `String` attribute types
+```

--- a/internal/service/cognitoidp/flex_test.go
+++ b/internal/service/cognitoidp/flex_test.go
@@ -14,10 +14,12 @@ func TestUserPoolSchemaAttributeMatchesStandardAttribute(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
+		Name     string
 		Input    *cognitoidentityprovider.SchemaAttributeType
 		Expected bool
 	}{
 		{
+			Name: "birthday standard",
 			Input: &cognitoidentityprovider.SchemaAttributeType{
 				AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
 				DeveloperOnlyAttribute: aws.Bool(false),
@@ -32,6 +34,7 @@ func TestUserPoolSchemaAttributeMatchesStandardAttribute(t *testing.T) {
 			Expected: true,
 		},
 		{
+			Name: "birthday non-standard DeveloperOnlyAttribute",
 			Input: &cognitoidentityprovider.SchemaAttributeType{
 				AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
 				DeveloperOnlyAttribute: aws.Bool(true),
@@ -46,6 +49,7 @@ func TestUserPoolSchemaAttributeMatchesStandardAttribute(t *testing.T) {
 			Expected: false,
 		},
 		{
+			Name: "birthday non-standard Mutable",
 			Input: &cognitoidentityprovider.SchemaAttributeType{
 				AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
 				DeveloperOnlyAttribute: aws.Bool(false),
@@ -60,6 +64,7 @@ func TestUserPoolSchemaAttributeMatchesStandardAttribute(t *testing.T) {
 			Expected: false,
 		},
 		{
+			Name: "non-standard Name",
 			Input: &cognitoidentityprovider.SchemaAttributeType{
 				AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
 				DeveloperOnlyAttribute: aws.Bool(false),
@@ -74,6 +79,7 @@ func TestUserPoolSchemaAttributeMatchesStandardAttribute(t *testing.T) {
 			Expected: false,
 		},
 		{
+			Name: "birthday non-standard Required",
 			Input: &cognitoidentityprovider.SchemaAttributeType{
 				AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
 				DeveloperOnlyAttribute: aws.Bool(false),
@@ -88,6 +94,7 @@ func TestUserPoolSchemaAttributeMatchesStandardAttribute(t *testing.T) {
 			Expected: false,
 		},
 		{
+			Name: "birthday non-standard StringAttributeConstraints.Max",
 			Input: &cognitoidentityprovider.SchemaAttributeType{
 				AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
 				DeveloperOnlyAttribute: aws.Bool(false),
@@ -102,6 +109,7 @@ func TestUserPoolSchemaAttributeMatchesStandardAttribute(t *testing.T) {
 			Expected: false,
 		},
 		{
+			Name: "birthday non-standard StringAttributeConstraints.Min",
 			Input: &cognitoidentityprovider.SchemaAttributeType{
 				AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
 				DeveloperOnlyAttribute: aws.Bool(false),
@@ -116,6 +124,7 @@ func TestUserPoolSchemaAttributeMatchesStandardAttribute(t *testing.T) {
 			Expected: false,
 		},
 		{
+			Name: "email_verified standard",
 			Input: &cognitoidentityprovider.SchemaAttributeType{
 				AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeBoolean),
 				DeveloperOnlyAttribute: aws.Bool(false),
@@ -126,6 +135,7 @@ func TestUserPoolSchemaAttributeMatchesStandardAttribute(t *testing.T) {
 			Expected: true,
 		},
 		{
+			Name: "updated_at standard",
 			Input: &cognitoidentityprovider.SchemaAttributeType{
 				AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeNumber),
 				DeveloperOnlyAttribute: aws.Bool(false),
@@ -141,9 +151,116 @@ func TestUserPoolSchemaAttributeMatchesStandardAttribute(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		output := UserPoolSchemaAttributeMatchesStandardAttribute(tc.Input)
-		if output != tc.Expected {
-			t.Fatalf("Expected %t match with standard attribute on input: \n\n%#v\n\n", tc.Expected, tc.Input)
-		}
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			output := UserPoolSchemaAttributeMatchesStandardAttribute(tc.Input)
+			if output != tc.Expected {
+				t.Fatalf("Expected %t match with standard attribute on input: \n\n%#v\n\n", tc.Expected, tc.Input)
+			}
+		})
+	}
+}
+
+func TestSkipFlatteningStringAttributeContraints(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		configured []*cognitoidentityprovider.SchemaAttributeType
+		input      *cognitoidentityprovider.SchemaAttributeType
+		want       bool
+	}{
+		{
+			name: "config omitted",
+			configured: []*cognitoidentityprovider.SchemaAttributeType{
+				{
+					AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+					DeveloperOnlyAttribute: aws.Bool(false),
+					Mutable:                aws.Bool(false),
+					Name:                   aws.String("email"),
+					Required:               aws.Bool(true),
+				},
+			},
+			input: &cognitoidentityprovider.SchemaAttributeType{
+				AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+				DeveloperOnlyAttribute: aws.Bool(false),
+				Mutable:                aws.Bool(false),
+				Name:                   aws.String("email"),
+				Required:               aws.Bool(true),
+				StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+					MaxLength: aws.String("2048"),
+					MinLength: aws.String("0"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "config set",
+			configured: []*cognitoidentityprovider.SchemaAttributeType{
+				{
+					AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+					DeveloperOnlyAttribute: aws.Bool(false),
+					Mutable:                aws.Bool(false),
+					Name:                   aws.String("email"),
+					Required:               aws.Bool(true),
+					StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+						MaxLength: aws.String("2048"),
+						MinLength: aws.String("0"),
+					},
+				},
+			},
+			input: &cognitoidentityprovider.SchemaAttributeType{
+				AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+				DeveloperOnlyAttribute: aws.Bool(false),
+				Mutable:                aws.Bool(false),
+				Name:                   aws.String("email"),
+				Required:               aws.Bool(true),
+				StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+					MaxLength: aws.String("2048"),
+					MinLength: aws.String("0"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "config set with diff",
+			configured: []*cognitoidentityprovider.SchemaAttributeType{
+				{
+					AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+					DeveloperOnlyAttribute: aws.Bool(false),
+					Mutable:                aws.Bool(false),
+					Name:                   aws.String("email"),
+					Required:               aws.Bool(true),
+					StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+						MaxLength: aws.String("1024"),
+						MinLength: aws.String("5"),
+					},
+				},
+			},
+			input: &cognitoidentityprovider.SchemaAttributeType{
+				AttributeDataType:      aws.String(cognitoidentityprovider.AttributeDataTypeString),
+				DeveloperOnlyAttribute: aws.Bool(false),
+				Mutable:                aws.Bool(false),
+				Name:                   aws.String("email"),
+				Required:               aws.Bool(true),
+				StringAttributeConstraints: &cognitoidentityprovider.StringAttributeConstraintsType{
+					MaxLength: aws.String("2048"),
+					MinLength: aws.String("0"),
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := skipFlatteningStringAttributeContraints(tc.configured, tc.input)
+			if got != tc.want {
+				t.Fatalf("skipFlatteningStringAttributeContraints() got %t, want %t\n\n%#v\n\n", got, tc.want, tc.input)
+			}
+		})
 	}
 }

--- a/internal/service/cognitoidp/user_pool.go
+++ b/internal/service/cognitoidp/user_pool.go
@@ -1813,7 +1813,7 @@ func flattenUserPoolSchema(configuredAttributes, inputs []*cognitoidentityprovid
 			value["number_attribute_constraints"] = []map[string]interface{}{subvalue}
 		}
 
-		if input.StringAttributeConstraints != nil {
+		if input.StringAttributeConstraints != nil && !skipFlatteningStringAttributeContraints(configuredAttributes, input) {
 			subvalue := make(map[string]interface{})
 
 			if input.StringAttributeConstraints.MinLength != nil {
@@ -2299,4 +2299,27 @@ func flattenUserPoolUserAttributeUpdateSettings(u *cognitoidentityprovider.UserA
 	m["attributes_require_verification_before_update"] = flex.FlattenStringSet(u.AttributesRequireVerificationBeforeUpdate)
 
 	return []map[string]interface{}{m}
+}
+
+// skipFlatteningStringAttributeContraints returns true when all of the schema arguments
+// match an existing configured attribute, except an empty "string_attribute_constraints" block.
+// In this situation the Describe API returns default constraint values, and a persistent diff
+// would be present if written to state.
+func skipFlatteningStringAttributeContraints(configuredAttributes []*cognitoidentityprovider.SchemaAttributeType, input *cognitoidentityprovider.SchemaAttributeType) bool {
+	skip := false
+	for _, configuredAttribute := range configuredAttributes {
+		// Root elements are all equal
+		if reflect.DeepEqual(input.AttributeDataType, configuredAttribute.AttributeDataType) &&
+			reflect.DeepEqual(input.DeveloperOnlyAttribute, configuredAttribute.DeveloperOnlyAttribute) &&
+			reflect.DeepEqual(input.Mutable, configuredAttribute.Mutable) &&
+			reflect.DeepEqual(input.Name, configuredAttribute.Name) &&
+			reflect.DeepEqual(input.Required, configuredAttribute.Required) &&
+			// The configured "string_attribute_constraints" object is empty, but the returned value is not
+			(aws.StringValue(configuredAttribute.AttributeDataType) == cognitoidentityprovider.AttributeDataTypeString &&
+				configuredAttribute.StringAttributeConstraints == nil &&
+				input.StringAttributeConstraints != nil) {
+			skip = true
+		}
+	}
+	return skip
 }

--- a/internal/service/cognitoidp/user_pool_test.go
+++ b/internal/service/cognitoidp/user_pool_test.go
@@ -1383,6 +1383,37 @@ func TestAccCognitoIDPUserPool_schemaAttributesModified(t *testing.T) {
 	})
 }
 
+// Ref: https://github.com/hashicorp/terraform-provider-aws/issues/21654
+func TestAccCognitoIDPUserPool_schemaAttributesStringAttributeConstraints(t *testing.T) {
+	ctx := acctest.Context(t)
+	var pool cognitoidentityprovider.DescribeUserPoolOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, cognitoidentityprovider.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				// Omit optional "string_attribute_constraints" schema argument to verify a persistent
+				// diff is not present when AWS returns default values in the nested object.
+				Config: testAccUserPoolConfig_schemaAttributesStringAttributeConstraints(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolExists(ctx, resourceName, &pool),
+				),
+			},
+			{
+				// Attempting to explicitly set constraints to non-default values after creation
+				// should trigger an error
+				Config:      testAccUserPoolConfig_schemaAttributes(rName),
+				ExpectError: regexp.MustCompile("cannot modify or remove schema items"),
+			},
+		},
+	})
+}
+
 func TestAccCognitoIDPUserPool_withVerificationMessageTemplate(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -2456,6 +2487,30 @@ resource "aws_cognito_user_pool" "test" {
   }
 }
 `, name, boolname)
+}
+
+func testAccUserPoolConfig_schemaAttributesStringAttributeConstraints(name string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = "%[1]s"
+
+  schema {
+    attribute_data_type      = "String"
+    developer_only_attribute = false
+    mutable                  = false
+    name                     = "email"
+    required                 = true
+  }
+
+  schema {
+    attribute_data_type      = "Boolean"
+    developer_only_attribute = true
+    mutable                  = false
+    name                     = "mybool"
+    required                 = false
+  }
+}
+`, name)
 }
 
 func testAccUserPoolConfig_verificationMessageTemplate(name string) string {


### PR DESCRIPTION
### Description
Handles persistent differences when the `schema.string_attribute_constraints` argument is omitted from configuration for a `String` attribute type, but returned from the AWS API with default values. Because all of the existing suppression logic was implemented in the flattener function, logic to handle this case was added there as well.


### Relations
Closes #21654

### References
- https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SchemaAttributeType.html#CognitoUserPools-Type-SchemaAttributeType-StringAttributeConstraints


### Output from Acceptance Testing

```console
$ make testacc PKG=cognitoidp TESTS=TestAccCognitoIDPUserPool_schemaAttributes
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPUserPool_schemaAttributes'  -timeout 180m

--- PASS: TestAccCognitoIDPUserPool_schemaAttributesRemoved (26.42s)
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesModified (26.87s)
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesStringAttributeConstraints (26.90s)
--- PASS: TestAccCognitoIDPUserPool_schemaAttributes (37.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 40.580s
```

```console
$ make testacc PKG=cognitoidp TESTS=TestAccCognitoIDPUserPool_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPUserPool_'  -timeout 180m

--- PASS: TestAccCognitoIDPUserPool_disappears (45.92s)
=== CONT  TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy
--- PASS: TestAccCognitoIDPUserPool_basic (67.04s)
=== CONT  TestAccCognitoIDPUserPool_withDevice
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesStringAttributeConstraints (78.54s)
=== CONT  TestAccCognitoIDPUserPool_schemaAttributes
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesModified (82.49s)
=== CONT  TestAccCognitoIDPUserPool_recovery
--- PASS: TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings (107.02s)
=== CONT  TestAccCognitoIDPUserPool_SMS_snsCallerARN
--- PASS: TestAccCognitoIDPUserPool_withPasswordPolicy (112.56s)
=== CONT  TestAccCognitoIDPUserPool_SMS_externalID
--- PASS: TestAccCognitoIDPUserPool_withAliasAttributes (112.68s)
=== CONT  TestAccCognitoIDPUserPool_SMS_snsRegion
--- PASS: TestAccCognitoIDPUserPool_withVerificationMessageTemplate (113.28s)
=== CONT  TestAccCognitoIDPUserPool_sms
--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy (68.60s)
=== CONT  TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS
--- PASS: TestAccCognitoIDPUserPool_smsVerificationMessage (114.54s)
=== CONT  TestAccCognitoIDPUserPool_MFA_softwareTokenMFA
--- PASS: TestAccCognitoIDPUserPool_withEmailVerificationMessage (114.71s)
=== CONT  TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA
--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUser (115.66s)
=== CONT  TestAccCognitoIDPUserPool_withEmail
--- PASS: TestAccCognitoIDPUserPool_withUsername (116.41s)
=== CONT  TestAccCognitoIDPUserPool_schemaAttributesRemoved
--- PASS: TestAccCognitoIDPUserPool_withTags (156.78s)
=== CONT  TestAccCognitoIDPUserPool_smsAuthenticationMessage
--- PASS: TestAccCognitoIDPUserPool_withAdvancedSecurityMode (157.03s)
=== CONT  TestAccCognitoIDPUserPool_deletionProtection
--- PASS: TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA (166.16s)
=== CONT  TestAccCognitoIDPUserPool_withUsernameAttributes
--- PASS: TestAccCognitoIDPUserPool_withDevice (111.58s)
--- PASS: TestAccCognitoIDPUserPool_update (179.24s)
--- PASS: TestAccCognitoIDPUserPool_withEmail (64.27s)
--- PASS: TestAccCognitoIDPUserPool_schemaAttributes (108.57s)
--- PASS: TestAccCognitoIDPUserPool_MFA_sms (187.52s)
--- PASS: TestAccCognitoIDPUserPool_WithLambda_sms (188.98s)
--- PASS: TestAccCognitoIDPUserPool_SMS_snsRegion (78.44s)
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesRemoved (75.03s)
--- PASS: TestAccCognitoIDPUserPool_WithLambda_email (192.20s)
--- PASS: TestAccCognitoIDPUserPool_withLambda (194.18s)
--- PASS: TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA (95.56s)
--- PASS: TestAccCognitoIDPUserPool_recovery (128.09s)
--- PASS: TestAccCognitoIDPUserPool_SMS_externalID (105.75s)
--- PASS: TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS (107.04s)
--- PASS: TestAccCognitoIDPUserPool_deletionProtection (64.82s)
--- PASS: TestAccCognitoIDPUserPool_smsAuthenticationMessage (65.09s)
--- PASS: TestAccCognitoIDPUserPool_MFA_softwareTokenMFA (107.92s)
--- PASS: TestAccCognitoIDPUserPool_SMS_snsCallerARN (117.01s)
--- PASS: TestAccCognitoIDPUserPool_withUsernameAttributes (59.36s)
--- PASS: TestAccCognitoIDPUserPool_sms (112.84s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 229.399s
```

```console
$ go test -v -count=1 -run "^(TestUserPoolSchemaAttributeMatchesStandardAttribute|TestSkipFlatteningStringAttributeContraints)$" ./internal/service/cognitoidp/...

--- PASS: TestSkipFlatteningStringAttributeContraints (0.00s)
    --- PASS: TestSkipFlatteningStringAttributeContraints/config_omitted (0.00s)
    --- PASS: TestSkipFlatteningStringAttributeContraints/config_set (0.00s)
    --- PASS: TestSkipFlatteningStringAttributeContraints/config_set_with_diff (0.00s)

--- PASS: TestUserPoolSchemaAttributeMatchesStandardAttribute (0.00s)
    --- PASS: TestUserPoolSchemaAttributeMatchesStandardAttribute/birthday_non-standard_DeveloperOnlyAttribute (0.00s)
    --- PASS: TestUserPoolSchemaAttributeMatchesStandardAttribute/birthday_non-standard_Mutable (0.00s)
    --- PASS: TestUserPoolSchemaAttributeMatchesStandardAttribute/non-standard_Name (0.00s)
    --- PASS: TestUserPoolSchemaAttributeMatchesStandardAttribute/birthday_non-standard_Required (0.00s)
    --- PASS: TestUserPoolSchemaAttributeMatchesStandardAttribute/email_verified_standard (0.00s)
    --- PASS: TestUserPoolSchemaAttributeMatchesStandardAttribute/updated_at_standard (0.00s)
    --- PASS: TestUserPoolSchemaAttributeMatchesStandardAttribute/birthday_non-standard_StringAttributeConstraints.Max (0.00s)
    --- PASS: TestUserPoolSchemaAttributeMatchesStandardAttribute/birthday_non-standard_StringAttributeConstraints.Min (0.00s)
    --- PASS: TestUserPoolSchemaAttributeMatchesStandardAttribute/birthday_standard (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 3.345s
```