### PR TITLE
sweeper: Skip KMS Keys if access is denied

### DIFF
--- a/internal/service/kms/sweep.go
+++ b/internal/service/kms/sweep.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/sdk"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -78,7 +79,7 @@ func sweepKeys(region string) error {
 			d.Set("key_id", keyID)
 			d.Set("deletion_window_in_days", "7")
 
-			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+			sweepResources = append(sweepResources, sdk.NewSweepResource(r, d, client))
 		}
 
 		return !lastPage

--- a/internal/service/opsworks/sweep.go
+++ b/internal/service/opsworks/sweep.go
@@ -377,7 +377,7 @@ func newUserProfileSweeper(resource *schema.Resource, d *schema.ResourceData, cl
 
 func (ups userProfileSweeper) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
 	err := ups.sweepable.Delete(ctx, timeout, optFns...)
-	if strings.Contains(err.Error(), "Cannot delete self") {
+	if err != nil && strings.Contains(err.Error(), "Cannot delete self") {
 		log.Printf("[WARN] Skipping OpsWorks User Profile (%s): %s", ups.d.Id(), err)
 		return nil
 	}


### PR DESCRIPTION
### Description

The sweeper for `aws_kms_key` fails if access is denied with an error similar to

> - aws_kms_key: 12 errors occurred:
	* error reading KMS Key (xxxxx): AccessDeniedException: User: arn:aws:sts::123456789012:assumed-role/xxxxx is not authorized to perform: kms:DescribeKey on resource: arn:aws:kms:us-west-2:123456789012:key/xxxxx because no resource-based policy allows the kms:DescribeKey action
  ...
	* error reading KMS Key (xxxxx): AccessDeniedException: User: arn:aws:sts::123456789012:assumed-role/xxxxx is not authorized to perform: kms:DescribeKey on resource: arn:aws:kms:us-west-2:123456789012:key/xxxxx because no resource-based policy allows the kms:DescribeKey action

Skips the individual keys if that error is returned

Now logs entries similar to:

> [DEBUG] Skipping KMS Key (xxxxx): AccessDeniedException: User: arn:aws:sts:: 123456789012:assumed-role/xxxxx is not authorized to perform: kms:DescribeKey on resource: arn:aws:kms:us-west-2: 123456789012:key/xxxxx because no resource-based policy allows the kms:DescribeKey action