### PR TITLE
sweep: `aws_batch_job_definition` sweeper was calling wrong resource implementation

### DIFF
--- a/internal/service/batch/sweep.go
+++ b/internal/service/batch/sweep.go
@@ -18,6 +18,7 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/sdk"
 )
 
 func init() {
@@ -141,7 +142,7 @@ func sweepComputeEnvironments(region string) error {
 			d := r.Data(nil)
 			d.SetId(name)
 
-			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+			sweepResources = append(sweepResources, sdk.NewSweepResource(r, d, client))
 		}
 
 		return !lastPage
@@ -187,7 +188,7 @@ func sweepJobDefinitions(region string) error {
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(v.JobDefinitionArn))
 
-			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+			sweepResources = append(sweepResources, sdk.NewSweepResource(r, d, client))
 		}
 
 		return !lastPage
@@ -232,7 +233,7 @@ func sweepJobQueues(region string) error {
 			d.SetId(aws.StringValue(v.JobQueueArn))
 			d.Set("name", v.JobQueueName)
 
-			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+			sweepResources = append(sweepResources, sdk.NewSweepResource(r, d, client))
 		}
 
 		return !lastPage
@@ -276,7 +277,7 @@ func sweepSchedulingPolicies(region string) error {
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(v.Arn))
 
-			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+			sweepResources = append(sweepResources, sdk.NewSweepResource(r, d, client))
 		}
 
 		return !lastPage

--- a/internal/service/batch/sweep.go
+++ b/internal/service/batch/sweep.go
@@ -187,7 +187,7 @@ func sweepJobDefinitions(region string) error {
 		}
 
 		for _, v := range page.JobDefinitions {
-			r := ResourceSchedulingPolicy()
+			r := ResourceJobDefinition()
 			d := r.Data(nil)
 			d.SetId(aws.StringValue(v.JobDefinitionArn))
 

--- a/internal/service/batch/sweep.go
+++ b/internal/service/batch/sweep.go
@@ -149,7 +149,7 @@ func sweepComputeEnvironments(region string) error {
 
 	if sweep.SkipSweepError(err) {
 		log.Printf("[WARN] Skipping Batch Compute Environment sweep for %s: %s", region, err)
-		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+		return nil
 	}
 
 	if err != nil {
@@ -160,10 +160,6 @@ func sweepComputeEnvironments(region string) error {
 
 	if err != nil {
 		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping Batch Compute Environments (%s): %w", region, err))
-	}
-
-	if err := sweep.SweepOrchestratorWithContext(ctx, sweepResources); err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping Batch Compute Environments: %w", err))
 	}
 
 	return sweeperErrs.ErrorOrNil()


### PR DESCRIPTION
### Description

`aws_batch_job_definition` sweeper was calling wrong resource implementation

Was returning error

> 	- aws_batch_job_definition: error sweeping Batch Job Definitions (us-west-2): 1 error occurred:
	* deleting Batch Scheduling Policy (arn:aws:batch:us-west-2:123456789012:job-definition/xxxxx): ClientException: Error executing request, Exception : Only scheduling policy Arn is allowed
