### PR TITLE
Document max items for `aws_wafv2_regex_pattern_set.regular_expression`

### DIFF
--- a/website/docs/r/wafv2_regex_pattern_set.html.markdown
+++ b/website/docs/r/wafv2_regex_pattern_set.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 * `name` - (Required) A friendly name of the regular expression pattern set.
 * `description` - (Optional) A friendly description of the regular expression pattern set.
 * `scope` - (Required) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the region `us-east-1` (N. Virginia) on the AWS provider.
-* `regular_expression` - (Optional) One or more blocks of regular expression patterns that you want AWS WAF to search for, such as `B[a@]dB[o0]t`. See [Regular Expression](#regular-expression) below for details.
+* `regular_expression` - (Optional) One or more blocks of regular expression patterns that you want AWS WAF to search for, such as `B[a@]dB[o0]t`. See [Regular Expression](#regular-expression) below for details. A maximum of 10 `regular_expression` blocks may be specified.
 * `tags` - (Optional) An array of key:value pairs to associate with the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Regular Expression


### PR DESCRIPTION
### Description

The `aws_wafv2_regex_pattern_set.regular_expression` argument can take a maximum of 10 regular expressions. This limitation was not documented, so this PR adds a note indicating the limitation.

### Relations

Closes #32311

### References

- [Resource Schema](https://github.com/hashicorp/terraform-provider-aws/blob/d54824dccd7179c11347981505be66d90db750a5/internal/service/wafv2/regex_pattern_set.go#L80)
- [AWS Quotas documentation](https://docs.aws.amazon.com/waf/latest/developerguide/limits.html) (this limit is not mentioned in the API or SDK documentation, but is indicated here)

### Output from Acceptance Testing

N/a, docs
