### PR TITLE
Correct typos in Quicksight flatteners for `visible_range`,  `rows`, and `visibility`

### DIFF
--- a/.changelog/32464.txt
+++ b/.changelog/32464.txt
@@ -1,11 +1,35 @@
 ```release-note:bug
-resource/aws_quicksight_*: Fix exception thrown when specifying `definition.sheets.visuals.bar_chart_visual.chart_configuration.category_axis.scrollbar_options.visible_range`
+resource/aws_quicksight_template: Fix exception thrown when specifying `definition.sheets.visuals.bar_chart_visual.chart_configuration.category_axis.scrollbar_options.visible_range`
 ```
 
 ```release-note:bug
-resource/aws_quicksight_*: Fix exception thrown when specifying `definition.sheets.visuals.pivot_table_visual.chart_configuration.field_options.selected_field_options.visibility`
+resource/aws_quicksight_template: Fix exception thrown when specifying `definition.sheets.visuals.pivot_table_visual.chart_configuration.field_options.selected_field_options.visibility`
 ```
 
 ```release-note:bug
-resource/aws_quicksight_*: Fix exception thrown when specifying `definition.sheets.visuals.pivot_table_visual.chart_configuration.field_wells.pivot_table_aggregated_field_wells.rows`
+resource/aws_quicksight_template: Fix exception thrown when specifying `definition.sheets.visuals.pivot_table_visual.chart_configuration.field_wells.pivot_table_aggregated_field_wells.rows`
+```
+
+```release-note:bug
+resource/aws_quicksight_dashboard: Fix exception thrown when specifying `definition.sheets.visuals.bar_chart_visual.chart_configuration.category_axis.scrollbar_options.visible_range`
+```
+
+```release-note:bug
+resource/aws_quicksight_dashboard: Fix exception thrown when specifying `definition.sheets.visuals.pivot_table_visual.chart_configuration.field_options.selected_field_options.visibility`
+```
+
+```release-note:bug
+resource/aws_quicksight_dashboard: Fix exception thrown when specifying `definition.sheets.visuals.pivot_table_visual.chart_configuration.field_wells.pivot_table_aggregated_field_wells.rows`
+```
+
+```release-note:bug
+resource/aws_quicksight_analysis: Fix exception thrown when specifying `definition.sheets.visuals.bar_chart_visual.chart_configuration.category_axis.scrollbar_options.visible_range`
+```
+
+```release-note:bug
+resource/aws_quicksight_analysis: Fix exception thrown when specifying `definition.sheets.visuals.pivot_table_visual.chart_configuration.field_options.selected_field_options.visibility`
+```
+
+```release-note:bug
+resource/aws_quicksight_analysis: Fix exception thrown when specifying `definition.sheets.visuals.pivot_table_visual.chart_configuration.field_wells.pivot_table_aggregated_field_wells.rows`
 ```

--- a/.changelog/32464.txt
+++ b/.changelog/32464.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/aws_quicksight_*: Fix exception thrown when specifying `definition.sheets.visuals.bar_chart_visual.chart_configuration.category_axis.scrollbar_options.visible_range`
+```
+
+```release-note:bug
+resource/aws_quicksight_*: Fix exception thrown when specifying `definition.sheets.visuals.pivot_table_visual.chart_configuration.field_options.selected_field_options.visibility`
+```
+
+```release-note:bug
+resource/aws_quicksight_*: Fix exception thrown when specifying `definition.sheets.visuals.pivot_table_visual.chart_configuration.field_wells.pivot_table_aggregated_field_wells.rows`
+```

--- a/internal/service/quicksight/schema/visual_chart_configuration.go
+++ b/internal/service/quicksight/schema/visual_chart_configuration.go
@@ -1368,7 +1368,7 @@ func flattenScrollBarOptions(apiObject *quicksight.ScrollBarOptions) []interface
 		tfMap["visibility"] = aws.StringValue(apiObject.Visibility)
 	}
 	if apiObject.VisibleRange != nil {
-		tfMap["visibile_range"] = flattenVisibleRangeOptions(apiObject.VisibleRange)
+		tfMap["visible_range"] = flattenVisibleRangeOptions(apiObject.VisibleRange)
 	}
 
 	return []interface{}{tfMap}

--- a/internal/service/quicksight/schema/visual_pivot_table.go
+++ b/internal/service/quicksight/schema/visual_pivot_table.go
@@ -1295,7 +1295,7 @@ func flattenPivotTableAggregatedFieldWells(apiObject *quicksight.PivotTableAggre
 		tfMap["columns"] = flattenDimensionFields(apiObject.Columns)
 	}
 	if apiObject.Rows != nil {
-		tfMap["row"] = flattenDimensionFields(apiObject.Rows)
+		tfMap["rows"] = flattenDimensionFields(apiObject.Rows)
 	}
 	if apiObject.Values != nil {
 		tfMap["values"] = flattenMeasureFields(apiObject.Values)
@@ -1671,7 +1671,7 @@ func flattenPivotTableFieldOption(apiObject []*quicksight.PivotTableFieldOption)
 			tfMap["custom_label"] = aws.StringValue(config.CustomLabel)
 		}
 		if config.Visibility != nil {
-			tfMap["visbility"] = aws.StringValue(config.Visibility)
+			tfMap["visibility"] = aws.StringValue(config.Visibility)
 		}
 
 		tfList = append(tfList, tfMap)


### PR DESCRIPTION
### Description

There were three typos in some of the Quicksight flattener functions that were leading to the following errors. This PR aims to correct them so that the data can successfully be written to the state.

I'm unsure on running the acceptance tests for this, so have left that out for now. I'd also be interested in how to properly approach the changelog entry for this, since it affects multiple resources due to the shared schema.

```shell
Error: setting definition: Invalid address to set: []string{"definition", "0", "sheets", "0", "visuals", "0", "bar_chart_visual", "0", "chart_configuration", "0", "category_axis", "0", "scrollbar_options", "0", "visibile_range"}
Error: setting definition: Invalid address to set: []string{"definition", "0", "sheets", "0", "visuals", "0", "pivot_table_visual", "0", "chart_configuration", "0", "field_options", "0", "selected_field_options", "0", "visbility"}
Error: setting definition: Invalid address to set: []string{"definition", "0", "sheets", "0", "visuals", "0", "pivot_table_visual", "0", "chart_configuration", "0", "field_wells", "0", "pivot_table_aggregated_field_wells", "0", "row"}
```

### Relations

Closes #31923
Closes #32347

### References

Schema reference for:

- [`visible_range`](https://github.com/hashicorp/terraform-provider-aws/blob/a2405f6611d18c0644d8c5ac967f1eb04bb5171f/internal/service/quicksight/schema/visual_chart_configuration.go#L147)
- [`rows`](https://github.com/hashicorp/terraform-provider-aws/blob/a2405f6611d18c0644d8c5ac967f1eb04bb5171f/internal/service/quicksight/schema/visual_pivot_table.go#L98)
- [`visibility`](https://github.com/hashicorp/terraform-provider-aws/blob/a2405f6611d18c0644d8c5ac967f1eb04bb5171f/internal/service/quicksight/schema/visual_pivot_table.go#L76)

### Output from Acceptance Testing

The acceptance tests for Quicksight are a bit unclear to me, so I'll need some assistance in running those, should it be needed for these typo fixes.
