### PR TITLE
resource/aws_iam_virtual_mfa_device: Correctly sweep associated devices and add `enable_date` and `user_name` attributes

### DIFF
--- a/.changelog/32462.txt
+++ b/.changelog/32462.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_iam_virtual_mfa_device: Add `enable_date` and `user_name` attributes
+```

--- a/internal/service/iam/virtual_mfa_device.go
+++ b/internal/service/iam/virtual_mfa_device.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -48,6 +49,10 @@ func ResourceVirtualMFADevice() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"enable_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"path": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -61,6 +66,10 @@ func ResourceVirtualMFADevice() *schema.Resource {
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			"user_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"virtual_mfa_device_name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -149,6 +158,14 @@ func resourceVirtualMFADeviceRead(ctx context.Context, d *schema.ResourceData, m
 
 	d.Set("path", path)
 	d.Set("virtual_mfa_device_name", name)
+
+	if v := vMFA.EnableDate; v != nil {
+		d.Set("enable_date", aws.TimeValue(v).Format(time.RFC3339))
+	}
+
+	if u := vMFA.User; u != nil {
+		d.Set("user_name", u.UserName)
+	}
 
 	// The call above returns empty tags.
 	output, err := conn.ListMFADeviceTagsWithContext(ctx, &iam.ListMFADeviceTagsInput{

--- a/internal/service/iam/virtual_mfa_device_test.go
+++ b/internal/service/iam/virtual_mfa_device_test.go
@@ -34,18 +34,58 @@ func TestAccIAMVirtualMFADevice_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVirtualMFADeviceConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &conf),
 					acctest.CheckResourceAttrGlobalARN(resourceName, "arn", "iam", fmt.Sprintf("mfa/%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "base_32_string_seed"),
+					resource.TestCheckResourceAttr(resourceName, "path", "/"),
 					resource.TestCheckResourceAttrSet(resourceName, "qr_code_png"),
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"path", "virtual_mfa_device_name", "base_32_string_seed", "qr_code_png"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"base_32_string_seed",
+					"qr_code_png",
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMVirtualMFADevice_path(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf iam.VirtualMFADevice
+	resourceName := "aws_iam_virtual_mfa_device.test"
+
+	path := "/path/"
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, iam.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVirtualMFADeviceConfig_path(rName, path),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &conf),
+					acctest.CheckResourceAttrGlobalARN(resourceName, "arn", "iam", fmt.Sprintf("mfa%s%s", path, rName)),
+					resource.TestCheckResourceAttr(resourceName, "path", path),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"base_32_string_seed",
+					"qr_code_png",
+				},
 			},
 		},
 	})
@@ -66,21 +106,24 @@ func TestAccIAMVirtualMFADevice_tags(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVirtualMFADeviceConfig_tags1(rName, "key1", "value1"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"path", "virtual_mfa_device_name", "base_32_string_seed", "qr_code_png"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"base_32_string_seed",
+					"qr_code_png",
+				},
 			},
 			{
 				Config: testAccVirtualMFADeviceConfig_tags2(rName, "key1", "value1updated", "key2", "value2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
@@ -89,7 +132,7 @@ func TestAccIAMVirtualMFADevice_tags(t *testing.T) {
 			},
 			{
 				Config: testAccVirtualMFADeviceConfig_tags1(rName, "key2", "value2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
@@ -114,9 +157,8 @@ func TestAccIAMVirtualMFADevice_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVirtualMFADeviceConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &conf),
-					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfiam.ResourceVirtualMFADevice(), resourceName),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfiam.ResourceVirtualMFADevice(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -180,6 +222,16 @@ resource "aws_iam_virtual_mfa_device" "test" {
   virtual_mfa_device_name = %[1]q
 }
 `, rName)
+}
+
+func testAccVirtualMFADeviceConfig_path(rName, path string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_virtual_mfa_device" "test" {
+  virtual_mfa_device_name = %[1]q
+
+  path = %[2]q
+}
+`, rName, path)
 }
 
 func testAccVirtualMFADeviceConfig_tags1(rName, tagKey1, tagValue1 string) string {

--- a/internal/service/iam/virtual_mfa_device_test.go
+++ b/internal/service/iam/virtual_mfa_device_test.go
@@ -38,8 +38,10 @@ func TestAccIAMVirtualMFADevice_basic(t *testing.T) {
 					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &conf),
 					acctest.CheckResourceAttrGlobalARN(resourceName, "arn", "iam", fmt.Sprintf("mfa/%s", rName)),
 					resource.TestCheckResourceAttrSet(resourceName, "base_32_string_seed"),
+					resource.TestCheckNoResourceAttr(resourceName, "enable_date"),
 					resource.TestCheckResourceAttr(resourceName, "path", "/"),
 					resource.TestCheckResourceAttrSet(resourceName, "qr_code_png"),
+					resource.TestCheckNoResourceAttr(resourceName, "user_name"),
 				),
 			},
 			{

--- a/internal/service/opsworks/sweep.go
+++ b/internal/service/opsworks/sweep.go
@@ -377,7 +377,7 @@ func newUserProfileSweeper(resource *schema.Resource, d *schema.ResourceData, cl
 
 func (ups userProfileSweeper) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
 	err := ups.sweepable.Delete(ctx, timeout, optFns...)
-	if strings.Contains(err.Error(), "Cannot delete self") {
+	if err != nil && strings.Contains(err.Error(), "Cannot delete self") {
 		log.Printf("[WARN] Skipping OpsWorks User Profile (%s): %s", ups.d.Id(), err)
 		return nil
 	}

--- a/website/docs/r/iam_virtual_mfa_device.html.markdown
+++ b/website/docs/r/iam_virtual_mfa_device.html.markdown
@@ -13,6 +13,10 @@ Provides an IAM Virtual MFA Device.
 ~> **Note:** All attributes will be stored in the raw state as plain-text.
 [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 
+~> **Note:** A virtual MFA device cannot be directly associated with an IAM User from Terraform.
+  To associate the virtual MFA device with a user and enable it, use the code returned in either `base_32_string_seed` or `qr_code_png` to generate TOTP authentication codes.
+  The authentication codes can then be used with the AWS CLI command [`aws iam enable-mfa-device`](https://docs.aws.amazon.com/cli/latest/reference/iam/enable-mfa-device.html) or the AWS API call [`EnableMFADevice`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_EnableMFADevice.html).
+
 ## Example Usage
 
 **Using certs on file:**
@@ -37,8 +41,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The Amazon Resource Name (ARN) specifying the virtual mfa device.
 * `base_32_string_seed` - The base32 seed defined as specified in [RFC3548](https://tools.ietf.org/html/rfc3548.txt). The `base_32_string_seed` is base64-encoded.
-* `qr_code_png` -  A QR code PNG image that encodes `otpauth://totp/$virtualMFADeviceName@$AccountName?secret=$Base32String` where `$virtualMFADeviceName` is one of the create call arguments. AccountName is the user name if set (otherwise, the account ID otherwise), and Base32String is the seed in base32 format.
+* `enable_date` - The date and time when the virtual MFA device was enabled.
+* `qr_code_png` -  A QR code PNG image that encodes `otpauth://totp/$virtualMFADeviceName@$AccountName?secret=$Base32String` where `$virtualMFADeviceName` is one of the create call arguments. AccountName is the user name if set (otherwise, the account ID), and Base32String is the seed in base32 format.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+* `user_name` - The associated IAM User name if the virtual MFA device is enabled.
 
 ## Import
 


### PR DESCRIPTION
### Description

Attempting to sweep an `aws_iam_virtual_mfa_device` that is associated with an IAM User fails with the error

> deleting IAM Virtual MFA Device (arn:aws:iam::123456789012:mfa/example): DeleteConflict: MFA VirtualDevice in use. Must deactivate first

Adds `user_name` attribute needed for MFA deactivation and `enable_date`.

Also fixes panic in OpsWorks user sweeper.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
$ make testacc PKG=iam TESTS=TestAccIAMVirtualMFADevice_

--- PASS: TestAccIAMVirtualMFADevice_disappears (18.19s)
--- PASS: TestAccIAMVirtualMFADevice_basic (23.26s)
--- PASS: TestAccIAMVirtualMFADevice_path (23.32s)
--- PASS: TestAccIAMVirtualMFADevice_tags (46.32s)
```
