### PR TITLE
B MQ replication user fix

### DIFF
--- a/.changelog/32454.txt
+++ b/.changelog/32454.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_mq_broker: default `replication_user` to `false`
+```

--- a/internal/service/mq/broker_test.go
+++ b/internal/service/mq/broker_test.go
@@ -120,19 +120,21 @@ func TestDiffUsers(t *testing.T) {
 			OldUsers: []interface{}{},
 			NewUsers: []interface{}{
 				map[string]interface{}{
-					"console_access": false,
-					"username":       "second",
-					"password":       "TestTest2222",
-					"groups":         schema.NewSet(schema.HashString, []interface{}{"admin"}),
+					"console_access":   false,
+					"username":         "second",
+					"password":         "TestTest2222",
+					"groups":           schema.NewSet(schema.HashString, []interface{}{"admin"}),
+					"replication_user": false,
 				},
 			},
 			Creations: []*mq.CreateUserRequest{
 				{
-					BrokerId:      aws.String("test"),
-					ConsoleAccess: aws.Bool(false),
-					Username:      aws.String("second"),
-					Password:      aws.String("TestTest2222"),
-					Groups:        aws.StringSlice([]string{"admin"}),
+					BrokerId:        aws.String("test"),
+					ConsoleAccess:   aws.Bool(false),
+					Username:        aws.String("second"),
+					Password:        aws.String("TestTest2222"),
+					Groups:          aws.StringSlice([]string{"admin"}),
+					ReplicationUser: aws.Bool(false),
 				},
 			},
 			Deletions: []*mq.DeleteUserInput{},
@@ -141,24 +143,27 @@ func TestDiffUsers(t *testing.T) {
 		{
 			OldUsers: []interface{}{
 				map[string]interface{}{
-					"console_access": true,
-					"username":       "first",
-					"password":       "TestTest1111",
+					"console_access":   true,
+					"username":         "first",
+					"password":         "TestTest1111",
+					"replication_user": false,
 				},
 			},
 			NewUsers: []interface{}{
 				map[string]interface{}{
-					"console_access": false,
-					"username":       "second",
-					"password":       "TestTest2222",
+					"console_access":   false,
+					"username":         "second",
+					"password":         "TestTest2222",
+					"replication_user": false,
 				},
 			},
 			Creations: []*mq.CreateUserRequest{
 				{
-					BrokerId:      aws.String("test"),
-					ConsoleAccess: aws.Bool(false),
-					Username:      aws.String("second"),
-					Password:      aws.String("TestTest2222"),
+					BrokerId:        aws.String("test"),
+					ConsoleAccess:   aws.Bool(false),
+					Username:        aws.String("second"),
+					Password:        aws.String("TestTest2222"),
+					ReplicationUser: aws.Bool(false),
 				},
 			},
 			Deletions: []*mq.DeleteUserInput{
@@ -169,22 +174,25 @@ func TestDiffUsers(t *testing.T) {
 		{
 			OldUsers: []interface{}{
 				map[string]interface{}{
-					"console_access": true,
-					"username":       "first",
-					"password":       "TestTest1111updated",
+					"console_access":   true,
+					"username":         "first",
+					"password":         "TestTest1111updated",
+					"replication_user": false,
 				},
 				map[string]interface{}{
-					"console_access": false,
-					"username":       "second",
-					"password":       "TestTest2222",
+					"console_access":   false,
+					"username":         "second",
+					"password":         "TestTest2222",
+					"replication_user": false,
 				},
 			},
 			NewUsers: []interface{}{
 				map[string]interface{}{
-					"console_access": false,
-					"username":       "second",
-					"password":       "TestTest2222",
-					"groups":         schema.NewSet(schema.HashString, []interface{}{"admin"}),
+					"console_access":   false,
+					"username":         "second",
+					"password":         "TestTest2222",
+					"groups":           schema.NewSet(schema.HashString, []interface{}{"admin"}),
+					"replication_user": false,
 				},
 			},
 			Creations: []*mq.CreateUserRequest{},
@@ -193,11 +201,12 @@ func TestDiffUsers(t *testing.T) {
 			},
 			Updates: []*mq.UpdateUserRequest{
 				{
-					BrokerId:      aws.String("test"),
-					ConsoleAccess: aws.Bool(false),
-					Username:      aws.String("second"),
-					Password:      aws.String("TestTest2222"),
-					Groups:        aws.StringSlice([]string{"admin"}),
+					BrokerId:        aws.String("test"),
+					ConsoleAccess:   aws.Bool(false),
+					Username:        aws.String("second"),
+					Password:        aws.String("TestTest2222"),
+					Groups:          aws.StringSlice([]string{"admin"}),
+					ReplicationUser: aws.Bool(false),
 				},
 			},
 		},

--- a/website/docs/r/mq_broker.html.markdown
+++ b/website/docs/r/mq_broker.html.markdown
@@ -146,6 +146,7 @@ The following arguments are required:
 * `console_access` - (Optional) Whether to enable access to the [ActiveMQ Web Console](http://activemq.apache.org/web-console.html) for the user. Applies to `engine_type` of `ActiveMQ` only.
 * `groups` - (Optional) List of groups (20 maximum) to which the ActiveMQ user belongs. Applies to `engine_type` of `ActiveMQ` only.
 * `password` - (Required) Password of the user. It must be 12 to 250 characters long, at least 4 unique characters, and must not contain commas.
+* `replication_user` - (Optional) Whether to set set replication user. Defaults to `false`.
 * `username` - (Required) Username of the user.
 
 ~> **NOTE:** AWS currently does not support updating RabbitMQ users. Updates to users can only be in the RabbitMQ UI.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds parameter to the MQ user update/creation API calls, so that new/existing AWS MQ resources don't fail to create/update.

I copied the pre-existing parameter `console_access`, and defaulted it to `false`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32446

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
[AWS recently announced support for cross-region data replication](https://aws.amazon.com/about-aws/whats-new/2023/06/amazon-mq-cross-region-data-replication-activemq/). 

While this PR does not enable any replication functionality, will hopefully unblock updating of existing, non-replicated Amazon MQ brokers managed by Terraform.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=mq
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/mq/... -v -count 1 -parallel 20   -timeout 180m
=== RUN   TestAccMQBrokerDataSource_basic
=== PAUSE TestAccMQBrokerDataSource_basic
=== RUN   TestAccMQBrokerInstanceTypeOfferingsDataSource_basic
=== PAUSE TestAccMQBrokerInstanceTypeOfferingsDataSource_basic
=== RUN   TestValidateBrokerName
=== PAUSE TestValidateBrokerName
=== RUN   TestBrokerPasswordValidation
=== PAUSE TestBrokerPasswordValidation
=== RUN   TestDiffUsers
=== PAUSE TestDiffUsers
=== RUN   TestAccMQBroker_basic
=== PAUSE TestAccMQBroker_basic
=== RUN   TestAccMQBroker_disappears
=== PAUSE TestAccMQBroker_disappears
=== RUN   TestAccMQBroker_tags
=== PAUSE TestAccMQBroker_tags
=== RUN   TestAccMQBroker_throughputOptimized
=== PAUSE TestAccMQBroker_throughputOptimized
=== RUN   TestAccMQBroker_AllFields_defaultVPC
=== PAUSE TestAccMQBroker_AllFields_defaultVPC
=== RUN   TestAccMQBroker_AllFields_customVPC
=== PAUSE TestAccMQBroker_AllFields_customVPC
=== RUN   TestAccMQBroker_EncryptionOptions_kmsKeyID
=== PAUSE TestAccMQBroker_EncryptionOptions_kmsKeyID
=== RUN   TestAccMQBroker_EncryptionOptions_managedKeyDisabled
=== PAUSE TestAccMQBroker_EncryptionOptions_managedKeyDisabled
=== RUN   TestAccMQBroker_EncryptionOptions_managedKeyEnabled
=== PAUSE TestAccMQBroker_EncryptionOptions_managedKeyEnabled
=== RUN   TestAccMQBroker_Update_users
=== PAUSE TestAccMQBroker_Update_users
=== RUN   TestAccMQBroker_Update_securityGroup
=== PAUSE TestAccMQBroker_Update_securityGroup
=== RUN   TestAccMQBroker_Update_engineVersion
=== PAUSE TestAccMQBroker_Update_engineVersion
=== RUN   TestAccMQBroker_Update_hostInstanceType
=== PAUSE TestAccMQBroker_Update_hostInstanceType
=== RUN   TestAccMQBroker_RabbitMQ_basic
=== PAUSE TestAccMQBroker_RabbitMQ_basic
=== RUN   TestAccMQBroker_RabbitMQ_logs
=== PAUSE TestAccMQBroker_RabbitMQ_logs
=== RUN   TestAccMQBroker_RabbitMQ_validationAuditLog
=== PAUSE TestAccMQBroker_RabbitMQ_validationAuditLog
=== RUN   TestAccMQBroker_RabbitMQ_cluster
=== PAUSE TestAccMQBroker_RabbitMQ_cluster
=== RUN   TestAccMQBroker_ldap
=== PAUSE TestAccMQBroker_ldap
=== RUN   TestAccMQConfiguration_basic
=== PAUSE TestAccMQConfiguration_basic
=== RUN   TestAccMQConfiguration_withData
=== PAUSE TestAccMQConfiguration_withData
=== RUN   TestAccMQConfiguration_withLdapData
=== PAUSE TestAccMQConfiguration_withLdapData
=== RUN   TestAccMQConfiguration_tags
=== PAUSE TestAccMQConfiguration_tags
=== RUN   TestCanonicalXML
=== PAUSE TestCanonicalXML
=== CONT  TestAccMQBrokerDataSource_basic
=== CONT  TestCanonicalXML
=== CONT  TestAccMQBroker_Update_users
=== CONT  TestAccMQBroker_tags
=== CONT  TestAccMQBroker_EncryptionOptions_managedKeyDisabled
=== CONT  TestAccMQBroker_disappears
=== CONT  TestValidateBrokerName
=== CONT  TestAccMQConfiguration_tags
=== CONT  TestAccMQConfiguration_withLdapData
=== CONT  TestBrokerPasswordValidation
=== CONT  TestAccMQBroker_EncryptionOptions_managedKeyEnabled
=== CONT  TestAccMQConfiguration_basic
=== RUN   TestCanonicalXML/Config_sample_from_MSDN
=== CONT  TestAccMQBroker_ldap
=== CONT  TestAccMQBroker_AllFields_defaultVPC
=== PAUSE TestCanonicalXML/Config_sample_from_MSDN
=== CONT  TestAccMQBroker_AllFields_customVPC
=== RUN   TestCanonicalXML/Config_sample_from_MSDN,_modified
=== PAUSE TestCanonicalXML/Config_sample_from_MSDN,_modified
=== RUN   TestCanonicalXML/Config_sample_from_MSDN,_flaw
=== PAUSE TestCanonicalXML/Config_sample_from_MSDN,_flaw
=== RUN   TestCanonicalXML/A_note
=== CONT  TestAccMQBroker_throughputOptimized
=== PAUSE TestCanonicalXML/A_note
=== CONT  TestAccMQBroker_RabbitMQ_cluster
=== CONT  TestDiffUsers
=== CONT  TestAccMQBrokerInstanceTypeOfferingsDataSource_basic
=== CONT  TestAccMQBroker_RabbitMQ_validationAuditLog
=== CONT  TestAccMQConfiguration_withData
=== CONT  TestAccMQBroker_basic
=== CONT  TestAccMQBroker_EncryptionOptions_kmsKeyID
--- PASS: TestValidateBrokerName (0.00s)
--- PASS: TestBrokerPasswordValidation (0.00s)
--- PASS: TestDiffUsers (0.00s)
=== CONT  TestAccMQBroker_Update_engineVersion
--- PASS: TestAccMQBrokerInstanceTypeOfferingsDataSource_basic (70.17s)
=== CONT  TestAccMQBroker_RabbitMQ_logs
--- PASS: TestAccMQConfiguration_withLdapData (84.66s)
=== CONT  TestAccMQBroker_RabbitMQ_basic
--- PASS: TestAccMQConfiguration_withData (84.83s)
=== CONT  TestAccMQBroker_Update_securityGroup
--- PASS: TestAccMQConfiguration_basic (116.20s)
=== CONT  TestAccMQBroker_Update_hostInstanceType
--- PASS: TestAccMQConfiguration_tags (138.01s)
=== CONT  TestCanonicalXML/Config_sample_from_MSDN
=== CONT  TestCanonicalXML/Config_sample_from_MSDN,_flaw
=== CONT  TestCanonicalXML/A_note
=== CONT  TestCanonicalXML/Config_sample_from_MSDN,_modified
--- PASS: TestCanonicalXML (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN,_flaw (0.00s)
    --- PASS: TestCanonicalXML/A_note (0.00s)
    --- PASS: TestCanonicalXML/Config_sample_from_MSDN,_modified (0.00s)
--- PASS: TestAccMQBroker_throughputOptimized (901.02s)
--- PASS: TestAccMQBroker_RabbitMQ_basic (901.79s)
--- PASS: TestAccMQBroker_RabbitMQ_logs (918.63s)
--- PASS: TestAccMQBroker_EncryptionOptions_managedKeyEnabled (1024.98s)
--- PASS: TestAccMQBroker_disappears (1063.66s)
--- PASS: TestAccMQBroker_basic (1071.62s)
--- PASS: TestAccMQBrokerDataSource_basic (1081.86s)
--- PASS: TestAccMQBroker_EncryptionOptions_managedKeyDisabled (1085.15s)
--- PASS: TestAccMQBroker_tags (1087.15s)
--- PASS: TestAccMQBroker_RabbitMQ_validationAuditLog (1088.56s)
--- PASS: TestAccMQBroker_ldap (1129.74s)
--- PASS: TestAccMQBroker_EncryptionOptions_kmsKeyID (1149.12s)
--- PASS: TestAccMQBroker_RabbitMQ_cluster (1302.46s)
--- PASS: TestAccMQBroker_Update_engineVersion (1309.70s)
--- PASS: TestAccMQBroker_Update_securityGroup (1311.17s)
--- PASS: TestAccMQBroker_Update_users (1556.98s)
--- PASS: TestAccMQBroker_Update_hostInstanceType (1464.86s)
--- PASS: TestAccMQBroker_AllFields_customVPC (1798.04s)
--- PASS: TestAccMQBroker_AllFields_defaultVPC (1801.71s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mq	1807.278s
...
```
