### PR TITLE
Remove `name` attribute from `aws_db_instance` docs

### DIFF
--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -407,7 +407,6 @@ in a Route 53 Alias record).
 * `maintenance_window` - The instance maintenance window.
 * `master_user_secret` - A block that specifies the master user secret. Only available when `manage_master_user_password` is set to true. [Documented below](#master_user_secret).
 * `multi_az` - If the RDS instance is multi AZ enabled.
-* `name` - The database name.
 * `port` - The database port.
 * `resource_id` - The RDS Resource ID of this instance.
 * `status` - The RDS instance status.


### PR DESCRIPTION
### Description

This PR removes the `name` attribute from the documentation on the `aws_db_instance` resource, as it does not exist within the schema.

### Relations

Closes #32475

### References

- [Resource schema](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/rds/instance.go)

### Output from Acceptance Testing

N/a, docs
