### PR TITLE
skaff: parallelize unit tests

### DIFF
--- a/skaff/datasource/datasourcetest.tmpl
+++ b/skaff/datasource/datasourcetest.tmpl
@@ -99,6 +99,8 @@ import (
 // intricate, they should be unit tested.
 {{- end }}
 func Test{{ .DataSource }}ExampleUnitTest(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		TestName string
 		Input    string
@@ -126,7 +128,9 @@ func Test{{ .DataSource }}ExampleUnitTest(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
 		t.Run(testCase.TestName, func(t *testing.T) {
+			t.Parallel()
 			got, err := tf{{ .ServicePackage }}.FunctionFromDataSource(testCase.Input)
 
 			if err != nil && !testCase.Error {

--- a/skaff/resource/resourcetest.tmpl
+++ b/skaff/resource/resourcetest.tmpl
@@ -98,6 +98,8 @@ import (
 // intricate, they should be unit tested.
 {{- end }}
 func Test{{ .Resource }}ExampleUnitTest(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		TestName string
 		Input    string
@@ -125,7 +127,9 @@ func Test{{ .Resource }}ExampleUnitTest(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
 		t.Run(testCase.TestName, func(t *testing.T) {
+			t.Parallel()
 			got, err := tf{{ .ServicePackage }}.FunctionFromResource(testCase.Input)
 
 			if err != nil && !testCase.Error {


### PR DESCRIPTION
### Description
Parallelizes `skaff` example unit tests to align with the pattern most commonly used throughout the provider.



### Output from Acceptance Testing
N/a skaff.
